### PR TITLE
Do not call ShapeHelper Compute functions within assert

### DIFF
--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -616,7 +616,9 @@ struct ONNXElementwiseBinaryOpLowering : public ConversionPattern {
 
     // Shape helper.
     ONNXOpBroadcastedShapeHelper shapeHelper(&rewriter, loc);
-    assert(succeeded(shapeHelper.Compute(operands)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operands));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape!");
     IndexExprContext outerContext(shapeHelper.context);
 
     // Insert an allocation and deallocation for the result of this operation.
@@ -680,7 +682,9 @@ struct ONNXElementwiseVariadicOpLowering : public ConversionPattern {
 
     // Shape helper.
     ONNXOpBroadcastedShapeHelper shapeHelper(&rewriter, loc);
-    assert(succeeded(shapeHelper.Compute(operands)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operands));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape!");
     IndexExprContext outerContext(shapeHelper.context);
 
     // Insert an allocation and deallocation for the result of this operation.

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -27,7 +27,9 @@ struct ONNXGemmOpLowering : public ConversionPattern {
     ONNXGemmOp gemmOp = llvm::cast<ONNXGemmOp>(op);
     Location loc = op->getLoc();
     ONNXGemmOpShapeHelper shapeHelper(&gemmOp, &rewriter);
-    assert(succeeded(shapeHelper.Compute(operandAdaptor)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operandAdaptor));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape!");
     IndexExprContext outerContext(shapeHelper.context);
 
     // Insert an allocation and deallocation for the output of this operation.

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -25,7 +25,9 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     ONNXMatMulOp matMulOp = llvm::cast<ONNXMatMulOp>(op);
     Location loc = op->getLoc();
     ONNXMatMulOpShapeHelper shapeHelper(&matMulOp, &rewriter);
-    assert(succeeded(shapeHelper.Compute(operandAdaptor)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operandAdaptor));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape");
     IndexExprContext outerContext(shapeHelper.context);
 
     // Insert an allocation and deallocation for the output of this operation.

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -25,7 +25,9 @@ struct ONNXConcatOpLowering : public ConversionPattern {
     ONNXConcatOpAdaptor operandAdaptor(operands);
     ONNXConcatOp concatOp = llvm::cast<ONNXConcatOp>(op);
     ONNXConcatOpShapeHelper shapeHelper(&concatOp, &rewriter);
-    assert(succeeded(shapeHelper.Compute(operandAdaptor)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operandAdaptor));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape!");
 
     auto axis = concatOp.axis();
     int inputNum = operands.size();

--- a/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
@@ -24,7 +24,9 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     auto loc = op->getLoc();
 
     ONNXGatherOpShapeHelper shapeHelper(&gatherOp, &rewriter);
-    assert(succeeded(shapeHelper.Compute(operandAdaptor)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operandAdaptor));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape!");
     IndexExprContext outerContext(shapeHelper.context);
 
     // Insert an allocation and deallocation for the output of this operation.

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -24,7 +24,9 @@ struct ONNXSliceOpLowering : public ConversionPattern {
     Location loc = op->getLoc();
 
     ONNXSliceOpShapeHelper shapeHelper(&sliceOp, &rewriter);
-    assert(succeeded(shapeHelper.Compute(operandAdaptor)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operandAdaptor));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape!");
 
     auto outputMemRefType = convertToMemRefType(*op->result_type_begin());
     int64_t outputRank = outputMemRefType.getShape().size();

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -29,7 +29,9 @@ struct ONNXSplitOpLowering : public ConversionPattern {
 
     // Get a shape helper.
     ONNXSplitOpShapeHelper shapeHelper(&splitOp, &rewriter);
-    assert(succeeded(shapeHelper.Compute(operandAdaptor)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operandAdaptor));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape!");
 
     // Alloc and dealloc.
     SmallVector<Value, 4> allocs;

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -33,7 +33,9 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
 
     // Get a shape helper.
     ONNXTransposeOpShapeHelper shapeHelper(&transposeOp, &rewriter);
-    assert(succeeded(shapeHelper.Compute(operandAdaptor)));
+    bool computeSucceeded = succeeded(shapeHelper.Compute(operandAdaptor));
+    (void)computeSucceeded;
+    assert(computeSucceeded && "Failed to compute shape!");
 
     // Insert an allocation and deallocation for the result of this operation.
     Value alloc = insertAllocAndDeallocSimple(


### PR DESCRIPTION
ShapeHelper's Compute functions such as ONNXOpShapeHelper::Compute
and ONNXOpBroadcastedShapeHelper::Compute have side-effects.
They cannot be placed within an ``assert'' macro, which becomes a
no-op in the release build. Consequently, we would end up with not
calling these functions at all and hitting subsequent failures.