### PR TITLE
update dropout Op to the new version

### DIFF
--- a/docs/Dialects/onnx.md
+++ b/docs/Dialects/onnx.md
@@ -1089,31 +1089,39 @@ ONNX Div operation
 
 ONNX Dropout operation
 
-"Dropout takes one input floating tensor and produces two tensor outputs,"
-"output (floating tensor) and mask (`Tensor<bool>`). Depending on whether it is"
-"in test mode or not, the output Y will either be a random dropout, or a simple"
-"copy of the input. Note that our implementation of Dropout does scaling in"
-"the training phase, so during testing nothing needs to be done."
+"Dropout takes an input floating-point tensor, an optional input ratio (floating-point scalar) and an optional input training_mode (boolean scalar). It produces two tensor outputs,"
+"output (floating-point tensor) and mask (optional `Tensor<bool>`). If `training_mode` is true then the output Y will be a random dropout;"
+"Note that this Dropout scales the masked input data by the following equation, so to convert the trained model into inference mode,"
+"the user can simply not pass `training_mode` input or set it to false."
+"```"
+"output = scale * data * mask,"
+"```"
+"where"
+"```"
+"scale = 1. / (1. - ratio)."
+"```"
 "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
 
 #### Attributes:
 
 | Attribute | MLIR Type | Description |
 | :-------: | :-------: | ----------- |
-`ratio` | ::mlir::FloatAttr | 32-bit float attribute
+`seed` | ::mlir::IntegerAttr | 64-bit signed integer attribute
 
 #### Operands:
 
 | Operand | Description |
 | :-----: | ----------- |
-`data` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or memref of any type values
+`data` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of bfloat16 type values or memref of any type values
+`ratio` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or memref of any type values or none type
+`training_mode` | tensor of 1-bit signless integer values or memref of any type values or none type
 
 #### Results:
 
 | Result | Description |
 | :----: | ----------- |
-`output` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or memref of any type values
-`mask` | tensor of 1-bit signless integer values or memref of any type values or none type
+`output` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of bfloat16 type values or memref of any type values
+`mask` | tensor of 1-bit signless integer values or memref of any type values or none type or none type
 
 ### `onnx.DynamicQuantizeLinear` (::mlir::ONNXDynamicQuantizeLinearOp)
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -12,16 +12,22 @@ cmake --build . --config Release --target check-onnx-backend
 ``` 
 Packages, such as third_party/onnx and ssl, needs to be installed to run the backend test.
 
-The node tests in onnx that will be run by check-onnx-backend is defined by variable test_to_enable in test/backend/test.py. User can test one test case by environment variable BACKEND_TEST. For example,
+The node tests in onnx that will be run by check-onnx-backend is defined by variable test_to_enable in test/backend/test.py. User can test one test case by environment variable TEST_CASE_BY_USER. For example,
 ```
-BACKEND_TEST=selected_test_name cmake --build . --config Release --target check-onnx-backend
+TEST_CASE_BY_USER=selected_test_name cmake --build . --config Release --target check-onnx-backend
 ```
-With BACKEND_TEST specified, the intermedia result, the .onnx file and .so file, are kept in build/test/backend for debugging.
+With TEST_CASE_BY_USER specified, the intermediate result, the .onnx file and .so file, are kept in build/test/backend for debugging.
 
 When the ONNX-to-Krnl conversion of an operator is added, the corresponding backend tests for this operator should be added to test.py. The available test cases can be found in third_part/onnx/onnx/backend/test/case/node. Please note to add suffix `_cpu` to the onnx test name. 
 
 ### Tests with unknown dimensions
-The onnx node tests usually have known dimension size for input tensors. To test tensor with unknown dimension, the model importer (Build/FrontendONNXTransformer.cpp) provides a functionality to generate such cases. When the environment variable, `IMPORTER_FORCE_DYNAMIC`, is set, the frontend import will turn the all the dimensions (by default) of all the input tensors of the model into -1. For example,
+
+Testing with dynamic tensor sizes is most easily performed by using the following command, also used by our checkers. 
+```
+cmake --build . --config Release --target check-onnx-backend-dynamic
+``` 
+
+The onnx node tests usually have known dimension size for input tensors. So, to test tensor with unknown dimension, the model importer (Build/FrontendONNXTransformer.cpp) provides a functionality to generate such cases. When the environment variable, `IMPORTER_FORCE_DYNAMIC`, is set, the frontend import will turn the all the dimensions (by default) of all the input tensors of the model into -1. For example,
 ```
 IMPORTER_FORCE_DYNAMIC='-1:-1' all dimensions of all the inputs will be changed
 IMPORTER_FORCE_DYNAMIC='0:-1' all dimensions of the first input will be changed
@@ -59,6 +65,7 @@ with IMPORTER_FORCE_DYNAMIC='0:0,2|1:1', the result is:
 `func @main_graph(%arg0: tensor<?x4x?xf32>, %arg1: tensor<3x?x5xf32>) -> tensor<3x4x5xf32>`.
 
 This is a way to use existing node test for dynamic tensors. Since not all test case can pass with dynamic tensor, there is a list in test/backend/test.py, test_not_for_dynamic, to specify which test can not pass with IMPORTER_FORCE_DYNAMIC is defined.
+
 
 ## LLVM FileCheck Tests
 

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -571,7 +571,7 @@ private:
   void ImportNodeDropout(const onnx::NodeProto &node) {
     int nOps = node.input().size();
     int nIn = mlir::ONNXDropoutOp::getNumberOfOperands();
-    if (nOps == nIn) { 
+    if (nOps == nIn) {
       // All inputs are specified
       buildOperation<mlir::ONNXDropoutOp>(node);
       return;

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -566,6 +566,69 @@ private:
   }
 
   /*!
+   * Special handle for Dropout operations.
+   */
+  void ImportNodeDropout(const onnx::NodeProto &node) {
+    int nOps = node.input().size();
+    int nIn = mlir::ONNXDropoutOp::getNumberOfOperands();
+    if (nOps ==  nIn) { 
+      // All inputs are specified
+      buildOperation<mlir::ONNXDropoutOp>(node);
+      return;
+    }
+
+    // Add the default value for optional input
+    // Copy the provided inputs first
+    std::vector<mlir::Value> inputs;
+    for (const auto &item : node.input()) {
+      if (initializedTensors.ContainKey(legalize_name(item))) {
+        inputs.push_back(initializedTensors.EmitInitializerForInputTensor(
+            UnknownLoc(), builder_, legalize_name(item)));
+      } else if (frontend_symbols_.ContainKey(legalize_name(item))) {
+        inputs.push_back(frontend_symbols_.GetTensorByOnnxName(item));
+      }
+    }
+
+    // If ratio is not specified, the default value is 0.5
+    if (nOps < 2) {
+      llvm::SmallVector<int64_t, 1> dims;
+      dims.push_back(1);
+      llvm::SmallVector<float, 1> values;
+      values.push_back(0.5);
+      auto elementType = builder_.getF32Type();
+      llvm::ArrayRef<int64_t> tensorDims(dims.data(), dims.size());
+      auto tensorType = mlir::RankedTensorType::get(tensorDims, elementType);
+      auto constantDenseAttribute =
+          mlir::DenseElementsAttr::get(tensorType, llvm::makeArrayRef(values));
+      auto constantOp = builder_.create<mlir::ONNXConstantOp>(
+          UnknownLoc(), mlir::Attribute(), constantDenseAttribute);
+      mlir::Value constantResult = *(constantOp.getODSResults(0).begin());
+      inputs.push_back(constantResult);
+    }
+
+    // If training_mode is not specified, the default value is false
+    if (nOps < 3) {
+      llvm::SmallVector<int64_t, 1> dims;
+      dims.push_back(1);
+      llvm::SmallVector<bool, 1> values;
+      values.push_back(false);
+      auto elementType = builder_.getIntegerType(1);
+      llvm::ArrayRef<int64_t> tensorDims(dims.data(), dims.size());
+      auto tensorType = mlir::RankedTensorType::get(tensorDims, elementType);
+      auto constantDenseAttribute =
+          mlir::DenseElementsAttr::get(tensorType, llvm::makeArrayRef(values));
+      auto constantOp = builder_.create<mlir::ONNXConstantOp>(
+          UnknownLoc(), mlir::Attribute(), constantDenseAttribute);
+      mlir::Value constantResult = *(constantOp.getODSResults(0).begin());
+      inputs.push_back(constantResult);
+    }
+    int nOut = mlir::ONNXDropoutOp::getNumberOfResults();
+    auto attributes = ImportNodeAttributes(node);
+    buildOutputAndOperation<mlir::ONNXDropoutOp>(
+          node, inputs, nIn, nOut, attributes);
+  }
+
+  /*!
    * Special handle for Pad operations.
    */
   void ImportNodePad(const onnx::NodeProto &node) {

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -571,7 +571,7 @@ private:
   void ImportNodeDropout(const onnx::NodeProto &node) {
     int nOps = node.input().size();
     int nIn = mlir::ONNXDropoutOp::getNumberOfOperands();
-    if (nOps ==  nIn) { 
+    if (nOps == nIn) { 
       // All inputs are specified
       buildOperation<mlir::ONNXDropoutOp>(node);
       return;
@@ -625,7 +625,7 @@ private:
     int nOut = mlir::ONNXDropoutOp::getNumberOfResults();
     auto attributes = ImportNodeAttributes(node);
     buildOutputAndOperation<mlir::ONNXDropoutOp>(
-          node, inputs, nIn, nOut, attributes);
+        node, inputs, nIn, nOut, attributes);
   }
 
   /*!

--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -69,7 +69,7 @@ import_handler_map_["Det"] =
 import_handler_map_["Div"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXDivOp>;
 import_handler_map_["Dropout"] = 
-   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXDropoutOp>;
+   &onnx_mlir::detail::FrontendGenImpl::ImportNodeDropout;
 import_handler_map_["DynamicQuantizeLinear"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXDynamicQuantizeLinearOp>;
 import_handler_map_["Elu"] = 

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -1045,20 +1045,28 @@ def ONNXDropoutOp:ONNX_Op<"Dropout",
   let hasCanonicalizer = 1;
   let summary = "ONNX Dropout operation";
   let description = [{
-  "Dropout takes one input floating tensor and produces two tensor outputs,"
-  "output (floating tensor) and mask (`Tensor<bool>`). Depending on whether it is"
-  "in test mode or not, the output Y will either be a random dropout, or a simple"
-  "copy of the input. Note that our implementation of Dropout does scaling in"
-  "the training phase, so during testing nothing needs to be done."
+  "Dropout takes an input floating-point tensor, an optional input ratio (floating-point scalar) and an optional input training_mode (boolean scalar). It produces two tensor outputs,"
+  "output (floating-point tensor) and mask (optional `Tensor<bool>`). If `training_mode` is true then the output Y will be a random dropout;"
+  "Note that this Dropout scales the masked input data by the following equation, so to convert the trained model into inference mode,"
+  "the user can simply not pass `training_mode` input or set it to false."
+  "```"
+  "output = scale * data * mask,"
+  "```"
+  "where"
+  "```"
+  "scale = 1. / (1. - ratio)."
+  "```"
   "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
   }];
-  let arguments = (ins AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, AnyMemRef]>:$data,
-    DefaultValuedAttr<F32Attr, "0.5">:$ratio);
-  let results = (outs AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, AnyMemRef]>:$output,
-    AnyTypeOf<[TensorOf<[I1]>, AnyMemRef, NoneType]>:$mask);
+  let arguments = (ins AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, AnyMemRef]>:$data,
+    AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, AnyMemRef, NoneType]>:$ratio,
+    AnyTypeOf<[TensorOf<[I1]>, AnyMemRef, NoneType]>:$training_mode,
+    OptionalAttr<SI64Attr>:$seed);
+  let results = (outs AnyTypeOf<[TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[BF16]>, AnyMemRef]>:$output,
+    AnyTypeOf<[TensorOf<[I1]>, AnyMemRef, NoneType, NoneType]>:$mask);
   let extraClassDeclaration = [{
     static int getNumberOfOperands() {
-      return 1;
+      return 3;
     }
     static int getNumberOfResults() {
       return 2;

--- a/src/Transform/ONNX/Combine.td
+++ b/src/Transform/ONNX/Combine.td
@@ -61,7 +61,7 @@ def IdentityEliminationPattern : Pat<(ONNXIdentityOp $arg),
                                      (replaceWithValue $arg)>;
 
 // y, mask = onnx.Dropout(x) -> y, mask = x, none
-def DropoutEliminationPattern : Pattern<(ONNXDropoutOp $arg, $ratio),
+def DropoutEliminationPattern : Pattern<(ONNXDropoutOp $arg, $arg1, $arg2, $ratio),
                                         [(replaceWithValue $arg),
                                          (ONNXConstantOp (GetNullAttr), (GetUnitAttr))]>;
 

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -239,6 +239,7 @@ test_to_enable_static_dynamic = {
     "test_dropout_default_cpu": (test_static_dynamic,),
     "test_dropout_default_ratio_cpu": (test_static_dynamic,),
     # Other dopout test case failed: implementation is missing
+    # mask is not supported for inference
     #"test_dropout_default_mask_cpu": (test_static_dynamic,),
     #"test_dropout_default_mask_ratio_cpu": (test_static_dynamic,),
 

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -222,6 +222,25 @@ test_to_enable_static_dynamic = {
     "test_div_example_cpu": (test_static_dynamic,),
 
     # Dropout
+    "test_dropout_default_cpu": (test_static_dynamic,),
+    "test_dropout_default_ratio_cpu": (test_static_dynamic,),
+    #"test_dropout_default_mask_cpu": (test_static_dynamic,),
+    #"test_dropout_default_mask_ratio_cpu": (test_static_dynamic,),
+
+    # Error: input arrays contain a mixture of endianness configuration
+    #"test_training_dropout_default_cpu": (test_static_dynamic,),
+
+    #"test_training_dropout_default_mask_cpu": (test_static_dynamic,),
+
+    # Error: input arrays contain a mixture of endianness configuration
+    #"test_training_dropout_default_cpu": (test_static_dynamic,),
+
+    #"test_training_dropout_mask_cpu": (test_static_dynamic,),
+
+    # Error: input arrays contain a mixture of endianness configuration
+    #"test_training_dropout_zero_ratio_cpu": (test_static_dynamic,),
+
+    #"test_training_dropout_zero_ratio_mask_cpu": (test_static_dynamic,),
 
     # DynamicQuantizeLinear
 

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1487,12 +1487,12 @@ func @test_reduce_mean_3(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
 /// Test shape inference for Dropout.
 //===----------------------------------------------------------------------===//
 
-func @test_dropout(%arg0: tensor<1x2x3x4xf32>) -> (tensor<*xf32>, tensor<*xi1>) {
-  %output, %mask = "onnx.Dropout"(%arg0) {ratio =  1.000000e-01 : f32} : (tensor<1x2x3x4xf32>) -> (tensor<*xf32>, tensor<*xi1>)
+func @test_dropout(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<1xf32>, %arg2: tensor<1xi1>) -> (tensor<*xf32>, tensor<*xi1>) {
+  %output, %mask = "onnx.Dropout"(%arg0, %arg1, %arg2) {ratio =  1.000000e-01 : f32} : (tensor<1x2x3x4xf32>, tensor<1xf32>, tensor<1xi1>) -> (tensor<*xf32>, tensor<*xi1>)
   "std.return"(%output, %mask) : (tensor<*xf32>, tensor<*xi1>) -> ()
 
   // CHECK-LABEL: test_dropout
-  // CHECK: [[RES:%.+]], [[MASK:%.+]] = "onnx.Dropout"(%arg0) {ratio =  1.000000e-01 : f32} : (tensor<1x2x3x4xf32>) -> (tensor<1x2x3x4xf32>, tensor<1x2x3x4xi1>)
+  // CHECK: [[RES:%.+]], [[MASK:%.+]] = "onnx.Dropout"(%arg0, %arg1, %arg2) {ratio =  1.000000e-01 : f32} : (tensor<1x2x3x4xf32>, tensor<1xf32>, tensor<1xi1>) -> (tensor<1x2x3x4xf32>, tensor<1x2x3x4xi1>)
   // CHECK: return [[RES]], [[MASK]] : tensor<1x2x3x4xf32>, tensor<1x2x3x4xi1>
 }
 

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -238,11 +238,12 @@ special_attr_types = dict([("Cast.to", 'type')])
 
 # Special operation importing handlers.
 special_op_handler = dict([
-    ("MaxPool", "ImportNodeMaxPool"),
     ("BatchNormalization", "ImportNodeBatchNormalization"),
+    ("Dropout", "ImportNodeDropout"),
+    ("Cast", "ImportNodeCast"),
+    ("MaxPool", "ImportNodeMaxPool"),
     ("Pad", "ImportNodePad"),
     ("Slice", "ImportNodeSlice"),
-    ("Cast", "ImportNodeCast")
     #("Transpose", "ImportNodeTranspose")
 ])
 

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -79,7 +79,7 @@ version_dict = {'Abs': 6,
  'DequantizeLinear': 10,
  'Det': 11,
  'Div': 7,
- 'Dropout': 10,
+ 'Dropout': 13,
  'DynamicQuantizeLinear': 11,
  'Elu': 6,
  'Equal': 11,
@@ -833,6 +833,7 @@ def parse_type_str(allowedType):
         'int32' : 'I32',
         'int64' : 'I64',
         'float16' : 'F16',
+        'bfloat16' : 'BF16',
         'float' : 'F32',
         'double' : 'F64',
         'unkown' : 'BF16',
@@ -1117,12 +1118,13 @@ def build_operator_schemas():
 
                     # Add checks against version_dict
                     if schema.name not in version_dict :
-                        print("Check-operation-version: Operation {} with version is new".format(
-                            schema.since_version, schema.name))
+                        print("Check-operation-version: Operation {} is new  with version {}"
+                            .format(schema.name, schema.since_version))
                     elif schema.since_version >  version_dict[schema.name]:
-                        print("Check-operation-version: Operation {} has a newer version {}"+
-                            "(old version {})".format( schema.name,
-                            schema.since_version, version_dict[schema.name]))
+                        print("Check-operation-version: Operation {}"
+                            .format(schema.name)+
+                            " has a newer version {} over old version {}"
+                            .format(schema.since_version, version_dict[schema.name]))
                 else:
                     # Generate operation according to the version in version_dict.
                     if schema.name not in version_dict :


### PR DESCRIPTION
Changes include:

1.  update the version of dropout in gen_onnx_mlir.py
2. add the default valid for optional inputs
3.  Update the document
4. change of test case for check-onnx-lit and check-onnx-backend

Future work: onnx-mlir failed other dropout tests in onnx unit test. Some are due to the data format and the rest may be related to our rewrite rule. We need new lowering function for the more complicated case in the new version. I will take a look into it.