### PR TITLE
Avoid model copy during import

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -40,7 +40,7 @@ public:
     InitHandlerMap();
   }
 
-  mlir::ModuleOp ImportONNXModel(const onnx::ModelProto& model) {
+  mlir::ModuleOp ImportONNXModel(const onnx::ModelProto &model) {
     ImportGraph(model.graph());
     return module_;
   }

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -40,7 +40,7 @@ public:
     InitHandlerMap();
   }
 
-  mlir::ModuleOp ImportONNXModel(onnx::ModelProto model) {
+  mlir::ModuleOp ImportONNXModel(const onnx::ModelProto& model) {
     ImportGraph(model.graph());
     return module_;
   }


### PR DESCRIPTION
Pass ONNX model via const-reference to avoid unnecessary copy of model when importing the model.