### PR TITLE
Minor documentation fix for frontend options

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,11 @@ ONNX MLIR Options:
 These are frontend options.
 
   Choose target to emit:
-      --EmitONNXIR - Ingest ONNX and emit corresponding ONNX dialect.
-      --EmitMLIR   - Lower model to MLIR built-in transformation dialect.
-      --EmitLLVMIR - Lower model to LLVM IR (LLVM dialect).
-      --EmitLLVMBC - Lower model to LLVM IR and emit (to file) LLVM bitcode for model.
+      --EmitONNXBasic - Ingest ONNX and emit the basic ONNX operations without inferred shapes.
+      --EmitONNXIR    - Ingest ONNX and emit corresponding ONNX dialect.
+      --EmitMLIR      - Lower model to MLIR built-in transformation dialect.
+      --EmitLLVMIR    - Lower model to LLVM IR (LLVM dialect).
+      --EmitLib       - Lower model to LLVM IR, emit (to file) LLVM bitcode for model, compile and link it to a shared library.
 ```
 
 ## Example

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
       llvm::cl::desc("Choose target to emit:"),
       llvm::cl::values(
           clEnumVal(EmitONNXBasic,
-              "Ingest ONNX and emit the basic ONNX operations without"
+              "Ingest ONNX and emit the basic ONNX operations without "
               "inferred shapes."),
           clEnumVal(
               EmitONNXIR, "Ingest ONNX and emit corresponding ONNX dialect."),


### PR DESCRIPTION
The PR has couple of fixes for documentation
1. Add a space between without and inferred so it read correctly
2. Update instructions in README to reflect the latest options

Signed-off-by: Chin Huang <chhuang@us.ibm.com>