### PR TITLE
Replace the tanh lowering by using std.tanh

### DIFF
--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -57,6 +57,9 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   target.addLegalDialect<KrnlOpsDialect, AffineDialect, StandardOpsDialect,
       shape::ShapeDialect>();
 
+  // std.tanh will be expanded.
+  target.addIllegalOp<mlir::TanhOp>();
+
   // TODO: enable this once more ops are supported.
   // We also define the ONNX dialect as Illegal so that the conversion will fail
   // if any of these operations are *not* converted.
@@ -117,6 +120,9 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   populateLoweringONNXRNNOpPattern(patterns, &getContext());
   // Entry point
   patterns.insert<ONNXEntryPointLowering>(&getContext());
+
+  // Expand std.tanh
+  populateExpandTanhPattern(patterns, &getContext());
 
   // With the target and rewrite patterns defined, we can now attempt the
   // conversion. The conversion will signal failure if any of our `illegal`

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -18,7 +18,6 @@ struct ScalarOp<ONNXTanhOp> {
   using IOp = TanhOp; // not use
 };
 
-
 template <>
 struct ScalarOp<ONNXAddOp> {
   using FOp = AddFOp;

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -13,6 +13,13 @@
 using namespace mlir;
 
 template <>
+struct ScalarOp<ONNXTanhOp> {
+  using FOp = TanhOp;
+  using IOp = TanhOp; // not use
+};
+
+
+template <>
 struct ScalarOp<ONNXAddOp> {
   using FOp = AddFOp;
   using IOp = AddIOp;
@@ -168,28 +175,6 @@ Value emitScalarOpFor<ONNXCoshOp>(ConversionPatternRewriter &rewriter,
   auto negExp = rewriter.create<ExpOp>(loc, neg);
   auto result = rewriter.create<DivFOp>(
       loc, rewriter.create<AddFOp>(loc, exp, negExp), two);
-
-  return result;
-}
-
-//===----------------------------------------------------------------------===//
-// Scalar unary ops for lowering ONNXTanhOp
-//===----------------------------------------------------------------------===//
-template <>
-Value emitScalarOpFor<ONNXTanhOp>(ConversionPatternRewriter &rewriter,
-    Location loc, Operation *op, Type elementType,
-    ArrayRef<Value> scalarOperands) {
-  // ONNXTanhOp(%X) = DivFOp(SubFOp(ExpOp(%X), ExpOp(NegFOp(%X))),
-  //                         AddFOp(ExpOp(%X), ExpOp(NegFOp(%X))))
-  Value operand = scalarOperands[0];
-
-  auto zero = emitConstantOp(rewriter, loc, elementType, 0);
-  auto neg = rewriter.create<SubFOp>(loc, zero, operand);
-  auto exp = rewriter.create<ExpOp>(loc, operand);
-  auto negExp = rewriter.create<ExpOp>(loc, neg);
-  auto dividend = rewriter.create<SubFOp>(loc, exp, negExp);
-  auto divisor = rewriter.create<AddFOp>(loc, exp, negExp);
-  auto result = rewriter.create<DivFOp>(loc, dividend, divisor);
 
   return result;
 }

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -15,6 +15,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/StandardOps/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"

--- a/test/mlir/onnx/onnx_lowering_with_dealloc.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_dealloc.mlir
@@ -286,14 +286,22 @@ func @test_tanh_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
-  // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
-  // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
-  // CHECK: [[EXP:%.+]] = exp [[LOAD]] : f32
-  // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
-  // CHECK: [[DIVIDEND:%.+]] = subf [[EXP]], [[NEXP]] : f32
-  // CHECK: [[DIVISOR:%.+]] = addf [[EXP]], [[NEXP]] : f32
-  // CHECK: [[TANH:%.+]] = divf [[DIVIDEND]], [[DIVISOR]] : f32
+  // CHECK: [[X:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[ONE:%.+]] = constant 1.000000e+00 : f32
+  // CHECK: [[TWO:%.+]] = constant 2.000000e+00 : f32
+  // CHECK: [[X_MUL_2:%.+]] = mulf [[X]], [[TWO]] : f32
+  // CHECK: [[NEG_X_MUL_2:%.+]] = negf [[X_MUL_2]] : f32
+  // CHECK: [[EXP_1:%.+]] = exp [[NEG_X_MUL_2]] : f32
+  // CHECK: [[SUB_1:%.+]] = subf %cst, [[EXP_1]] : f32
+  // CHECK: [[ADD_1:%.+]] = addf %cst, [[EXP_1]] : f32
+  // CHECK: [[DIV_1:%.+]] = divf [[SUB_1]], [[ADD_1]] : f32
+  // CHECK: [[EXP_2:%.+]] = exp [[X_MUL_2]] : f32
+  // CHECK: [[SUB_2:%.+]] = subf [[EXP_2]], %cst : f32
+  // CHECK: [[ADD_2:%.+]] = addf [[EXP_2]], %cst : f32
+  // CHECK: [[DIV_2:%.+]] = divf [[SUB_2]], [[ADD_2]] : f32
+  // CHECK: [[ZERO:%.+]] = constant 0.000000e+00 : f32
+  // CHECK: [[CMP:%.+]] = cmpf "oge", [[X]], [[ZERO]] : f32
+  // CHECK: [[TANH:%.+]] = select [[CMP]], [[DIV_1]], [[DIV_2]] : f32
   // CHECK: affine.store [[TANH]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   
   /// Second Tanh
@@ -304,14 +312,22 @@ func @test_tanh_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
-  // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
-  // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
-  // CHECK: [[EXP:%.+]] = exp [[LOAD]] : f32
-  // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
-  // CHECK: [[DIVIDEND:%.+]] = subf [[EXP]], [[NEXP]] : f32
-  // CHECK: [[DIVISOR:%.+]] = addf [[EXP]], [[NEXP]] : f32
-  // CHECK: [[TANH_RES:%.+]] = divf [[DIVIDEND]], [[DIVISOR]] : f32
+  // CHECK: [[X:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[ONE:%.+]] = constant 1.000000e+00 : f32
+  // CHECK: [[TWO:%.+]] = constant 2.000000e+00 : f32
+  // CHECK: [[X_MUL_2:%.+]] = mulf [[X]], [[TWO]] : f32
+  // CHECK: [[NEG_X_MUL_2:%.+]] = negf [[X_MUL_2]] : f32
+  // CHECK: [[EXP_1:%.+]] = exp [[NEG_X_MUL_2]] : f32
+  // CHECK: [[SUB_1:%.+]] = subf %cst, [[EXP_1]] : f32
+  // CHECK: [[ADD_1:%.+]] = addf %cst, [[EXP_1]] : f32
+  // CHECK: [[DIV_1:%.+]] = divf [[SUB_1]], [[ADD_1]] : f32
+  // CHECK: [[EXP_2:%.+]] = exp [[X_MUL_2]] : f32
+  // CHECK: [[SUB_2:%.+]] = subf [[EXP_2]], %cst : f32
+  // CHECK: [[ADD_2:%.+]] = addf [[EXP_2]], %cst : f32
+  // CHECK: [[DIV_2:%.+]] = divf [[SUB_2]], [[ADD_2]] : f32
+  // CHECK: [[ZERO:%.+]] = constant 0.000000e+00 : f32
+  // CHECK: [[CMP:%.+]] = cmpf "oge", [[X]], [[ZERO]] : f32
+  // CHECK: [[TANH_RES:%.+]] = select [[CMP]], [[DIV_1]], [[DIV_2]] : f32
   // CHECK: affine.store [[TANH_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.


### PR DESCRIPTION
TanhOp is in the std dialect, so we lower ONNXTanhOp to TanhOp instead of manually compute tanh using exp.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>