### PR TITLE
Update llvm commit ID to 1d01fc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,34 +14,39 @@ env:
 jobs:
   allow_failures:
     - env: NIGHTLY=true
-script:
-  - export CPU_ARCH=$TRAVIS_CPU_ARCH
-  - if [ "$CPU_ARCH" == "amd64" ] ; then
-      export CPU_ARCH="x86";
-    fi
-  - echo "CPU Architecture is " $CPU_ARCH
-  - echo "commit is " $TRAVIS_COMMIT
-  - df -h
-  - if [ "$NIGHTLY" = true ] ; then
-      echo "Using nightly llvm-mlir image, build may fail.";
-      docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:${CPU_ARCH}-nightly"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
-    else
-      echo "Using latest compatible llvm-mlir image, build should not fail.";
-      docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:$CPU_ARCH"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
-    fi
-  - docker run -itd --name build onnx-mlir-build:initial
-  - echo "docker is running now"
-  - df -h
-  - docker cp $(pwd) build:/build/onnx-mlir
-  - cd docker
-  - chmod a+x compile-onnx-mlir.sh test-onnx-mlir.sh
-  - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
-  - docker cp test-onnx-mlir.sh build:/usr/bin/test-onnx-mlir.sh
-  - echo "about to execute build inside docker"
-  - docker exec build df -h
-  - docker exec build compile-onnx-mlir.sh
-  - docker exec build test-onnx-mlir.sh
-  - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
+  include:
+    - stage: prereq
+      script:
+        - echo "Helloworld!"
+    - stage: test
+      script:
+        - export CPU_ARCH=$TRAVIS_CPU_ARCH
+        - if [ "$CPU_ARCH" == "amd64" ] ; then
+            export CPU_ARCH="x86";
+          fi
+        - echo "CPU Architecture is " $CPU_ARCH
+        - echo "commit is " $TRAVIS_COMMIT
+        - df -h
+        - if [ "$NIGHTLY" = true ] ; then
+            echo "Using nightly llvm-mlir image, build may fail.";
+            docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:${CPU_ARCH}-nightly"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
+          else
+            echo "Using latest compatible llvm-mlir image, build should not fail.";
+            docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:$CPU_ARCH"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
+          fi
+        - docker run -itd --name build onnx-mlir-build:initial
+        - echo "docker is running now"
+        - df -h
+        - docker cp $(pwd) build:/build/onnx-mlir
+        - cd docker
+        - chmod a+x compile-onnx-mlir.sh test-onnx-mlir.sh
+        - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
+        - docker cp test-onnx-mlir.sh build:/usr/bin/test-onnx-mlir.sh
+        - echo "about to execute build inside docker"
+        - docker exec build df -h
+        - docker exec build compile-onnx-mlir.sh
+        - docker exec build test-onnx-mlir.sh
+        - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
 after_success: 
   - if [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_BRANCH == "master" ] && [ $NIGHTLY == false ]; then
             echo "Pushing new build to docker hub";

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,52 @@ env:
   - NIGHTLY=true
   - NIGHTLY=false
 stages:
-  - name: prereq
+  - name: prereq-init
+  - name: prereq-0
+  - name: prereq-1
+  - name: prereq-2
+  - name: prereq-final
   - name: test
 jobs:
   allow_failures:
     - env: NIGHTLY=true
   include:
-    - stage: prereq
+    # Iteratively (5 times * 40 min max time each) build docker pre-req image for s390x.
+    - stage: prereq-init
       arch:
         - s390x
       script:
-        - echo "Helloworld!"
-    - stage: prereq
+        - docker build -t onnxmlirczar/onnx-mlir-prereq-intermediate:s390x -f docker/prereq.s390x.Dockerfile --build-arg BASE_IMAGE="ubuntu:focal" ./utils
+        - docker login -u onnxmlirczar -p "$DOCKER_HUB_TOKEN"
+        - docker push onnxmlirczar/onnx-mlir-prereq-intermediate:s390x
+    - stage: prereq-0
+      arch:
+        - s390x
+      script:
+        - docker build -t onnxmlirczar/onnx-mlir-prereq-intermediate:s390x -f docker/prereq.s390x.Dockerfile --build-arg BASE_IMAGE="onnxmlirczar/onnx-mlir-prereq-intermediate:s390x" ./utils
+        - docker login -u onnxmlirczar -p "$DOCKER_HUB_TOKEN"
+        - docker push onnxmlirczar/onnx-mlir-prereq-intermediate:s390x
+    - stage: prereq-1
+      arch:
+        - s390x
+      script:
+        - docker build -t onnxmlirczar/onnx-mlir-prereq-intermediate:s390x -f docker/prereq.s390x.Dockerfile --build-arg BASE_IMAGE="onnxmlirczar/onnx-mlir-prereq-intermediate:s390x" ./utils
+        - docker login -u onnxmlirczar -p "$DOCKER_HUB_TOKEN"
+        - docker push onnxmlirczar/onnx-mlir-prereq-intermediate:s390x
+    - stage: prereq-2
+      arch:
+        - s390x
+      script:
+        - docker build -t onnxmlirczar/onnx-mlir-prereq-intermediate:s390x -f docker/prereq.s390x.Dockerfile --build-arg BASE_IMAGE="onnxmlirczar/onnx-mlir-prereq-intermediate:s390x" ./utils
+        - docker login -u onnxmlirczar -p "$DOCKER_HUB_TOKEN"
+        - docker push onnxmlirczar/onnx-mlir-prereq-intermediate:s390x
+    - stage: prereq-final
+        - docker build -t onnxmlirczar/onnx-mlir-prereq-intermediate:s390x -f docker/prereq.s390x.Dockerfile --build-arg BASE_IMAGE="onnxmlirczar/onnx-mlir-prereq-intermediate:s390x" ./utils
+        - docker login -u onnxmlirczar -p "$DOCKER_HUB_TOKEN"
+        - docker push onnxmlirczar/onnx-mlir-prereq:s390x
+    
+    # Iteratively (5 times * 40 min max time each) build docker pre-req image for x86.
+    - stage: prereq-init
       arch:
         - amd64
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ arch:
 env:
   - NIGHTLY=true
   - NIGHTLY=false
+stages:
+  - name: prereq
+  - name: test
 jobs:
   allow_failures:
     - env: NIGHTLY=true
@@ -18,6 +21,7 @@ jobs:
     - stage: prereq
       script:
         - echo "Helloworld!"
+        
     - stage: test
       script:
         - export CPU_ARCH=$TRAVIS_CPU_ARCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ jobs:
     - stage: prereq
       arch:
         - s390x
-        - ppc64le
+      script:
+        - echo "Helloworld!"
+    - stage: prereq
+      arch:
         - amd64
       script:
         - echo "Helloworld!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ jobs:
     - env: NIGHTLY=true
   include:
     - stage: prereq
+      arch:
+        - s390x
+        - ppc64le
+        - amd64
       script:
         - echo "Helloworld!"
         

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -253,8 +253,8 @@ set(MLIRLibs
         ${MLIRSideEffectInterfaces}
         ${MLIRStandardOps}
         ${MLIRStandardToLLVM}
-        ${MLIRSupport}
         ${MLIRTranslation}
+        ${MLIRSupport}
         ${MLIRLinalgOps}
         ${MLIRLinalgEDSC}
         ${MLIRLinalgAnalysis}

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 9c94908320549a1a2328c758d6bbb694466021e7 && cd ..
+cd llvm-project && git checkout 1d01fc100bb5bef5f5eaf92520b2e52f64ee1d6e && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 9c94908320549a1a2328c758d6bbb694466021e7 && cd ..
+cd llvm-project && git checkout 1d01fc100bb5bef5f5eaf92520b2e52f64ee1d6e && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docker/prereq.s390x.Dockerfile
+++ b/docker/prereq.s390x.Dockerfile
@@ -50,7 +50,7 @@ RUN if [ ! -f "/build/llvm-project/build/CMakeCache.txt" ]; then \
        -DLLVM_ENABLE_RTTI=ON; \
     fi
 
-# Build for 5 minutes:
-RUN timeout 5m cmake --build . --target -- ${MAKEFLAGS} || true
+# Build for 40 minutes:
+RUN timeout 40m cmake --build . --target -- ${MAKEFLAGS} || true
 
 # RUN cmake --build . --target check-mlir

--- a/docker/prereq.s390x.Dockerfile
+++ b/docker/prereq.s390x.Dockerfile
@@ -1,43 +1,56 @@
-FROM ubuntu:focal
+ARG BASE_IMAGE
+
+# By default, use ubuntu:focal;
+FROM $BASE_IMAGE
 
 WORKDIR /build
 
 # install stuff that is needed for compiling LLVM, MLIR and ONNX
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git cmake ninja-build libprotobuf-dev protobuf-compiler 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git cmake ninja-build libprotobuf-dev protobuf-compiler
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
     apt-get -y install \
         make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
         libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils \
         libffi-dev liblzma-dev
-RUN git clone git://github.com/yyuu/pyenv.git .pyenv
-RUN git clone https://github.com/yyuu/pyenv-virtualenv.git ~/.pyenv/plugins/pyenv-virtualenv
+
+RUN if [ ! -d .pyenv ]; then \
+      git clone git://github.com/yyuu/pyenv.git .pyenv && \
+      git clone https://github.com/yyuu/pyenv-virtualenv.git ~/.pyenv/plugins/pyenv-virtualenv; \
+    fi
 
 ENV HOME=/build
 ENV PYENV_ROOT=$HOME/.pyenv
 ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
-RUN pyenv install 3.7.0
-
-RUN pyenv global 3.7.0
-RUN pyenv rehash
+RUN if [ ! -d .pyenv ]; then \
+      pyenv install 3.7.0 && \
+      pyenv global 3.7.0 && \
+      pyenv rehash; \
+    fi
 
 # first install MLIR in llvm-project
-RUN mkdir bin
+RUN mkdir -p bin
 ENV PATH=$PATH:/build/bin
 COPY clone-mlir.sh bin/clone-mlir.sh
 RUN chmod a+x bin/clone-mlir.sh
-RUN clone-mlir.sh
+RUN if [ ! -d /build/llvm-project ]; then \
+      clone-mlir.sh; \
+    fi
 
 WORKDIR /build/llvm-project/build
-RUN cmake -G Ninja ../llvm \
-   -DLLVM_ENABLE_PROJECTS=mlir \
-   -DLLVM_BUILD_EXAMPLES=ON \
-   -DLLVM_TARGETS_TO_BUILD="host" \
-   -DCMAKE_BUILD_TYPE=Release \
-   -DLLVM_ENABLE_ASSERTIONS=ON \
-   -DLLVM_ENABLE_RTTI=ON
+RUN if [ ! -f "/build/llvm-project/build/CMakeCache.txt" ]; then \
+      cmake -G Ninja ../llvm \
+       -DLLVM_ENABLE_PROJECTS=mlir \
+       -DLLVM_BUILD_EXAMPLES=ON \
+       -DLLVM_TARGETS_TO_BUILD="host" \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DLLVM_ENABLE_ASSERTIONS=ON \
+       -DLLVM_ENABLE_RTTI=ON; \
+    fi
 
-RUN cmake --build . --target -- ${MAKEFLAGS}
+# Build for 5 minutes:
+RUN timeout 5m cmake --build . --target -- ${MAKEFLAGS} || true
+
 # RUN cmake --build . --target check-mlir

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 9c94908320549a1a2328c758d6bbb694466021e7 && cd ..
+cd llvm-project && git checkout 1d01fc100bb5bef5f5eaf92520b2e52f64ee1d6e && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)
@@ -110,7 +110,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 9c94908320549a1a2328c758d6bbb694466021e7 && cd ..
+cd llvm-project && git checkout 1d01fc100bb5bef5f5eaf92520b2e52f64ee1d6e && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -309,162 +309,167 @@ std::vector<Value> getLoopIVsForBroadcasting(Location loc,
 Value emitConstantOp(
     PatternRewriter &rewriter, Location loc, Type type, double value) {
   Attribute constantAttr;
-  auto typeKind = type.getKind();
-  if (typeKind == StandardTypes::F16) {
-    constantAttr = rewriter.getF16FloatAttr((float)value);
-  } else if (typeKind == StandardTypes::F32) {
-    constantAttr = rewriter.getF32FloatAttr((float)value);
-  } else if (typeKind == StandardTypes::F64) {
-    constantAttr = rewriter.getF64FloatAttr(value);
-  } else if (typeKind == StandardTypes::Integer) {
-    auto width = type.cast<IntegerType>().getWidth();
-    if (width == 1) {
-      constantAttr = rewriter.getBoolAttr(false);
-    } else {
-      constantAttr =
-          rewriter.getIntegerAttr(type, APInt(width, (int64_t)value));
-    }
-  } else if (typeKind == StandardTypes::Index) {
-    constantAttr = rewriter.getIntegerAttr(type, (int64_t)value);
-  } else {
-    llvm_unreachable("unsupported element type");
-  }
 
+  TypeSwitch<Type>(type)
+      .Case<Float16Type>(
+          [&](Type) { constantAttr = rewriter.getF16FloatAttr((float)value); })
+      .Case<Float32Type>(
+          [&](Type) { constantAttr = rewriter.getF32FloatAttr((float)value); })
+      .Case<Float64Type>(
+          [&](Type) { constantAttr = rewriter.getF64FloatAttr((float)value); })
+      .Case<IntegerType>([&](Type) {
+        auto width = type.cast<IntegerType>().getWidth();
+        if (width == 1) {
+          constantAttr = rewriter.getBoolAttr(false);
+        } else {
+          constantAttr =
+              rewriter.getIntegerAttr(type, APInt(width, (int64_t)value));
+        }
+      })
+      .Case<IndexType>([&](Type) {
+        constantAttr = rewriter.getIntegerAttr(type, (int64_t)value);
+      })
+      .Default([](Type) { llvm_unreachable("unsupported element type"); });
   return rewriter.create<ConstantOp>(loc, constantAttr);
 }
 
 Value emitPositiveInfinityConstantOp(
     ConversionPatternRewriter &rewriter, Location loc, Type type) {
   Attribute constantAttr;
-  auto typeKind = type.getKind();
-  if (typeKind == StandardTypes::F16) {
-    // 0x7C00
-    float value = std::numeric_limits<float>::infinity();
-    constantAttr = rewriter.getF16FloatAttr(value);
-  } else if (typeKind == StandardTypes::F32) {
-    // 0x7F800000
-    float value = std::numeric_limits<float>::infinity();
-    constantAttr = rewriter.getF32FloatAttr(value);
-  } else if (typeKind == StandardTypes::F64) {
-    // 0x7FF0000000000000
-    double value = std::numeric_limits<double>::infinity();
-    constantAttr = rewriter.getF64FloatAttr(value);
-  } else if (typeKind == StandardTypes::Integer) {
-    auto width = type.cast<IntegerType>().getWidth();
-    // The latest llvm-project includes a patch which allows getting the sign of
-    // IntegerType:
-    // https://github.com/llvm/llvm-project/commit/35b685270b410f6a1351c2a527021f22330c25b9
-    // as follows:
-    //   auto isSigned = type.cast<IntegerType>().isSigned();
-    // TODO (tungld): update the following statement once our llvm-project is
-    // upgraded to include the patch.
-    auto isSigned = true;
-    if (width == 8) {
-      if (isSigned) {
-        int8_t value = std::numeric_limits<int8_t>::max();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      } else {
-        uint8_t value = std::numeric_limits<uint8_t>::max();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      }
-    } else if (width == 16) {
-      if (isSigned) {
-        int16_t value = std::numeric_limits<int16_t>::max();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      } else {
-        uint16_t value = std::numeric_limits<uint16_t>::max();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      }
-    } else if (width == 32) {
-      if (isSigned) {
-        int32_t value = std::numeric_limits<int32_t>::max();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      } else {
-        uint32_t value = std::numeric_limits<uint32_t>::max();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      }
-    } else if (width == 64) {
-      if (isSigned) {
-        int64_t value = std::numeric_limits<int64_t>::max();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      } else {
-        uint64_t value = std::numeric_limits<uint64_t>::max();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      }
-    } else {
-      llvm_unreachable("unsupported element type");
-    }
-  } else {
-    llvm_unreachable("unsupported element type");
-  }
 
+  TypeSwitch<Type>(type)
+      .Case<Float16Type>([&](Type) {
+        // 0x7C00
+        float value = std::numeric_limits<float>::infinity();
+        constantAttr = rewriter.getF16FloatAttr(value);
+      })
+      .Case<Float32Type>([&](Type) {
+        // 0x7F800000
+        float value = std::numeric_limits<float>::infinity();
+        constantAttr = rewriter.getF32FloatAttr(value);
+      })
+      .Case<Float64Type>([&](Type) {
+        // 0x7FF0000000000000
+        double value = std::numeric_limits<double>::infinity();
+        constantAttr = rewriter.getF64FloatAttr(value);
+      })
+      .Case<IntegerType>([&](Type) {
+        auto width = type.cast<IntegerType>().getWidth();
+        // The latest llvm-project includes a patch which allows getting the
+        // sign of IntegerType:
+        // https://github.com/llvm/llvm-project/commit/35b685270b410f6a1351c2a527021f22330c25b9
+        // as follows:
+        //   auto isSigned = type.cast<IntegerType>().isSigned();
+        // TODO (tungld): update the following statement once our llvm-project
+        // is upgraded to include the patch.
+        auto isSigned = true;
+        if (width == 8) {
+          if (isSigned) {
+            int8_t value = std::numeric_limits<int8_t>::max();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          } else {
+            uint8_t value = std::numeric_limits<uint8_t>::max();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          }
+        } else if (width == 16) {
+          if (isSigned) {
+            int16_t value = std::numeric_limits<int16_t>::max();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          } else {
+            uint16_t value = std::numeric_limits<uint16_t>::max();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          }
+        } else if (width == 32) {
+          if (isSigned) {
+            int32_t value = std::numeric_limits<int32_t>::max();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          } else {
+            uint32_t value = std::numeric_limits<uint32_t>::max();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          }
+        } else if (width == 64) {
+          if (isSigned) {
+            int64_t value = std::numeric_limits<int64_t>::max();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          } else {
+            uint64_t value = std::numeric_limits<uint64_t>::max();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          }
+        } else {
+          llvm_unreachable("unsupported element type");
+        }
+      })
+      .Default([](Type) { llvm_unreachable("unsupported element type"); });
   return rewriter.create<ConstantOp>(loc, constantAttr);
 }
 
 Value emitNegativeInfinityConstantOp(
     ConversionPatternRewriter &rewriter, Location loc, Type type) {
   Attribute constantAttr;
-  auto typeKind = type.getKind();
-  if (typeKind == StandardTypes::F16) {
-    // 0xFC00
-    float value = -std::numeric_limits<float>::infinity();
-    constantAttr = rewriter.getF16FloatAttr(value);
-  } else if (typeKind == StandardTypes::F32) {
-    // 0xFF800000
-    float value = -std::numeric_limits<float>::infinity();
-    constantAttr = rewriter.getF32FloatAttr(value);
-  } else if (typeKind == StandardTypes::F64) {
-    // 0xFFF0000000000000
-    double value = -std::numeric_limits<double>::infinity();
-    constantAttr = rewriter.getF64FloatAttr(value);
-  } else if (typeKind == StandardTypes::Integer) {
-    auto width = type.cast<IntegerType>().getWidth();
-    // The latest llvm-project includes a patch which allows getting the sign of
-    // IntegerType:
-    // https://github.com/llvm/llvm-project/commit/35b685270b410f6a1351c2a527021f22330c25b9
-    // as follows:
-    //   auto isSigned = type.cast<IntegerType>().isSigned();
-    // TODO (tungld): update the following statement once our llvm-project is
-    // upgraded to include the patch.
-    auto isSigned = true;
-    if (width == 8) {
-      if (isSigned) {
-        int8_t value = std::numeric_limits<int8_t>::min();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      } else {
-        uint8_t value = std::numeric_limits<uint8_t>::min();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      }
-    } else if (width == 16) {
-      if (isSigned) {
-        int16_t value = std::numeric_limits<int16_t>::min();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      } else {
-        uint16_t value = std::numeric_limits<uint16_t>::min();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      }
-    } else if (width == 32) {
-      if (isSigned) {
-        int32_t value = std::numeric_limits<int32_t>::min();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      } else {
-        uint32_t value = std::numeric_limits<uint32_t>::min();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      }
-    } else if (width == 64) {
-      if (isSigned) {
-        int64_t value = std::numeric_limits<int64_t>::min();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      } else {
-        uint64_t value = std::numeric_limits<uint64_t>::min();
-        constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
-      }
-    } else {
-      llvm_unreachable("unsupported element type");
-    }
-  } else {
-    llvm_unreachable("unsupported element type");
-  }
+
+  TypeSwitch<Type>(type)
+      .Case<Float16Type>([&](Type) {
+        // 0xFC00
+        float value = -std::numeric_limits<float>::infinity();
+        constantAttr = rewriter.getF16FloatAttr(value);
+      })
+      .Case<Float32Type>([&](Type) {
+        // 0xFF800000
+        float value = -std::numeric_limits<float>::infinity();
+        constantAttr = rewriter.getF32FloatAttr(value);
+      })
+      .Case<Float64Type>([&](Type) {
+        // 0xFFF0000000000000
+        double value = -std::numeric_limits<double>::infinity();
+        constantAttr = rewriter.getF64FloatAttr(value);
+      })
+      .Case<IntegerType>([&](Type) {
+        auto width = type.cast<IntegerType>().getWidth();
+        // The latest llvm-project includes a patch which allows getting the
+        // sign of IntegerType:
+        // https://github.com/llvm/llvm-project/commit/35b685270b410f6a1351c2a527021f22330c25b9
+        // as follows:
+        //   auto isSigned = type.cast<IntegerType>().isSigned();
+        // TODO (tungld): update the following statement once our llvm-project
+        // is upgraded to include the patch.
+        auto isSigned = true;
+        if (width == 8) {
+          if (isSigned) {
+            int8_t value = std::numeric_limits<int8_t>::min();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          } else {
+            uint8_t value = std::numeric_limits<uint8_t>::min();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          }
+        } else if (width == 16) {
+          if (isSigned) {
+            int16_t value = std::numeric_limits<int16_t>::min();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          } else {
+            uint16_t value = std::numeric_limits<uint16_t>::min();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          }
+        } else if (width == 32) {
+          if (isSigned) {
+            int32_t value = std::numeric_limits<int32_t>::min();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          } else {
+            uint32_t value = std::numeric_limits<uint32_t>::min();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          }
+        } else if (width == 64) {
+          if (isSigned) {
+            int64_t value = std::numeric_limits<int64_t>::min();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          } else {
+            uint64_t value = std::numeric_limits<uint64_t>::min();
+            constantAttr = rewriter.getIntegerAttr(type, APInt(width, value));
+          }
+        } else {
+          llvm_unreachable("unsupported element type");
+        }
+      })
+      .Default([](Type) { llvm_unreachable("unsupported element type"); });
 
   return rewriter.create<ConstantOp>(loc, constantAttr);
 }

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -20,6 +20,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include "src/Dialect/Krnl/KrnlHelper.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -33,8 +33,8 @@
 using namespace mlir;
 
 namespace mlir {
-KrnlOpsDialect::KrnlOpsDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context) {
+  KrnlOpsDialect::KrnlOpsDialect(MLIRContext *context)
+    : Dialect(getDialectNamespace(), context, TypeID::get<KrnlOpsDialect>()) {
   addOperations<
 #define GET_OP_LIST
 #include "src/Dialect/Krnl/KrnlOps.cpp.inc"

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -33,7 +33,7 @@
 using namespace mlir;
 
 namespace mlir {
-  KrnlOpsDialect::KrnlOpsDialect(MLIRContext *context)
+KrnlOpsDialect::KrnlOpsDialect(MLIRContext *context)
     : Dialect(getDialectNamespace(), context, TypeID::get<KrnlOpsDialect>()) {
   addOperations<
 #define GET_OP_LIST

--- a/src/Dialect/Krnl/KrnlOps.hpp
+++ b/src/Dialect/Krnl/KrnlOps.hpp
@@ -17,6 +17,7 @@
 #include "mlir/IR/Function.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/StandardTypes.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include "KrnlHelper.hpp"
 #include "KrnlTypes.hpp"
@@ -38,11 +39,17 @@ public:
 
   /// Print a type registered to this dialect.
   void printType(Type type, DialectAsmPrinter &os) const override {
+    TypeSwitch<Type>(type).Case<LoopType>([&](Type) {
+      os << "loop";
+      return;
+    });
+    /*
     switch (type.getKind()) {
     case KrnlTypes::Loop:
       os << "loop";
       return;
     }
+    */
   }
 };
 

--- a/src/Dialect/Krnl/KrnlOps.hpp
+++ b/src/Dialect/Krnl/KrnlOps.hpp
@@ -43,13 +43,6 @@ public:
       os << "loop";
       return;
     });
-    /*
-    switch (type.getKind()) {
-    case KrnlTypes::Loop:
-      os << "loop";
-      return;
-    }
-    */
   }
 };
 

--- a/src/Dialect/Krnl/KrnlTypes.hpp
+++ b/src/Dialect/Krnl/KrnlTypes.hpp
@@ -22,8 +22,6 @@ public:
   // Support type inquiry through isa, cast and dyn_cast.
 
   // Get a unique instance of Loop type.
-  static LoopType get(mlir::MLIRContext *context) {
-    return Base::get(context);
-  }
+  static LoopType get(mlir::MLIRContext *context) { return Base::get(context); }
 };
 } // namespace mlir

--- a/src/Dialect/Krnl/KrnlTypes.hpp
+++ b/src/Dialect/Krnl/KrnlTypes.hpp
@@ -13,16 +13,6 @@
 #include <mlir/IR/Types.h>
 
 namespace mlir {
-
-namespace KrnlTypes {
-enum Kinds {
-  // A krnl.loop is simply a reference to a for loop and will be used to:
-  // - Indicate the presence of a for loop in krnl.iterate.
-  // - Identify the loop in optimization intrinsics.
-  Loop = mlir::Type::Kind::FIRST_PRIVATE_EXPERIMENTAL_0_TYPE,
-};
-}
-
 class LoopType
     : public mlir::Type::TypeBase<LoopType, mlir::Type, mlir::TypeStorage> {
 
@@ -30,11 +20,10 @@ public:
   using Base::Base;
 
   // Support type inquiry through isa, cast and dyn_cast.
-  static bool kindof(unsigned kind) { return kind == KrnlTypes::Loop; }
 
   // Get a unique instance of Loop type.
   static LoopType get(mlir::MLIRContext *context) {
-    return Base::get(context, KrnlTypes::Loop);
+    return Base::get(context);
   }
 };
 } // namespace mlir

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -478,7 +478,7 @@ static void insertConvTransposeSpatialDim(SmallVectorImpl<int64_t> &outputDims,
 /// Dialect creation, the instance will be owned by the context. This is the
 /// point of registration of custom types and operations for the dialect.
 ONNXOpsDialect::ONNXOpsDialect(mlir::MLIRContext *ctx)
-  : mlir::Dialect(getDialectNamespace(), ctx, TypeID::get<ONNXOpsDialect>()) {
+    : mlir::Dialect(getDialectNamespace(), ctx, TypeID::get<ONNXOpsDialect>()) {
   addOperations<
 #define GET_OP_LIST
 #include "src/Dialect/ONNX/ONNXOps.cpp.inc"

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -2885,7 +2885,7 @@ struct SeqTypeStorage : public mlir::TypeStorage {
 SeqType SeqType::get(llvm::ArrayRef<mlir::Type> elementTypes) {
   assert(!elementTypes.empty() && "expected non-empty seq");
   mlir::MLIRContext *ctx = elementTypes.front().getContext();
-  return Base::get(ctx, ONNXTypes::SEQ, elementTypes);
+  return Base::get(ctx, elementTypes);
 }
 
 llvm::ArrayRef<mlir::Type> SeqType::getElementTypes() {

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -478,7 +478,7 @@ static void insertConvTransposeSpatialDim(SmallVectorImpl<int64_t> &outputDims,
 /// Dialect creation, the instance will be owned by the context. This is the
 /// point of registration of custom types and operations for the dialect.
 ONNXOpsDialect::ONNXOpsDialect(mlir::MLIRContext *ctx)
-    : mlir::Dialect(getDialectNamespace(), ctx) {
+  : mlir::Dialect(getDialectNamespace(), ctx, TypeID::get<ONNXOpsDialect>()) {
   addOperations<
 #define GET_OP_LIST
 #include "src/Dialect/ONNX/ONNXOps.cpp.inc"

--- a/src/Dialect/ONNX/ONNXOps.hpp
+++ b/src/Dialect/ONNX/ONNXOps.hpp
@@ -59,9 +59,7 @@ class StringType
 public:
   using Base::Base;
 
-  static StringType get(MLIRContext *ctx) {
-    return Base::get(ctx);
-  }
+  static StringType get(MLIRContext *ctx) { return Base::get(ctx); }
 };
 
 namespace detail {

--- a/src/Dialect/ONNX/ONNXOps.hpp
+++ b/src/Dialect/ONNX/ONNXOps.hpp
@@ -54,29 +54,13 @@ public:
 // Or we need two namespace?
 // Will put all the ONNXOps into this namespace
 namespace onnxmlir {
-
-namespace ONNXTypes {
-
-enum Kind {
-  FIRST_USED_ONNX_TYPE = Type::FIRST_PRIVATE_EXPERIMENTAL_1_TYPE,
-  //#define HANDLE_TF_TYPE(tftype, enumerant, name) enumerant,
-  //#include "src/Dialect/ONNX/ONXTypes.def"
-  STRING,
-  SEQ,
-  LAST_USED_ONNX_TYPE,
-};
-} // namespace ONNXTypes
-
 class StringType
     : public mlir::Type::TypeBase<StringType, mlir::Type, mlir::TypeStorage> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) { return kind == ONNXTypes::STRING; }
-
-  static unsigned getTypeKind() { return ONNXTypes::STRING; }
 
   static StringType get(MLIRContext *ctx) {
-    return Base::get(ctx, ONNXTypes::STRING);
+    return Base::get(ctx);
   }
 };
 
@@ -88,9 +72,6 @@ class SeqType
     : public mlir::Type::TypeBase<SeqType, mlir::Type, detail::SeqTypeStorage> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) { return kind == ONNXTypes::SEQ; }
-
-  static unsigned getTypeKind() { return ONNXTypes::SEQ; }
 
   static SeqType get(llvm::ArrayRef<mlir::Type> elementTypes);
 

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -376,8 +376,7 @@ void compileModuleToJniJar(
   genJniJar(module, modelSharedLibPath, modelJniJarPath);
 }
 
-void registerDialects() {
-  mlir::MLIRContext context(/*loadAllDialects=*/false);
+void registerDialects(mlir::MLIRContext &context) {
   // Load our Dialect in this MLIR Context.
   context.getOrLoadDialect<mlir::AffineDialect>();
   context.getOrLoadDialect<mlir::LLVM::LLVMDialect>();

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -377,13 +377,15 @@ void compileModuleToJniJar(
 }
 
 void registerDialects() {
-  mlir::registerDialect<mlir::AffineDialect>();
-  mlir::registerDialect<mlir::LLVM::LLVMDialect>();
-  mlir::registerDialect<mlir::scf::SCFDialect>();
-  mlir::registerDialect<mlir::StandardOpsDialect>();
-  mlir::registerDialect<mlir::shape::ShapeDialect>();
-  mlir::registerDialect<mlir::ONNXOpsDialect>();
-  mlir::registerDialect<mlir::KrnlOpsDialect>();
+  mlir::MLIRContext context(/*loadAllDialects=*/false);
+  // Load our Dialect in this MLIR Context.
+  context.getOrLoadDialect<mlir::AffineDialect>();
+  context.getOrLoadDialect<mlir::LLVM::LLVMDialect>();
+  context.getOrLoadDialect<mlir::scf::SCFDialect>();
+  context.getOrLoadDialect<mlir::StandardOpsDialect>();
+  context.getOrLoadDialect<mlir::shape::ShapeDialect>();
+  context.getOrLoadDialect<mlir::ONNXOpsDialect>();
+  context.getOrLoadDialect<mlir::KrnlOpsDialect>();
 }
 
 void addONNXToMLIRPasses(mlir::PassManager &pm) {

--- a/src/MainUtils.hpp
+++ b/src/MainUtils.hpp
@@ -59,7 +59,7 @@ void compileModuleToSharedLibrary(
 void compileModuleToJniJar(
     const mlir::OwningModuleRef &module, std::string outputBaseName);
 
-void registerDialects();
+void registerDialects(mlir::MLIRContext &context);
 
 void addONNXToMLIRPasses(mlir::PassManager &pm);
 

--- a/src/Tool/ONNXMLIROpt/ONNXMLIROpt.cpp
+++ b/src/Tool/ONNXMLIROpt/ONNXMLIROpt.cpp
@@ -60,13 +60,14 @@ static llvm::cl::opt<bool> allowUnregisteredDialects(
     llvm::cl::init(false));
 
 int main(int argc, char **argv) {
-  mlir::registerDialect<mlir::linalg::LinalgDialect>();
-  mlir::registerDialect<mlir::AffineDialect>();
-  mlir::registerDialect<mlir::LLVM::LLVMDialect>();
-  mlir::registerDialect<mlir::scf::SCFDialect>();
-  mlir::registerDialect<mlir::StandardOpsDialect>();
-  mlir::registerDialect<mlir::vector::VectorDialect>();
-  mlir::registerDialect<mlir::shape::ShapeDialect>();
+  mlir::DialectRegistry registry;
+  registry.insert<mlir::linalg::LinalgDialect>();
+  registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::scf::SCFDialect>();
+  registry.insert<mlir::StandardOpsDialect>();
+  registry.insert<mlir::vector::VectorDialect>();
+  registry.insert<mlir::shape::ShapeDialect>();
 
   registerTransformsPasses();
   registerAffinePasses();
@@ -97,7 +98,8 @@ int main(int argc, char **argv) {
   auto output = mlir::openOutputFile(output_filename, &error_message);
   assert(output);
 
+  // TODO(imaihal): Change preloadDialectsInContext to false.
   return failed(mlir::MlirOptMain(output->os(), std::move(file), passPipeline,
-      split_input_file, verify_diagnostics, verify_passes,
-      allowUnregisteredDialects));
+      registry, split_input_file, verify_diagnostics, verify_passes,
+      allowUnregisteredDialects, /*preloadDialectsInContext*/ true));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,8 @@ using namespace onnx_mlir;
 
 int main(int argc, char *argv[]) {
   setExecPath(argv[0], (void *)main);
-  registerDialects();
+  mlir::MLIRContext context;
+  registerDialects(context);
 
   llvm::cl::OptionCategory OnnxMlirOptions(
       "ONNX MLIR Options", "These are frontend options.");
@@ -43,7 +44,6 @@ int main(int argc, char *argv[]) {
   llvm::cl::ParseCommandLineOptions(
       argc, argv, "ONNX MLIR modular optimizer driver\n");
 
-  mlir::MLIRContext context;
   mlir::OwningModuleRef module;
   processInputFile(inputFilename, emissionTarget, context, module);
 

--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -23,8 +23,8 @@ using namespace std;
 bool isOMConvTheSameAsNaiveImplFor(const int N, const int C, const int H,
     const int W, const int kH, const int kW, const int pHBegin, const int pHEnd,
     const int pWBegin, const int pWEnd) {
-  registerDialects();
   MLIRContext ctx;
+  registerDialects(ctx);
 
   auto module = ModuleOp::create(UnknownLoc::get(&ctx));
   OpBuilder builder(&ctx);

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 9c94908320549a1a2328c758d6bbb694466021e7 && cd ..
+cd llvm-project && git checkout 1d01fc100bb5bef5f5eaf92520b2e52f64ee1d6e && cd ..


### PR DESCRIPTION
This PR includes fixes for LLVM revisions: [D85495](https://reviews.llvm.org/D85495), [D85622](https://reviews.llvm.org/D85622), and [D86121](https://reviews.llvm.org/D86121) to use newer LLVM commit.



- D85495
`TypeID` should be set to `mlir::Dialect` by LLVM revision [D85495](https://reviews.llvm.org/D85495) I updated as it is done at `ToyDialect` in the revision https://reviews.llvm.org/D85495#change-M9kXqI8sOFkn

- D85622
This revision includes change in how to register dialects. I updated as it is done in the revision. For example. https://reviews.llvm.org/D85622#change-2drP7BXp5CDr

- D86121
`type.getKind()` was removed by LLVM revision [D86121](https://reviews.llvm.org/D86121). So, I needed to modify it as described in https://llvm.discourse.group/t/removing-kinds-from-attributes-and-types/1547
I used `TypeSwitch<Type>(type)` instead of `switch (type.getKind())` 

I confirmed this works on [1d01fc1](https://github.com/llvm/llvm-project/commit/1d01fc100bb5bef5f5eaf92520b2e52f64ee1d6e) (Aug 31, 2020)
