### PR TITLE
Keep the .inc files generated with script (gen_doc.py)

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -6,23 +6,18 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/ONNXOps.td.inc
 
 # Copy the generated files to respective destinations:
 # ONNXOps.td.inc -> src/Dialect/ONNX/ONNXOps.td.inc
-add_custom_command(OUTPUT ${ONNX_MLIR_SRC_ROOT}/src/Dialect/ONNX/ONNXOps.td.inc
+add_custom_target(OMONNXOpsTableGenIncGen
         COMMAND ${CMAKE_COMMAND} -E copy
                 ${CMAKE_CURRENT_SOURCE_DIR}/ONNXOps.td.inc
                 ${ONNX_MLIR_SRC_ROOT}/src/Dialect/ONNX/ONNXOps.td.inc
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ONNXOps.td.inc)
 
 # OpBuildTable.inc -> src/Builder/OpBuildTable.inc
-add_custom_command(OUTPUT ${ONNX_MLIR_SRC_ROOT}/src/Builder/OpBuildTable.inc
+add_custom_target(OMONNXOpsBuildTableIncGen
         COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_CURRENT_SOURCE_DIR}/OpBuildTable.inc
         ${ONNX_MLIR_SRC_ROOT}/src/Builder/OpBuildTable.inc
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/OpBuildTable.inc)
-
-add_custom_target(OMONNXOpsTableGenIncGen
-        DEPENDS ${ONNX_MLIR_SRC_ROOT}/src/Dialect/ONNX/ONNXOps.td.inc)
-add_custom_target(OMONNXOpsBuildTableIncGen
-        DEPENDS ${ONNX_MLIR_SRC_ROOT}/src/Builder/OpBuildTable.inc)
 
 add_custom_target(OMONNXOpsIncTranslation
         DEPENDS OMONNXOpsTableGenIncGen


### PR DESCRIPTION
After the PR #58 , I ran into an error in make if I run "make clean" first. The reason is that the .inc files in src are removed because they are intermediate result to Cmake now. 
Simple change is not to expose them as intermediate result.