### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,3 @@ after_success:
         else 
             echo "Skip pushing build"; 
         fi
-    
-  - docker login -u onnxmlirczar -p 143f1da2-332f-45a1-8587-d6cb07c13230 
-  - docker push onnxmlirczar/onnx-mlir-build:latest 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ services:
   - docker
 language: cpp
 dist: bionic
-script:
-  - cd docker
-  - chmod a+x compile-onnx-mlir.sh
+script: 
   - docker build --tag onnx-mlir-build:initial .
   - docker run -itd --name build onnx-mlir-build:initial
   - docker cp $(pwd) build:/onnx-mlir
+  - cd docker
+  - chmod a+x compile-onnx-mlir.sh
   - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
   - docker exec -itd build compile-onnx-mlir.sh
   - docker commit build onnxmlirczar/onnx-mlir-build:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - cd docker
   - chmod a+x compile-onnx-mlir.sh
   - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
-  - docker exec -itd build compile-onnx-mlir.sh
+  - docker exec -it build compile-onnx-mlir.sh
   - docker commit build onnxmlirczar/onnx-mlir-build:latest
   - docker login -u onnxmlirczar -p 143f1da2-332f-45a1-8587-d6cb07c13230 
   - docker push onnxmlirczar/onnx-mlir-build:latest 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ dist: bionic
 script:
   - cd docker
   - chmod a+x compile-onnx-mlir.sh
-  - docker pull onnxmlirczar/onnx-mlir-build:initial
-  - docker run -itd -v $(pwd):/build --name build onnxmlirczar/onnx-mlir-build:initial
+  - docker build --tag onnx-mlir-build:initial .
+  - docker run -itd -v $(pwd):/onnx-mlir --name build onnx-mlir-build:initial
   - docker run build mkdir /build/bin
-  - docker copy build compile-onnx-mlir.sh bin/compile-onnx-mlir.sh
-  - docker run build export PATH=$PATH:/build/bin 
+  - docker copy build compile-onnx-mlir.sh /usr/bin/compile-onnx-mlir.sh
   - docker run build compile-onnx-mlir.sh
   - docker run build export LIT_OPT=v
-  - docker run build cd /build/onnx-mlir/build
+  - docker run build cd /onnx-mlir/build
   - docker run build cmake --build . --target check-onnx-lit
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: bionic
 script: 
   - docker build --tag onnx-mlir-build:initial ./docker
   - docker run -itd --name build onnx-mlir-build:initial
-  - docker cp $(pwd) build:/onnx-mlir
+  - docker cp $(pwd) build:/build/onnx-mlir
   - cd docker
   - chmod a+x compile-onnx-mlir.sh
   - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,14 @@ script:
   - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
   - docker exec -it build compile-onnx-mlir.sh
   - docker commit build onnxmlirczar/onnx-mlir-build:latest
+after_success: 
+  - if [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_BRANCH == "master" ]; then
+            echo "Pushing new build to docker hub";
+            docker login -u onnxmlirczar -p 143f1da2-332f-45a1-8587-d6cb07c13230;
+            docker push onnxmlirczar/onnx-mlir-build:latest;
+        else 
+            echo "Skip pushing build"; 
+        fi
+    
   - docker login -u onnxmlirczar -p 143f1da2-332f-45a1-8587-d6cb07c13230 
   - docker push onnxmlirczar/onnx-mlir-build:latest 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ script:
   - cd docker
   - chmod a+x compile-onnx-mlir.sh
   - docker build --tag onnx-mlir-build:initial .
-  - docker run -itd -v $(pwd):/onnx-mlir --name build onnx-mlir-build:initial
+  - docker run -itd --name build onnx-mlir-build:initial
+  - docker cp $(pwd) build:/onnx-mlir
   - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
   - docker exec -itd build compile-onnx-mlir.sh
   - docker commit build onnxmlirczar/onnx-mlir-build:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 language: cpp
 dist: bionic
 script: 
-  - docker build --tag onnx-mlir-build:initial .
+  - docker build --tag onnx-mlir-build:initial ./docker
   - docker run -itd --name build onnx-mlir-build:initial
   - docker cp $(pwd) build:/onnx-mlir
   - cd docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ script:
   - docker run -itd -v $(pwd):/onnx-mlir --name build onnx-mlir-build:initial
   - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
   - docker exec -itd build compile-onnx-mlir.sh
-  - docker exec -itd -w /onnx-mlir/build -e LIT_OPT=v build cmake --build . --target check-onnx-lit
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ script:
   - docker run -itd -v $(pwd):/onnx-mlir --name build onnx-mlir-build:initial
   - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
   - docker exec -itd build compile-onnx-mlir.sh
-  
+  - docker login -u onnxmlirczar -p 143f1da2-332f-45a1-8587-d6cb07c13230 
+  - docker push onnxmlirczar/onnx-mlir-build:latest 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ script:
   - docker run -itd -v $(pwd):/onnx-mlir --name build onnx-mlir-build:initial
   - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
   - docker exec -itd build compile-onnx-mlir.sh
+  - docker commit build onnxmlirczar/onnx-mlir-build:latest
   - docker login -u onnxmlirczar -p 143f1da2-332f-45a1-8587-d6cb07c13230 
   - docker push onnxmlirczar/onnx-mlir-build:latest 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,13 @@ dist: bionic
 script:
   - cd docker
   - chmod a+x compile-onnx-mlir.sh
-  - docker build --tag onnx-mlir-build:initial .
-
+  - docker pull onnxmlirczar/onnx-mlir-build:initial
+  - docker run -itd -v $(pwd):/build --name build onnxmlirczar/onnx-mlir-build:initial
+  - docker run build mkdir /build/bin
+  - docker copy build compile-onnx-mlir.sh bin/compile-onnx-mlir.sh
+  - docker run build export PATH=$PATH:/build/bin 
+  - docker run build compile-onnx-mlir.sh
+  - docker run build export LIT_OPT=v
+  - docker run build cd /build/onnx-mlir/build
+  - docker run build cmake --build . --target check-onnx-lit
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ script:
   - chmod a+x compile-onnx-mlir.sh
   - docker build --tag onnx-mlir-build:initial .
   - docker run -itd -v $(pwd):/onnx-mlir --name build onnx-mlir-build:initial
-  - docker exec build mkdir /build/bin
-  - docker copy build compile-onnx-mlir.sh /usr/bin/compile-onnx-mlir.sh
-  - docker exec build compile-onnx-mlir.sh
-  - docker exec build export LIT_OPT=v
-  - docker exec build cd /onnx-mlir/build
-  - docker exec build cmake --build . --target check-onnx-lit
+  - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
+  - docker exec -itd build compile-onnx-mlir.sh
+  - docker exec -itd -w /onnx-mlir/build -e LIT_OPT=v build cmake --build . --target check-onnx-lit
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ script:
   - chmod a+x compile-onnx-mlir.sh
   - docker build --tag onnx-mlir-build:initial .
   - docker run -itd -v $(pwd):/onnx-mlir --name build onnx-mlir-build:initial
-  - docker run build mkdir /build/bin
+  - docker exec build mkdir /build/bin
   - docker copy build compile-onnx-mlir.sh /usr/bin/compile-onnx-mlir.sh
-  - docker run build compile-onnx-mlir.sh
-  - docker run build export LIT_OPT=v
-  - docker run build cd /onnx-mlir/build
-  - docker run build cmake --build . --target check-onnx-lit
+  - docker exec build compile-onnx-mlir.sh
+  - docker exec build export LIT_OPT=v
+  - docker exec build cd /onnx-mlir/build
+  - docker exec build cmake --build . --target check-onnx-lit
   

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,9 +10,3 @@ RUN pyenv global 3.7.0
 RUN pyenv rehash
 
 ENV PATH=$PATH:/build/bin
-RUN git clone --recursive https://github.com/onnx/onnx-mlir.git
-COPY compile-onnx-mlir.sh bin/compile-onnx-mlir.sh
-RUN compile-onnx-mlir.sh
-WORKDIR /build/onnx-mlir/build
-ENV LIT_OPT=v
-RUN cmake --build . --target check-onnx-lit

--- a/docker/compile-onnx-mlir.sh
+++ b/docker/compile-onnx-mlir.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-# Export environment variables pointing to LLVM-Projects
+# Export environment variables pointing to LLVM-Projects.
 export LLVM_PROJ_SRC=$(pwd)/llvm-project/
 export LLVM_PROJ_BUILD=$(pwd)/llvm-project/build
-HOME=/
-PYENV_ROOT=$HOME/.pyenv
-PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-eval "$(pyenv init -)"
-# use python 3
-pyenv shell 3.7.0
+
 mkdir onnx-mlir/build && cd onnx-mlir/build
 cmake ..
 cmake --build . --target onnx-mlir
+
+# Run FileCheck tests:
+export LIT_OPTS=-v
+cmake --build . --target check-onnx-lit

--- a/docker/compile-onnx-mlir.sh
+++ b/docker/compile-onnx-mlir.sh
@@ -3,6 +3,8 @@
 export LLVM_PROJ_SRC=$(pwd)/llvm-project/
 export LLVM_PROJ_BUILD=$(pwd)/llvm-project/build
 
+pwd
+ls -al
 mkdir onnx-mlir/build && cd onnx-mlir/build
 cmake ..
 cmake --build . --target onnx-mlir


### PR DESCRIPTION
Previously the build always built the latest commit on the master branch, even for a PR. Now it builds the merge for a PR. Also, for pushes to the master branch it now saves the resulting docker image in docker hub, so we can grab that image and use it when developing new tests etc.