### PR TITLE
Remove whole archive linkage

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -252,26 +252,6 @@ set(MLIRLibs
 	      ${CURSES_LIBRARIES}
 	      ${ZLIB_LIBRARIES})
 
-# ONNX MLIR libraries that must be linked with --whole-archive for static build or
-# must be specified on LD_PRELOAD for shared build.
-set(OMLibs
-        OMBuilder
-        OMKrnlOps
-        OMONNXOps
-        OMKrnlToAffine
-        OMKrnlToLLVM
-        OMONNXToKrnl
-        OMONNXRewrite
-        OMShapeInference
-        OMShapeInferenceOpInterface
-        OMAttributePromotion
-        OMPromotableConstOperandsOpInterface
-        OMResultTypeInferenceOpInterface
-        OMElideConstants
-        OMElideKrnlGlobalConstants
-        OMPackKrnlGlobalConstants
-        OMEnableMemoryPool)
-
 set(LLVM_CMAKE_DIR
         "${LLVM_PROJ_BUILD}/lib/cmake/llvm"
         CACHE PATH "Path to LLVM cmake modules")

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -255,6 +255,9 @@ set(MLIRLibs
 # ONNX MLIR libraries that must be linked with --whole-archive for static build or
 # must be specified on LD_PRELOAD for shared build.
 set(OMLibs
+        OMBuilder
+        OMKrnlOps
+        OMONNXOps
         OMKrnlToAffine
         OMKrnlToLLVM
         OMONNXToKrnl

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -266,6 +266,7 @@ set(OMLibs
         OMShapeInferenceOpInterface
         OMAttributePromotion
         OMPromotableConstOperandsOpInterface
+        OMResultTypeInferenceOpInterface
         OMElideConstants
         OMElideKrnlGlobalConstants
         OMPackKrnlGlobalConstants

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -186,6 +186,16 @@ find_mlir_lib(LLVMDemangle)
 find_mlir_lib(LLVMFrontendOpenMP)
 
 set(MLIRLibs
+        ${MLIRAffineToStandard}
+        ${MLIRAffineOps}
+        ${MLIRLLVMIR}
+        ${MLIRStandardOps}
+        ${MLIRStandardToLLVM}
+        ${MLIRTransforms}
+        ${MLIRSCFToStandard}
+        ${MLIRVector}
+        ${MLIRSCF}
+        ${MLIRIR}
         ${MLIRLLVMIR}
         ${MLIROptLib}
         ${MLIRParser}
@@ -242,23 +252,9 @@ set(MLIRLibs
 	      ${CURSES_LIBRARIES}
 	      ${ZLIB_LIBRARIES})
 
-# MLIR libraries that must be linked with --whole-archive for static build or
-# must be specified on LD_PRELOAD for shared build.
-set(MLIRWholeArchiveLibs
-        MLIRAffineToStandard
-        MLIRAffineOps
-        MLIRLLVMIR
-        MLIRStandardOps
-        MLIRStandardToLLVM
-        MLIRTransforms
-        MLIRSCFToStandard
-        MLIRVector
-        MLIRSCF
-        MLIRIR)
-
 # ONNX MLIR libraries that must be linked with --whole-archive for static build or
 # must be specified on LD_PRELOAD for shared build.
-set(ONNXMLIRWholeArchiveLibs
+set(OMLibs
         OMKrnlToAffine
         OMKrnlToLLVM
         OMONNXToKrnl

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,9 +22,10 @@ set(OMLibs
         OMElideConstants
         OMElideKrnlGlobalConstants
         OMPackKrnlGlobalConstants
-        OMEnableMemoryPool
-        PARENT_SCOPE)
+        OMEnableMemoryPool)
+set(OMLibs ${OMLibs} PARENT_SCOPE)
 
+message(SATUS "OMLibs" ${OMLibs})
 add_subdirectory(Tool)
 
 add_library(MainUtils

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,8 @@ set(OMLibs
         OMElideConstants
         OMElideKrnlGlobalConstants
         OMPackKrnlGlobalConstants
-        OMEnableMemoryPool)
+        OMEnableMemoryPool
+        PARENT_SCOPE)
 
 add_subdirectory(Tool)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,6 @@ add_subdirectory(Interface)
 add_subdirectory(Dialect)
 add_subdirectory(Conversion)
 add_subdirectory(Transform)
-add_subdirectory(Tool)
 add_subdirectory(Builder)
 add_subdirectory(Runtime)
 
@@ -24,6 +23,8 @@ set(OMLibs
         OMElideKrnlGlobalConstants
         OMPackKrnlGlobalConstants
         OMEnableMemoryPool)
+
+add_subdirectory(Tool)
 
 add_library(MainUtils
         MainUtils.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,22 +43,7 @@ endif()
 # targets, or only use it for libraries that have no further dependencies
 # (except system libraries such as libc).
 target_link_libraries(MainUtils
-        OMBuilder
-        OMKrnlOps
-        OMONNXOps
-        OMShapeInference
-        OMShapeInferenceOpInterface
-        OMAttributePromotion
-        OMPromotableConstOperandsOpInterface
-        OMResultTypeInferenceOpInterface
-        OMElideConstants
-        OMElideKrnlGlobalConstants
-        OMPackKrnlGlobalConstants
-        OMEnableMemoryPool
-        OMKrnlToAffine
-        OMKrnlToLLVM
-        OMONNXToKrnl
-        OMONNXRewrite
+        ${OMLibs}
         ${MLIRLibs}
         ${CMAKE_DL_LIBS})
 add_dependencies(onnx-mlir OMKrnlOpsInc OMONNXOpsInc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,25 @@ add_subdirectory(Tool)
 add_subdirectory(Builder)
 add_subdirectory(Runtime)
 
+# All ONNX-MLIR libraries.
+set(OMLibs
+        OMBuilder
+        OMKrnlOps
+        OMONNXOps
+        OMKrnlToAffine
+        OMKrnlToLLVM
+        OMONNXToKrnl
+        OMONNXRewrite
+        OMShapeInference
+        OMShapeInferenceOpInterface
+        OMAttributePromotion
+        OMPromotableConstOperandsOpInterface
+        OMResultTypeInferenceOpInterface
+        OMElideConstants
+        OMElideKrnlGlobalConstants
+        OMPackKrnlGlobalConstants
+        OMEnableMemoryPool)
+
 add_library(MainUtils
         MainUtils.hpp
         MainUtils.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ExternalUtil.hpp.in
         ${CMAKE_CURRENT_BINARY_DIR}/ExternalUtil.hpp)
 
 set(ONNX_MLIR_LD_PRELOAD_onnx-mlir "" CACHE STRING "" FORCE)
-whole_archive_link_mlir(onnx-mlir ${MLIRWholeArchiveLibs})
 if(BUILD_SHARED_LIBS)
   message(STATUS "To run dynamically linked onnx-mlir, you must specify:")
   message(STATUS "LD_PRELOAD=${ONNX_MLIR_LD_PRELOAD_onnx-mlir}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,11 @@ add_subdirectory(Tool)
 add_library(MainUtils
         MainUtils.hpp
         MainUtils.cpp)
-target_link_libraries(MainUtils onnx)
+target_link_libraries(MainUtils
+        ${OMLibs}
+        ${MLIRLibs}
+        ${CMAKE_DL_LIBS}
+        onnx)
 
 target_include_directories(MainUtils PRIVATE ${ONNX_MLIR_SRC_ROOT})
 target_include_directories(MainUtils PRIVATE ${CMAKE_BINARY_DIR})
@@ -63,10 +67,6 @@ endif()
 # So it's better not to use target_link_libraries for the add_subdirectory
 # targets, or only use it for libraries that have no further dependencies
 # (except system libraries such as libc).
-target_link_libraries(MainUtils
-        ${OMLibs}
-        ${MLIRLibs}
-        ${CMAKE_DL_LIBS})
 add_dependencies(onnx-mlir OMKrnlOpsInc OMONNXOpsInc)
 
 if (INCLUDE_ONNX_ML)

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -119,6 +119,3 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
 std::unique_ptr<Pass> mlir::createLowerToKrnlPass() {
   return std::make_unique<FrontendToKrnlLoweringPass>();
 }
-
-static PassRegistration<FrontendToKrnlLoweringPass> pass(
-    "lower-frontend", "Lower frontend ops to Krnl dialect.");

--- a/src/InitOMPasses.hpp
+++ b/src/InitOMPasses.hpp
@@ -5,7 +5,8 @@
 namespace onnx_mlir {
 
 void initOMPasses() {
-
+  // All passes implemented within onnx-mlir should register within this
+  // function to make themselves available as a command-line option.
   mlir::registerPass("decompose-onnx",
       "Decompose ONNX operations into composition of other ONNX operations.",
       []() -> std::unique_ptr<mlir::Pass> {

--- a/src/InitOMPasses.hpp
+++ b/src/InitOMPasses.hpp
@@ -1,0 +1,72 @@
+#include "mlir/Pass/Pass.h"
+
+#include "src/Pass/Passes.hpp"
+
+namespace onnx_mlir {
+
+void initOMPasses() {
+
+  mlir::registerPass("decompose-onnx",
+      "Decompose ONNX operations into composition of other ONNX operations.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createDecomposeONNXToONNXPass();
+      });
+
+  mlir::registerPass("shape-inference",
+      "Shape inference for frontend dialects.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createShapeInferencePass();
+      });
+
+  mlir::registerPass("constprop-onnx",
+      "ConstProp ONNX operations into composition of other ONNX operations.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createConstPropONNXToONNXPass();
+      });
+
+  mlir::registerPass("attribute-promotion",
+      "Promote constant operands to attributes.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createAttributePromotionPass();
+      });
+
+  mlir::registerPass("elide-constants", "Elide values of constant operations.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createElideConstantValuePass();
+      });
+
+  mlir::registerPass("enable-memory-pool",
+      "Enable a memory pool for allocating internal MemRefs.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createKrnlEnableMemoryPoolPass();
+      });
+
+  mlir::registerPass(
+      "lower-krnl", "Lower Krnl dialect.", []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createLowerKrnlPass();
+      });
+
+  mlir::registerPass("lower-frontend", "Lower frontend ops to Krnl dialect.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createLowerToKrnlPass();
+      });
+
+  mlir::registerPass("elide-krnl-constants",
+      "Elide the constant values of the Global Krnl operations.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createElideConstGlobalValuePass();
+      });
+
+  mlir::registerPass("lower-all-llvm",
+      "Lower the Krnl Affine and Std dialects to LLVM.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createKrnlLowerToLLVMPass();
+      });
+
+  mlir::registerPass("pack-krnl-constants",
+      "Elide the constant values of the Global Krnl operations.",
+      []() -> std::unique_ptr<mlir::Pass> {
+        return mlir::createPackKrnlGlobalConstantsPass();
+      });
+}
+} // namespace onnx_mlir

--- a/src/Tool/ONNXMLIROpt/CMakeLists.txt
+++ b/src/Tool/ONNXMLIROpt/CMakeLists.txt
@@ -5,8 +5,6 @@ target_include_directories(onnx-mlir-opt PRIVATE ${ONNX_MLIR_SRC_ROOT})
 target_include_directories(onnx-mlir-opt PRIVATE ${ONNX_MLIR_BIN_ROOT})
 
 set(ONNX_MLIR_LD_PRELOAD_onnx-mlir-opt "" CACHE STRING "" FORCE)
-whole_archive_link_onnx_mlir(onnx-mlir-opt ${ONNXMLIRWholeArchiveLibs})
-whole_archive_link_mlir(onnx-mlir-opt ${MLIRWholeArchiveLibs})
 if(BUILD_SHARED_LIBS)
   message(STATUS "To run dynamically linked onnx-mlir-opt, you must specify:")
   message(STATUS "LD_PRELOAD=${ONNX_MLIR_LD_PRELOAD_onnx-mlir-opt}")
@@ -17,4 +15,5 @@ target_link_libraries(onnx-mlir-opt
         OMKrnlOps
         OMONNXOps
         OMONNXRewrite
+        ${OMLibs}
         ${MLIRLibs})

--- a/src/Tool/ONNXMLIROpt/CMakeLists.txt
+++ b/src/Tool/ONNXMLIROpt/CMakeLists.txt
@@ -11,9 +11,5 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 target_link_libraries(onnx-mlir-opt
-        OMBuilder
-        OMKrnlOps
-        OMONNXOps
-        OMONNXRewrite
         ${OMLibs}
         ${MLIRLibs})

--- a/src/Tool/ONNXMLIROpt/CMakeLists.txt
+++ b/src/Tool/ONNXMLIROpt/CMakeLists.txt
@@ -12,4 +12,5 @@ endif()
 
 target_link_libraries(onnx-mlir-opt
         ${OMLibs}
-        ${MLIRLibs})
+        ${MLIRLibs}
+        onnx)

--- a/src/Tool/ONNXMLIROpt/ONNXMLIROpt.cpp
+++ b/src/Tool/ONNXMLIROpt/ONNXMLIROpt.cpp
@@ -21,6 +21,7 @@
 
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/InitOMPasses.hpp"
 #include "src/Pass/Passes.hpp"
 
 using namespace onnx_mlir;
@@ -68,6 +69,7 @@ int main(int argc, char **argv) {
 
   mlir::registerDialect<mlir::ONNXOpsDialect>();
   mlir::registerDialect<mlir::KrnlOpsDialect>();
+  initOMPasses();
 
   mlir::registerAsmPrinterCLOptions();
   mlir::registerMLIRContextCLOptions();

--- a/src/Transform/ElideKrnlGlobalConstants.cpp
+++ b/src/Transform/ElideKrnlGlobalConstants.cpp
@@ -69,6 +69,3 @@ public:
 std::unique_ptr<Pass> mlir::createElideConstGlobalValuePass() {
   return std::make_unique<ElideConstGlobalValuePass>();
 }
-
-static PassRegistration<ElideConstGlobalValuePass> pass("elide-krnl-constants",
-    "Elide the constant values of the Global Krnl operations.");

--- a/src/Transform/EnableMemoryPool.cpp
+++ b/src/Transform/EnableMemoryPool.cpp
@@ -154,6 +154,3 @@ public:
 std::unique_ptr<Pass> mlir::createKrnlEnableMemoryPoolPass() {
   return std::make_unique<KrnlEnableMemoryPoolPass>();
 }
-
-static PassRegistration<KrnlEnableMemoryPoolPass> pass("enable-memory-pool",
-    "Enable a memory pool for allocating internal MemRefs.");

--- a/src/Transform/LowerKrnl.cpp
+++ b/src/Transform/LowerKrnl.cpp
@@ -181,6 +181,3 @@ void KrnlToAffineLoweringPass::runOnFunction() {
 std::unique_ptr<Pass> mlir::createLowerKrnlPass() {
   return std::make_unique<KrnlToAffineLoweringPass>();
 }
-
-static PassRegistration<KrnlToAffineLoweringPass> pass(
-    "lower-krnl", "Lower Krnl dialect.");

--- a/src/Transform/LowerToLLVM.cpp
+++ b/src/Transform/LowerToLLVM.cpp
@@ -865,6 +865,3 @@ void KrnlToLLVMLoweringPass::runOnOperation() {
 std::unique_ptr<mlir::Pass> mlir::createKrnlLowerToLLVMPass() {
   return std::make_unique<KrnlToLLVMLoweringPass>();
 }
-
-static PassRegistration<KrnlToLLVMLoweringPass> pass(
-    "lower-all-llvm", "Lower the Krnl Affine and Std dialects to LLVM.");

--- a/src/Transform/ONNX/AttributePromotion.cpp
+++ b/src/Transform/ONNX/AttributePromotion.cpp
@@ -101,6 +101,3 @@ public:
 std::unique_ptr<mlir::Pass> mlir::createAttributePromotionPass() {
   return std::make_unique<AttributePromotionPass>();
 }
-
-static PassRegistration<AttributePromotionPass> pass(
-    "attribute-promotion", "Promote constant operands to attributes.");

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -375,6 +375,3 @@ void ConstPropONNXToONNXPass::runOnFunction() {
 std::unique_ptr<mlir::Pass> mlir::createConstPropONNXToONNXPass() {
   return std::make_unique<ConstPropONNXToONNXPass>();
 }
-
-static PassRegistration<ConstPropONNXToONNXPass> pass("constprop-onnx",
-    "ConstProp ONNX operations into composition of other ONNX operations.");

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -61,6 +61,3 @@ void DecomposeONNXToONNXPass::runOnFunction() {
 std::unique_ptr<mlir::Pass> mlir::createDecomposeONNXToONNXPass() {
   return std::make_unique<DecomposeONNXToONNXPass>();
 }
-
-static PassRegistration<DecomposeONNXToONNXPass> pass("decompose-onnx",
-    "Decompose ONNX operations into composition of other ONNX operations.");

--- a/src/Transform/ONNX/ElideConstants.cpp
+++ b/src/Transform/ONNX/ElideConstants.cpp
@@ -78,6 +78,3 @@ public:
 std::unique_ptr<mlir::Pass> mlir::createElideConstantValuePass() {
   return std::make_unique<ElideConstantValuePass>();
 }
-
-static PassRegistration<ElideConstantValuePass> pass(
-    "elide-constants", "Elide values of constant operations.");

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -87,6 +87,3 @@ public:
 std::unique_ptr<mlir::Pass> mlir::createShapeInferencePass() {
   return std::make_unique<ShapeInferencePass>();
 }
-
-static PassRegistration<ShapeInferencePass> pass(
-    "shape-inference", "Shape inference for frontend dialects.");

--- a/test/mlir/lit.site.cfg.py.in
+++ b/test/mlir/lit.site.cfg.py.in
@@ -1,8 +1,5 @@
 import lit.llvm
 
-if '@BUILD_SHARED_LIBS@' == 'ON':
-    config.environment['LD_LIBRARY_PATH'] = r"@LLVM_PROJ_BUILD@/lib:@ONNX_MLIR_BIN_ROOT@/lib:" + config.environment['LD_LIBRARY_PATH']
-
 config.llvm_tools_dir = r"@MLIR_TOOLS_DIR@"
 config.mlir_obj_root = r"@LLVM_PROJ_BUILD@"
 config.mlir_tools_dir = r"@MLIR_TOOLS_DIR@"

--- a/test/mlir/lit.site.cfg.py.in
+++ b/test/mlir/lit.site.cfg.py.in
@@ -1,7 +1,7 @@
 import lit.llvm
 
 if '@BUILD_SHARED_LIBS@' == 'ON':
-    config.environment['LD_PRELOAD'] = r"@ONNX_MLIR_LD_PRELOAD_onnx-mlir-opt@"
+    config.environment['LD_LIBRARY_PATH'] = r"@LLVM_PROJ_BUILD@/lib:@ONNX_MLIR_BIN_ROOT@/lib:" + config.environment['LD_LIBRARY_PATH']
 
 config.llvm_tools_dir = r"@MLIR_TOOLS_DIR@"
 config.mlir_obj_root = r"@LLVM_PROJ_BUILD@"

--- a/test/numerical/CMakeLists.txt
+++ b/test/numerical/CMakeLists.txt
@@ -1,18 +1,6 @@
 add_executable(TestConv TestConv.cpp)
 target_link_libraries(TestConv
-        OMBuilder
-        OMKrnlOps
-        OMONNXOps
-        OMShapeInference
-        OMShapeInferenceOpInterface
-        OMAttributePromotion
-        OMPromotableConstOperandsOpInterface
-        OMElideConstants
-        OMElideKrnlGlobalConstants
-        OMKrnlToAffine
-        OMKrnlToLLVM
-        OMONNXToKrnl
-        OMONNXRewrite
+        ${OMLibs}
         ${MLIRLibs}
         ${CMAKE_DL_LIBS}
         rapidcheck

--- a/test/numerical/CMakeLists.txt
+++ b/test/numerical/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(TestConv
         MainUtils
         ExecutionSession
         DynMemRefUtils)
-whole_archive_link_mlir(TestConv ${MLIRWholeArchiveLibs})
+
 target_include_directories(TestConv
         PRIVATE
         ${ONNX_MLIR_SRC_ROOT}


### PR DESCRIPTION
Change all implicit self-registering transformation passes to use explicit registration. This follows from changes in the upstream mlir. It allows us to remove all whole-archive linking related build scripts.