### PR TITLE
constant folding for transpose of constant tensors

### DIFF
--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -68,17 +68,9 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
     // Read perm attribute.
     SmallVector<int, 4> perm;
     auto permAttribute = llvm::dyn_cast<ONNXTransposeOp>(op).permAttr();
-    if (permAttribute) {
-      for (auto permVal : permAttribute.getValue())
-        perm.emplace_back(permVal.cast<IntegerAttr>().getInt());
-    } else {
-      // TODO: Remove when perm is guaranteed to be present (even for
-      // the default case). This means that perm was added by shape
-      // inference or another pass to contain the values corresponding
-      // to the default behavior of Transpose.
-      for (int i = iterationBlock.getArguments().size() - 1; i >= 0; i--)
-        perm.emplace_back(i);
-    }
+    assert(permAttribute && "permute attribute expected to be defined here");
+    for (auto permVal : permAttribute.getValue())
+      perm.emplace_back(permVal.cast<IntegerAttr>().getInt());
 
     SmallVector<Value, 4> inLoopIVs;
     for (auto arg : iterationBlock.getArguments())

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -1217,16 +1217,21 @@ LogicalResult ONNXTransposeOp::inferShapes() {
   auto arrayTy = data().getType().cast<RankedTensorType>();
   SmallVector<int64_t, 2> dims;
   auto permutation = ONNXTransposeOp::permAttr();
-  if (permutation) {
-    // Perform transposition according to perm attribute.
-    for (auto perm : permutation.getValue())
-      dims.emplace_back(arrayTy.getShape()[perm.cast<IntegerAttr>().getInt()]);
-  } else {
-    // Default
-    for (auto dim : llvm::reverse(arrayTy.getShape()))
-      dims.emplace_back(dim);
+  if (!permutation) {
+    // Generate revese order for default transpose operation.
+    SmallVector<int64_t, 4> defaultVals;
+    auto builder = mlir::Builder(getContext());
+    auto rank = arrayTy.getShape().size();
+    for (int i = rank-1; i >= 0; --i)
+      defaultVals.emplace_back(i);
+    // Set default attribute.
+    ArrayRef<int64_t> defaultRefs(defaultVals);
+    permAttr(builder.getI64ArrayAttr(defaultRefs));
+    permutation = permAttr();
   }
-
+  // Perform transposition according to perm attribute.
+  for (auto perm : permutation.getValue())
+    dims.emplace_back(arrayTy.getShape()[perm.cast<IntegerAttr>().getInt()]);
   getResult().setType(RankedTensorType::get(dims, arrayTy.getElementType()));
   return success();
 }

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -1222,7 +1222,7 @@ LogicalResult ONNXTransposeOp::inferShapes() {
     SmallVector<int64_t, 4> defaultVals;
     auto builder = mlir::Builder(getContext());
     auto rank = arrayTy.getShape().size();
-    for (int i = rank-1; i >= 0; --i)
+    for (int i = rank - 1; i >= 0; --i)
       defaultVals.emplace_back(i);
     // Set default attribute.
     ArrayRef<int64_t> defaultRefs(defaultVals);

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -69,7 +69,6 @@ Attribute ComputeConstPropElementwiseBinary<ONNXAddOp>(
     double lhsVal = lhsAttr.cast<FloatAttr>().getValueAsDouble();
     double rhsVal = secondAttr.cast<FloatAttr>().getValueAsDouble();
     double res = lhsVal + rhsVal;
-    // printf("  %f + %f -> %f\n", lhsVal, rhsVal, res);
     // Could use the APFloat interface to emulate the results, are ok to simply
     // perform them in the highest possible precision.
     return rewriter.getFloatAttr(elementType, res);
@@ -78,7 +77,6 @@ Attribute ComputeConstPropElementwiseBinary<ONNXAddOp>(
     uint64_t lhsVal = lhsAttr.cast<IntegerAttr>().getInt();
     uint64_t rhsVal = secondAttr.cast<IntegerAttr>().getInt();
     uint64_t res = lhsVal + rhsVal;
-    // printf("  %llu + %llu -> %llu\n", lhsVal, rhsVal, res);
     return rewriter.getIntegerAttr(elementType, res);
   }
   llvm_unreachable("constant propagation for AddOp: unkonwn data type");
@@ -137,7 +135,6 @@ void RecurseConstPropElementwiseBinary(PatternRewriter &rewriter,
     std::vector<Attribute> &resVector, DenseElementsAttr &lhsAttr,
     DenseElementsAttr &rhsAttr, SmallVector<uint64_t, 4> &lhsIndices,
     SmallVector<uint64_t, 4> &rhsIndices, int lhsFreeRank, int rhsFreeRank) {
-  // printf("recurse with free %d/%d\n", lhsFreeRank, rhsFreeRank);
   if (lhsFreeRank == 0) {
     // Fully defined ranks.
     assert(
@@ -253,7 +250,6 @@ template <typename ElementwiseUnaryOp>
 void RecurseConstPropElementwiseUnary(PatternRewriter &rewriter,
     std::vector<Attribute> &resVector, DenseElementsAttr &attr,
     SmallVector<uint64_t, 4> &indices, int freeRank) {
-  // printf("recurse with free %d\n", freeRank);
   if (freeRank == 0) {
     // Fully defined ranks.
     auto elementAttr = attr.getValue(ArrayRef<uint64_t>(indices));
@@ -303,7 +299,6 @@ void RecurseConstPropTranspose(PatternRewriter &rewriter,
     std::vector<Attribute> &resVector, DenseElementsAttr &attr,
     SmallVector<uint64_t, 4> &indices, SmallVector<uint64_t, 4> &perm,
     int freeRank) {
-  // printf("recurse with free %d\n", freeRank);
   if (freeRank == 0) {
     // Fully defined ranks.
     auto res = attr.getValue(ArrayRef<uint64_t>(indices));

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -63,6 +63,9 @@ def CreateNegOfConst :
  def CreateMulOfTwoConst :
    NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXMulOp>($_builder, $0, $1, $2)">;
 
+def CreateTransposeOfConst :
+   NativeCodeCall<"ConstPropTranspose($_builder, $0, $1, $2)">;
+
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise ADD operations.
 //===----------------------------------------------------------------------===//
@@ -229,4 +232,17 @@ def MulConstProp : Pat<
     // Mulitional constraints (no sparse)
     [(AttributeIsNull:$s1), (AttributeIsNull:$s2)]>;
 
+//===----------------------------------------------------------------------===//
+// Patterns to enable opportunities with Transpose operations.
+//===----------------------------------------------------------------------===//
+
+// Neg of constant is simly -const
+def TransposeofConst :  Pat<
+    // From TransposeOp(c, p)
+    (ONNXTransposeOp:$resOp (ONNXConstantOp $s, $v), $p),
+    // To c' where c' is transposed attribute
+    (ONNXConstantOp (GetNullAttr), (CreateTransposeOfConst $resOp, $v, $p)),
+    [(AttributeIsNull:$s)]>;
+
+  
 #endif // ONNX_CONSTPROP

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --constprop-onnx %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --constprop-onnx %s -split-input-file | FileCheck %s
 
 
 //===----------------------------------------------------------------------===//
@@ -195,3 +195,34 @@ func @test_neg_3(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<3x2xi32>
 }
 
+//===----------------------------------------------------------------------===//
+/// Transpose tests.
+
+// check default transpose
+// -----  
+func @test_default_transpose_const_1() -> tensor<*xi32> {
+  // CHECK-LABEL: test_default_transpose_const_1
+  %0 = "onnx.Constant"() {value = dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>} : () -> tensor<2x3x4xi32>
+  %1 = "onnx.Transpose"(%0) : (tensor<2x3x4xi32>) -> tensor<*xi32>
+  "std.return"(%1) : (tensor<*xi32>) -> ()
+  // CHECK: [[RES:%.+]] = "onnx.Constant"() {value = dense<[{{.}}[111, 211], [121, 221], [131, 231]{{.}}, [{{.}}112, 212], [122, 222], [132, 232]{{.}}, [{{.}}113, 213], [123, 223], [133, 233]{{.}}, [{{.}}114, 214], [124, 224], [134, 234]{{.}}]> : tensor<4x3x2xi32>} : () -> tensor<4x3x2xi32>
+  // CHECK: return [[RES]] : tensor<4x3x2xi32>
+}
+
+func @test_default_transpose_const_2() -> tensor<*xi32> {
+  // CHECK-LABEL: test_default_transpose_const_2
+  %0 = "onnx.Constant"() {value = dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>} : () -> tensor<2x3x4xi32>
+  %1 = "onnx.Transpose"(%0) {perm = [0, 2, 1]} : (tensor<2x3x4xi32>) -> tensor<*xi32>
+  "std.return"(%1) : (tensor<*xi32>) -> ()
+  // CHECK: [[RES:%.+]] = "onnx.Constant"() {value = dense<[{{.}}[111, 121, 131], [112, 122, 132], [113, 123, 133], [114, 124, 134]{{.}}, [{{.}}211, 221, 231], [212, 222, 232], [213, 223, 233], [214, 224, 234]{{.}}]> : tensor<2x4x3xi32>} : () -> tensor<2x4x3xi32>
+  // CHECK: return [[RES]] : tensor<2x4x3xi32>
+}
+
+func @test_default_transpose_const_3() -> tensor<*xi32> {
+  // CHECK-LABEL: test_default_transpose_const_3
+  %0 = "onnx.Constant"() {value = dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>} : () -> tensor<2x3x4xi32>
+  %1 = "onnx.Transpose"(%0) {perm = [1, 0, 2]} : (tensor<2x3x4xi32>) -> tensor<*xi32>
+  "std.return"(%1) : (tensor<*xi32>) -> ()
+  // CHECK: [[RES:%.+]] =  "onnx.Constant"() {value = dense<[{{.}}[111, 112, 113, 114], [211, 212, 213, 214]{{.}}, [{{.}}121, 122, 123, 124], [221, 222, 223, 224]{{.}}, [{{.}}131, 132, 133, 134], [231, 232, 233, 234]{{.}}]> : tensor<3x2x4xi32>} : () -> tensor<3x2x4xi32>
+  // CHECK: return [[RES]] : tensor<3x2x4xi32>
+}

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -198,10 +198,9 @@ func @test_neg_3(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
 //===----------------------------------------------------------------------===//
 /// Transpose tests.
 
-// check default transpose
 // -----  
-func @test_default_transpose_const_1() -> tensor<*xi32> {
-  // CHECK-LABEL: test_default_transpose_const_1
+// CHECK-LABEL: test_default_transpose_const_1
+  func @test_default_transpose_const_1() -> tensor<*xi32> {
   %0 = "onnx.Constant"() {value = dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>} : () -> tensor<2x3x4xi32>
   %1 = "onnx.Transpose"(%0) : (tensor<2x3x4xi32>) -> tensor<*xi32>
   "std.return"(%1) : (tensor<*xi32>) -> ()
@@ -209,8 +208,9 @@ func @test_default_transpose_const_1() -> tensor<*xi32> {
   // CHECK: return [[RES]] : tensor<4x3x2xi32>
 }
 
+// -----  
+// CHECK-LABEL: test_default_transpose_const_2
 func @test_default_transpose_const_2() -> tensor<*xi32> {
-  // CHECK-LABEL: test_default_transpose_const_2
   %0 = "onnx.Constant"() {value = dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>} : () -> tensor<2x3x4xi32>
   %1 = "onnx.Transpose"(%0) {perm = [0, 2, 1]} : (tensor<2x3x4xi32>) -> tensor<*xi32>
   "std.return"(%1) : (tensor<*xi32>) -> ()
@@ -218,8 +218,9 @@ func @test_default_transpose_const_2() -> tensor<*xi32> {
   // CHECK: return [[RES]] : tensor<2x4x3xi32>
 }
 
+// -----  
+// CHECK-LABEL: test_default_transpose_const_3
 func @test_default_transpose_const_3() -> tensor<*xi32> {
-  // CHECK-LABEL: test_default_transpose_const_3
   %0 = "onnx.Constant"() {value = dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>} : () -> tensor<2x3x4xi32>
   %1 = "onnx.Transpose"(%0) {perm = [1, 0, 2]} : (tensor<2x3x4xi32>) -> tensor<*xi32>
   "std.return"(%1) : (tensor<*xi32>) -> ()

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -12,7 +12,7 @@ func @test_default_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_transpose
-  // CHECK: [[RES:%.+]] = "onnx.Transpose"(%arg0) : (tensor<5x5x1x32xf32>) -> tensor<32x1x5x5xf32>
+  // CHECK: [[RES:%.+]] = "onnx.Transpose"(%arg0) {perm = [3, 2, 1, 0]} : (tensor<5x5x1x32xf32>) -> tensor<32x1x5x5xf32>
   // CHECK: return [[RES]] : tensor<32x1x5x5xf32>
 }
 


### PR DESCRIPTION
Added constant folding for for transpose of constant tensors.

Also made the optional transpose attribute (which is the normal math transpose) explicit, that is, the permute attribute (a vector of int) is now defined in all cases, so that we don't have to check "if defined, use explicit, otherwise use default" in the rest of the code. Changed lowering to Kernel accordingly