### PR TITLE
Lower MaxPooling and AveragePool to Krnl dialect using AffineMap

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -62,7 +62,7 @@ function(find_mlir_lib lib)
           PATHS ${LLVM_PROJECT_LIB}
           NO_DEFAULT_PATH)
   if(${${lib}} STREQUAL ${lib}-NOTFOUND)
-    message(FATAL_ERROR "${lib} not found")
+    message(FATAL_ERROR "${lib} not found, did you forget to build llvm-project?")
   endif()
 endfunction(find_mlir_lib)
 

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/IR/AffineExpr.h"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 
 using namespace mlir;
@@ -20,6 +21,19 @@ Value getIdentityValue<ONNXMaxPoolSingleOutOp>(
 }
 
 template <>
+Value getIdentityValue<ONNXAveragePoolOp>(
+    ConversionPatternRewriter &rewriter, Location loc, Type type) {
+  return emitConstantOp(rewriter, loc, type, 0);
+}
+
+// Scalar operations
+template <>
+struct ScalarOp<ONNXAveragePoolOp> {
+  using FOp = AddFOp;
+  using IOp = AddIOp;
+};
+
+template <>
 Value emitScalarOpFor<ONNXMaxPoolSingleOutOp>(
     ConversionPatternRewriter &rewriter, Location loc, Operation *op,
     Type elementType, ArrayRef<Value> scalarOperands) {
@@ -30,288 +44,519 @@ Value emitScalarOpFor<ONNXMaxPoolSingleOutOp>(
   return result;
 }
 
-struct ONNXMaxPoolSingleOutOpLowering : public ConversionPattern {
-  ONNXMaxPoolSingleOutOpLowering(MLIRContext *ctx)
-      : ConversionPattern(
-            mlir::ONNXMaxPoolSingleOutOp::getOperationName(), 1, ctx) {}
+//===----------------------------------------------------------------------===//
+// Get dilation values
+//
+template <typename PoolOp>
+std::vector<int64_t> getDilations(PoolOp poolOp) {
+  return {};
+}
+
+// MaxPool has dilations attribute.
+template <>
+std::vector<int64_t> getDilations<ONNXMaxPoolSingleOutOp>(
+    ONNXMaxPoolSingleOutOp poolOp) {
+  std::vector<int64_t> dilations;
+  auto dilationsAttribute = poolOp.dilationsAttr();
+  bool isDefaultDilations = true;
+  for (auto dilation : dilationsAttribute.getValue()) {
+    int64_t dilationValue = dilation.cast<IntegerAttr>().getInt();
+    if (dilationValue > 1 and isDefaultDilations)
+      isDefaultDilations = false;
+    dilations.emplace_back(dilationValue);
+  }
+  if (isDefaultDilations)
+    return {};
+  else
+    return dilations;
+}
+
+//===----------------------------------------------------------------------===//
+// Get count_include_pad values
+//
+template <typename PoolOp>
+bool getCountIncludePad(PoolOp poolOp) {
+  return false;
+}
+
+// AveragePool has count_include_pad attribute.
+template <>
+bool getCountIncludePad<ONNXAveragePoolOp>(ONNXAveragePoolOp poolOp) {
+  return (poolOp.count_include_pad() == 1);
+}
+
+//===----------------------------------------------------------------------===//
+// Helper function to do post-processing after applying a filter window.
+//
+template <typename PoolOp>
+void postProcessPoolingWindow(ConversionPatternRewriter &rewriter, Location loc,
+    PoolOp poolOp, Value alloc, ArrayRef<Value> resultIndices,
+    ArrayRef<int64_t> kernelShape, ArrayRef<Value> poolDimValues) {}
+
+// Calculate the average value for AveragePool.
+template <>
+void postProcessPoolingWindow<ONNXAveragePoolOp>(
+    ConversionPatternRewriter &rewriter, Location loc, ONNXAveragePoolOp poolOp,
+    Value alloc, ArrayRef<Value> resultIndices, ArrayRef<int64_t> kernelShape,
+    ArrayRef<Value> poolDimValues) {
+  // AveragePool's result type is FloatType, so it's safe to use DivFOp, SubFOp.
+  bool countIncludePad = getCountIncludePad<ONNXAveragePoolOp>(poolOp);
+  Value numerator = rewriter.create<LoadOp>(loc, alloc, resultIndices);
+  Value denominator;
+  if (countIncludePad) {
+    int64_t kernelSize = 1;
+    for (int i = 0; i < kernelShape.size(); ++i)
+      kernelSize *= kernelShape[i];
+    denominator =
+        emitConstantOp(rewriter, loc, numerator.getType(), kernelSize);
+  } else {
+    denominator = poolDimValues[0];
+    for (int i = 1; i < poolDimValues.size(); ++i)
+      denominator = rewriter.create<MulIOp>(loc, denominator, poolDimValues[i]);
+    denominator = rewriter.create<IndexCastOp>(
+        loc, denominator, rewriter.getIntegerType(64));
+    denominator =
+        rewriter.create<SIToFPOp>(loc, denominator, numerator.getType());
+  }
+
+  Value average = rewriter.create<DivFOp>(loc, numerator, denominator);
+
+  rewriter.create<StoreOp>(loc, average, alloc, resultIndices);
+}
+
+//===----------------------------------------------------------------------===//
+// Helper function to insert alloc and dealloc ops for memref of dynamic shape.
+//
+Value insertAllocAndDeallocForPooling(ConversionPatternRewriter &rewriter,
+    Location loc, bool insertDealloc, MemRefType memRefType, Value inputOperand,
+    ArrayRef<int64_t> kernelShape, ArrayRef<int64_t> pads,
+    ArrayRef<int64_t> strides, ArrayRef<int64_t> dilations, bool ceilMode) {
+  AllocOp alloc;
+
+  // Shape and rank information related to result and kernel.
+  auto resultShape = memRefType.getShape();
+  auto resultRank = resultShape.size();
+  auto kernelRank = kernelShape.size();
+  auto kernelOffset = resultRank - kernelRank;
+
+  // Compute dimensions of the result of this operation.
+  SmallVector<Value, 2> allocOperands;
+  for (int i = 0; i < kernelOffset; ++i) {
+    if (resultShape[i] < 0) {
+      auto dim = rewriter.create<DimOp>(loc, inputOperand, i);
+      allocOperands.emplace_back(dim);
+    }
+  }
+
+  Value zero, one;
+  if (ceilMode) {
+    zero = rewriter.create<ConstantOp>(
+        loc, rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+  }
+  one = rewriter.create<ConstantOp>(
+      loc, rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
+
+  for (int i = kernelOffset; i < resultShape.size(); ++i) {
+    if (resultShape[i] < 0) {
+      // dim =
+      //   let numerator = (input + pad - (kernel - 1) * dilation - 1)
+      //   in let denominator = stride
+      //      in
+      //        if (ceilMode)
+      //          ceil(numerator / denominator) + 1
+      //        else
+      //          floor(numerator / denominator) + 1
+      int spatialIndex = i - kernelOffset;
+
+      // numerator = (input + pad - (kernel - 1) * dilation - 1)
+      int64_t dilation = dilations.empty() ? 1 : dilations[spatialIndex];
+      int64_t padKernelDilation =
+          (pads[spatialIndex] + pads[spatialIndex + kernelRank]) -
+          (kernelShape[spatialIndex] - 1) * dilation - 1;
+      auto padKernelDilationVal = emitConstantOp(
+          rewriter, loc, rewriter.getIntegerType(64), padKernelDilation);
+      auto inputDim = rewriter.create<DimOp>(loc, inputOperand, i);
+      auto inputDimVal = rewriter.create<IndexCastOp>(
+          loc, inputDim, rewriter.getIntegerType(64));
+      auto numeratorVal =
+          rewriter.create<AddIOp>(loc, inputDimVal, padKernelDilationVal);
+      // denominator
+      auto denominatorVal = emitConstantOp(
+          rewriter, loc, rewriter.getIntegerType(64), strides[spatialIndex]);
+
+      // numerator / denominator
+      Value dimVal =
+          rewriter.create<SignedDivIOp>(loc, numeratorVal, denominatorVal);
+
+      if (ceilMode) {
+        auto remainder =
+            rewriter.create<SignedRemIOp>(loc, numeratorVal, denominatorVal);
+        auto isZero =
+            rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, remainder, zero);
+        auto dimPlusOne = rewriter.create<AddIOp>(loc, dimVal, one);
+        dimVal = rewriter.create<SelectOp>(loc, isZero, dimVal, dimPlusOne);
+      }
+
+      dimVal = rewriter.create<AddIOp>(loc, dimVal, one);
+      allocOperands.emplace_back(
+          rewriter.create<IndexCastOp>(loc, dimVal, rewriter.getIndexType()));
+    }
+  }
+  alloc = rewriter.create<AllocOp>(loc, memRefType, allocOperands);
+  if (insertDealloc) {
+    auto *parentBlock = alloc.getOperation()->getBlock();
+    auto dealloc = rewriter.create<DeallocOp>(loc, alloc);
+    dealloc.getOperation()->moveBefore(&parentBlock->back());
+  }
+  return alloc;
+}
+
+//===----------------------------------------------------------------------===//
+// Template function that does pooling.
+//
+template <typename PoolOp>
+struct ONNXPoolOpLowering : public ConversionPattern {
+  ONNXPoolOpLowering(MLIRContext *ctx)
+      : ConversionPattern(PoolOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     ONNXMaxPoolSingleOutOpOperandAdaptor operandAdaptor(operands);
     auto loc = op->getLoc();
 
-    // Match
-    ONNXMaxPoolSingleOutOp poolOp = llvm::dyn_cast<ONNXMaxPoolSingleOutOp>(op);
+    PoolOp poolOp = llvm::dyn_cast<PoolOp>(op);
 
     // Read kernel_shape attribute
-    SmallVector<int, 4> kernelShape;
+    SmallVector<int64_t, 4> kernelShape;
     auto kernelShapeAttribute = poolOp.kernel_shapeAttr();
-    for (auto dim : kernelShapeAttribute.getValue())
+    for (Attribute dim : kernelShapeAttribute.getValue())
       kernelShape.emplace_back(dim.cast<IntegerAttr>().getInt());
 
     // Read strides attribute
-    SmallVector<int, 4> strides;
+    SmallVector<int64_t, 4> strides;
     auto stridesAttribute = poolOp.stridesAttr();
-    for (auto stride : stridesAttribute.getValue())
+    for (Attribute stride : stridesAttribute.getValue())
       strides.emplace_back(stride.cast<IntegerAttr>().getInt());
 
     // Read ceil_mode attribute
     auto ceilMode = poolOp.ceil_mode().getSExtValue();
 
     // Read pads attribute
-    SmallVector<int, 4> pads;
+    SmallVector<int64_t, 4> pads;
     auto padsAttribute = poolOp.padsAttr();
-    for (auto pad : padsAttribute.getValue())
+    for (Attribute pad : padsAttribute.getValue())
       pads.emplace_back(pad.cast<IntegerAttr>().getInt());
 
-    // Read dilations attribute
-    SmallVector<int, 4> dilations;
-    auto dilationsAttribute = poolOp.dilationsAttr();
-    for (auto dilation : dilationsAttribute.getValue())
-      dilations.emplace_back(dilation.cast<IntegerAttr>().getInt());
+    // Read dilations attribute if the op has.
+    std::vector<int64_t> dilations = getDilations<PoolOp>(poolOp);
+    bool isDilated = !dilations.empty();
 
     // Type information about the input and result of this operation.
     auto inputOperand = operandAdaptor.X();
     auto inputShape = inputOperand.getType().cast<MemRefType>().getShape();
     auto memRefType = convertToMemRefType(*op->result_type_begin());
-    auto resultShape = memRefType.getShape();
-    auto resultElementType = memRefType.getElementType();
+    auto outputShape = memRefType.getShape();
+    auto outputElementType = memRefType.getElementType();
 
-    // Batch indices: N and C dimensions
-    int batchRank = 2;
+    // Kernel offset in the input shape.
+    int kernelOffset = inputShape.size() - kernelShape.size();
 
-    // Insert an allocation and deallocation for the result of this operation.
+    // Insert an allocation and deallocation for the output of this operation.
     Value alloc;
     bool insertDealloc = checkInsertDealloc(op);
 
     if (hasAllConstantDimensions(memRefType))
       alloc = insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc);
     else {
-      // Compute dimensions of the result of this operation.
-      SmallVector<Value, 2> allocOperands;
-      for (int i = 0; i < batchRank; ++i) {
-        if (resultShape[i] < 0) {
-          auto dim = rewriter.create<DimOp>(loc, inputOperand, i);
-          allocOperands.emplace_back(dim);
-        }
-      }
-
-      Value zero, one;
-      if (ceilMode) {
-        zero = rewriter.create<ConstantOp>(
-            loc, rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-      }
-      one = rewriter.create<ConstantOp>(
-          loc, rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
-
-      int spatialRank = resultShape.size() - batchRank;
-      for (int i = batchRank; i < resultShape.size(); ++i) {
-        if (resultShape[i] < 0) {
-          // dim =
-          //   let numerator = (input + pad - (kernel - 1) * dilation - 1)
-          //   in let denomitor = stride
-          //      in
-          //        if (ceilMode)
-          //          ceil(numerator / denominator) + 1
-          //        else
-          //          floor(numerator / denominator) + 1
-          int spatialIndex = i - batchRank;
-
-          // numerator = (input + pad - (kernel - 1) * dilation - 1)
-          auto inputDim = rewriter.create<DimOp>(loc, inputOperand, i);
-          auto inputVal = rewriter.create<IndexCastOp>(
-              loc, inputDim, rewriter.getIntegerType(64));
-          int64_t padKernelDilation =
-              (pads[spatialIndex] + pads[spatialIndex + spatialRank]) -
-              (kernelShape[spatialIndex] - 1) * dilations[spatialIndex] - 1;
-          auto padKernelDilationVal = rewriter.create<ConstantOp>(
-              loc, rewriter.getIntegerAttr(
-                       rewriter.getIntegerType(64), padKernelDilation));
-          auto numeratorVal =
-              rewriter.create<AddIOp>(loc, inputVal, padKernelDilationVal);
-          // denominator
-          auto denominatorVal = rewriter.create<ConstantOp>(
-              loc, rewriter.getIntegerAttr(
-                       rewriter.getIntegerType(64), strides[spatialIndex]));
-
-          // numerator / denominator
-          Value dimVal =
-              rewriter.create<SignedDivIOp>(loc, numeratorVal, denominatorVal);
-
-          if (ceilMode) {
-            auto remainder = rewriter.create<SignedRemIOp>(
-                loc, numeratorVal, denominatorVal);
-            auto isZero = rewriter.create<CmpIOp>(
-                loc, CmpIPredicate::eq, remainder, zero);
-            auto dimPlusOne = rewriter.create<AddIOp>(loc, dimVal, one);
-            dimVal = rewriter.create<SelectOp>(loc, isZero, dimVal, dimPlusOne);
-          }
-
-          dimVal = rewriter.create<AddIOp>(loc, dimVal, one);
-          allocOperands.emplace_back(rewriter.create<IndexCastOp>(
-              loc, dimVal, rewriter.getIndexType()));
-        }
-      }
-      alloc = rewriter.create<AllocOp>(loc, memRefType, allocOperands);
-      if (insertDealloc) {
-        auto *parentBlock = alloc.getDefiningOp()->getBlock();
-        auto dealloc = rewriter.create<DeallocOp>(loc, alloc);
-        dealloc.getOperation()->moveBefore(&parentBlock->back());
-      }
+      alloc = insertAllocAndDeallocForPooling(rewriter, loc, insertDealloc,
+          memRefType, inputOperand, kernelShape, pads, strides, dilations,
+          ceilMode);
     }
 
-    // R = MaxPool(D)
+    // input = Pool(output)
     //
     // The input/output shapes will look like this:
     //
-    // D (NxCxHxW) -> R (NxCxRHxRW)
+    // input (NxCxHxW) -> output (NxCxHOxWO)
     //
     // The loop nest will look as follows:
     //
-    // strides = [s1, s2]
+    // kernelShape = [kH, kW]
+    // pads = [ptH, ptW, pbH, pbW]
+    // strides = [sH, sW]
+    // dilations = [dH, dW]
+    // round = ceil if ceilMode else floor
     //
-    // for n = 0 .. N:
-    //   for c = 0 .. C:
-    //     for r1 = 0 .. RH:
-    //       for r2 = 0 .. RW:
-    //         R[n][c][r1][r2] = negative_infinity;
-    //         for k1 = 0 .. KH:
-    //           for k2 = 0 .. KW:
-    //             t = D[n][c][s1 * r1 + k1 * d1][s2 * r2 + k2 * d2];
-    //             R[n][c][r1][r2] = max(R[n][c][r1][r2], t);
+    // for n in range(N):
+    //   for c in range(C):
+    //     for ho in range(HO):
+    //       for wo in range(WO):
+    //         # Initialize values for the output.
+    //         output[n][c][ho][wo] = getIdentityValue(...);
     //
-    // Naming:
-    //   n, c, r1, r2: outer loop nest indices
-    //   k1, k2: inner loop nest indices
-    //   s1, s2: strides
-    //   d1, d2: dilations
+    //         # Thanks to Tian (@tjingrant) for the following derivation about
+    //         # firstValid.
+    //         # When dilation is non-unit, the first valid pixel to
+    //         # apply pooling on will not be the 0-th pixel, but rather
+    //         # the smallest integer n to make -pH + n * 3 greater than
+    //         # or equal to 0.
+    //         # We derive what is this smallest n:
+    //         # -pH + n * dH >= 0
+    //         #       n * dH >= pH
+    //         #            n >= pH/dH
+    //         # thus n = ceil(pH/dH)
+    //         # thus the first valid pixel location is
+    //         # ceil(pH / dilation) * dilation - pH
     //
-    // TODO: handle padding.
+    //         firstValidH = ceil(float(ptH / dH)) * dH - ptH
+    //         startH = max(firstValidH, ho * sH - ptH)
+    //         endH = min(H, ho * sH + (kH -1) * dH  + 1 - ptH)
+    //
+    //         firstValidW= ceil(float(pW / dW)) * dW - ptW
+    //         startW = max(firstValidW, wo * sW - ptW)
+    //         endW = min(W, wo * sW + (kW - 1) * dW + 1 - ptW)
+    //
+    //         hDim= round(float(endH - startH) / float(dH))
+    //         wDim= round(float(endW - startW) / float(dW))
+    //
+    //         # Apply the pooling window.
+    //         # The pooling window can be smaller than the kernel when slicing
+    //         # over the border edges.
+    //         for hi in range(startH, endH, dH):
+    //           for wi in range(startW, endW, dW):
+    //             output[n, c, ho, wo] = emitScalarOpFor(output[n, c, ho, wo],
+    //                                                    input[n, c, hi, wi]);
+    //
+    //         # The above two for-loops are rewritten as follows:
+    //         # (since KrnlIterateOp has not supported `step` yet)
+    //         for hp in range(hDim):
+    //           for wp in range(wDim):
+    //             hi = hp * dH + startH
+    //             wi = wp * dW + startW
+    //             output[n, c, ho, wo] = emitScalarOpFor(output[n, c, ho, wo],
+    //                                                    input[n, c, hi, wi]);
+    //
+    //         # Do post processing such as taking average pooling:
+    //         postProcessPoolingWindow(...)
+    //
+    // Helper functions:
+    //   getIdentityValue(): to return the indentity value
+    //     - negative infinity for MaxPool
+    //     - 0 for AveragePool
+    //   emitScalarOpFor(): to do primitive computation for Pooling, e.g.
+    //     - compute max for MaxPool
+    //     - compute sum for AveragePool
+    //   postProcessPoolingWindow(): to do post processing over the whole
+    //   pooling window, e.g.
+    //     - do nothing in case of MaxPool
+    //     - calculate the average in case of AveragePool, e.g.
+    //         if hDim * wDim> 0:
+    //           output[n, c, ho, wo] = output[n, c, ho, wo] / (hDim*wDim)
     //
 
-    // 1. Define outer loops and emit empty optimization block.
-    auto nOuterLoops = resultShape.size();
-    BuildKrnlLoop outerLoops(rewriter, loc, nOuterLoops);
-    outerLoops.createDefineOptimizeAndIterateOp(alloc);
+    // Identity value of the operation.
+    auto identity = getIdentityValue<PoolOp>(rewriter, loc, outputElementType);
 
-    rewriter.setInsertionPointToStart(outerLoops.getIterateBlock());
+    // 1. Define output loops to compute one output pixel.
+    // for n in range(N):
+    //   for c in range(C):
+    //     for ho in range(HO):
+    //       for wo in range(WO):
+    BuildKrnlLoop outputLoops(rewriter, loc, outputShape.size());
+    outputLoops.createDefineOptimizeAndIterateOp(alloc);
+
+    auto ipMainRegion = rewriter.saveInsertionPoint();
+    rewriter.setInsertionPointToStart(outputLoops.getIterateBlock());
     {
-      // 2. Emit the body of the outer loop nest.
-      SmallVector<Value, 4> resultIndices;
-      for (int i = 0; i < nOuterLoops; ++i)
-        resultIndices.emplace_back(outerLoops.getInductionVar(i));
+      // 2. Emit the body of the output loop nest, which applies a pooling
+      // window to a region in the input, producing one output pixel.
+      SmallVector<Value, 4> outputIndices;
+      for (int i = 0; i < outputShape.size(); ++i)
+        outputIndices.emplace_back(outputLoops.getInductionVar(i));
 
-      // 2.1 Emit: R[n][c][r1][r2] = negative_infinity;
-      Value identity = getIdentityValue<ONNXMaxPoolSingleOutOp>(
-          rewriter, loc, resultElementType);
-      rewriter.create<StoreOp>(loc, identity, alloc, resultIndices);
+      // 2.1 Emit: output[n][c][ho][wo] = identity
+      rewriter.create<StoreOp>(loc, identity, alloc, outputIndices);
 
-      // 2.2 Define inner loops.
-      int nInnerLoops = kernelShape.size();
-      BuildKrnlLoop innerLoops(rewriter, loc, nInnerLoops);
-      innerLoops.createDefineAndOptimizeOp();
-      //   for Kx = 0 .. KX
-      for (int i = 0; i < nInnerLoops; ++i)
-        innerLoops.pushBounds(0, kernelShape[i]);
+      // 2.2 Emit affine maps which express the lower and upper bounds for the
+      // pooling window's dimensions.
+      // The pooling window can be smaller than the kernel when slicing it over
+      // the border edges. Thus, we will compute the start and end indices for
+      // each dimension as follows.
+      //   firstValidH = ceil(float(ptH / dH)) * dH - ptH
+      //   startH = max(firstValidH, ho * sH - ptH)
+      //   endH = min(H, ho * sH + (kH - 1) * dH  + 1 - pbH)
+      //   hDim = round(float(endH - startH) / float(dH))
 
-      // 2.3 Emit inner loop nest.
-      innerLoops.createIterateOp();
-      rewriter.setInsertionPointToStart(innerLoops.getIterateBlock());
-      {
-        // 3. Emit inner loop body
-        // t = D[n][c][s1 * r1 + k1 * d1][s2 * r2 + k2 * d2];
-        // R[n][c][r1][r2] = max(R[n][c][r1][r2], t);
-
-        // 3.1 Prepare indices for accesing the data tensor.
-        SmallVector<Value, 4> dataIndices;
-        // 3.1.1 Batch indices: n, c
-        for (int i = 0; i < batchRank; ++i)
-          dataIndices.emplace_back(outerLoops.getInductionVar(i));
-        // 3.1.2 Insert spatial indices: sX * rX + kX * dX
-        for (int i = batchRank; i < nOuterLoops; ++i) {
-          // Get index along the inner loop's induction variables.
-          // It is used to obtain kernel/pad/stride/dilation index.
-          int j = i - batchRank;
-
-          Value spatialIndex = outerLoops.getInductionVar(i);
-          // If strides are present (not default) then emit the correct access
-          // index.
-          // sX *= rX
-          if (strides[i - batchRank] > 1) {
-            auto strideIndex = emitConstantOp(
-                rewriter, loc, rewriter.getIndexType(), strides[j]);
-            spatialIndex = rewriter.create<MulIOp>(
-                loc, strideIndex, outerLoops.getInductionVar(i));
-          }
-
-          // Dilate the kernel index only if the dilation value is not one (not
-          // default). Otherwise, just add kernelIndex.
-          auto kernelIndex = innerLoops.getInductionVar(j);
-          if (dilations[j] > 1) {
-            // sX += dX * kW
-            auto dilationIndex = emitConstantOp(
-                rewriter, loc, rewriter.getIndexType(), dilations[j]);
-            auto dilationKernelIndex =
-                rewriter.create<MulIOp>(loc, dilationIndex, kernelIndex);
-            spatialIndex =
-                rewriter.create<AddIOp>(loc, spatialIndex, dilationKernelIndex);
+      // Prepare induction variables and constants as arguments for the affine
+      // maps.
+      SmallVector<SmallVector<Value, 4>, 4> IVsAndConstants;
+      { // Construct IVsAndConstants.
+        for (int i = 0; i < kernelShape.size(); ++i) {
+          SmallVector<Value, 4> ic;
+          // d0, output
+          ic.emplace_back(outputLoops.getInductionVar(i + kernelOffset));
+          // s0, input dim
+          if (inputShape[i + kernelOffset] < 0) {
+            ic.emplace_back(
+                rewriter.create<DimOp>(loc, inputOperand, i + kernelOffset));
           } else {
-            // sX += kX
-            spatialIndex =
-                rewriter.create<AddIOp>(loc, spatialIndex, kernelIndex);
+            ic.emplace_back(emitConstantOp(rewriter, loc,
+                rewriter.getIndexType(), inputShape[i + kernelOffset]));
           }
+          // s1, kernel dim
+          ic.emplace_back(emitConstantOp(
+              rewriter, loc, rewriter.getIndexType(), kernelShape[i]));
+          // s2, pad dim
+          ic.emplace_back(
+              emitConstantOp(rewriter, loc, rewriter.getIndexType(), pads[i]));
+          // s3, stride dim
+          ic.emplace_back(emitConstantOp(
+              rewriter, loc, rewriter.getIndexType(), strides[i]));
+          // s4, dilation dim
+          ic.emplace_back(emitConstantOp(rewriter, loc, rewriter.getIndexType(),
+              (isDilated) ? dilations[i] : 1));
+          IVsAndConstants.emplace_back(ic);
+        }
+      }
 
-          // If ceil mode or dilation is enabled, then the calculated access
-          // index may exceed its dimension. In such a case, we will use the
-          // maximum index, which causes multiple visits to the element of the
-          // maximum index.
-          // TODO: Avoid multiple visits.
-          // Example of out-of-bound.
-          // - Given a 5x5 input X
-          //  X = [[0, 0, 0, 0, 0],
-          //       [1, 1, 1, 1, 1],
-          //       [2, 2, 2, 2, 2],
-          //       [3, 3, 3, 3, 3],
-          //       [4, 4, 4, 4, 4]]
-          // - Do MaxPool with strides=[2, 2], kernel=[2, 2], ceilMode=true,
-          // output is a 3x3 array:
-          // Y = [[1, 1, 1],
-          //      [3, 3, 3],
-          //      [4, 4, 4]]
-          // - When computing Y[2, 0]:
-          //    - In case of kernelIndex = 1, stride = 2
-          //      - No dilation: spatialIndex = 2 * 2 + 1 = 5
-          //        => out of bound
-          //      - dilation = 2: spatialIndex = 2 * 2 + 2 * 1 = 6
-          //        => out of bound
-          if (dilations[j] > 1 or ceilMode) {
-            Value upperIndex;
-            if (inputShape[i] < 0) {
-              Value inputDim = rewriter.create<DimOp>(loc, inputOperand, i);
-              Value one = rewriter.create<ConstantIndexOp>(loc, 1);
-              upperIndex = rewriter.create<SubIOp>(loc, inputDim, one);
-            } else {
-              upperIndex =
-                  rewriter.create<ConstantIndexOp>(loc, inputShape[i] - 1);
+      // Affine maps for the pooling window.
+      AffineMap poolStartMap, poolEndMap, poolDimMap;
+      { // Construct poolStartMap, poolEndMap and poolDimMap.
+        // AffineExpr(s) to obtain the dimensions and symbols.
+        AffineExpr outputIndex = rewriter.getAffineDimExpr(0);
+        AffineExpr inputDim = rewriter.getAffineSymbolExpr(0);
+        AffineExpr kernelDim = rewriter.getAffineSymbolExpr(1);
+        AffineExpr padTopDim = rewriter.getAffineSymbolExpr(2);
+        AffineExpr strideDim = rewriter.getAffineSymbolExpr(3);
+        AffineExpr dilationDim = rewriter.getAffineSymbolExpr(4);
+        AffineExpr start1 =
+            (padTopDim).ceilDiv(dilationDim) * dilationDim - padTopDim;
+        AffineExpr start2 = outputIndex * strideDim - padTopDim;
+        AffineExpr end1 = inputDim;
+        AffineExpr end2 = outputIndex * strideDim +
+                          (kernelDim - 1) * dilationDim + 1 - padTopDim;
+
+        // poolDimMap
+        SmallVector<AffineExpr, 4> dimExpr;
+        // Upperbound for an affine.for is `min AffineMap`, where `min` is
+        // automatically inserted when an affine.for is constructed from
+        // an AffineMap, thus we rewrite `endH - startH` as follows:
+        //   endH - start H
+        //     = min(end1, end2) - max(start1, start2)
+        //     = min(end1 - start1, end1 - start2, end2 - start1, end2 - start2)
+        AffineExpr dimExpr1 = end1 - start1;
+        AffineExpr dimExpr2 = end1 - start2;
+        AffineExpr dimExpr3 = end2 - start1;
+        AffineExpr dimExpr4 = end2 - start2;
+        for (AffineExpr de : {dimExpr1, dimExpr2, dimExpr3, dimExpr4}) {
+          if (isDilated) {
+            de = de + 1;
+            de =
+                (ceilMode) ? de.ceilDiv(dilationDim) : de.floorDiv(dilationDim);
+          }
+          dimExpr.emplace_back(de);
+        }
+        poolDimMap = AffineMap::get(1, 5, dimExpr);
+
+        // poolStartMap and poolEndMap
+        poolStartMap = AffineMap::get(1, 5, {start1, start2});
+        poolEndMap = AffineMap::get(1, 5, {end1, end2});
+      }
+
+      // Obtain values from the affine maps.
+      SmallVector<Value, 4> poolStartValues;
+      SmallVector<Value, 4> poolDimValues;
+      { // Construct poolStartValues and poolDimValues.
+        for (int i = 0; i < kernelShape.size(); ++i) {
+          Value startIndex = rewriter.create<AffineMaxOp>(
+              loc, poolStartMap, ValueRange(IVsAndConstants[i]));
+          poolStartValues.emplace_back(startIndex);
+
+          Value endIndex = rewriter.create<AffineMinOp>(
+              loc, poolEndMap, ValueRange(IVsAndConstants[i]));
+
+          Value dim = rewriter.create<SubIOp>(loc, endIndex, startIndex);
+          if (isDilated) {
+            Value one =
+                emitConstantOp(rewriter, loc, rewriter.getIndexType(), 1);
+            Value numerator = rewriter.create<AddIOp>(loc, dim, one);
+            Value denominator = IVsAndConstants[i][5]; // dilations[i]
+            dim = rewriter.create<SignedDivIOp>(loc, numerator, denominator);
+            if (ceilMode) {
+              auto remainder =
+                  rewriter.create<SignedRemIOp>(loc, numerator, denominator);
+              Value zero =
+                  emitConstantOp(rewriter, loc, rewriter.getIndexType(), 0);
+              auto isZero = rewriter.create<CmpIOp>(
+                  loc, CmpIPredicate::eq, remainder, zero);
+              auto dimPlusOne = rewriter.create<AddIOp>(loc, dim, one);
+              dim = rewriter.create<SelectOp>(loc, isZero, dim, dimPlusOne);
             }
-            auto greaterCondition = rewriter.create<CmpIOp>(
-                loc, CmpIPredicate::sgt, spatialIndex, upperIndex);
-            spatialIndex = rewriter.create<SelectOp>(
-                loc, greaterCondition, upperIndex, spatialIndex);
           }
+          poolDimValues.emplace_back(dim);
+        }
+      }
 
-          dataIndices.emplace_back(spatialIndex);
+      // 2.3 Define pooling loops.
+      //  for hp in range(hDim):
+      //    for wp in range(wDim):
+      //      hi = hp * dH + startH
+      //      wi = wp * dW + startW
+      //      output[n][c][ho][wo] =
+      //        emitScalarOpFor(output[n][c][ho][wo], input[n, c, hi, wi]);
+      BuildKrnlLoop poolingLoops(rewriter, loc, kernelShape.size());
+      poolingLoops.createDefineAndOptimizeOp();
+      for (int i = 0; i < kernelShape.size(); ++i)
+        poolingLoops.pushBounds(
+            0, poolDimMap, llvm::makeArrayRef(IVsAndConstants[i]));
+      poolingLoops.createIterateOp();
+
+      auto ipOuterLoops = rewriter.saveInsertionPoint();
+      rewriter.setInsertionPointToStart(poolingLoops.getIterateBlock());
+      {
+        // 2.4 Emit the body of the pooling loop nest.
+        // Prepare indices to access a pixel in the input.
+        std::vector<Value> inputIndices;
+        { // Construct inputIndices
+          for (int i = 0; i < kernelOffset; ++i)
+            inputIndices.emplace_back(outputIndices[i]);
+          for (int i = kernelOffset; i < inputShape.size(); ++i) {
+            int j = i - kernelOffset;
+            if (isDilated) {
+              // hi = hp * dH + startH
+              Value index = rewriter.create<MulIOp>(
+                  loc, poolingLoops.getInductionVar(j), IVsAndConstants[j][5]);
+              index = rewriter.create<AddIOp>(loc, index, poolStartValues[j]);
+              inputIndices.emplace_back(index);
+            } else {
+              // hi = hp + startH
+              inputIndices.emplace_back(rewriter.create<AddIOp>(
+                  loc, poolingLoops.getInductionVar(j), poolStartValues[j]));
+            }
+          }
         }
 
-        // 3.2 Do pooling.
-        auto loadData = rewriter.create<LoadOp>(loc, inputOperand, dataIndices);
-        auto loadPartialResult =
-            rewriter.create<LoadOp>(loc, alloc, resultIndices);
-        Value result = emitScalarOpFor<ONNXMaxPoolSingleOutOp>(rewriter, loc,
-            op, resultElementType, {loadPartialResult, loadData});
-        rewriter.create<StoreOp>(loc, result, alloc, resultIndices);
+        // Apply pooling operation.
+        //      output[n][c][ho][wo] =
+        //        emitScalarOpFor(output[n][c][ho][wo], input[n, c, hi, wi]);
+        Value loadInput =
+            rewriter.create<LoadOp>(loc, inputOperand, inputIndices);
+        Value loadPartialOutput =
+            rewriter.create<LoadOp>(loc, alloc, outputIndices);
+        Value output = emitScalarOpFor<PoolOp>(rewriter, loc, op,
+            outputElementType, {loadPartialOutput, loadInput});
+        rewriter.create<StoreOp>(loc, output, alloc, outputIndices);
       }
+
+      // 2.5 Post-processing for the pooling window, e.g. taking average.
+      rewriter.restoreInsertionPoint(ipOuterLoops);
+      postProcessPoolingWindow<PoolOp>(rewriter, loc, poolOp, alloc,
+          outputIndices, kernelShape, poolDimValues);
     }
+
+    // Go back to the main region.
+    rewriter.restoreInsertionPoint(ipMainRegion);
+
     rewriter.replaceOp(op, alloc);
 
     return success();
@@ -320,5 +565,6 @@ struct ONNXMaxPoolSingleOutOpLowering : public ConversionPattern {
 
 void populateLoweringONNXPoolingOpPattern(
     OwningRewritePatternList &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXMaxPoolSingleOutOpLowering>(ctx);
+  patterns.insert<ONNXPoolOpLowering<ONNXMaxPoolSingleOutOp>>(ctx);
+  patterns.insert<ONNXPoolOpLowering<ONNXAveragePoolOp>>(ctx);
 }

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -149,6 +149,15 @@ void KrnlIterateOperandPack::pushOperandBound(Value operand) {
   _operands.emplace_back(operand);
 }
 
+void KrnlIterateOperandPack::pushAffineMapBound(
+    AffineMap map, ArrayRef<Value> operands) {
+  if (boundMaps.size() % 2 == 0)
+    _operands.emplace_back(inputLoops[boundMaps.size() / 2]);
+  boundMaps.emplace_back(AffineMapAttr::get(map));
+  for (auto operand : operands)
+    _operands.emplace_back(operand);
+}
+
 BuildKrnlLoop::BuildKrnlLoop(
     ConversionPatternRewriter &rewriter, Location loc, int loopNum)
     : rewriter(rewriter), loc(loc), originalLoopNum(loopNum), pack(NULL),
@@ -206,6 +215,13 @@ int BuildKrnlLoop::pushBounds(int64_t lowerBound, int64_t upperBound) {
 int BuildKrnlLoop::pushBounds(int64_t lowerBound, Value upperBound) {
   pack->pushConstantBound(lowerBound);
   pack->pushOperandBound(upperBound);
+  return pushCount++;
+}
+
+int BuildKrnlLoop::pushBounds(int64_t lowerBound, AffineMap upperBound,
+    ArrayRef<Value> operandsForUpperBoundMap) {
+  pack->pushConstantBound(lowerBound);
+  pack->pushAffineMapBound(upperBound, operandsForUpperBoundMap);
   return pushCount++;
 }
 

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -87,6 +87,8 @@ struct KrnlIterateOperandPack {
 
   void pushOperandBound(mlir::Value operand);
 
+  void pushAffineMapBound(mlir::AffineMap map, ArrayRef<Value> operands);
+
   llvm::SmallVector<mlir::Value, 8> getOperands() const { return _operands; }
 
   mlir::ArrayAttr getAttributes() const {
@@ -159,6 +161,8 @@ public:
   // must be of MemRef type.
   int pushBounds(int64_t lowerBound, int64_t upperBound);
   int pushBounds(int64_t lowerBound, Value upperBound);
+  int pushBounds(int64_t lowerBound, AffineMap upperBound,
+      ArrayRef<Value> operandsForUpperBoundMap);
   int pushBounds(Value lowerBound, Value upperBound);
   int pushBounds(int64_t lowerBound, Value upperBoundMemRefOperand,
       int upperBoundMemRefIndex, bool upperBoundMustBeConstant = false);

--- a/src/Dialect/ONNX/ONNXOps.td
+++ b/src/Dialect/ONNX/ONNXOps.td
@@ -98,7 +98,6 @@ def ONNXEntryPointOp: ONNX_Op<"EntryPoint"> {
 
 def ONNXMaxPoolSingleOutOp: ONNX_Op<"MaxPoolSingleOut",
     [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
-  let hasCanonicalizer = 1;
   let summary = "ONNX MaxPool operation with a single output.";
   let description = [{
     "ONNX MaxPool operation with a single output."

--- a/src/Runtime/CMakeLists.txt
+++ b/src/Runtime/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_library(cruntime
+# Create shared libcruntime.so since model.so linkage for backend tests
+# will fail on x86 Linux if cruntime is statically linked.
+add_library(cruntime SHARED
         DynMemRef.cpp
         DynMemRef.h
         DataType.h)

--- a/src/Transform/ONNX/ONNXRewrite.cpp
+++ b/src/Transform/ONNX/ONNXRewrite.cpp
@@ -33,7 +33,7 @@ bool hasNonZeroInArrayAttr(ArrayAttr attrs) {
 }
 
 // Create an ArrayAttr of IntergerAttr(s) of zero values.
-// This function is used for padding attribute in MaxPoolSingleOut.
+// This function is used for padding attribute in Conv.
 ArrayAttr createArrayAttrOfZeros(
     PatternRewriter &rewriter, ArrayAttr origAttrs) {
   int nElements = origAttrs.getValue().size();
@@ -51,7 +51,7 @@ ArrayAttr createArrayAttrOfZeros(
 //         |_____|                  |_____|
 //                 nZeros                    nZeros
 //
-// This function is used for padding attribute in MaxPoolSingleOut.
+// This function is used for padding attribute in Conv.
 ArrayAttr insertZerosForNonPaddedDims(
     PatternRewriter &rewriter, ArrayAttr origAttrs, int extensionLength) {
   int nDims = (int)origAttrs.getValue().size() / 2;
@@ -72,11 +72,6 @@ ArrayAttr insertZerosForNonPaddedDims(
 
 } // end anonymous namespace
 
-/// on the ONNXMaxPoolSingleOutOp.
-void ONNXMaxPoolSingleOutOp::getCanonicalizationPatterns(
-    OwningRewritePatternList &results, MLIRContext *context) {
-  results.insert<MaxPoolSingleOutOpPaddingPattern>(context);
-}
 /// on the ONNXConvOp.
 void ONNXConvOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {

--- a/src/Transform/ONNX/ONNXRewrite.td
+++ b/src/Transform/ONNX/ONNXRewrite.td
@@ -33,13 +33,8 @@ class StringAttrOfValue<string val>:
 class FloatAttrOfValue<int val>:
   NativeCodeCall<"FloatAttr::get($0.getType().cast<TensorType>().getElementType(), " # val # ")">;
 
-// Create a FloatAttr for the negative infinity.
-def FloatAttrOfNegativeInfinity:
-  NativeCodeCall<"FloatAttr::get($0.getType().cast<TensorType>().getElementType(), "
-                                "-std::numeric_limits<double>::infinity())">;
-
 // Create an ArrayAttr of IntergerAttr(s) of zero values.
-// This function is used for padding attribute in MaxPoolSingleOut.
+// This function is used for padding attribute in Conv.
 def createArrayAttrOfZerosFrom:
   NativeCodeCall<"createArrayAttrOfZeros($_builder, $0)">;
 
@@ -53,7 +48,7 @@ def createArrayAttrOfZerosFrom:
 //         |_____|                  |_____|
 //                 nZeros                    nZeros
 //
-// This function is used for padding attribute in MaxPoolSingleOut.
+// This function is used for padding attribute in Conv.
 class insertZerosForNonPaddedDims<int extensionLength>:
   NativeCodeCall<"insertZerosForNonPaddedDims($_builder, $0,"
                                               # extensionLength # ")">;
@@ -65,37 +60,6 @@ def HasNonZeroInArrayAttr: Constraint<CPred<"hasNonZeroInArrayAttr($_self)">,
 // Check that a StrAttr does not contain a specific value.
 class IsNotStringAttrOfValue<string val>:
   Constraint<CPred<"$0.cast<StringAttr>().getValue() != \"" # val # "\"">>;
-
-//===----------------------------------------------------------------------===//
-// Rewrite:
-// %0 = onnx.MaxPoolSingleOutOp(%D : tensor<DShape>)
-//     {pads = [b0, b1, ... bK, e0, e1, ..., eK]} ->
-//         tensor<OutShape>
-//
-// as:
-// %0 = onnx.PadConstantValuePadOp(%D)
-//     {pads = [0, 0, b0, b1, ... bK, 0, 0, e0, e1, ..., eK]} ->
-//     tensor<DPaddedShape>
-// %1 = onnx.MaxPoolSingleOut(%0 : tensor<DPaddedShape>) {pads = [0, ..., 0]} ->
-//     tensor<OutShape>
-//===----------------------------------------------------------------------===//
-
-def MaxPoolSingleOutOpPaddingPattern: Pat<
-  (ONNXMaxPoolSingleOutOp:$res
-     $x,
-     $auto_pad, $ceil_mode, $dilation, $kernel_shape,
-     $pads,
-     $storage_order, $strides),
-  (ONNXMaxPoolSingleOutOp
-     (ONNXPadConstantValuePadOp $x,
-        (insertZerosForNonPaddedDims<2> $pads),
-        (FloatAttrOfNegativeInfinity $res),
-        (StringAttrOfValue<"constant">)),
-     $auto_pad, $ceil_mode, $dilation, $kernel_shape,
-     (createArrayAttrOfZerosFrom $pads),
-     $storage_order, $strides),
-  [(HasNonZeroInArrayAttr:$pads), (IsNotStringAttrOfValue<"VALID"> $auto_pad)]
->;
 
 //===----------------------------------------------------------------------===//
 // Rewrite:

--- a/test/backend/CMakeLists.txt
+++ b/test/backend/CMakeLists.txt
@@ -3,7 +3,7 @@ configure_file(test_config.py.in test_config.py)
 
 find_package(PythonInterp 3 REQUIRED)
 add_custom_target(check-onnx-backend
-        COMMAND ${PYTHON_EXECUTABLE}
+        COMMAND LD_PRELOAD=${CMAKE_BINARY_DIR}/lib/libcruntime.so ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_BINARY_DIR}/test.py)
 
 add_dependencies(check-onnx-backend onnx-mlir)

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -327,7 +327,7 @@ test_to_enable = [
     "test_batchnorm_epsilon_cpu",
     "test_batchnorm_example_cpu",
 
-    # Pooling
+    # MaxPoolSingleOut
     "test_maxpool_1d_default_cpu",
     "test_maxpool_2d_ceil_cpu",
     "test_maxpool_2d_default_cpu",
@@ -340,6 +340,21 @@ test_to_enable = [
     "test_maxpool_2d_same_upper_cpu",
     "test_maxpool_2d_strides_cpu",
     "test_maxpool_3d_default_cpu",
+
+    # AveragePool
+    "test_averagepool_1d_default_cpu",
+    "test_averagepool_2d_ceil_cpu",
+    "test_averagepool_2d_default_cpu",
+    "test_averagepool_2d_pads_count_include_pad_cpu",
+    "test_averagepool_2d_pads_cpu",
+    "test_averagepool_2d_precomputed_pads_count_include_pad_cpu",
+    "test_averagepool_2d_precomputed_pads_cpu",
+    "test_averagepool_2d_precomputed_same_upper_cpu",
+    "test_averagepool_2d_precomputed_strides_cpu",
+    "test_averagepool_2d_same_lower_cpu",
+    "test_averagepool_2d_same_upper_cpu",
+    "test_averagepool_2d_strides_cpu",
+    "test_averagepool_3d_default_cpu",
 
 ]
 

--- a/test/mlir/krnl/constant.mlir
+++ b/test/mlir/krnl/constant.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --shape-inference --lower-frontend --lower-krnl --lower-all-llvm %s -split-input-file | FileCheck %s
 
+// -----
+
 func @test_constant(%arg0 : tensor<1xf32>) -> tensor<*xf32> {
   %0 = "onnx.Constant"() {value = dense<[[0.0, 0.0], [1.0, 1.1], [2.0, 2.1]]> : tensor<3x2xf32>} : () -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()

--- a/test/mlir/krnl/ops.mlir
+++ b/test/mlir/krnl/ops.mlir
@@ -1,6 +1,8 @@
 // RUN: onnx-mlir-opt %s -mlir-print-op-generic | FileCheck -check-prefix=GENERIC %s
 // RUN: onnx-mlir-opt %s | FileCheck %s
 
+// -----
+
 // GENERIC-DAG: #{{.*}} = affine_map<() -> (0)>
 // GENERIC-DAG: #{{.*}} = affine_map<() -> (10)>
 // GENERIC-DAG: #{{.*}} = affine_map<() -> (1)>
@@ -45,6 +47,8 @@ func @simple_iterate(%N : index) {
 
   return
 }
+
+// -----
 
 func @affine_map_bound(%N : index) {
   %ii, %ij, %ik = krnl.define_loops 3

--- a/test/mlir/krnl/reshape.mlir
+++ b/test/mlir/krnl/reshape.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --shape-inference --lower-frontend --lower-krnl --lower-all-llvm %s -split-input-file | FileCheck %s
 
+// -----
+
 func @test_reshape(%arg0 : tensor<?x10xf32>, %arg1 : tensor<4xi32>) -> tensor<*xf32> {
   %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<?x10xf32>, tensor<4xi32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -94,27 +94,3 @@ func @test_gemm_add_fusion_rank3(%arg0: tensor<128x128x256xf32>, %arg1: tensor<1
   // return [[GEMM]] : tensor<*xf32>
 }
 
-// -----
-
-//CHECK-LABEL: @test_maxpoolsingleout_split(%{{.*}}: tensor<5x5x32x32xf32>) -> tensor<5x5x36x38xf32> {
-func @test_maxpoolsingleout_split(%arg0: tensor<5x5x32x32xf32>) -> tensor<5x5x36x38xf32> {
-  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [5,3], pads = [1, 2, 3, 4] } : (tensor<5x5x32x32xf32>) -> tensor<5x5x36x38xf32>
-  "std.return"(%0) : (tensor<5x5x36x38xf32>) -> ()
-
-  // CHECK-NEXT: %0 = "onnx.PadConstantValuePad"(%arg0) {constant_value = 0xFF800000 : f32, mode = "constant", pads = [0, 0, 1, 2, 0, 0, 3, 4]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x36x38xf32>
-  // CHECK-NEXT: %1 = "onnx.MaxPoolSingleOut"(%0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, kernel_shape = [5, 3], pads = [0, 0, 0, 0], storage_order = 0 : i64} : (tensor<5x5x36x38xf32>) -> tensor<5x5x36x38xf32>
-  // CHECK-NEXT: return %1 : tensor<5x5x36x38xf32>
-}
-
-// -----
-
-//CHECK-LABEL: @test_maxpoolsingleout_split_unknown_dims(%{{.*}}: tensor<*xf32>) -> tensor<*xf32> {
-func @test_maxpoolsingleout_split_unknown_dims(%arg0: tensor<*xf32>) -> tensor<*xf32> {
-  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [5,3], pads = [1, 2, 3, 4] } : (tensor<*xf32>) -> tensor<*xf32>
-  "std.return"(%0) : (tensor<*xf32>) -> ()
-
-  // CHECK-NEXT: %0 = "onnx.PadConstantValuePad"(%arg0) {constant_value = 0xFF800000 : f32, mode = "constant", pads = [0, 0, 1, 2, 0, 0, 3, 4]} : (tensor<*xf32>) -> tensor<*xf32>
-  // CHECK-NEXT: %1 = "onnx.MaxPoolSingleOut"(%0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, kernel_shape = [5, 3], pads = [0, 0, 0, 0], storage_order = 0 : i64} : (tensor<*xf32>) -> tensor<*xf32>
-  // CHECK-NEXT: return %1 : tensor<*xf32>
-}
-

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --canonicalize %s -split-input-file | FileCheck %s
 
+// -----
+
 // CHECK-LABEL: func @test_matmul_add_fused(%{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>) -> tensor<10x10xf32> {
 func @test_matmul_add_fused(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>, %a2: tensor<10x10xf32>) -> tensor<10x10xf32> {
   // CHECK-NEXT: %{{[0-9]+}} = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : i64, transB = 0 : i64} : (tensor<10x10xf32>, tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
@@ -7,6 +9,8 @@ func @test_matmul_add_fused(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>, %a2:
   %1 = "onnx.Add"(%0, %a2) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
   "std.return"(%1) : (tensor<10x10xf32>) -> ()
 }
+
+// -----
 
 // onnx.MatMul ops for non 2-D matrices should not get fused because Gemm only supports 2-D matrices.
 // CHECK-LABEL: func @test_matmul_add_not_fused(%{{.*}}: tensor<10x10x10xf32>, %{{.*}}: tensor<10x10x10xf32>, %{{.*}}: tensor<10x10x10xf32>) -> tensor<10x10x10xf32> {
@@ -17,6 +21,7 @@ func @test_matmul_add_not_fused(%a0: tensor<10x10x10xf32>, %a1: tensor<10x10x10x
   "std.return"(%1) : (tensor<10x10x10xf32>) -> ()
 }
 
+// -----
 
 // onnx.MatMul ops with more than one result uses should not get fused.
 // CHECK-LABEL: func @test_sigmoid_add(%{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>) -> tensor<10x10xf32>
@@ -29,6 +34,8 @@ func @test_sigmoid_add(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>, %a2: tens
   "std.return"(%3) : (tensor<10x10xf32>) -> ()
 }
 
+// -----
+
 // CHECK-LABEL: @test_identity_identity(%{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>) -> tensor<10x10xf32>
 func @test_identity_identity(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>) -> tensor<10x10xf32> {
   // CHECK-NEXT: %{{[0-9]+}} = "onnx.Add"(%{{.*}}, %{{.*}}) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
@@ -38,6 +45,8 @@ func @test_identity_identity(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>) -> 
   "std.return"(%2) : (tensor<10x10xf32>) -> ()
 }
 
+// -----
+
 // CHECK-LABEL: @test_constant_pad(%{{.*}}: tensor<?x?xf32>) -> tensor<*xf32> {
 func @test_constant_pad(%arg0 : tensor<?x?xf32>) -> tensor<*xf32> {
   // CHECK-NEXT: [[SQUARE:%.+]] = "onnx.PadConstantValuePad"(%arg0) {constant_value = 0.000000e+00 : f32, mode = "constant", pads = [0, 2, 0, 0]} : (tensor<?x?xf32>) -> tensor<*xf32> 
@@ -45,6 +54,8 @@ func @test_constant_pad(%arg0 : tensor<?x?xf32>) -> tensor<*xf32> {
   %2 = "onnx.PadConstantValue"(%arg0, %0) {constant_value=0. : f32, mode = "constant"} : (tensor<?x?xf32>, tensor<?xi64>)-> tensor<*xf32>
   "std.return"(%2) : (tensor<*xf32>) -> ()
 }
+
+// -----
 
 // CHECK-LABEL: @test_conv_split(%{{.*}}: tensor<1x9x32x64xf32>, %{{.*}}: tensor<5x9x6x7xf32>) -> tensor<*xf32> {
 func @test_conv_split(%arg0 : tensor<1x9x32x64xf32>, %arg1 : tensor<5x9x6x7xf32>) -> tensor<*xf32> {
@@ -57,6 +68,8 @@ func @test_conv_split(%arg0 : tensor<1x9x32x64xf32>, %arg1 : tensor<5x9x6x7xf32>
   // CHECK-NEXT: return %1 : tensor<*xf32>
 }
 
+// -----
+
 //CHECK-LABEL: @test_gemm_add_fusion(%{{.*}}: tensor<128x128xf32>, %{{.*}}: tensor<128x128xf32>, %{{.*}}: tensor<128xf32>) -> tensor<*xf32> {
 func @test_gemm_add_fusion(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128xf32>) -> tensor<*xf32> {
   %cst = constant unit
@@ -67,6 +80,8 @@ func @test_gemm_add_fusion(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32
   // CHECK-NEXT: [[GEMM:%.+]] = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : i64, transB = 0 : i64} : (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128xf32>) -> tensor<*xf32>
   // return [[GEMM]] : tensor<*xf32>
 }
+
+// -----
 
 //CHECK-LABEL: @test_gemm_add_fusion_rank3(%{{.*}}: tensor<128x128x256xf32>, %{{.*}}: tensor<128x128x256xf32>, %{{.*}}: tensor<256xf32>) -> tensor<*xf32> {
 func @test_gemm_add_fusion_rank3(%arg0: tensor<128x128x256xf32>, %arg1: tensor<128x128x256xf32>, %arg2: tensor<256xf32>) -> tensor<*xf32> {
@@ -79,6 +94,8 @@ func @test_gemm_add_fusion_rank3(%arg0: tensor<128x128x256xf32>, %arg1: tensor<1
   // return [[GEMM]] : tensor<*xf32>
 }
 
+// -----
+
 //CHECK-LABEL: @test_maxpoolsingleout_split(%{{.*}}: tensor<5x5x32x32xf32>) -> tensor<5x5x36x38xf32> {
 func @test_maxpoolsingleout_split(%arg0: tensor<5x5x32x32xf32>) -> tensor<5x5x36x38xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [5,3], pads = [1, 2, 3, 4] } : (tensor<5x5x32x32xf32>) -> tensor<5x5x36x38xf32>
@@ -88,6 +105,8 @@ func @test_maxpoolsingleout_split(%arg0: tensor<5x5x32x32xf32>) -> tensor<5x5x36
   // CHECK-NEXT: %1 = "onnx.MaxPoolSingleOut"(%0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, kernel_shape = [5, 3], pads = [0, 0, 0, 0], storage_order = 0 : i64} : (tensor<5x5x36x38xf32>) -> tensor<5x5x36x38xf32>
   // CHECK-NEXT: return %1 : tensor<5x5x36x38xf32>
 }
+
+// -----
 
 //CHECK-LABEL: @test_maxpoolsingleout_split_unknown_dims(%{{.*}}: tensor<*xf32>) -> tensor<*xf32> {
 func @test_maxpoolsingleout_split_unknown_dims(%arg0: tensor<*xf32>) -> tensor<*xf32> {

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --decompose-onnx %s -split-input-file | FileCheck %s
 
+// -----
+
 // CHECK-LABEL: @test_reducel1(%{{.*}}: tensor<?x?x?xf32>) -> tensor<*xf32>
 func @test_reducel1(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {
   %0 ="onnx.ReduceL1"(%arg0) {axes=[1], keepdims = 0 : i64} : (tensor<?x?x?xf32>)-> tensor<*xf32>
@@ -8,6 +10,8 @@ func @test_reducel1(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {
   // CHECK-NEXT: [[ABS:%.+]] =  "onnx.Abs"(%arg0) : (tensor<?x?x?xf32>) -> tensor<*xf32>
   // CHECK-NEXT: %{{[0-9]+}} = "onnx.ReduceSum"([[ABS]]) {axes = [1], keepdims = 0 : i64} : (tensor<*xf32>) -> tensor<*xf32>
 }
+
+// -----
 
 // CHECK-LABEL: @test_reducel2(%{{.*}}: tensor<?x?x?xf32>) -> tensor<*xf32>
 func @test_reducel2(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {
@@ -19,6 +23,8 @@ func @test_reducel2(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {
   // CHECK-NEXT: [[SQRT:%.+]] =  "onnx.Sqrt"([[REDUCE_SUM]]) : (tensor<*xf32>) -> tensor<*xf32>
 }
 
+// -----
+
 // CHECK-LABEL: @test_reducelogsum(%{{.*}}: tensor<?x?x?xf32>) -> tensor<*xf32>
 func @test_reducelogsum(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {
   %0 ="onnx.ReduceLogSum"(%arg0) {axes=[1], keepdims = 0 : i64} : (tensor<?x?x?xf32>)-> tensor<*xf32>
@@ -27,6 +33,8 @@ func @test_reducelogsum(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {
   // CHECK-NEXT: [[REDUCE_SUM:%.+]] = "onnx.ReduceSum"(%arg0) {axes = [1], keepdims = 0 : i64} : (tensor<?x?x?xf32>) -> tensor<*xf32>
   // CHECK-NEXT: [[LOG:%.+]] =  "onnx.Log"([[REDUCE_SUM]]) : (tensor<*xf32>) -> tensor<*xf32>
 }
+
+// -----
 
 // CHECK-LABEL: @test_reducelogsumexp(%{{.*}}: tensor<?x?x?xf32>) -> tensor<*xf32>
 func @test_reducelogsumexp(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {
@@ -37,6 +45,8 @@ func @test_reducelogsumexp(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {
   // CHECK-NEXT: [[REDUCE_SUM:%.+]] = "onnx.ReduceSum"([[EXP]]) {axes = [1], keepdims = 0 : i64} : (tensor<*xf32>) -> tensor<*xf32>
   // CHECK-NEXT: [[LOG:%.+]] =  "onnx.Log"([[REDUCE_SUM]]) : (tensor<*xf32>) -> tensor<*xf32>
 }
+
+// -----
 
 // CHECK-LABEL: @test_reducesumsquare(%{{.*}}: tensor<?x?x?xf32>) -> tensor<*xf32>
 func @test_reducesumsquare(%arg0 : tensor<?x?x?xf32>) -> tensor<*xf32> {

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -1505,231 +1505,6 @@ func @test_batchnorm_testmode_1d(%arg0: tensor<10xf32>, %arg1: tensor<1xf32>, %a
 
 // -----
 
-func @test_maxpooling_singleout_no_pad(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
-  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
-  "std.return"(%0) : (tensor<*xf32>) -> ()
-
-  // CHECK-LABEL: test_maxpooling_singleout_no_pad
-  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x31x31xf32>
-  // CHECK: [[DEF_LOOPS_0:%.+]]:4 = krnl.define_loops 4
-  // CHECK: [[OPT_LOOPS_0:%.+]]:4 = krnl.optimize_loops  {
-  // CHECK:   krnl.return_loops [[DEF_LOOPS_0]]#0, [[DEF_LOOPS_0]]#1, [[DEF_LOOPS_0]]#2, [[DEF_LOOPS_0]]#3
-  // CHECK: } : () -> (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop)
-  // CHECK: krnl.iterate([[OPT_LOOPS_0]]#0, [[OPT_LOOPS_0]]#1, [[OPT_LOOPS_0]]#2, [[OPT_LOOPS_0]]#3) with ([[DEF_LOOPS_0]]#0 -> %arg1 = 0 to 1, [[DEF_LOOPS_0]]#1 -> %arg2 = 0 to 3, [[DEF_LOOPS_0]]#2 -> %arg3 = 0 to 31, [[DEF_LOOPS_0]]#3 -> %arg4 = 0 to 31) {
-  // CHECK:   [[NEGATIVE_INFINITY:%.+]] = constant 0xFF800000 : f32
-  // CHECK:   store [[NEGATIVE_INFINITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
-  // CHECK:   [[DEF_LOOPS_1:%.+]]:2 = krnl.define_loops 2
-  // CHECK:   [[OPT_LOOPS_1:%.+]]:2 = krnl.optimize_loops  {
-  // CHECK:     krnl.return_loops [[DEF_LOOPS_1]]#0, [[DEF_LOOPS_1]]#1
-  // CHECK:   } : () -> (!krnl.loop, !krnl.loop)
-  // CHECK:   krnl.iterate([[OPT_LOOPS_1]]#0, [[OPT_LOOPS_1]]#1) with ([[DEF_LOOPS_1]]#0 -> %arg5 = 0 to 2, [[DEF_LOOPS_1]]#1 -> %arg6 = 0 to 2) {
-  // CHECK:     [[H:%.+]] = addi %arg3, %arg5 : index
-  // CHECK:     [[W:%.+]] = addi %arg4, %arg6 : index
-  // CHECK:     [[LOAD_X:%.+]] = load %arg0[%arg1, %arg2, [[H]], [[W]]] : memref<1x3x32x32xf32>
-  // CHECK:     [[LOAD_Y:%.+]] = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
-  // CHECK:     [[COMPARE:%.+]] = cmpf "ogt", [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     [[SELECT:%.+]] = select [[COMPARE]], [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     store [[SELECT]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
-  // CHECK:   }
-  // CHECK: }
-  // CHECK: return [[RES]] : memref<1x3x31x31xf32>
-}
-
-// -----
-
-func @test_maxpooling_singleout_no_pad_w_strides(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
-  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2], strides = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
-  "std.return"(%0) : (tensor<*xf32>) -> ()
-
-  // CHECK-LABEL: test_maxpooling_singleout_no_pad_w_strides
-  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x16x16xf32>
-  // CHECK: [[DEF_LOOPS_0:%.+]]:4 = krnl.define_loops 4
-  // CHECK: [[OPT_LOOPS_0:%.+]]:4 = krnl.optimize_loops  {
-  // CHECK:   krnl.return_loops [[DEF_LOOPS_0]]#0, [[DEF_LOOPS_0]]#1, [[DEF_LOOPS_0]]#2, [[DEF_LOOPS_0]]#3
-  // CHECK: } : () -> (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop)
-  // CHECK: krnl.iterate([[OPT_LOOPS_0]]#0, [[OPT_LOOPS_0]]#1, [[OPT_LOOPS_0]]#2, [[OPT_LOOPS_0]]#3) with ([[DEF_LOOPS_0]]#0 -> %arg1 = 0 to 1, [[DEF_LOOPS_0]]#1 -> %arg2 = 0 to 3, [[DEF_LOOPS_0]]#2 -> %arg3 = 0 to 16, [[DEF_LOOPS_0]]#3 -> %arg4 = 0 to 16) {
-  // CHECK:   [[NEGATIVE_INFINITY:%.+]] = constant 0xFF800000 : f32
-  // CHECK:   store [[NEGATIVE_INFINITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x16x16xf32>
-  // CHECK:   [[DEF_LOOPS_1:%.+]]:2 = krnl.define_loops 2
-  // CHECK:   [[OPT_LOOPS_1:%.+]]:2 = krnl.optimize_loops  {
-  // CHECK:     krnl.return_loops [[DEF_LOOPS_1]]#0, [[DEF_LOOPS_1]]#1
-  // CHECK:   } : () -> (!krnl.loop, !krnl.loop)
-  // CHECK:   krnl.iterate([[OPT_LOOPS_1]]#0, [[OPT_LOOPS_1]]#1) with ([[DEF_LOOPS_1]]#0 -> %arg5 = 0 to 2, [[DEF_LOOPS_1]]#1 -> %arg6 = 0 to 2) {
-  // CHECK:     [[STRIDE_0:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_0:%.+]] = muli [[STRIDE_0]], %arg3 : index
-  // CHECK:     [[H:%.+]] = addi [[MUL_0]], %arg5 : index
-  // CHECK:     [[STRIDE_1:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_1:%.+]] = muli [[STRIDE_1]], %arg4 : index
-  // CHECK:     [[W:%.+]] = addi [[MUL_1]], %arg6 : index
-  // CHECK:     [[LOAD_X:%.+]] = load %arg0[%arg1, %arg2, [[H]], [[W]]] : memref<1x3x32x32xf32>
-  // CHECK:     [[LOAD_Y:%.+]] = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x16x16xf32>
-  // CHECK:     [[COMPARE:%.+]] = cmpf "ogt", [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     [[SELECT:%.+]] = select [[COMPARE]], [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     store [[SELECT]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x16x16xf32>
-  // CHECK:   }
-  // CHECK: }
-  // CHECK: return [[RES]] : memref<1x3x16x16xf32>
-}
-
-// -----
-
-func @test_maxpooling_singleout_no_pad_w_strides_w_ceil_mode(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
-  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [3, 3], strides = [2, 2], ceil_mode = 1} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
-  "std.return"(%0) : (tensor<*xf32>) -> ()
-
-  // CHECK-LABEL: test_maxpooling_singleout_no_pad_w_strides_w_ceil_mode
-  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x16x16xf32>
-  // CHECK: [[DEF_LOOPS_0:%.+]]:4 = krnl.define_loops 4
-  // CHECK: [[OPT_LOOPS_0:%.+]]:4 = krnl.optimize_loops  {
-  // CHECK:   krnl.return_loops [[DEF_LOOPS_0]]#0, [[DEF_LOOPS_0]]#1, [[DEF_LOOPS_0]]#2, [[DEF_LOOPS_0]]#3
-  // CHECK: } : () -> (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop)
-  // CHECK: krnl.iterate([[OPT_LOOPS_0]]#0, [[OPT_LOOPS_0]]#1, [[OPT_LOOPS_0]]#2, [[OPT_LOOPS_0]]#3) with ([[DEF_LOOPS_0]]#0 -> %arg1 = 0 to 1, [[DEF_LOOPS_0]]#1 -> %arg2 = 0 to 3, [[DEF_LOOPS_0]]#2 -> %arg3 = 0 to 16, [[DEF_LOOPS_0]]#3 -> %arg4 = 0 to 16) {
-  // CHECK:   [[NEGATIVE_INFINITY:%.+]] = constant 0xFF800000 : f32
-  // CHECK:   store [[NEGATIVE_INFINITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x16x16xf32>
-  // CHECK:   [[DEF_LOOPS_1:%.+]]:2 = krnl.define_loops 2
-  // CHECK:   [[OPT_LOOPS_1:%.+]]:2 = krnl.optimize_loops  {
-  // CHECK:     krnl.return_loops [[DEF_LOOPS_1]]#0, [[DEF_LOOPS_1]]#1
-  // CHECK:   } : () -> (!krnl.loop, !krnl.loop)
-  // CHECK:   krnl.iterate([[OPT_LOOPS_1]]#0, [[OPT_LOOPS_1]]#1) with ([[DEF_LOOPS_1]]#0 -> %arg5 = 0 to 3, [[DEF_LOOPS_1]]#1 -> %arg6 = 0 to 3) {
-  // CHECK:     [[STRIDE_0:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_0:%.+]] = muli [[STRIDE_0]], %arg3 : index
-  // CHECK:     [[SPATIAL_H:%.+]] = addi [[MUL_0]], %arg5 : index
-  // CHECK:     [[UPPER_INDEX_0:%.+]] = constant 31 : index
-  // CHECK:     [[GREATER_THAN_UPPER_0:%.+]] = cmpi "sgt", [[SPATIAL_H]], [[UPPER_INDEX_0]] : index
-  // CHECK:     [[H:%.+]] = select [[GREATER_THAN_UPPER_0]], [[UPPER_INDEX_0]], [[SPATIAL_H]] : index
-
-  // CHECK:     [[STRIDE_1:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_1:%.+]] = muli [[STRIDE_1]], %arg4 : index
-  // CHECK:     [[SPATIAL_W:%.+]] = addi [[MUL_1]], %arg6 : index
-  // CHECK:     [[UPPER_INDEX_1:%.+]] = constant 31 : index
-  // CHECK:     [[GREATER_THAN_UPPER_1:%.+]] = cmpi "sgt", [[SPATIAL_W]], [[UPPER_INDEX_1]] : index
-  // CHECK:     [[W:%.+]] = select [[GREATER_THAN_UPPER_1]], [[UPPER_INDEX_1]], [[SPATIAL_W]] : index
-
-  // CHECK:     [[LOAD_X:%.+]] = load %arg0[%arg1, %arg2, [[H]], [[W]]] : memref<1x3x32x32xf32>
-  // CHECK:     [[LOAD_Y:%.+]] = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x16x16xf32>
-  // CHECK:     [[CMP_2:%.+]] = cmpf "ogt", [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     [[SELECT:%.+]] = select [[CMP_2]], [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     store [[SELECT]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x16x16xf32>
-  // CHECK:   }
-  // CHECK: }
-  // CHECK: return [[RES]] : memref<1x3x16x16xf32>
-}
-
-// -----
-
-func @test_maxpooling_singleout_no_pad_w_strides_w_dilation(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
-  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [3, 3], strides = [2, 2], dilations = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
-  "std.return"(%0) : (tensor<*xf32>) -> ()
-
-  // CHECK-LABEL: test_maxpooling_singleout_no_pad_w_strides_w_dilation
-  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x14x14xf32>
-  // CHECK: [[DEF_LOOPS_0:%.+]]:4 = krnl.define_loops 4
-  // CHECK: [[OPT_LOOPS_0:%.+]]:4 = krnl.optimize_loops  {
-  // CHECK:   krnl.return_loops [[DEF_LOOPS_0]]#0, [[DEF_LOOPS_0]]#1, [[DEF_LOOPS_0]]#2, [[DEF_LOOPS_0]]#3
-  // CHECK: } : () -> (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop)
-  // CHECK: krnl.iterate([[OPT_LOOPS_0]]#0, [[OPT_LOOPS_0]]#1, [[OPT_LOOPS_0]]#2, [[OPT_LOOPS_0]]#3) with ([[DEF_LOOPS_0]]#0 -> %arg1 = 0 to 1, [[DEF_LOOPS_0]]#1 -> %arg2 = 0 to 3, [[DEF_LOOPS_0]]#2 -> %arg3 = 0 to 14, [[DEF_LOOPS_0]]#3 -> %arg4 = 0 to 14) {
-  // CHECK:   [[NEGATIVE_INFINITY:%.+]] = constant 0xFF800000 : f32
-  // CHECK:   store [[NEGATIVE_INFINITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x14x14xf32>
-  // CHECK:   [[DEF_LOOPS_1:%.+]]:2 = krnl.define_loops 2
-  // CHECK:   [[OPT_LOOPS_1:%.+]]:2 = krnl.optimize_loops  {
-  // CHECK:     krnl.return_loops [[DEF_LOOPS_1]]#0, [[DEF_LOOPS_1]]#1
-  // CHECK:   } : () -> (!krnl.loop, !krnl.loop)
-  // CHECK:   krnl.iterate([[OPT_LOOPS_1]]#0, [[OPT_LOOPS_1]]#1) with ([[DEF_LOOPS_1]]#0 -> %arg5 = 0 to 3, [[DEF_LOOPS_1]]#1 -> %arg6 = 0 to 3) {
-  // CHECK:     [[STRIDE_0:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_0:%.+]] = muli [[STRIDE_0]], %arg3 : index
-  // CHECK:     [[STRIDE_1:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_1:%.+]] = muli [[STRIDE_1]], %arg5 : index
-  // CHECK:     [[SPATIAL_H:%.+]] = addi [[MUL_0]], [[MUL_1]] : index
-  // CHECK:     [[UPPER_INDEX_0:%.+]] = constant 31 : index
-  // CHECK:     [[GREATER_THAN_UPPER_0:%.+]] = cmpi "sgt", [[SPATIAL_H]], [[UPPER_INDEX_0]] : index
-  // CHECK:     [[H:%.+]] = select [[GREATER_THAN_UPPER_0]], [[UPPER_INDEX_0]], [[SPATIAL_H]] : index
-
-  // CHECK:     [[STRIDE_0_1:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_0_1:%.+]] = muli [[STRIDE_0_1]], %arg4 : index
-  // CHECK:     [[STRIDE_1_1:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_1_1:%.+]] = muli [[STRIDE_1_1]], %arg6 : index
-  // CHECK:     [[SPATIAL_W:%.+]] = addi [[MUL_0_1]], [[MUL_1_1]] : index
-  // CHECK:     [[UPPER_INDEX_1:%.+]] = constant 31 : index
-  // CHECK:     [[GREATER_THAN_UPPER_1:%.+]] = cmpi "sgt", [[SPATIAL_W]], [[UPPER_INDEX_1]] : index
-  // CHECK:     [[W:%.+]] = select [[GREATER_THAN_UPPER_1]], [[UPPER_INDEX_1]], [[SPATIAL_W]] : index
-
-  // CHECK:     [[LOAD_X:%.+]] = load %arg0[%arg1, %arg2, [[H]], [[W]]] : memref<1x3x32x32xf32>
-  // CHECK:     [[LOAD_Y:%.+]] = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x14x14xf32>
-  // CHECK:     [[CMP_2:%.+]] = cmpf "ogt", [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     [[SELECT:%.+]] = select [[CMP_2]], [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     store [[SELECT]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x14x14xf32>
-  // CHECK:   }
-  // CHECK: }
-  // CHECK: return [[RES]] : memref<1x3x14x14xf32>
-}
-
-// -----
-
-func @test_maxpooling_singleout_no_pad_w_strides_w_ceil_mode_w_unknown_dims(%arg0 : tensor<?x3x?x32xf32>) -> tensor<*xf32> {
-  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [3, 3], strides = [2, 2], ceil_mode = 1} : (tensor<?x3x?x32xf32>) -> tensor<*xf32>
-  "std.return"(%0) : (tensor<*xf32>) -> ()
-
-  // CHECK-LABEL: test_maxpooling_singleout_no_pad_w_strides_w_ceil_mode_w_unknown_dims
-
-  // CHECK: [[DIM_0:%.+]] = dim %arg0, 0 : memref<?x3x?x32xf32>
-  // CHECK: [[ZERO:%.+]] = constant 0 : i64
-  // CHECK: [[ONE:%.+]] = constant 1 : i64
-  // CHECK: [[DIM_1:%.+]] = dim %arg0, 2 : memref<?x3x?x32xf32>
-  // CHECK: [[DIM_1_i64:%.+]] = index_cast [[DIM_1]] : index to i64
-  // CHECK: [[KERNEL_PAD_DILATION:%.+]] = constant -3 : i64
-  // CHECK: [[NUMERATOR:%.+]] = addi [[DIM_1_i64]], [[KERNEL_PAD_DILATION]] : i64
-  // CHECK: [[DENOMINATOR:%.+]] = constant 2 : i64
-  // CHECK: [[DIV:%.+]] = divi_signed [[NUMERATOR]], [[DENOMINATOR]] : i64
-  // CHECK: [[REMAINDER:%.+]] = remi_signed [[NUMERATOR]], [[DENOMINATOR]] : i64
-  // CHECK: [[IS_ZERO:%.+]] = cmpi "eq", [[REMAINDER]], [[ZERO]] : i64
-  // CHECK: [[DIV_PLUS_ONE:%.+]] = addi [[DIV]], [[ONE]] : i64
-  // CHECK: [[SELECT:%.+]] = select [[IS_ZERO]], [[DIV]], [[DIV_PLUS_ONE]] : i64
-  // CHECK: [[SELECT_PLUS_ONE:%.+]] = addi [[SELECT]], [[ONE]] : i64
-  // CHECK: [[DIM_1_FINAL:%.+]] = index_cast [[SELECT_PLUS_ONE]] : i64 to index
-  // CHECK: [[RES:%.+]] = alloc([[DIM_0]], [[DIM_1_FINAL]]) : memref<?x3x?x16xf32>
-
-  // CHECK: [[DEF_LOOPS_0:%.+]]:4 = krnl.define_loops 4
-  // CHECK: [[OPT_LOOPS_0:%.+]]:4 = krnl.optimize_loops  {
-  // CHECK:   krnl.return_loops [[DEF_LOOPS_0]]#0, [[DEF_LOOPS_0]]#1, [[DEF_LOOPS_0]]#2, [[DEF_LOOPS_0]]#3
-  // CHECK: } : () -> (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop)
-  // CHECK: [[DIM_2:%.+]] = dim [[RES]], 0 : memref<?x3x?x16xf32>
-  // CHECK: [[DIM_3:%.+]] = dim [[RES]], 2 : memref<?x3x?x16xf32>
-  // CHECK: krnl.iterate([[OPT_LOOPS_0]]#0, [[OPT_LOOPS_0]]#1, [[OPT_LOOPS_0]]#2, [[OPT_LOOPS_0]]#3) with ([[DEF_LOOPS_0]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS_0]]#1 -> %arg2 = 0 to 3, [[DEF_LOOPS_0]]#2 -> %arg3 = 0 to [[DIM_3]], [[DEF_LOOPS_0]]#3 -> %arg4 = 0 to 16) {
-  // CHECK:   [[NEGATIVE_INFINITY:%.+]] = constant 0xFF800000 : f32
-  // CHECK:   store [[NEGATIVE_INFINITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<?x3x?x16xf32>
-  // CHECK:   [[DEF_LOOPS_1:%.+]]:2 = krnl.define_loops 2
-  // CHECK:   [[OPT_LOOPS_1:%.+]]:2 = krnl.optimize_loops  {
-  // CHECK:     krnl.return_loops [[DEF_LOOPS_1]]#0, [[DEF_LOOPS_1]]#1
-  // CHECK:   } : () -> (!krnl.loop, !krnl.loop)
-  // CHECK:   krnl.iterate([[OPT_LOOPS_1]]#0, [[OPT_LOOPS_1]]#1) with ([[DEF_LOOPS_1]]#0 -> %arg5 = 0 to 3, [[DEF_LOOPS_1]]#1 -> %arg6 = 0 to 3) {
-  // CHECK:     [[STRIDE_0:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_0:%.+]] = muli [[STRIDE_0]], %arg3 : index
-  // CHECK:     [[SPATIAL_H:%.+]] = addi [[MUL_0]], %arg5 : index
-  // CHECK:     [[DIM_0_0:%.+]] = dim %arg0, 2 : memref<?x3x?x32xf32>
-  // CHECK:     [[ONE_INDEX:%.+]] = constant 1 : index
-  // CHECK:     [[UPPER_INDEX_0:%.+]] = subi [[DIM_0_0]], [[ONE_INDEX]] : index
-  // CHECK:     [[GREATER_THAN_UPPER_0:%.+]] = cmpi "sgt", [[SPATIAL_H]], [[UPPER_INDEX_0]] : index
-  // CHECK:     [[H:%.+]] = select [[GREATER_THAN_UPPER_0]], [[UPPER_INDEX_0]], [[SPATIAL_H]] : index
-
-  // CHECK:     [[STRIDE_1:%.+]] = constant 2 : index
-  // CHECK:     [[MUL_1:%.+]] = muli [[STRIDE_1]], %arg4 : index
-  // CHECK:     [[SPATIAL_W:%.+]] = addi [[MUL_1]], %arg6 : index
-  // CHECK:     [[UPPER_INDEX_1:%.+]] = constant 31 : index
-  // CHECK:     [[GREATER_THAN_UPPER_1:%.+]] = cmpi "sgt", [[SPATIAL_W]], [[UPPER_INDEX_1]] : index
-  // CHECK:     [[W:%.+]] = select [[GREATER_THAN_UPPER_1]], [[UPPER_INDEX_1]], [[SPATIAL_W]] : index
-
-  // CHECK:     [[LOAD_X:%.+]] = load %arg0[%arg1, %arg2, [[H]], [[W]]] : memref<?x3x?x32xf32>
-  // CHECK:     [[LOAD_Y:%.+]] = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<?x3x?x16xf32>
-  // CHECK:     [[CMP_2:%.+]] = cmpf "ogt", [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     [[SELECT:%.+]] = select [[CMP_2]], [[LOAD_Y]], [[LOAD_X]] : f32
-  // CHECK:     store [[SELECT]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<?x3x?x16xf32>
-  // CHECK:   }
-  // CHECK: }
-  // CHECK: return [[RES]] : memref<?x3x?x16xf32>
-}
-
-// -----
-
 func @test_abs_float(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Abs"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -1810,7 +1585,6 @@ func @test_constant_dense_2d_value(%arg0: tensor<1xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
 
-
 // -----
 
 func @test_concat_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x32xf32>, %arg2 : tensor<5x5x5x32xf32>) -> tensor<5x5x9x32xf32> {
@@ -1849,3 +1623,133 @@ func @test_concat_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x32xf32>, 
 
   // CHECK: return [[RES]] :  memref<5x5x9x32xf32>
 }
+
+// -----
+
+func @test_pool_general_computation(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
+  %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
+  "std.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-DAG: #{{.*}} = affine_map<(d0)[s0, s1, s2, s3, s4] -> ((s2 ceildiv s4) * s4 - s2, d0 * s3 - s2)>
+  // CHECK-DAG: #{{.*}} = affine_map<(d0)[s0, s1, s2, s3, s4] -> (s0, d0 * s3 + (s1 - 1) * s4 - s2 + 1)>
+  // CHECK-DAG: #{{.*}} = affine_map<() -> (0)>
+  // CHECK-DAG: #{{.*}} = affine_map<(d0)[s0, s1, s2, s3, s4] -> (s0 - ((s2 ceildiv s4) * s4 - s2), -(d0 * s3 - s2) + s0, d0 * s3 + (s1 - 1) * s4 - s2 - ((s2 ceildiv s4) * s4 - s2) + 1, d0 * s3 + (s1 - 1) * s4 - s2 - (d0 * s3 - s2) + 1)>
+
+  // CHECK-LABEL: @test_pool_general_computation
+
+  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x31x31xf32>
+  // CHECK: [[IDENTITY:%.+]] = constant 0.000000e+00 : f32
+
+  // CHECK: [[OUTPUT_LOOPS:%.+]]:4 = krnl.define_loops 4
+  // CHECK: [[OPT_OUTPUT_LOOPS:%.+]]:4 = krnl.optimize_loops  {
+  // CHECK:   krnl.return_loops [[OUTPUT_LOOPS]]#0, [[OUTPUT_LOOPS]]#1, [[OUTPUT_LOOPS]]#2, [[OUTPUT_LOOPS]]#3
+  // CHECK: } : () -> (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop)
+  // CHECK: krnl.iterate([[OPT_OUTPUT_LOOPS]]#0, [[OPT_OUTPUT_LOOPS]]#1, [[OPT_OUTPUT_LOOPS]]#2, [[OPT_OUTPUT_LOOPS]]#3) with ([[OUTPUT_LOOPS]]#0 -> %arg1 = 0 to 1, [[OUTPUT_LOOPS]]#1 -> %arg2 = 0 to 3, [[OUTPUT_LOOPS]]#2 -> %arg3 = 0 to 31, [[OUTPUT_LOOPS]]#3 -> %arg4 = 0 to 31) {
+
+  // CHECK:   store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+
+  // CHECK:   [[POOL_LOOPS:%.+]]:2 = krnl.define_loops 2
+  // CHECK:   [[OPT_POOL_LOOPS:%.+]]:2 = krnl.optimize_loops  {
+  // CHECK:     krnl.return_loops [[POOL_LOOPS]]#0, [[POOL_LOOPS]]#1
+  // CHECK:   } : () -> (!krnl.loop, !krnl.loop)
+  // CHECK:   krnl.iterate([[OPT_POOL_LOOPS]]#0, [[OPT_POOL_LOOPS]]#1) with ([[POOL_LOOPS]]#0 -> %arg5 = 0 to min #map3(%arg3)[%c32, %c2, %c0, %c1, %c1_0], [[POOL_LOOPS]]#1 -> %arg6 = 0 to min #map3(%arg4)[%c32_1, %c2_2, %c0_3, %c1_4, %c1_5]) {
+  // CHECK:     {{.*}} = load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
+  // CHECK:     {{.*}} = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   }
+
+  // CHECK:   {{.*}} = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK: }
+}
+
+// -----
+
+func @test_averagepool_identity_value(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
+  %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
+  "std.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: @test_averagepool_identity_value
+  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x31x31xf32>
+  // CHECK: [[IDENTITY:%.+]] = constant 0.000000e+00 : f32
+  // CHECK: store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+}
+
+// -----
+
+func @test_maxpool_identity_value(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
+  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
+  "std.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: @test_maxpool_identity_value
+  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x31x31xf32>
+  // CHECK: [[IDENTITY:%.+]] = constant 0xFF800000 : f32
+  // CHECK: store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+}
+
+// -----
+
+func @test_averagepool_pooling_operation(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
+  %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
+  "std.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: @test_averagepool_pooling_operation
+  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x31x31xf32>
+
+  // CHECK: [[OUTPUT_LOOPS:%.+]]:4 = krnl.define_loops 4
+  // CHECK: [[OPT_OUTPUT_LOOPS:%.+]]:4 = krnl.optimize_loops  {
+  // CHECK:   krnl.return_loops [[OUTPUT_LOOPS]]#0, [[OUTPUT_LOOPS]]#1, [[OUTPUT_LOOPS]]#2, [[OUTPUT_LOOPS]]#3
+  // CHECK: } : () -> (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop)
+  // CHECK: krnl.iterate([[OPT_OUTPUT_LOOPS]]#0, [[OPT_OUTPUT_LOOPS]]#1, [[OPT_OUTPUT_LOOPS]]#2, [[OPT_OUTPUT_LOOPS]]#3) with ([[OUTPUT_LOOPS]]#0 -> %arg1 = 0 to 1, [[OUTPUT_LOOPS]]#1 -> %arg2 = 0 to 3, [[OUTPUT_LOOPS]]#2 -> %arg3 = 0 to 31, [[OUTPUT_LOOPS]]#3 -> %arg4 = 0 to 31) {
+
+  // CHECK:   [[POOL_LOOPS:%.+]]:2 = krnl.define_loops 2
+  // CHECK:   [[OPT_POOL_LOOPS:%.+]]:2 = krnl.optimize_loops  {
+  // CHECK:     krnl.return_loops [[POOL_LOOPS]]#0, [[POOL_LOOPS]]#1
+  // CHECK:   } : () -> (!krnl.loop, !krnl.loop)
+  // CHECK:   krnl.iterate([[OPT_POOL_LOOPS]]#0, [[OPT_POOL_LOOPS]]#1) with ([[POOL_LOOPS]]#0 -> %arg5 = 0 to min #map3(%arg3)[%c32, %c2, %c0, %c1, %c1_0], [[POOL_LOOPS]]#1 -> %arg6 = 0 to min #map3(%arg4)[%c32_1, %c2_2, %c0_3, %c1_4, %c1_5]) {
+
+  // CHECK:     [[INPUT_LOAD:%.+]] = load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
+  // CHECK:     [[OUTPUT_LOAD:%.+]] = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     [[SUM:%.+]] = addf [[OUTPUT_LOAD]], [[INPUT_LOAD]] : f32
+  // CHECK:     store [[SUM]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   }
+
+  // CHECK:   [[NUMERATOR:%.+]] = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   [[AVERAGE:%.+]] = divf [[NUMERATOR]], {{.*}} : f32
+  // CHECK:   store [[AVERAGE]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK: }
+}
+
+// -----
+
+func @test_maxpool_pooling_operation(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
+  %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
+  "std.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: @test_maxpool_pooling_operation
+  // CHECK: [[RES:%.+]] = alloc() : memref<1x3x31x31xf32>
+
+  // CHECK: [[OUTPUT_LOOPS:%.+]]:4 = krnl.define_loops 4
+  // CHECK: [[OPT_OUTPUT_LOOPS:%.+]]:4 = krnl.optimize_loops  {
+  // CHECK:   krnl.return_loops [[OUTPUT_LOOPS]]#0, [[OUTPUT_LOOPS]]#1, [[OUTPUT_LOOPS]]#2, [[OUTPUT_LOOPS]]#3
+  // CHECK: } : () -> (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop)
+  // CHECK: krnl.iterate([[OPT_OUTPUT_LOOPS]]#0, [[OPT_OUTPUT_LOOPS]]#1, [[OPT_OUTPUT_LOOPS]]#2, [[OPT_OUTPUT_LOOPS]]#3) with ([[OUTPUT_LOOPS]]#0 -> %arg1 = 0 to 1, [[OUTPUT_LOOPS]]#1 -> %arg2 = 0 to 3, [[OUTPUT_LOOPS]]#2 -> %arg3 = 0 to 31, [[OUTPUT_LOOPS]]#3 -> %arg4 = 0 to 31) {
+
+  // CHECK:   [[POOL_LOOPS:%.+]]:2 = krnl.define_loops 2
+  // CHECK:   [[OPT_POOL_LOOPS:%.+]]:2 = krnl.optimize_loops  {
+  // CHECK:     krnl.return_loops [[POOL_LOOPS]]#0, [[POOL_LOOPS]]#1
+  // CHECK:   } : () -> (!krnl.loop, !krnl.loop)
+  // CHECK:   krnl.iterate([[OPT_POOL_LOOPS]]#0, [[OPT_POOL_LOOPS]]#1) with ([[POOL_LOOPS]]#0 -> %arg5 = 0 to min #map3(%arg3)[%c32, %c2, %c0, %c1, %c1_0], [[POOL_LOOPS]]#1 -> %arg6 = 0 to min #map3(%arg4)[%c32_1, %c2_2, %c0_3, %c1_4, %c1_5]) {
+
+  // CHECK:     [[INPUT_LOAD:%.+]] = load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
+  // CHECK:     [[OUTPUT_LOAD:%.+]] = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     [[GREATER:%.+]] = cmpf "ogt", [[OUTPUT_LOAD]], [[INPUT_LOAD]] : f32
+  // CHECK:     [[SELECT:%.+]] = select [[GREATER]], [[OUTPUT_LOAD]], [[INPUT_LOAD]] : f32
+  // CHECK:     store [[SELECT]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   }
+
+  // CHECK-NOT:   {{.*}} = load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK-NOT:   store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK: }
+}
+

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --shape-inference --lower-frontend %s -split-input-file | FileCheck %s
 
+// -----
+
 func @test_add(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -17,6 +19,8 @@ func @test_add(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*
   // CHECK: store [[ADDF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
+
+// -----
 
 func @test_mul(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -36,6 +40,8 @@ func @test_mul(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
+// -----
+
 func @test_div(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Div"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -53,6 +59,8 @@ func @test_div(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*
   // CHECK: store [[DIVF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
+
+// -----
 
 func @test_sub(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sub"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -72,6 +80,8 @@ func @test_sub(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
+// -----
+
 func @test_and(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*xi32> {
   %0 = "onnx.And"(%arg0, %arg1) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<*xi32>
   "std.return"(%0) : (tensor<*xi32>) -> ()
@@ -89,6 +99,8 @@ func @test_and(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*
   // CHECK: store [[AND]], [[RES]][%arg2, %arg3] : memref<10x10xi32>
   // CHECK: return [[RES]] : memref<10x10xi32>
 }
+
+// -----
 
 func @test_or(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*xi32> {
   %0 = "onnx.Or"(%arg0, %arg1) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<*xi32>
@@ -108,6 +120,8 @@ func @test_or(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*x
   // CHECK: return [[RES]] : memref<10x10xi32>
 }
 
+// -----
+
 func @test_xor(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*xi32> {
   %0 = "onnx.Xor"(%arg0, %arg1) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<*xi32>
   "std.return"(%0) : (tensor<*xi32>) -> ()
@@ -125,6 +139,8 @@ func @test_xor(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*
   // CHECK: store [[XOR]], [[RES]][%arg2, %arg3] : memref<10x10xi32>
   // CHECK: return [[RES]] : memref<10x10xi32>
 }
+
+// -----
 
 func @test_exp(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Exp"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -144,6 +160,8 @@ func @test_exp(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[EXP]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Tanh"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -170,6 +188,8 @@ func @test_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sinh"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -194,6 +214,8 @@ func @test_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[SINH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Cosh"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -220,6 +242,8 @@ func @test_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_cos(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Cos"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -239,6 +263,8 @@ func @test_cos(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_log(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Log"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -257,6 +283,8 @@ func @test_log(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[LOG]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sigmoid"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -282,6 +310,8 @@ func @test_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Relu"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -302,6 +332,8 @@ func @test_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[RELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_reshape(%arg0 : tensor<?x10xf32>, %arg1 : tensor<4xi32>) -> tensor<*xf32> {
   %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<?x10xf32>, tensor<4xi32>) -> tensor<*xf32>
@@ -374,6 +406,8 @@ func @test_reshape(%arg0 : tensor<?x10xf32>, %arg1 : tensor<4xi32>) -> tensor<*x
   // CHECK: return [[ALLOC]] : memref<?x?x?x?xf32>
 }
 
+// -----
+
 func @test_sum(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sum"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -391,6 +425,8 @@ func @test_sum(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*
   // CHECK: store [[ADD]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
+
+// -----
 
 func @test_max(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Max"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -411,6 +447,8 @@ func @test_max(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
+// -----
+
 func @test_min(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Min"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -429,6 +467,8 @@ func @test_min(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*
   // CHECK: store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
+
+// -----
 
 func @test_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Elu"(%arg0) {alpha=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -456,6 +496,8 @@ func @test_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.LeakyRelu"(%arg0) {alpha=1.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -478,6 +520,8 @@ func @test_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Selu"(%arg0) {alpha=1.0:f32, gamma=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -505,6 +549,8 @@ func @test_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[SELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.HardSigmoid"(%arg0) {alpha=1.0:f32, beta=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -534,6 +580,8 @@ func @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_reciprocal(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Reciprocal"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -553,6 +601,8 @@ func @test_reciprocal(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[RECIPROCAL_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_softplus(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Softplus"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -576,6 +626,8 @@ func @test_softplus(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_softsign(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Softsign"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -597,6 +649,8 @@ func @test_softsign(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[SOFTSIGN_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_add_with_broadcasting(%arg0 : tensor<?xf32>, %arg1 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?xf32>, tensor<?x10xf32>) -> tensor<*xf32>
@@ -623,6 +677,8 @@ func @test_add_with_broadcasting(%arg0 : tensor<?xf32>, %arg1 : tensor<?x10xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_reducemax(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   %0 ="onnx.ReduceMax"(%arg0) {axes=[1], keepdims = 0 : i64} : (tensor<3x2x2xf32>)-> tensor<*xf32>
@@ -652,6 +708,8 @@ func @test_reducemax(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
 
+// -----
+
 func @test_reducemin(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   %0 ="onnx.ReduceMin"(%arg0) {axes=[1], keepdims = 0 : i64} : (tensor<3x2x2xf32>)-> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -680,6 +738,8 @@ func @test_reducemin(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
 
+// -----
+
 func @test_reduceprod(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   %0 ="onnx.ReduceProd"(%arg0) {axes=[1], keepdims = 0 : i64} : (tensor<3x2x2xf32>)-> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -706,6 +766,8 @@ func @test_reduceprod(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
+
+// -----
 
 func @test_reducesum(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   %0 ="onnx.ReduceSum"(%arg0) {axes=[1], keepdims = 0 : i64} : (tensor<3x2x2xf32>)-> tensor<*xf32>
@@ -734,6 +796,8 @@ func @test_reducesum(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
   
+// -----
+
 func @test_softmax(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Softmax"(%arg0) {axis=1:i64} : (tensor<10x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -780,6 +844,8 @@ func @test_softmax(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
+// -----
+
 func @test_gemm(%arg0 : tensor<5x10xf32>, %arg1 : tensor<5x10xf32>, %arg2: tensor<10xf32>) -> tensor<*xf32> {
   %0 ="onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.0 : f32, beta = 5.0 : f32, transA = 1, transB = 0} : (tensor<5x10xf32>, tensor<5x10xf32>, tensor<10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -812,6 +878,8 @@ func @test_gemm(%arg0 : tensor<5x10xf32>, %arg1 : tensor<5x10xf32>, %arg2: tenso
   // CHECK: }
 }
 
+// -----
+
 func @test_sqrt(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sqrt"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -831,6 +899,8 @@ func @test_sqrt(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_unsqueeze(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Unsqueeze"(%arg0) {axes=[0,3]} : (tensor<10x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -849,6 +919,8 @@ func @test_unsqueeze(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
   // CHECK: "krnl.memcpy"([[RES]], %arg0, [[SIZE4]]) : (memref<1x10x10x1xf32>, memref<10x10xf32>, i64) -> ()
   // CHECK: return [[RES]] : memref<1x10x10x1xf32>
 }
+
+// -----
 
 func @test_transpose(%arg0 : tensor<10x20x30x40xf32>) -> tensor<*xf32> {
   %0 = "onnx.Transpose"(%arg0) : (tensor<10x20x30x40xf32>) -> tensor<*xf32>
@@ -879,6 +951,8 @@ func @test_transpose(%arg0 : tensor<10x20x30x40xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES0]] : memref<40x10x30x20xf32>
 }
 
+// -----
+
 func @test_identity(%arg0 : tensor<10x20x30x40xf32>) -> tensor<*xf32> {
   %0 = "onnx.Identity"(%arg0) : (tensor<10x20x30x40xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -886,6 +960,8 @@ func @test_identity(%arg0 : tensor<10x20x30x40xf32>) -> tensor<*xf32> {
   // CHECK-LABEL: test_identity
   // CHECK: return %arg0 : memref<10x20x30x40xf32>
 }
+
+// -----
 
 func @test_sign_f(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sign"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -912,6 +988,8 @@ func @test_sign_f(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_sign_i(%arg0 : tensor<?x10xi32>) -> tensor<*xi32> {
   %0 = "onnx.Sign"(%arg0) : (tensor<?x10xi32>) -> tensor<*xi32>
   "std.return"(%0) : (tensor<*xi32>) -> ()
@@ -936,6 +1014,8 @@ func @test_sign_i(%arg0 : tensor<?x10xi32>) -> tensor<*xi32> {
   // CHECK: store [[SIGN_RES]], [[RES]][%arg1, %arg2] : memref<?x10xi32>
   // CHECK: return [[RES]] : memref<?x10xi32>
 }
+
+// -----
 
 // 2-D x 2-D
 func @test_matmul1(%arg0 : tensor<10x5xf32>, %arg1 : tensor<5x10xf32>) -> tensor<*xf32> {
@@ -966,6 +1046,8 @@ func @test_matmul1(%arg0 : tensor<10x5xf32>, %arg1 : tensor<5x10xf32>) -> tensor
   // CHECK: }
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
+
+// -----
 
 // 2-D x N-D
 func @test_matmul2(%arg0 : tensor<10x5xf32>, %arg1 : tensor<2x3x5x10xf32>) -> tensor<*xf32> {
@@ -999,6 +1081,8 @@ func @test_matmul2(%arg0 : tensor<10x5xf32>, %arg1 : tensor<2x3x5x10xf32>) -> te
   // CHECK: return [[RES]] : memref<2x3x10x10xf32>
 }
 
+// -----
+
 // N-D x N-D
 func @test_matmul3(%arg0 : tensor<2x3x10x5xf32>, %arg1 : tensor<2x3x5x10xf32>) -> tensor<*xf32> {
   %0 ="onnx.MatMul"(%arg0, %arg1) : (tensor<2x3x10x5xf32>, tensor<2x3x5x10xf32>) -> tensor<*xf32>
@@ -1031,6 +1115,8 @@ func @test_matmul3(%arg0 : tensor<2x3x10x5xf32>, %arg1 : tensor<2x3x5x10xf32>) -
   // CHECK: return [[RES]] : memref<2x3x10x10xf32>
 }
 
+// -----
+
 // 1-D x 2-D
 func @test_matmul4(%arg0 : tensor<5xf32>, %arg1 : tensor<5x10xf32>) -> tensor<*xf32> {
   %0 ="onnx.MatMul"(%arg0, %arg1) : (tensor<5xf32>, tensor<5x10xf32>) -> tensor<*xf32>
@@ -1060,6 +1146,8 @@ func @test_matmul4(%arg0 : tensor<5xf32>, %arg1 : tensor<5x10xf32>) -> tensor<*x
   // CHECK: }
   // CHECK: return [[RES]] : memref<10xf32>
 }
+
+// -----
 
 // 1-D x N-D
 func @test_matmul5(%arg0 : tensor<5xf32>, %arg1 : tensor<?x5x10xf32>) -> tensor<*xf32> {
@@ -1095,6 +1183,8 @@ func @test_matmul5(%arg0 : tensor<5xf32>, %arg1 : tensor<?x5x10xf32>) -> tensor<
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 // N-D x 1-D
 func @test_matmul6(%arg0 : tensor<?x10x5xf32>, %arg1 : tensor<5xf32>) -> tensor<*xf32> {
   %0 ="onnx.MatMul"(%arg0, %arg1) : (tensor<?x10x5xf32>, tensor<5xf32>) -> tensor<*xf32>
@@ -1129,6 +1219,8 @@ func @test_matmul6(%arg0 : tensor<?x10x5xf32>, %arg1 : tensor<5xf32>) -> tensor<
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
+// -----
+
 // 1-D x 1-D
 func @test_matmul7(%arg0 : tensor<5xf32>, %arg1 : tensor<5xf32>) -> tensor<*xf32> {
   %0 ="onnx.MatMul"(%arg0, %arg1) : (tensor<5xf32>, tensor<5xf32>) -> tensor<*xf32>
@@ -1153,6 +1245,8 @@ func @test_matmul7(%arg0 : tensor<5xf32>, %arg1 : tensor<5xf32>) -> tensor<*xf32
   // CHECK: }
   // CHECK: return [[RES]] : memref<1xf32>
 }
+
+// -----
 
 func @test_conv_no_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
   %cst = constant unit
@@ -1197,6 +1291,8 @@ func @test_conv_no_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 
   // CHECK: return [[RES]] : memref<1x5x27x58xf32>
 }
+
+// -----
 
 func @test_conv_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>, %arg2 : tensor<5xf32>) -> tensor<*xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "NOTSET", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, tensor<5xf32>) -> tensor<*xf32>
@@ -1243,6 +1339,8 @@ func @test_conv_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x
   // CHECK: }
   // CHECK: return [[RES]] : memref<1x5x27x58xf32>
 }
+
+// -----
 
 func @test_conv_no_bias_no_pad_w_group(%arg0 : tensor<1x9x32x64xf32>, %arg1 : tensor<5x3x6x7xf32>) -> tensor<*xf32> {
   %cst = constant unit
@@ -1292,6 +1390,8 @@ func @test_conv_no_bias_no_pad_w_group(%arg0 : tensor<1x9x32x64xf32>, %arg1 : te
   // CHECK: return [[RES]] : memref<1x5x27x58xf32>
 }
 
+// -----
+
 func @test_conv_no_bias_no_pad_w_strides(%arg0 : tensor<1x9x32x64xf32>, %arg1 : tensor<5x9x6x7xf32>) -> tensor<*xf32> {
   %cst = constant unit
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : i64, strides = [2, 2]} : (tensor<1x9x32x64xf32>, tensor<5x9x6x7xf32>, none) -> tensor<*xf32>
@@ -1340,6 +1440,8 @@ func @test_conv_no_bias_no_pad_w_strides(%arg0 : tensor<1x9x32x64xf32>, %arg1 : 
   // CHECK: return [[RES]] : memref<1x5x14x29xf32>
 }
 
+// -----
+
 func @test_batchnorm_testmode_Nd(%arg0: tensor<1x2x1x3xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>, %arg3: tensor<2xf32>, %arg4: tensor<2xf32>) -> tensor<1x2x1x3xf32> {
   %0 = "onnx.BatchNormalizationTestMode"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<1x2x1x3xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<1x2x1x3xf32>
   return %0 : tensor<1x2x1x3xf32>
@@ -1370,6 +1472,8 @@ func @test_batchnorm_testmode_Nd(%arg0: tensor<1x2x1x3xf32>, %arg1: tensor<2xf32
   // CHECK: return [[RES]] : memref<1x2x1x3xf32>
 }
 
+// -----
+
 func @test_batchnorm_testmode_1d(%arg0: tensor<10xf32>, %arg1: tensor<1xf32>, %arg2: tensor<1xf32>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<10xf32> {
   %0 = "onnx.BatchNormalizationTestMode"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<10xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<10xf32>
   return %0 : tensor<10xf32>
@@ -1398,6 +1502,8 @@ func @test_batchnorm_testmode_1d(%arg0: tensor<10xf32>, %arg1: tensor<1xf32>, %a
   // CHECK: }
   // CHECK: return [[RES]] : memref<10xf32>
 }
+
+// -----
 
 func @test_maxpooling_singleout_no_pad(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
@@ -1428,6 +1534,8 @@ func @test_maxpooling_singleout_no_pad(%arg0 : tensor<1x3x32x32xf32>) -> tensor<
   // CHECK: }
   // CHECK: return [[RES]] : memref<1x3x31x31xf32>
 }
+
+// -----
 
 func @test_maxpooling_singleout_no_pad_w_strides(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2], strides = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
@@ -1462,6 +1570,8 @@ func @test_maxpooling_singleout_no_pad_w_strides(%arg0 : tensor<1x3x32x32xf32>) 
   // CHECK: }
   // CHECK: return [[RES]] : memref<1x3x16x16xf32>
 }
+
+// -----
 
 func @test_maxpooling_singleout_no_pad_w_strides_w_ceil_mode(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [3, 3], strides = [2, 2], ceil_mode = 1} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
@@ -1504,6 +1614,8 @@ func @test_maxpooling_singleout_no_pad_w_strides_w_ceil_mode(%arg0 : tensor<1x3x
   // CHECK: }
   // CHECK: return [[RES]] : memref<1x3x16x16xf32>
 }
+
+// -----
 
 func @test_maxpooling_singleout_no_pad_w_strides_w_dilation(%arg0 : tensor<1x3x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [3, 3], strides = [2, 2], dilations = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
@@ -1550,6 +1662,8 @@ func @test_maxpooling_singleout_no_pad_w_strides_w_dilation(%arg0 : tensor<1x3x3
   // CHECK: }
   // CHECK: return [[RES]] : memref<1x3x14x14xf32>
 }
+
+// -----
 
 func @test_maxpooling_singleout_no_pad_w_strides_w_ceil_mode_w_unknown_dims(%arg0 : tensor<?x3x?x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", kernel_shape = [3, 3], strides = [2, 2], ceil_mode = 1} : (tensor<?x3x?x32xf32>) -> tensor<*xf32>
@@ -1614,6 +1728,8 @@ func @test_maxpooling_singleout_no_pad_w_strides_w_ceil_mode_w_unknown_dims(%arg
   // CHECK: return [[RES]] : memref<?x3x?x16xf32>
 }
 
+// -----
+
 func @test_abs_float(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Abs"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -1632,6 +1748,8 @@ func @test_abs_float(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: store [[ABS]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_abs_int(%arg0 : tensor<?x10xi32>) -> tensor<*xi32> {
   %0 = "onnx.Abs"(%arg0) : (tensor<?x10xi32>) -> tensor<*xi32>
@@ -1654,6 +1772,8 @@ func @test_abs_int(%arg0 : tensor<?x10xi32>) -> tensor<*xi32> {
   // CHECK: store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xi32>
   // CHECK: return [[RES]] : memref<?x10xi32>
 }
+
+// -----
 
 func @test_constant_pad1(%arg0: tensor<16x16xf32>) -> tensor<18x20xf32> {
   %0 = "onnx.PadConstantValuePad"(%arg0) {constant_value = 0.000000e+00 : f32, mode = "constant", pads = [0, 3, 2, 1]} : (tensor<16x16xf32>) -> tensor<18x20xf32>
@@ -1680,6 +1800,8 @@ func @test_constant_pad1(%arg0: tensor<16x16xf32>) -> tensor<18x20xf32> {
   // CHECK: }
 }
 
+// -----
+
 func @test_constant_dense_2d_value(%arg0: tensor<1xf32>) -> tensor<*xf32> {
   %0 = "onnx.Constant"() {value = dense<[[0.0, 0.0], [1.0, 1.1], [2.0, 2.1]]> : tensor<3x2xf32>} : () -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
@@ -1688,6 +1810,8 @@ func @test_constant_dense_2d_value(%arg0: tensor<1xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
 
+
+// -----
 
 func @test_concat_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x32xf32>, %arg2 : tensor<5x5x5x32xf32>) -> tensor<5x5x9x32xf32> {
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) { axis = 2 } : (tensor<5x5x1x32xf32>, tensor<5x5x3x32xf32>, tensor<5x5x5x32xf32>)  -> tensor<5x5x9x32xf32>

--- a/test/mlir/onnx/onnx_lowering_with_dealloc.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_dealloc.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --shape-inference --lower-frontend %s -split-input-file | FileCheck %s
 
+// -----
+
 func @test_add_add(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   %1 = "onnx.Add"(%0, %arg1) : (tensor<*xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -37,6 +39,7 @@ func @test_add_add(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: return [[RET_RES]] : memref<10x10xf32>
 }
 
+// -----
 
 func @test_mul_mul(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -75,6 +78,8 @@ func @test_mul_mul(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: return [[RET_RES]] : memref<10x10xf32>
 }
 
+// -----
+
 func @test_div_div(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Div"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   %1 = "onnx.Div"(%0, %arg1) : (tensor<*xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -111,6 +116,8 @@ func @test_div_div(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
 
   // CHECK: return [[RET_RES]] : memref<10x10xf32>
 }
+
+// -----
 
 func @test_sub_sub(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sub"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -149,6 +156,8 @@ func @test_sub_sub(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: return [[RET_RES]] : memref<10x10xf32>
 }
 
+// -----
+
 func @test_and_and(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*xi32> {
   %0 = "onnx.And"(%arg0, %arg1) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<*xi32>
   %1 = "onnx.And"(%0, %arg1) : (tensor<*xi32>, tensor<10x10xi32>) -> tensor<*xi32>
@@ -185,6 +194,8 @@ func @test_and_and(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tens
 
   // CHECK: return [[RET_RES]] : memref<10x10xi32>
 }
+
+// -----
 
 func @test_or_or(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*xi32> {
   %0 = "onnx.Or"(%arg0, %arg1) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<*xi32>
@@ -223,6 +234,8 @@ func @test_or_or(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor
   // CHECK: return [[RET_RES]] : memref<10x10xi32>
 }
 
+// -----
+
 func @test_xor_xor(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tensor<*xi32> {
   %0 = "onnx.Xor"(%arg0, %arg1) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<*xi32>
   %1 = "onnx.Xor"(%0, %arg1) : (tensor<*xi32>, tensor<10x10xi32>) -> tensor<*xi32>
@@ -259,6 +272,8 @@ func @test_xor_xor(%arg0 : tensor<10x10xi32>, %arg1 : tensor<10x10xi32>) -> tens
 
   // CHECK: return [[RET_RES]] : memref<10x10xi32>
 }
+
+// -----
 
 func @test_exp_exp(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Exp"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -298,6 +313,8 @@ func @test_exp_exp(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_tanh_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Tanh"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -350,6 +367,8 @@ func @test_tanh_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_sinh_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sinh"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   %1 = "onnx.Sinh"(%0) : (tensor<*xf32>) -> tensor<*xf32>
@@ -400,6 +419,8 @@ func @test_sinh_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_cosh_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Cosh"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -452,6 +473,8 @@ func @test_cosh_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_sigmoid_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sigmoid"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   %1 = "onnx.Sigmoid"(%0) : (tensor<*xf32>) -> tensor<*xf32>
@@ -501,6 +524,8 @@ func @test_sigmoid_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_relu_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Relu"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>
   %1 = "onnx.Relu"(%0) : (tensor<*xf32>) -> tensor<*xf32>
@@ -544,6 +569,8 @@ func @test_relu_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_sum_sum(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sum"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   %1 = "onnx.Sum"(%0, %arg1) : (tensor<*xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -580,6 +607,8 @@ func @test_sum_sum(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
 
   // CHECK: return [[RET_RES]] : memref<10x10xf32>
 }
+
+// -----
 
 func @test_max_max(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Max"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -620,6 +649,8 @@ func @test_max_max(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: return [[RET_RES]] : memref<10x10xf32>
 }
 
+// -----
+
 func @test_min_min(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Min"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   %1 = "onnx.Min"(%0, %arg1) : (tensor<*xf32>, tensor<10x10xf32>) -> tensor<*xf32>
@@ -658,6 +689,8 @@ func @test_min_min(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   
   // CHECK: return [[RET_RES]] : memref<10x10xf32>
 }
+
+// -----
 
 func @test_elu_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Elu"(%arg0) {alpha=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -712,6 +745,8 @@ func @test_elu_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
 
+// -----
+
 func @test_leakyrelu_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.LeakyRelu"(%arg0) {alpha=1.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
   %1 = "onnx.LeakyRelu"(%0) {alpha=1.0:f32} : (tensor<*xf32>) -> tensor<*xf32>
@@ -758,6 +793,8 @@ func @test_leakyrelu_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_selu_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Selu"(%arg0) {alpha=1.0:f32, gamma=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -813,6 +850,8 @@ func @test_selu_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_hardsigmoid_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.HardSigmoid"(%arg0) {alpha=1.0:f32, beta=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
@@ -870,6 +909,8 @@ func @test_hardsigmoid_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
   // CHECK: return [[RET_RES]] : memref<?x10xf32>
 }
+
+// -----
 
 func @test_reciprocal_reciprocal(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Reciprocal"(%arg0) : (tensor<?x10xf32>) -> tensor<*xf32>

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --shape-inference %s -split-input-file | FileCheck %s
 
+// -----
+
 //===----------------------------------------------------------------------===//
 /// Test the default behavior of transpose when no information for the
 /// permutation of the axes is provided and when a permutation is provided.
@@ -14,6 +16,8 @@ func @test_default_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : tensor<32x1x5x5xf32>
 }
 
+// -----
+
 /// Test shape inference for transposition when perm attribute is specified.
 
 func @test_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
@@ -24,6 +28,8 @@ func @test_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Transpose"(%arg0) {perm = [2, 0, 3, 1]} : (tensor<5x5x1x32xf32>) -> tensor<1x5x32x5xf32>
   // CHECK: return [[RES_ATTR]] : tensor<1x5x32x5xf32>
 }
+
+// -----
 
 //===----------------------------------------------------------------------===//
 /// Test the shape inferencing scheme for the matmul operation.
@@ -40,6 +46,8 @@ func @test_matmul_1(%arg0 : tensor<32xf32>, %arg1 : tensor<32xf32>) -> tensor<*x
   // CHECK: return [[RES1]] : tensor<1xf32>
 }
 
+// -----
+
 /// MatMul: K-D x 2-D (K > 2)
 
 func @test_matmul_2(%arg0 : tensor<16x?x64x42xf32>, %arg1 : tensor<42x32xf32>) -> tensor<*xf32> {
@@ -50,6 +58,8 @@ func @test_matmul_2(%arg0 : tensor<16x?x64x42xf32>, %arg1 : tensor<42x32xf32>) -
   // CHECK: [[RES2:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<16x?x64x42xf32>, tensor<42x32xf32>) -> tensor<16x?x64x32xf32>
   // CHECK: return [[RES2]] : tensor<16x?x64x32xf32>
 }
+
+// -----
 
 /// MatMul: 2-D x K-D (K > 2)
 
@@ -62,6 +72,8 @@ func @test_matmul_3(%arg0 : tensor<64x42xf32>, %arg1 : tensor<16x?x42x32xf32>) -
   // CHECK: return [[RES3]] : tensor<16x?x64x32xf32>
 }
 
+// -----
+
 /// MatMul: 2-D x K-D (K > 2)
 
 func @test_matmul_4(%arg0 : tensor<64x42xf32>, %arg1 : tensor<?x?x?x?xf32>) -> tensor<*xf32> {
@@ -72,6 +84,8 @@ func @test_matmul_4(%arg0 : tensor<64x42xf32>, %arg1 : tensor<?x?x?x?xf32>) -> t
   // CHECK: [[RES4:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<64x42xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x64x?xf32>
   // CHECK: return [[RES4]] : tensor<?x?x64x?xf32>
 }
+
+// -----
 
 /// MatMul: K1-D x K2-D (K1 > 2, K2 > 2)
 
@@ -84,6 +98,8 @@ func @test_matmul_5(%arg0 : tensor<16x?x?x42xf32>, %arg1 : tensor<32x?x64x42x32x
   // CHECK: return [[RES5]] : tensor<32x16x64x?x32xf32>
 }
 
+// -----
+
 /// MatMul: 1-D x 2-D
 
 func @test_matmul_6(%arg0 : tensor<32xf32>, %arg1 : tensor<32x64xf32>) -> tensor<*xf32> {
@@ -94,6 +110,8 @@ func @test_matmul_6(%arg0 : tensor<32xf32>, %arg1 : tensor<32x64xf32>) -> tensor
   // CHECK: [[RES6:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<32xf32>, tensor<32x64xf32>) -> tensor<64xf32>
   // CHECK: return [[RES6]] : tensor<64xf32>
 }
+
+// -----
 
 /// MatMul: 2-D x 1-D
 
@@ -106,6 +124,8 @@ func @test_matmul_7(%arg0 : tensor<32x64xf32>, %arg1 : tensor<64xf32>) -> tensor
   // CHECK: return [[RES7]] : tensor<32xf32>
 }
 
+// -----
+
 /// MatMul: 2-D x 2-D
 
 func @test_matmul_8(%arg0 : tensor<32x64xf32>, %arg1 : tensor<64x128xf32>) -> tensor<*xf32> {
@@ -116,6 +136,8 @@ func @test_matmul_8(%arg0 : tensor<32x64xf32>, %arg1 : tensor<64x128xf32>) -> te
   // CHECK: [[RES8:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<32x64xf32>, tensor<64x128xf32>) -> tensor<32x128xf32>
   // CHECK: return [[RES8]] : tensor<32x128xf32>
 }
+
+// -----
 
 /// MatMul: 1-D x N-D
 
@@ -128,6 +150,8 @@ func @test_matmul_9(%arg0 : tensor<42xf32>, %arg1 : tensor<?x42x32xf32>) -> tens
   // CHECK: return [[RES1]] : tensor<?x32xf32>
 }
 
+// -----
+
 /// MatMul: N-D x 1-D
 
 func @test_matmul_10(%arg0 : tensor<?x42x32xf32>, %arg1 : tensor<32xf32>) -> tensor<*xf32> {
@@ -138,6 +162,8 @@ func @test_matmul_10(%arg0 : tensor<?x42x32xf32>, %arg1 : tensor<32xf32>) -> ten
   // CHECK: [[RES1:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<?x42x32xf32>, tensor<32xf32>) -> tensor<?x42xf32>
   // CHECK: return [[RES1]] : tensor<?x42xf32>
 }
+
+// -----
 
 //===----------------------------------------------------------------------===//
 /// Test shape inference for Conv (first with no bias) operation and all its attributes.
@@ -155,6 +181,8 @@ func @test_conv_no_bias_0(%arg0 : tensor<1x2x32xf32>, %arg1 : tensor<5x2x6xf32>)
   // CHECK: return [[RES_ATTR]] : tensor<1x5x27xf32>
 }
 
+// -----
+
 /// Default and required attributes.
 
 func @test_conv_no_bias_1(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
@@ -167,6 +195,8 @@ func @test_conv_no_bias_1(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7x
   // CHECK: return [[RES_ATTR]] : tensor<1x5x27x58xf32>
 }
 
+// -----
+
 /// kernel_shape attribute.
 
 func @test_conv_no_bias_2(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
@@ -178,6 +208,8 @@ func @test_conv_no_bias_2(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7x
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : i64, kernel_shape = [8, 9], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x25x56xf32>
   // CHECK: return [[RES_ATTR]] : tensor<1x5x25x56xf32>
 }
+
+// -----
 
 /// pads attribute.
 /// Use pads to make output size equal to input size by adding K - 1 to the result.
@@ -192,6 +224,8 @@ func @test_conv_no_bias_3(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10
   // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 }
 
+// -----
+
 /// auto_pad set to SAME_UPPER and SAME_LOWER.
 
 func @test_conv_no_bias_4(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
@@ -204,6 +238,8 @@ func @test_conv_no_bias_4(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10
   // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 }
 
+// -----
+
 func @test_conv_no_bias_5(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
   %cst = constant unit
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "SAME_LOWER", group = 1 : i64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<*xf32>
@@ -213,6 +249,8 @@ func @test_conv_no_bias_5(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : i64, kernel_shape = [6, 10], pads = [3, 5, 2, 4], strides = [1, 1]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<1x5x32x64xf32>
   // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 }
+
+// -----
 
 /// auto_pad set to VALID.
 
@@ -226,6 +264,8 @@ func @test_conv_no_bias_6(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10
   // CHECK: return [[RES_ATTR]] : tensor<1x5x27x55xf32>
 }
 
+// -----
+
 /// With strides attribute.
 
 func @test_conv_no_bias_7(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
@@ -237,6 +277,8 @@ func @test_conv_no_bias_7(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7x
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : i64, kernel_shape = [6, 7], pads = [0, 0, 0, 0], strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x14x20xf32>
   // CHECK: return [[RES_ATTR]] : tensor<1x5x14x20xf32>
 }
+
+// -----
 
 /// auto_pad set to SAME_UPPER with strides attribute.
 /// The auto_pad will pas as if stride is equal to 1.
@@ -251,6 +293,8 @@ func @test_conv_no_bias_8(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7x
   // CHECK: return [[RES_ATTR]] : tensor<1x5x16x22xf32>
 }
 
+// -----
+
 /// dilations attribute.
 
 func @test_conv_no_bias_9(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
@@ -262,6 +306,8 @@ func @test_conv_no_bias_9(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7x
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : i64, kernel_shape = [6, 7], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x22x46xf32>
   // CHECK: return [[RES_ATTR]] : tensor<1x5x22x46xf32>
 }
+
+// -----
 
 /// dilations attribute with stride.
 
@@ -275,6 +321,8 @@ func @test_conv_no_bias_10(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7
   // CHECK: return [[RES_ATTR]] : tensor<1x5x11x23xf32>
 }
 
+// -----
+
 /// dilations attribute with auto_pad set to SAME_UPPER.
 
 func @test_conv_no_bias_11(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
@@ -287,6 +335,8 @@ func @test_conv_no_bias_11(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7
   // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 }
  
+// -----
+
 // Test convolution with bias input.
 
 func @test_conv_12(%arg0 : tensor<1x2x32xf32>, %arg1 : tensor<5x2x6xf32>, %arg2 : tensor<5xf32>) -> tensor<*xf32> {
@@ -297,6 +347,8 @@ func @test_conv_12(%arg0 : tensor<1x2x32xf32>, %arg1 : tensor<5x2x6xf32>, %arg2 
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "NOTSET", dilations = [1], group = 1 : i64, kernel_shape = [6], pads = [0, 0], strides = [1]} : (tensor<1x2x32xf32>, tensor<5x2x6xf32>, tensor<5xf32>) -> tensor<1x5x27xf32>
   // CHECK: return [[RES_ATTR]] : tensor<1x5x27xf32>
 }
+
+// -----
 
 //===----------------------------------------------------------------------===//
 /// Test shape inference for PadConstantValuePad.
@@ -312,6 +364,8 @@ func @test_PadConstantValuePad_1(%arg0 : tensor<16x13xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : tensor<18x13xf32>
 }
 
+// -----
+
 /// Test PadConstantPad_1
 func @test_PadConstantPad_1(%arg0 : tensor<16x13xf32>, %arg1 : tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.PadConstantPad"(%arg0, %arg1) {mode = "constant", pads = [0, 3, 2, 1]} : (tensor<16x13xf32>, tensor<*xf32>) -> tensor<*xf32>
@@ -320,6 +374,8 @@ func @test_PadConstantPad_1(%arg0 : tensor<16x13xf32>, %arg1 : tensor<*xf32>) ->
   // CHECK: [[RES:%.+]] = "onnx.PadConstantPad"(%arg0, %arg1) {mode = "constant", pads = [0, 3, 2, 1]} : (tensor<16x13xf32>, tensor<*xf32>) -> tensor<18x17xf32>
   // CHECK: return [[RES]] : tensor<18x17xf32>
 }
+
+// -----
 
 /// Test PadConstantPad_2
 func @test_PadConstantPad_2(%arg0 : tensor<16x?xf32>, %arg1 : tensor<*xf32>) -> tensor<*xf32> {
@@ -330,6 +386,8 @@ func @test_PadConstantPad_2(%arg0 : tensor<16x?xf32>, %arg1 : tensor<*xf32>) -> 
   // CHECK: [[RES:%.+]] = "onnx.PadConstantPad"(%arg0, %arg1) {mode = "constant", pads = [0, 3, 2, 1]} : (tensor<16x?xf32>, tensor<*xf32>) -> tensor<18x?xf32>
   // CHECK: return [[RES]] : tensor<18x?xf32>
 }
+
+// -----
 
 //===----------------------------------------------------------------------===//
 /// Test for constant op.
@@ -345,6 +403,8 @@ func @test_constant_dense_1d_value() -> tensor<*xf32> {
   // CHECK: return [[RES]] : tensor<3xf32>
 }
 
+// -----
+
 /// Test ConstantOp shape inference for 2-D dense tensor.
 func @test_constant_dense_2d_value() -> tensor<*xf32> {
   %0 = "onnx.Constant"() {value = dense<[[0.0, 0.0], [1.0, 1.1], [2.0, 2.1]]> : tensor<3x2xf32>} : () -> tensor<*xf32>
@@ -354,6 +414,8 @@ func @test_constant_dense_2d_value() -> tensor<*xf32> {
   // CHECK: [[RES:%.+]] = "onnx.Constant"() {value = dense<{{\[}}[0.000000e+00, 0.000000e+00], [1.000000e+00, 1.100000e+00], [2.000000e+00, 2.100000e+00{{\]}}]> : tensor<3x2xf32>} : () -> tensor<3x2xf32>
   // CHECK: return [[RES]] : tensor<3x2xf32>
 }
+
+// -----
 
 /// Test ConstantOp shape inference for 1-D sparse tensor.
 func @test_constant_sparse_1d_value() -> tensor<*xf32> {
@@ -365,6 +427,8 @@ func @test_constant_sparse_1d_value() -> tensor<*xf32> {
   // CHECK: return [[RES]] : tensor<3xf32>
 }
 
+// -----
+
 /// Test ConstantOp shape inference for 2-D sparse tensor.
 func @test_constant_sparse_2d_value() -> tensor<*xf32> {
   %0 = "onnx.Constant"() {sparse_value = sparse<[[0, 1]], [2.0]> : tensor<3x2xf32>} : () -> tensor<*xf32>
@@ -374,6 +438,8 @@ func @test_constant_sparse_2d_value() -> tensor<*xf32> {
   // CHECK: [[RES:%.+]] = "onnx.Constant"() {sparse_value = sparse<{{\[}}[0, 1{{\]}}], 2.000000e+00> : tensor<3x2xf32>} : () -> tensor<3x2xf32>
   // CHECK: return [[RES]] : tensor<3x2xf32>
 }
+
+// -----
 
 /// Test the default behavior of Average Pool with no padding (pad are set but shoud be ignored)
 func @test_default_averagepool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
@@ -385,6 +451,8 @@ func @test_default_averagepool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : tensor<5x5x30x30xf32>
 }
 
+// -----
+
 /// Test the default behavior of Average Pool with no padding (pad are not set, default to zero)
 func @test_default_averagepool_defpad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [3,3]} : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
@@ -394,6 +462,8 @@ func @test_default_averagepool_defpad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
   // CHECK: return [[RES]] : tensor<5x5x30x30xf32>
 }
+
+// -----
 
 /// Test the default behavior of Average Pool with uniform padding
 func @test_default_averagepool_pad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
@@ -405,6 +475,8 @@ func @test_default_averagepool_pad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf3
   // CHECK: return [[RES]] : tensor<5x5x32x32xf32>
 }
 
+// -----
+
 /// Test the default behavior of Average Pool with non uniform padding
 func @test_default_averagepool_pad_nonunif(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [5,3], pads = [2, 1, 1, 0] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
@@ -414,6 +486,8 @@ func @test_default_averagepool_pad_nonunif(%arg0 : tensor<5x5x32x32xf32>) -> ten
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, kernel_shape = [5, 3], pads = [2, 1, 1, 0], strides = [1, 1]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x31x31xf32>
   // CHECK: return [[RES]] : tensor<5x5x31x31xf32>
 }
+
+// -----
 
 /// Test the default behavior of Average Pool with non uniform padding
 func @test_default_averagepool_strides(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
@@ -425,6 +499,8 @@ func @test_default_averagepool_strides(%arg0 : tensor<5x5x32x32xf32>) -> tensor<
   // CHECK: return [[RES]] : tensor<5x5x16x16xf32>
 }
 
+// -----
+
 /// Test the default behavior of Average Pool with non uniform padding
 func @test_default_averagepool_strides_nonunifpad(%arg0 : tensor<5x5x30x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [2,2], pads = [1, 0, 0, 0], strides = [2, 2] } : (tensor<5x5x30x32xf32>) -> tensor<*xf32>
@@ -435,6 +511,8 @@ func @test_default_averagepool_strides_nonunifpad(%arg0 : tensor<5x5x30x32xf32>)
   // CHECK: return [[RES]] : tensor<5x5x15x16xf32>
 }
 
+// -----
+
 /// Test the default behavior of Average Pool with non uniform padding
 func @test_default_averagepool_strides_nonunifpad_ceil(%arg0 : tensor<5x5x30x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 1, kernel_shape = [2,2], pads = [1, 0, 0, 0], strides = [2, 2] } : (tensor<5x5x30x32xf32>) -> tensor<*xf32>
@@ -444,6 +522,8 @@ func @test_default_averagepool_strides_nonunifpad_ceil(%arg0 : tensor<5x5x30x32x
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 1 : i64, kernel_shape = [2, 2], pads = [1, 0, 0, 0], strides = [2, 2]} : (tensor<5x5x30x32xf32>) -> tensor<5x5x16x16xf32>
   // CHECK: return [[RES]] : tensor<5x5x16x16xf32>
 }
+
+// -----
 
 //===----------------------------------------------------------------------===//
 /// Test the reshape op inference when constants are present.
@@ -458,6 +538,8 @@ func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi32>) 
   // CHECK: return [[RES]] : tensor<?x?x?x?xf32>
 }
 
+// -----
+
 func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.Constant"() {value = dense<[5, 5, 16, 2]> : tensor<4xi32> } : () -> tensor<4xi32>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi32>) -> tensor<*xf32>
@@ -467,6 +549,8 @@ func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi32>) -> tensor<5x5x16x2xf32>
   // CHECK: return [[RES]] : tensor<5x5x16x2xf32>
 }
+
+// -----
 
 func @test_reshape_2(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.Constant"() {value = dense<[-1, 16, 2]> : tensor<3xi32> } : () -> tensor<3xi32>
@@ -478,6 +562,8 @@ func @test_reshape_2(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   // CHECK: return [[RES]] : tensor<25x16x2xf32>
 }
 
+// -----
+
 func @test_reshape_3(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.Constant"() {value = dense<[-1, 0, 2]> : tensor<3xi32> } : () -> tensor<3xi32>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi32>) -> tensor<*xf32>
@@ -487,6 +573,8 @@ func @test_reshape_3(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi32>) -> tensor<80x5x2xf32>
   // CHECK: return [[RES]] : tensor<80x5x2xf32>
 }
+
+// -----
 
 //===----------------------------------------------------------------------===//
 /// Test the reshape op inference when concat are present.
@@ -501,6 +589,8 @@ func @test_concat_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x32xf32>, 
   // CHECK: return [[RES]] : tensor<5x5x9x32xf32>
 }
 
+// -----
+
 func @test_concat_2(%arg0 : tensor<5x1x32xf32>, %arg1 : tensor<5x3x32xf32>, %arg2 : tensor<5x5x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) { axis = 1 } : (tensor<5x1x32xf32>, tensor<5x3x32xf32>, tensor<5x5x32xf32>)  -> tensor<*xf32>
   "std.return"(%1) : (tensor<*xf32>) -> ()
@@ -509,6 +599,8 @@ func @test_concat_2(%arg0 : tensor<5x1x32xf32>, %arg1 : tensor<5x3x32xf32>, %arg
   // CHECK: [[RES:%.+]] = "onnx.Concat"(%arg0, %arg1, %arg2) {axis = 1 : i64} : (tensor<5x1x32xf32>, tensor<5x3x32xf32>, tensor<5x5x32xf32>) -> tensor<5x9x32xf32>
   // CHECK: return [[RES]] : tensor<5x9x32xf32>
 }
+
+// -----
 
 func @test_concat_3(%arg0 : tensor<5x1x32xf32>, %arg1 : tensor<5x3x32xf32>, %arg2 : tensor<5x5x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) { axis = -2 } : (tensor<5x1x32xf32>, tensor<5x3x32xf32>, tensor<5x5x32xf32>)  -> tensor<*xf32>

--- a/test/mlir/onnx/onnx_shape_inference_maxpool.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_maxpool.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --shape-inference %s -split-input-file | FileCheck %s
 
+// -----
+
 /// Test the default behavior of Max Pool with no padding (pad are set but shoudl be ignored)
 func @test_default_maxpoolsingleout(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "VALID", ceil_mode = 0, kernel_shape = [3,3], pads = [1, 1, 1, 1] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
@@ -9,6 +11,8 @@ func @test_default_maxpoolsingleout(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, dilations = [1, 1], kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
 // CHECK: return [[RES]] : tensor<5x5x30x30xf32>
 
+
+// -----
 
 /// Test the default behavior of Max Pool with no padding (pad are not set, default to zero)
 func @test_default_maxpoolsingleout_defpad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
@@ -20,6 +24,8 @@ func @test_default_maxpoolsingleout_defpad(%arg0 : tensor<5x5x32x32xf32>) -> ten
 // CHECK: return [[RES]] : tensor<5x5x30x30xf32>
 
 
+// -----
+
 /// Test the default behavior of Max Pool with uniform padding
 func @test_default_maxpoolsingleout_pad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [3,3], pads = [1, 1, 1, 1] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
@@ -30,6 +36,8 @@ func @test_default_maxpoolsingleout_pad(%arg0 : tensor<5x5x32x32xf32>) -> tensor
 // CHECK: return [[RES]] : tensor<5x5x32x32xf32>
 
 
+// -----
+
 /// Test the default behavior of Max Pool with non uniform padding
 func @test_default_maxpoolsingleout_pad_nonunif(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [5,3], pads = [2, 1, 1, 0] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
@@ -39,6 +47,7 @@ func @test_default_maxpoolsingleout_pad_nonunif(%arg0 : tensor<5x5x32x32xf32>) -
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, dilations = [1, 1], kernel_shape = [5, 3], pads = [2, 1, 1, 0], strides = [1, 1]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x31x31xf32>
 // CHECK: return [[RES]] : tensor<5x5x31x31xf32>
 
+// -----
 
 /// Test the default behavior of Max Pool with non uniform padding
 func @test_default_maxpoolsingleout_strides(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
@@ -49,6 +58,7 @@ func @test_default_maxpoolsingleout_strides(%arg0 : tensor<5x5x32x32xf32>) -> te
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, dilations = [1, 1], kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [2, 2]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x16x16xf32>
 // CHECK: return [[RES]] : tensor<5x5x16x16xf32>
 
+// -----
 
 /// Test the default behavior of Max Pool with non uniform padding
 func @test_default_maxpoolsingleout_strides_nonunifpad(%arg0 : tensor<5x5x30x32xf32>) -> tensor<*xf32> {
@@ -59,6 +69,7 @@ func @test_default_maxpoolsingleout_strides_nonunifpad(%arg0 : tensor<5x5x30x32x
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, dilations = [1, 1], kernel_shape = [2, 2], pads = [1, 0, 0, 0], strides = [2, 2]} : (tensor<5x5x30x32xf32>) -> tensor<5x5x15x16xf32>
 // CHECK: return [[RES]] : tensor<5x5x15x16xf32>
 
+// -----
 
 /// Test the default behavior of Max Pool with non uniform padding
 func @test_default_maxpoolsingleout_strides_nonunifpad_ceil(%arg0 : tensor<5x5x30x32xf32>) -> tensor<*xf32> {
@@ -70,6 +81,8 @@ func @test_default_maxpoolsingleout_strides_nonunifpad_ceil(%arg0 : tensor<5x5x3
 // CHECK: return [[RES]] : tensor<5x5x16x16xf32>
 
 
+// -----
+
 /// Test the default behavior of Max Pool with dilatation
 func @test_default_maxpoolsingleout_strides_dilatation(%arg0 : tensor<5x5x8x8xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0, kernel_shape = [2,2], dilations = [2, 2], strides = [3, 3] } : (tensor<5x5x8x8xf32>) -> tensor<*xf32>
@@ -78,6 +91,8 @@ func @test_default_maxpoolsingleout_strides_dilatation(%arg0 : tensor<5x5x8x8xf3
 // CHECK-LABEL: test_default_maxpoolsingleout_strides_dilatation
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, dilations = [2, 2], kernel_shape = [2, 2], pads = [0, 0, 0, 0], strides = [3, 3]} : (tensor<5x5x8x8xf32>) -> tensor<5x5x2x2xf32>
 // CHECK: return [[RES]] : tensor<5x5x2x2xf32>
+
+// -----
 
 /// Test the default behavior of Max Pool with dilatation
 func @test_default_maxpoolsingleout_upper(%arg0 : tensor<5x5x16x13xf32>) -> tensor<*xf32> {
@@ -88,6 +103,8 @@ func @test_default_maxpoolsingleout_upper(%arg0 : tensor<5x5x16x13xf32>) -> tens
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : i64, dilations = [1, 1], kernel_shape = [4, 4], pads = [0, 1, 0, 2], strides = [4, 4]} : (tensor<5x5x16x13xf32>) -> tensor<5x5x4x4xf32>
 // CHECK: return [[RES]] : tensor<5x5x4x4xf32>
 
+
+// -----
 
 /// Test the default behavior of Max Pool with dilatation
 func @test_default_maxpoolsingleout_lower(%arg0 : tensor<5x5x16x13xf32>) -> tensor<*xf32> {


### PR DESCRIPTION
This patch is to implement common functions for lowering pooling ops where:
- It supports padding directly in the lowering, thus there is no need to pad the input separately.
    - Remove this rewriting rule: `MaxPoolSingleOut(X, pads) = MaxPoolSinglePut(onnx.PadConstantValuePadOp(X,pads), pads = [0, 0, 0, 0])`
- It uses AffineMap to compute a pooling window for border edges instead of using a fixed pooling window of kernel size.
    - Helper function `pushAffineBound(AffineMap map, ArrayRef<Value> operands)` is newly added to help add an AffineMap as a bound for KrnlIterateOp.

TODO:
- [x] Add MLIR tests