### PR TITLE
Add macOS build support on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ services:
 language: cpp
 os:
   - linux
+  - osx
 dist: bionic
 arch:
   - s390x
   - ppc64le
   - amd64
+osx_image: xcode11.6
 env:
   - NIGHTLY=true
   - NIGHTLY=false


### PR DESCRIPTION
As we discussed in #252, I've added macOS build support on Travis CI.