### PR TITLE
[WIP] Removing errors

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -76,13 +76,10 @@ private:
       return builder_.getIntegerType(64);
     case onnx::TensorProto_DataType::TensorProto_DataType_BOOL:
       return builder_.getI1Type();
-    case onnx::TensorProto_DataType::TensorProto_DataType_STRING:
-    case onnx::TensorProto_DataType::TensorProto_DataType_COMPLEX64:
-    case onnx::TensorProto_DataType::TensorProto_DataType_COMPLEX128:
-    case onnx::TensorProto_DataType::TensorProto_DataType_UNDEFINED:
-      assert(false && "Unsupported data type encountered.");
-      return nullptr;
+    default:
+      llvm_unreachable("Unsupported data type encountered.");
     }
+    
   }
 
   /*!

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -424,9 +424,8 @@ Value mapToLowerScalarOp<ONNXSignOp>(Operation *op, ArrayRef<Type> result_types,
     auto result =
         rewriter.create<SelectOp>(loc, zeroPredicate, zero, plusSelect);
     return result;
-  } else {
-    emitError(loc, "unsupported element type");
   }
+  llvm_unreachable("unsupported element type");
 }
 
 //===----------------------------------------------------------------------===//
@@ -484,9 +483,8 @@ Value mapToLowerScalarOp<ONNXAbsOp>(Operation *op, ArrayRef<Type> result_types,
     auto negativeOperand = rewriter.create<SubIOp>(loc, zero, operand);
     return rewriter.create<SelectOp>(
         loc, lessThanZero, negativeOperand, operand);
-  } else {
-    emitError(loc, "unsupported element type");
   }
+  llvm_unreachable("unsupported element type");
 }
 
 // Element-wise unary ops lowering to Krnl dialect.

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -258,12 +258,12 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
         for (auto arg : loopBatchIVs)
           loopBatchKNIVs.emplace_back(arg);
       loopBatchKNIVs.emplace_back(loopKIVs[0]);
-      if (BShape.size() >= 2)
+      if (BShape.size() >= 2) {
         if (AShape.size() >= 2)
           loopBatchKNIVs.emplace_back(loopMNIVs[1]);
         else
           loopBatchKNIVs.emplace_back(loopMNIVs[0]);
-
+      }
       // Matmul computation
       auto loadedA = rewriter.create<LoadOp>(loc, A, loopBatchMKIVs);
       auto loadedB = rewriter.create<LoadOp>(loc, B, loopBatchKNIVs);

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -76,6 +76,7 @@ ParseResult parseKrnlDefineLoopsOp(OpAsmParser &parser,
       numLoops.getValue().getSExtValue(), LoopType::get(builder.getContext()));
   if (parser.addTypesToList(loopTypes, result.types))
     return failure();
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -291,6 +292,7 @@ ParseResult parseKrnlIterateOp(OpAsmParser &parser, OperationState &result) {
           builder.getConstantAffineMap(integerAttr.getValue().getSExtValue());
       boundMaps.emplace_back(AffineMapAttr::get(map));
     }
+    //TODO(Tian) return success? or failure here, but success in branch above?
   };
 
   bool keepParsing; // Do we keep parsing loops/bounds?
@@ -342,6 +344,7 @@ ParseResult parseKrnlIterateOp(OpAsmParser &parser, OperationState &result) {
 static LogicalResult verify(KrnlIterateOp op) {
   // TODO: Verify number of induction variable bounds matches the number of
   // input loops.
+  // TODO(Tian): return success while waiting for the full implementation?
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/Krnl/KrnlOps.hpp
+++ b/src/Dialect/Krnl/KrnlOps.hpp
@@ -30,8 +30,7 @@ public:
   Type parseType(DialectAsmParser &parser) const override {
     if (succeeded(parser.parseOptionalKeyword("loop")))
       return LoopType::get(parser.getBuilder().getContext());
-
-    parser.emitError(parser.getCurrentLocation(), "Unknown type");
+    llvm_unreachable("Unknown type encountered.");
   }
 
   /// Print a type registered to this dialect.


### PR DESCRIPTION
Fixing warning in compilations, which relates to error handling and functions that returns nothing.

In the process of working on this, Tian and I also located the most relevant error handling suggestions in LLVM, listed below:

http://llvm.org/docs/ProgrammersManual.html#error-handling

and

https://llvm.org/docs/CodingStandards.html#assert-liberally

I suggest that we follow these practices, it may take a while to get there but let's try to do the right thing for the new code