### PR TITLE
change tag to x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ seen in the docs folder. The Dockerfile is shown here.
 
 [same-as-file]: <> (docs/docker-example/Dockerfile)
 ```
-FROM onnxmlirczar/onnx-mlir-build:amd64
+FROM onnxmlirczar/onnx-mlir-build:x86
 
 WORKDIR /build
 ENV HOME=/build

--- a/docs/docker-example/Dockerfile
+++ b/docs/docker-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM onnxmlirczar/onnx-mlir-build:amd64
+FROM onnxmlirczar/onnx-mlir-build:x86
 
 WORKDIR /build
 ENV HOME=/build


### PR DESCRIPTION
tag of build image was changed by PR #268 from amd64 to x86 --- fix here to pick up latest build