### PR TITLE
Move to more recent LLVM commit ID

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             git submodule update --init --recursive
       # Use cached mlir installation if possible.
       - restore_cache:
-          key: V11-LLVM-PROJECT-{{ arch }}
+          key: V12-LLVM-PROJECT-{{ arch }}
       - run:
           name: Install MLIR
           command: |
@@ -29,7 +29,7 @@ jobs:
               source onnx-mlir/utils/install-mlir.sh
             fi
       - save_cache:
-          key: V11-LLVM-PROJECT-{{ arch }}
+          key: V12-LLVM-PROJECT-{{ arch }}
           paths:
             - llvm-project
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             git submodule update --init --recursive
       # Use cached mlir installation if possible.
       - restore_cache:
-          key: V12-LLVM-PROJECT-{{ arch }}
+          key: V13-LLVM-PROJECT-{{ arch }}
       - run:
           name: Install MLIR
           command: |
@@ -29,7 +29,7 @@ jobs:
               source onnx-mlir/utils/install-mlir.sh
             fi
       - save_cache:
-          key: V12-LLVM-PROJECT-{{ arch }}
+          key: V13-LLVM-PROJECT-{{ arch }}
           paths:
             - llvm-project
       - run:

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -153,7 +153,7 @@ find_mlir_lib(MLIRParser)
 find_mlir_lib(MLIRPass)
 find_mlir_lib(MLIRStandardOps)
 find_mlir_lib(MLIRStandardToLLVM)
-find_mlir_lib(MLIRSideEffects)
+find_mlir_lib(MLIRSideEffectInterfaces)
 find_mlir_lib(MLIRTargetLLVMIR)
 find_mlir_lib(MLIRTransforms)
 find_mlir_lib(MLIRTransformUtils)
@@ -211,7 +211,7 @@ set(MLIRLibs
         ${MLIRLoopLikeInterface}
         ${MLIROpenMP}
         ${MLIRMlirOptMain}
-        ${MLIRSideEffects}        
+        ${MLIRSideEffectInterfaces}
         ${MLIRStandardOps}
         ${MLIRStandardToLLVM}
         ${MLIRSupport}

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -145,8 +145,8 @@ find_mlir_lib(MLIRIR)
 find_mlir_lib(MLIRLLVMIR)
 find_mlir_lib(MLIRLoopAnalysis)
 find_mlir_lib(MLIRLoopToStandard)
-find_mlir_lib(MLIRLoopOps)
 find_mlir_lib(MLIRLoopLikeInterface)
+find_mlir_lib(MLIRSCF)
 find_mlir_lib(MLIRLLVMIRTransforms)
 find_mlir_lib(MLIRMlirOptMain)
 find_mlir_lib(MLIRParser)
@@ -206,7 +206,7 @@ set(MLIRLibs
         ${MLIRIR}
         ${MLIRLLVMIRTransforms}        
         ${MLIRLoopToStandard}
-        ${MLIRLoopOps}
+        ${MLIRSCF}
         ${MLIRLoopAnalysis}
         ${MLIRLoopLikeInterface}
         ${MLIROpenMP}
@@ -253,7 +253,7 @@ set(MLIRWholeArchiveLibs
         MLIRTransforms
         MLIRLoopToStandard
         MLIRVector
-        MLIRLoopOps
+        MLIRSCF
         MLIRIR)
 
 # ONNX MLIR libraries that must be linked with --whole-archive for static build or

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -144,7 +144,7 @@ find_mlir_lib(MLIRExecutionEngine)
 find_mlir_lib(MLIRIR)
 find_mlir_lib(MLIRLLVMIR)
 find_mlir_lib(MLIRLoopAnalysis)
-find_mlir_lib(MLIRLoopToStandard)
+find_mlir_lib(MLIRSCFToStandard)
 find_mlir_lib(MLIRLoopLikeInterface)
 find_mlir_lib(MLIRSCF)
 find_mlir_lib(MLIRLLVMIRTransforms)
@@ -205,7 +205,7 @@ set(MLIRLibs
         ${MLIRExecutionEngine}
         ${MLIRIR}
         ${MLIRLLVMIRTransforms}        
-        ${MLIRLoopToStandard}
+        ${MLIRSCFToStandard}
         ${MLIRSCF}
         ${MLIRLoopAnalysis}
         ${MLIRLoopLikeInterface}
@@ -251,7 +251,7 @@ set(MLIRWholeArchiveLibs
         MLIRStandardOps
         MLIRStandardToLLVM
         MLIRTransforms
-        MLIRLoopToStandard
+        MLIRSCFToStandard
         MLIRVector
         MLIRSCF
         MLIRIR)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 3ce0ad1b336e67a76d78ae7ff7d66fe127586620 && cd ..
+cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
+cd llvm-project && git checkout 0dc91bfd11e6cced0c46c1a25cc96edea0d8fc22 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)
@@ -114,7 +114,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
+cd llvm-project && git checkout 0dc91bfd11e6cced0c46c1a25cc96edea0d8fc22 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 3ce0ad1b336e67a76d78ae7ff7d66fe127586620 && cd ..
+cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
+cd llvm-project && git checkout 0dc91bfd11e6cced0c46c1a25cc96edea0d8fc22 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)
@@ -110,7 +110,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
+cd llvm-project && git checkout 0dc91bfd11e6cced0c46c1a25cc96edea0d8fc22 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 3ce0ad1b336e67a76d78ae7ff7d66fe127586620 && cd ..
+cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)
@@ -110,7 +110,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 3ce0ad1b336e67a76d78ae7ff7d66fe127586620 && cd ..
+cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Builder/FrontendDialectHelper.hpp
+++ b/src/Builder/FrontendDialectHelper.hpp
@@ -14,7 +14,6 @@
 #include <regex>
 #include <tuple>
 
-#include "mlir/Analysis/Verifier.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -26,6 +25,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/IR/Types.h"
+#include "mlir/IR/Verifier.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopedHashTable.h"

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -84,8 +84,7 @@ ParseResult parseKrnlDefineLoopsOp(
 
 void KrnlOptimizeLoopsOp::build(
     OpBuilder &builder, OperationState &result, int num_optimized_loops) {
-  result.types.append(
-      num_optimized_loops, LoopType::get(builder.getContext()));
+  result.types.append(num_optimized_loops, LoopType::get(builder.getContext()));
   // Create a region and a block for the body.
   // Schedule intrinsics will be placed into this region.
   Region *region = result.addRegion();

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -29,7 +29,7 @@ def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
   let arguments = (ins);
   let results = (outs Variadic<AnyType>);
   let skipDefaultBuilders = 1;
-  let builders = [ OpBuilder<"Builder *builder, OperationState &result,"
+  let builders = [ OpBuilder<"OpBuilder &builder, OperationState &result,"
                              "int64_t num_loops"> ];
 
   let printer = [{ return ::print(p, *this); }];
@@ -67,7 +67,7 @@ def KrnlOptimizeLoopsOp : Op<Krnl_Dialect, "optimize_loops"> {
 
   let skipDefaultBuilders = 1;
 
-  let builders = [ OpBuilder<"Builder *builder, OperationState &result, "
+  let builders = [ OpBuilder<"OpBuilder &builder, OperationState &result, "
                              "int timestamp_space_rank"> ];
 
   let printer = [{ return ::print(p, *this); }];
@@ -100,7 +100,7 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator]> {
   let arguments = (ins Variadic<AnyType>);
   let regions = (region SizedRegion<1>:$bodyRegion);
   let skipDefaultBuilders = 1;
-  let builders = [ OpBuilder<"Builder *builder, OperationState &result, "
+  let builders = [ OpBuilder<"OpBuilder &builder, OperationState &result, "
                              "KrnlIterateOperandPack operandPack"> ];
 
   let extraClassDeclaration = [{
@@ -165,7 +165,7 @@ def KrnlEntryPointOp : Op<Krnl_Dialect, "entry_point"> {
   let summary = "Indicate ONNX entry point";
   let description = [{The "krnl.entry_point" function indicates the main entry
                            point of ONNX model.}];
-  let builders = [ OpBuilder<"Builder *builder, OperationState &result, "
+  let builders = [ OpBuilder<"OpBuilder &builder, OperationState &result, "
                              "SymbolRefAttr funcAttr, IntegerAttr numInputs, "
                              "IntegerAttr numOutputs"> ];
 

--- a/src/Dialect/MLONNX/MLONNXOps.td
+++ b/src/Dialect/MLONNX/MLONNXOps.td
@@ -61,7 +61,7 @@ class MLONNX_Op<string mnemonic, list<OpTrait> traits = []> :
 // 4. type of string, complex64 and complex128 for input/output are ignored 
 // 5. unsigned int are treated as signed one
 
-include "mlir/Interfaces/SideEffects.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "src/Dialect/MLONNX/MLONNXOps.td.inc"
 
 #endif // MLONNX_OPS

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -438,22 +438,22 @@ ONNXOpsDialect::ONNXOpsDialect(mlir::MLIRContext *ctx)
       >();
 }
 
-void ONNXEntryPointOp::build(mlir::Builder *builder,
+void ONNXEntryPointOp::build(mlir::OpBuilder &builder,
     mlir::OperationState &state, mlir::FuncOp function, int numInputs,
     int numOutputs) {
   state.addAttribute(ONNXEntryPointOp::getEntryPointFuncAttrName(),
-      builder->getSymbolRefAttr(function));
+      builder.getSymbolRefAttr(function));
   state.addAttribute(ONNXEntryPointOp::getNumInputsAttrName(),
-      builder->getI32IntegerAttr(numInputs));
+      builder.getI32IntegerAttr(numInputs));
   state.addAttribute(ONNXEntryPointOp::getNumOutputsAttrName(),
-      builder->getI32IntegerAttr(numOutputs));
+      builder.getI32IntegerAttr(numOutputs));
 }
 
 ONNXEntryPointOp ONNXEntryPointOp::create(mlir::Location location,
     mlir::FuncOp &func, int numInputs, int numOutputs) {
   mlir::OperationState state(location, "onnx.EntryPoint");
-  Builder builder(location->getContext());
-  mlir::ONNXEntryPointOp::build(&builder, state, func, numInputs, numOutputs);
+  OpBuilder builder(location->getContext());
+  mlir::ONNXEntryPointOp::build(builder, state, func, numInputs, numOutputs);
   Operation *op = mlir::Operation::create(state);
   auto onnxEntryOp = llvm::cast<mlir::ONNXEntryPointOp>(op);
   return onnxEntryOp;
@@ -1573,7 +1573,7 @@ bool ONNXPadConstantValuePadOp::inferShapes() {
   return false;
 }
 
-void ONNXPadConstantValuePadOp::build(Builder *builder, OperationState &state,
+void ONNXPadConstantValuePadOp::build(OpBuilder &builder, OperationState &state,
     Value data, ArrayAttr pads, FloatAttr constant_value, StringAttr mode) {
   Type outputType = padShapeInferenceHelper(data, pads);
   if (!outputType) {

--- a/src/Dialect/ONNX/ONNXOps.td
+++ b/src/Dialect/ONNX/ONNXOps.td
@@ -61,7 +61,7 @@ class ONNX_Op<string mnemonic, list<OpTrait> traits = []> :
 // 4. type of string, complex64 and complex128 for input/output are ignored 
 // 5. unsigned int are treated as signed one
 
-include "mlir/Interfaces/SideEffects.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "src/Dialect/ONNX/ONNXOps.td.inc"
 
 // Indicate entry point functions of ONNX graph.
@@ -71,7 +71,7 @@ def ONNXEntryPointOp: ONNX_Op<"EntryPoint"> {
     The "onnx.EntryPoint" function indicates the main entry point of ONNX model.
   }];
 
-  let builders = [OpBuilder<[{Builder *builder, OperationState &state,
+  let builders = [OpBuilder<[{OpBuilder &builder, OperationState &state,
                              FuncOp function, int numInputs, int numOutputs}]>];
 
   let extraClassDeclaration = [{
@@ -183,7 +183,7 @@ def ONNXPadConstantValuePadOp : ONNX_Op<"PadConstantValuePad",
            DefaultValuedAttr<StrAttr, "constant">:$mode);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$output);
   // A build method with the result type deduction.
-  let builders = [OpBuilder<"Builder *builder, OperationState &state, "
+  let builders = [OpBuilder<"OpBuilder &builder, OperationState &state, "
                             "Value data, ArrayAttr pads, "
                             "FloatAttr constant_value, StringAttr mode">];
 }

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -15,11 +15,11 @@ def ONNXAbsOp:ONNX_Op<"Abs",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$Y);
   let builders = [
-    OpBuilder<"Builder *builder, OperationState &state, Value X", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, Value X", [{
       auto elementType = X.getType().cast<TensorType>().getElementType();
       build(builder, state, UnrankedTensorType::get(elementType), X);
     }]>,
-    OpBuilder<"Builder *builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
       auto elementType = operands[0].getType().cast<TensorType>().getElementType();
       std::vector<mlir::Type> outputTypes;
       outputTypes.emplace_back(UnrankedTensorType::get(elementType));
@@ -349,7 +349,7 @@ def ONNXConstantOp:ONNX_Op<"Constant",
     OptionalAttr<AnyAttr>:$value);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$output);
     let builders = [
-    OpBuilder<"Builder *builder, OperationState &state, Attribute sparse_value, Attribute value", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, Attribute sparse_value, Attribute value", [{
       if (value) {
         auto tensorType = value.getType();
         build(builder, state, tensorType, sparse_value, value);
@@ -673,11 +673,11 @@ def ONNXExpOp:ONNX_Op<"Exp",
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$input);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$output);
   let builders = [
-    OpBuilder<"Builder *builder, OperationState &state, Value input", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, Value input", [{
       auto elementType = input.getType().cast<TensorType>().getElementType();
       build(builder, state, UnrankedTensorType::get(elementType), input);
     }]>,
-    OpBuilder<"Builder *builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
       auto elementType = operands[0].getType().cast<TensorType>().getElementType();
       std::vector<mlir::Type> outputTypes;
       outputTypes.emplace_back(UnrankedTensorType::get(elementType));
@@ -1780,11 +1780,11 @@ def ONNXMulOp:ONNX_Op<"Mul",
     AnyTypeOf<[AnyMemRef, AnyTensor]>:$B);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$C);
   let builders = [
-    OpBuilder<"Builder *builder, OperationState &state, Value A, Value B", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, Value A, Value B", [{
       auto elementType = A.getType().cast<TensorType>().getElementType();
       build(builder, state, UnrankedTensorType::get(elementType), A, B);
     }]>,
-    OpBuilder<"Builder *builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
       auto elementType = operands[0].getType().cast<TensorType>().getElementType();
       std::vector<mlir::Type> outputTypes;
       outputTypes.emplace_back(UnrankedTensorType::get(elementType));
@@ -2014,11 +2014,11 @@ def ONNXPadOp:ONNX_Op<"Pad",
     DefaultValuedAttr<StrAttr, "constant">:$mode);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$output);
   let builders = [
-    OpBuilder<"Builder *builder, OperationState &state, Value data, Value pads, Value constant_value, StringAttr mode", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, Value data, Value pads, Value constant_value, StringAttr mode", [{
       auto elementType = data.getType().cast<TensorType>().getElementType();
       build(builder, state, UnrankedTensorType::get(elementType), data, pads, constant_value, mode);
     }]>,
-    OpBuilder<"Builder *builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
       auto elementType = operands[0].getType().cast<TensorType>().getElementType();
       std::vector<mlir::Type> outputTypes;
       outputTypes.emplace_back(UnrankedTensorType::get(elementType));
@@ -2473,11 +2473,11 @@ def ONNXReduceSumOp:ONNX_Op<"ReduceSum",
     DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$reduced);
   let builders = [
-    OpBuilder<"Builder *builder, OperationState &state, Value data, ArrayAttr axes, IntegerAttr keepdims", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, Value data, ArrayAttr axes, IntegerAttr keepdims", [{
       auto elementType = data.getType().cast<TensorType>().getElementType();
       build(builder, state, UnrankedTensorType::get(elementType), data, axes, keepdims);
     }]>,
-    OpBuilder<"Builder *builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
       auto elementType = operands[0].getType().cast<TensorType>().getElementType();
       std::vector<mlir::Type> outputTypes;
       outputTypes.emplace_back(UnrankedTensorType::get(elementType));
@@ -2502,11 +2502,11 @@ def ONNXReduceSumSquareOp:ONNX_Op<"ReduceSumSquare",
     DefaultValuedAttr<I64Attr, "1">:$keepdims);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$reduced);
   let builders = [
-    OpBuilder<"Builder *builder, OperationState &state, Value data, ArrayAttr axes, IntegerAttr keepdims", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, Value data, ArrayAttr axes, IntegerAttr keepdims", [{
       auto elementType = data.getType().cast<TensorType>().getElementType();
       build(builder, state, UnrankedTensorType::get(elementType), data, axes, keepdims);
     }]>,
-    OpBuilder<"Builder *builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{
       auto elementType = operands[0].getType().cast<TensorType>().getElementType();
       std::vector<mlir::Type> outputTypes;
       outputTypes.emplace_back(UnrankedTensorType::get(elementType));

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -56,7 +56,7 @@ void EmitLLVMBitCode(
 void registerDialects() {
   mlir::registerDialect<mlir::AffineDialect>();
   mlir::registerDialect<mlir::LLVM::LLVMDialect>();
-  mlir::registerDialect<mlir::loop::LoopOpsDialect>();
+  mlir::registerDialect<mlir::scf::SCFDialect>();
   mlir::registerDialect<mlir::StandardOpsDialect>();
   mlir::registerDialect<mlir::ONNXOpsDialect>();
   mlir::registerDialect<mlir::KrnlOpsDialect>();

--- a/src/MainUtils.hpp
+++ b/src/MainUtils.hpp
@@ -25,7 +25,7 @@
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Pass/Passes.hpp"
 
-#include "mlir/Conversion/LoopToStandard/ConvertLoopToStandard.h"
+#include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
 #include "mlir/ExecutionEngine/ExecutionEngine.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/IR/MLIRContext.h"

--- a/src/Tool/ONNXMLIROpt/ONNXMLIROpt.cpp
+++ b/src/Tool/ONNXMLIROpt/ONNXMLIROpt.cpp
@@ -57,7 +57,7 @@ static llvm::cl::opt<bool> allowUnregisteredDialects(
 int main(int argc, char **argv) {
   mlir::registerDialect<mlir::AffineDialect>();
   mlir::registerDialect<mlir::LLVM::LLVMDialect>();
-  mlir::registerDialect<mlir::loop::LoopOpsDialect>();
+  mlir::registerDialect<mlir::scf::SCFDialect>();
   mlir::registerDialect<mlir::StandardOpsDialect>();
 
   // Register transformation passes.

--- a/src/Transform/LowerToLLVM.cpp
+++ b/src/Transform/LowerToLLVM.cpp
@@ -14,7 +14,7 @@
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/LoopOps/LoopOps.h"
+#include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"

--- a/src/Transform/LowerToLLVM.cpp
+++ b/src/Transform/LowerToLLVM.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-#include "mlir/Conversion/LoopToStandard/ConvertLoopToStandard.h"
+#include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..
+cd llvm-project && git checkout 0dc91bfd11e6cced0c46c1a25cc96edea0d8fc22 && cd ..

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 3ce0ad1b336e67a76d78ae7ff7d66fe127586620 && cd ..
+cd llvm-project && git checkout f58e78f9920531f85d98e8041f6967eeb1bd0d3a && cd ..

--- a/utils/gen_doc.py
+++ b/utils/gen_doc.py
@@ -94,7 +94,7 @@ custom_builder_ops_list = ['Abs', 'Mul', 'Exp', 'ReduceSum', 'ReduceSumSquare', 
 #a dictionary to add any special definition for an operation
 custom_definition_misc = dict([ ('Constant', 
   '''    let builders = [
-    OpBuilder<"Builder *builder, OperationState &state, Attribute sparse_value, Attribute value", [{
+    OpBuilder<"OpBuilder &builder, OperationState &state, Attribute sparse_value, Attribute value", [{
       if (value) {
         auto tensorType = value.getType();
         build(builder, state, tensorType, sparse_value, value);
@@ -430,9 +430,9 @@ def gen_op_def(schema):
         else:
             s += indent + 'let builders = [\n'
             # Custom builders with operands and attributes having a seperate parameter.
-            # E.g. OpBuilder<"Builder *builder, OperationState &state, Value X, Value, Y, Attribute A", [{}]>
+            # E.g. OpBuilder<"OpBuilder &builder, OperationState &state, Value X, Value, Y, Attribute A", [{}]>
             indent = inc_indent(indent)
-            s += indent + 'OpBuilder<"Builder *builder, OperationState &state'
+            s += indent + 'OpBuilder<"OpBuilder &builder, OperationState &state'
             operands_dict = get_operands_or_results(schema, is_input=True)
             for name, ty in operands_dict.items():
                 s += ', {} {}'.format(tblgen_operand_type_to_cpp_type(ty),
@@ -454,8 +454,8 @@ def gen_op_def(schema):
             s += indent + '}]>,\n'
 
             # Custom builders with all operands and attributes having aggregate parameters.
-            # E.g. OpBuilder<"Builder *builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{}]>'
-            s += indent + 'OpBuilder<"Builder *builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{\n'
+            # E.g. OpBuilder<"OpBuilder &builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{}]>'
+            s += indent + 'OpBuilder<"OpBuilder &builder, OperationState &state, ValueRange operands, ArrayRef<NamedAttribute> attributes", [{\n'
             indent = inc_indent(indent)
             s += indent + 'auto elementType = operands[0].getType().cast<TensorType>().getElementType();\n'
             s += indent + 'std::vector<mlir::Type> outputTypes;\n'


### PR DESCRIPTION
The new LLVM commit ID contains some important changes:
- The use of `Builder` is changed to `OpBuilder` in op build methods.
- AffineScope trait which is to define a new scope for polyhedral optimization purposes. I will enable this feature in onnx-mlir for loop-fusion once this patch is landed.