### PR TITLE
[MLIR] Add Shape op conversion from ONNX to Krnl dialect

### DIFF
--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -12,18 +12,19 @@ add_library(OMONNXToKrnl
         RNN/RNNBase.cpp
         RNN/RNNBase.hpp
         RNN/LSTM.cpp
-        Tensor/Identity.cpp
-        Tensor/Reshape.cpp
-        Tensor/PadConstantValuePad.cpp
-        Tensor/Pad.cpp
-        Tensor/Transpose.cpp
-        Tensor/Squeeze.cpp
-        Tensor/Unsqueeze.cpp
+        Tensor/Concat.cpp
         Tensor/Constant.cpp
         Tensor/ConstantOfShape.cpp
-        Tensor/Concat.cpp
-        Tensor/Split.cpp
         Tensor/Gather.cpp
+        Tensor/Identity.cpp
+        Tensor/Pad.cpp
+        Tensor/PadConstantValuePad.cpp
+        Tensor/Reshape.cpp
+        Tensor/Shape.cpp
+        Tensor/Split.cpp
+        Tensor/Squeeze.cpp
+        Tensor/Transpose.cpp
+        Tensor/Unsqueeze.cpp
         ConvertONNXToKrnl.cpp)
 target_link_libraries(OMONNXToKrnl
         onnx)

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -91,18 +91,19 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   populateLoweringONNXSoftmaxOpPattern(patterns, &getContext());
   populateLoweringONNXMatMulOpPattern(patterns, &getContext());
   // Tensor
-  populateLoweringONNXReshapeOpPattern(patterns, &getContext());
-  populateLoweringONNXPadConstantValuePadOpPattern(patterns, &getContext());
-  populateLoweringONNXPadOpPattern(patterns, &getContext());
-  populateLoweringONNXUnsqueezeOpPattern(patterns, &getContext());
-  populateLoweringONNXTransposeOpPattern(patterns, &getContext());
+  populateLoweringONNXConcatOpPattern(patterns, &getContext());
+  populateLoweringONNXConstantOpPattern(patterns, &getContext());
+  populateLoweringONNXConstantOfShapeOpPattern(patterns, &getContext());
   populateLoweringONNXGatherOpPattern(patterns, &getContext());
   populateLoweringONNXIdentityOpPattern(patterns, &getContext());
-  populateLoweringONNXConstantOfShapeOpPattern(patterns, &getContext());
-  populateLoweringONNXConstantOpPattern(patterns, &getContext());
-  populateLoweringONNXConcatOpPattern(patterns, &getContext());
-  populateLoweringONNXSqueezeOpPattern(patterns, &getContext());
+  populateLoweringONNXPadConstantValuePadOpPattern(patterns, &getContext());
+  populateLoweringONNXPadOpPattern(patterns, &getContext());
+  populateLoweringONNXReshapeOpPattern(patterns, &getContext());
+  populateLoweringONNXShapeOpPattern(patterns, &getContext());
   populateLoweringONNXSplitOpPattern(patterns, &getContext());
+  populateLoweringONNXSqueezeOpPattern(patterns, &getContext());
+  populateLoweringONNXTransposeOpPattern(patterns, &getContext());
+  populateLoweringONNXUnsqueezeOpPattern(patterns, &getContext());
   // Neural network
   populateLoweringONNXConvOpPattern(patterns, &getContext());
   populateLoweringONNXNormalizationOpPattern(patterns, &getContext());

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -247,6 +247,9 @@ void populateLoweringONNXConstantOpPattern(
 void populateLoweringONNXConcatOpPattern(
     OwningRewritePatternList &patterns, MLIRContext *ctx);
 
+void populateLoweringONNXShapeOpPattern(
+    OwningRewritePatternList &patterns, MLIRContext *ctx);
+
 void populateLoweringONNXSqueezeOpPattern(
     OwningRewritePatternList &patterns, MLIRContext *ctx);
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
@@ -1,0 +1,67 @@
+//===----------------Shape.cpp - Lowering Shape Op----------------------=== //
+//
+// Copyright 2020 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file lowers the ONNX Shape Operator to Krnl dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+
+using namespace mlir;
+
+struct ONNXShapeOpLowering : public ConversionPattern {
+  ONNXShapeOpLowering(MLIRContext *ctx)
+      : ConversionPattern(mlir::ONNXShapeOp::getOperationName(), 1, ctx) {}
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const final {
+    ONNXShapeOpAdaptor operandAdaptor(operands);
+    ONNXShapeOp shapeOp = llvm::cast<ONNXShapeOp>(op);
+    bool insertDealloc = checkInsertDealloc(op);
+    Location loc = op->getLoc();
+    // Get input data.
+    Value data = operandAdaptor.data();
+    ArrayRef<int64_t> dataShape = data.getType().cast<MemRefType>().getShape();
+    unsigned dataRank = dataShape.size();
+
+    Value resultOperand = shapeOp.shape();
+    MemRefType outputMemRefType = convertToMemRefType(*op->result_type_begin());
+
+    Value alloc;
+    if (hasAllConstantDimensions(outputMemRefType))
+      alloc =
+          insertAllocAndDealloc(outputMemRefType, loc, rewriter, insertDealloc);
+    else
+      alloc = insertAllocAndDealloc(
+          outputMemRefType, loc, rewriter, insertDealloc, {resultOperand});
+
+    // Iterate along the data shape storing dim value to result.
+    for (int i = 0; i < dataRank; i++) {
+      // Create store index value.
+      Value storeVal;
+      Value storeIndex =
+          emitConstantOp(rewriter, loc, rewriter.getIndexType(), i);
+
+      // Checking for dynamic dimensions.
+      if (dataShape[i] == -1) {
+        Value shapeVal = rewriter.create<DimOp>(loc, data, storeIndex);
+        storeVal = rewriter.create<IndexCastOp>(
+            loc, shapeVal, outputMemRefType.getElementType());
+      } else
+        storeVal = emitConstantOp(
+            rewriter, loc, outputMemRefType.getElementType(), dataShape[i]);
+
+      rewriter.create<StoreOp>(loc, storeVal, alloc, storeIndex);
+    }
+    rewriter.replaceOp(op, alloc);
+    return success();
+  }
+};
+
+void populateLoweringONNXShapeOpPattern(
+    OwningRewritePatternList &patterns, MLIRContext *ctx) {
+  patterns.insert<ONNXShapeOpLowering>(ctx);
+}

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -2250,3 +2250,36 @@ func @test_constant_of_shape_static_dims() -> tensor<*xf32> {
   // CHECK: return [[RES]] : memref<3x4x5xf32>
 }
 
+// Test shape known
+func @test_shape_known(%arg0 : tensor<10x10xf32>) -> tensor<2xi64> {
+  %0 = "onnx.Shape"(%arg0) : (tensor<10x10xf32>) -> tensor<2xi64>
+  "std.return"(%0) : (tensor<2xi64>) -> ()
+
+   // CHECK-LABEL: test_shape_known
+   // CHECK: [[ALLOC:%.+]] = alloc() : memref<2xi64>
+   // CHECK: [[IND0:%.+]] = constant 0 : index
+   // CHECK: [[STORE0:%.+]] = constant 10 : i64
+   // CHECK: store [[STORE0]], [[ALLOC]]{{.}}[[IND0]]{{.}} : memref<2xi64>
+   // CHECK: [[IND1:%.+]] = constant 1 : index
+   // CHECK: [[STORE1:%.+]] = constant 10 : i64
+   // CHECK: store [[STORE1]], [[ALLOC]]{{.}}[[IND1]]{{.}} : memref<2xi64>
+   // CHECK: return [[ALLOC]] : memref<2xi64>
+}
+
+// Test shape unknown
+func @test_shape_unknown(%arg0 : tensor<?x?xf32>) -> tensor<2xi64> {
+  %0 = "onnx.Shape"(%arg0) : (tensor<?x?xf32>) -> tensor<2xi64>
+  "std.return"(%0) : (tensor<2xi64>) -> ()
+
+    // CHECK-LABEL: test_shape_unknown
+    // CHECK: [[ALLOC:%.+]] = alloc() : memref<2xi64>
+    // CHECK: [[STOREIND0:%.+]] = constant 0 : index
+    // CHECK: [[STOREVAL0:%.+]] = dim %arg0, [[STOREIND0]] : memref<?x?xf32>
+    // CHECK: [[STOREINT0:%.+]] = index_cast [[STOREVAL0]] : index to i64
+    // CHECK: store [[STOREINT0]], [[ALLOC]]{{.}}[[STOREIND0]]{{.}} : memref<2xi64>
+    // CHECK: [[STOREIND1:%.+]] = constant 1 : index
+    // CHECK: [[STOREVAL1:%.+]] = dim %arg0, [[STOREIND1]] : memref<?x?xf32>
+    // CHECK: [[STOREINT1:%.+]] = index_cast [[STOREVAL1]] : index to i64
+    // CHECK: store [[STOREINT1]], [[ALLOC]]{{.}}[[STOREIND1]]{{.}} : memref<2xi64>
+    // CHECK: return [[ALLOC]] : memref<2xi64>
+}


### PR DESCRIPTION
Shape Op conversion is added as a part of convert-onnx-to-krnl pass.

Signed-off-by: Prashant Kumar <pk5561@gmail.com>