### PR TITLE
Import all initialized tensors as dense constants

### DIFF
--- a/src/dialect/onnx/onnx_ops.cpp
+++ b/src/dialect/onnx/onnx_ops.cpp
@@ -875,7 +875,6 @@ void ONNXReshapeOp::inferShapes() {
   auto constantOp = getONNXConstantOp(shape());
 
   SmallVector<int64_t, 2> dims(outputRank, -1);
-  mlir::ShapedType outputTy;
   if (constantOp) {
     DenseElementsAttr valueAttribute =
         constantOp.valueAttr().dyn_cast<DenseElementsAttr>();

--- a/src/dialect/onnx/onnx_ops.cpp
+++ b/src/dialect/onnx/onnx_ops.cpp
@@ -888,6 +888,9 @@ void ONNXReshapeOp::inferShapes() {
     for (int i=0; i<outputRank; ++i)
       dims[i] = (*valueIt++).cast<IntegerAttr>().getInt();
 
+    if (valueIt != valueAttribute.getValues<IntegerAttr>().end())
+      emitError("Constant value must have same rank as output");
+
     int64_t numberOfDynamicInputs = 0;
     int64_t totalKnownDimsSize = 1;
     int64_t dynamicValueIndex = -1;

--- a/src/dialect/onnx/onnx_ops.cpp
+++ b/src/dialect/onnx/onnx_ops.cpp
@@ -665,17 +665,18 @@ void ONNXReshapeOp::inferShapes() {
       dyn_cast_or_null<mlir::ONNXConstantOp>(secondArgDefiningOp);
 
   SmallVector<int64_t, 2> dims(outputRank, -1);
+  mlir::ShapedType outputTy;
   if (constantOp) {
-    ArrayAttr valueAttribute = constantOp.valueAttr().dyn_cast<ArrayAttr>();
+    DenseElementsAttr valueAttribute =
+        constantOp.valueAttr().dyn_cast<DenseElementsAttr>();
 
     if (!valueAttribute)
-      emitError("ArrayAttr expected");
+      emitError("DenseElementsAttr expected");
 
-    if (valueAttribute.getValue().size() != outputRank)
-      emitError("Constant value must have same rank as output");
+    auto valueIt = valueAttribute.getValues<IntegerAttr>().begin();
 
     for (int i=0; i<outputRank; ++i)
-      dims[i] = valueAttribute.getValue()[i].cast<IntegerAttr>().getInt();
+      dims[i] = (*valueIt++).cast<IntegerAttr>().getInt();
   }
 
   getResult().setType(

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -332,4 +332,27 @@ for test_name in test_to_enable:
 globals().update(backend_test.test_cases)
 
 if __name__ == '__main__':
-    unittest.main()
+    #unittest.main()
+    import onnx
+    from onnx import numpy_helper
+    import numpy as np
+    test_data_dir = '/home/tungld/dl/dlc-misc/mnist/'
+    model = onnx.load(test_data_dir + 'model.onnx')
+
+    #inputs = []
+    #input_file = test_data_dir + 'test_data_set_0/input_0.pb'
+    #tensor = onnx.TensorProto()
+    #with open(input_file, 'rb') as f:
+    #    tensor.ParseFromString(f.read())
+    #inputs.append(numpy_helper.to_array(tensor))
+    #outputs = DummyBackend.run_model(model, inputs)
+    #print(outputs[0])
+
+    true_outputs = []
+    output_file = test_data_dir + 'test_data_set_0/output_0.pb'
+    output_tensor = onnx.TensorProto()
+    with open(output_file, 'rb') as f:
+        output_tensor.ParseFromString(f.read())
+    true_outputs.append(numpy_helper.to_array(output_tensor))
+    print("True output: \n")
+    print(true_outputs)

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -332,27 +332,4 @@ for test_name in test_to_enable:
 globals().update(backend_test.test_cases)
 
 if __name__ == '__main__':
-    #unittest.main()
-    import onnx
-    from onnx import numpy_helper
-    import numpy as np
-    test_data_dir = '/home/tungld/dl/dlc-misc/mnist/'
-    model = onnx.load(test_data_dir + 'model.onnx')
-
-    #inputs = []
-    #input_file = test_data_dir + 'test_data_set_0/input_0.pb'
-    #tensor = onnx.TensorProto()
-    #with open(input_file, 'rb') as f:
-    #    tensor.ParseFromString(f.read())
-    #inputs.append(numpy_helper.to_array(tensor))
-    #outputs = DummyBackend.run_model(model, inputs)
-    #print(outputs[0])
-
-    true_outputs = []
-    output_file = test_data_dir + 'test_data_set_0/output_0.pb'
-    output_tensor = onnx.TensorProto()
-    with open(output_file, 'rb') as f:
-        output_tensor.ParseFromString(f.read())
-    true_outputs.append(numpy_helper.to_array(output_tensor))
-    print("True output: \n")
-    print(true_outputs)
+    unittest.main()

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -435,7 +435,7 @@ func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi32>) 
 }
 
 func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
-  %0 = "onnx.Constant"() {sparse_value = [], value = [5, 5, 16, 2] } : () -> tensor<4xi32>
+  %0 = "onnx.Constant"() {value = dense<[5, 5, 16, 2]> : tensor<4xi32> } : () -> tensor<4xi32>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi32>) -> tensor<*xf32>
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
@@ -445,7 +445,7 @@ func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
 }
 
 func @test_reshape_2(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
-  %0 = "onnx.Constant"() {sparse_value = [], value = [-1, 16, 2] } : () -> tensor<3xi32>
+  %0 = "onnx.Constant"() {value = dense<[-1, 16, 2]> : tensor<3xi32> } : () -> tensor<3xi32>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi32>) -> tensor<*xf32>
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
@@ -455,7 +455,7 @@ func @test_reshape_2(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
 }
 
 func @test_reshape_3(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
-  %0 = "onnx.Constant"() {sparse_value = [], value = [-1, 0, 2] } : () -> tensor<3xi32>
+  %0 = "onnx.Constant"() {value = dense<[-1, 0, 2]> : tensor<3xi32> } : () -> tensor<3xi32>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi32>) -> tensor<*xf32>
   "std.return"(%1) : (tensor<*xf32>) -> ()
 


### PR DESCRIPTION
This patch is to:
- Fix value attribute format for ConstantOp by using dense tensor,
- Import all initialized tensors as dense constants

By this patch, I successfully ran MNIST model (which was obtained from: https://github.com/onnx/models/tree/master/vision/classification/mnist)

Python script (Implementation of DummyBackend is not shown here):
```python
import onnx
from onnx import numpy_helper
import numpy as np
test_data_dir = '/home/tungld/dl/dlc-misc/mnist/'
model = onnx.load(test_data_dir + 'model.onnx')

inputs = []
input_file = test_data_dir + 'test_data_set_0/input_0.pb'
tensor = onnx.TensorProto()
with open(input_file, 'rb') as f:
    tensor.ParseFromString(f.read())
inputs.append(numpy_helper.to_array(tensor))

# Run inference with onnx-mlir
outputs = DummyBackend.run_model(model, inputs)
print("Predicted output: \n")
print(outputs)

true_outputs = []
output_file = test_data_dir + 'test_data_set_0/output_0.pb'
output_tensor = onnx.TensorProto()
with open(output_file, 'rb') as f:
    output_tensor.ParseFromString(f.read())
true_outputs.append(numpy_helper.to_array(output_tensor))
print("True output: \n")
print(true_outputs)
```

Here is output (ignored unrelated parts):
```shell
[  1%] Built target cruntime
[  3%] Built target pyruntime
[  5%] Built target gen_onnx_decompose
[  7%] Built target gen_shape_inference
[ 10%] Built target gen_onnx_combine
[ 15%] Built target gen_onnx_rewrite
[ 21%] Built target gen_onnx
[ 28%] Built target gen_krnl_ops
[ 35%] Built target compiler
[ 35%] Built target gen_onnx_proto
[ 40%] Built target onnx_proto
[ 75%] Built target onnx
[ 78%] Built target builder
[ 80%] Built target onnf_shape_inference
[ 94%] Built target onnf_lower_frontend
[ 96%] Built target onnf_onnx_decompose
[ 98%] Built target onnf_transform
[100%] Built target onnf
Predicted output:

[array([[  975.6703  ,  -618.7241  ,  6574.5684  ,   668.02795 ,
         -917.2716  , -1671.636   , -1952.7598  ,   -61.549263,
         -777.1762  , -1439.5306  ]], dtype=float32)]
True output:

[array([[  975.6701  ,  -618.72394 ,  6574.5684  ,   668.02893 ,
         -917.27094 , -1671.6359  , -1952.7599  ,   -61.549873,
         -777.17664 , -1439.5316  ]], dtype=float32)]
```