### PR TITLE
ShapeHelper for broadcasting operations using IndexExpr

### DIFF
--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -154,7 +154,7 @@ struct ONNXLoopOpLowering : public ConversionPattern {
         alloc = insertAllocAndDealloc(memRefType, loc, rewriter, shouldDealloc);
       else
         alloc = insertAllocAndDealloc(
-            memRefType, loc, rewriter, shouldDealloc, {vInit});
+            memRefType, loc, rewriter, shouldDealloc, vInit);
       outputs.emplace_back(alloc);
     }
   }

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -554,12 +554,6 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
     // Insert an allocation and deallocation for the result of this operation.
     auto memRefType = convertToMemRefType(*op->result_type_begin());
 
-    // If the output has a dynamic dimension, pass the operands required for
-    // each dynamic dimension to the AllocOp. The first operand of the
-    // operation is used. The operands of the op need to match in terms of
-    // dimensions with the result at this pre-optimization phase.
-    // TODO: verify that dimensions match.
-    // TODO: can the dimension of the result differ after optimizations?
     Value alloc;
     bool insertDealloc = checkInsertDealloc(op);
 
@@ -567,7 +561,7 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
       alloc = insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc);
     else
       alloc =
-          insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc, {X});
+          insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc, X);
 
     SmallVector<Value, 4> loopIVs;
     // Only create krnl.iterate if one of the operands is not scalar tensor.

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -48,8 +48,8 @@ MemRefType convertToMemRefType(Type type);
 
 /// Insert an allocation and deallocation for the given MemRefType.
 Value insertAllocAndDealloc(MemRefType type, Location loc,
-    PatternRewriter &rewriter, bool insertDealloc,
-    ArrayRef<Value> operands = {}, int64_t alignment = -1);
+    PatternRewriter &rewriter, bool insertDealloc, Value operand = nullptr,
+    int64_t alignment = -1);
 
 // Insert an allocation and deallocation for the given MemRefType, handling
 // compile time relying on the above function, and extracting the runtime
@@ -77,18 +77,6 @@ void addDimensionToPack(ConversionPatternRewriter &rewriter, Location loc,
 // number of krnl loops, and fill `loop` with the newly defined loops.
 void defineLoops(ConversionPatternRewriter &rewriter, Location loc,
     std::vector<Value> &loops, int64_t numLoops);
-
-// Get run-time dimension information for unknown dimensions used for
-// broadcasting.
-std::map<int, std::map<int, Value>> getBroadcastedDimInfo(Location loc,
-    ConversionPatternRewriter &rewriter, MemRefType memRefType,
-    ArrayRef<Value> operands);
-
-// Extract induction variables that are used for broadcasting values of a
-// given operand.
-std::vector<Value> getLoopIVsForBroadcasting(Location loc,
-    ConversionPatternRewriter &rewriter, ArrayRef<Value> loopIVs, Value operand,
-    std::map<int, Value> broadcastedDims);
 
 // Emit a positive infinity constant of a specific type.
 // Supported types: F16, F32, F64, Int8, Int16, Int32, Int64.

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -63,6 +63,41 @@ private:
   SmallVector<DimsExpr, 1> outputsDims;
 };
 
+/// Compute a broadcasted shape from the shapes of given operands. Operands must
+/// be ranked in advance.
+struct ONNXOpBroadcastedShapeHelper {
+  ONNXOpBroadcastedShapeHelper(
+      ConversionPatternRewriter *rewriter, Location loc);
+
+  // Compute a vector of IndexExprs to represent the output shape. Results are
+  // stored in 'outputDims'.
+  // Used in shape inference and memory allocation for the output.
+  // Parameters:
+  //   - operands: a list of input tensors.
+  LogicalResult Compute(ArrayRef<Value> operands);
+
+  // Compute access indices to load/store value from/to a given 'operand'.
+  // Used in a loop to access the operand.
+  // Parameters:
+  //   - outerContext: shape helper context obtained outside the loop.
+  //   - operand: operand to access
+  //   - operandIndex: index of the operand in 'inputsDims'
+  //   - loopAccessExprs: IndexExprs for the loop's IVs
+  //   - operandAccessExprs: access indices to access the operand.
+  LogicalResult GetAccessExprs(IndexExprContext &outerContext, Value operand,
+      unsigned operandIndex,
+      const SmallVectorImpl<IndexExpr> &outputAccessExprs,
+      SmallVectorImpl<IndexExpr> &operandAccessExprs);
+
+  IndexExprContext context;
+  // A vector of input shapes where dimensions are padded with 1 if necessary,
+  // so that all inputs have the same rank.
+  SmallVector<DimsExpr, 4> inputsDims;
+  // A vector of IndexExprs representing the output shape.
+  DimsExpr outputDims;
+  int64_t outputRank = -1;
+};
+
 // Shape for concat
 struct ONNXConcatOpShapeHelper : public ONNXOpShapeHelper<ONNXConcatOp> {
   ONNXConcatOpShapeHelper(

--- a/test/mlir/onnx/onnx_enable_memory_pool.mlir
+++ b/test/mlir/onnx/onnx_enable_memory_pool.mlir
@@ -23,6 +23,8 @@ func @test_enable_memory_pool(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
+// -----
+
 /// Two intermediate values to allocate in the memory pool.
 func @test_enable_memory_pool_2(%arg0: tensor<10x10xf32>, %arg1: tensor<10x20xf32>) -> tensor<10x20xf32> {
   %0 = "onnx.Add"(%arg0, %arg0) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
@@ -63,6 +65,8 @@ func @test_enable_memory_pool_2(%arg0: tensor<10x10xf32>, %arg1: tensor<10x20xf3
   // CHECK: return [[RES]] : memref<10x20xf32>
 }
 
+// -----
+
 // Two intermediate dynamic sized MemRefs.
 func @test_enable_memory_pool_3(%arg0: tensor<?x?xf32>, %arg1: tensor<?x10xf32>, %arg2: tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<?x?xf32>, tensor<?x10xf32>) -> tensor<*xf32>
@@ -85,12 +89,11 @@ func @test_enable_memory_pool_3(%arg0: tensor<?x?xf32>, %arg1: tensor<?x10xf32>,
   // CHECK: krnl.define_loops 2
   // CHECK: krnl.iterate
   // CHECK: affine.store {{.*}}, [[DATA1]][%arg3, %arg4] : memref<?x10xf32>
-  // CHECK: [[CMP1:%.+]] = cmpi "sgt", [[DIM1]], [[DIM1]] : index
-  // CHECK: [[SELECT1:%.+]] = select [[CMP1]], [[DIM1]], [[DIM1]] : index
-  // CHECK: [[TMP3:%.+]] = muli [[SELECT1]], [[CONST4]] : index
+  // CHECK: [[CMP1:%.+]] = affine.max {{.*}}([[DIM1]], [[DIM1]])
+  // CHECK: [[TMP3:%.+]] = muli [[CMP1]], [[CONST4]] : index
   // CHECK: [[TMP4:%.+]] = muli [[TMP3]], [[CONST10]] : index
   // CHECK: [[MEMPOOL2:%.+]] = alloc([[TMP4]]) : memref<?xi8>
-  // CHECK: [[DATA2:%.+]] = "krnl.getref"([[MEMPOOL2]], [[CONST0_I64]], [[SELECT1]]) : (memref<?xi8>, i64, index) -> memref<?x10xf32>
+  // CHECK: [[DATA2:%.+]] = "krnl.getref"([[MEMPOOL2]], [[CONST0_I64]], [[CMP1]]) : (memref<?xi8>, i64, index) -> memref<?x10xf32>
   // CHECK: krnl.define_loops 2
   // CHECK: krnl.iterate
   // CHECK: affine.store {{.*}}, [[DATA2]][%arg3, %arg4] : memref<?x10xf32>

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -3070,8 +3070,7 @@ func @loop_body(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<1xi64>) -> 
   // CHECK:           [[VAR_0:%.+]] = alloc() : memref<1xi64>
   // CHECK:           [[VAR_1:%.+]] = krnl.define_loops 1
   // CHECK:           krnl.iterate([[VAR_1]]) with ([[VAR_1]] -> [[VAR_arg3:%.+]] = 0 to 1) {
-  // CHECK:             [[VAR_c0:%.+]] = constant 0 : index
-  // CHECK:             [[VAR_2:%.+]] = affine.load [[VAR_arg2]]{{.}}[[VAR_c0]]{{.}} : memref<1xi64>
+  // CHECK:             [[VAR_2:%.+]] = affine.load [[VAR_arg2]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
   // CHECK:             [[VAR_3:%.+]] = affine.load [[VAR_arg0]][] : memref<i64>
   // CHECK:             [[VAR_4:%.+]] = addi [[VAR_2]], [[VAR_3]] : i64
   // CHECK:             affine.store [[VAR_4]], [[VAR_0]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -699,61 +699,71 @@ func @test_reducemean_f32_unknown_dims(%arg0 : tensor<3x?x2xf32>) -> tensor<*xf3
 // -----
 
 // COM: Check the template for lowering binary operations whose output type can be different from its input type.
-func @test_binary_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5xf32>, %arg1: tensor<3x4x1xf32>) -> tensor<3x4x5xi1> {
-  %0 = "onnx.Less"(%arg0, %arg1) : (tensor<?x4x5xf32>, tensor<3x4x1xf32>) -> tensor<3x4x5xi1>
-  return %0 : tensor<3x4x5xi1>
-
+func @test_binary_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5xf32>, %arg1: tensor<1x?x1xf32>) -> tensor<?x4x5xi1> {
+  %0 = "onnx.Less"(%arg0, %arg1) : (tensor<?x4x5xf32>, tensor<1x?x1xf32>) -> tensor<?x4x5xi1>
+  return %0 : tensor<?x4x5xi1>
 // CHECK-LABEL:  func @test_binary_elementwise_op_template_unknown_dims
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x4x5xf32>, [[PARAM_1_:%.+]]: memref<3x4x1xf32>) -> memref<3x4x5xi1> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x4x5xf32>, [[PARAM_1_:%.+]]: memref<1x?x1xf32>) -> memref<?x4x5xi1> {
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<3x4x5xi1>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x4x5xf32>
+// CHECK-DAG:       [[DIM_1_:%.+]] = dim [[PARAM_1_]], [[CST_1_]] : memref<1x?x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = affine.max #map0(){{.}}[[DIM_0_]]{{.}}
+// CHECK-DAG:       [[RES_:%.+]] = alloc([[VAR_2_]]) : memref<?x4x5xi1>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
-// CHECK:             [[VAR_3_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
-// CHECK:             [[VAR_4_:%.+]] = select [[VAR_3_]], [[I_0_]], [[CST_0_]] : index
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = load [[PARAM_0_]]{{.}}[[VAR_4_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x4x5xf32>
-// CHECK-DAG:         [[LOAD_PARAM_1_MEM_:%.+]] = affine.load [[PARAM_1_]][symbol([[I_0_]]), symbol([[I_1_]]), 0] : memref<3x4x1xf32>
-// CHECK:             [[VAR_7_:%.+]] = cmpf "olt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
-// CHECK:             affine.store [[VAR_7_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<3x4x5xi1>
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_2_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
+// CHECK:             [[VAR_5_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
+// CHECK:             [[VAR_6_:%.+]] = select [[VAR_5_]], [[I_0_]], [[CST_0_]] : index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = load [[PARAM_0_]]{{.}}[[VAR_6_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x4x5xf32>
+// CHECK-DAG:         [[VAR_8_:%.+]] = cmpi "sgt", [[DIM_1_]], [[CST_1_]] : index
+// CHECK:             [[VAR_9_:%.+]] = select [[VAR_8_]], [[I_1_]], [[CST_0_]] : index
+// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = load [[PARAM_1_]]{{.}}[[CST_0_]], [[VAR_9_]], [[CST_0_]]{{.}} : memref<1x?x1xf32>
+// CHECK:             [[VAR_11_:%.+]] = cmpf "olt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK:             affine.store [[VAR_11_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x4x5xi1>
 // CHECK:           }
-// CHECK:           return [[RES_]] : memref<3x4x5xi1>
+// CHECK:           return [[RES_]] : memref<?x4x5xi1>
 // CHECK:         }
 }
 
 // -----
 
 // COM: Check the template for lowering variadic operations and binary operations whose output type is the same as its input type: Min, Max, Add, Sub, etc. 
-func @test_variadic_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5xf32>, %arg1: tensor<3x?x5xf32>, %arg2: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
-  %0 = "onnx.Max"(%arg0, %arg1, %arg2) : (tensor<?x4x5xf32>, tensor<3x?x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-  return %0 : tensor<3x4x5xf32>
-
+func @test_variadic_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x1xf32>, %arg1: tensor<?x?x5xf32>, %arg2: tensor<?x1x5xf32>) -> tensor<?x4x5xf32> {
+  %0 = "onnx.Max"(%arg0, %arg1, %arg2) : (tensor<?x4x1xf32>, tensor<?x?x5xf32>, tensor<?x1x5xf32>) -> tensor<?x4x5xf32>
+  return %0 : tensor<?x4x5xf32>
 // CHECK-LABEL:  func @test_variadic_elementwise_op_template_unknown_dims
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x4x5xf32>, [[PARAM_1_:%.+]]: memref<3x?x5xf32>, [[PARAM_2_:%.+]]: memref<3x4x5xf32>) -> memref<3x4x5xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x4x1xf32>, [[PARAM_1_:%.+]]: memref<?x?x5xf32>, [[PARAM_2_:%.+]]: memref<?x1x5xf32>) -> memref<?x4x5xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<3x4x5xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x4x5xf32>
-// CHECK-DAG:       [[DIM_1_:%.+]] = dim [[PARAM_1_]], [[CST_1_]] : memref<3x?x5xf32>
+// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x4x1xf32>
+// CHECK-DAG:       [[DIM_1_:%.+]] = dim [[PARAM_1_]], [[CST_0_]] : memref<?x?x5xf32>
+// CHECK-DAG:       [[DIM_2_:%.+]] = dim [[PARAM_1_]], [[CST_1_]] : memref<?x?x5xf32>
+// CHECK-DAG:       [[DIM_3_:%.+]] = dim [[PARAM_2_]], [[CST_0_]] : memref<?x1x5xf32>
+// CHECK:           [[VAR_4_:%.+]] = affine.max #map0(){{.}}[[DIM_0_]], [[DIM_1_]]{{.}}
+// CHECK-DAG:       [[RES_:%.+]] = alloc([[VAR_4_]]) : memref<?x4x5xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
-// CHECK:             [[VAR_4_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
-// CHECK:             [[VAR_5_:%.+]] = select [[VAR_4_]], [[I_0_]], [[CST_0_]] : index
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = load [[PARAM_0_]]{{.}}[[VAR_5_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x4x5xf32>
-// CHECK-DAG:         [[VAR_7_:%.+]] = cmpi "sgt", [[DIM_1_]], [[CST_1_]] : index
-// CHECK:             [[VAR_8_:%.+]] = select [[VAR_7_]], [[I_1_]], [[CST_0_]] : index
-// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = load [[PARAM_1_]]{{.}}[[I_0_]], [[VAR_8_]], [[I_2_]]{{.}} : memref<3x?x5xf32>
-// CHECK:             [[VAR_10_:%.+]] = cmpf "ogt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
-// CHECK-DAG:         [[VAR_11_:%.+]] = select [[VAR_10_]], [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
-// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = affine.load [[PARAM_2_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<3x4x5xf32>
-// CHECK:             [[VAR_13_:%.+]] = cmpf "ogt", [[VAR_11_]], [[LOAD_PARAM_2_MEM_]] : f32
-// CHECK:             [[VAR_14_:%.+]] = select [[VAR_13_]], [[VAR_11_]], [[LOAD_PARAM_2_MEM_]] : f32
-// CHECK:             affine.store [[VAR_14_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<3x4x5xf32>
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_4_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
+// CHECK:             [[VAR_7_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
+// CHECK:             [[VAR_8_:%.+]] = select [[VAR_7_]], [[I_0_]], [[CST_0_]] : index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = load [[PARAM_0_]]{{.}}[[VAR_8_]], [[I_1_]], [[CST_0_]]{{.}} : memref<?x4x1xf32>
+// CHECK-DAG:         [[VAR_10_:%.+]] = cmpi "sgt", [[DIM_1_]], [[CST_1_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_11_:%.+]] = select [[VAR_10_]], [[I_0_]], [[CST_0_]] : index
+// CHECK-DAG:         [[VAR_12_:%.+]] = cmpi "sgt", [[DIM_2_]], [[CST_1_]] : index
+// CHECK:             [[VAR_13_:%.+]] = select [[VAR_12_]], [[I_1_]], [[CST_0_]] : index
+// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = load [[PARAM_1_]]{{.}}[[VAR_11_]], [[VAR_13_]], [[I_2_]]{{.}} : memref<?x?x5xf32>
+// CHECK:             [[VAR_15_:%.+]] = cmpf "ogt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK-DAG:         [[VAR_16_:%.+]] = select [[VAR_15_]], [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK-DAG:         [[VAR_17_:%.+]] = cmpi "sgt", [[DIM_3_]], [[CST_1_]] : index
+// CHECK:             [[VAR_18_:%.+]] = select [[VAR_17_]], [[I_0_]], [[CST_0_]] : index
+// CHECK:             [[LOAD_PARAM_2_MEM_:%.+]] = load [[PARAM_2_]]{{.}}[[VAR_18_]], [[CST_0_]], [[I_2_]]{{.}} : memref<?x1x5xf32>
+// CHECK:             [[VAR_20_:%.+]] = cmpf "ogt", [[VAR_16_]], [[LOAD_PARAM_2_MEM_]] : f32
+// CHECK:             [[VAR_21_:%.+]] = select [[VAR_20_]], [[VAR_16_]], [[LOAD_PARAM_2_MEM_]] : f32
+// CHECK:             affine.store [[VAR_21_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x4x5xf32>
 // CHECK:           }
-// CHECK:           return [[RES_]] : memref<3x4x5xf32>
+// CHECK:           return [[RES_]] : memref<?x4x5xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -713,14 +713,12 @@ func @test_binary_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5xf32>,
 // CHECK-DAG:       [[RES_:%.+]] = alloc([[VAR_2_]]) : memref<?x4x5xi1>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_2_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
-// CHECK:             [[VAR_5_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
-// CHECK:             [[VAR_6_:%.+]] = select [[VAR_5_]], [[I_0_]], [[CST_0_]] : index
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = load [[PARAM_0_]]{{.}}[[VAR_6_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x4x5xf32>
-// CHECK-DAG:         [[VAR_8_:%.+]] = cmpi "sgt", [[DIM_1_]], [[CST_1_]] : index
-// CHECK:             [[VAR_9_:%.+]] = select [[VAR_8_]], [[I_1_]], [[CST_0_]] : index
-// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = load [[PARAM_1_]]{{.}}[[CST_0_]], [[VAR_9_]], [[CST_0_]]{{.}} : memref<1x?x1xf32>
-// CHECK:             [[VAR_11_:%.+]] = cmpf "olt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
-// CHECK:             affine.store [[VAR_11_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x4x5xi1>
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = affine.load [[PARAM_0_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x4x5xf32>
+// CHECK-DAG:         [[VAR_6_:%.+]] = cmpi "sgt", [[DIM_1_]], [[CST_1_]] : index
+// CHECK:             [[VAR_7_:%.+]] = select [[VAR_6_]], [[I_1_]], [[CST_0_]] : index
+// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = load [[PARAM_1_]]{{.}}[[CST_0_]], [[VAR_7_]], [[CST_0_]]{{.}} : memref<1x?x1xf32>
+// CHECK:             [[VAR_9_:%.+]] = cmpf "olt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK:             affine.store [[VAR_9_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x4x5xi1>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x4x5xi1>
 // CHECK:         }

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -663,4 +663,64 @@ func @test_split_unknown_dimension_equal_split(%arg0 : tensor<?x?x64xf32>) -> (t
 // CHECK:         }
 }
 
+// -----
+
+// COM: Check the template for lowering binary operations whose output type can be different from its input type.
+func @test_binary_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5xf32>, %arg1: tensor<3x4x1xf32>) -> tensor<3x4x5xi1> {
+  %0 = "onnx.Less"(%arg0, %arg1) : (tensor<?x4x5xf32>, tensor<3x4x1xf32>) -> tensor<3x4x5xi1>
+  return %0 : tensor<3x4x5xi1>
+
+// CHECK-LABEL:  func @test_binary_elementwise_op_template_unknown_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x4x5xf32>, [[PARAM_1_:%.+]]: memref<3x4x1xf32>) -> memref<3x4x5xi1> {
+// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<3x4x5xi1>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x4x5xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
+// CHECK:             [[VAR_3_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
+// CHECK:             [[VAR_4_:%.+]] = select [[VAR_3_]], [[I_0_]], [[CST_0_]] : index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = load [[PARAM_0_]]{{.}}[[VAR_4_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x4x5xf32>
+// CHECK-DAG:         [[LOAD_PARAM_1_MEM_:%.+]] = affine.load [[PARAM_1_]][symbol([[I_0_]]), symbol([[I_1_]]), 0] : memref<3x4x1xf32>
+// CHECK:             [[VAR_7_:%.+]] = cmpf "olt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK:             affine.store [[VAR_7_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<3x4x5xi1>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<3x4x5xi1>
+// CHECK:         }
+}
+
+// -----
+
+// COM: Check the template for lowering variadic operations and binary operations whose output type is the same as its input type: Min, Max, Add, Sub, etc. 
+func @test_variadic_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5xf32>, %arg1: tensor<3x?x5xf32>, %arg2: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
+  %0 = "onnx.Max"(%arg0, %arg1, %arg2) : (tensor<?x4x5xf32>, tensor<3x?x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
+  return %0 : tensor<3x4x5xf32>
+
+// CHECK-LABEL:  func @test_variadic_elementwise_op_template_unknown_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x4x5xf32>, [[PARAM_1_:%.+]]: memref<3x?x5xf32>, [[PARAM_2_:%.+]]: memref<3x4x5xf32>) -> memref<3x4x5xf32> {
+// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<3x4x5xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x4x5xf32>
+// CHECK-DAG:       [[DIM_1_:%.+]] = dim [[PARAM_1_]], [[CST_1_]] : memref<3x?x5xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
+// CHECK:             [[VAR_4_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
+// CHECK:             [[VAR_5_:%.+]] = select [[VAR_4_]], [[I_0_]], [[CST_0_]] : index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = load [[PARAM_0_]]{{.}}[[VAR_5_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x4x5xf32>
+// CHECK-DAG:         [[VAR_7_:%.+]] = cmpi "sgt", [[DIM_1_]], [[CST_1_]] : index
+// CHECK:             [[VAR_8_:%.+]] = select [[VAR_7_]], [[I_1_]], [[CST_0_]] : index
+// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = load [[PARAM_1_]]{{.}}[[I_0_]], [[VAR_8_]], [[I_2_]]{{.}} : memref<3x?x5xf32>
+// CHECK:             [[VAR_10_:%.+]] = cmpf "ogt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK-DAG:         [[VAR_11_:%.+]] = select [[VAR_10_]], [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = affine.load [[PARAM_2_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<3x4x5xf32>
+// CHECK:             [[VAR_13_:%.+]] = cmpf "ogt", [[VAR_11_]], [[LOAD_PARAM_2_MEM_]] : f32
+// CHECK:             [[VAR_14_:%.+]] = select [[VAR_13_]], [[VAR_11_]], [[LOAD_PARAM_2_MEM_]] : f32
+// CHECK:             affine.store [[VAR_14_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<3x4x5xf32>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<3x4x5xf32>
+// CHECK:         }
+}
 


### PR DESCRIPTION
This patch uses IndexExpr for broadcasting operations such as binary ops, variadic ops that support multi-directional broadcasting.