### PR TITLE
add builder for CastOp

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -494,6 +494,14 @@ def ONNXCastOp:ONNX_Op<"Cast",
       return resultTypes;
     }
   }];
+     let builders = [
+    OpBuilder<"OpBuilder &builder, OperationState &state, Value input, IntegerAttr to", [{
+      auto toAttr = to.getValue().getSExtValue();
+      auto resultType = mlir::UnrankedTensorType::get(
+        convertONNXTypeToMLIRType(builder, static_cast<onnx::TensorProto_DataType>(toAttr)));
+      build(builder, state, resultType, input, to);
+    }] >
+    ];
 }
 
 def ONNXCeilOp:ONNX_Op<"Ceil",

--- a/src/Transform/ONNX/Rewrite.cpp
+++ b/src/Transform/ONNX/Rewrite.cpp
@@ -116,6 +116,7 @@ void ONNXScalerOp::getCanonicalizationPatterns(
   result.insert<ScalerNullPattern>(context);
   result.insert<ScalerNullPattern2>(context);
   result.insert<ScalerNoScalePattern>(context);
+  result.insert<ScalerNoScalePattern2>(context);
   result.insert<ScalerNoOffsetPattern>(context);
   result.insert<ScalerPattern>(context);
 }

--- a/src/Transform/ONNX/Rewrite.td
+++ b/src/Transform/ONNX/Rewrite.td
@@ -115,7 +115,8 @@ def HasFloatType : Constraint<CPred<"(($_self).getType().dyn_cast<ShapedType>().
 def createDenseArrayAttr:
   NativeCodeCall<"createDenseArrayAttr($_builder, $0)">;
 
-def ScalerT : NativeCodeCall<"$_builder.getI64IntegerAttr(0)">;
+// TensorProt_DataType_FLOAT is 1
+def ScalerT : NativeCodeCall<"$_builder.getI64IntegerAttr(1)">;
 
 // No attribute
 def ScalerNullPattern : Pat<
@@ -134,6 +135,14 @@ def ScalerNoScalePattern : Pat<
   (ONNXScalerOp $x, $a, $b),
     (ONNXSubOp $x,
       (ONNXConstantOp (GetNullAttr), (createDenseArrayAttr $a))),
+    [(HasFloatType:$x), (AttributeIsNull:$b)]>;
+
+def ScalerNoScalePattern2 : Pat<
+  (ONNXScalerOp $x, $a, $b),
+    (ONNXSubOp 
+      (ONNXCastOp $x, (ScalerT)),
+      (ONNXConstantOp (GetNullAttr), (createDenseArrayAttr $a))
+    ),
     [(AttributeIsNull:$b)]>;
 
 // No offset

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -118,7 +118,7 @@ func @test_scaler_null(%arg0: tensor<3xi32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) : (tensor<3xi32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 
-    // CHECK-NEXT: %0 = "onnx.Cast"(%arg0) {to = 0 : i64} : (tensor<3xi32>) -> tensor<3xf32>
+    // CHECK-NEXT: %0 = "onnx.Cast"(%arg0) {to = 1 : i64} : (tensor<3xi32>) -> tensor<3xf32>
     // CHECK-NEXT: return %0 : tensor<3xf32>
 }
 
@@ -148,6 +148,19 @@ func @test_scaler_no_scale(%arg0: tensor<3xf32>) -> tensor<3xf32> {
     // CHECK-NEXT: %1 = "onnx.Sub"(%arg0, %0) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
     // CHECK-NEXT: return %1 : tensor<3xf32>
 }
+
+// scaler no scale for i32 tensor
+
+//CHECK-LABEL: func @test_scaler_no_scale2(%arg0: tensor<3xi32>) -> tensor<3xf32> {
+func @test_scaler_no_scale2(%arg0: tensor<3xi32>) -> tensor<3xf32> {
+  %0 = "onnx.Scaler"(%arg0) {offset = [1986.99939 : f32, 0.99999988 : f32, 0.999999701 : f32]} : (tensor<3xi32>) -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+ //CHECK-NEXT: %0 = "onnx.Cast"(%arg0) {to = 1 : i64} : (tensor<3xi32>) -> tensor<*xf32>
+ //CHECK-NEXT: %1 = "onnx.Constant"() {value = dense<[1986.99939, 0.99999988, 0.999999701]> : tensor<3xf32>} : () -> tensor<3xf32>
+ //CHECK-NEXT: %2 = "onnx.Sub"(%0, %1) : (tensor<*xf32>, tensor<3xf32>) -> tensor<3xf32>
+ //CHECK-NEXT: return %2 : tensor<3xf32>
+}
+
 
 // -----
 

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -315,7 +315,18 @@ custom_definition_misc = dict([ ('Constant',
       }
     }]>
     ];'''
-  )])
+  ),
+    ('Cast',
+  '''     let builders = [
+    OpBuilder<"OpBuilder &builder, OperationState &state, Value input, IntegerAttr to", [{
+      auto toAttr = to.getValue().getSExtValue();
+      auto resultType = mlir::UnrankedTensorType::get(
+        convertONNXTypeToMLIRType(builder, static_cast<onnx::TensorProto_DataType>(toAttr)));
+      build(builder, state, resultType, input, to);
+    }] >
+    ];'''
+  )
+  ])
 
 
 onnx_types = (


### PR DESCRIPTION
1. Add Special builder for CastOp so that it can be used in rewrite rule

2. Fixed the error in the Rewrite rules for ScalerOp

3. Add a test example