### PR TITLE
include stdlib.h when compiling on macOS

### DIFF
--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -1,5 +1,9 @@
 #include <assert.h>
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include <string.h>
 
 #include "RtMemRef.h"


### PR DESCRIPTION
On macOS, `<stdlib.h>` contains malloc. So `<stdlib.h>` should be included instead of `<malloc.h>`.
In this PR, I added `#ifdef` to switch include header.