### PR TITLE
Constant propagation for SplitOp

### DIFF
--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -425,7 +425,6 @@ void registerDialects(mlir::MLIRContext &context) {
 
 void addONNXToMLIRPasses(mlir::PassManager &pm) {
   pm.addNestedPass<FuncOp>(mlir::createDecomposeONNXToONNXPass());
-  pm.addNestedPass<FuncOp>(mlir::createConstPropONNXToONNXPass());
   pm.addPass(mlir::createShapeInferencePass());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addNestedPass<FuncOp>(mlir::createAttributePromotionPass());

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -398,7 +398,7 @@ DenseElementsAttr ConstPropUnsqueeze(
 
   // Unqueeze does not change the order of access, so just copy the whole data.
   std::vector<Attribute> resVector;
-  for (Attribute value : denseAttr.getValues<Attribute>()) {
+  for (auto value : denseAttr.getValues<Attribute>()) {
     resVector.emplace_back(value);
   }
 

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -513,11 +513,12 @@ public:
     SmallVector<::mlir::Value, 4> returnValues;
     for (int i = 0; i < outputNum; ++i) {
       Value splitOutput = splitOp->getResults()[i];
-      Value constOp = rewriter.create<ONNXConstantOp>(loc, splitOutput.getType(),
-          /*sparse_value=*/Attribute(),
-          /*dense_value=*/
-          ConstPropSplit(
-              rewriter, splitOutput, denseAttr, axisAttr, splitAttr, i));
+      Value constOp =
+          rewriter.create<ONNXConstantOp>(loc, splitOutput.getType(),
+              /*sparse_value=*/Attribute(),
+              /*dense_value=*/
+              ConstPropSplit(
+                  rewriter, splitOutput, denseAttr, axisAttr, splitAttr, i));
       returnValues.emplace_back(constOp);
     }
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -300,3 +300,15 @@ func @test_split_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
   // CHECK-NOT: {{.*}} = "onnx.Split"{{.*}}
 }
 
+// -----
+
+// COM: There is no constant propagation if the split's input is not a constant.
+
+// CHECK-LABEL: @test_split_axis_2(%arg0: tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>) {
+func @test_split_axis_2(%arg0 : tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>) {
+  %1, %2 = "onnx.Split"(%arg0) { axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
+  "std.return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
+
+  // CHECK: {{.*}} = "onnx.Split"(%arg0) {axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
+}
+

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -271,3 +271,32 @@ func @test_unsqueeze() -> tensor<*xf32> {
   // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
 }
 
+//===----------------------------------------------------------------------===//
+/// Split tests
+
+// -----
+
+// CHECK-LABEL: @test_split_axis_0() -> (tensor<1x10xf32>, tensor<1x10xf32>) {
+func @test_split_axis_0() -> (tensor<1x10xf32>, tensor<1x10xf32>) {
+  %0 = "onnx.Constant"() {value = dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>} : () -> tensor<2x10xf32>
+  %1, %2 = "onnx.Split"(%0) { axis = 0 : si64, split = [1, 1]} : (tensor<2x10xf32>) -> (tensor<1x10xf32>, tensor<1x10xf32>)
+  "std.return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
+
+  // CHECK: {{.*}} = "onnx.Constant"() {value = dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00]]> : tensor<1x10xf32>} : () -> tensor<1x10xf32>
+  // CHECK: {{.*}} = "onnx.Constant"() {value = dense<{{\[}}[1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<1x10xf32>} : () -> tensor<1x10xf32>
+  // CHECK-NOT: {{.*}} = "onnx.Split"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_split_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
+func @test_split_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
+  %0 = "onnx.Constant"() {value = dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>} : () -> tensor<2x10xf32>
+  %1, %2 = "onnx.Split"(%0) { axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
+  "std.return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
+
+  // CHECK: {{.*}} = "onnx.Constant"() {value = dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01]]> : tensor<2x5xf32>} : () -> tensor<2x5xf32>
+  // CHECK: {{.*}}  = "onnx.Constant"() {value = dense<{{\[}}[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00], [1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<2x5xf32>} : () -> tensor<2x5xf32>
+  // CHECK-NOT: {{.*}} = "onnx.Split"{{.*}}
+}
+

--- a/test/mlir/onnx/onnx_constprop_with_memref.mlir
+++ b/test/mlir/onnx/onnx_constprop_with_memref.mlir
@@ -270,3 +270,31 @@ func @test_unsqueeze() -> memref<2x1x1xf32> {
   // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
 }
 
+//===----------------------------------------------------------------------===//
+/// Split tests
+
+// -----
+
+// CHECK-LABEL: @test_split_axis_0() -> (memref<1x10xf32>, memref<1x10xf32>) {
+func @test_split_axis_0() -> (memref<1x10xf32>, memref<1x10xf32>) {
+  %0 = "onnx.Constant"() {value = dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>} : () -> memref<2x10xf32>
+  %1, %2 = "onnx.Split"(%0) { axis = 0 : si64, split = [1, 1]} : (memref<2x10xf32>) -> (memref<1x10xf32>, memref<1x10xf32>)
+  "std.return"(%1, %2) : (memref<1x10xf32>, memref<1x10xf32>) -> ()
+
+  // CHECK: {{.*}} = "onnx.Constant"() {value = dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00]]> : tensor<1x10xf32>} : () -> memref<1x10xf32>
+  // CHECK: {{.*}} = "onnx.Constant"() {value = dense<{{\[}}[1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<1x10xf32>} : () -> memref<1x10xf32>
+  // CHECK-NOT: {{.*}} = "onnx.Split"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_split_axis_1() -> (memref<2x5xf32>, memref<2x5xf32>) {
+func @test_split_axis_1() -> (memref<2x5xf32>, memref<2x5xf32>) {
+  %0 = "onnx.Constant"() {value = dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>} : () -> memref<2x10xf32>
+  %1, %2 = "onnx.Split"(%0) { axis = 1 : si64, split = [5, 5]} : (memref<2x10xf32>) -> (memref<2x5xf32>, memref<2x5xf32>)
+  "std.return"(%1, %2) : (memref<2x5xf32>, memref<2x5xf32>) -> ()
+
+  // CHECK: {{.*}} = "onnx.Constant"() {value = dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01]]> : tensor<2x5xf32>} : () -> memref<2x5xf32>
+  // CHECK: {{.*}}  = "onnx.Constant"() {value = dense<{{\[}}[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00], [1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<2x5xf32>} : () -> memref<2x5xf32>
+  // CHECK-NOT: {{.*}} = "onnx.Split"{{.*}}
+}


### PR DESCRIPTION
This patch does constant propagation for SplitOp.

It also removes the call to constant propagation that happens before shape inference. This solves the issue #471. Because constant propagation now supports both tensor and memref (by PR #462), it always expects a ranked data and is able to return ranked data. 