### PR TITLE
Fix garbled filename output

### DIFF
--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -107,8 +107,8 @@ void outputCode(
   // Start a separate process to redirect the model output. I/O redirection
   // changes will not be visible to the parent process.
   if (fork() == 0) {
-    const char * tempFilename = (filename + extension).c_str();
-    freopen(tempFilename, "w", stderr);
+    string tempFilename = filename + extension;
+    freopen(tempFilename.c_str(), "w", stderr);
     module->dump();
     fclose(stderr);
     exit(0);


### PR DESCRIPTION
Refer to issue: https://github.com/onnx/onnx-mlir/issues/112

Saving the concatenation to a local variable should prevent `.c_str()` from getting invalid memory.