### PR TITLE
Support model debugging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "third_party/variant"]
 	path = third_party/variant
 	url = https://github.com/mpark/variant.git
-[submodule "third_party/rapidcheck"]
-	path = third_party/rapidcheck
-	url = https://github.com/emil-e/rapidcheck.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "third_party/variant"]
 	path = third_party/variant
 	url = https://github.com/mpark/variant.git
+[submodule "third_party/rapidcheck"]
+	path = third_party/rapidcheck
+	url = https://github.com/emil-e/rapidcheck.git

--- a/docs/DebuggingNumericalError.md
+++ b/docs/DebuggingNumericalError.md
@@ -1,0 +1,26 @@
+# Debugging Numerical Error
+
+Use `util/debug.py` python script to debug numerical errors, when onnx-mlir-compiled inference executable produces 
+numerical results that are inconsistent with those produced by the training framework.
+This python script will run the model through onnx-mlir and a reference backend, and compare
+the intermediate results produced by these two backends layer by layer.
+
+## Rrerequisite
+- Set `ONNX_MLIR_HOME` environment variable to be the path to
+  the HOME directory for onnx-mlir. The HOME directory for onnx-mlir refers to 
+  the parent folder containing the `bin`, `lib`, etc sub-folders in which ONNX-MLIR 
+  executables and libraries can be found.
+- Install an ONNX backend, by default onnx-runtime is used as testing backend. Install by 
+  running `pip install onnxruntime`. To use a different testing backend, simply replace code
+  importing onnxruntime to some other ONNX-compliant backend.
+
+## Usage
+
+`util/debug.py` supports the following command-line options:
+
+```bash
+usage: debug.py [-h] model_path
+
+positional arguments:
+  model_path  Path to the model to debug.
+```

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -29,5 +29,7 @@ toc:
 #        url: /piece1.html
   - title: Tools
     subfolderitems:
+      - page: debug.py - Debug Numerical Errors
+        url: /DebuggingNumericalError.html
       - page: DocCheck - Handling Necessary Code Duplication
         url: /doc_check/

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -10,9 +10,7 @@
 
 #include <cstdio>
 #include <fcntl.h>
-#include "llvm/Support/Program.h"
-
-#include "llvm/Support/Program.h"
+#include <llvm/Support/Program.h>
 
 #include "src/ExternalUtil.hpp"
 #include "src/MainUtils.hpp"
@@ -176,9 +174,9 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
   // elision of these constants is not strictly required. Elision is also not
   // necessary when emitting the .bc file.
   if (emissionTarget == EmitLib) {
-      // Write LLVM bitcode to disk, compile & link.
-      compileModuleToSharedLibrary(module, outputBaseName);
-      printf("Shared library %s.so has been compiled.", outputBaseName.c_str());
+    // Write LLVM bitcode to disk, compile & link.
+    compileModuleToSharedLibrary(module, outputBaseName);
+    printf("Shared library %s.so has been compiled.", outputBaseName.c_str());
   } else {
     // Emit the version with all constants included.
     outputCode(module, outputBaseName, ".onnx.mlir");

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -175,24 +175,10 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
   // outside the function code at the beginning of the file in which case the
   // elision of these constants is not strictly required. Elision is also not
   // necessary when emitting the .bc file.
-<<<<<<< HEAD
-<<<<<<< HEAD
   if (emissionTarget == EmitLib) {
-    // Write LLVM bitcode to disk, compile & link.
-    compileModuleToSharedLibrary(module, outputBaseName);
-    printf("Shared library %s.so has been compiled.", outputBaseName.c_str());
-=======
-  if (emissionTarget == EmitLLVMBC) {
-    // Write LLVM bitcode to disk, compile & link.
-    compileModuleToSharedLibrary(module, outputBaseName);
-    printf("Shared %s.so library has been compiled.", outputBaseName.c_str());
->>>>>>> Call llc, ld from within onnx-mlir.
-=======
-  if (emissionTarget == EmitLib) {
-    // Write LLVM bitcode to disk, compile & link.
-    compileModuleToSharedLibrary(module, outputBaseName);
-    printf("Shared library %s.so has been compiled.", outputBaseName.c_str());
->>>>>>> Rename EmitLLVMBC -> EmitLib., reorder header files
+      // Write LLVM bitcode to disk, compile & link.
+      compileModuleToSharedLibrary(module, outputBaseName);
+      printf("Shared library %s.so has been compiled.", outputBaseName.c_str());
   } else {
     // Emit the version with all constants included.
     outputCode(module, outputBaseName, ".onnx.mlir");

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -10,11 +10,13 @@
 
 #include <cstdio>
 #include <fcntl.h>
-
 #include "llvm/Support/Program.h"
 
 #include "src/ExternalUtil.hpp"
 #include "src/MainUtils.hpp"
+#include "src/ExternalUtil.hpp"
+
+#include "MainUtils.hpp"
 
 #ifdef _WIN32
 #include <io.h>
@@ -172,10 +174,17 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
   // outside the function code at the beginning of the file in which case the
   // elision of these constants is not strictly required. Elision is also not
   // necessary when emitting the .bc file.
+<<<<<<< HEAD
   if (emissionTarget == EmitLib) {
     // Write LLVM bitcode to disk, compile & link.
     compileModuleToSharedLibrary(module, outputBaseName);
     printf("Shared library %s.so has been compiled.", outputBaseName.c_str());
+=======
+  if (emissionTarget == EmitLLVMBC) {
+    // Write LLVM bitcode to disk, compile & link.
+    compileModuleToSharedLibrary(module, outputBaseName);
+    printf("Shared %s.so library has been compiled.", outputBaseName.c_str());
+>>>>>>> Call llc, ld from within onnx-mlir.
   } else {
     // Emit the version with all constants included.
     outputCode(module, outputBaseName, ".onnx.mlir");

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -12,9 +12,10 @@
 #include <fcntl.h>
 #include "llvm/Support/Program.h"
 
+#include "llvm/Support/Program.h"
+
 #include "src/ExternalUtil.hpp"
 #include "src/MainUtils.hpp"
-#include "src/ExternalUtil.hpp"
 
 #include "MainUtils.hpp"
 
@@ -175,6 +176,7 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
   // elision of these constants is not strictly required. Elision is also not
   // necessary when emitting the .bc file.
 <<<<<<< HEAD
+<<<<<<< HEAD
   if (emissionTarget == EmitLib) {
     // Write LLVM bitcode to disk, compile & link.
     compileModuleToSharedLibrary(module, outputBaseName);
@@ -185,6 +187,12 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
     compileModuleToSharedLibrary(module, outputBaseName);
     printf("Shared %s.so library has been compiled.", outputBaseName.c_str());
 >>>>>>> Call llc, ld from within onnx-mlir.
+=======
+  if (emissionTarget == EmitLib) {
+    // Write LLVM bitcode to disk, compile & link.
+    compileModuleToSharedLibrary(module, outputBaseName);
+    printf("Shared library %s.so has been compiled.", outputBaseName.c_str());
+>>>>>>> Rename EmitLLVMBC -> EmitLib., reorder header files
   } else {
     // Emit the version with all constants included.
     outputCode(module, outputBaseName, ".onnx.mlir");

--- a/src/Transform/LowerToLLVM.cpp
+++ b/src/Transform/LowerToLLVM.cpp
@@ -387,9 +387,9 @@ public:
       staticInputs.emplace_back(ptrToMemRef);
     }
 
-//    // If more than one output exists, the struct becomes a nested struct,
-//    // the unpacking logic can be more involved, so no support for now.
-//    assert(numOutputs == 1 && "only support 1 output tensor now.");
+    //    // If more than one output exists, the struct becomes a nested struct,
+    //    // the unpacking logic can be more involved, so no support for now.
+    //    assert(numOutputs == 1 && "only support 1 output tensor now.");
 
     // Call static entry point with the memref ptrs created, and get output.
     auto outMemRefs =
@@ -632,7 +632,6 @@ void KrnlToLLVMLoweringPass::runOnOperation() {
   ConversionTarget target(getContext());
   target.addLegalDialect<LLVM::LLVMDialect>();
   target.addLegalOp<ModuleOp, ModuleTerminatorOp>();
-//  target.addLegalOp<KrnlEntryPointOp>();
 
   // Lower the MemRef types to a representation in LLVM.
   LLVMTypeConverter typeConverter(&getContext());
@@ -645,11 +644,11 @@ void KrnlToLLVMLoweringPass::runOnOperation() {
   populateStdToLLVMConversionPatterns(typeConverter, patterns,
       /*emitCWrapperS=*/true,
       /*useAlignedAlloc=*/false);
-  patterns.insert<KrnlEntryPointOpLowering>(&getContext());
   patterns.insert<KrnlGlobalOpLowering>(&getContext(), typeConverter);
 
   // Lower from the `krnl` dialect i.e. the Reshape operation.
-  patterns.insert<KrnlMemcpyOpLowering>(&getContext());
+  patterns.insert<KrnlMemcpyOpLowering, KrnlEntryPointOpLowering>(
+      &getContext());
 
   // We want to completely lower to LLVM, so we use a `FullConversion`. This
   // ensures that only legal operations will remain after the conversion.

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -81,7 +81,7 @@ def main(model_path):
                 assert dim.dim_value, "Can only debug models with inputs that have explicit shapes."
                 explicit_shape.append(dim.dim_value)
             inputs.append(
-                np.random.uniform(-1, 1, explicit_shape).astype(np.float32))
+                np.random.uniform(-1.0, 1.0, explicit_shape).astype(np.float32))
         outs = sess.run(inputs)
 
         ref_session = ref_backend.InferenceSession(temp_model_path)

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import argparse
+import onnx
+import subprocess
+import numpy as np
+import tempfile
+
+from functools import reduce
+from collections import OrderedDict
+
+# Reference backend.
+import onnxruntime as ref_backend
+
+if (not os.environ.get('ONNX_MLIR_HOME', None)):
+    raise RuntimeError(
+        "Environment variable ONNX_MLIR_HOME is not set, please set it to the path to "
+        "the HOME directory for onnx-mlir. The Home directory for onnx-mlir refers to "
+        "the parent folder containing the bin, lib, etc sub-folders in which ONNX-MLIR "
+        "executables and libraries can be found.")
+
+VERBOSE = os.environ.get('VERBOSE', False)
+ONNX_MLIR = os.path.join(os.environ['ONNX_MLIR_HOME'], "bin/onnx-mlir")
+
+# Include runtime directory in python paths, so pyruntime can be imported.
+RUNTIME_DIR = os.path.join(os.environ['ONNX_MLIR_HOME'], "lib")
+sys.path.append(RUNTIME_DIR)
+
+try:
+    from pyruntime import ExecutionSession
+except ImportError:
+    raise ImportError(
+        "Looks like you did not build the pyruntime target, build it by running `make pyruntime`."
+    )
+
+
+def execute_commands(cmds):
+    if (VERBOSE):
+        print(" ".join(cmds))
+    subprocess.run(cmds, stdout=subprocess.PIPE)
+
+
+def extend_model_output(model, intermediate_outputs):
+    # onnx-mlir doesn't care about manually specified output types & shapes.
+    DUMMY_TENSOR_TYPE = onnx.TensorProto.FLOAT
+    DUMMY_TENSOR_SHAPE = []
+
+    while(len(model.graph.output)):
+        model.graph.output.pop()
+
+    for output_name in intermediate_outputs:
+        output_value_info = onnx.helper.make_tensor_value_info(
+            output_name, DUMMY_TENSOR_TYPE, None)
+        model.graph.output.extend([output_value_info])
+    return model
+
+
+def main(model_path):
+    model = onnx.load(model_path)
+    intermediate_outputs = sum(
+        [list(node.output) for node in model.graph.node], [])
+    intermediate_outputs = list(OrderedDict.fromkeys(intermediate_outputs))
+    model = extend_model_output(model, intermediate_outputs)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        print("Temporary directory has been created at {}".format(temp_dir))
+        temp_model_path = os.path.join(temp_dir, "model.onnx")
+        onnx.save(model, temp_model_path)
+        execute_commands([ONNX_MLIR, temp_model_path])
+
+        temp_shared_lib_path = os.path.join(temp_dir, "model.so")
+        sess = ExecutionSession(temp_shared_lib_path, "_dyn_entry_point_main_graph")
+        img = np.ones([1, 1, 28, 28], dtype=np.float32)
+        outs = sess.run([img])
+
+        ref_session = ref_backend.InferenceSession(temp_model_path)
+        output_names = list(map(lambda x: x.name, model.graph.output))
+        input_names = list(map(lambda x: x.name, model.graph.input))
+        input_feed = dict(zip(input_names, [img]))
+        ref_outs = ref_session.run(output_names, input_feed)
+
+        for i, name in enumerate(intermediate_outputs):
+            print("Verifying value of {}".format(name))
+            np.testing.assert_array_almost_equal(ref_outs[i], outs[i])
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('model_path', type=str)
+    args = parser.parse_args()
+    main(**vars(args))

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -6,16 +6,16 @@ import subprocess
 import numpy as np
 import tempfile
 
-from functools import reduce
 from collections import OrderedDict
 
-# Reference backend.
-import onnxruntime as ref_backend
+# Reference backend, use onnxruntime by default
+import onnxruntime
+prepare = onnxruntime.InferenceSession
 
 if (not os.environ.get('ONNX_MLIR_HOME', None)):
     raise RuntimeError(
         "Environment variable ONNX_MLIR_HOME is not set, please set it to the path to "
-        "the HOME directory for onnx-mlir. The Home directory for onnx-mlir refers to "
+        "the HOME directory for onnx-mlir. The HOME directory for onnx-mlir refers to "
         "the parent folder containing the bin, lib, etc sub-folders in which ONNX-MLIR "
         "executables and libraries can be found.")
 
@@ -37,13 +37,12 @@ except ImportError:
 def execute_commands(cmds):
     if (VERBOSE):
         print(" ".join(cmds))
-    subprocess.run(cmds, stdout=subprocess.PIPE)
+    subprocess.run(cmds, stdout=subprocess.PIPE, check=True)
 
 
 def extend_model_output(model, intermediate_outputs):
     # onnx-mlir doesn't care about manually specified output types & shapes.
     DUMMY_TENSOR_TYPE = onnx.TensorProto.FLOAT
-    DUMMY_TENSOR_SHAPE = []
 
     while (len(model.graph.output)):
         model.graph.output.pop()
@@ -64,14 +63,18 @@ def main(model_path):
 
     with tempfile.TemporaryDirectory() as temp_dir:
         print("Temporary directory has been created at {}".format(temp_dir))
+
+        # Save modified model & invoke onnx-mlir to compile it.
         temp_model_path = os.path.join(temp_dir, "model.onnx")
         onnx.save(model, temp_model_path)
         execute_commands([ONNX_MLIR, temp_model_path])
 
+        # Use the generated shared library to create an execution session.
         temp_shared_lib_path = os.path.join(temp_dir, "model.so")
         sess = ExecutionSession(temp_shared_lib_path,
                                 "_dyn_entry_point_main_graph")
 
+        # Generate random data as input.
         inputs = []
         np.random.seed(42)
         for input_proto in model.graph.input:
@@ -82,14 +85,18 @@ def main(model_path):
                 explicit_shape.append(dim.dim_value)
             inputs.append(
                 np.random.uniform(-1.0, 1.0, explicit_shape).astype(np.float32))
+
+        # Run the compiled inference function on the randomly generated data.
         outs = sess.run(inputs)
 
-        ref_session = ref_backend.InferenceSession(temp_model_path)
+        # Run the model with reference backend and get results.
+        ref_session = prepare(temp_model_path)
         output_names = list(map(lambda x: x.name, model.graph.output))
         input_names = list(map(lambda x: x.name, model.graph.input))
         input_feed = dict(zip(input_names, inputs))
         ref_outs = ref_session.run(output_names, input_feed)
 
+        # For each intermediate output tensor, compare results.
         for i, name in enumerate(intermediate_outputs):
             print("Verifying value of {}".format(name))
             np.testing.assert_array_almost_equal(ref_outs[i], outs[i])
@@ -97,6 +104,6 @@ def main(model_path):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('model_path', type=str)
+    parser.add_argument('model_path', type=str, help="Path to the model to debug.")
     args = parser.parse_args()
     main(**vars(args))


### PR DESCRIPTION
# Debugging Numerical Error

Use `util/debug.py` python script to debug numerical errors, when onnx-mlir-compiled inference executable produces 
numerical results that are inconsistent with those produced by the training framework.
This python script will run the model through onnx-mlir and a reference backend, and compare
the intermediate results produced by these two backends layer by layer.

## Rrerequisite
- Set `ONNX_MLIR_HOME` environment variable to be the path to
  the HOME directory for onnx-mlir. The HOME directory for onnx-mlir refers to 
  the parent folder containing the `bin`, `lib`, etc sub-folders in which ONNX-MLIR 
  executables and libraries can be found.
- Install an ONNX backend, by default onnx-runtime is used as testing backend. Install by 
  running `pip install onnxruntime`. To use a different testing backend, simply replace code
  importing onnxruntime to some other ONNX-compliant backend.

## Usage

`util/debug.py` supports the following command-line options:

```bash
usage: debug.py [-h] model_path

positional arguments:
  model_path  Path to the model to debug.
```
