### PR TITLE
save and check the version of ONNX operation

### DIFF
--- a/docs/ImportONNXDefs.md
+++ b/docs/ImportONNXDefs.md
@@ -33,4 +33,5 @@ Several tables are defined at the beginning of the script:
 
 ## Version of Operations
 As stated previous, we try to support the latest version of ONNX operations. The version of each operation currently supported is recorded in gen_onnx_mlir.py. This mechanism provides some stability in version. To check the changes in version, run gen_onnx_mlir.py with flag "--check-version" and the changes will be reported. To move to a newer version, manually update the version dictionary in the script.
+Supporting mulitple versions of one operation is not available yet.
 

--- a/docs/ImportONNXDefs.md
+++ b/docs/ImportONNXDefs.md
@@ -22,7 +22,7 @@ Even though we strive to support the latest version of ONNX specification as qui
 Due to the possibility of such a delay, operator definition within the ONNX project repository may describe features and schemas that we do not yet support.
 
 ## Customization
-In addition to following the ONNX specification, the modified gen_doc.py provides some mechanism for you to customize the output. 
+In addition to following the ONNX specification, the script gen_onnx_mlir.py,  modified gen_doc.py, provides some mechanism for you to customize the output. 
 Several tables are defined at the beginning of the script:
 1. `special_attr_defaults`: gives attribute special default value.
 2. `special_op_handler`: creates special import function in frontend_dialect_transformer.cpp. Currently, a special handler is used for operations with operational arguments
@@ -30,3 +30,7 @@ Several tables are defined at the beginning of the script:
 4. `OpsWithCanonicalizer`: list of operations which have a canonical form
 5. `OpsWithPromotableConstOperands`: list of operations which have operands that, if produced by constant operations, should be promoted to become an attribute (via attribute promotion)
 6. `custom_builder_ops_list`: list of operations which need custom build methods to deduce result types
+
+## Version of Operations
+As stated previous, we try to support the latest version of ONNX operations. The version of each operation currently supported is recorded in gen_onnx_mlir.py. This mechanism provides some stability in version. To check the changes in version, run gen_onnx_mlir.py with flag "--check-version" and the changes will be reported. To move to a newer version, manually update the version dictionary in the script.
+

--- a/src/Builder/OpBuildTable.inc.dc
+++ b/src/Builder/OpBuildTable.inc.dc
@@ -1,1 +1,1 @@
-file-same-as-stdout({"file": "src/Builder/OpBuildTable.inc", "cmd": ["python", "utils/gen_doc.py", "--dry-run-op-build-table"]})
+file-same-as-stdout({"file": "src/Builder/OpBuildTable.inc", "cmd": ["python", "utils/gen_onnx_mlir.py", "--dry-run-op-build-table"]})

--- a/src/Dialect/ONNX/ONNXOps.td.inc.dc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc.dc
@@ -1,1 +1,1 @@
-file-same-as-stdout({"file": "src/Dialect/ONNX/ONNXOps.td.inc", "cmd": ["python", "utils/gen_doc.py", "--dry-run-onnx-ops"]})
+file-same-as-stdout({"file": "src/Dialect/ONNX/ONNXOps.td.inc", "cmd": ["python", "utils/gen_onnx_mlir.py", "--dry-run-onnx-ops"]})

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Invoke gen_doc.py to obtain ONNXOps.td.inc, OpBuildTable.inc.
+# Invoke gen_onnx_mlir.py to obtain ONNXOps.td.inc, OpBuildTable.inc.
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/ONNXOps.td.inc
                 ${CMAKE_CURRENT_SOURCE_DIR}/OpBuildTable.inc
-        COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen_doc.py
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_doc.py)
+        COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py)
 
 # Move the generated files to respective destinations:
 # ONNXOps.td.inc -> src/Dialect/ONNX/ONNXOps.td.inc
@@ -23,11 +23,11 @@ add_custom_target(OMONNXOpsIncTranslation
         DEPENDS OMONNXOpsTableGenIncGen
                 OMONNXOpsBuildTableIncGen)
 
-# Invoke gen_doc.py to obtain ONNXOps.td.inc, OpBuildTable.inc.
+# Invoke gen_onnx_mlir.py to obtain ONNXOps.td.inc, OpBuildTable.inc.
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/MLONNXOps.td.inc
                 ${CMAKE_CURRENT_SOURCE_DIR}/MLOpBuildTable.inc
-       	COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen_doc.py --domain="ONNX_ML"
-       	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_doc.py)
+       	COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py --domain="ONNX_ML"
+       	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py)
 
 # Move the generated files to respective destinations:
 # MLONNXOps.td.inc -> src/Dialect/MLONNX/MLONNXOps.td.inc
@@ -47,3 +47,11 @@ add_custom_target(OMMLONNXOpsBuildTableIncGen
 add_custom_target(OMMLONNXOpsIncTranslation
        	DEPENDS OMMLONNXOpsTableGenIncGen
                	OMMLONNXOpsBuildTableIncGen)
+
+add_custom_target(OMONNXCheckVersion
+       	COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py --check-operation-version)
+
+add_custom_target(OMMLONNXCheckVersion
+       	COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py 
+                --check-operation-version --domain="ONNX_ML")
+        

--- a/utils/gen_doc.py
+++ b/utils/gen_doc.py
@@ -32,7 +32,7 @@ parser.add_argument("--dry-run-op-build-table",
                     action="store_true",
                     default=False)
 parser.add_argument("--generate-for-latest-version",
-                    help="generate operation for the latest version,"+
+                    help="generate operation for the latest versionin your installation,"+
                          " not according to version_dicts",
                     action="store_true",
                     default=False)
@@ -45,9 +45,9 @@ args = parser.parse_args()
 generate_for_latest_version = args.generate_for_latest_version
 
 
-#Record the version of each operation that is treated as the current version
-#To include the newer version, run this script with --generate-for-latest-version flag.
-#Update this dictionary with the output of the script.
+# Record the version of each operation that is treated as the current version.
+# To include the newer version, run this script with --generate-for-latest-version flag.
+# Update this dictionary with the output of the script.
 version_dict = {'Abs': 6,
  'Acos': 7,
  'Acosh': 9,
@@ -718,23 +718,23 @@ def build_operator_schemas():
                     continue
 
                 if generate_for_latest_version :
-                    #As did preciously, generate operation for the latest version.
+                    # Generate operation of the latest version of your onnx.
                     exsting_ops.add(schema.name)
                     processed_namemap.append((n, schema, versions))
 
-                    #Add checks against version_dict
+                    # Add checks against version_dict
                     if schema.name not in version_dict :
                         print("Warning: a new schema {}".format(schema.name))
                     if schema.since_version <  version_dict[schema.name]:
                         print("Warning: a newer version for schema {}".format(
                             schema.name))
                 else:
-                    #Generate operation according to the version in version_dict.
+                    # Generate operation according to the version in version_dict.
                     if schema.name not in version_dict :
                         continue
                     found = False
                     for schema in reversed(versions):
-                        # check the version number
+                        # Check the version number against the version_dict
                         if schema.since_version == version_dict[schema.name]:
                             exsting_ops.add(schema.name)
                             processed_namemap.append((n, schema, versions))

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -748,10 +748,10 @@ def build_operator_schemas():
 
                     # Add checks against version_dict
                     if schema.name not in version_dict :
-                        print("Warning: Operation {} with version is new".format(
+                        print("Check-operation-version: Operation {} with version is new".format(
                             schema.since_version, schema.name))
                     elif schema.since_version >  version_dict[schema.name]:
-                        print("Warning: Operation {} has a newer version {}"+
+                        print("Check-operation-version: Operation {} has a newer version {}"+
                             "(old version {})".format( schema.name, 
                             schema.since_version, version_dict[schema.name]))
                 else:

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -751,8 +751,9 @@ def build_operator_schemas():
                         print("Warning: Operation {} with version is new".format(
                             schema.since_version, schema.name))
                     elif schema.since_version >  version_dict[schema.name]:
-                        print("Warning: Operation {} has a newer version {} (old version {})".format(
-                            schema.name, schema.since_version, version_dict[schema.name]))
+                        print("Warning: Operation {} has a newer version {}"+
+                            "(old version {})".format( schema.name, 
+                            schema.since_version, version_dict[schema.name]))
                 else:
                     # Generate operation according to the version in version_dict.
                     if schema.name not in version_dict :


### PR DESCRIPTION
This patch is intended to handle the change of ONNX specification. The current latest version of operations are saved as a dictionary in the script. The generation for onnx-mlir Tablegen will choose that version even if ONNX package is upgraded. 
To move forward to the latest version of onnx installed in your system, run the script with --generate-for-latest-version.  In addition to using the latest version for Tablegen, the change in version, compared to the saved version, is reported and the new version dictionary is generated on standard output.

