### PR TITLE
Fix AzurePipeline Failure: disable conda-forge channel for conda install

### DIFF
--- a/utils/setup-onnx-mlir-windows.cmd
+++ b/utils/setup-onnx-mlir-windows.cmd
@@ -4,7 +4,7 @@ call MiniConda.exe /S /D=%UserProfile%\Miniconda3
 set PATH=%PATH%;%UserProfile%\Miniconda3\Scripts
 set PATH "%UserProfile%\Miniconda3\Scripts;%PATH%" /M
 
-call conda create --yes --quiet --name onnx-mlir -c conda-forge python=3.7 libprotobuf=3.11.4
+call conda create --yes --quiet --name onnx-mlir python=3.7 libprotobuf=3.11.4
 call activate.bat onnx-mlir
 call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 


### PR DESCRIPTION
**Description**
To fix the conda-forge issue on AzurePipeline, simply use the package from conda instead of conda-forge.

**Motivation**
Windows-CI is failing on AzurePipeline. conda-forge channel is broken on AzurePipeline.