### PR TITLE
Lower ONNXPRelu to krnl dialect

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -762,8 +762,12 @@ LogicalResult ONNXPReluOp::inferShapes(
     return emitError("Input tensor(s) not ranked");
   auto xShape = X().getType().cast<ShapedType>().getShape();
   auto slopeShape = slope().getType().cast<ShapedType>().getShape();
+
   // PRelu supports unidirectional broadcasting, that is slope should be
   // unidirectional broadcastable to input X.
+  if (slopeShape.size() > xShape.size())
+    return emitError("Slope tensor has a wrong shape");
+
   // To do unidirectional broadcasting, we first apply bidirectional
   // broadcasting. Then, fine-tune by getting constant dimensions from X.
   SmallVector<int64_t, 4> shape;

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -66,8 +66,8 @@ private:
 /// Compute a broadcasted shape from the shapes of given operands. Operands must
 /// be ranked in advance.
 struct ONNXOpBroadcastedShapeHelper {
-  ONNXOpBroadcastedShapeHelper(
-      ConversionPatternRewriter *rewriter, Location loc);
+  ONNXOpBroadcastedShapeHelper(ConversionPatternRewriter *rewriter,
+      Location loc, bool uniBroadcasting = false);
 
   // Compute a vector of IndexExprs to represent the output shape. Results are
   // stored in 'outputDims'.
@@ -96,6 +96,11 @@ struct ONNXOpBroadcastedShapeHelper {
   // A vector of IndexExprs representing the output shape.
   DimsExpr outputDims;
   int64_t outputRank = -1;
+
+private:
+  // If unidirectional broadcasting, the other operands are always
+  // unidirectional broadcastable to the first operand.
+  bool isUniBroadcasting;
 };
 
 // Shape for concat

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -434,6 +434,8 @@ test_to_enable_static_dynamic = {
     # Does not support integer power yet
 
     # PRelu
+    "test_prelu_example_cpu": (test_static_dynamic,),
+    "test_prelu_broadcast_cpu": (test_static_dynamic,),
 
     # QLinear Conv
 

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -3184,3 +3184,118 @@ func private @test_pown(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> t
 // CHECK:           return [[RES_]] : memref<3x4x5xf32>
 // CHECK:         }
 }
+
+// -----
+
+// COM: Check float PRelu without broadcasting.
+func @test_prelu_float(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tensor<*xf32> {
+  %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+  // CHECK-LABEL: func @test_prelu_float
+  // CHECK: [[RES:%.+]] = alloc() : memref<3x4x5xf32>
+  // CHECK: [[MAIN_LOOP:%.+]]:3 = krnl.define_loops 3
+  // CHECK: krnl.iterate([[MAIN_LOOP]]#0, [[MAIN_LOOP]]#1, [[MAIN_LOOP]]#2) with ([[MAIN_LOOP]]#0 -> %arg2 = 0 to 3, [[MAIN_LOOP]]#1 -> %arg3 = 0 to 4, [[MAIN_LOOP]]#2 -> %arg4 = 0 to 5) {
+  // CHECK:   [[LOAD_X:%.+]] = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK:   [[LOAD_SLOPE:%.+]] = affine.load %arg1[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK:   [[CST_0:%.+]] = constant 0.000000e+00 : f32
+  // CHECK:   [[LESS_THAN_ZERO:%.+]] = cmpf "olt", [[LOAD_X]], [[CST_0]] : f32
+  // CHECK:   [[MUL:%.+]] = mulf [[LOAD_SLOPE]], [[LOAD_X]] : f32
+  // CHECK:   [[SELECT:%.+]] = select [[LESS_THAN_ZERO]], [[MUL]], [[LOAD_X]] : f32
+  // CHECK:   affine.store [[SELECT]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK: }
+  // CHECK: return [[RES]] : memref<3x4x5xf32>
+}
+
+// -----
+
+// COM: Check int PRelu without broadcasting.
+func @test_prelu_int(%arg0: tensor<3x4x5xi32>, %arg1: tensor<3x4x5xi32>) -> tensor<*xi32> {
+  %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xi32>, tensor<3x4x5xi32>) -> tensor<*xi32>
+  return %0 : tensor<*xi32>
+
+  // CHECK-LABEL: func @test_prelu_int
+  // CHECK: [[RES:%.+]] = alloc() : memref<3x4x5xi32>
+  // CHECK: [[MAIN_LOOP:%.+]]:3 = krnl.define_loops 3
+  // CHECK: krnl.iterate([[MAIN_LOOP]]#0, [[MAIN_LOOP]]#1, [[MAIN_LOOP]]#2) with ([[MAIN_LOOP]]#0 -> %arg2 = 0 to 3, [[MAIN_LOOP]]#1 -> %arg3 = 0 to 4, [[MAIN_LOOP]]#2 -> %arg4 = 0 to 5) {
+  // CHECK:   [[LOAD_X:%.+]] = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xi32>
+  // CHECK:   [[LOAD_SLOPE:%.+]] = affine.load %arg1[%arg2, %arg3, %arg4] : memref<3x4x5xi32>
+  // CHECK:   [[CST_0:%.+]] = constant 0 : i32
+  // CHECK:   [[LESS_THAN_ZERO:%.+]] = cmpi "slt", [[LOAD_X]], [[CST_0]] : i32
+  // CHECK:   [[MUL:%.+]] = muli [[LOAD_SLOPE]], [[LOAD_X]] : i32
+  // CHECK:   [[SELECT:%.+]] = select [[LESS_THAN_ZERO]], [[MUL]], [[LOAD_X]] : i32
+  // CHECK:   affine.store [[SELECT]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xi32>
+  // CHECK: }
+  // CHECK: return [[RES]] : memref<3x4x5xi32>
+}
+
+
+// -----
+
+// COM: Check PRelu with unidirectional broadcasting.
+func @test_prelu_broadcast1(%arg0: tensor<3x4x5xf32>, %arg1: tensor<5xf32>) -> tensor<*xf32> {
+  %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<5xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+  // CHECK-LABEL: func @test_prelu_broadcast1
+  // CHECK: [[RES:%.+]] = alloc() : memref<3x4x5xf32>
+  // CHECK: [[MAIN_LOOP:%.+]]:3 = krnl.define_loops 3
+  // CHECK: krnl.iterate([[MAIN_LOOP]]#0, [[MAIN_LOOP]]#1, [[MAIN_LOOP]]#2) with ([[MAIN_LOOP]]#0 -> %arg2 = 0 to 3, [[MAIN_LOOP]]#1 -> %arg3 = 0 to 4, [[MAIN_LOOP]]#2 -> %arg4 = 0 to 5) {
+  // CHECK:       [[LOAD_X:%.+]] = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK:       [[LOAD_SLOPE:%.+]] = affine.load %arg1[%arg4] : memref<5xf32>
+  // CHECK-DAG:   [[CST_0:%.+]] = constant 0.000000e+00 : f32
+  // CHECK:       [[LESS_THAN_ZERO:%.+]] = cmpf "olt", [[LOAD_X]], [[CST_0]] : f32
+  // CHECK:       [[MUL:%.+]] = mulf [[LOAD_SLOPE]], [[LOAD_X]] : f32
+  // CHECK:       [[SELECT:%.+]] = select [[LESS_THAN_ZERO]], [[MUL]], [[LOAD_X]] : f32
+  // CHECK:       affine.store [[SELECT]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK: }
+  // CHECK: return [[RES]] : memref<3x4x5xf32>
+}
+
+// -----
+
+// COM: Check PRelu with unidirectional broadcasting.
+// COM: Tensor slope should be unidirectional broadcastable to input tensor X
+func @test_prelu_broadcast2(%arg0: tensor<3x4x5xf32>, %arg1: tensor<1x5xf32>) -> tensor<*xf32> {
+  %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<1x5xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+  // CHECK-LABEL: func @test_prelu_broadcast2
+  // CHECK: [[RES:%.+]] = alloc() : memref<3x4x5xf32>
+  // CHECK: [[MAIN_LOOP:%.+]]:3 = krnl.define_loops 3
+  // CHECK: krnl.iterate([[MAIN_LOOP]]#0, [[MAIN_LOOP]]#1, [[MAIN_LOOP]]#2) with ([[MAIN_LOOP]]#0 -> %arg2 = 0 to 3, [[MAIN_LOOP]]#1 -> %arg3 = 0 to 4, [[MAIN_LOOP]]#2 -> %arg4 = 0 to 5) {
+  // CHECK:       [[LOAD_X:%.+]] = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK-DAG:   [[ZERO_INDEX:%.+]] = constant 0 : index
+  // CHECK:       [[LOAD_SLOPE:%.+]] = affine.load %arg1{{\[}}[[ZERO_INDEX]], %arg4] : memref<1x5xf32>
+  // CHECK-DAG:   [[CST_0:%.+]] = constant 0.000000e+00 : f32
+  // CHECK:       [[LESS_THAN_ZERO:%.+]] = cmpf "olt", [[LOAD_X]], [[CST_0]] : f32
+  // CHECK:       [[MUL:%.+]] = mulf [[LOAD_SLOPE]], [[LOAD_X]] : f32
+  // CHECK:       [[SELECT:%.+]] = select [[LESS_THAN_ZERO]], [[MUL]], [[LOAD_X]] : f32
+  // CHECK:       affine.store [[SELECT]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK: }
+  // CHECK: return [[RES]] : memref<3x4x5xf32>
+}
+
+// -----
+// COM: Check PRelu with unidirectional broadcasting.
+// COM: Tensor slope should be unidirectional broadcastable to input tensor X
+func @test_prelu_broadcast3(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x1x5xf32>) -> tensor<*xf32> {
+  %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x1x5xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+  // CHECK-LABEL: func @test_prelu_broadcast3
+  // CHECK: [[RES:%.+]] = alloc() : memref<3x4x5xf32>
+  // CHECK: [[MAIN_LOOP:%.+]]:3 = krnl.define_loops 3
+  // CHECK: krnl.iterate([[MAIN_LOOP]]#0, [[MAIN_LOOP]]#1, [[MAIN_LOOP]]#2) with ([[MAIN_LOOP]]#0 -> %arg2 = 0 to 3, [[MAIN_LOOP]]#1 -> %arg3 = 0 to 4, [[MAIN_LOOP]]#2 -> %arg4 = 0 to 5) {
+  // CHECK:       [[LOAD_X:%.+]] = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK-DAG:   [[ZERO_INDEX:%.+]] = constant 0 : index
+  // CHECK:       [[LOAD_SLOPE:%.+]] = affine.load %arg1[%arg2, [[ZERO_INDEX]], %arg4] : memref<3x1x5xf32>
+  // CHECK-DAG:   [[CST_0:%.+]] = constant 0.000000e+00 : f32
+  // CHECK:       [[LESS_THAN_ZERO:%.+]] = cmpf "olt", [[LOAD_X]], [[CST_0]] : f32
+  // CHECK:       [[MUL:%.+]] = mulf [[LOAD_SLOPE]], [[LOAD_X]] : f32
+  // CHECK:       [[SELECT:%.+]] = select [[LESS_THAN_ZERO]], [[MUL]], [[LOAD_X]] : f32
+  // CHECK:       affine.store [[SELECT]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK: }
+  // CHECK: return [[RES]] : memref<3x4x5xf32>
+}
+

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -765,3 +765,53 @@ func @test_variadic_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x1xf32
 // CHECK:         }
 }
 
+// -----
+
+// COM: Check PRelu with unidirectional broadcasting and unknown dimensions.
+// COM: Because of unidirectional broadcasting, always get constant dimensions from X even thought their values are 1.
+func @test_prelu_broadcast_unknown_dims(%arg0: tensor<3x1x5xf32>, %arg1: tensor<3x?x1xf32>) -> tensor<*xf32> {
+  %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x1x5xf32>, tensor<3x?x1xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+  // CHECK-LABEL: @test_prelu_broadcast_unknown_dims
+  // CHECK-DAG: [[CST0_f32:%.+]] = constant 0.000000e+00 : f32
+  // CHECK:     [[RES:%.+]] = alloc() : memref<3x1x5xf32>
+  // CHECK:     [[MAIN_LOOP:%.+]]:3 = krnl.define_loops 3
+  // CHECK:     krnl.iterate([[MAIN_LOOP]]#0, [[MAIN_LOOP]]#1, [[MAIN_LOOP]]#2) with ([[MAIN_LOOP]]#0 -> %arg2 = 0 to 3, [[MAIN_LOOP]]#1 -> %arg3 = 0 to 1, [[MAIN_LOOP]]#2 -> %arg4 = 0 to 5) {
+  // CHECK:       [[LOAD_X:%.+]] = affine.load %arg0[symbol(%arg2), symbol(%arg3), symbol(%arg4)] : memref<3x1x5xf32>
+  // CHECK:       [[LOAD_SLOPE:%.+]] = affine.load %arg1[symbol(%arg2), symbol(%arg3), 0] : memref<3x?x1xf32>
+  // CHECK:       [[LESS_THAN_ZERO:%.+]] = cmpf "olt", [[LOAD_X]], [[CST0_f32]] : f32
+  // CHECK:       [[MUL:%.+]] = mulf [[LOAD_SLOPE]], [[LOAD_X]] : f32
+  // CHECK:       [[SELECT:%.+]] = select [[LESS_THAN_ZERO]], [[MUL]], [[LOAD_X]] : f32
+  // CHECK:       affine.store [[SELECT]], [[RES]][symbol(%arg2), symbol(%arg3), symbol(%arg4)] : memref<3x1x5xf32>
+  // CHECK: }
+  // CHECK: return [[RES]] : memref<3x1x5xf32>
+}
+
+// -----
+
+// COM: Check PRelu with unidirectional broadcasting and unknown dimensions.
+// COM: If X's dimensions are unknown, get dimensions from slope whenever they are non-zero constants.
+func @test_prelu_broadcast_unknown_dims1(%arg0: tensor<?x2x?xf32>, %arg1: tensor<?x5xf32>) -> tensor<*xf32> {
+  %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<?x2x?xf32>, tensor<?x5xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+  // CHECK-LABEL: @test_prelu_broadcast_unknown_dims1
+  // CHECK-DAG: [[CST0:%.+]] = constant 0 : index
+  // CHECK-DAG: [[CST1:%.+]] = constant 1 : index
+  // CHECK-DAG: [[CST0_f32:%.+]] = constant 0.000000e+00 : f32
+  // CHECK:     [[DIM0_X:%.+]] = dim %arg0, [[CST0]] : memref<?x2x?xf32>
+  // CHECK:     [[DIM0_SLOPE:%.+]] = dim %arg1, [[CST0]] : memref<?x5xf32>
+  // CHECK:     [[RES:%.+]] = alloc([[DIM0_X]]) : memref<?x2x5xf32>
+  // CHECK:     [[MAIN_LOOP:%.+]]:3 = krnl.define_loops 3
+  // CHECK:     krnl.iterate([[MAIN_LOOP]]#0, [[MAIN_LOOP]]#1, [[MAIN_LOOP]]#2) with ([[MAIN_LOOP]]#0 -> %arg2 = 0 to [[DIM0_X]], [[MAIN_LOOP]]#1 -> %arg3 = 0 to 2, [[MAIN_LOOP]]#2 -> %arg4 = 0 to 5) {
+  // CHECK:       [[LOAD_X:%.+]] = affine.load %arg0[symbol(%arg2), symbol(%arg3), symbol(%arg4)] : memref<?x2x?xf32>
+  // CHECK:       [[GREATER_THAN_ONE:%.+]] = cmpi "sgt", [[DIM0_SLOPE]], [[CST1]] : index
+  // CHECK:       [[SELECT1:%.+]] = select [[GREATER_THAN_ONE]], %arg3, [[CST0]] : index
+  // CHECK:       [[LOAD_SLOPE:%.+]] = load %arg1{{\[}}[[SELECT1]], %arg4] : memref<?x5xf32>
+  // CHECK:       [[LESS_THAN_ZERO:%.+]] = cmpf "olt", [[LOAD_X]], [[CST0_f32]] : f32
+  // CHECK:       [[MUL:%.+]] = mulf [[LOAD_SLOPE]], [[LOAD_X]] : f32
+  // CHECK:       [[SELECT2:%.+]] = select [[LESS_THAN_ZERO]], [[MUL]], [[LOAD_X]] : f32
+  // CHECK:       affine.store [[SELECT2]], [[RES]][symbol(%arg2), symbol(%arg3), symbol(%arg4)] : memref<?x2x5xf32>
+  // CHECK:     }
+  // CHECK:     return [[RES]] : memref<?x2x5xf32>
+}


### PR DESCRIPTION
This patch revises shape inference for ONNXPRelu and lowers ONNXPRelu to krnl dialect. 

Signed-off-by: Tung D. Le <tung@jp.ibm.com>