### PR TITLE
[WIP] Make krnl.getref compatiable with affine ops

### DIFF
--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -271,6 +271,6 @@ def KrnlGetRefOp : Op<Krnl_Dialect, "getref", [AffineScope]> {
   let regions = (region AnyRegion:$region);
   let results = (outs AnyTypeOf<[AnyMemRef]>:$output);
 
-  let parser = ?;
-  let printer = ?;
+  let printer = [{ return ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
 }

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -256,7 +256,7 @@ def KrnlPackedConstantOp : Op<Krnl_Dialect, "packed_const"> {
   let printer = ?;
 }
 
-def KrnlGetRefOp : Op<Krnl_Dialect, "getref"> {
+def KrnlGetRefOp : Op<Krnl_Dialect, "getref", [AffineScope]> {
   let summary = "Krnl a MemRef from within another MemRef starting at a specific offset.";
   let description = [{
     Retreieves a MemRef from within another MemRef:
@@ -268,6 +268,7 @@ def KrnlGetRefOp : Op<Krnl_Dialect, "getref"> {
   }];
 
   let arguments = (ins AnyTypeOf<[AnyMemRef]>:$mempool, AnyInteger:$offset);
+  let regions = (region AnyRegion:$region);
   let results = (outs AnyTypeOf<[AnyMemRef]>:$output);
 
   let parser = ?;

--- a/test/mlir/krnl/krnl_getref_lowering.mlir
+++ b/test/mlir/krnl/krnl_getref_lowering.mlir
@@ -3,7 +3,7 @@
 func @test_getref_lowering(%arg0: memref<2x2xf32>) -> memref<2x2xf32> {
   %c13_i64 = constant 13 : i64
   %1 = alloc() : memref<10x10xf32>
-  %2 = "krnl.getref"(%1, %c13_i64) : (memref<10x10xf32>, i64) -> memref<2x2xf32>
+  %2 = krnl.getref(%1, %c13_i64) : (memref<10x10xf32>, i64) -> memref<2x2xf32>
   return %2 : memref<2x2xf32>
 
   // CHECK-LABEL: test_getref_lowering

--- a/test/mlir/krnl/ops.mlir
+++ b/test/mlir/krnl/ops.mlir
@@ -77,3 +77,17 @@ func @affine_map_bound(%N : index) {
 
   return
 }
+
+// -----
+
+func @getref(%arg0: memref<2x2xf32>) -> memref<2x2xf32> {
+  %c42_i64 = constant 42 : i64
+  %0 = alloc() : memref<10x10xf32>
+
+  // GENERIC: "krnl.getref"(%{{.*}}, %{{.*}}) ( {
+  // GENERIC-NEXT: }) : ({{.*}}, {{.*}}) -> {{.*}}
+  %1 = krnl.getref (%0, %c42_i64) : (memref<10x10xf32>, i64) -> memref<2x2xf32>
+
+  return %1 : memref<2x2xf32>
+
+}

--- a/test/mlir/onnx/onnx_enable_memory_pool.mlir
+++ b/test/mlir/onnx/onnx_enable_memory_pool.mlir
@@ -10,7 +10,7 @@ func @test_enable_memory_pool(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
   // CHECK: [[CONST0:%.+]] = constant 0 : i64
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[MEMPOOL:%.+]] = alloc() : memref<400xi8>
-  // CHECK: [[GETREF:%.+]] = "krnl.getref"([[MEMPOOL]], [[CONST0]]) : (memref<400xi8>, i64) -> memref<10x10xf32>
+  // CHECK: [[GETREF:%.+]] = krnl.getref([[MEMPOOL]], [[CONST0]]) : (memref<400xi8>, i64) -> memref<10x10xf32>
   // CHECK: krnl.define_loops
   // CHECK: krnl.optimize_loops
   // CHECK: krnl.iterate
@@ -37,9 +37,9 @@ func @test_enable_memory_pool_2(%arg0: tensor<10x10xf32>, %arg1: tensor<10x20xf3
   // CHECK: [[CONST1:%.+]] = constant 0.000000e+00 : f32
   // CHECK: [[RES:%.+]] = alloc() : memref<10x20xf32>
   // CHECK: [[MEMPOOL0:%.+]] = alloc() : memref<800xi8>
-  // CHECK: [[GETREF0:%.+]] = "krnl.getref"([[MEMPOOL0]], [[CONST0]]) : (memref<800xi8>, i64) -> memref<10x20xf32>
+  // CHECK: [[GETREF0:%.+]] = krnl.getref([[MEMPOOL0]], [[CONST0]]) : (memref<800xi8>, i64) -> memref<10x20xf32>
   // CHECK: [[MEMPOOL1:%.+]] = alloc() : memref<400xi8>
-  // CHECK: [[GETREF1:%.+]] = "krnl.getref"([[MEMPOOL1]], [[CONST0]]) : (memref<400xi8>, i64) -> memref<10x10xf32>
+  // CHECK: [[GETREF1:%.+]] = krnl.getref([[MEMPOOL1]], [[CONST0]]) : (memref<400xi8>, i64) -> memref<10x10xf32>
   // CHECK: krnl.define_loops
   // CHECK: krnl.optimize_loops
   // CHECK: krnl.iterate


### PR DESCRIPTION
Currently, if we enabled `affine-loop-fusion` pass, we would get an error saying 
```bash
/home/tungld/dl/llvm-project/mlir/lib/Dialect/Affine/IR/AffineOps.cpp:482: mlir::AffineMap promoteComposedSymbolsAsDims(mlir::AffineMap, llvm::ArrayRef<mlir::Value>): Assertion `isValidSymbol(sym) && "Expected only valid symbols"' failed.
```

This was because the return value of `krnl.getref` was invalid to be used in the pass.

According to AffineOps.cpp (https://github.com/llvm/llvm-project/blob/master/mlir/lib/Dialect/Affine/IR/AffineOps.cpp#L224), conditions for a valid value are:
>// A value can be used as a symbol (at all its use sites) iff it meets one of
// the following conditions:
// *) It is a constant.
// *) Its defining op or block arg appearance is immediately enclosed by an op
//    with `AffineScope` trait.
// *) It is the result of an affine.apply operation with symbol operands.
// *) It is a result of the dim op on a memref whose corresponding size is a
//    valid symbol.

This patch is to make the `krnl.getref`'s return value valid by adding `AffineScope` trait into `getref`'s definition.