### PR TITLE
Fix converting type for functions with no argument

### DIFF
--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -181,7 +181,8 @@ struct TensorTypeConverter : public TypeConverter {
   /// override needs to be removed in favour of the original MLIR one.]
   bool isSignatureLegal(FunctionType funcType) {
     return llvm::all_of(
-        funcType.getInputs(), [this](Type type) { return isLegal(type); });
+        llvm::concat<const Type>(funcType.getInputs(), funcType.getResults()),
+        [this](Type type) { return isLegal(type); });
   }
 };
 

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -1,5 +1,21 @@
 // RUN: onnx-mlir-opt --shape-inference --lower-frontend %s -split-input-file | FileCheck %s
 
+// ----
+
+func @test_no_argument_1() -> () {
+}
+
+func @test_no_argument_2() -> tensor<*xf32> {
+  %0 = "onnx.Constant"() {value =  dense<[[1.000000e+0, 2.000000e+00], [3.000000e+00, 4.000000e+00]]> : tensor<2x2xf32>} : () -> tensor<*xf32>
+  "std.return"(%0) : (tensor<*xf32>) -> ()
+
+}
+
+// CHECK: test_no_argument_1
+// CHECK-NEXT: test_no_argument_2
+// CHECK: [[RES:%.+]] = "{{.*}}"({{.*}}) {{.*}} : ({{.*}}) -> memref<2x2xf32>
+// CHECK: return [[RES]] : memref<2x2xf32>
+
 // -----
 
 func @test_add(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {


### PR DESCRIPTION
Resolves #65.

With this patch, we are able to lower the following code:
```mlir
func @main() -> tensor<*xf32> {
  %0 = "onnx.Constant"() {value =  dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf32>} : () -> tensor<*xf32>
  "std.return"(%0) : (tensor<*xf32>) -> ()
}
````

`onnx-mlir-opt --shape-inference  --lower-frontend test-constant.mlir ` yields:
```mlir
module {
  func @main() -> memref<2x3xf32> {
    %0 = "krnl.global"() {name = "constant_0", shape = [2, 3], value = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf32>} : () -> memref<2x3xf32>
    return %0 : memref<2x3xf32>
  }
}
````