### PR TITLE
name change for tests, to be check-onnx-(lit | backend)

### DIFF
--- a/.buildbot/p9.sh
+++ b/.buildbot/p9.sh
@@ -48,4 +48,4 @@ make -j "$(nproc)" install
 OMP_NUM_THREADS=20 OMP_THREAD_LIMIT=20 ctest3 -j "$(nproc)"
 
 # Run lit+FileCheck tests:
-make check-mlir-lit
+make check-onnx-lit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           command: |
             sudo pip install -q -e ./onnx-mlir/third_party/onnx
             cd onnx-mlir/build
-            cmake --build . --target run-onnx-backend-test
+            cmake --build . --target check-onnx-backend
       - run:
           name: Run DocCheck
           command: cd onnx-mlir/build && cmake --build . --target check-doc

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cmake --build . --target onnx-mlir
 
 # Run FileCheck tests:
 export LIT_OPTS=-v
-cmake --build . --target check-mlir-lit
+cmake --build . --target check-onnx-lit
 ```
 
 After the above commands succeed, an `onnx-mlir` executable should appear in the `bin` directory. 

--- a/test/backend/CMakeLists.txt
+++ b/test/backend/CMakeLists.txt
@@ -2,9 +2,9 @@ configure_file(test.py test.py COPYONLY)
 configure_file(test_config.py.in test_config.py)
 
 find_package(PythonInterp 3 REQUIRED)
-add_custom_target(run-onnx-backend-test
+add_custom_target(check-onnx-backend
         COMMAND ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_BINARY_DIR}/test.py)
 
-add_dependencies(run-onnx-backend-test onnx-mlir)
-add_dependencies(run-onnx-backend-test pyruntime)
+add_dependencies(check-onnx-backend onnx-mlir)
+add_dependencies(check-onnx-backend pyruntime)

--- a/test/mlir/CMakeLists.txt
+++ b/test/mlir/CMakeLists.txt
@@ -8,12 +8,12 @@ configure_lit_site_cfg(${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
 
 set(ONNX_MLIR_TEST_DEPENDS onnx-mlir-opt)
 
-add_lit_testsuite(check-mlir-lit
+add_lit_testsuite(check-onnx-lit
                   "Running the ONNX MLIR regression tests"
                   ${CMAKE_CURRENT_BINARY_DIR}
                   DEPENDS
                   ${ONNX_MLIR_TEST_DEPENDS})
-set_target_properties(check-mlir-lit PROPERTIES FOLDER "Tests")
+set_target_properties(check-onnx-lit PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(ONNX_MLIR
                    ${CMAKE_CURRENT_SOURCE_DIR}

--- a/utils/install-onnx-mlir.sh
+++ b/utils/install-onnx-mlir.sh
@@ -8,4 +8,4 @@ cmake --build . --target onnx-mlir
 
 # Run FileCheck tests:
 export LIT_OPTS=-v
-cmake --build . --target check-mlir-lit
+cmake --build . --target check-onnx-lit


### PR DESCRIPTION
Minor updates, but I got tiered to use 

check-mlir-lit  or run-onnx-backend-test

with very different names. Normalized both to be

check-onnx-lit or check-onnx-backend

