### PR TITLE
Normalize memrefs with affine_map in a function containing krnl.getref

### DIFF
--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -218,7 +218,7 @@ def KrnlPackedConstantOp : Op<Krnl_Dialect, "packed_const"> {
   let printer = ?;
 }
 
-def KrnlGetRefOp : Op<Krnl_Dialect, "getref"> {
+def KrnlGetRefOp : Op<Krnl_Dialect, "getref", [MemRefsNormalizable]> {
   let summary = "Krnl a MemRef from within another MemRef starting at a specific offset.";
   let description = [{
     Retreieves a MemRef from within another MemRef:

--- a/test/mlir/krnl/krnl_normalization.mlir
+++ b/test/mlir/krnl/krnl_normalization.mlir
@@ -14,3 +14,17 @@ func @test_krnl_memcpy_norm(%arg0: memref<1x16384xf32>) -> memref<1x16x4x4xf32, 
   return %0 : memref<1x16x4x4xf32, #map_tile>
   // CHECK: return [[ALLOC]] : memref<1x16x1x1x32x32xf32>  
 }
+
+// CHECK-LABEL: test_getref_norm
+func @test_getref_norm() ->  () {
+  %c0_i64 = constant 0 : i64
+  %0 = alloc() : memref<1x81920xf32>
+  %1 = alloc() : memref<1x16x4x4xf32, #map_tile>
+  // CHECK: [[ALLOC:%.+]] = alloc() : memref<1x16x1x1x32x32xf32>
+  %2 = "krnl.getref"(%0, %c0_i64) : (memref<1x81920xf32>, i64) -> memref<1x16x4x4xf32>
+  // Do something using %1 and %2
+  dealloc %1: memref<1x16x4x4xf32, #map_tile>
+  // CHECK: dealloc [[ALLOC:%.+]] : memref<1x16x1x1x32x32xf32>
+  dealloc %0: memref<1x81920xf32>
+  return
+}


### PR DESCRIPTION
This PR enable us to normalize memrefs with affine_map in a function containing `krnl.getref` .
Without this PR, memrefs in this test case are not normalized because krnl.memcpy is not normalizable operation.
To have krnl.getref normalizable, this PR adds a trait of MemRefsNormalizable.

This PR should have been included in https://github.com/onnx/onnx-mlir/pull/322

Reference: https://reviews.llvm.org/D86236
