### PR TITLE
Gen doc using travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ script:
   - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
 # Script to deploy documentations.
 deploy:
+  before_deploy:
+    - doxygen
   provider: pages
   strategy: git
   cleanup: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ arch:
 env:
   - NIGHTLY=true
   - NIGHTLY=false
+addons:
+  apt:
+    packages:
+      - doxygen
+      - doxygen-doc
+      - doxygen-latex
 # Do not test branch update unless it's mater.
 branches:
   only:
@@ -53,11 +59,12 @@ script:
   - docker exec build test-onnx-mlir.sh
   - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
 # Script to deploy documentations.
+before_deploy:
+  - doxygen
 deploy:
-  before_deploy:
-    - doxygen
   provider: pages
   strategy: git
+  skip_cleanup: true
   cleanup: false
   github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
   keep_history: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ stages:
   - name: prereq-2
   - name: prereq-final
   - name: test
+  - name: deploy
 script:
   - export CPU_ARCH=$TRAVIS_CPU_ARCH
   - if [ "$CPU_ARCH" == "amd64" ] ; then
@@ -50,7 +51,15 @@ script:
   - docker exec build compile-onnx-mlir.sh
   - docker exec build test-onnx-mlir.sh
   - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
-
+# Script to deploy documentations.
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep_history: true
+  local_dir: docs
+  on:
+    branch: gen-doc-travis # change to master
 jobs:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ addons:
 # Do not test branch update unless it's mater.
 branches:
   only:
-  # change to master
-  - gen-doc-travis
+  - master
 stages:
   - name: prereq-init
   - name: prereq-0
@@ -75,8 +74,7 @@ deploy:
   keep_history: true
   local_dir: docs
   on:
-    # change to master
-    branch: gen-doc-travis
+    branch: master
 jobs:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,34 +35,38 @@ script:
   - if [ "$CPU_ARCH" == "amd64" ] ; then
       export CPU_ARCH="x86";
     fi
-  # - echo "CPU Architecture is " $CPU_ARCH
-  # - echo "commit is " $TRAVIS_COMMIT
-  # - df -h
-  # - if [ "$NIGHTLY" = true ] ; then
-  #     echo "Using nightly llvm-mlir image, build may fail.";
-  #     docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:${CPU_ARCH}-nightly"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
-  #   else
-  #     echo "Using latest compatible llvm-mlir image, build should not fail.";
-  #     docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:$CPU_ARCH"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
-  #   fi
-  # - docker run -itd --name build onnx-mlir-build:initial
-  # - echo "docker is running now"
-  # - df -h
-  # - docker cp $(pwd) build:/build/onnx-mlir
-  # - cd docker
-  # - chmod a+x compile-onnx-mlir.sh test-onnx-mlir.sh
-  # - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
-  # - docker cp test-onnx-mlir.sh build:/usr/bin/test-onnx-mlir.sh
-  # - echo "about to execute build inside docker"
-  # - docker exec build df -h
-  # - docker exec build compile-onnx-mlir.sh
-  # - docker exec build test-onnx-mlir.sh
-  # - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
+  - echo "CPU Architecture is " $CPU_ARCH
+  - echo "commit is " $TRAVIS_COMMIT
+  - df -h
+  - if [ "$NIGHTLY" = true ] ; then
+      echo "Using nightly llvm-mlir image, build may fail.";
+      docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:${CPU_ARCH}-nightly"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
+    else
+      echo "Using latest compatible llvm-mlir image, build should not fail.";
+      docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:$CPU_ARCH"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
+    fi
+  - docker run -itd --name build onnx-mlir-build:initial
+  - echo "docker is running now"
+  - df -h
+  - docker cp $(pwd) build:/build/onnx-mlir
+  - cd docker
+  - chmod a+x compile-onnx-mlir.sh test-onnx-mlir.sh
+  - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
+  - docker cp test-onnx-mlir.sh build:/usr/bin/test-onnx-mlir.sh
+  - echo "about to execute build inside docker"
+  - docker exec build df -h
+  - docker exec build compile-onnx-mlir.sh
+  - docker exec build test-onnx-mlir.sh
+  - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
 # Script to deploy documentations.
 before_deploy:
-  - ls
+  - cd $TRAVIS_BUILD_DIR
   - doxygen
 deploy:
+  arch:
+    - amd64
+  env:
+    - NIGHTLY=false
   provider: pages
   strategy: git
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,31 +35,32 @@ script:
   - if [ "$CPU_ARCH" == "amd64" ] ; then
       export CPU_ARCH="x86";
     fi
-  - echo "CPU Architecture is " $CPU_ARCH
-  - echo "commit is " $TRAVIS_COMMIT
-  - df -h
-  - if [ "$NIGHTLY" = true ] ; then
-      echo "Using nightly llvm-mlir image, build may fail.";
-      docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:${CPU_ARCH}-nightly"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
-    else
-      echo "Using latest compatible llvm-mlir image, build should not fail.";
-      docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:$CPU_ARCH"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
-    fi
-  - docker run -itd --name build onnx-mlir-build:initial
-  - echo "docker is running now"
-  - df -h
-  - docker cp $(pwd) build:/build/onnx-mlir
-  - cd docker
-  - chmod a+x compile-onnx-mlir.sh test-onnx-mlir.sh
-  - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
-  - docker cp test-onnx-mlir.sh build:/usr/bin/test-onnx-mlir.sh
-  - echo "about to execute build inside docker"
-  - docker exec build df -h
-  - docker exec build compile-onnx-mlir.sh
-  - docker exec build test-onnx-mlir.sh
-  - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
+  # - echo "CPU Architecture is " $CPU_ARCH
+  # - echo "commit is " $TRAVIS_COMMIT
+  # - df -h
+  # - if [ "$NIGHTLY" = true ] ; then
+  #     echo "Using nightly llvm-mlir image, build may fail.";
+  #     docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:${CPU_ARCH}-nightly"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
+  #   else
+  #     echo "Using latest compatible llvm-mlir image, build should not fail.";
+  #     docker build --tag onnx-mlir-build:initial --build-arg BASE="onnxmlirczar/onnx-mlir-llvmimage:$CPU_ARCH"  -f ./docker/$CPU_ARCH.Dockerfile ./docker;
+  #   fi
+  # - docker run -itd --name build onnx-mlir-build:initial
+  # - echo "docker is running now"
+  # - df -h
+  # - docker cp $(pwd) build:/build/onnx-mlir
+  # - cd docker
+  # - chmod a+x compile-onnx-mlir.sh test-onnx-mlir.sh
+  # - docker cp compile-onnx-mlir.sh build:/usr/bin/compile-onnx-mlir.sh
+  # - docker cp test-onnx-mlir.sh build:/usr/bin/test-onnx-mlir.sh
+  # - echo "about to execute build inside docker"
+  # - docker exec build df -h
+  # - docker exec build compile-onnx-mlir.sh
+  # - docker exec build test-onnx-mlir.sh
+  # - docker commit build onnxmlirczar/onnx-mlir-build:$CPU_ARCH
 # Script to deploy documentations.
 before_deploy:
+  - ls
   - doxygen
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ env:
 # Do not test branch update unless it's mater.
 branches:
   only:
-  - master
+  # change to master
+  - gen-doc-travis
 stages:
   - name: prereq-init
   - name: prereq-0

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,14 @@ script:
 # Script to deploy documentations.
 deploy:
   provider: pages
-  skip_cleanup: true
+  strategy: git
+  cleanup: false
   github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
   keep_history: true
   local_dir: docs
   on:
-    branch: gen-doc-travis # change to master
+    # change to master
+    branch: gen-doc-travis
 jobs:
   fast_finish: true
   allow_failures:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,3 +5,6 @@ defaults:
       path: "README.md"
     values:
       permalink: "README.html"
+
+# Doxygen generated per-file doc references.
+include: ["_*.html"]

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -23,7 +23,7 @@ toc:
         url: /doxygen_html/_o_m_tensor_8h.html
       - page: OMTensorList C99 Runtime API
         url: /doxygen_html/_o_m_tensor_list_8h.html
-      - page: Generating ONNX Dialect
+      - page: Generate ONNX Dialect
         url: /ImportONNXDefs.html
       - page: About Documentation
         url: /Documentation.html

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -13,12 +13,16 @@ toc:
 #        url: /piece1.html
   - title: How-tos
     subfolderitems:
-      - page: Runtime API
+      - page: Perform Inference Using ONNX-MLIR Runtime API
         url: /doxygen_html/index.html
   - title: References
     subfolderitems:
       - page: ONNX Dialect
         url: /Dialects/onnx.html
+      - page: OMTensor C99 Runtime API
+        url: /doxygen_html/_o_m_tensor_8h.html
+      - page: OMTensorList C99 Runtime API
+        url: /doxygen_html/_o_m_tensor_list_8h.html
       - page: Generating ONNX Dialect
         url: /ImportONNXDefs.html
       - page: About Documentation


### PR DESCRIPTION
Generate doxygen documentation html pages and deploy the content to gh-pages branch. The onnx-mlir documentation web page will point to content/files in the gh-pages branch.

To see the effect of this patch, view:
http://onnx.ai/onnx-mlir/