### PR TITLE
Update available python3 version on AzurePipelines

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -13,7 +13,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7.7'
+      versionSpec: '3.7.9'
       architecture: 'x64'
 
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The Open Neural Network Exchange implementation in MLIR.
 
 [![CircleCI](https://circleci.com/gh/onnx/onnx-mlir/tree/master.svg?style=svg)](https://circleci.com/gh/onnx/onnx-mlir/tree/master)
-[![Build Status](https://dev.azure.com/onnx-pipelines/onnx/_apis/build/status/jacky82226.onnx-mlir?branchName=master)](https://dev.azure.com/onnx-pipelines/onnx/_build/latest?definitionId=8&branchName=master)
+[![Build Status](https://dev.azure.com/onnx-pipelines/onnx/_apis/build/status/MLIR-Windows-CI?branchName=master)](https://dev.azure.com/onnx-pipelines/onnx/_build/latest?definitionId=9&branchName=master)
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This project uses lit ([LLVM's Integrated Tester](http://llvm.org/docs/CommandGu
 
 To build ONNX MLIR, use the following command:
 
-[same-as-file]: <> (utils/install-onnx-mlir.cmd)
+[same-as-file]: <> ({"ref": "utils/install-onnx-mlir.cmd", "skip-doc": 2})
 ```shell
 git clone --recursive https://github.com/onnx/onnx-mlir.git
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,7 +143,7 @@ This project uses lit ([LLVM's Integrated Tester](http://llvm.org/docs/CommandGu
 
 To build ONNX MLIR, use the following command:
 
-[same-as-file]: <> (utils/install-onnx-mlir.cmd)
+[same-as-file]: <> ({"ref": "utils/install-onnx-mlir.cmd", "skip-doc": 2})
 ```shell
 git clone --recursive https://github.com/onnx/onnx-mlir.git
 

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -61,7 +61,7 @@ std::vector<int64_t> getDilations<ONNXMaxPoolSingleOutOp>(
   bool isDefaultDilations = true;
   for (auto dilation : dilationsAttribute.getValue()) {
     int64_t dilationValue = dilation.cast<IntegerAttr>().getInt();
-    if (dilationValue > 1 and isDefaultDilations)
+    if (dilationValue > 1 && isDefaultDilations)
       isDefaultDilations = false;
     dilations.emplace_back(dilationValue);
   }

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -11,7 +11,12 @@
 #include "src/MainUtils.hpp"
 #include <fcntl.h>
 #include <stdio.h>
+
+#ifdef _WIN32
+#include <io.h>
+#else 
 #include <unistd.h>
+#endif
 
 using namespace std;
 using namespace onnx_mlir;
@@ -106,13 +111,23 @@ void outputCode(
     mlir::OwningModuleRef &module, string filename, string extension) {
   // Start a separate process to redirect the model output. I/O redirection
   // changes will not be visible to the parent process.
+  string tempFilename = filename + extension;
+#ifdef _WIN32
+  // copy original stderr file number
+  int stderrOrigin = _dup(_fileno(stderr));
+  freopen(tempFilename.c_str(), "w", stderr);
+  module->dump();
+  fflush(stderr);
+  // set modified stderr as original stderr
+  _dup2(stderrOrigin, _fileno( stderr ));
+#else 
   if (fork() == 0) {
-    string tempFilename = filename + extension;
     freopen(tempFilename.c_str(), "w", stderr);
     module->dump();
     fclose(stderr);
     exit(0);
   }
+#endif
 }
 
 void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,

--- a/utils/install-onnx-mlir.cmd
+++ b/utils/install-onnx-mlir.cmd
@@ -1,5 +1,3 @@
-git clone --recursive https://github.com/onnx/onnx-mlir.git
-
 REM Export environment variables pointing to LLVM-Projects.
 set root_dir=%cd%
 set CURSES_LIB_PATH=%root_dir%/PDCurses

--- a/utils/setup-onnx-mlir-windows.cmd
+++ b/utils/setup-onnx-mlir-windows.cmd
@@ -7,6 +7,11 @@ call conda create --yes --quiet --name onnx-mlir -c conda-forge python=3.7 libpr
 call activate.bat onnx-mlir
 call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 
+REM Copy original repo directory to onnx-mlir
+git submodule update --init --recursive
+set onnx-mlir_dir=%cd%
+cd ..
+cp -r %onnx-mlir_dir% onnx-mlir 
 set root_dir=%cd%
 
 REM Build PDcurses
@@ -18,8 +23,8 @@ call nmake -f wincon/Makefile.vc
 
 REM Build LLVM
 cd /d %root_dir%
-call utils/install-mlir.cmd
+call onnx-mlir/utils/install-mlir.cmd
 
 REM Build onnx-mlir
 cd /d %root_dir%
-call utils/install-onnx-mlir.cmd
+call onnx-mlir/utils/install-onnx-mlir.cmd


### PR DESCRIPTION
**Description**
Update available python3 version (3.7.9) on AzurePipelines

**Motivation and Context**
CI on Azurepipelines is failing because the python3 version (3.7.7) s not available.