### PR TITLE
Use type/shape information from input ONNX model for import

### DIFF
--- a/src/Builder/FrontendDialectTransformer.hpp
+++ b/src/Builder/FrontendDialectTransformer.hpp
@@ -30,13 +30,24 @@ class OwningModuleRef;
 //===----------------------------------------------------------------------===//
 
 namespace onnx_mlir {
+
+/*!
+ * Options to control the translation of an ONNX model to ONNX-MLIR.
+ */
+struct ImportOptions {
+  // Use types/shapes in the input-model for translation (for intermediate
+  // variables)
+  bool useOnnxModelTypes = false;
+};
+
 /*!
  *  Import an ONNX model file into the ONNX Dialect.
  *  @param model_fname file name pointing to the onnx model protobuf.
  *  @return MLIR::module generated for the ONNX model.
  */
 void ImportFrontendModelFile(std::string model_fname,
-    mlir::MLIRContext &context, mlir::OwningModuleRef &module);
+    mlir::MLIRContext &context, mlir::OwningModuleRef &module,
+    ImportOptions options = ImportOptions());
 
 /*!
  *  Import an ONNX model proto into the ONNX Dialect.
@@ -44,7 +55,8 @@ void ImportFrontendModelFile(std::string model_fname,
  *  @return MLIR::module generated for the ONNX model.
  */
 void ImportFrontendModel(const onnx::ModelProto &model,
-    mlir::MLIRContext &context, mlir::OwningModuleRef &module);
+    mlir::MLIRContext &context, mlir::OwningModuleRef &module,
+    ImportOptions options = ImportOptions());
 
 /*!
  *  TODO: Import models into other extension dialects that cover the

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -16,6 +16,8 @@ using namespace ONNX_NAMESPACE;
 #define ONNX_OPSET_VERSION 11
 
 void RegisterFunSchema() {
+  static bool registered = false;
+  if (registered) return;
   ONNX_NAMESPACE::OpSchema schema;
   schema.SetName("SquareFn")
       .SetDomain(ONNX_DOMAIN)
@@ -32,6 +34,7 @@ void RegisterFunSchema() {
               {{"Y"}, "Mul", {"Two", "X"}}}));
   ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce unused(schema);
   (void)unused;
+  registered = true;
 }
 
 void registerDialects(mlir::MLIRContext &context) {
@@ -140,7 +143,7 @@ void testUseOfOnnxModelTypes() {
 }
 
 int main(int argc, char *argv[]) {
-  // testCustomFunTranslation();
+  testCustomFunTranslation();
   testUseOfOnnxModelTypes();
 
   return 0;


### PR DESCRIPTION
(1) Introduce options to allow callers to customize translation of ONNX model to ONNX-MLIR
(2) Add option to use type/shape information from input ONNX model for import

An ONNX model allows type-annotations to be stored for all variables in a model (including intermediate temporaries). ONNX type/shape inference can produced a fully annotated ONNX model. The translation of such a fully-annotated model can use the type/shape information contained in the input ONNX model. This is useful in cases where ONNX-MLIR does not have a corresponding type/shape inference method (eg. for custom-ops) or for cases where there is a mismatch between the type/shape inference methods.

The test-case in this PR shows how this can be used with custom-ops.