### PR TITLE
temporarily allow ppc64le build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,10 @@ script:
   - docker exec build test-onnx-mlir.sh
   - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
 jobs:
+  fast_finish: true
   allow_failures:
     - env: NIGHTLY=true
+    - arch: ppc64le
   include:
     ##########################################################################################
     #

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
   - docker exec build compile-onnx-mlir.sh
   - docker exec build test-onnx-mlir.sh
   - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
+  
 jobs:
   fast_finish: true
   allow_failures:
@@ -193,7 +194,6 @@ jobs:
         - docker build -t onnxmlirczar/onnx-mlir-llvmimage:x86 -f docker/prereq.amd64.Dockerfile --build-arg BASE_IMAGE="onnxmlirczar/onnx-mlir-llvmimage-partial:x86" ./utils
         - docker login -u onnxmlirczar -p "$DOCKER_HUB_TOKEN"
         - docker push onnxmlirczar/onnx-mlir-llvmimage:x86
-
 after_success:
   - if [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_BRANCH == "master" ] && [ $NIGHTLY == false ]; then
             echo "Pushing new build to docker hub";


### PR DESCRIPTION
There is some problem with the Travis server for ppc64le, so until it gets fixed, we should allow ppc64le builds to fail