### PR TITLE
Use ubuntu focal as ppc64le base image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ jobs:
       arch:
         - ppc64le
       script:
-        - docker build -t onnxmlirczar/onnx-mlir-llvmimage-partial:ppc64le -f docker/prereq.ppc64le.Dockerfile --build-arg BASE_IMAGE="ubuntu:bionic" ./utils
+        - docker build -t onnxmlirczar/onnx-mlir-llvmimage-partial:ppc64le -f docker/prereq.ppc64le.Dockerfile --build-arg BASE_IMAGE="ubuntu:focal" ./utils
         - docker login -u onnxmlirczar -p "$DOCKER_HUB_TOKEN"
         - docker push onnxmlirczar/onnx-mlir-llvmimage-partial:ppc64le
     - stage: prereq-0

--- a/docker/prereq.ppc64le.Dockerfile
+++ b/docker/prereq.ppc64le.Dockerfile
@@ -51,6 +51,7 @@ RUN if [ ! -f "/build/llvm-project/build/CMakeCache.txt" ]; then \
        -DLLVM_ENABLE_RTTI=ON; \
     fi
 
+ENV MAKEFLAGS=-j2
 RUN if timeout 30m cmake --build . --target -- ${MAKEFLAGS} ; then \
       cmake --build . --target check-mlir; \
     fi


### PR DESCRIPTION
ppc64le non-nightly build restored.