### PR TITLE
Updated llvm commit to b3b4cda (Replacement of #343)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             git submodule update --init --recursive
       # Use cached mlir installation if possible.
       - restore_cache:
-          key: V20-LLVM-PROJECT-{{ arch }}
+          key: V21-LLVM-PROJECT-{{ arch }}
       - run:
           name: Install MLIR
           command: |
@@ -29,7 +29,7 @@ jobs:
               source onnx-mlir/utils/install-mlir.sh
             fi
       - save_cache:
-          key: V20-LLVM-PROJECT-{{ arch }}
+          key: V21-LLVM-PROJECT-{{ arch }}
           paths:
             - llvm-project
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             git submodule update --init --recursive
       # Use cached mlir installation if possible.
       - restore_cache:
-          key: V21-LLVM-PROJECT-{{ arch }}
+          key: V22-LLVM-PROJECT-{{ arch }}
       - run:
           name: Install MLIR
           command: |
@@ -29,7 +29,7 @@ jobs:
               source onnx-mlir/utils/install-mlir.sh
             fi
       - save_cache:
-          key: V21-LLVM-PROJECT-{{ arch }}
+          key: V22-LLVM-PROJECT-{{ arch }}
           paths:
             - llvm-project
       - run:

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -132,7 +132,7 @@ function(find_mlir_lib lib)
   endif()
 endfunction(find_mlir_lib)
 
-find_mlir_lib(MLIRAffineOps)
+find_mlir_lib(MLIRAffine)
 find_mlir_lib(MLIRAffineUtils)
 find_mlir_lib(MLIRAffineToStandard)
 find_mlir_lib(MLIRAffineTransforms)
@@ -149,7 +149,7 @@ find_mlir_lib(MLIRLLVMIR)
 find_mlir_lib(MLIRLoopAnalysis)
 find_mlir_lib(MLIRSCFToStandard)
 find_mlir_lib(MLIRLoopLikeInterface)
-find_mlir_lib(MLIRLinalgOps)
+find_mlir_lib(MLIRLinalg)
 find_mlir_lib(MLIRLinalgEDSC)
 find_mlir_lib(MLIRLinalgAnalysis)
 find_mlir_lib(MLIRLinalgTransforms)
@@ -160,7 +160,7 @@ find_mlir_lib(MLIRLLVMIRTransforms)
 find_mlir_lib(MLIRMlirOptMain)
 find_mlir_lib(MLIRParser)
 find_mlir_lib(MLIRPass)
-find_mlir_lib(MLIRStandardOps)
+find_mlir_lib(MLIRStandard)
 find_mlir_lib(MLIRStandardOpsTransforms)
 find_mlir_lib(MLIRStandardToLLVM)
 find_mlir_lib(MLIRSideEffectInterfaces)
@@ -208,11 +208,11 @@ find_mlir_lib(LLVMFrontendOpenMP)
 
 set(MLIRLibs
         ${MLIRAffineToStandard}
-        ${MLIRAffineOps}
+        ${MLIRAffine}
         ${MLIRAffineUtils}
         ${MLIRCopyOpInterface}
         ${MLIRLLVMIR}
-        ${MLIRStandardOps}
+        ${MLIRStandard}
         ${MLIRStandardOpsTransforms}
         ${MLIRStandardToLLVM}
         ${MLIRTransforms}
@@ -231,7 +231,7 @@ set(MLIRLibs
         ${MLIRTargetLLVMIRModuleTranslation}
         ${MLIRTransforms}
         ${MLIRTransformUtils}
-        ${MLIRAffineOps}
+        ${MLIRAffine}
         ${MLIRAffineToStandard}
         ${MLIRAffineTransforms}
         ${MLIRAnalysis}
@@ -250,11 +250,11 @@ set(MLIRLibs
         ${MLIROpenMP}
         ${MLIRMlirOptMain}
         ${MLIRSideEffectInterfaces}
-        ${MLIRStandardOps}
+        ${MLIRStandard}
         ${MLIRStandardToLLVM}
         ${MLIRTranslation}
         ${MLIRSupport}
-        ${MLIRLinalgOps}
+        ${MLIRLinalg}
         ${MLIRLinalgEDSC}
         ${MLIRLinalgAnalysis}
         ${MLIRLinalgTransforms}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 91671e13efbc5dbd17b832d7973401350d0a6ee6 && cd ..
+cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)
@@ -152,7 +152,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 91671e13efbc5dbd17b832d7973401350d0a6ee6 && cd ..
+cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
+cd llvm-project && git checkout b3b4cda104068e92b77f18c4e3fc0e0b8f3650e0 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)
@@ -152,7 +152,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
+cd llvm-project && git checkout b3b4cda104068e92b77f18c4e3fc0e0b8f3650e0 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
+cd llvm-project && git checkout b3b4cda104068e92b77f18c4e3fc0e0b8f3650e0 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)
@@ -110,7 +110,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
+cd llvm-project && git checkout b3b4cda104068e92b77f18c4e3fc0e0b8f3650e0 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 91671e13efbc5dbd17b832d7973401350d0a6ee6 && cd ..
+cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)
@@ -110,7 +110,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 91671e13efbc5dbd17b832d7973401350d0a6ee6 && cd ..
+cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -419,7 +419,7 @@ void ConstPropONNXToONNXPass::runOnFunction() {
   target.addLegalDialect<ONNXOpsDialect>();
 
   OwningRewritePatternList patterns;
-  populateWithGenerated(context, &patterns);
+  populateWithGenerated(context, patterns);
 
   applyPatternsAndFoldGreedily(function, patterns);
 } // end anonymous namespace

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -67,7 +67,7 @@ void DecomposeONNXToONNXPass::runOnFunction() {
   target.addIllegalOp<ONNXScalerOp>();
 
   OwningRewritePatternList patterns;
-  populateWithGenerated(context, &patterns);
+  populateWithGenerated(context, patterns);
 
   if (failed(applyPartialConversion(function, target, patterns)))
     signalPassFailure();

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..
+cd llvm-project && git checkout b3b4cda104068e92b77f18c4e3fc0e0b8f3650e0 && cd ..

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX MLIR.
-cd llvm-project && git checkout 91671e13efbc5dbd17b832d7973401350d0a6ee6 && cd ..
+cd llvm-project && git checkout cddb49bcc0b2853f594e4245977f6c89c75384c8 && cd ..


### PR DESCRIPTION
Updated llvm commit to b3b4cda (This PR replace #343.  Newer commit is used.)

This PR includes fix to reflect following update in MLIR.

- Remove Ops suffix from dialect library names: llvm/llvm-project@d4e889f
- API change of  `OwningRewritePatternList`. (`OwningRewritePatternList * -> OwningRewritePatternList &`): llvm/llvm-project@422aaf3

(I created this PR to use latest --normalize-memrefs.)