### PR TITLE
Extend ONNX function translation to handle optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ export LIT_OPTS=-v
 cmake --build . --target check-onnx-lit
 ```
 
+If you are running on OSX Big Sur, you need to add `-DCMAKE_CXX_COMPILER=/usr/bin/c++`
+to the `cmake ..` command due to changes in the compilers.
 After the above commands succeed, an `onnx-mlir` executable should appear in the `bin` directory. 
 
 ## Installation on Windows

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -697,14 +697,18 @@ private:
 
     // Collect input/output MLIR types, input ONNX types, and input MLIR values.
     // TODO: Optional inputs/outputs of functions not handled yet.
+    onnx::TypeProto unspecifiedType;
     llvm::SmallVector<mlir::Type, 16> operandTypes;
     llvm::SmallVector<mlir::Type, 16> resultTypes;
     llvm::SmallVector<::mlir::Value, 16> operands;
     std::vector<onnx::TypeProto> operandOnnxTypes;
 
     for (auto &v : node.input()) {
-      if (v.empty())
-        return false;
+      if (v.empty()) {
+        // Use default TypeProto() to indicate missing input/type
+        operandOnnxTypes.push_back(unspecifiedType);
+        continue;
+      }
       operandOnnxTypes.push_back(value_info_map[v].type());
       auto val = LookupOnnxName(v);
       operands.push_back(val);
@@ -712,7 +716,7 @@ private:
     }
     for (auto &v : node.output()) {
       if (v.empty())
-        return false;
+        continue;
       auto resultType = ImportTensorType(value_info_map[v]);
       resultTypes.push_back(resultType);
     }

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -742,7 +742,8 @@ private:
     }
 
     // Create MLIR function:
-    const std::string& func_name_prefix = node.name().empty() ? node.op_type() : node.name();
+    const std::string &func_name_prefix =
+        node.name().empty() ? node.op_type() : node.name();
     auto funcOp = CreateFuncOp(func_name_prefix, operandTypes, resultTypes);
     auto *fnEntryBlock = funcOp.addEntryBlock();
 

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -742,7 +742,8 @@ private:
     }
 
     // Create MLIR function:
-    auto funcOp = CreateFuncOp(node.name(), operandTypes, resultTypes);
+    const std::string& func_name_prefix = node.name().empty() ? node.op_type() : node.name();
+    auto funcOp = CreateFuncOp(func_name_prefix, operandTypes, resultTypes);
     auto *fnEntryBlock = funcOp.addEntryBlock();
 
     // Save caller context, while generating callee function body.

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -17,7 +17,8 @@ using namespace ONNX_NAMESPACE;
 
 void RegisterFunSchema() {
   static bool registered = false;
-  if (registered) return;
+  if (registered)
+    return;
   ONNX_NAMESPACE::OpSchema schema;
   schema.SetName("SquareFn")
       .SetDomain(ONNX_DOMAIN)
@@ -142,9 +143,85 @@ void testUseOfOnnxModelTypes() {
   check(model_proto);
 }
 
+void RegisterOptParamFunSchema() {
+  static bool registered = false;
+  if (registered)
+    return;
+  ONNX_NAMESPACE::OpSchema schema;
+  // A sample function with an optional first parameter.
+  schema.SetName("TestFun1")
+      .SetDomain(ONNX_DOMAIN)
+      .SinceVersion(ONNX_OPSET_VERSION)
+      .SetDoc("This operator returns the second input.")
+      .Input(0, "X", "Input tensor", "T", OpSchema::Optional)
+      .Input(0, "Y", "Input tensor", "T", OpSchema::Single)
+      .Output(0, "Z", "Output tensor", "T", OpSchema::Single)
+      .TypeConstraint(
+          "T", {"tensor(float)"}, "Type of the input and output values")
+      .FunctionBody(FunctionBodyHelper::BuildNodes(
+          {// nodes: {outputs, op, inputs, attributes}
+              {{"Z"}, "Identity", {"Y"}}}));
+  ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce unused(schema);
+  (void)unused;
+  registered = true;
+}
+
+void testOptionalParameter() {
+  RegisterOptParamFunSchema();
+
+  ModelProto model_proto;
+  model_proto.set_ir_version(7);
+  auto *opset_version = model_proto.add_opset_import();
+  opset_version->set_domain(ONNX_DOMAIN);
+  opset_version->set_version(ONNX_OPSET_VERSION);
+
+  auto *graph = model_proto.mutable_graph();
+
+  auto float_type = TensorProto_DataType::TensorProto_DataType_FLOAT;
+  auto int_type = TensorProto_DataType::TensorProto_DataType_INT32;
+
+  auto *x = graph->add_input();
+  x->set_name("x");
+  auto *x_type = x->mutable_type()->mutable_tensor_type();
+  x_type->set_elem_type(float_type);
+  auto *x_shape = x_type->mutable_shape();
+  x_shape->add_dim()->set_dim_value(10);
+
+  auto *y = graph->add_output();
+  y->set_name("y");
+  auto *y_type = y->mutable_type()->mutable_tensor_type();
+  y_type->set_elem_type(float_type);
+  auto *y_shape = y_type->mutable_shape();
+  y_shape->add_dim()->set_dim_value(10);
+
+  auto *z = graph->add_output();
+  z->set_name("z");
+  auto *z_type = z->mutable_type()->mutable_tensor_type();
+  z_type->set_elem_type(float_type);
+  auto *z_shape = z_type->mutable_shape();
+  z_shape->add_dim()->set_dim_value(10);
+
+  // An invocation with optional parameter absent:
+  auto *node = graph->add_node();
+  node->add_input("");
+  node->add_input("x");
+  node->add_output("y");
+  node->set_op_type("TestFun1");
+
+  // An invocation with optional parameter present:
+  node = graph->add_node();
+  node->add_input("y");
+  node->add_input("x");
+  node->add_output("z");
+  node->set_op_type("TestFun1");
+
+  check(model_proto);
+}
+
 int main(int argc, char *argv[]) {
   testCustomFunTranslation();
   testUseOfOnnxModelTypes();
+  testOptionalParameter();
 
   return 0;
 }

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -54,6 +54,7 @@ void check(ModelProto &model) {
 
   module->verify();
   module->dump();
+  std::cerr << std::endl;
 }
 
 void testCustomFunTranslation() {


### PR DESCRIPTION
ONNX functions permit optional parameters (just like ONNX ops). Extend the translation of ONNX function to MLIR function to handle missing optional parameters. Add a test-case to test it.