### PR TITLE
Fix importing optional inputs

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -309,7 +309,13 @@ private:
     int expectedNumOperands = T::getNumberOfOperands();
     int expectedNumResults = T::getNumberOfResults();
     for (const auto &item : node.input())
-      if (initializedTensors.ContainKey(legalize_name(item))) {
+      if (item.empty()) {
+        // Optional inputs using empty string will be imported as NoneType.
+        if (!none_)
+          none_ = builder_.create<mlir::ConstantOp>(
+              UnknownLoc(), builder_.getUnitAttr());
+        inputs.emplace_back(none_);
+      } else if (initializedTensors.ContainKey(legalize_name(item))) {
         inputs.push_back(initializedTensors.EmitInitializerForInputTensor(
             UnknownLoc(), builder_, legalize_name(item)));
       } else if (frontend_symbols_.ContainKey(legalize_name(item))) {


### PR DESCRIPTION
This patch is to import optional inputs sandwiched between two others inputs. These optional inputs are represented as empty strings in ONNX models.

e.g. This patch is to import the 5-th input in this LSTM op correctly:
```mlir
%Y, %Y_h, %Y_c = "onnx.LSTM"(%0, %1, %2, %3, %cst, %4, %5, %cst) {hidden_size = 200 : i64} : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>, tensor<*xf32>, none, tensor<*xf32>, tensor<*xf32>, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
```

Without this fix, the 5-th input will be bypassed, and output will be wrong like this:
```mlir
%Y, %Y_h, %Y_c = "onnx.LSTM"(%0, %1, %2, %3, %4, %5, %cst,  %cst) {hidden_size = 200 : i64} : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>, tensor<*xf32>, tensor<*xf32>, tensor<*xf32>, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
```