### PR TITLE
Elide large attributes when dumping a model

### DIFF
--- a/src/MainUtils.hpp
+++ b/src/MainUtils.hpp
@@ -31,6 +31,7 @@
 #include "mlir/InitAllDialects.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Module.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/Parser.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,8 @@ int main(int argc, char *argv[]) {
       EmitLLVMBitCode(module);
       printf("LLVM bitcode written to ./model.bc");
   } else
-    module->dump();
+    module->print(
+        llvm::errs(), mlir::OpPrintingFlags().elideLargeElementsAttrs(32));
 
   return 0;
 }


### PR DESCRIPTION
Sometimes, a program has constants with a large number of element data, which is not neat when we dump the program and is hard to read the program. This patch enables the elision of large elements attributes instead of the element data. We will see an output like the following when invoking `onnx-mlir`:
```mlir
%0 = "onnx.Constant"() {value = opaque<"", "0xDEADBEEF"> : tensor<16x4x4x10xf32>} : () -> tensor<16x4x4x10xf32>
```

This is just for printing and does not affect the actual data.

If we use `onnx-mlir-opt` command, we can enable the elision with a built-in option `--mlir-elide-elementsattrs-if-larger=32`.
