### PR TITLE
Rewrite shape and size OP 

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -2353,18 +2353,6 @@ LogicalResult ONNXShapeOp::inferShapes() {
 }
 
 //===----------------------------------------------------------------------===//
-// Size
-//===----------------------------------------------------------------------===//
-
-LogicalResult ONNXSizeOp::inferShapes() {
-  // Output is scalar of int64 containing the size of the input tensor.
-  SmallVector<int64_t, 1> outDims(1, 0);
-  getResult().setType(
-      RankedTensorType::get(outDims, IntegerType::get(64, getContext())));
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // Tile
 //===----------------------------------------------------------------------===//
 

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -2353,6 +2353,18 @@ LogicalResult ONNXShapeOp::inferShapes() {
 }
 
 //===----------------------------------------------------------------------===//
+// Size
+//===----------------------------------------------------------------------===//
+
+LogicalResult ONNXSizeOp::inferShapes() {
+  // Output is scalar of int64 containing the size of the input tensor.
+  SmallVector<int64_t, 1> outDims(1, 0);
+  getResult().setType(
+      RankedTensorType::get(outDims, IntegerType::get(64, getContext())));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Tile
 //===----------------------------------------------------------------------===//
 

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -4861,7 +4861,7 @@ def ONNXSinhOp:ONNX_Op<"Sinh",
 }
 
 def ONNXSizeOp:ONNX_Op<"Size",
-  [NoSideEffect]> {
+  [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
   let summary = "ONNX Size operation";
   let description = [{
   "Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor."

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -4728,6 +4728,7 @@ def ONNXSequenceLengthOp:ONNX_Op<"SequenceLength",
 
 def ONNXShapeOp:ONNX_Op<"Shape",
   [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Shape operation";
   let description = [{
   "Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor."
@@ -4862,6 +4863,7 @@ def ONNXSinhOp:ONNX_Op<"Sinh",
 
 def ONNXSizeOp:ONNX_Op<"Size",
   [NoSideEffect]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Size operation";
   let description = [{
   "Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor."

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -4861,7 +4861,7 @@ def ONNXSinhOp:ONNX_Op<"Sinh",
 }
 
 def ONNXSizeOp:ONNX_Op<"Size",
-  [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
+  [NoSideEffect]> {
   let summary = "ONNX Size operation";
   let description = [{
   "Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor."

--- a/src/Transform/ONNX/Rewrite.cpp
+++ b/src/Transform/ONNX/Rewrite.cpp
@@ -27,36 +27,30 @@ DenseElementsAttr createDenseElementsAttrFromFloatAttr(
   return mlir::DenseElementsAttr::get(tensorType, llvm::makeArrayRef(values));
 }
 
+// Create a DenseElementsAttr based on the shape of type.
 DenseElementsAttr createDenseElementsAttrFromShape(
     PatternRewriter &rewriter, Value value) {
-  auto inType = value.getType().dyn_cast<ShapedType>();
+  auto inType = value.getType().cast<ShapedType>();
   ;
   if (!inType)
     llvm_unreachable("Shaped type is execptd\n");
   auto shape = inType.getShape();
-  SmallVector<int64_t, 1> dims(1, inType.getRank());
-  SmallVector<int64_t, 4> values;
-  for (auto s : shape) {
-    values.push_back(s);
-  }
+  SmallVector<int64_t, 1> dims = {inType.getRank()};
+  SmallVector<int64_t, 4> values(shape.begin(), shape.end());
   auto tensorType =
       mlir::RankedTensorType::get(dims, rewriter.getIntegerType(64));
   return mlir::DenseElementsAttr::get(tensorType, llvm::makeArrayRef(values));
 }
 
+// Create a DenseElementsAttr based on the size of type.
 DenseElementsAttr createDenseElementsAttrFromSize(
     PatternRewriter &rewriter, Value value) {
-  auto inType = value.getType().dyn_cast<ShapedType>();
+  auto inType = value.getType().cast<ShapedType>();
   ;
   if (!inType)
     llvm_unreachable("Shaped type is execptd\n");
-  auto shape = inType.getShape();
   SmallVector<int64_t, 1> dims(1, 1);
-  int64_t size = 1;
-  for (auto s : shape) {
-    size *= s;
-  }
-  SmallVector<int64_t, 1> values(1, size);
+  SmallVector<int64_t, 1> values = {inType.getNumElements()};
   auto tensorType =
       mlir::RankedTensorType::get(dims, rewriter.getIntegerType(64));
   return mlir::DenseElementsAttr::get(tensorType, llvm::makeArrayRef(values));

--- a/src/Transform/ONNX/Rewrite.cpp
+++ b/src/Transform/ONNX/Rewrite.cpp
@@ -29,32 +29,36 @@ DenseElementsAttr createDenseElementsAttrFromFloatAttr(
 
 DenseElementsAttr createDenseElementsAttrFromShape(
     PatternRewriter &rewriter, Value value) {
-  auto inType = value.getType().dyn_cast<ShapedType>();;
-  if (!inType) 
+  auto inType = value.getType().dyn_cast<ShapedType>();
+  ;
+  if (!inType)
     llvm_unreachable("Shaped type is execptd\n");
   auto shape = inType.getShape();
   SmallVector<int64_t, 1> dims(1, inType.getRank());
   SmallVector<int64_t, 4> values;
-  for(auto s : shape) {
+  for (auto s : shape) {
     values.push_back(s);
   }
-  auto tensorType = mlir::RankedTensorType::get(dims, rewriter.getIntegerType(64));
+  auto tensorType =
+      mlir::RankedTensorType::get(dims, rewriter.getIntegerType(64));
   return mlir::DenseElementsAttr::get(tensorType, llvm::makeArrayRef(values));
 }
 
 DenseElementsAttr createDenseElementsAttrFromSize(
     PatternRewriter &rewriter, Value value) {
-  auto inType = value.getType().dyn_cast<ShapedType>();;
-  if (!inType) 
+  auto inType = value.getType().dyn_cast<ShapedType>();
+  ;
+  if (!inType)
     llvm_unreachable("Shaped type is execptd\n");
   auto shape = inType.getShape();
   SmallVector<int64_t, 1> dims(1, 1);
   int64_t size = 1;
-  for(auto s : shape) {
+  for (auto s : shape) {
     size *= s;
   }
   SmallVector<int64_t, 1> values(1, size);
-  auto tensorType = mlir::RankedTensorType::get(dims, rewriter.getIntegerType(64));
+  auto tensorType =
+      mlir::RankedTensorType::get(dims, rewriter.getIntegerType(64));
   return mlir::DenseElementsAttr::get(tensorType, llvm::makeArrayRef(values));
 }
 

--- a/src/Transform/ONNX/Rewrite.cpp
+++ b/src/Transform/ONNX/Rewrite.cpp
@@ -31,9 +31,6 @@ DenseElementsAttr createDenseElementsAttrFromFloatAttr(
 DenseElementsAttr createDenseElementsAttrFromShape(
     PatternRewriter &rewriter, Value value) {
   auto inType = value.getType().cast<ShapedType>();
-  ;
-  if (!inType)
-    llvm_unreachable("Shaped type is execptd\n");
   auto shape = inType.getShape();
   SmallVector<int64_t, 1> dims = {inType.getRank()};
   SmallVector<int64_t, 4> values(shape.begin(), shape.end());
@@ -46,9 +43,6 @@ DenseElementsAttr createDenseElementsAttrFromShape(
 DenseElementsAttr createDenseElementsAttrFromSize(
     PatternRewriter &rewriter, Value value) {
   auto inType = value.getType().cast<ShapedType>();
-  ;
-  if (!inType)
-    llvm_unreachable("Shaped type is execptd\n");
   SmallVector<int64_t, 1> dims(1, 1);
   SmallVector<int64_t, 1> values = {inType.getNumElements()};
   auto tensorType =

--- a/src/Transform/ONNX/Rewrite.td
+++ b/src/Transform/ONNX/Rewrite.td
@@ -28,6 +28,14 @@ include "src/Dialect/ONNX/ONNXOps.td"
 def createDenseElementsAttrFromFloatAttr : NativeCodeCall<
   "createDenseElementsAttrFromFloatAttr($_builder, $0.getType().cast<ShapedType>().getElementType(), $1)">;
 
+// Create a DenseElementsAttr from the shape of the type of a value.
+def createDenseElementsAttrFromShape : NativeCodeCall<
+  "createDenseElementsAttrFromShape($_builder, $0)">;
+
+// Create a DenseElementsAttr from the size of the type of a value.
+def createDenseElementsAttrFromSize : NativeCodeCall<
+  "createDenseElementsAttrFromSize($_builder, $0)">;
+
 // If '$1' is not NoneType, do subtraction '$1 - $2'.
 // Otherwise, take the negative of '$2'.
 def subtractOrNeg: NativeCodeCall<
@@ -172,4 +180,19 @@ def FuseBatchNormTestModeConvPattern: Pat<
      $auto_pad, $dilation, $group, $kernel_shape, $pads, $strides)
 >;
 
+def ShapeToConstantPattern: Pat<
+     (ONNXShapeOp $A),
+     (ONNXConstantOp
+        (GetNullAttr),
+        (createDenseElementsAttrFromShape $A)),
+     []
+>;
+
+def SizeToConstantPattern: Pat<
+     (ONNXSizeOp $A),
+     (ONNXConstantOp
+        (GetNullAttr),
+        (createDenseElementsAttrFromSize $A)),
+     []
+>;
 #endif // ONNX_REWRITE

--- a/src/Transform/ONNX/Rewrite.td
+++ b/src/Transform/ONNX/Rewrite.td
@@ -180,12 +180,18 @@ def FuseBatchNormTestModeConvPattern: Pat<
      $auto_pad, $dilation, $group, $kernel_shape, $pads, $strides)
 >;
 
+def IsStaticShapeTensor:
+   Constraint<
+     CPred<
+       "$_self.getType().cast<::mlir::ShapedType>().hasStaticShape()">,
+     "hasStaticShape">;
+
 def ShapeToConstantPattern: Pat<
      (ONNXShapeOp $A),
      (ONNXConstantOp
         (GetNullAttr),
         (createDenseElementsAttrFromShape $A)),
-     []
+     [(IsStaticShapeTensor:$A)]
 >;
 
 def SizeToConstantPattern: Pat<
@@ -193,6 +199,6 @@ def SizeToConstantPattern: Pat<
      (ONNXConstantOp
         (GetNullAttr),
         (createDenseElementsAttrFromSize $A)),
-     []
+     [(IsStaticShapeTensor:$A)]
 >;
 #endif // ONNX_REWRITE

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -191,3 +191,24 @@ func @test_conv_batchnormtestmode_fusion(%arg0 : tensor<1x3x224x224xf32>, %arg1 
     // CHECK: return [[RES]] : tensor<1x64x112x112xf32>
 }
 
+// -----
+
+func @test_shape1(%arg0 : tensor<2x4x8x16xf32>) -> tensor<*xi64> {
+  %0 = "onnx.Shape"(%arg0) : (tensor<2x4x8x16xf32>) -> tensor<*xi64>
+  return %0 : tensor<*xi64>
+
+  // CHECK-LABEL: @test_shape1
+  // CHECK-NEXT: %0 = "onnx.Constant"() {value = dense<[2, 4, 8, 16]> : tensor<4xi64>} : () -> tensor<*xi64>
+  // CHECK-NEXT: %0 : tensor<*xi64>
+}
+
+// -----
+
+func @test_size1(%arg0 : tensor<2x4x8x16xf32>) -> tensor<*xi64> {
+  %0 = "onnx.Size"(%arg0) : (tensor<2x4x8x16xf32>) -> tensor<*xi64>
+  return %0 : tensor<*xi64>
+
+  // CHECK-LABEL: @test_size1
+  // CHECK-NEXT: %0 = "onnx.Constant"() {value = dense<1024> : tensor<1xi64>} : () -> tensor<*xi64>
+  // CHECK-NEXT: %0 : tensor<*xi64>
+}

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -191,6 +191,8 @@ func @test_conv_batchnormtestmode_fusion(%arg0 : tensor<1x3x224x224xf32>, %arg1 
     // CHECK: return [[RES]] : tensor<1x64x112x112xf32>
 }
 
+// -----
+
 // Check the removal of identity transposes.
 // CHECK-LABEL: func @test_transpose_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
 func @test_transpose_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
@@ -198,6 +200,8 @@ func @test_transpose_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x
   // CHECK-NEXT: return %arg0 : tensor<10x11x12x13xf32>
   "std.return"(%0) : (tensor<10x11x12x13xf32>) -> ()
 }
+
+// -----
 
 // Check the combining of transposes into a simple transpose.
 // CHECK-LABEL: func @test_transpose_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10x13x12xf32> {
@@ -207,6 +211,8 @@ func @test_transpose_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10x13x1
   // CHECK-NEXT: %{{.*}} = "onnx.Transpose"(%arg0) {perm = [1, 0, 3, 2]} : (tensor<10x11x12x13xf32>) -> tensor<11x10x13x12xf32>
   "std.return"(%1) : (tensor<11x10x13x12xf32>) -> ()
 }
+
+// -----
 
 // Check the combining of transposes into an identity transpose, which in turns is removed.
 // CHECK-LABEL: func @test_transpose_fusion_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -204,6 +204,17 @@ func @test_shape1(%arg0 : tensor<2x4x8x16xf32>) -> tensor<*xi64> {
 
 // -----
 
+func @test_shape2(%arg0 : tensor<?x4x8x16xf32>) -> tensor<*xi64> {
+  %0 = "onnx.Shape"(%arg0) : (tensor<?x4x8x16xf32>) -> tensor<*xi64>
+  return %0 : tensor<*xi64>
+
+  // CHECK-LABEL: @test_shape2
+  // CHECK-NEXT: %0 = "onnx.Shape"(%arg0) : (tensor<?x4x8x16xf32>) -> tensor<*xi64>
+  // CHECK-NEXT: return %0 : tensor<*xi64>
+}
+
+// -----
+
 func @test_size1(%arg0 : tensor<2x4x8x16xf32>) -> tensor<*xi64> {
   %0 = "onnx.Size"(%arg0) : (tensor<2x4x8x16xf32>) -> tensor<*xi64>
   return %0 : tensor<*xi64>
@@ -212,3 +223,15 @@ func @test_size1(%arg0 : tensor<2x4x8x16xf32>) -> tensor<*xi64> {
   // CHECK-NEXT: %0 = "onnx.Constant"() {value = dense<1024> : tensor<1xi64>} : () -> tensor<*xi64>
   // CHECK-NEXT: %0 : tensor<*xi64>
 }
+
+// -----
+
+func @test_size2(%arg0 : tensor<*xf32>) -> tensor<*xi64> {
+  %0 = "onnx.Size"(%arg0) : (tensor<*xf32>) -> tensor<*xi64>
+  return %0 : tensor<*xi64>
+
+  // CHECK-LABEL: @test_size2
+  // CHECK-NEXT: %0 = "onnx.Size"(%arg0) : (tensor<*xf32>) -> tensor<*xi64>
+  // CHECK-NEXT: return %0 : tensor<*xi64>
+}
+

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -301,6 +301,7 @@ OpsWithShapeInference=[
     'Sign',
     'Sin',
     'Sinh',
+    'Size',
     'Slice',
     'Softmax',
     'Softplus',

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -321,7 +321,7 @@ OpsWithShapeInference=[
 ]
 
 # Operations supporting canonicalization.
-OpsWithCanonicalizer = ['Add', 'Identity', 'Gemm', 'Conv', 'Cast']
+OpsWithCanonicalizer = ['Add', 'Identity', 'Gemm', 'Conv', 'Cast', 'Shape', 'Size']
 
 # Operations who have operands that, if produced by constant operations, should
 # be promoted to become an attribute (via attribute promotion).

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -301,7 +301,6 @@ OpsWithShapeInference=[
     'Sign',
     'Sin',
     'Sinh',
-    'Size',
     'Slice',
     'Softmax',
     'Softplus',


### PR DESCRIPTION
When the input tensor of Shape and Size Op is ShapedTensor,  rewrite them with its constant output.