### PR TITLE
TileOp implementation with  IndexExpr

### DIFF
--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -61,8 +61,8 @@ struct ONNXTileOpLowering : public ConversionPattern {
 
     ONNXTileOpShapeHelper shapeHelper(&tileOp, &rewriter);
 
-    if (failed(shapeHelper.Compute(operandAdaptor)))
-      return op->emitError("Failed to scan Tile parameters successfully");
+    assert(
+        !failed(shapeHelper.Compute(operandAdaptor)) && "expected to succeed");
 
     auto resultOperand = tileOp.output();
     auto outputMemRefType = convertToMemRefType(*op->result_type_begin());

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+#include "src/Dialect/ONNX/ONNXShapeHelper.hpp"
 
 using namespace mlir;
 
@@ -58,44 +59,34 @@ struct ONNXTileOpLowering : public ConversionPattern {
     ONNXTileOp tileOp = llvm::cast<ONNXTileOp>(op);
     auto loc = op->getLoc();
 
-    // get input operands, shapes, and rank
-    Value input = operandAdaptor.input();
-    auto inputMemRefType = input.getType().cast<MemRefType>();
-    auto inputShape = inputMemRefType.getShape();
-    int64_t inputRank = inputShape.size();
-    Value repeats = operandAdaptor.repeats();
+    ONNXTileOpShapeHelper shapeHelper(&tileOp, &rewriter);
+   
+    if (failed(shapeHelper.Compute(operandAdaptor)))
+      return op->emitError("Failed to scan Tile parameters successfully");
 
-    // get output info
     auto resultOperand = tileOp.output();
     auto outputMemRefType = convertToMemRefType(*op->result_type_begin());
     auto outputMemRefShape = outputMemRefType.getShape();
     int64_t outputRank = outputMemRefShape.size();
 
-    bool insertDealloc = checkInsertDealloc(op);
-    Value alloc;
-    if (hasAllConstantDimensions(outputMemRefType))
-      alloc =
-          insertAllocAndDealloc(outputMemRefType, loc, rewriter, insertDealloc);
-    else
-      alloc = insertAllocAndDeallocForTile(
-          outputMemRefType, loc, rewriter, insertDealloc, input, repeats);
+    Value input = operandAdaptor.input();
+
+    Value alloc = insertAllocAndDeallocSimple(
+        rewriter, op, outputMemRefType, loc, shapeHelper.outputDims);
 
     // Define loops and iteration trip counts (equivalent to size of output)
-    std::vector<Value> originalLoops;
-    defineLoops(rewriter, loc, originalLoops, outputRank);
-    KrnlIterateOperandPack pack(rewriter, originalLoops);
-    for (int ii = 0; ii < outputRank; ++ii)
-      addDimensionToPack(rewriter, loc, pack, alloc, ii);
+    BuildKrnlLoop outputLoops(rewriter, loc, outputRank);
+    outputLoops.createDefineOp();
+    for (int i = 0; i < outputRank; i++) {
+      outputLoops.pushBounds(shapeHelper.context, 0, shapeHelper.outputDims[i]);
+    }
+    outputLoops.createIterateOp();
+    rewriter.setInsertionPointToStart(outputLoops.getIterateBlock());
 
-    // Create the loops
-    auto iterateOp = rewriter.create<KrnlIterateOp>(loc, pack);
-    Block &iterationBlock = iterateOp.bodyRegion().front();
+    IndexExprContext childContext(shapeHelper.context);
 
-    // Now perform the insertions into the body of the just generated loops.
-    // Insert instructions inside the KernelIterateOp body.
-    rewriter.setInsertionPointToStart(&iterationBlock);
-
-    // Handle the operations.
+    SmallVector<Value, 4> loadIndices;
+    bool isAffineLoad = true;
 
     // This implementation is to iterate the output tensor.
     // The store has simple affine subscript expression.
@@ -103,39 +94,30 @@ struct ONNXTileOpLowering : public ConversionPattern {
     // The load of elements in input tensor can be reused explicitly.
     // But the subscript of store is not contigous, or even not affine.
     // Alternative implementation can be found at the end of this file.
-    SmallVector<Value, 4> inputMemRefVal;
-    for (int i = 0; i < outputRank; ++i) {
-      if (inputShape[i] != -1) {
-        auto indexAE = rewriter.getAffineDimExpr(0);
-        auto offsetAE = rewriter.getAffineSymbolExpr(0);
-        auto dimMap = AffineMap::get(1, 1, indexAE % offsetAE);
 
-        auto inputDimSizeVal = rewriter.create<DimOp>(loc, input, i);
-        auto loopVarVal = iterationBlock.getArguments()[i];
-        auto exprVal = rewriter.create<AffineApplyOp>(
-            loc, dimMap, ArrayRef<Value>{loopVarVal, inputDimSizeVal});
-        inputMemRefVal.emplace_back(exprVal);
-      } else {
-        auto indexExpr = iterationBlock.getArguments()[i];
-        auto inputDim = rewriter.create<DimOp>(loc, input, i);
-        auto exprVal =
-            rewriter.create<UnsignedRemIOp>(loc, indexExpr, inputDim);
-        inputMemRefVal.emplace_back(exprVal);
+    for (int i = 0; i < outputRank; i++) {
+      // ToFIX: merge the two step into one?
+      Value loopVal = outputLoops.getInductionVar(i);
+      IndexExpr index = childContext.createLoopIterIndex(loopVal);
+      IndexExpr dimSize = childContext.createDimIndexFromShapedType(input, i);
+      IndexExpr exprVal = index % dimSize;
+      if (!exprVal.isAffine()) {
+        isAffineLoad = false;
       }
-    }
+      loadIndices.emplace_back(exprVal.getValue());
+    } 
 
-    // Load the value from input
-    // Tried to use affine load when the input has constant shape
-    Value inputVal;
-    if (hasAllConstantDimensions(inputMemRefType))
-      inputVal = rewriter.create<AffineLoadOp>(loc, input, inputMemRefVal);
+    Value loadVal;
+    if (isAffineLoad)
+      loadVal = rewriter.create<AffineLoadOp>(loc, input, loadIndices);
     else
-      inputVal = rewriter.create<LoadOp>(loc, input, inputMemRefVal);
-    SmallVector<Value, 4> outputMemRefVal(iterationBlock.getArguments().begin(),
-        iterationBlock.getArguments().end());
+      loadVal = rewriter.create<LoadOp>(loc, input, loadIndices);
 
-    // Then store the value in the output.
-    rewriter.create<AffineStoreOp>(loc, inputVal, alloc, outputMemRefVal);
+    SmallVector<Value, 4> storeIndices;
+    for (int i = 0; i < outputRank; ++i) {
+      storeIndices.emplace_back(outputLoops.getInductionVar(i));
+    }
+    rewriter.create<AffineStoreOp>(loc, loadVal, alloc, storeIndices);
 
     rewriter.replaceOp(op, alloc);
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -78,9 +78,6 @@ struct ONNXTileOpLowering : public ConversionPattern {
     BuildKrnlLoop outputLoops(rewriter, loc, outputRank);
     outputLoops.createDefineOp();
     outputLoops.pushAllBounds(shapeHelper.outputDims);
-    //for (int i = 0; i < outputRank; i++) {
-     // outputLoops.pushBounds(0, shapeHelper.outputDims[i]);
-    //}
     outputLoops.createIterateOp();
     rewriter.setInsertionPointToStart(outputLoops.getIterateBlock());
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -77,10 +77,10 @@ struct ONNXTileOpLowering : public ConversionPattern {
     // Define loops and iteration trip counts (equivalent to size of output)
     BuildKrnlLoop outputLoops(rewriter, loc, outputRank);
     outputLoops.createDefineOp();
-    for (int i = 0; i < outputRank; i++) {
-      //  Why the shapeHelper.context is needed here?
-      outputLoops.pushBounds(shapeHelper.context, 0, shapeHelper.outputDims[i]);
-    }
+    outputLoops.pushAllBounds(shapeHelper.outputDims);
+    //for (int i = 0; i < outputRank; i++) {
+     // outputLoops.pushBounds(0, shapeHelper.outputDims[i]);
+    //}
     outputLoops.createIterateOp();
     rewriter.setInsertionPointToStart(outputLoops.getIterateBlock());
 

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -2706,49 +2706,14 @@ LogicalResult ONNXTileOp::inferShapes() {
   if (repeatsTensorTy.getShape().size() != 1)
     return emitError("Repeats tensor must have rank one");
 
-  // 'repeats' tensor must have constant shape.
-  int64_t repeatsLength = repeatsTensorTy.getShape()[0];
-
-  // Check the 1D repeats tensor length.
-  int64_t inputRank = inputTensorTy.getShape().size();
-  if (repeatsLength != -1 && inputRank != repeatsLength)
-    return emitError("Repeats tensor must have the same length as the input's "
-                     "dimension number.");
-
-  // Check if second argument of TileOp is a constant.
-  auto constantOp = getONNXConstantOp(repeats());
-
-  // Compute output's dimensions: output_dim[i] = input_dim[i] * repeats[i]
-  SmallVector<int64_t, 2> dims(inputRank, -1);
-  if (constantOp) {
-    // 1. Initialize output_dim with values from 'input'.
-    //   output_dim[i] = input[i]
-    for (decltype(inputRank) i = 0; i < inputRank; ++i)
-      dims[i] = inputTensorTy.getShape()[i];
-
-    // 2. Update output_dim using values from 'repeats'.
-    // Do this only for static 'input_dim[i]'.
-    //   if (output_dim[i] != -1) output_dim[i] *= repeats[i]
-    DenseElementsAttr valueAttribute =
-        constantOp.valueAttr().dyn_cast<DenseElementsAttr>();
-    if (!valueAttribute)
-      return emitError("DenseElementsAttr expected");
-    // Get repeat values from valueAttribute.
-    auto valueIt = valueAttribute.getValues<IntegerAttr>().begin();
-    for (int i = 0; i < inputRank; ++i) {
-      if (dims[i] != -1)
-        dims[i] *= (*valueIt).cast<IntegerAttr>().getInt();
-      else
-        dims[i] = -1;
-      valueIt++;
-    }
-
-    if (valueIt != valueAttribute.getValues<IntegerAttr>().end())
-      return emitError("Constant value must have same length as output's rank");
-  }
-
-  getResult().setType(
-      RankedTensorType::get(dims, inputTensorTy.getElementType()));
+  auto elementType = input().getType().cast<ShapedType>().getElementType();
+  ONNXTileOpAdaptor operandAdaptor(*this);
+  ONNXTileOpShapeHelper shapeHelper(this, nullptr);
+  if (failed(shapeHelper.Compute(operandAdaptor)))
+    return emitError("Failed to scan Tile parameters successfully");
+  SmallVector<int64_t, 4> outputDims;
+  IndexExprContext::getOutputDimsForType(shapeHelper.outputDims, outputDims);
+  getResult().setType(RankedTensorType::get(outputDims, elementType));
 
   return success();
 }

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -179,8 +179,7 @@ ONNXTileOpShapeHelper::ONNXTileOpShapeHelper(
     ONNXTileOp *newOp, ConversionPatternRewriter *rewriter)
     : ONNXOpShapeHelper<ONNXTileOp>(newOp, rewriter) {}
 
-LogicalResult ONNXTileOpShapeHelper::Compute(
-    ONNXTileOpAdaptor operandAdaptor) {
+LogicalResult ONNXTileOpShapeHelper::Compute(ONNXTileOpAdaptor operandAdaptor) {
   // Shape inference indicated by passing a null rewriter pointer.
   Operation *genericOp = reinterpret_cast<Operation *>(op);
 
@@ -192,10 +191,10 @@ LogicalResult ONNXTileOpShapeHelper::Compute(
 
   // Compute outputDims
   outputDims.resize(inputRank);
-  for (auto i=0; i < inputRank; i++) {
+  for (auto i = 0; i < inputRank; i++) {
     IndexExpr dimInput = context.createDimIndexFromShapedType(input, i);
-    IndexExpr repeatsValue = context.createSymbolIndexFromArrayAtIndex(
-        genericOp, repeats, i);
+    IndexExpr repeatsValue =
+        context.createSymbolIndexFromArrayAtIndex(genericOp, repeats, i);
     IndexExpr dimOutput = dimInput * repeatsValue;
     outputDims[i] = dimOutput;
   }

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -63,6 +63,13 @@ struct ONNXSliceOpShapeHelper : public ONNXOpShapeHelper<ONNXSliceOp> {
   SmallVector<IndexExpr, 4> steps;
 };
 
+struct ONNXTileOpShapeHelper : public ONNXOpShapeHelper<ONNXTileOp> {
+  ONNXTileOpShapeHelper(
+      ONNXTileOp *newOp, ConversionPatternRewriter *rewriter);
+
+  LogicalResult Compute(ONNXTileOpAdaptor operandAdaptor);
+};
+
 //===----------------------------------------------------------------------===//
 // Low Level Helpers
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -67,8 +67,7 @@ struct ONNXSliceOpShapeHelper : public ONNXOpShapeHelper<ONNXSliceOp> {
 };
 
 struct ONNXTileOpShapeHelper : public ONNXOpShapeHelper<ONNXTileOp> {
-  ONNXTileOpShapeHelper(
-      ONNXTileOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXTileOpShapeHelper( ONNXTileOp *newOp, ConversionPatternRewriter *rewriter);
 
   LogicalResult Compute(ONNXTileOpAdaptor operandAdaptor);
 };

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -67,7 +67,7 @@ struct ONNXSliceOpShapeHelper : public ONNXOpShapeHelper<ONNXSliceOp> {
 };
 
 struct ONNXTileOpShapeHelper : public ONNXOpShapeHelper<ONNXTileOp> {
-  ONNXTileOpShapeHelper( ONNXTileOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXTileOpShapeHelper(ONNXTileOp *newOp, ConversionPatternRewriter *rewriter);
 
   LogicalResult Compute(ONNXTileOpAdaptor operandAdaptor);
 };

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -3089,35 +3089,6 @@ func @test_flatten1(%arg0 : tensor<2x?x4xf32>) -> tensor<*xf32> {
 
 }
 
-// -----
-
-// Test Tile with 1D unknown input 
-func @test_tile3(%arg0 : tensor<?xf32>, %arg1 : tensor<1xi64>) -> tensor<*xf32> {
-  %1 = "onnx.Tile"(%arg0, %arg1) : (tensor<?xf32>, tensor<1xi64>) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
-// CHECK-LABEL:       func @test_tile3       
-// CHECK-SAME:     ([[VAR_arg0:%.+]]: memref<?xf32>, [[VAR_arg1:%.+]]: memref<1xi64>) -> memref<?xf32> {
-// CHECK:           [[VAR_c0:%.+]] = constant 0 : index
-// CHECK:           [[VAR_0:%.+]] = affine.load [[VAR_arg1]]{{.}}[[VAR_c0]]{{.}} : memref<1xi64>
-// CHECK:           [[VAR_1:%.+]] = index_cast [[VAR_0]] : i64 to index
-// CHECK:           [[VAR_c0_0:%.+]] = constant 0 : index
-// CHECK:           [[VAR_2:%.+]] = dim [[VAR_arg0]], [[VAR_c0_0]] : memref<?xf32>
-// CHECK:           [[VAR_3:%.+]] = muli [[VAR_2]], [[VAR_1]] : index
-// CHECK:           [[VAR_4:%.+]] = alloc([[VAR_3]]) : memref<?xf32>
-// CHECK:           [[VAR_5:%.+]] = krnl.define_loops 1
-// CHECK:           [[VAR_c0_1:%.+]] = constant 0 : index
-// CHECK:           [[VAR_6:%.+]] = dim [[VAR_4]], [[VAR_c0_1]] : memref<?xf32>
-// CHECK:           krnl.iterate([[VAR_5]]) with ([[VAR_5]] -> [[VAR_arg2:%.+]] = 0 to [[VAR_6]]) {
-// CHECK:             [[VAR_c0_2:%.+]] = constant 0 : index
-// CHECK:             [[VAR_7:%.+]] = dim [[VAR_arg0]], [[VAR_c0_2]] : memref<?xf32>
-// CHECK:             [[VAR_8:%.+]] = remi_unsigned [[VAR_arg2]], [[VAR_7]] : index
-// CHECK:             [[VAR_9:%.+]] = load [[VAR_arg0]]{{.}}[[VAR_8]]{{.}} : memref<?xf32>
-// CHECK:             affine.store [[VAR_9]], [[VAR_4]]{{.}}[[VAR_arg2]]{{.}} : memref<?xf32>
-// CHECK:           }
-// CHECK:           return [[VAR_4]] : memref<?xf32>
-// CHECK:         }
-// CHECK:       }
-}
 
 // -----
 


### PR DESCRIPTION
The shape inference and ONNX to Krnl is implemented with IndexExpr. Different from the previous example of Slice, I put all the lowering code in lowering. The ShapeHelper for TileOp only shares the computation of outputDims. I think that this approach divides the code closer to their semantics:  all the loops for lowering are in the lowering code. In the Shape, there is no need for loops. Consequently, in the lowering, there is no need to inherit IndexExpr context from the ShapeHelper. 
The patch failed some test with dynamic shape because the llvm patch for % is not ready yet. I removed that test case.