### PR TITLE
Fix wrong setting for datatype size and enable dynamic dims for all inputs and all dimensions

### DIFF
--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -260,7 +260,8 @@ int64_t *omTensorGetStrides(OMTensor *tensor) { return tensor->_strides; }
 /* OMTensor data strides setter */
 void omTensorSetStrides(OMTensor *tensor, int64_t *stridesInBytes) {
   for (int i = 0; i < tensor->_rank; i++)
-    tensor->_strides[i] = stridesInBytes[i] / sizeof(tensor->_dataType);
+    tensor->_strides[i] =
+      stridesInBytes[i] / getDataTypeSize(tensor->_dataType);
 }
 
 /* OMTensor data type getter */

--- a/test/backend/CMakeLists.txt
+++ b/test/backend/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_target(check-onnx-backend
 
 add_custom_target(check-onnx-backend-dynamic
         COMMAND ${PYTHON_EXECUTABLE}
-        ${CMAKE_CURRENT_BINARY_DIR}/test.py --dynamic --input=-1 --dim=0)
+        ${CMAKE_CURRENT_BINARY_DIR}/test.py --dynamic --input=-1 --dim=-1)
 
 add_custom_target(clean-onnx-backend
         COMMAND ${CMAKE_COMMAND} -E remove

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -24,8 +24,8 @@ parser.add_argument('--dynamic', action='store_true',
     help='enable dynamic (default: false)')
 parser.add_argument('-i', '--input', type=int, default=-1,
     help='input whose dimensions to be changed to unknown (default: all inputs')
-parser.add_argument('-d', '--dim', type=int, default=0,
-    help='dimension to be changed to unknown (default: first dimension')
+parser.add_argument('-d', '--dim', type=int, default=-1,
+    help='dimension to be changed to unknown (default: all dimension')
 parser.add_argument('unittest_args', nargs='*')
 args = parser.parse_args()
 sys.argv[1:] = args.unittest_args
@@ -71,9 +71,9 @@ test_static_dynamicNA = test_static # static tests for which dyn not available.
 # - 'dynamic_dict' is a dict to define which inputs/dimensions are changed to
 #     unknown, where its key is an input index and its value is a set of
 #     dimension indices, e.g. {0:{0,1}, 1:{-1}, 2:{0}}
-# If 'dynamic_dict' is not given, by default, the first dimension of all inputs
-#   will be changed to unknown. Use this script's arguments '--input' and
-#   '--dim' to control the default values.
+# If 'dynamic_dict' is not given, by default, all dimension of all inputs will
+#   be changed to unknown. Use this script's arguments '--input' and '--dim' to
+#   control the default values.
 # Input and dimension indices start from 0. -1 means all inputs or all dimensions.
 
 test_to_enable_static_dynamic = {
@@ -93,8 +93,8 @@ test_to_enable_static_dynamic = {
     # Adam
 
     # Add
-    "test_add_cpu": (test_static_dynamic,{-1: {-1}}),
-    "test_add_bcast_cpu": (test_static_dynamic,{-1: {-1}}),
+    "test_add_cpu": (test_static_dynamic,),
+    "test_add_bcast_cpu": (test_static_dynamic,),
 
     # And
     "test_and2d_cpu": (test_static_dynamic,),

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -562,9 +562,8 @@ test_to_enable_static_dynamic = {
     "test_sinh_example_cpu": (test_static_dynamic,),
 
     # Size
-    # TODO(tjingrant): fix unit test for size ops.
-    "test_size_cpu": (test_static,),
-    "test_size_example_cpu": (test_static,),
+    "test_size_cpu": (test_static_dynamic,),
+    "test_size_example_cpu": (test_static_dynamic,),
 
     # Slice (makes Axis a runtime argument, which is not supported).
 

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -172,8 +172,7 @@ test_to_enable_static_dynamic = {
     "test_concat_3d_axis_negative_3_cpu": (test_static_dynamic,{0:{0}}),
 
     # Constant (dynamic NA)
-    # TODO look into error
-    "test_constant_cpu": (test_disabled,), # get very larger error, unsure why
+    "test_constant_cpu": (test_static_dynamicNA,),
 
     # ConstantOfShape (dynamic NA)
     "test_constantofshape_float_ones_cpu": (test_static_dynamicNA,),


### PR DESCRIPTION
Resolve #449 and enable testing all dynamic dims in all inputs (by default). Thus, by default, `check-onnx-backend-dynamic" will import all dimensions in all inputs as unknown dims.

Enable tests for Constant and Size. It seems these tests work with master branch. Not sure which PRs solved issues about these tests. So just enable them here. 