### PR TITLE
Remove dangling constant ops when importing non-optional-input ops.

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -222,8 +222,12 @@ private:
 
     // Trailing optional inputs.
     if (!variadicIn)
-      for (auto i = inputs.size(); i < expectedNumOperands; i++)
+      for (auto i = inputs.size(); i < expectedNumOperands; i++) {
+        if (!none_)
+          none_ = builder_.create<mlir::ConstantOp>(
+              UnknownLoc(), builder_.getUnitAttr());
         inputs.emplace_back(none_);
+      }
 
     std::vector<mlir::Type> outputTypes;
 
@@ -481,11 +485,6 @@ private:
         entryBlockArgIdx++;
       }
     }
-
-    // Create a NoneTyped constant to be used for optional operation inputs
-    // which are not used.
-    none_ =
-        builder_.create<mlir::ConstantOp>(UnknownLoc(), builder_.getUnitAttr());
 
     // Import nodes in the graph.
     for (const auto &item : graph.node()) {


### PR DESCRIPTION
`constant unit` is used for optional inputs.

This patch is to create `constant unit` ops for optional inputs only when we are importing ops with optional inputs. Hence, it avoids creating dangling `constant unit` ops in the other cases.