### PR TITLE
generate Operations for ONNX.ML domain

### DIFF
--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -316,3 +316,39 @@ if (opName == "Where")
   return buildOperation<mlir::ONNXWhereOp>(node, /* expected_num_operands = */ 3, /* expected_num_results = */ 1);
 if (opName == "Xor")
   return buildOperation<mlir::ONNXXorOp>(node, /* expected_num_operands = */ 2, /* expected_num_results = */ 1);
+if (opName == "ArrayFeatureExtractor")
+  return buildOperation<mlir::ONNXArrayFeatureExtractorOp>(node, /* expected_num_operands = */ 2, /* expected_num_results = */ 1);
+if (opName == "Binarizer")
+  return buildOperation<mlir::ONNXBinarizerOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "CastMap")
+  return buildOperation<mlir::ONNXCastMapOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "CategoryMapper")
+  return buildOperation<mlir::ONNXCategoryMapperOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "DictVectorizer")
+  return buildOperation<mlir::ONNXDictVectorizerOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "FeatureVectorizer")
+  return buildOperation<mlir::ONNXFeatureVectorizerOp>(node, /* expected_num_operands = */ -1, /* expected_num_results = */ 1);
+if (opName == "Imputer")
+  return buildOperation<mlir::ONNXImputerOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "LabelEncoder")
+  return buildOperation<mlir::ONNXLabelEncoderOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "LinearClassifier")
+  return buildOperation<mlir::ONNXLinearClassifierOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 2);
+if (opName == "LinearRegressor")
+  return buildOperation<mlir::ONNXLinearRegressorOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "Normalizer")
+  return buildOperation<mlir::ONNXNormalizerOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "OneHotEncoder")
+  return buildOperation<mlir::ONNXOneHotEncoderOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "SVMClassifier")
+  return buildOperation<mlir::ONNXSVMClassifierOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 2);
+if (opName == "SVMRegressor")
+  return buildOperation<mlir::ONNXSVMRegressorOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "Scaler")
+  return buildOperation<mlir::ONNXScalerOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "TreeEnsembleClassifier")
+  return buildOperation<mlir::ONNXTreeEnsembleClassifierOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 2);
+if (opName == "TreeEnsembleRegressor")
+  return buildOperation<mlir::ONNXTreeEnsembleRegressorOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);
+if (opName == "ZipMap")
+  return buildOperation<mlir::ONNXZipMapOp>(node, /* expected_num_operands = */ 1, /* expected_num_results = */ 1);

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -1475,15 +1475,15 @@ def ONNXLoopOp:ONNX_Op<"Loop",
   "    }"
   ""
   "    graph body-net ("
-  "      %i[INT32, scalar]"
-  "      %keepgoing[BOOL, scalar]"
-  "      %b[INT32, scalar]"
+  "      %i[INT32, scalar]           // iteration number"
+  "      %keepgoing_in[BOOL, scalar] // incoming loop-termination-condition; not used"
+  "      %b_in[INT32, scalar]        // incoming value of loop-carried-dependency b"
   "    ) {"
-  "      %my_local = Add(%a, %b)"
-  "      %b_out = Sub(%a, %b)"
-  "      %keepgoing_out = Greater(%my_local, %b_out)"
-  "      %user_defined_vals = Add(%b, %b)"
-  "      return %keepgoing_out, %b_out, %user_defined_vals"
+  "      %my_local = Add(%a, %b_in)"
+  "      %b_out = Sub(%a, %b_in) // outgoing value of loop-carried-dependency b"
+  "      %keepgoing_out = Greater(%my_local, %b_out) // outgoing loop-termination-condition"
+  "      %user_defined_val = Add(%b_in, %b_in) // scan-output value to be accumulated"
+  "      return %keepgoing_out, %b_out, %user_defined_val"
   "    }"
   ""
   "*Sample equivalent C code*"
@@ -1498,29 +1498,49 @@ def ONNXLoopOp:ONNX_Op<"Loop",
   "      const int max_trip_count = 10; // Analogous to input M"
   "      int user_defined_vals[]; // Imagine this is resizable"
   "      /* End implicitly-defined code */"
-  "      for (int i=0; i < max_trip_count && keepgoing; ++i) {"
-  "        /* User-defined code (loop body) */"
-  "        int my_local = a + b; // Reading values in the enclosing scope is fine"
-  "        b = a - b; // writes fine if we specify b as a loop-carried dependency"
-  "        keepgoing = my_local > b; // keepgoing is a loop-carried dependency"
-  "        user_defined_vals[i] = b + b;"
-  "        /* End user-defined code */"
-  "      }"
-  "      // my_local = 123; // Can't do this. my_local was defined in the the body"
+  "      /* initialize loop-carried variables and scan-output variables */"
+  "      bool keepgoing_out = keepgoing"
+  "      int b_out = b"
   ""
-  "      // These below values are live-out from the loop and therefore accessible"
-  "      b_out; user_defined_vals; keepgoing_out;"
+  "      for (int i=0; i < max_trip_count && keepgoing_out; ++i) {"
+  "        /* Implicitly-defined code: bind actual parameter values"
+  "           to formal parameter variables of loop-body */"
+  "        bool keepgoing_in = keepgoing_out; "
+  "        bool b_in = b_out;"
+  ""
+  "        /* User-defined code (loop body) */"
+  "        int my_local = a + b_in; // Reading value \"a\" from the enclosing scope is fine"
+  "        b_out = a - b_in;"
+  "        keepgoing_out = my_local > b_out; "
+  "        user_defined_val = b_in + b_in; // b_in and b_out are different variables"
+  "        /* End user-defined code */"
+  ""
+  "        /* Implicitly defined-code */"
+  "        user_defined_vals[i] = user_defined_val // accumulate scan-output values"
+  "      }"
+  "      // int t = my_local; // Can't do this. my_local is not accessible here."
+  ""
+  "      // The values below are bound to the output variables of the loop and therefore accessible"
+  "      // b_out; user_defined_vals; keepgoing_out;"
   "    }"
   ""
   "There are several things of note in this code snippet:"
   ""
-  "1) Values from the enclosing scope (i.e. variable a here) are in scope and can"
+  "1) Values from the enclosing scope (i.e. variable \"a\" here) are in scope and can"
   "   be referenced in the inputs of the loop."
-  "2) Any variables which you wish to make available in the enclosing scope (i.e."
-  "   the variables b and keepgoing) must be declared as either loop-carried"
-  "   dependencies (both at the op inputs and output and at the body net input and"
-  "   output) or scan_outputs."
-  "3) Values created in the body cannot be accessed in the enclosing scope."
+  "2) Any values computed in the loop body that needs to be used in a subsequent"
+  "   iteration or after the loop are modelled using a pair of variables in the loop-body,"
+  "   consisting of an input variable (eg., b_in) and an output variable (eg., b_out)."
+  "   These are referred to as loop-carried dependences. The loop operation node"
+  "   supplies the input value of the input variable for the first iteration, and"
+  "   returns the output value of the output variable produced by the final"
+  "   iteration."
+  "3) Scan_output variables are used to implicitly concatenate values computed across"
+  "   all the iterations. In the above example, the value of user_defined_val computed"
+  "   over all iterations are concatenated and returned as the value of user_defined_vals"
+  "   after the loop."
+  "4) Values created in the body cannot be accessed in the enclosing scope,"
+  "   except using the mechanism described above."
   ""
   "Note that the semantics of this op support \"diagonal\" or \"wavefront\" execution."
   "(See Step 3 here for an example:"
@@ -3633,5 +3653,372 @@ def ONNXXorOp:ONNX_Op<"Xor",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$A,
     AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$C);
+}
+
+def ONNXArrayFeatureExtractorOp:ONNX_Op<"ArrayFeatureExtractor",
+  [NoSideEffect]> {
+  let summary = "ONNX ArrayFeatureExtractor operation";
+  let description = [{
+  "Select elements of the input tensor based on the indices passed.<br>"
+  "    The indices are applied to the last axes of the tensor."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Z);
+}
+
+def ONNXBinarizerOp:ONNX_Op<"Binarizer",
+  [NoSideEffect]> {
+  let summary = "ONNX Binarizer operation";
+  let description = [{
+  "Maps the values of the input tensor to either 0 or 1, element-wise, based on the outcome of a comparison against a threshold value."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    DefaultValuedAttr<F32Attr, "0.0">:$threshold);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXCastMapOp:ONNX_Op<"CastMap",
+  [NoSideEffect]> {
+  let summary = "ONNX CastMap operation";
+  let description = [{
+  "Converts a map to a tensor.<br>The map key must be an int64 and the values will be ordered"
+  "    in ascending order based on this key.<br>The operator supports dense packing or sparse packing."
+  "    If using sparse packing, the key cannot exceed the max_map-1 value."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    DefaultValuedAttr<StrAttr, "TO_FLOAT">:$cast_to,
+    DefaultValuedAttr<StrAttr, "DENSE">:$map_form,
+    DefaultValuedAttr<I64Attr, "1">:$max_map);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXCategoryMapperOp:ONNX_Op<"CategoryMapper",
+  [NoSideEffect]> {
+  let summary = "ONNX CategoryMapper operation";
+  let description = [{
+  "Converts strings to integers and vice versa.<br>"
+  "    Two sequences of equal length are used to map between integers and strings,"
+  "    with strings and integers at the same index detailing the mapping.<br>"
+  "    Each operator converts either integers to strings or strings to integers, depending "
+  "    on which default value attribute is provided. Only one default value attribute"
+  "    should be defined.<br>"
+  "    If the string default value is set, it will convert integers to strings."
+  "    If the int default value is set, it will convert strings to integers."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<I64ArrayAttr>:$cats_int64s,
+    OptionalAttr<StrArrayAttr>:$cats_strings,
+    DefaultValuedAttr<I64Attr, "-1">:$default_int64,
+    DefaultValuedAttr<StrAttr, "_Unused">:$default_string);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXDictVectorizerOp:ONNX_Op<"DictVectorizer",
+  [NoSideEffect]> {
+  let summary = "ONNX DictVectorizer operation";
+  let description = [{
+  "Uses an index mapping to convert a dictionary to an array.<br>"
+  "    Given a dictionary, each key is looked up in the vocabulary attribute corresponding to"
+  "    the key type. The index into the vocabulary array at which the key is found is then"
+  "    used to index the output 1-D tensor 'Y' and insert into it the value found in the dictionary 'X'.<br>"
+  "    The key type of the input map must correspond to the element type of the defined vocabulary attribute."
+  "    Therefore, the output array will be equal in length to the index mapping vector parameter."
+  "    All keys in the input dictionary must be present in the index mapping vector."
+  "    For each item in the input dictionary, insert its value in the output array."
+  "    Any keys not present in the input dictionary, will be zero in the output array.<br>"
+  "    For example: if the ``string_vocabulary`` parameter is set to ``[\"a\", \"c\", \"b\", \"z\"]``,"
+  "    then an input of ``{\"a\": 4, \"c\": 8}`` will produce an output of ``[4, 8, 0, 0]``."
+  "    "
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<I64ArrayAttr>:$int64_vocabulary,
+    OptionalAttr<StrArrayAttr>:$string_vocabulary);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXFeatureVectorizerOp:ONNX_Op<"FeatureVectorizer",
+  [NoSideEffect]> {
+  let summary = "ONNX FeatureVectorizer operation";
+  let description = [{
+  "Concatenates input tensors into one continuous output.<br>"
+  "    All input shapes are 2-D and are concatenated along the second dimention. 1-D tensors are treated as [1,C]."
+  "    Inputs are copied to the output maintaining the order of the input arguments.<br>"
+  "    All inputs must be integers or floats, while the output will be all floating point values."
+  }];
+  let arguments = (ins Variadic<AnyTypeOf<[AnyMemRef, AnyTensor]>>:$X,
+    OptionalAttr<I64ArrayAttr>:$inputdimensions);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXImputerOp:ONNX_Op<"Imputer",
+  [NoSideEffect]> {
+  let summary = "ONNX Imputer operation";
+  let description = [{
+  "Replaces inputs that equal one value with another, leaving all other elements alone.<br>"
+  "    This operator is typically used to replace missing values in situations where they have a canonical"
+  "    representation, such as -1, 0, NaN, or some extreme value.<br>"
+  "    One and only one of imputed_value_floats or imputed_value_int64s should be defined -- floats if the input tensor"
+  "    holds floats, integers if the input tensor holds integers. The imputed values must all fit within the"
+  "    width of the tensor element type. One and only one of the replaced_value_float or replaced_value_int64 should be defined,"
+  "    which one depends on whether floats or integers are being processed.<br>"
+  "    The imputed_value attribute length can be 1 element, or it can have one element per input feature.<br>In other words, if the input tensor has the shape [*,F], then the length of the attribute array may be 1 or F. If it is 1, then it is broadcast along the last dimension and applied to each feature."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<F32ArrayAttr>:$imputed_value_floats,
+    OptionalAttr<I64ArrayAttr>:$imputed_value_int64s,
+    DefaultValuedAttr<F32Attr, "0.0">:$replaced_value_float,
+    DefaultValuedAttr<I64Attr, "0">:$replaced_value_int64);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXLabelEncoderOp:ONNX_Op<"LabelEncoder",
+  [NoSideEffect]> {
+  let summary = "ONNX LabelEncoder operation";
+  let description = [{
+  "Maps each element in the input tensor to another value.<br>"
+  "    The mapping is determined by the two parallel attributes, 'keys_*' and"
+  "    'values_*' attribute. The i-th value in the specified 'keys_*' attribute"
+  "    would be mapped to the i-th value in the specified 'values_*' attribute. It"
+  "    implies that input's element type and the element type of the specified"
+  "    'keys_*' should be identical while the output type is identical to the"
+  "    specified 'values_*' attribute. If an input element can not be found in the"
+  "    specified 'keys_*' attribute, the 'default_*' that matches the specified"
+  "    'values_*' attribute may be used as its output value.<br>"
+  "    Let's consider an example which maps a string tensor to an integer tensor."
+  "    Assume and 'keys_strings' is [\"Amy\", \"Sally\"], 'values_int64s' is [5, 6],"
+  "    and 'default_int64' is '-1'.  The input [\"Dori\", \"Amy\", \"Amy\", \"Sally\","
+  "    \"Sally\"] would be mapped to [-1, 5, 5, 6, 6].<br>"
+  "    Since this operator is an one-to-one mapping, its input and output shapes"
+  "    are the same. Notice that only one of 'keys_*'/'values_*' can be set.<br>"
+  "    For key look-up, bit-wise comparison is used so even a float NaN can be"
+  "    mapped to a value in 'values_*' attribute.<br>"
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    DefaultValuedAttr<F32Attr, "-0.0">:$default_float,
+    DefaultValuedAttr<I64Attr, "-1">:$default_int64,
+    DefaultValuedAttr<StrAttr, "_Unused">:$default_string,
+    OptionalAttr<F32ArrayAttr>:$keys_floats,
+    OptionalAttr<I64ArrayAttr>:$keys_int64s,
+    OptionalAttr<StrArrayAttr>:$keys_strings,
+    OptionalAttr<F32ArrayAttr>:$values_floats,
+    OptionalAttr<I64ArrayAttr>:$values_int64s,
+    OptionalAttr<StrArrayAttr>:$values_strings);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXLinearClassifierOp:ONNX_Op<"LinearClassifier",
+  [NoSideEffect]> {
+  let summary = "ONNX LinearClassifier operation";
+  let description = [{
+  "Linear classifier"
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<I64ArrayAttr>:$classlabels_ints,
+    OptionalAttr<StrArrayAttr>:$classlabels_strings,
+    F32ArrayAttr:$coefficients,
+    OptionalAttr<F32ArrayAttr>:$intercepts,
+    DefaultValuedAttr<I64Attr, "0">:$multi_class,
+    DefaultValuedAttr<StrAttr, "NONE">:$post_transform);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y,
+    AnyTypeOf<[AnyMemRef, AnyTensor]>:$Z);
+}
+
+def ONNXLinearRegressorOp:ONNX_Op<"LinearRegressor",
+  [NoSideEffect]> {
+  let summary = "ONNX LinearRegressor operation";
+  let description = [{
+  "Generalized linear regression evaluation.<br>"
+  "    If targets is set to 1 (default) then univariate regression is performed.<br>"
+  "    If targets is set to M then M sets of coefficients must be passed in as a sequence"
+  "    and M results will be output for each input n in N.<br>"
+  "    The coefficients array is of length n, and the coefficients for each target are contiguous."
+  "    Intercepts are optional but if provided must match the number of targets."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<F32ArrayAttr>:$coefficients,
+    OptionalAttr<F32ArrayAttr>:$intercepts,
+    DefaultValuedAttr<StrAttr, "NONE">:$post_transform,
+    DefaultValuedAttr<I64Attr, "1">:$targets);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXNormalizerOp:ONNX_Op<"Normalizer",
+  [NoSideEffect]> {
+  let summary = "ONNX Normalizer operation";
+  let description = [{
+  "Normalize the input.  There are three normalization modes, which have the corresponding formulas,"
+  "    defined using element-wise infix operators '/' and '^' and tensor-wide functions 'max' and 'sum':<br>"
+  "<br>"
+  "    Max: Y = X / max(X)<br>"
+  "    L1:  Y = X / sum(X)<br>"
+  "    L2:  Y = sqrt(X^2 / sum(X^2)}<br>"
+  "    In all modes, if the divisor is zero, Y == X."
+  "<br>"
+  "    For batches, that is, [N,C] tensors, normalization is done along the C axis. In other words, each row"
+  "    of the batch is normalized independently."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    DefaultValuedAttr<StrAttr, "MAX">:$norm);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXOneHotEncoderOp:ONNX_Op<"OneHotEncoder",
+  [NoSideEffect]> {
+  let summary = "ONNX OneHotEncoder operation";
+  let description = [{
+  "Replace each input element with an array of ones and zeros, where a single"
+  "    one is placed at the index of the category that was passed in. The total category count "
+  "    will determine the size of the extra dimension of the output array Y.<br>"
+  "    For example, if we pass a tensor with a single value of 4, and a category count of 8, "
+  "    the output will be a tensor with ``[0,0,0,0,1,0,0,0]``.<br>"
+  "    This operator assumes every input feature is from the same set of categories.<br>"
+  "    If the input is a tensor of float, int32, or double, the data will be cast"
+  "    to integers and the cats_int64s category list will be used for the lookups."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<I64ArrayAttr>:$cats_int64s,
+    OptionalAttr<StrArrayAttr>:$cats_strings,
+    DefaultValuedAttr<I64Attr, "1">:$zeros);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXSVMClassifierOp:ONNX_Op<"SVMClassifier",
+  [NoSideEffect]> {
+  let summary = "ONNX SVMClassifier operation";
+  let description = [{
+  "Support Vector Machine classifier"
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<I64ArrayAttr>:$classlabels_ints,
+    OptionalAttr<StrArrayAttr>:$classlabels_strings,
+    OptionalAttr<F32ArrayAttr>:$coefficients,
+    OptionalAttr<F32ArrayAttr>:$kernel_params,
+    DefaultValuedAttr<StrAttr, "LINEAR">:$kernel_type,
+    DefaultValuedAttr<StrAttr, "NONE">:$post_transform,
+    OptionalAttr<F32ArrayAttr>:$prob_a,
+    OptionalAttr<F32ArrayAttr>:$prob_b,
+    OptionalAttr<F32ArrayAttr>:$rho,
+    OptionalAttr<F32ArrayAttr>:$support_vectors,
+    OptionalAttr<I64ArrayAttr>:$vectors_per_class);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y,
+    AnyTypeOf<[AnyMemRef, AnyTensor]>:$Z);
+}
+
+def ONNXSVMRegressorOp:ONNX_Op<"SVMRegressor",
+  [NoSideEffect]> {
+  let summary = "ONNX SVMRegressor operation";
+  let description = [{
+  "Support Vector Machine regression prediction and one-class SVM anomaly detection."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<F32ArrayAttr>:$coefficients,
+    OptionalAttr<F32ArrayAttr>:$kernel_params,
+    DefaultValuedAttr<StrAttr, "LINEAR">:$kernel_type,
+    DefaultValuedAttr<I64Attr, "0">:$n_supports,
+    DefaultValuedAttr<I64Attr, "0">:$one_class,
+    DefaultValuedAttr<StrAttr, "NONE">:$post_transform,
+    OptionalAttr<F32ArrayAttr>:$rho,
+    OptionalAttr<F32ArrayAttr>:$support_vectors);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXScalerOp:ONNX_Op<"Scaler",
+  [NoSideEffect]> {
+  let summary = "ONNX Scaler operation";
+  let description = [{
+  "Rescale input data, for example to standardize features by removing the mean and scaling to unit variance."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<F32ArrayAttr>:$offset,
+    OptionalAttr<F32ArrayAttr>:$scale);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXTreeEnsembleClassifierOp:ONNX_Op<"TreeEnsembleClassifier",
+  [NoSideEffect]> {
+  let summary = "ONNX TreeEnsembleClassifier operation";
+  let description = [{
+  "Tree Ensemble classifier.  Returns the top class for each of N inputs.<br>"
+  "    The attributes named 'nodes_X' form a sequence of tuples, associated by "
+  "    index into the sequences, which must all be of equal length. These tuples"
+  "    define the nodes.<br>"
+  "    Similarly, all fields prefixed with 'class_' are tuples of votes at the leaves."
+  "    A leaf may have multiple votes, where each vote is weighted by"
+  "    the associated class_weights index.<br>"
+  "    One and only one of classlabels_strings or classlabels_int64s"
+  "    will be defined. The class_ids are indices into this list."
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<F32ArrayAttr>:$base_values,
+    OptionalAttr<I64ArrayAttr>:$class_ids,
+    OptionalAttr<I64ArrayAttr>:$class_nodeids,
+    OptionalAttr<I64ArrayAttr>:$class_treeids,
+    OptionalAttr<F32ArrayAttr>:$class_weights,
+    OptionalAttr<I64ArrayAttr>:$classlabels_int64s,
+    OptionalAttr<StrArrayAttr>:$classlabels_strings,
+    OptionalAttr<I64ArrayAttr>:$nodes_falsenodeids,
+    OptionalAttr<I64ArrayAttr>:$nodes_featureids,
+    OptionalAttr<F32ArrayAttr>:$nodes_hitrates,
+    OptionalAttr<I64ArrayAttr>:$nodes_missing_value_tracks_true,
+    OptionalAttr<StrArrayAttr>:$nodes_modes,
+    OptionalAttr<I64ArrayAttr>:$nodes_nodeids,
+    OptionalAttr<I64ArrayAttr>:$nodes_treeids,
+    OptionalAttr<I64ArrayAttr>:$nodes_truenodeids,
+    OptionalAttr<F32ArrayAttr>:$nodes_values,
+    DefaultValuedAttr<StrAttr, "NONE">:$post_transform);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y,
+    AnyTypeOf<[AnyMemRef, AnyTensor]>:$Z);
+}
+
+def ONNXTreeEnsembleRegressorOp:ONNX_Op<"TreeEnsembleRegressor",
+  [NoSideEffect]> {
+  let summary = "ONNX TreeEnsembleRegressor operation";
+  let description = [{
+  "Tree Ensemble regressor.  Returns the regressed values for each input in N.<br>"
+  "    All args with nodes_ are fields of a tuple of tree nodes, and"
+  "    it is assumed they are the same length, and an index i will decode the"
+  "    tuple across these inputs.  Each node id can appear only once"
+  "    for each tree id.<br>"
+  "    All fields prefixed with target_ are tuples of votes at the leaves.<br>"
+  "    A leaf may have multiple votes, where each vote is weighted by"
+  "    the associated target_weights index.<br>"
+  "    All trees must have their node ids start at 0 and increment by 1.<br>"
+  "    Mode enum is BRANCH_LEQ, BRANCH_LT, BRANCH_GTE, BRANCH_GT, BRANCH_EQ, BRANCH_NEQ, LEAF"
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    DefaultValuedAttr<StrAttr, "SUM">:$aggregate_function,
+    OptionalAttr<F32ArrayAttr>:$base_values,
+    OptionalAttr<I64Attr>:$n_targets,
+    OptionalAttr<I64ArrayAttr>:$nodes_falsenodeids,
+    OptionalAttr<I64ArrayAttr>:$nodes_featureids,
+    OptionalAttr<F32ArrayAttr>:$nodes_hitrates,
+    OptionalAttr<I64ArrayAttr>:$nodes_missing_value_tracks_true,
+    OptionalAttr<StrArrayAttr>:$nodes_modes,
+    OptionalAttr<I64ArrayAttr>:$nodes_nodeids,
+    OptionalAttr<I64ArrayAttr>:$nodes_treeids,
+    OptionalAttr<I64ArrayAttr>:$nodes_truenodeids,
+    OptionalAttr<F32ArrayAttr>:$nodes_values,
+    DefaultValuedAttr<StrAttr, "NONE">:$post_transform,
+    OptionalAttr<I64ArrayAttr>:$target_ids,
+    OptionalAttr<I64ArrayAttr>:$target_nodeids,
+    OptionalAttr<I64ArrayAttr>:$target_treeids,
+    OptionalAttr<F32ArrayAttr>:$target_weights);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
+}
+
+def ONNXZipMapOp:ONNX_Op<"ZipMap",
+  [NoSideEffect]> {
+  let summary = "ONNX ZipMap operation";
+  let description = [{
+  "Creates a map from the input and the attributes.<br>"
+  "    The values are provided by the input tensor, while the keys are specified by the attributes."
+  "    Must provide keys in either classlabels_strings or classlabels_int64s (but not both).<br>"
+  "    The columns of the tensor correspond one-by-one to the keys specified by the attributes. There must be as many columns as keys.<br>"
+  }];
+  let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
+    OptionalAttr<I64ArrayAttr>:$classlabels_int64s,
+    OptionalAttr<StrArrayAttr>:$classlabels_strings);
+  let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Z);
 }
 

--- a/utils/gen_doc.py
+++ b/utils/gen_doc.py
@@ -86,22 +86,8 @@ custom_builder_ops_list = ['Abs', 'Mul', 'Exp', 'ReduceSum', 'ReduceSumSquare']
 
 SNIPPETS = collect_snippets()
 SAMPLE_IMPLEMENTATIONS = collect_sample_implementations()
-ONNX_ML = not bool(os.getenv('ONNX_ML') == '0')
-
-ONNX_ML = False
-sys.stderr.write("ONNX_ML {}\n".format(ONNX_ML))
-
-if ONNX_ML:
-    ext = '-ml.md'
-else:
-    ext = '.md'
-
 
 def should_render_domain(domain):  # type: (Text) -> bool
-    if domain == ONNX_ML_DOMAIN and not ONNX_ML:
-        return False
-    elif ONNX_ML and domain != ONNX_ML_DOMAIN:
-        return False
     return True
 
 


### PR DESCRIPTION
Allow ONNX.ML domain in operation generation. 
Attached to the previous ONNX operations
ONNX.ML operations are not separated from ONNX. Do we want another dialect? Or put a mark in name?