### PR TITLE
Introduce krnl.load and krnl.store

### DIFF
--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -269,9 +269,9 @@ public:
         !llvm::any_of(indices, [](Value v) { return !isValidDim(v); });
 
     if (affineIndices)
-      rewriter.replaceOpWithNewOp<StoreOp>(op, value, memref, indices);
-    else
       rewriter.replaceOpWithNewOp<AffineStoreOp>(op, value, memref, indices);
+    else
+      rewriter.replaceOpWithNewOp<StoreOp>(op, value, memref, indices);
 
     return success();
   }

--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -212,6 +212,71 @@ LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// Krnl to Affine Rewrite Patterns: KrnlLoad operation.
+//===----------------------------------------------------------------------===//
+
+/// KrnlLoad will be lowered to std.load or affine.load, depending on whether
+/// the access indices are all affine maps or not.
+class KrnlLoadLowering : public OpRewritePattern<KrnlLoadOp> {
+public:
+  using OpRewritePattern<KrnlLoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      KrnlLoadOp op, PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    KrnlLoadOpAdaptor operandAdaptor = KrnlLoadOpAdaptor(op);
+
+    // Prepare inputs.
+    Value memref = operandAdaptor.memref();
+    SmallVector<Value, 4> indices = operandAdaptor.indices();
+
+    // Check whether all indices are affine maps or not.
+    bool affineIndices =
+        !llvm::any_of(indices, [](Value v) { return !isValidDim(v); });
+
+    if (affineIndices)
+      rewriter.replaceOpWithNewOp<AffineLoadOp>(op, memref, indices);
+    else
+      rewriter.replaceOpWithNewOp<LoadOp>(op, memref, indices);
+
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Krnl to Affine Rewrite Patterns: KrnlStore operation.
+//===----------------------------------------------------------------------===//
+
+/// KrnlStore will be lowered to std.store or affine.store, depending on whether
+/// the access indices are all affine maps or not.
+class KrnlStoreLowering : public OpRewritePattern<KrnlStoreOp> {
+public:
+  using OpRewritePattern<KrnlStoreOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      KrnlStoreOp op, PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    KrnlStoreOpAdaptor operandAdaptor = KrnlStoreOpAdaptor(op);
+
+    // Prepare inputs.
+    Value value = operandAdaptor.value();
+    Value memref = operandAdaptor.memref();
+    SmallVector<Value, 4> indices = operandAdaptor.indices();
+
+    // Check whether all indices are affine maps or not.
+    bool affineIndices =
+        !llvm::any_of(indices, [](Value v) { return !isValidDim(v); });
+
+    if (affineIndices)
+      rewriter.replaceOpWithNewOp<StoreOp>(op, value, memref, indices);
+    else
+      rewriter.replaceOpWithNewOp<AffineStoreOp>(op, value, memref, indices);
+
+    return success();
+  }
+};
+
 void ConvertKrnlToAffinePass::runOnFunction() {
   OpBuilder builder(&getContext());
   mlir::Operation *funcOp = getFunction();
@@ -253,8 +318,14 @@ void ConvertKrnlToAffinePass::runOnFunction() {
   // krnl.dim operations must be lowered prior to this pass.
   target.addIllegalOp<KrnlDimOp>();
   target.addLegalOp<AffineYieldOp>();
+  target.addLegalOp<AffineLoadOp>();
+  target.addLegalOp<AffineStoreOp>();
+  target.addLegalOp<LoadOp>();
+  target.addLegalOp<StoreOp>();
   OwningRewritePatternList patterns;
   patterns.insert<KrnlTerminatorLowering>(&getContext());
+  patterns.insert<KrnlLoadLowering>(&getContext());
+  patterns.insert<KrnlStoreLowering>(&getContext());
   DenseSet<Operation *> unconverted;
   if (failed(applyPartialConversion(
           getFunction(), target, std::move(patterns), &unconverted)))

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -60,6 +60,14 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   target.addLegalDialect<KrnlOpsDialect, AffineDialect, StandardOpsDialect,
       shape::ShapeDialect, scf::SCFDialect>();
 
+  // Use krnl.load/store instead of std.load/store and affine.load/store.
+  // krnl.load/store will be lowered to std.load/store and affine.load/store by
+  // `convert-krnl-to-affine` pass.
+  target.addIllegalOp<mlir::LoadOp>();
+  target.addIllegalOp<mlir::AffineLoadOp>();
+  target.addIllegalOp<mlir::StoreOp>();
+  target.addIllegalOp<mlir::AffineStoreOp>();
+
   // std.tanh will be expanded.
   target.addIllegalOp<mlir::TanhOp>();
 

--- a/src/Conversion/ONNXToKrnl/Math/Clip.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Clip.cpp
@@ -56,31 +56,31 @@ struct ONNXClipOpLowering : public ConversionPattern {
     }
 
     // Load unary first operand.
-    Value loadedVal = rewriter.create<AffineLoadOp>(loc, input, loopIVs);
+    Value loadedVal = rewriter.create<KrnlLoadOp>(loc, input, loopIVs);
     Type inputType = loadedVal.getType();
     Value res = loadedVal;
     if (inputType.isa<FloatType>()) {
       if (!min.getType().isa<NoneType>()) {
-        Value minVal = rewriter.create<AffineLoadOp>(loc, min).getResult();
+        Value minVal = rewriter.create<KrnlLoadOp>(loc, min).getResult();
         Value lessThanMin =
             rewriter.create<CmpFOp>(loc, CmpFPredicate::OLT, res, minVal);
         res = rewriter.create<SelectOp>(loc, lessThanMin, minVal, res);
       }
       if (!max.getType().isa<NoneType>()) {
-        Value maxVal = rewriter.create<AffineLoadOp>(loc, max).getResult();
+        Value maxVal = rewriter.create<KrnlLoadOp>(loc, max).getResult();
         Value lessThanMax =
             rewriter.create<CmpFOp>(loc, CmpFPredicate::OLT, res, maxVal);
         res = rewriter.create<SelectOp>(loc, lessThanMax, res, maxVal);
       }
     } else if (inputType.isa<IntegerType>()) {
       if (!min.getType().isa<NoneType>()) {
-        Value minVal = rewriter.create<AffineLoadOp>(loc, min).getResult();
+        Value minVal = rewriter.create<KrnlLoadOp>(loc, min).getResult();
         Value lessThanMin =
             rewriter.create<CmpIOp>(loc, CmpIPredicate::slt, res, minVal);
         res = rewriter.create<SelectOp>(loc, lessThanMin, minVal, res);
       }
       if (!max.getType().isa<NoneType>()) {
-        Value maxVal = rewriter.create<AffineLoadOp>(loc, max).getResult();
+        Value maxVal = rewriter.create<KrnlLoadOp>(loc, max).getResult();
         Value lessThanMax =
             rewriter.create<CmpIOp>(loc, CmpIPredicate::slt, res, maxVal);
         res = rewriter.create<SelectOp>(loc, lessThanMax, res, maxVal);
@@ -90,7 +90,7 @@ struct ONNXClipOpLowering : public ConversionPattern {
     }
 
     // Store result in the resulting array.
-    rewriter.create<AffineStoreOp>(loc, res, alloc, loopIVs);
+    rewriter.create<KrnlStoreOp>(loc, res, alloc, loopIVs);
 
     rewriter.replaceOp(op, alloc);
     return success();

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -742,7 +742,8 @@ struct ONNXElementwiseVariadicOpLowering : public ConversionPattern {
     SmallVector<IndexExpr, 4> oprdAccessExprs;
     shapeHelper.GetAccessExprs(
         outerContext, operands[0], 0, outputAccessExprs, oprdAccessExprs);
-    Value accumulated = outerContext.createLoadOp(operands[0], oprdAccessExprs);
+    Value accumulated =
+        outerContext.createKrnlLoadOp(operands[0], oprdAccessExprs);
 
     // Iterate over the remaining operands.
     for (unsigned i = 1; i < numArgs; i++) {
@@ -750,14 +751,14 @@ struct ONNXElementwiseVariadicOpLowering : public ConversionPattern {
       SmallVector<IndexExpr, 4> oprdAccessExprs;
       shapeHelper.GetAccessExprs(
           outerContext, operands[i], i, outputAccessExprs, oprdAccessExprs);
-      Value next = outerContext.createLoadOp(operands[i], oprdAccessExprs);
+      Value next = outerContext.createKrnlLoadOp(operands[i], oprdAccessExprs);
       // Fold.
       accumulated = emitScalarOpFor<ElementwiseVariadicOp>(
           rewriter, loc, op, outputElementType, {accumulated, next});
     }
 
     // Store result in the resulting array.
-    outerContext.createStoreOp(accumulated, alloc, outputAccessExprs);
+    outerContext.createKrnlStoreOp(accumulated, alloc, outputAccessExprs);
 
     rewriter.replaceOp(op, alloc);
 

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -617,11 +617,11 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
         loopIVs.push_back(arg);
     }
 
-    auto loadedVal = rewriter.create<AffineLoadOp>(loc, X, loopIVs);
+    auto loadedVal = rewriter.create<KrnlLoadOp>(loc, X, loopIVs);
     auto loweredOpResult = emitScalarOpFor<ElementwiseUnaryOp>(
         rewriter, loc, op, memRefType.getElementType(), {loadedVal});
     // Store result in the resulting array.
-    rewriter.create<AffineStoreOp>(loc, loweredOpResult, alloc, loopIVs);
+    rewriter.create<KrnlStoreOp>(loc, loweredOpResult, alloc, loopIVs);
 
     rewriter.replaceOp(op, alloc);
     return success();
@@ -675,20 +675,20 @@ struct ONNXElementwiseBinaryOpLowering : public ConversionPattern {
     SmallVector<IndexExpr, 4> lhsAccessExprs;
     shapeHelper.GetAccessExprs(
         outerContext, operands[0], 0, outputAccessExprs, lhsAccessExprs);
-    Value lhs = outerContext.createLoadOp(operands[0], lhsAccessExprs);
+    Value lhs = outerContext.createKrnlLoadOp(operands[0], lhsAccessExprs);
 
     // Load the sencond value.
     SmallVector<IndexExpr, 4> rhsAccessExprs;
     shapeHelper.GetAccessExprs(
         outerContext, operands[1], 1, outputAccessExprs, rhsAccessExprs);
-    Value rhs = outerContext.createLoadOp(operands[1], rhsAccessExprs);
+    Value rhs = outerContext.createKrnlLoadOp(operands[1], rhsAccessExprs);
 
     // Apply the element-wise function.
     Value result = emitScalarOpFor<ElementwiseBinaryOp>(
         rewriter, loc, op, outputElementType, {lhs, rhs});
 
     // Store result in the resulting array.
-    outerContext.createStoreOp(result, alloc, outputAccessExprs);
+    outerContext.createKrnlStoreOp(result, alloc, outputAccessExprs);
 
     rewriter.replaceOp(op, alloc);
 

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -52,7 +52,7 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     outerContext.createLoopInductionIndicesFromArrayValues(
         outputLoops.getAllInductionVar(), resAccessFct);
     // Insert res[...] = 0.
-    outerContext.createStoreOp(zero, alloc, resAccessFct);
+    outerContext.createKrnlStoreOp(zero, alloc, resAccessFct);
 
     // Create the inner reduction loop; trip count is last dim of A.
     BuildKrnlLoop innerLoops(rewriter, loc, 1);
@@ -96,12 +96,14 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     }
 
     // Add mat mul operation.
-    Value loadedA = outerContext.createLoadOp(operandAdaptor.A(), aAccessFct);
-    Value loadedB = outerContext.createLoadOp(operandAdaptor.B(), bAccessFct);
-    Value loadedY = outerContext.createLoadOp(alloc, resAccessFct);
+    Value loadedA =
+        outerContext.createKrnlLoadOp(operandAdaptor.A(), aAccessFct);
+    Value loadedB =
+        outerContext.createKrnlLoadOp(operandAdaptor.B(), bAccessFct);
+    Value loadedY = outerContext.createKrnlLoadOp(alloc, resAccessFct);
     Value AB = rewriter.create<MulFOp>(loc, loadedA, loadedB);
     Value accumulated = rewriter.create<AddFOp>(loc, loadedY, AB);
-    outerContext.createStoreOp(accumulated, alloc, resAccessFct);
+    outerContext.createKrnlStoreOp(accumulated, alloc, resAccessFct);
 
     // Done.
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -163,7 +163,7 @@ struct ONNXConvOpLowering : public ConversionPattern {
         for (auto arg : spatialLoops.getIterateBlock()->getArguments())
           resultIndices.emplace_back(arg);
         // Store initializer value into output location.
-        rewriter.create<AffineStoreOp>(loc, zero, alloc, resultIndices);
+        rewriter.create<KrnlStoreOp>(loc, zero, alloc, resultIndices);
 
         // 3.2 Define inner loops.
         int64_t nInnerLoops = 1 + (kernelShape.size() - 2);
@@ -181,15 +181,14 @@ struct ONNXConvOpLowering : public ConversionPattern {
         // Emit the bias, if needed.
         if (hasBias) {
           auto loadResult =
-              rewriter.create<AffineLoadOp>(loc, alloc, resultIndices);
+              rewriter.create<KrnlLoadOp>(loc, alloc, resultIndices);
           SmallVector<Value, 4> biasIndices;
           biasIndices.emplace_back(kernel);
-          auto loadBias =
-              rewriter.create<AffineLoadOp>(loc, biasOperand, kernel);
+          auto loadBias = rewriter.create<KrnlLoadOp>(loc, biasOperand, kernel);
           auto resultWithBias =
               rewriter.create<AddFOp>(loc, loadResult, loadBias);
           // Store initializer value into output location.
-          rewriter.create<AffineStoreOp>(
+          rewriter.create<KrnlStoreOp>(
               loc, resultWithBias, alloc, resultIndices);
         }
 
@@ -251,15 +250,15 @@ struct ONNXConvOpLowering : public ConversionPattern {
 
           // 4.3 Compute convolution.
           auto loadData =
-              rewriter.create<AffineLoadOp>(loc, inputOperand, dataIndices);
+              rewriter.create<KrnlLoadOp>(loc, inputOperand, dataIndices);
           auto loadKernel =
-              rewriter.create<AffineLoadOp>(loc, kernelOperand, kernelIndices);
+              rewriter.create<KrnlLoadOp>(loc, kernelOperand, kernelIndices);
           auto loadPartialSum =
-              rewriter.create<AffineLoadOp>(loc, alloc, resultIndices);
+              rewriter.create<KrnlLoadOp>(loc, alloc, resultIndices);
           Value result = rewriter.create<AddFOp>(loc, loadPartialSum,
               rewriter.create<MulFOp>(loc, loadData, loadKernel));
           // 4.4 Store computed value into output location.
-          rewriter.create<AffineStoreOp>(loc, result, alloc, resultIndices);
+          rewriter.create<KrnlStoreOp>(loc, result, alloc, resultIndices);
         }
       }
     }

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -76,10 +76,10 @@ struct ONNXBatchNormalizationTestModeOpLowering : public ConversionPattern {
       loopCIVs.emplace_back(rewriter.create<ConstantIndexOp>(loc, 0));
     }
 
-    auto scaleVal = rewriter.create<AffineLoadOp>(loc, scale, loopCIVs);
-    auto biasVal = rewriter.create<AffineLoadOp>(loc, bias, loopCIVs);
-    auto meanVal = rewriter.create<AffineLoadOp>(loc, mean, loopCIVs);
-    auto varianceVal = rewriter.create<AffineLoadOp>(loc, variance, loopCIVs);
+    auto scaleVal = rewriter.create<KrnlLoadOp>(loc, scale, loopCIVs);
+    auto biasVal = rewriter.create<KrnlLoadOp>(loc, bias, loopCIVs);
+    auto meanVal = rewriter.create<KrnlLoadOp>(loc, mean, loopCIVs);
+    auto varianceVal = rewriter.create<KrnlLoadOp>(loc, variance, loopCIVs);
 
     // Create a KrnlIterateOp along the other dimensions.
     SmallVector<int64_t, 4> axes;
@@ -113,7 +113,7 @@ struct ONNXBatchNormalizationTestModeOpLowering : public ConversionPattern {
       loopIVs.emplace_back(args[0]);
     }
 
-    auto xVal = rewriter.create<AffineLoadOp>(loc, operand, loopIVs);
+    auto xVal = rewriter.create<KrnlLoadOp>(loc, operand, loopIVs);
     // normalize
     auto dividend = rewriter.create<SubFOp>(loc, xVal, meanVal);
     auto adjustedVarianceVal =
@@ -124,7 +124,7 @@ struct ONNXBatchNormalizationTestModeOpLowering : public ConversionPattern {
     auto scaleNormVal = rewriter.create<MulFOp>(loc, scaleVal, normVal);
     auto shiftScaleNormVal =
         rewriter.create<AddFOp>(loc, scaleNormVal, biasVal);
-    rewriter.create<AffineStoreOp>(loc, shiftScaleNormVal, alloc, loopIVs);
+    rewriter.create<KrnlStoreOp>(loc, shiftScaleNormVal, alloc, loopIVs);
 
     rewriter.replaceOp(op, alloc);
 

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -100,7 +100,7 @@ void postProcessPoolingWindow<ONNXAveragePoolOp>(
     ArrayRef<Value> poolDimValues) {
   // AveragePool's result type is FloatType, so it's safe to use DivFOp, SubFOp.
   bool countIncludePad = getCountIncludePad<ONNXAveragePoolOp>(poolOp);
-  Value numerator = rewriter.create<AffineLoadOp>(loc, alloc, resultIndices);
+  Value numerator = rewriter.create<KrnlLoadOp>(loc, alloc, resultIndices);
   Value denominator;
   if (countIncludePad) {
     int64_t kernelSize = 1;
@@ -120,7 +120,7 @@ void postProcessPoolingWindow<ONNXAveragePoolOp>(
 
   Value average = rewriter.create<DivFOp>(loc, numerator, denominator);
 
-  rewriter.create<AffineStoreOp>(loc, average, alloc, resultIndices);
+  rewriter.create<KrnlStoreOp>(loc, average, alloc, resultIndices);
 }
 
 //===----------------------------------------------------------------------===//
@@ -344,7 +344,7 @@ struct ONNXPoolOpLowering : public ConversionPattern {
         outputIndices.emplace_back(outputLoops.getInductionVar(i));
 
       // 2.1 Emit: output[n][c][ho][wo] = identity
-      rewriter.create<AffineStoreOp>(loc, identity, alloc, outputIndices);
+      rewriter.create<KrnlStoreOp>(loc, identity, alloc, outputIndices);
 
       // 2.2 Emit affine maps which express the lower and upper bounds for the
       // pooling window's dimensions.
@@ -510,12 +510,12 @@ struct ONNXPoolOpLowering : public ConversionPattern {
         //      output[n][c][ho][wo] =
         //        emitScalarOpFor(output[n][c][ho][wo], input[n, c, hi, wi]);
         Value loadInput =
-            rewriter.create<LoadOp>(loc, inputOperand, inputIndices);
+            rewriter.create<KrnlLoadOp>(loc, inputOperand, inputIndices);
         Value loadPartialOutput =
-            rewriter.create<AffineLoadOp>(loc, alloc, outputIndices);
+            rewriter.create<KrnlLoadOp>(loc, alloc, outputIndices);
         Value output = emitScalarOpFor<PoolOp>(rewriter, loc, op,
             outputElementType, {loadPartialOutput, loadInput});
-        rewriter.create<AffineStoreOp>(loc, output, alloc, outputIndices);
+        rewriter.create<KrnlStoreOp>(loc, output, alloc, outputIndices);
       }
 
       // 2.5 Post-processing for the pooling window, e.g. taking average.

--- a/src/Conversion/ONNXToKrnl/RNN/GRU.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/GRU.cpp
@@ -350,16 +350,16 @@ void calculateState<ONNXGRUOp, GruState, GruActivationPack>(
       if (!state.linearBeforeReset && (i == GATES - 1))
         continue;
       Value xwAlloc = rewriter.create<AllocOp>(loc, scalarMemRefType);
-      rewriter.create<AffineStoreOp>(loc, zero, xwAlloc, ArrayRef<Value>{});
+      rewriter.create<KrnlStoreOp>(loc, zero, xwAlloc, ArrayRef<Value>{});
       xwZRH.emplace_back(xwAlloc);
       Value hrAlloc = rewriter.create<AllocOp>(loc, scalarMemRefType);
-      rewriter.create<AffineStoreOp>(loc, zero, hrAlloc, ArrayRef<Value>{});
+      rewriter.create<KrnlStoreOp>(loc, zero, hrAlloc, ArrayRef<Value>{});
       hrZRH.emplace_back(hrAlloc);
     }
 
     // Initialize the global buffer for Xt*(Wh^T).
     if (!state.linearBeforeReset)
-      rewriter.create<AffineStoreOp>(loc, zero, xwHMemRef, mIVs);
+      rewriter.create<KrnlStoreOp>(loc, zero, xwHMemRef, mIVs);
 
     { // Emit instructions for Xt*(Wz^T), Xt*(Wr^T), Xt*(Wh^T)
       // input_size is the reduction dimension.
@@ -391,24 +391,24 @@ void calculateState<ONNXGRUOp, GruState, GruActivationPack>(
         }
 
         Value loadX =
-            rewriter.create<AffineLoadOp>(loc, operandAdaptor.X(), xIVs);
+            rewriter.create<KrnlLoadOp>(loc, operandAdaptor.X(), xIVs);
         for (unsigned i = 0; i < GATES; ++i) {
           // Xt * W[zrh]
-          Value loadW = rewriter.create<AffineLoadOp>(
-              loc, operandAdaptor.W(), wZRHIVs[i]);
+          Value loadW =
+              rewriter.create<KrnlLoadOp>(loc, operandAdaptor.W(), wZRHIVs[i]);
           Value xwVal = rewriter.create<MulFOp>(loc, loadX, loadW);
           Value loadXW;
           if (!state.linearBeforeReset && (i == GATES - 1))
             // in case of not linearBeforeReset, load from the global buffer.
-            loadXW = rewriter.create<AffineLoadOp>(loc, xwHMemRef, mIVs);
+            loadXW = rewriter.create<KrnlLoadOp>(loc, xwHMemRef, mIVs);
           else
-            loadXW = rewriter.create<AffineLoadOp>(loc, xwZRH[i]);
+            loadXW = rewriter.create<KrnlLoadOp>(loc, xwZRH[i]);
           Value nextXW = rewriter.create<AddFOp>(loc, loadXW, xwVal);
           if (!state.linearBeforeReset && (i == GATES - 1))
             // in case of not linearBeforeReset, store to the global buffer.
-            rewriter.create<AffineStoreOp>(loc, nextXW, xwHMemRef, mIVs);
+            rewriter.create<KrnlStoreOp>(loc, nextXW, xwHMemRef, mIVs);
           else
-            rewriter.create<AffineStoreOp>(
+            rewriter.create<KrnlStoreOp>(
                 loc, nextXW, xwZRH[i], ArrayRef<Value>{});
         }
       }
@@ -444,17 +444,17 @@ void calculateState<ONNXGRUOp, GruState, GruActivationPack>(
         }
 
         // Ht-1 * R[zrh]
-        Value loadH = rewriter.create<AffineLoadOp>(loc, state.ht, hIVs);
+        Value loadH = rewriter.create<KrnlLoadOp>(loc, state.ht, hIVs);
         for (unsigned i = 0; i < GATES; ++i) {
           // Ht-1*(Rh^T) is unnecessary if not linearBeforeReset
           if (!state.linearBeforeReset && (i == GATES - 1))
             continue;
-          Value loadR = rewriter.create<AffineLoadOp>(
-              loc, operandAdaptor.R(), rZRHIVs[i]);
+          Value loadR =
+              rewriter.create<KrnlLoadOp>(loc, operandAdaptor.R(), rZRHIVs[i]);
           Value hrVal = rewriter.create<MulFOp>(loc, loadH, loadR);
-          Value loadHR = rewriter.create<AffineLoadOp>(loc, hrZRH[i]);
+          Value loadHR = rewriter.create<KrnlLoadOp>(loc, hrZRH[i]);
           Value nextHR = rewriter.create<AddFOp>(loc, loadHR, hrVal);
-          rewriter.create<AffineStoreOp>(
+          rewriter.create<KrnlStoreOp>(
               loc, nextHR, hrZRH[i], ArrayRef<Value>{});
         }
       }
@@ -462,57 +462,57 @@ void calculateState<ONNXGRUOp, GruState, GruActivationPack>(
     }
 
     // zt = f(Xt*(Wz^T) + Ht-1*(Rz^T) + Wbz + Rbz)
-    Value loadXWZ = rewriter.create<AffineLoadOp>(loc, xwZRH[0]);
-    Value loadHRZ = rewriter.create<AffineLoadOp>(loc, hrZRH[0]);
+    Value loadXWZ = rewriter.create<KrnlLoadOp>(loc, xwZRH[0]);
+    Value loadHRZ = rewriter.create<KrnlLoadOp>(loc, hrZRH[0]);
     Value zt = rewriter.create<AddFOp>(loc, loadXWZ, loadHRZ);
     if (hasBiasForInput) {
       Value loadWB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), wbZRHIVs[0]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), wbZRHIVs[0]);
       zt = rewriter.create<AddFOp>(loc, zt, loadWB);
       Value loadRB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), rbZRHIVs[0]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), rbZRHIVs[0]);
       zt = rewriter.create<AddFOp>(loc, zt, loadRB);
     }
     zt = applyActivation(rewriter, loc, activationPack.f, zt);
-    rewriter.create<AffineStoreOp>(loc, zt, ztMemRef, mIVs);
+    rewriter.create<KrnlStoreOp>(loc, zt, ztMemRef, mIVs);
 
     // rt = f(Xt*(Wr^T) + Ht-1*(Rr^T) + Wbr + Rbr)
-    Value loadXWR = rewriter.create<AffineLoadOp>(loc, xwZRH[1]);
-    Value loadHRR = rewriter.create<AffineLoadOp>(loc, hrZRH[1]);
+    Value loadXWR = rewriter.create<KrnlLoadOp>(loc, xwZRH[1]);
+    Value loadHRR = rewriter.create<KrnlLoadOp>(loc, hrZRH[1]);
     Value rt = rewriter.create<AddFOp>(loc, loadXWR, loadHRR);
     if (hasBiasForInput) {
       Value loadWB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), wbZRHIVs[1]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), wbZRHIVs[1]);
       rt = rewriter.create<AddFOp>(loc, rt, loadWB);
       Value loadRB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), rbZRHIVs[1]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), rbZRHIVs[1]);
       rt = rewriter.create<AddFOp>(loc, rt, loadRB);
     }
     rt = applyActivation(rewriter, loc, activationPack.f, rt);
 
     if (!state.linearBeforeReset) {
       // compute and store (rt . Ht-1) to a global buffer.
-      Value loadH = rewriter.create<AffineLoadOp>(loc, state.ht, stateIVs);
+      Value loadH = rewriter.create<KrnlLoadOp>(loc, state.ht, stateIVs);
       Value rtHt = rewriter.create<MulFOp>(loc, rt, loadH);
-      rewriter.create<AffineStoreOp>(loc, rtHt, rhMemRef, mIVs);
+      rewriter.create<KrnlStoreOp>(loc, rtHt, rhMemRef, mIVs);
     } else {
       // compute ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*(Rh^T) + Rbh)) + Wbh)
-      Value ht = rewriter.create<AffineLoadOp>(loc, xwZRH[2]);
-      Value linear = rewriter.create<AffineLoadOp>(loc, hrZRH[2]);
+      Value ht = rewriter.create<KrnlLoadOp>(loc, xwZRH[2]);
+      Value linear = rewriter.create<KrnlLoadOp>(loc, hrZRH[2]);
       if (hasBiasForInput) {
         Value loadRB =
-            rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), rbZRHIVs[2]);
+            rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), rbZRHIVs[2]);
         linear = rewriter.create<AddFOp>(loc, linear, loadRB);
       }
       Value reset = rewriter.create<MulFOp>(loc, rt, linear);
       ht = rewriter.create<AddFOp>(loc, ht, reset);
       if (hasBiasForInput) {
         Value loadWB =
-            rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), wbZRHIVs[2]);
+            rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), wbZRHIVs[2]);
         ht = rewriter.create<AddFOp>(loc, ht, loadWB);
       }
       ht = applyActivation(rewriter, loc, activationPack.g, ht);
-      rewriter.create<AffineStoreOp>(loc, ht, htMemRef, mIVs);
+      rewriter.create<KrnlStoreOp>(loc, ht, htMemRef, mIVs);
     }
 
     // Deallocate the temporary results of matrix multiplications.
@@ -547,7 +547,7 @@ void calculateState<ONNXGRUOp, GruState, GruActivationPack>(
           std::vector<Value>{hiddenIV, constantIndices[2], hiddenDimVal});
 
       Value zero = emitConstantOp(rewriter, loc, elementType, 0);
-      rewriter.create<AffineStoreOp>(loc, zero, rhrHMemRef, mIVs);
+      rewriter.create<KrnlStoreOp>(loc, zero, rhrHMemRef, mIVs);
       {
         // Emit instructions for 'rtHt*(Rh^T)'.
         // hidden_size is the reduction dimension.
@@ -567,13 +567,13 @@ void calculateState<ONNXGRUOp, GruState, GruActivationPack>(
           SmallVector<Value, 3> rIVs = {directionIV, rOffsetIV, reductionIV};
 
           // 'rtHt*(Rh^T)'
-          Value loadRtHt = rewriter.create<AffineLoadOp>(loc, rhMemRef, rhIVs);
+          Value loadRtHt = rewriter.create<KrnlLoadOp>(loc, rhMemRef, rhIVs);
           Value loadR =
-              rewriter.create<AffineLoadOp>(loc, operandAdaptor.R(), rIVs);
+              rewriter.create<KrnlLoadOp>(loc, operandAdaptor.R(), rIVs);
           Value rhrVal = rewriter.create<MulFOp>(loc, loadRtHt, loadR);
-          Value loadRHR = rewriter.create<AffineLoadOp>(loc, rhrHMemRef, mIVs);
+          Value loadRHR = rewriter.create<KrnlLoadOp>(loc, rhrHMemRef, mIVs);
           Value nextRHR = rewriter.create<AddFOp>(loc, loadRHR, rhrVal);
-          rewriter.create<AffineStoreOp>(loc, nextRHR, rhrHMemRef, mIVs);
+          rewriter.create<KrnlStoreOp>(loc, nextRHR, rhrHMemRef, mIVs);
         }
         rewriter.restoreInsertionPoint(ipReductionLoops);
       }
@@ -600,42 +600,42 @@ void calculateState<ONNXGRUOp, GruState, GruActivationPack>(
     Value ht;
     if (!state.linearBeforeReset) {
       //   ht = g(Xt*(Wh^T) + (rt (.) Ht-1)*(Rh^T) + Rbh + Wbh)
-      ht = rewriter.create<AffineLoadOp>(loc, xwHMemRef, mIVs);
-      Value linear = rewriter.create<AffineLoadOp>(loc, rhrHMemRef, mIVs);
+      ht = rewriter.create<KrnlLoadOp>(loc, xwHMemRef, mIVs);
+      Value linear = rewriter.create<KrnlLoadOp>(loc, rhrHMemRef, mIVs);
       ht = rewriter.create<AddFOp>(loc, ht, linear);
       if (hasBiasForInput) {
         Value rHiddenIV = rewriter.create<AffineApplyOp>(loc, accessByOffsetMap,
             std::vector<Value>{/*iv=*/hiddenIV,
                 /*index=*/constantIndices[5], /*size=*/hiddenDimVal});
-        Value loadRB = rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(),
+        Value loadRB = rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(),
             SmallVector<Value, 2>{directionIV, rHiddenIV});
         ht = rewriter.create<AddFOp>(loc, ht, loadRB);
 
         Value wHiddenIV = rewriter.create<AffineApplyOp>(loc, accessByOffsetMap,
             std::vector<Value>{/*iv=*/hiddenIV,
                 /*index=*/constantIndices[2], /*size=*/hiddenDimVal});
-        Value loadWB = rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(),
+        Value loadWB = rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(),
             SmallVector<Value, 2>{directionIV, wHiddenIV});
         ht = rewriter.create<AddFOp>(loc, ht, loadWB);
       }
       ht = applyActivation(rewriter, loc, activationPack.g, ht);
     } else
-      ht = rewriter.create<AffineLoadOp>(loc, htMemRef, mIVs);
+      ht = rewriter.create<KrnlLoadOp>(loc, htMemRef, mIVs);
 
     // Ht = (1 - zt) (.) ht + zt (.) Ht-1
-    Value zt = rewriter.create<AffineLoadOp>(loc, ztMemRef, mIVs);
-    Value loadH = rewriter.create<AffineLoadOp>(loc, state.ht, stateIVs);
+    Value zt = rewriter.create<KrnlLoadOp>(loc, ztMemRef, mIVs);
+    Value loadH = rewriter.create<KrnlLoadOp>(loc, state.ht, stateIVs);
     Value one = emitConstantOp(rewriter, loc, elementType, 1);
     Value subZt = rewriter.create<SubFOp>(loc, one, zt);
     Value mulHt = rewriter.create<MulFOp>(loc, subZt, ht);
     Value mulH = rewriter.create<MulFOp>(loc, zt, loadH);
     Value Ht = rewriter.create<AddFOp>(loc, mulHt, mulH);
-    rewriter.create<AffineStoreOp>(loc, Ht, state.ht, stateIVs);
+    rewriter.create<KrnlStoreOp>(loc, Ht, state.ht, stateIVs);
 
     // Store the current Ht if required.
     if (!isNoneType(state.allH)) {
       SmallVector<Value, 4> allHIVs{sequenceIV, directionIV, batchIV, hiddenIV};
-      rewriter.create<AffineStoreOp>(loc, Ht, state.allH, allHIVs);
+      rewriter.create<KrnlStoreOp>(loc, Ht, state.allH, allHIVs);
     }
   }
   rewriter.restoreInsertionPoint(ipStateLoops);

--- a/src/Conversion/ONNXToKrnl/RNN/LSTM.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/LSTM.cpp
@@ -303,8 +303,8 @@ void calculateState<ONNXLSTMOp, LstmState, LstmActivationPack>(
     // Initialize matrix multiplication result.
     Value zero = emitConstantOp(rewriter, loc, elementType, 0);
     for (unsigned i = 0; i < 4; ++i) {
-      rewriter.create<AffineStoreOp>(loc, zero, xwIOFC[i], mIVs);
-      rewriter.create<AffineStoreOp>(loc, zero, hrIOFC[i], mIVs);
+      rewriter.create<KrnlStoreOp>(loc, zero, xwIOFC[i], mIVs);
+      rewriter.create<KrnlStoreOp>(loc, zero, hrIOFC[i], mIVs);
     }
 
     { // Emit instructions for matrix multiplications.
@@ -339,15 +339,15 @@ void calculateState<ONNXLSTMOp, LstmState, LstmActivationPack>(
         }
 
         Value loadX =
-            rewriter.create<AffineLoadOp>(loc, operandAdaptor.X(), xIVs);
+            rewriter.create<KrnlLoadOp>(loc, operandAdaptor.X(), xIVs);
         for (unsigned i = 0; i < 4; ++i) {
           // Xt * Wiofc
-          Value loadW = rewriter.create<AffineLoadOp>(
-              loc, operandAdaptor.W(), wIOFCIVs[i]);
+          Value loadW =
+              rewriter.create<KrnlLoadOp>(loc, operandAdaptor.W(), wIOFCIVs[i]);
           Value xwVal = rewriter.create<MulFOp>(loc, loadX, loadW);
-          Value loadXW = rewriter.create<AffineLoadOp>(loc, xwIOFC[i], mIVs);
+          Value loadXW = rewriter.create<KrnlLoadOp>(loc, xwIOFC[i], mIVs);
           Value nextXW = rewriter.create<AddFOp>(loc, loadXW, xwVal);
-          rewriter.create<AffineStoreOp>(loc, nextXW, xwIOFC[i], mIVs);
+          rewriter.create<KrnlStoreOp>(loc, nextXW, xwIOFC[i], mIVs);
         }
       }
       rewriter.restoreInsertionPoint(ipReductionLoops);
@@ -382,15 +382,15 @@ void calculateState<ONNXLSTMOp, LstmState, LstmActivationPack>(
           rIOFCIVs.emplace_back(rIVs);
         }
 
-        Value loadH = rewriter.create<AffineLoadOp>(loc, state.ht, hIVs);
+        Value loadH = rewriter.create<KrnlLoadOp>(loc, state.ht, hIVs);
         for (unsigned i = 0; i < 4; ++i) {
           // Ht-1 * Riofc
-          Value loadR = rewriter.create<AffineLoadOp>(
-              loc, operandAdaptor.R(), rIOFCIVs[i]);
+          Value loadR =
+              rewriter.create<KrnlLoadOp>(loc, operandAdaptor.R(), rIOFCIVs[i]);
           Value hrVal = rewriter.create<MulFOp>(loc, loadH, loadR);
-          Value loadHR = rewriter.create<AffineLoadOp>(loc, hrIOFC[i], mIVs);
+          Value loadHR = rewriter.create<KrnlLoadOp>(loc, hrIOFC[i], mIVs);
           Value nextHR = rewriter.create<AddFOp>(loc, loadHR, hrVal);
-          rewriter.create<AffineStoreOp>(loc, nextHR, hrIOFC[i], mIVs);
+          rewriter.create<KrnlStoreOp>(loc, nextHR, hrIOFC[i], mIVs);
         }
       }
       rewriter.restoreInsertionPoint(ipReductionLoops);
@@ -462,56 +462,56 @@ void calculateState<ONNXLSTMOp, LstmState, LstmActivationPack>(
     }
 
     // it = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Pi (.) Ct-1 + Wbi + Rbi)
-    Value loadC = rewriter.create<AffineLoadOp>(loc, state.ct, cIVs);
-    Value loadXWI = rewriter.create<AffineLoadOp>(loc, xwIOFC[0], mIVs);
-    Value loadHRI = rewriter.create<AffineLoadOp>(loc, hrIOFC[0], mIVs);
+    Value loadC = rewriter.create<KrnlLoadOp>(loc, state.ct, cIVs);
+    Value loadXWI = rewriter.create<KrnlLoadOp>(loc, xwIOFC[0], mIVs);
+    Value loadHRI = rewriter.create<KrnlLoadOp>(loc, hrIOFC[0], mIVs);
     Value it = rewriter.create<AddFOp>(loc, loadXWI, loadHRI);
     if (hasPeepholes) {
       Value loadP =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.P(), pIOFIVs[0]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.P(), pIOFIVs[0]);
       Value PC = rewriter.create<MulFOp>(loc, loadP, loadC);
       it = rewriter.create<AddFOp>(loc, it, PC);
     }
     if (hasBiasForInput) {
       Value loadWB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), wbIOFCIVs[0]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), wbIOFCIVs[0]);
       it = rewriter.create<AddFOp>(loc, it, loadWB);
       Value loadRB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), rbIOFCIVs[0]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), rbIOFCIVs[0]);
       it = rewriter.create<AddFOp>(loc, it, loadRB);
     }
     it = applyActivation(rewriter, loc, activationPack.f, it);
 
     // ft = f(Xt*(Wf^T) + Ht-1*(Rf^T) + Pf (.) Ct-1 + Wbf + Rbf)
-    Value loadXWF = rewriter.create<AffineLoadOp>(loc, xwIOFC[2], mIVs);
-    Value loadHRF = rewriter.create<AffineLoadOp>(loc, hrIOFC[2], mIVs);
+    Value loadXWF = rewriter.create<KrnlLoadOp>(loc, xwIOFC[2], mIVs);
+    Value loadHRF = rewriter.create<KrnlLoadOp>(loc, hrIOFC[2], mIVs);
     Value ft = rewriter.create<AddFOp>(loc, loadXWF, loadHRF);
     if (hasPeepholes) {
       Value loadP =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.P(), pIOFIVs[2]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.P(), pIOFIVs[2]);
       Value PC = rewriter.create<MulFOp>(loc, loadP, loadC);
       ft = rewriter.create<AddFOp>(loc, ft, PC);
     }
     if (hasBiasForInput) {
       Value loadWB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), wbIOFCIVs[2]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), wbIOFCIVs[2]);
       ft = rewriter.create<AddFOp>(loc, ft, loadWB);
       Value loadRB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), rbIOFCIVs[2]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), rbIOFCIVs[2]);
       ft = rewriter.create<AddFOp>(loc, ft, loadRB);
     }
     ft = applyActivation(rewriter, loc, activationPack.f, ft);
 
     // ct = g(Xt*(Wc^T) + Ht-1*(Rc^T) + Wbc + Rbc)
-    Value loadXWC = rewriter.create<AffineLoadOp>(loc, xwIOFC[3], mIVs);
-    Value loadHRC = rewriter.create<AffineLoadOp>(loc, hrIOFC[3], mIVs);
+    Value loadXWC = rewriter.create<KrnlLoadOp>(loc, xwIOFC[3], mIVs);
+    Value loadHRC = rewriter.create<KrnlLoadOp>(loc, hrIOFC[3], mIVs);
     Value ct = rewriter.create<AddFOp>(loc, loadXWC, loadHRC);
     if (hasBiasForInput) {
       Value loadWB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), wbIOFCIVs[3]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), wbIOFCIVs[3]);
       ct = rewriter.create<AddFOp>(loc, ct, loadWB);
       Value loadRB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), rbIOFCIVs[3]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), rbIOFCIVs[3]);
       ct = rewriter.create<AddFOp>(loc, ct, loadRB);
     }
     ct = applyActivation(rewriter, loc, activationPack.g, ct);
@@ -520,24 +520,24 @@ void calculateState<ONNXLSTMOp, LstmState, LstmActivationPack>(
     Value FtCt1 = rewriter.create<MulFOp>(loc, ft, loadC);
     Value itct = rewriter.create<MulFOp>(loc, it, ct);
     Value Ct = rewriter.create<AddFOp>(loc, FtCt1, itct);
-    rewriter.create<AffineStoreOp>(loc, Ct, state.ct, cIVs);
+    rewriter.create<KrnlStoreOp>(loc, Ct, state.ct, cIVs);
 
     // ot = f(Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo)
-    Value loadXWO = rewriter.create<AffineLoadOp>(loc, xwIOFC[1], mIVs);
-    Value loadHRO = rewriter.create<AffineLoadOp>(loc, hrIOFC[1], mIVs);
+    Value loadXWO = rewriter.create<KrnlLoadOp>(loc, xwIOFC[1], mIVs);
+    Value loadHRO = rewriter.create<KrnlLoadOp>(loc, hrIOFC[1], mIVs);
     Value ot = rewriter.create<AddFOp>(loc, loadXWO, loadHRO);
     if (hasPeepholes) {
       Value loadP =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.P(), pIOFIVs[1]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.P(), pIOFIVs[1]);
       Value PC = rewriter.create<MulFOp>(loc, loadP, Ct);
       ot = rewriter.create<AddFOp>(loc, ot, PC);
     }
     if (hasBiasForInput) {
       Value loadWB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), wbIOFCIVs[1]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), wbIOFCIVs[1]);
       ot = rewriter.create<AddFOp>(loc, ot, loadWB);
       Value loadRB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), rbIOFCIVs[1]);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), rbIOFCIVs[1]);
       ot = rewriter.create<AddFOp>(loc, ot, loadRB);
     }
     ot = applyActivation(rewriter, loc, activationPack.f, ot);
@@ -545,12 +545,12 @@ void calculateState<ONNXLSTMOp, LstmState, LstmActivationPack>(
     // Ht = ot (.) h(Ct)
     Value hCt = applyActivation(rewriter, loc, activationPack.h, Ct);
     Value Ht = rewriter.create<MulFOp>(loc, ot, hCt);
-    rewriter.create<AffineStoreOp>(loc, Ht, state.ht, hIVs);
+    rewriter.create<KrnlStoreOp>(loc, Ht, state.ht, hIVs);
 
     // Store the current Ht if required.
     if (!isNoneType(state.allH)) {
       SmallVector<Value, 4> allHIVs{sequenceIV, directionIV, batchIV, hiddenIV};
-      rewriter.create<AffineStoreOp>(loc, Ht, state.allH, allHIVs);
+      rewriter.create<KrnlStoreOp>(loc, Ht, state.allH, allHIVs);
     }
   }
   rewriter.restoreInsertionPoint(ipStateLoops);

--- a/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
@@ -229,8 +229,8 @@ void calculateState<ONNXRNNOp, RnnState, RnnActivationPack>(
 
     // Initialize matrix multiplication result.
     Value zero = emitConstantOp(rewriter, loc, elementType, 0);
-    rewriter.create<AffineStoreOp>(loc, zero, xwI, mIVs);
-    rewriter.create<AffineStoreOp>(loc, zero, hrI, mIVs);
+    rewriter.create<KrnlStoreOp>(loc, zero, xwI, mIVs);
+    rewriter.create<KrnlStoreOp>(loc, zero, hrI, mIVs);
 
     { // Emit instructions for matrix multiplication Xt*(Wi^T).
       // input_size is the reduction dimension.
@@ -252,13 +252,13 @@ void calculateState<ONNXRNNOp, RnnState, RnnActivationPack>(
 
         // Xt * Wi
         Value loadX =
-            rewriter.create<AffineLoadOp>(loc, operandAdaptor.X(), xIVs);
+            rewriter.create<KrnlLoadOp>(loc, operandAdaptor.X(), xIVs);
         Value loadW =
-            rewriter.create<AffineLoadOp>(loc, operandAdaptor.W(), wIIVs);
+            rewriter.create<KrnlLoadOp>(loc, operandAdaptor.W(), wIIVs);
         Value xwVal = rewriter.create<MulFOp>(loc, loadX, loadW);
-        Value loadXW = rewriter.create<AffineLoadOp>(loc, xwI, mIVs);
+        Value loadXW = rewriter.create<KrnlLoadOp>(loc, xwI, mIVs);
         Value nextXW = rewriter.create<AddFOp>(loc, loadXW, xwVal);
-        rewriter.create<AffineStoreOp>(loc, nextXW, xwI, mIVs);
+        rewriter.create<KrnlStoreOp>(loc, nextXW, xwI, mIVs);
       }
       rewriter.restoreInsertionPoint(ipReductionLoops);
     }
@@ -281,13 +281,13 @@ void calculateState<ONNXRNNOp, RnnState, RnnActivationPack>(
         SmallVector<Value, 3> rIIVs = {directionIV, hiddenIV, reductionIV};
 
         // Ht-1 * Riofc
-        Value loadH = rewriter.create<AffineLoadOp>(loc, state.ht, hIVs);
+        Value loadH = rewriter.create<KrnlLoadOp>(loc, state.ht, hIVs);
         Value loadR =
-            rewriter.create<AffineLoadOp>(loc, operandAdaptor.R(), rIIVs);
+            rewriter.create<KrnlLoadOp>(loc, operandAdaptor.R(), rIIVs);
         Value hrVal = rewriter.create<MulFOp>(loc, loadH, loadR);
-        Value loadHR = rewriter.create<AffineLoadOp>(loc, hrI, mIVs);
+        Value loadHR = rewriter.create<KrnlLoadOp>(loc, hrI, mIVs);
         Value nextHR = rewriter.create<AddFOp>(loc, loadHR, hrVal);
-        rewriter.create<AffineStoreOp>(loc, nextHR, hrI, mIVs);
+        rewriter.create<KrnlStoreOp>(loc, nextHR, hrI, mIVs);
       }
       rewriter.restoreInsertionPoint(ipReductionLoops);
     }
@@ -331,24 +331,24 @@ void calculateState<ONNXRNNOp, RnnState, RnnActivationPack>(
     SmallVector<Value, 2> mIVs = {batchIV, hiddenIV};
 
     // Emit instructions for 'Ht = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)'
-    Value loadXWI = rewriter.create<AffineLoadOp>(loc, xwI, mIVs);
-    Value loadHRI = rewriter.create<AffineLoadOp>(loc, hrI, mIVs);
+    Value loadXWI = rewriter.create<KrnlLoadOp>(loc, xwI, mIVs);
+    Value loadHRI = rewriter.create<KrnlLoadOp>(loc, hrI, mIVs);
     Value Ht = rewriter.create<AddFOp>(loc, loadXWI, loadHRI);
     if (hasBiasForInput) {
       Value loadWB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), wbiIVs);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), wbiIVs);
       Ht = rewriter.create<AddFOp>(loc, Ht, loadWB);
       Value loadRB =
-          rewriter.create<AffineLoadOp>(loc, operandAdaptor.B(), rbiIVs);
+          rewriter.create<KrnlLoadOp>(loc, operandAdaptor.B(), rbiIVs);
       Ht = rewriter.create<AddFOp>(loc, Ht, loadRB);
     }
     Ht = applyActivation(rewriter, loc, activationPack.f, Ht);
-    rewriter.create<AffineStoreOp>(loc, Ht, state.ht, hIVs);
+    rewriter.create<KrnlStoreOp>(loc, Ht, state.ht, hIVs);
 
     // Store the current Ht if required.
     if (!isNoneType(state.allH)) {
       SmallVector<Value, 4> allHIVs{sequenceIV, directionIV, batchIV, hiddenIV};
-      rewriter.create<AffineStoreOp>(loc, Ht, state.allH, allHIVs);
+      rewriter.create<KrnlStoreOp>(loc, Ht, state.allH, allHIVs);
     }
   }
   rewriter.restoreInsertionPoint(ipStateLoops);

--- a/src/Conversion/ONNXToKrnl/RNN/RNNBase.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNNBase.cpp
@@ -131,14 +131,14 @@ void initializeHiddenAndCell(ConversionPatternRewriter &rewriter, Location loc,
 
     Value hiddenVal = zero;
     if (!isNoneType(initialH))
-      hiddenVal = rewriter.create<AffineLoadOp>(loc, initialH, IVs);
-    rewriter.create<AffineStoreOp>(loc, hiddenVal, ht, IVs);
+      hiddenVal = rewriter.create<KrnlLoadOp>(loc, initialH, IVs);
+    rewriter.create<KrnlStoreOp>(loc, hiddenVal, ht, IVs);
 
     if (!onlyHidden) {
       Value cellVal = zero;
       if (!isNoneType(initialC))
-        cellVal = rewriter.create<AffineLoadOp>(loc, initialC, IVs);
-      rewriter.create<AffineStoreOp>(loc, cellVal, ct, IVs);
+        cellVal = rewriter.create<KrnlLoadOp>(loc, initialC, IVs);
+      rewriter.create<KrnlStoreOp>(loc, cellVal, ct, IVs);
     }
   }
   rewriter.restoreInsertionPoint(ipInitializationLoops);
@@ -152,7 +152,7 @@ Value applyActivation(ConversionPatternRewriter &rewriter, Location loc,
   MemRefType scalarMemRefType =
       MemRefType::get({}, scalarOperand.getType(), {}, 0);
   Value alloc = rewriter.create<AllocOp>(loc, scalarMemRefType);
-  rewriter.create<AffineStoreOp>(loc, scalarOperand, alloc, ArrayRef<Value>{});
+  rewriter.create<KrnlStoreOp>(loc, scalarOperand, alloc, ArrayRef<Value>{});
 
   std::vector<mlir::NamedAttribute> attributes;
   if (activation.alpha) {
@@ -192,6 +192,6 @@ Value applyActivation(ConversionPatternRewriter &rewriter, Location loc,
   else
     llvm_unreachable("Unsupported activation");
 
-  Value result = rewriter.create<AffineLoadOp>(loc, res);
+  Value result = rewriter.create<KrnlLoadOp>(loc, res);
   return result;
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -76,8 +76,8 @@ struct ONNXConcatOpLowering : public ConversionPattern {
       }
       // Insert copy.
       auto loadData =
-          rewriter.create<AffineLoadOp>(loc, operands[i], readIndices);
-      rewriter.create<AffineStoreOp>(loc, loadData, alloc, writeIndices);
+          rewriter.create<KrnlLoadOp>(loc, operands[i], readIndices);
+      rewriter.create<KrnlStoreOp>(loc, loadData, alloc, writeIndices);
     }
     rewriter.replaceOp(op, alloc);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/ConstantOfShape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConstantOfShape.cpp
@@ -42,7 +42,7 @@ struct ONNXConstantOfShapeOpLowering : public ConversionPattern {
       for (decltype(rank) i = 0; i < rank; ++i) {
         auto index = emitConstantOp(rewriter, loc, rewriter.getIndexType(), i);
         auto dim =
-            rewriter.create<AffineLoadOp>(loc, operandAdaptor.input(), index);
+            rewriter.create<KrnlLoadOp>(loc, operandAdaptor.input(), index);
         auto dimIndex =
             rewriter.create<IndexCastOp>(loc, rewriter.getIndexType(), dim);
         allocOperands.emplace_back(dimIndex);
@@ -85,7 +85,7 @@ struct ONNXConstantOfShapeOpLowering : public ConversionPattern {
     }
 
     // Store the constant value to the output.
-    rewriter.create<AffineStoreOp>(loc, constantVal, alloc, loopIVs);
+    rewriter.create<KrnlStoreOp>(loc, constantVal, alloc, loopIVs);
 
     // Replace this operation with the generated alloc.
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/Tensor/Flatten.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Flatten.cpp
@@ -104,7 +104,7 @@ struct ONNXFlattenOpLowering : public ConversionPattern {
     // Generate the load of input
     SmallVector<Value, 4> inputMemRefVal(iterationBlock.getArguments().begin(),
         iterationBlock.getArguments().end());
-    auto inputVal = rewriter.create<AffineLoadOp>(loc, input, inputMemRefVal);
+    auto inputVal = rewriter.create<KrnlLoadOp>(loc, input, inputMemRefVal);
 
     // Generate the store for output
     // Define affine map for first dim of output
@@ -157,9 +157,9 @@ struct ONNXFlattenOpLowering : public ConversionPattern {
     // Create the store
     SmallVector<Value, 2> outputMemRefVal = {firstDimVal, secondDimVal};
     if (hasAllConstantDimensions(outputMemRefType))
-      rewriter.create<AffineStoreOp>(loc, inputVal, alloc, outputMemRefVal);
+      rewriter.create<KrnlStoreOp>(loc, inputVal, alloc, outputMemRefVal);
     else
-      rewriter.create<StoreOp>(loc, inputVal, alloc, outputMemRefVal);
+      rewriter.create<KrnlStoreOp>(loc, inputVal, alloc, outputMemRefVal);
 
     rewriter.replaceOp(op, alloc);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
@@ -76,8 +76,8 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     SmallVector<IndexExpr, 4> indicesAccessFct;
     for (int j = 0; j < indicesRank; ++j)
       indicesAccessFct.emplace_back(outputAccessFct[jIndexStart + j]);
-    Value indexVal =
-        outerContext.createLoadOp(operandAdaptor.indices(), indicesAccessFct);
+    Value indexVal = outerContext.createKrnlLoadOp(
+        operandAdaptor.indices(), indicesAccessFct);
     // Loaded value is an index that is not affine
     IndexExpr index = outerContext.createNonAffineIndex(indexVal);
     // When index may be negative, add axis Dim to it.
@@ -96,10 +96,10 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     for (int k = axisLit + 1; k < dataRank; ++k)
       dataAccessFct.emplace_back(outputAccessFct[kIndexStart + k]);
     Value data =
-        outerContext.createLoadOp(operandAdaptor.data(), dataAccessFct);
+        outerContext.createKrnlLoadOp(operandAdaptor.data(), dataAccessFct);
 
     // Save data into output
-    outerContext.createStoreOp(data, alloc, outputAccessFct);
+    outerContext.createKrnlStoreOp(data, alloc, outputAccessFct);
     rewriter.replaceOp(op, alloc);
     return success();
   }

--- a/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
@@ -97,8 +97,8 @@ struct ONNXPadOpLowering : public ConversionPattern {
     }
 
     auto originValue =
-        rewriter.create<AffineLoadOp>(loc, operandAdaptor.data(), inLoopIVs);
-    rewriter.create<AffineStoreOp>(loc, originValue, alloc, outLoopIVs);
+        rewriter.create<KrnlLoadOp>(loc, operandAdaptor.data(), inLoopIVs);
+    rewriter.create<KrnlStoreOp>(loc, originValue, alloc, outLoopIVs);
     rewriter.setInsertionPointToStart(padLoops.getIterateBlock());
 
     SmallVector<Value, 4> outLoopIVs1;
@@ -106,7 +106,7 @@ struct ONNXPadOpLowering : public ConversionPattern {
       outLoopIVs1.emplace_back(padLoops.getInductionVar(i));
 
     auto paddingValue = rewriter.create<ConstantOp>(loc, valueAttr);
-    rewriter.create<AffineStoreOp>(loc, paddingValue, alloc, outLoopIVs1);
+    rewriter.create<KrnlStoreOp>(loc, paddingValue, alloc, outLoopIVs1);
 
     // Replace the original op with the generated code.
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/Tensor/PadConstantValuePad.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/PadConstantValuePad.cpp
@@ -86,8 +86,8 @@ struct ONNXPadConstantValuePadOpLowering : public ConversionPattern {
     }
 
     auto inVal =
-        rewriter.create<AffineLoadOp>(loc, operandAdaptor.data(), inLoopIVs);
-    rewriter.create<AffineStoreOp>(loc, inVal, alloc, outLoopIVs);
+        rewriter.create<KrnlLoadOp>(loc, operandAdaptor.data(), inLoopIVs);
+    rewriter.create<KrnlStoreOp>(loc, inVal, alloc, outLoopIVs);
     rewriter.setInsertionPointToStart(padLoops.getIterateBlock());
 
     SmallVector<Value, 4> outLoopIVs1;
@@ -95,7 +95,7 @@ struct ONNXPadConstantValuePadOpLowering : public ConversionPattern {
       outLoopIVs1.emplace_back(padLoops.getInductionVar(i));
 
     auto inVal1 = rewriter.create<ConstantOp>(loc, constantValAttr);
-    rewriter.create<AffineStoreOp>(loc, inVal1, alloc, outLoopIVs1);
+    rewriter.create<KrnlStoreOp>(loc, inVal1, alloc, outLoopIVs1);
 
     // Replace the original op with the generated code.
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/Tensor/Reshape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Reshape.cpp
@@ -64,8 +64,7 @@ struct ONNXReshapeOpLowering : public ConversionPattern {
       for (int i = 0; i < memRefShape.size(); ++i) {
         Value index = emitConstantOp(rewriter, loc, rewriter.getIndexType(), i);
         // Load index from array of indices.
-        Value loadedVal =
-            rewriter.create<AffineLoadOp>(loc, operands[1], index);
+        Value loadedVal = rewriter.create<KrnlLoadOp>(loc, operands[1], index);
         // If a dimension is zero, the actual dimension value is taken from the
         // input tensor.
         //

--- a/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
@@ -46,7 +46,7 @@ struct ONNXShapeOpLowering : public ConversionPattern {
       IndexExpr shapeVal = IEContext.createDimIndexFromShapedType(data, i);
       Value storeVal = rewriter.create<IndexCastOp>(
           loc, shapeVal.getValue(), outputMemRefType.getElementType());
-      rewriter.create<StoreOp>(loc, storeVal, alloc, storeIndex.getValue());
+      rewriter.create<KrnlStoreOp>(loc, storeVal, alloc, storeIndex.getValue());
     }
     rewriter.replaceOp(op, alloc);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
@@ -61,7 +61,7 @@ struct ONNXSizeOpLowering : public ConversionPattern {
       }
     }
 
-    rewriter.create<AffineStoreOp>(loc, noElements, alloc, llvm::None);
+    rewriter.create<KrnlStoreOp>(loc, noElements, alloc, llvm::None);
     rewriter.replaceOp(op, alloc);
     return success();
   }

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -60,8 +60,8 @@ struct ONNXSliceOpLowering : public ConversionPattern {
     }
     // Load data and store in alloc data.
     Value loadVal =
-        childContext.createLoadOp(operandAdaptor.data(), loadIndices);
-    childContext.createStoreOp(loadVal, alloc, storeIndices);
+        childContext.createKrnlLoadOp(operandAdaptor.data(), loadIndices);
+    childContext.createKrnlStoreOp(loadVal, alloc, storeIndices);
 
     rewriter.replaceOp(op, alloc);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -75,8 +75,8 @@ struct ONNXSplitOpLowering : public ConversionPattern {
       }
       // Insert copy.
       Value loadData =
-          childContext.createLoadOp(operandAdaptor.input(), readIndices);
-      childContext.createStoreOp(loadData, allocs[i], writeIndices);
+          childContext.createKrnlLoadOp(operandAdaptor.input(), readIndices);
+      childContext.createKrnlStoreOp(loadData, allocs[i], writeIndices);
     }
     rewriter.replaceOp(op, allocs);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -63,8 +63,8 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
       }
 
       // Copy data.
-      Value loadData = childContext.createLoadOp(data, readIndices);
-      childContext.createStoreOp(loadData, alloc, writeIndices);
+      Value loadData = childContext.createKrnlLoadOp(data, readIndices);
+      childContext.createKrnlStoreOp(loadData, alloc, writeIndices);
     }
 
     rewriter.replaceOp(op, alloc);

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -10,6 +10,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Dialect/Shape/IR/ShapeBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def Krnl_Dialect : Dialect {
   let name = "krnl";
@@ -405,3 +406,86 @@ def KrnlDummyCastOp : Op<Krnl_Dialect, "dummy_cast"> {
   }];
 }
 
+def KrnlLoadOp : Op<Krnl_Dialect, "load",
+  [TypesMatchWith<"result type matches element type of 'memref'",
+                  "memref", "result",
+                  "$_self.cast<MemRefType>().getElementType()">,
+                  MemRefsNormalizable]> {
+  let summary = "A Krnl operation to load data from the memref.";
+
+  let description = [{
+    The `krnl.load` op reads an element from a memref specified by an index
+    list. The output of load is a new value with the same type as the elements
+    of the memref. The arity of indices is the rank of the memref (i.e., if the
+    memref loaded from is of rank 3, then 3 indices are required for the load
+    following the memref identifier).
+  }];
+
+  let arguments = (ins Arg<AnyMemRef, "the reference to load from",
+                           [MemRead]>:$memref,
+                       Variadic<Index>:$indices);
+  let results = (outs AnyType:$result);
+
+  let builders = [
+    OpBuilderDAG<(ins "Value":$memref, CArg<"ValueRange", "{}">:$indices), [{
+      auto memrefType = memref.getType().cast<MemRefType>();
+      $_state.addOperands(memref);
+      $_state.addOperands(indices);
+      $_state.types.push_back(memrefType.getElementType());
+    }]>];
+
+  let extraClassDeclaration = [{
+    Value getMemRef() { return getOperand(0); }
+    void setMemRef(Value value) { setOperand(0, value); }
+    MemRefType getMemRefType() {
+      return getMemRef().getType().cast<MemRefType>();
+    }
+
+    operand_range getIndices() { return {operand_begin() + 1, operand_end()}; }
+  }];
+
+  let assemblyFormat = [{$memref `[` $indices `]` attr-dict `:` type($memref)}];
+}
+
+def KrnlStoreOp : Op<Krnl_Dialect, "store",
+     [TypesMatchWith<"type of 'value' matches element type of 'memref'",
+                     "memref", "value",
+                     "$_self.cast<MemRefType>().getElementType()">,
+                     MemRefsNormalizable]> {
+  let summary = "A Krnl operation to store data to the memref.";
+  let description = [{
+    The `krnl.store` stores a value to a memref location given by indices. The
+    value stored should have the same type as the elemental type of the memref.
+    The number of arguments provided within brackets need to match the rank of
+    the memref.
+  }];
+
+  let arguments = (ins AnyType:$value,
+                       Arg<AnyMemRef, "the reference to store to",
+                           [MemWrite]>:$memref,
+                       Variadic<Index>:$indices);
+
+  let builders = [
+    OpBuilderDAG<(ins "Value":$valueToStore, "Value":$memref), [{
+      $_state.addOperands(valueToStore);
+      $_state.addOperands(memref);
+    }]>];
+
+  let extraClassDeclaration = [{
+      Value getValueToStore() { return getOperand(0); }
+
+      Value getMemRef() { return getOperand(1); }
+      void setMemRef(Value value) { setOperand(1, value); }
+      MemRefType getMemRefType() {
+        return getMemRef().getType().cast<MemRefType>();
+      }
+
+      operand_range getIndices() {
+        return {operand_begin() + 2, operand_end()};
+      }
+  }];
+
+  let assemblyFormat = [{
+    $value `,` $memref `[` $indices `]` attr-dict `:` type($memref)
+  }];
+}

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -49,7 +49,7 @@ def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
 }];
 }
 
-def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator, AffineScope]> {
+def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator]> {
   let summary = "iterate operation";
   let description = [{
     The "krnl.iterate" operation is conceptually equivalent to a nested for loops.

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/MathExtras.h"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+#include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/ONNX/ONNXShapeHelper.hpp"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Sequence.h"
@@ -279,6 +280,18 @@ Value IndexExprContext::createLoadOp(
   return getRewriter().create<LoadOp>(getLoc(), memref, loadIndices);
 }
 
+Value IndexExprContext::createKrnlLoadOp(
+    Value memref, SmallVectorImpl<IndexExpr> &indices) {
+  bool affineIndices = true;
+  SmallVector<Value, 4> loadIndices;
+  for (IndexExpr ie : indices) {
+    if (!ie.isAffine())
+      affineIndices = false;
+    loadIndices.emplace_back(ie.getValue());
+  }
+  return getRewriter().create<KrnlLoadOp>(getLoc(), memref, loadIndices);
+}
+
 void IndexExprContext::createStoreOp(
     Value val, Value memref, SmallVectorImpl<IndexExpr> &indices) {
   bool affineIndices = true;
@@ -293,6 +306,18 @@ void IndexExprContext::createStoreOp(
   } else { // Not affine, use regular load.
     getRewriter().create<StoreOp>(getLoc(), val, memref, storeIndices);
   }
+}
+
+void IndexExprContext::createKrnlStoreOp(
+    Value val, Value memref, SmallVectorImpl<IndexExpr> &indices) {
+  bool affineIndices = true;
+  SmallVector<Value, 4> storeIndices;
+  for (IndexExpr ie : indices) {
+    if (!ie.isAffine())
+      affineIndices = false;
+    storeIndices.emplace_back(ie.getValue());
+  }
+  getRewriter().create<KrnlStoreOp>(getLoc(), val, memref, storeIndices);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -262,43 +262,9 @@ void IndexExprContext::createLoopInductionIndicesFromArrayValues(
 }
 
 //===----------------------------------------------------------------------===//
-// IndexExprContext support for creating possibly affine load and store ops.
-//===----------------------------------------------------------------------===//
-
-Value IndexExprContext::createLoadOp(
-    Value memref, SmallVectorImpl<IndexExpr> &indices) {
-  bool affineIndices = true;
-  SmallVector<Value, 4> loadIndices;
-  for (IndexExpr ie : indices) {
-    if (!ie.isAffine())
-      affineIndices = false;
-    loadIndices.emplace_back(ie.getValue());
-  }
-  if (affineIndices)
-    return getRewriter().create<AffineLoadOp>(getLoc(), memref, loadIndices);
-  // Not affine, use regular load.
-  return getRewriter().create<LoadOp>(getLoc(), memref, loadIndices);
-}
-
-void IndexExprContext::createStoreOp(
-    Value val, Value memref, SmallVectorImpl<IndexExpr> &indices) {
-  bool affineIndices = true;
-  SmallVector<Value, 4> storeIndices;
-  for (IndexExpr ie : indices) {
-    if (!ie.isAffine())
-      affineIndices = false;
-    storeIndices.emplace_back(ie.getValue());
-  }
-  if (affineIndices) {
-    getRewriter().create<AffineStoreOp>(getLoc(), val, memref, storeIndices);
-  } else { // Not affine, use regular load.
-    getRewriter().create<StoreOp>(getLoc(), val, memref, storeIndices);
-  }
-}
-
-//===----------------------------------------------------------------------===//
 // IndexExprContext support for creating krnl load and store ops.
 //===----------------------------------------------------------------------===//
+
 Value IndexExprContext::createKrnlLoadOp(
     Value memref, SmallVectorImpl<IndexExpr> &indices) {
   SmallVector<Value, 4> loadIndices;
@@ -531,7 +497,7 @@ void IndexExprImpl::initAsSymbolFromArrayAtIndex(IndexExprContext &newContext,
   Value indexVal = emitConstantOp(newContext.getRewriter(), newContext.getLoc(),
       newContext.getRewriter().getIndexType(), indexInArray);
   SmallVector<Value, 1> memrefVal = {indexVal};
-  Value loadVal = newContext.getRewriter().create<AffineLoadOp>(
+  Value loadVal = newContext.getRewriter().create<KrnlLoadOp>(
       newContext.getLoc(), array, memrefVal);
   initAsType(newContext, loadVal, IndexExprType::Symbol);
 }
@@ -567,7 +533,7 @@ void IndexExprImpl::initAsSymbolFromArrayAtIndex(IndexExprContext &newContext,
   Value indexVal = emitConstantOp(newContext.getRewriter(), newContext.getLoc(),
       newContext.getRewriter().getIndexType(), indexInArray);
   SmallVector<Value, 1> memrefVal = {indexVal};
-  Value loadVal = newContext.getRewriter().create<AffineLoadOp>(
+  Value loadVal = newContext.getRewriter().create<KrnlLoadOp>(
       newContext.getLoc(), array, memrefVal);
   initAsType(newContext, loadVal, IndexExprType::Symbol);
 }

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -301,25 +301,17 @@ void IndexExprContext::createStoreOp(
 //===----------------------------------------------------------------------===//
 Value IndexExprContext::createKrnlLoadOp(
     Value memref, SmallVectorImpl<IndexExpr> &indices) {
-  bool affineIndices = true;
   SmallVector<Value, 4> loadIndices;
-  for (IndexExpr ie : indices) {
-    if (!ie.isAffine())
-      affineIndices = false;
+  for (IndexExpr ie : indices)
     loadIndices.emplace_back(ie.getValue());
-  }
   return getRewriter().create<KrnlLoadOp>(getLoc(), memref, loadIndices);
 }
 
 void IndexExprContext::createKrnlStoreOp(
     Value val, Value memref, SmallVectorImpl<IndexExpr> &indices) {
-  bool affineIndices = true;
   SmallVector<Value, 4> storeIndices;
-  for (IndexExpr ie : indices) {
-    if (!ie.isAffine())
-      affineIndices = false;
+  for (IndexExpr ie : indices)
     storeIndices.emplace_back(ie.getValue());
-  }
   getRewriter().create<KrnlStoreOp>(getLoc(), val, memref, storeIndices);
 }
 

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -280,18 +280,6 @@ Value IndexExprContext::createLoadOp(
   return getRewriter().create<LoadOp>(getLoc(), memref, loadIndices);
 }
 
-Value IndexExprContext::createKrnlLoadOp(
-    Value memref, SmallVectorImpl<IndexExpr> &indices) {
-  bool affineIndices = true;
-  SmallVector<Value, 4> loadIndices;
-  for (IndexExpr ie : indices) {
-    if (!ie.isAffine())
-      affineIndices = false;
-    loadIndices.emplace_back(ie.getValue());
-  }
-  return getRewriter().create<KrnlLoadOp>(getLoc(), memref, loadIndices);
-}
-
 void IndexExprContext::createStoreOp(
     Value val, Value memref, SmallVectorImpl<IndexExpr> &indices) {
   bool affineIndices = true;
@@ -306,6 +294,21 @@ void IndexExprContext::createStoreOp(
   } else { // Not affine, use regular load.
     getRewriter().create<StoreOp>(getLoc(), val, memref, storeIndices);
   }
+}
+
+//===----------------------------------------------------------------------===//
+// IndexExprContext support for creating krnl load and store ops.
+//===----------------------------------------------------------------------===//
+Value IndexExprContext::createKrnlLoadOp(
+    Value memref, SmallVectorImpl<IndexExpr> &indices) {
+  bool affineIndices = true;
+  SmallVector<Value, 4> loadIndices;
+  for (IndexExpr ie : indices) {
+    if (!ie.isAffine())
+      affineIndices = false;
+    loadIndices.emplace_back(ie.getValue());
+  }
+  return getRewriter().create<KrnlLoadOp>(getLoc(), memref, loadIndices);
 }
 
 void IndexExprContext::createKrnlStoreOp(

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -285,6 +285,10 @@ public:
   void createStoreOp(
       Value val, Value memref, SmallVectorImpl<IndexExpr> &indices);
 
+  Value createKrnlLoadOp(Value memref, SmallVectorImpl<IndexExpr> &indices);
+  void createKrnlStoreOp(
+      Value val, Value memref, SmallVectorImpl<IndexExpr> &indices);
+
   // Support functions for AffineExpr.
   int addDim(Value const value);
   int addSymbol(Value const value);

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -285,7 +285,9 @@ public:
   void createStoreOp(
       Value val, Value memref, SmallVectorImpl<IndexExpr> &indices);
 
+  // Emit a krnl.load to load an element from the memref.
   Value createKrnlLoadOp(Value memref, SmallVectorImpl<IndexExpr> &indices);
+  // Emit a krnl.store to store an element to the memref.
   void createKrnlStoreOp(
       Value val, Value memref, SmallVectorImpl<IndexExpr> &indices);
 

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -276,18 +276,10 @@ public:
       ArrayRef<BlockArgument> inductionVarArray,
       SmallVectorImpl<IndexExpr> &loopInductionIndices);
 
-  // Code Create for possibly affine load and store. Memref shape is expected to
-  // be of the same dimension than the indices array size. Each index expression
-  // will be transformed to a value to be used as indices to the memref. When
-  // all index expressions are affine, then an affine memory operation is
-  // generated. Otherwise, a standard memory operation is generated.
-  Value createLoadOp(Value memref, SmallVectorImpl<IndexExpr> &indices);
-  void createStoreOp(
-      Value val, Value memref, SmallVectorImpl<IndexExpr> &indices);
-
-  // Emit a krnl.load to load an element from the memref.
+  // Code Create for krnl load and store. Memref shape is expected to be of the
+  // same dimension than the indices array size. Each index expression will be
+  // transformed to a value to be used as indices to the memref.
   Value createKrnlLoadOp(Value memref, SmallVectorImpl<IndexExpr> &indices);
-  // Emit a krnl.store to store an element to the memref.
   void createKrnlStoreOp(
       Value val, Value memref, SmallVectorImpl<IndexExpr> &indices);
 

--- a/src/Support/KrnlSupport.cpp
+++ b/src/Support/KrnlSupport.cpp
@@ -87,14 +87,12 @@ Value emitConstantOp(
 
 /// Operation is a LoadOp or AffineLoadOp.
 bool isLoad(Operation *op) {
-  return llvm::dyn_cast_or_null<LoadOp>(op) ||
-         llvm::dyn_cast_or_null<AffineLoadOp>(op);
+  return llvm::dyn_cast_or_null<KrnlLoadOp>(op);
 }
 
 /// Operation is a StoreOp or AffineStoreOp.
 bool isStore(Operation *op) {
-  return llvm::dyn_cast_or_null<StoreOp>(op) ||
-         llvm::dyn_cast_or_null<AffineStoreOp>(op);
+  return llvm::dyn_cast_or_null<KrnlStoreOp>(op);
 }
 
 /// Operation is a KrnlMemcpyOp.

--- a/src/Support/KrnlSupport.cpp
+++ b/src/Support/KrnlSupport.cpp
@@ -86,14 +86,10 @@ Value emitConstantOp(
 //===----------------------------------------------------------------------===//
 
 /// Operation is a LoadOp or AffineLoadOp.
-bool isLoad(Operation *op) {
-  return llvm::dyn_cast_or_null<KrnlLoadOp>(op);
-}
+bool isLoad(Operation *op) { return llvm::dyn_cast_or_null<KrnlLoadOp>(op); }
 
 /// Operation is a StoreOp or AffineStoreOp.
-bool isStore(Operation *op) {
-  return llvm::dyn_cast_or_null<KrnlStoreOp>(op);
-}
+bool isStore(Operation *op) { return llvm::dyn_cast_or_null<KrnlStoreOp>(op); }
 
 /// Operation is a KrnlMemcpyOp.
 bool isKrnlMemcpy(Operation *op) {

--- a/src/Transform/BundleMemoryPools.cpp
+++ b/src/Transform/BundleMemoryPools.cpp
@@ -320,8 +320,7 @@ public:
             // Check if the current operation is a DimOp or a LoadOp.
             if (llvm::dyn_cast<DimOp>(definingOperation) ||
                 llvm::dyn_cast<KrnlDimOp>(definingOperation) ||
-                llvm::dyn_cast<LoadOp>(definingOperation) ||
-                llvm::dyn_cast<AffineLoadOp>(definingOperation)) {
+                llvm::dyn_cast<KrnlLoadOp>(definingOperation)) {
               Operation *operandOp = operand.getDefiningOp();
               if (operandOp) {
                 auto localAlloc = llvm::dyn_cast<AllocOp>(operandOp);

--- a/src/Transform/OptimizeMemoryPools.cpp
+++ b/src/Transform/OptimizeMemoryPools.cpp
@@ -63,13 +63,7 @@ std::vector<Operation *> getGetRefStores(KrnlGetRefOp *getRef) {
   auto parentBlock = getRef->getOperation()->getBlock();
   std::vector<Operation *> stores;
 
-  parentBlock->walk([&stores, getRef](StoreOp op) {
-    for (const auto &operand : op.getOperands())
-      if (operand == getRef->getResult())
-        stores.emplace_back(op);
-  });
-
-  parentBlock->walk([&stores, getRef](AffineStoreOp op) {
+  parentBlock->walk([&stores, getRef](KrnlStoreOp op) {
     for (const auto &operand : op.getOperands())
       if (operand == getRef->getResult())
         stores.emplace_back(op);
@@ -166,8 +160,7 @@ bool getRefUsesAreDisjoint(
         // Add value to dependent values list.
         dependentOps.insert(definingOperation);
 
-        if (llvm::dyn_cast<AffineLoadOp>(definingOperation) ||
-            llvm::dyn_cast<LoadOp>(definingOperation)) {
+        if (llvm::dyn_cast<KrnlLoadOp>(definingOperation)) {
           // Check that the MemRef operand of this load operation is
           // not in the firstGetRefList.
           Value loadOperand = definingOperation->getOperands()[0];

--- a/test/mlir/conversion/krnl_to_affine.mlir
+++ b/test/mlir/conversion/krnl_to_affine.mlir
@@ -13,3 +13,101 @@ func @test_lower_degenerate_iterate(%arg0: memref<f32>) -> memref<f32> {
   // CHECK-NEXT: store [[LOAD]], [[ALLOC]][] : memref<f32>
   // CHECK-NEXT: return [[ALLOC]] : memref<f32>
 }
+
+// -----
+
+// COM: Simple krnl.load/store to affine.load/store.
+func @test_krnl_load_store(%arg0: memref<10x10xf32>) -> memref<1xf32> {
+  %c0 = constant 0 : index
+  %1 = krnl.load %arg0[%c0, %c0] : memref<10x10xf32>
+  %2 = alloc() : memref<1xf32>
+  krnl.store %1, %2[%c0] : memref<1xf32>
+  return %2 : memref<1xf32>
+
+  // CHECK-LABEL: test_krnl_load_store
+  // CHECK: [[C0:%.+]] = constant 0 : index
+  // CHECK: [[LOAD:%.+]] = affine.load %arg0{{\[}}[[C0]], [[C0]]{{\]}} : memref<10x10xf32>
+  // CHECK: [[RES:%.+]]  = alloc() : memref<1xf32>
+  // CHECK: affine.store [[LOAD]], [[RES]]{{\[}}[[C0]]{{\]}} : memref<1xf32>
+
+}
+
+// -----
+
+// COM: Check whether krnl.load is lowered to std.load due to non-affine indices.
+func @test_krnl_load_with_krnl_iterate(%arg0: memref<10x10xf32>, %arg1: memref<10x?xf32>) -> memref<10x10xf32> {
+  %0 = alloc() : memref<10x10xf32>
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %1 = dim %arg1, %c1 : memref<10x?xf32>
+  %2:2 = krnl.define_loops 2
+  krnl.iterate(%2#0, %2#1) with (%2#0 -> %arg2 = 0 to 10, %2#1 -> %arg3 = 0 to 10) {
+    %3 = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+    %4 = cmpi "sgt", %1, %c1 : index
+    %5 = select %4, %arg3, %c0 : index
+    %6 = krnl.load %arg1[%arg2, %5] : memref<10x?xf32>
+    %7 = addf %3, %6 : f32
+    krnl.store %7, %0[%arg2, %arg3] : memref<10x10xf32>
+  }
+  return %0 : memref<10x10xf32>
+
+  // CHECK-LABEL:  @test_krnl_load_with_krnl_iterate
+  // CHECK:  affine.for {{.*}}
+  // CHECK:    affine.for {{.*}}
+  // CHECK:      {{.*}} = affine.load {{.*}} : memref<10x10xf32>
+  // CHECK:      {{.*}} = load {{.*}} : memref<10x?xf32>
+  // CHECK:      affine.store {{.*}} : memref<10x10xf32>
+}
+
+// -----
+
+// COM: Check whether krnl.store is lowered to std.load due to non-affine indices.
+func @test_krnl_store_with_krnl_iterate(%arg0: memref<10x10xf32>, %arg1: memref<10x?xf32>) -> memref<10x10xf32> {
+  %0 = alloc() : memref<10x10xf32>
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %1 = dim %arg1, %c1 : memref<10x?xf32>
+  %2:2 = krnl.define_loops 2
+  krnl.iterate(%2#0, %2#1) with (%2#0 -> %arg2 = 0 to 10, %2#1 -> %arg3 = 0 to 10) {
+    %3 = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+    %4 = cmpi "sgt", %1, %c1 : index
+    %5 = select %4, %arg3, %c0 : index
+    %6 = krnl.load %arg1[%arg2, %5] : memref<10x?xf32>
+    %7 = addf %3, %6 : f32
+    krnl.store %7, %0[%arg2, %5] : memref<10x10xf32>
+  }
+  return %0 : memref<10x10xf32>
+
+  // CHECK-LABEL:  @test_krnl_store_with_krnl_iterate
+  // CHECK:  affine.for {{.*}}
+  // CHECK:    affine.for {{.*}}
+  // CHECK:      {{.*}} = affine.load {{.*}} : memref<10x10xf32>
+  // CHECK:      {{.*}} = load {{.*}} : memref<10x?xf32>
+  // CHECK:      store {{.*}} : memref<10x10xf32>
+}
+
+// -----
+
+// COM: Check whether krnl.load/store is lowered to affine.load/store due to affine indices.
+#map = affine_map<(d0) -> (d0 + 1)>
+func @test_krnl_load_store_with_affine(%arg0: memref<10x10xf32>, %arg1: memref<10x?xf32>) -> memref<10x10xf32> {
+  %0 = alloc() : memref<10x10xf32>
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %1 = dim %arg1, %c1 : memref<10x?xf32>
+  %2:2 = krnl.define_loops 2
+  krnl.iterate(%2#0, %2#1) with (%2#0 -> %arg2 = 0 to 10, %2#1 -> %arg3 = 0 to 10) {
+    %3 = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+    %4 = affine.apply #map(%arg3)
+    %5 = krnl.load %arg1[%arg2, %4] : memref<10x?xf32>
+    krnl.store %5, %0[%arg2, %4] : memref<10x10xf32>
+  }
+  return %0 : memref<10x10xf32>
+
+  // CHECK-LABEL:  @test_krnl_load_store_with_affine
+  // CHECK:  affine.for {{.*}}
+  // CHECK:    affine.for {{.*}}
+  // CHECK:      {{.*}} = affine.load {{.*}} : memref<10x10xf32>
+  // CHECK:      {{.*}} = affine.load {{.*}} : memref<10x?xf32>
+  // CHECK:      affine.store {{.*}} : memref<10x10xf32>
+}

--- a/test/mlir/krnl/krnl_bundle_lstm_memory_pool.mlir
+++ b/test/mlir/krnl/krnl_bundle_lstm_memory_pool.mlir
@@ -30,8 +30,8 @@ module {
     %7 = "krnl.getref"(%6, %c0_i64, %3) : (memref<?xi8>, i64, index) -> memref<1x?x3xf32>
     %8:3 = krnl.define_loops 3
     krnl.iterate(%8#0, %8#1, %8#2) with (%8#0 -> %arg3 = 0 to 1, %8#1 -> %arg4 = 0 to %1, %8#2 -> %arg5 = 0 to 3) {
-      affine.store %cst_1, %2[%arg3, %arg4, %arg5] : memref<1x?x3xf32>
-      affine.store %cst_1, %7[%arg3, %arg4, %arg5] : memref<1x?x3xf32>
+      krnl.store %cst_1, %2[%arg3, %arg4, %arg5] : memref<1x?x3xf32>
+      krnl.store %cst_1, %7[%arg3, %arg4, %arg5] : memref<1x?x3xf32>
     }
     %9 = krnl.define_loops 1
     %10 = dim %arg0, %c0 : memref<?x?x2xf32>
@@ -75,41 +75,41 @@ module {
       %47:2 = krnl.define_loops 2
       %48 = dim %arg0, %c1 : memref<?x?x2xf32>
       krnl.iterate(%47#0, %47#1) with (%47#0 -> %arg4 = 0 to %48, %47#1 -> %arg5 = 0 to 3) {
-        affine.store %cst_1, %15[%arg4, %arg5] : memref<?x3xf32>
-        affine.store %cst_1, %19[%arg4, %arg5] : memref<?x3xf32>
-        affine.store %cst_1, %24[%arg4, %arg5] : memref<?x3xf32>
-        affine.store %cst_1, %28[%arg4, %arg5] : memref<?x3xf32>
-        affine.store %cst_1, %33[%arg4, %arg5] : memref<?x3xf32>
-        affine.store %cst_1, %37[%arg4, %arg5] : memref<?x3xf32>
-        affine.store %cst_1, %42[%arg4, %arg5] : memref<?x3xf32>
-        affine.store %cst_1, %46[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %cst_1, %15[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %cst_1, %19[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %cst_1, %24[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %cst_1, %28[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %cst_1, %33[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %cst_1, %37[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %cst_1, %42[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %cst_1, %46[%arg4, %arg5] : memref<?x3xf32>
         %51 = krnl.define_loops 1
         krnl.iterate(%51) with (%51 -> %arg6 = 0 to 2) {
           %53 = affine.apply #map6(%arg5)[%c0, %c3]
           %54 = affine.apply #map6(%arg5)[%c1, %c3]
           %55 = affine.apply #map6(%arg5)[%c2, %c3]
           %56 = affine.apply #map6(%arg5)[%c3, %c3]
-          %57 = affine.load %arg0[%arg3, %arg4, %arg6] : memref<?x?x2xf32>
-          %58 = affine.load %arg1[%c0, %53, %arg6] : memref<1x12x2xf32>
+          %57 = krnl.load %arg0[%arg3, %arg4, %arg6] : memref<?x?x2xf32>
+          %58 = krnl.load %arg1[%c0, %53, %arg6] : memref<1x12x2xf32>
           %59 = mulf %57, %58 : f32
-          %60 = affine.load %15[%arg4, %arg5] : memref<?x3xf32>
+          %60 = krnl.load %15[%arg4, %arg5] : memref<?x3xf32>
           %61 = addf %60, %59 : f32
-          affine.store %61, %15[%arg4, %arg5] : memref<?x3xf32>
-          %62 = affine.load %arg1[%c0, %54, %arg6] : memref<1x12x2xf32>
+          krnl.store %61, %15[%arg4, %arg5] : memref<?x3xf32>
+          %62 = krnl.load %arg1[%c0, %54, %arg6] : memref<1x12x2xf32>
           %63 = mulf %57, %62 : f32
-          %64 = affine.load %24[%arg4, %arg5] : memref<?x3xf32>
+          %64 = krnl.load %24[%arg4, %arg5] : memref<?x3xf32>
           %65 = addf %64, %63 : f32
-          affine.store %65, %24[%arg4, %arg5] : memref<?x3xf32>
-          %66 = affine.load %arg1[%c0, %55, %arg6] : memref<1x12x2xf32>
+          krnl.store %65, %24[%arg4, %arg5] : memref<?x3xf32>
+          %66 = krnl.load %arg1[%c0, %55, %arg6] : memref<1x12x2xf32>
           %67 = mulf %57, %66 : f32
-          %68 = affine.load %33[%arg4, %arg5] : memref<?x3xf32>
+          %68 = krnl.load %33[%arg4, %arg5] : memref<?x3xf32>
           %69 = addf %68, %67 : f32
-          affine.store %69, %33[%arg4, %arg5] : memref<?x3xf32>
-          %70 = affine.load %arg1[%c0, %56, %arg6] : memref<1x12x2xf32>
+          krnl.store %69, %33[%arg4, %arg5] : memref<?x3xf32>
+          %70 = krnl.load %arg1[%c0, %56, %arg6] : memref<1x12x2xf32>
           %71 = mulf %57, %70 : f32
-          %72 = affine.load %42[%arg4, %arg5] : memref<?x3xf32>
+          %72 = krnl.load %42[%arg4, %arg5] : memref<?x3xf32>
           %73 = addf %72, %71 : f32
-          affine.store %73, %42[%arg4, %arg5] : memref<?x3xf32>
+          krnl.store %73, %42[%arg4, %arg5] : memref<?x3xf32>
         }
         %52 = krnl.define_loops 1
         krnl.iterate(%52) with (%52 -> %arg6 = 0 to 3) {
@@ -117,27 +117,27 @@ module {
           %54 = affine.apply #map6(%arg5)[%c1, %c3]
           %55 = affine.apply #map6(%arg5)[%c2, %c3]
           %56 = affine.apply #map6(%arg5)[%c3, %c3]
-          %57 = affine.load %2[%c0, %arg4, %arg6] : memref<1x?x3xf32>
-          %58 = affine.load %arg2[%c0, %53, %arg6] : memref<1x12x3xf32>
+          %57 = krnl.load %2[%c0, %arg4, %arg6] : memref<1x?x3xf32>
+          %58 = krnl.load %arg2[%c0, %53, %arg6] : memref<1x12x3xf32>
           %59 = mulf %57, %58 : f32
-          %60 = affine.load %19[%arg4, %arg5] : memref<?x3xf32>
+          %60 = krnl.load %19[%arg4, %arg5] : memref<?x3xf32>
           %61 = addf %60, %59 : f32
-          affine.store %61, %19[%arg4, %arg5] : memref<?x3xf32>
-          %62 = affine.load %arg2[%c0, %54, %arg6] : memref<1x12x3xf32>
+          krnl.store %61, %19[%arg4, %arg5] : memref<?x3xf32>
+          %62 = krnl.load %arg2[%c0, %54, %arg6] : memref<1x12x3xf32>
           %63 = mulf %57, %62 : f32
-          %64 = affine.load %28[%arg4, %arg5] : memref<?x3xf32>
+          %64 = krnl.load %28[%arg4, %arg5] : memref<?x3xf32>
           %65 = addf %64, %63 : f32
-          affine.store %65, %28[%arg4, %arg5] : memref<?x3xf32>
-          %66 = affine.load %arg2[%c0, %55, %arg6] : memref<1x12x3xf32>
+          krnl.store %65, %28[%arg4, %arg5] : memref<?x3xf32>
+          %66 = krnl.load %arg2[%c0, %55, %arg6] : memref<1x12x3xf32>
           %67 = mulf %57, %66 : f32
-          %68 = affine.load %37[%arg4, %arg5] : memref<?x3xf32>
+          %68 = krnl.load %37[%arg4, %arg5] : memref<?x3xf32>
           %69 = addf %68, %67 : f32
-          affine.store %69, %37[%arg4, %arg5] : memref<?x3xf32>
-          %70 = affine.load %arg2[%c0, %56, %arg6] : memref<1x12x3xf32>
+          krnl.store %69, %37[%arg4, %arg5] : memref<?x3xf32>
+          %70 = krnl.load %arg2[%c0, %56, %arg6] : memref<1x12x3xf32>
           %71 = mulf %57, %70 : f32
-          %72 = affine.load %46[%arg4, %arg5] : memref<?x3xf32>
+          %72 = krnl.load %46[%arg4, %arg5] : memref<?x3xf32>
           %73 = addf %72, %71 : f32
-          affine.store %73, %46[%arg4, %arg5] : memref<?x3xf32>
+          krnl.store %73, %46[%arg4, %arg5] : memref<?x3xf32>
         }
       }
       %49:2 = krnl.define_loops 2
@@ -153,40 +153,40 @@ module {
         %58 = "krnl.getref"(%57, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
         %59 = alloc() : memref<4xi8>
         %60 = "krnl.getref"(%59, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-        %61 = affine.load %7[%c0, %arg4, %arg5] : memref<1x?x3xf32>
-        %62 = affine.load %15[%arg4, %arg5] : memref<?x3xf32>
-        %63 = affine.load %19[%arg4, %arg5] : memref<?x3xf32>
+        %61 = krnl.load %7[%c0, %arg4, %arg5] : memref<1x?x3xf32>
+        %62 = krnl.load %15[%arg4, %arg5] : memref<?x3xf32>
+        %63 = krnl.load %19[%arg4, %arg5] : memref<?x3xf32>
         %64 = addf %62, %63 : f32
         %65 = alloc() : memref<4xi8>
         %66 = "krnl.getref"(%65, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-        affine.store %64, %66[] : memref<f32>
-        %67 = affine.load %66[] : memref<f32>
+        krnl.store %64, %66[] : memref<f32>
+        %67 = krnl.load %66[] : memref<f32>
         %68 = subf %cst_1, %67 : f32
         %69 = exp %68 : f32
         %70 = addf %cst, %69 : f32
         %71 = divf %cst, %70 : f32
-        affine.store %71, %60[] : memref<f32>
-        %72 = affine.load %60[] : memref<f32>
-        %73 = affine.load %33[%arg4, %arg5] : memref<?x3xf32>
-        %74 = affine.load %37[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %71, %60[] : memref<f32>
+        %72 = krnl.load %60[] : memref<f32>
+        %73 = krnl.load %33[%arg4, %arg5] : memref<?x3xf32>
+        %74 = krnl.load %37[%arg4, %arg5] : memref<?x3xf32>
         %75 = addf %73, %74 : f32
         %76 = alloc() : memref<4xi8>
         %77 = "krnl.getref"(%76, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-        affine.store %75, %77[] : memref<f32>
-        %78 = affine.load %77[] : memref<f32>
+        krnl.store %75, %77[] : memref<f32>
+        %78 = krnl.load %77[] : memref<f32>
         %79 = subf %cst_1, %78 : f32
         %80 = exp %79 : f32
         %81 = addf %cst, %80 : f32
         %82 = divf %cst, %81 : f32
-        affine.store %82, %58[] : memref<f32>
-        %83 = affine.load %58[] : memref<f32>
-        %84 = affine.load %42[%arg4, %arg5] : memref<?x3xf32>
-        %85 = affine.load %46[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %82, %58[] : memref<f32>
+        %83 = krnl.load %58[] : memref<f32>
+        %84 = krnl.load %42[%arg4, %arg5] : memref<?x3xf32>
+        %85 = krnl.load %46[%arg4, %arg5] : memref<?x3xf32>
         %86 = addf %84, %85 : f32
         %87 = alloc() : memref<4xi8>
         %88 = "krnl.getref"(%87, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-        affine.store %86, %88[] : memref<f32>
-        %89 = affine.load %88[] : memref<f32>
+        krnl.store %86, %88[] : memref<f32>
+        %89 = krnl.load %88[] : memref<f32>
         %90 = mulf %89, %cst_0 : f32
         %91 = negf %90 : f32
         %92 = exp %91 : f32
@@ -199,29 +199,29 @@ module {
         %99 = divf %97, %98 : f32
         %100 = cmpf "oge", %89, %cst_1 : f32
         %101 = select %100, %95, %99 : f32
-        affine.store %101, %56[] : memref<f32>
-        %102 = affine.load %56[] : memref<f32>
+        krnl.store %101, %56[] : memref<f32>
+        %102 = krnl.load %56[] : memref<f32>
         %103 = mulf %83, %61 : f32
         %104 = mulf %72, %102 : f32
         %105 = addf %103, %104 : f32
-        affine.store %105, %7[%c0, %arg4, %arg5] : memref<1x?x3xf32>
-        %106 = affine.load %24[%arg4, %arg5] : memref<?x3xf32>
-        %107 = affine.load %28[%arg4, %arg5] : memref<?x3xf32>
+        krnl.store %105, %7[%c0, %arg4, %arg5] : memref<1x?x3xf32>
+        %106 = krnl.load %24[%arg4, %arg5] : memref<?x3xf32>
+        %107 = krnl.load %28[%arg4, %arg5] : memref<?x3xf32>
         %108 = addf %106, %107 : f32
         %109 = alloc() : memref<4xi8>
         %110 = "krnl.getref"(%109, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-        affine.store %108, %110[] : memref<f32>
-        %111 = affine.load %110[] : memref<f32>
+        krnl.store %108, %110[] : memref<f32>
+        %111 = krnl.load %110[] : memref<f32>
         %112 = subf %cst_1, %111 : f32
         %113 = exp %112 : f32
         %114 = addf %cst, %113 : f32
         %115 = divf %cst, %114 : f32
-        affine.store %115, %54[] : memref<f32>
-        %116 = affine.load %54[] : memref<f32>
+        krnl.store %115, %54[] : memref<f32>
+        %116 = krnl.load %54[] : memref<f32>
         %117 = alloc() : memref<4xi8>
         %118 = "krnl.getref"(%117, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-        affine.store %105, %118[] : memref<f32>
-        %119 = affine.load %118[] : memref<f32>
+        krnl.store %105, %118[] : memref<f32>
+        %119 = krnl.load %118[] : memref<f32>
         %120 = mulf %119, %cst_0 : f32
         %121 = negf %120 : f32
         %122 = exp %121 : f32
@@ -234,10 +234,10 @@ module {
         %129 = divf %127, %128 : f32
         %130 = cmpf "oge", %119, %cst_1 : f32
         %131 = select %130, %125, %129 : f32
-        affine.store %131, %52[] : memref<f32>
-        %132 = affine.load %52[] : memref<f32>
+        krnl.store %131, %52[] : memref<f32>
+        %132 = krnl.load %52[] : memref<f32>
         %133 = mulf %116, %132 : f32
-        affine.store %133, %2[%c0, %arg4, %arg5] : memref<1x?x3xf32>
+        krnl.store %133, %2[%c0, %arg4, %arg5] : memref<1x?x3xf32>
         dealloc %117 : memref<4xi8>
         dealloc %109 : memref<4xi8>
         dealloc %87 : memref<4xi8>

--- a/test/mlir/krnl/krnl_bundle_memory_pool.mlir
+++ b/test/mlir/krnl/krnl_bundle_memory_pool.mlir
@@ -15,12 +15,12 @@ func @test_pool_bundling(%arg0: memref<10x10xf32>, %arg1: memref<10x20xf32>) -> 
   %8 = "krnl.getref"(%7, %c0_i64) : (memref<800xi8>, i64) -> memref<10x20xf32>
   %9 = alloc() : memref<400xi8>
   %10 = "krnl.getref"(%9, %c0_i64) : (memref<400xi8>, i64) -> memref<10x10xf32>
-  affine.store %cst, %10[%ind, %ind] : memref<10x10xf32>
-  affine.store %cst, %8[%ind, %ind] : memref<10x20xf32>
-  affine.store %cst, %6[%ind, %ind] : memref<10x20xf32>
-  affine.store %cst, %4[%ind, %ind] : memref<10x10xf32>
-  affine.store %cst, %2[%ind, %ind] : memref<10x20xf32>
-  affine.store %cst, %0[%ind, %ind] : memref<10x20xf32>
+  krnl.store %cst, %10[%ind, %ind] : memref<10x10xf32>
+  krnl.store %cst, %8[%ind, %ind] : memref<10x20xf32>
+  krnl.store %cst, %6[%ind, %ind] : memref<10x20xf32>
+  krnl.store %cst, %4[%ind, %ind] : memref<10x10xf32>
+  krnl.store %cst, %2[%ind, %ind] : memref<10x20xf32>
+  krnl.store %cst, %0[%ind, %ind] : memref<10x20xf32>
   dealloc %9 : memref<400xi8>
   dealloc %7 : memref<800xi8>
   dealloc %5 : memref<800xi8>
@@ -30,6 +30,7 @@ func @test_pool_bundling(%arg0: memref<10x10xf32>, %arg1: memref<10x20xf32>) -> 
 
   // CHECK-LABEL: test_pool_bundling
   // CHECK: [[CONST_0:%.+]] = constant 0 : i64
+  // CHECK-DAG: [[CONST_0_INDEX:%.+]] = constant 0 : index
   // CHECK: [[CONST_CST:%.+]] = constant 0.000000e+00 : f32
   // CHECK: [[CONST_2400:%.+]] = constant 2400 : i64
   // CHECK: [[CONST_2000:%.+]] = constant 2000 : i64
@@ -42,12 +43,12 @@ func @test_pool_bundling(%arg0: memref<10x10xf32>, %arg1: memref<10x20xf32>) -> 
   // CHECK: [[MEMREF3:%.+]] = "krnl.getref"([[MEMPOOL]], [[CONST_1200]]) : (memref<3200xi8>, i64) -> memref<10x20xf32>
   // CHECK: [[MEMREF4:%.+]] = "krnl.getref"([[MEMPOOL]], [[CONST_400]]) : (memref<3200xi8>, i64) -> memref<10x20xf32>
   // CHECK: [[MEMREF5:%.+]] = "krnl.getref"([[MEMPOOL]], [[CONST_0]]) : (memref<3200xi8>, i64) -> memref<10x10xf32>
-  // CHECK: affine.store %cst, [[MEMREF5]][0, 0] : memref<10x10xf32>
-  // CHECK: affine.store %cst, [[MEMREF4]][0, 0] : memref<10x20xf32>
-  // CHECK: affine.store %cst, [[MEMREF3]][0, 0] : memref<10x20xf32>
-  // CHECK: affine.store %cst, [[MEMREF2]][0, 0] : memref<10x10xf32>
-  // CHECK: affine.store %cst, [[MEMREF1]][0, 0] : memref<10x20xf32>
-  // CHECK: affine.store %cst, [[RES]][0, 0] : memref<10x20xf32>
+  // CHECK: krnl.store %cst, [[MEMREF5]]{{\[}}[[CONST_0_INDEX]], [[CONST_0_INDEX]]{{\]}} : memref<10x10xf32>
+  // CHECK: krnl.store %cst, [[MEMREF4]]{{\[}}[[CONST_0_INDEX]], [[CONST_0_INDEX]]{{\]}} : memref<10x20xf32>
+  // CHECK: krnl.store %cst, [[MEMREF3]]{{\[}}[[CONST_0_INDEX]], [[CONST_0_INDEX]]{{\]}} : memref<10x20xf32>
+  // CHECK: krnl.store %cst, [[MEMREF2]]{{\[}}[[CONST_0_INDEX]], [[CONST_0_INDEX]]{{\]}} : memref<10x10xf32>
+  // CHECK: krnl.store %cst, [[MEMREF1]]{{\[}}[[CONST_0_INDEX]], [[CONST_0_INDEX]]{{\]}} : memref<10x20xf32>
+  // CHECK: krnl.store %cst, [[RES]]{{\[}}[[CONST_0_INDEX]], [[CONST_0_INDEX]]{{\]}} : memref<10x20xf32>
   // CHECK: dealloc [[MEMPOOL]] : memref<3200xi8>
   // CHECK: return [[RES]] : memref<10x20xf32>
 }
@@ -76,9 +77,9 @@ func @test_dynamic_pool_bundling(%arg0: memref<?x?xf32>) -> memref<?x10xf32> {
   %12 = cmpi "eq", %0, %c1 : index
   %13 = cmpi "eq", %0, %c1 : index
   %15 = alloc(%0) : memref<?x10xf32>
-  affine.store %cst, %4[%ind, %ind] : memref<?x10xf32>
-  affine.store %cst, %11[%ind, %ind] : memref<?x10xf32>
-  affine.store %cst, %15[%ind, %ind] : memref<?x10xf32>
+  krnl.store %cst, %4[%ind, %ind] : memref<?x10xf32>
+  krnl.store %cst, %11[%ind, %ind] : memref<?x10xf32>
+  krnl.store %cst, %15[%ind, %ind] : memref<?x10xf32>
   dealloc %10 : memref<?xi8>
   dealloc %3 : memref<?xi8>
   return %15 : memref<?x10xf32>
@@ -100,9 +101,9 @@ func @test_dynamic_pool_bundling(%arg0: memref<?x?xf32>) -> memref<?x10xf32> {
   // CHECK: [[DATA1:%.+]] = "krnl.getref"([[DYN_MEMPOOL]], [[OFFSET1_I64]], [[DIM]]) : (memref<?xi8>, i64, index) -> memref<?x10xf32>
   // CHECK: [[DATA2:%.+]] = "krnl.getref"([[DYN_MEMPOOL]], [[C0_I64]], [[DIM]]) : (memref<?xi8>, i64, index) -> memref<?x10xf32>
   // CHECK: [[RES:%.+]] = alloc([[DIM]]) : memref<?x10xf32>
-  // CHECK: affine.store [[CST]], [[DATA1]][0, 0] : memref<?x10xf32>
-  // CHECK: affine.store [[CST]], [[DATA2]][0, 0] : memref<?x10xf32>
-  // CHECK: affine.store [[CST]], [[RES]][0, 0] : memref<?x10xf32>
+  // CHECK: krnl.store [[CST]], [[DATA1]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<?x10xf32>
+  // CHECK: krnl.store [[CST]], [[DATA2]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<?x10xf32>
+  // CHECK: krnl.store [[CST]], [[RES]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<?x10xf32>
   // CHECK: dealloc [[DYN_MEMPOOL]] : memref<?xi8>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
@@ -137,12 +138,12 @@ func @test_dynamic_and_static_pool_bundling(%arg0: memref<?x?xf32>, %arg1: memre
   %15 = alloc(%0) : memref<?x10xf32>
   %const_alloc3 = alloc() : memref<1600xi8>
   %const_ref3 = "krnl.getref"(%const_alloc3, %c0_i64) : (memref<1600xi8>, i64) -> memref<10x40xf32>
-  affine.store %cst, %4[%ind, %ind] : memref<?x10xf32>
-  affine.store %cst, %11[%ind, %ind] : memref<?x10xf32>
-  affine.store %cst, %15[%ind, %ind] : memref<?x10xf32>
-  affine.store %cst, %const_ref2[%ind, %ind] : memref<10x10xf32>
-  affine.store %cst, %const_ref1[%ind, %ind] : memref<10x20xf32>
-  affine.store %cst, %const_ref3[%ind, %ind] : memref<10x40xf32>
+  krnl.store %cst, %4[%ind, %ind] : memref<?x10xf32>
+  krnl.store %cst, %11[%ind, %ind] : memref<?x10xf32>
+  krnl.store %cst, %15[%ind, %ind] : memref<?x10xf32>
+  krnl.store %cst, %const_ref2[%ind, %ind] : memref<10x10xf32>
+  krnl.store %cst, %const_ref1[%ind, %ind] : memref<10x20xf32>
+  krnl.store %cst, %const_ref3[%ind, %ind] : memref<10x40xf32>
   dealloc %10 : memref<?xi8>
   dealloc %3 : memref<?xi8>
   dealloc %const_alloc1 : memref<800xi8>
@@ -173,12 +174,12 @@ func @test_dynamic_and_static_pool_bundling(%arg0: memref<?x?xf32>, %arg1: memre
   // CHECK: [[DATA1:%.+]] = "krnl.getref"([[DYN_MEMPOOL]], [[C0_I64]], [[DIM]]) : (memref<?xi8>, i64, index) -> memref<?x10xf32>
   // CHECK: [[RES:%.+]] = alloc([[DIM]]) : memref<?x10xf32>
   // CHECK: [[DATA5:%.+]] = "krnl.getref"([[STATIC_MEMPOOL]], [[C0_I64]]) : (memref<2800xi8>, i64) -> memref<10x40xf32>
-  // CHECK: affine.store [[CST]], [[DATA2]][0, 0] : memref<?x10xf32>
-  // CHECK: affine.store [[CST]], [[DATA1]][0, 0] : memref<?x10xf32>
-  // CHECK: affine.store [[CST]], [[RES]][0, 0] : memref<?x10xf32>
-  // CHECK: affine.store [[CST]], [[DATA4]][0, 0] : memref<10x10xf32>
-  // CHECK: affine.store [[CST]], [[DATA3]][0, 0] : memref<10x20xf32>
-  // CHECK: affine.store [[CST]], [[DATA5]][0, 0] : memref<10x40xf32>
+  // CHECK: krnl.store [[CST]], [[DATA2]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<?x10xf32>
+  // CHECK: krnl.store [[CST]], [[DATA1]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<?x10xf32>
+  // CHECK: krnl.store [[CST]], [[RES]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<?x10xf32>
+  // CHECK: krnl.store [[CST]], [[DATA4]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<10x10xf32>
+  // CHECK: krnl.store [[CST]], [[DATA3]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<10x20xf32>
+  // CHECK: krnl.store [[CST]], [[DATA5]]{{\[}}[[C0]], [[C0]]{{\]}} : memref<10x40xf32>
   // CHECK: dealloc [[DYN_MEMPOOL]] : memref<?xi8>
   // CHECK: dealloc [[STATIC_MEMPOOL]] : memref<2800xi8>
   // CHECK: return [[RES]] : memref<?x10xf32>
@@ -190,6 +191,7 @@ func @test_dynamic_and_static_pool_bundling(%arg0: memref<?x?xf32>, %arg1: memre
 func @static_mem_pool_rnn_subblock(%arg0: memref<1x3x2xf32>, %arg1: memref<1x4x2xf32>, %arg2: memref<1x4x4xf32>) -> memref<1x3x4xf32> attributes {input_names = ["X", "W", "R"], output_names = ["Y"]} {
   %cst = constant 0.000000e+00 : f32
   %c0_i64 = constant 0 : i64
+  %c0 = constant 0 : index
   %0 = alloc() : memref<1x3x4xf32>
   %2 = krnl.define_loops 1
   krnl.iterate(%2) with (%2 -> %arg3 = 0 to 1) {
@@ -197,43 +199,43 @@ func @static_mem_pool_rnn_subblock(%arg0: memref<1x3x2xf32>, %arg1: memref<1x4x2
     krnl.iterate(%3#0, %3#1) with (%3#0 -> %arg4 = 0 to 3, %3#1 -> %arg5 = 0 to 4) {
       %4 = alloc() : memref<4xi8>
       %5 = "krnl.getref"(%4, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-      %6 = affine.load %0[0, symbol(%arg4), symbol(%arg5)] : memref<1x3x4xf32>
+      %6 = krnl.load %0[%c0, %arg4, %arg5] : memref<1x3x4xf32>
       %7 = alloc() : memref<4xi8>
       %8 = "krnl.getref"(%7, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-      affine.store %cst, %8[] : memref<f32>
+      krnl.store %cst, %8[] : memref<f32>
       %9 = alloc() : memref<4xi8>
       %10 = "krnl.getref"(%9, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-      affine.store %cst, %10[] : memref<f32>
+      krnl.store %cst, %10[] : memref<f32>
       %11 = krnl.define_loops 1
       krnl.iterate(%11) with (%11 -> %arg6 = 0 to 2) {
-        %25 = affine.load %arg0[symbol(%arg3), symbol(%arg4), symbol(%arg6)] : memref<1x3x2xf32>
-        %26 = affine.load %arg1[0, symbol(%arg5), symbol(%arg6)] : memref<1x4x2xf32>
+        %25 = krnl.load %arg0[%arg3, %arg4, %arg6] : memref<1x3x2xf32>
+        %26 = krnl.load %arg1[%c0, %arg5, %arg6] : memref<1x4x2xf32>
         %27 = mulf %25, %26 : f32
-        %28 = affine.load %8[] : memref<f32>
+        %28 = krnl.load %8[] : memref<f32>
         %29 = addf %28, %27 : f32
-        affine.store %29, %8[] : memref<f32>
-        %30 = affine.load %arg2[0, symbol(%arg5), symbol(%arg6)] : memref<1x4x4xf32>
+        krnl.store %29, %8[] : memref<f32>
+        %30 = krnl.load %arg2[%c0, %arg5, %arg6] : memref<1x4x4xf32>
         %31 = mulf %6, %30 : f32
-        %32 = affine.load %10[] : memref<f32>
+        %32 = krnl.load %10[] : memref<f32>
         %33 = addf %32, %31 : f32
-        affine.store %33, %10[] : memref<f32>
+        krnl.store %33, %10[] : memref<f32>
       }
-      %12 = affine.load %8[] : memref<f32>
-      %13 = affine.load %10[] : memref<f32>
+      %12 = krnl.load %8[] : memref<f32>
+      %13 = krnl.load %10[] : memref<f32>
       %14 = addf %12, %13 : f32
       %15 = alloc() : memref<4xi8>
       %16 = "krnl.getref"(%15, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-      affine.store %14, %16[] : memref<f32>
-      %17 = affine.load %16[] : memref<f32>
+      krnl.store %14, %16[] : memref<f32>
+      %17 = krnl.load %16[] : memref<f32>
       %18 = subf %cst, %17 : f32
       %19 = exp %17 : f32
       %20 = exp %18 : f32
       %21 = subf %19, %20 : f32
       %22 = addf %19, %20 : f32
       %23 = divf %21, %22 : f32
-      affine.store %23, %5[] : memref<f32>
-      %24 = affine.load %5[] : memref<f32>
-      affine.store %24, %0[0, symbol(%arg4), symbol(%arg5)] : memref<1x3x4xf32>
+      krnl.store %23, %5[] : memref<f32>
+      %24 = krnl.load %5[] : memref<f32>
+      krnl.store %24, %0[%c0, %arg4, %arg5] : memref<1x3x4xf32>
       dealloc %15 : memref<4xi8>
       dealloc %9 : memref<4xi8>
       dealloc %7 : memref<4xi8>
@@ -255,11 +257,11 @@ func @static_mem_pool_rnn_subblock(%arg0: memref<1x3x2xf32>, %arg1: memref<1x4x2
   // CHECK: krnl.iterate
   // CHECK: [[STATIC_MEM_POOL:%.+]] = alloc() : memref<16xi8>
   // CHECK: [[REF1:%.+]] = "krnl.getref"([[STATIC_MEM_POOL]], [[C12]]) : (memref<16xi8>, i64) -> memref<f32>
-  // CHECK: affine.load
+  // CHECK: krnl.load
   // CHECK: [[REF2:%.+]] = "krnl.getref"([[STATIC_MEM_POOL]], [[C8]]) : (memref<16xi8>, i64) -> memref<f32>
-  // CHECK: affine.store
+  // CHECK: krnl.store
   // CHECK: [[REF3:%.+]] = "krnl.getref"([[STATIC_MEM_POOL]], [[C4]]) : (memref<16xi8>, i64) -> memref<f32>
-  // CHECK: affine.store
+  // CHECK: krnl.store
   // CHECK: krnl.define_loops 1
   // CHECK: krnl.iterate
   // CHECK: [[REF4:%.+]] = "krnl.getref"([[STATIC_MEM_POOL]], [[C0]]) : (memref<16xi8>, i64) -> memref<f32>
@@ -273,6 +275,7 @@ func @static_mem_pool_rnn_subblock(%arg0: memref<1x3x2xf32>, %arg1: memref<1x4x2
 func @static_mem_pool_rnn_sub_and_main_block(%arg0: memref<1x3x2xf32>, %arg1: memref<1x4x2xf32>, %arg2: memref<1x4x4xf32>) -> memref<1x3x4xf32> attributes {input_names = ["X", "W", "R"], output_names = ["Y"]} {
   %cst = constant 0.000000e+00 : f32
   %c0_i64 = constant 0 : i64
+  %c0 = constant 0 : index 
   %0 = alloc() : memref<1x3x4xf32>
   %mem0 = alloc() : memref<4xi8>
   %ref0 = "krnl.getref"(%mem0, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
@@ -284,45 +287,45 @@ func @static_mem_pool_rnn_sub_and_main_block(%arg0: memref<1x3x2xf32>, %arg1: me
     krnl.iterate(%3#0, %3#1) with (%3#0 -> %arg4 = 0 to 3, %3#1 -> %arg5 = 0 to 4) {
       %4 = alloc() : memref<4xi8>
       %5 = "krnl.getref"(%4, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-      %6 = affine.load %0[0, symbol(%arg4), symbol(%arg5)] : memref<1x3x4xf32>
+      %6 = krnl.load %0[%c0, %arg4, %arg5] : memref<1x3x4xf32>
       %7 = alloc() : memref<4xi8>
       %8 = "krnl.getref"(%7, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-      affine.store %cst, %8[] : memref<f32>
+      krnl.store %cst, %8[] : memref<f32>
       %9 = alloc() : memref<4xi8>
       %10 = "krnl.getref"(%9, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-      affine.store %cst, %10[] : memref<f32>
+      krnl.store %cst, %10[] : memref<f32>
       %11 = krnl.define_loops 1
       krnl.iterate(%11) with (%11 -> %arg6 = 0 to 2) {
-        %25 = affine.load %arg0[symbol(%arg3), symbol(%arg4), symbol(%arg6)] : memref<1x3x2xf32>
-        %26 = affine.load %arg1[0, symbol(%arg5), symbol(%arg6)] : memref<1x4x2xf32>
+        %25 = krnl.load %arg0[%arg3, %arg4, %arg6] : memref<1x3x2xf32>
+        %26 = krnl.load %arg1[%c0, %arg5, %arg6] : memref<1x4x2xf32>
         %27 = mulf %25, %26 : f32
-        %28 = affine.load %8[] : memref<f32>
+        %28 = krnl.load %8[] : memref<f32>
         %29 = addf %28, %27 : f32
-        affine.store %29, %8[] : memref<f32>
-        %30 = affine.load %arg2[0, symbol(%arg5), symbol(%arg6)] : memref<1x4x4xf32>
+        krnl.store %29, %8[] : memref<f32>
+        %30 = krnl.load %arg2[%c0, %arg5, %arg6] : memref<1x4x4xf32>
         %31 = mulf %6, %30 : f32
-        %32 = affine.load %10[] : memref<f32>
+        %32 = krnl.load %10[] : memref<f32>
         %33 = addf %32, %31 : f32
-        affine.store %33, %10[] : memref<f32>
-        affine.store %33, %ref0[] : memref<f32>
+        krnl.store %33, %10[] : memref<f32>
+        krnl.store %33, %ref0[] : memref<f32>
       }
-      %12 = affine.load %8[] : memref<f32>
-      %13 = affine.load %10[] : memref<f32>
+      %12 = krnl.load %8[] : memref<f32>
+      %13 = krnl.load %10[] : memref<f32>
       %14 = addf %12, %13 : f32
       %15 = alloc() : memref<4xi8>
       %16 = "krnl.getref"(%15, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-      affine.store %14, %16[] : memref<f32>
-      %17 = affine.load %16[] : memref<f32>
+      krnl.store %14, %16[] : memref<f32>
+      %17 = krnl.load %16[] : memref<f32>
       %18 = subf %cst, %17 : f32
       %19 = exp %17 : f32
       %20 = exp %18 : f32
       %21 = subf %19, %20 : f32
       %22 = addf %19, %20 : f32
       %23 = divf %21, %22 : f32
-      affine.store %23, %5[] : memref<f32>
-      %24 = affine.load %5[] : memref<f32>
-      affine.store %24, %0[0, symbol(%arg4), symbol(%arg5)] : memref<1x3x4xf32>
-      affine.store %24, %ref1[] : memref<f32>
+      krnl.store %23, %5[] : memref<f32>
+      %24 = krnl.load %5[] : memref<f32>
+      krnl.store %24, %0[%c0, %arg4, %arg5] : memref<1x3x4xf32>
+      krnl.store %24, %ref1[] : memref<f32>
       dealloc %15 : memref<4xi8>
       dealloc %9 : memref<4xi8>
       dealloc %7 : memref<4xi8>
@@ -331,8 +334,8 @@ func @static_mem_pool_rnn_sub_and_main_block(%arg0: memref<1x3x2xf32>, %arg1: me
   }
   %mem2 = alloc() : memref<4xi8>
   %ref2 = "krnl.getref"(%mem2, %c0_i64) : (memref<4xi8>, i64) -> memref<f32>
-  %val = affine.load %ref1[] : memref<f32>
-  affine.store %val, %ref2[] : memref<f32>
+  %val = krnl.load %ref1[] : memref<f32>
+  krnl.store %val, %ref2[] : memref<f32>
   dealloc %mem2 : memref<4xi8>
   dealloc %mem1 : memref<4xi8>
   dealloc %mem0 : memref<4xi8>
@@ -354,18 +357,18 @@ func @static_mem_pool_rnn_sub_and_main_block(%arg0: memref<1x3x2xf32>, %arg1: me
   // CHECK: krnl.iterate
   // CHECK: [[STATIC_MEM_POOL:%.+]] = alloc() : memref<16xi8>
   // CHECK: [[REF1:%.+]] = "krnl.getref"([[STATIC_MEM_POOL]], [[C12]]) : (memref<16xi8>, i64) -> memref<f32>
-  // CHECK: affine.load
+  // CHECK: krnl.load
   // CHECK: [[REF2:%.+]] = "krnl.getref"([[STATIC_MEM_POOL]], [[C8]]) : (memref<16xi8>, i64) -> memref<f32>
-  // CHECK: affine.store
+  // CHECK: krnl.store
   // CHECK: [[REF3:%.+]] = "krnl.getref"([[STATIC_MEM_POOL]], [[C4]]) : (memref<16xi8>, i64) -> memref<f32>
-  // CHECK: affine.store
+  // CHECK: krnl.store
   // CHECK: krnl.define_loops 1
   // CHECK: krnl.iterate
   // CHECK: [[REF4:%.+]] = "krnl.getref"([[STATIC_MEM_POOL]], [[C0]]) : (memref<16xi8>, i64) -> memref<f32>
   // CHECK: dealloc [[STATIC_MEM_POOL]] : memref<16xi8>
   // CHECK: [[MAIN_REF_2:%.+]] = "krnl.getref"([[STATIC_MEM_POOL_MAIN]], [[C0]]) : (memref<12xi8>, i64) -> memref<f32>
-  // CHECK: [[LOAD:%.+]] = affine.load [[MAIN_REF_1]][] : memref<f32>
-  // CHECK: affine.store [[LOAD]], [[MAIN_REF_2]][] : memref<f32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[MAIN_REF_1]][] : memref<f32>
+  // CHECK: krnl.store [[LOAD]], [[MAIN_REF_2]][] : memref<f32>
   // CHECK: dealloc [[STATIC_MEM_POOL_MAIN]] : memref<12xi8>
   // CHECK: return [[RES]] : memref<1x3x4xf32>
 }
@@ -376,12 +379,13 @@ func @static_mem_pool_rnn_sub_and_main_block(%arg0: memref<1x3x2xf32>, %arg1: me
 func @test_dynamic_pool_rnn(%arg0: memref<1x3x2xf32>, %arg1: memref<1x4x2xf32>, %arg2: memref<1x?x?xf32>) -> memref<1x3x?xf32> attributes {input_names = ["X", "W", "R"], output_names = ["Y"]} {
   %cst = constant 0.000000e+00 : f32
   %c0_i64 = constant 0 : i64
+  %c0 = constant 0 : index
   %c_ind = constant 1 : index
   %dim0 = dim %arg1, %c_ind : memref<1x4x2xf32>
   %0 = alloc(%dim0) : memref<1x3x?xf32>
   %1:3 = krnl.define_loops 3
   krnl.iterate(%1#0, %1#1, %1#2) with (%1#0 -> %arg3 = 0 to 1, %1#1 -> %arg4 = 0 to 3, %1#2 -> %arg5 = 0 to 4) {
-    affine.store %cst, %0[symbol(%arg3), symbol(%arg4), symbol(%arg5)] : memref<1x3x?xf32>
+    krnl.store %cst, %0[%arg3, %arg4, %arg5] : memref<1x3x?xf32>
   }
   %2 = krnl.define_loops 1
   krnl.iterate(%2) with (%2 -> %arg3 = 0 to 1) {
@@ -390,45 +394,45 @@ func @test_dynamic_pool_rnn(%arg0: memref<1x3x2xf32>, %arg1: memref<1x4x2xf32>, 
       %dim1 = dim %arg2, %c_ind : memref<1x?x?xf32>
       %4 = alloc(%dim1) : memref<?xi8>
       %5 = "krnl.getref"(%4, %c0_i64) : (memref<?xi8>, i64) -> memref<f32>
-      %6 = affine.load %0[0, symbol(%arg4), symbol(%arg5)] : memref<1x3x?xf32>
+      %6 = krnl.load %0[%c0, %arg4, %arg5] : memref<1x3x?xf32>
       %7 = alloc(%dim1) : memref<?xi8>
       %8 = "krnl.getref"(%7, %c0_i64) : (memref<?xi8>, i64) -> memref<f32>
-      affine.store %cst, %8[] : memref<f32>
+      krnl.store %cst, %8[] : memref<f32>
       %c_ind_2 = constant 2 : index
       %dim2 = dim %arg2, %c_ind_2 : memref<1x?x?xf32>
       %9 = alloc(%dim2) : memref<?xi8>
       %10 = "krnl.getref"(%9, %c0_i64) : (memref<?xi8>, i64) -> memref<f32>
-      affine.store %cst, %10[] : memref<f32>
+      krnl.store %cst, %10[] : memref<f32>
       %11 = krnl.define_loops 1
       krnl.iterate(%11) with (%11 -> %arg6 = 0 to 2) {
-        %25 = affine.load %arg0[symbol(%arg3), symbol(%arg4), symbol(%arg6)] : memref<1x3x2xf32>
-        %26 = affine.load %arg1[0, symbol(%arg5), symbol(%arg6)] : memref<1x4x2xf32>
+        %25 = krnl.load %arg0[%arg3, %arg4, %arg6] : memref<1x3x2xf32>
+        %26 = krnl.load %arg1[%c0, %arg5, %arg6] : memref<1x4x2xf32>
         %27 = mulf %25, %26 : f32
-        %28 = affine.load %8[] : memref<f32>
+        %28 = krnl.load %8[] : memref<f32>
         %29 = addf %28, %27 : f32
-        affine.store %29, %8[] : memref<f32>
-        %30 = affine.load %arg2[0, symbol(%arg5), symbol(%arg6)] : memref<1x?x?xf32>
+        krnl.store %29, %8[] : memref<f32>
+        %30 = krnl.load %arg2[%c0, %arg5, %arg6] : memref<1x?x?xf32>
         %31 = mulf %6, %30 : f32
-        %32 = affine.load %10[] : memref<f32>
+        %32 = krnl.load %10[] : memref<f32>
         %33 = addf %32, %31 : f32
-        affine.store %33, %10[] : memref<f32>
+        krnl.store %33, %10[] : memref<f32>
       }
-      %12 = affine.load %8[] : memref<f32>
-      %13 = affine.load %10[] : memref<f32>
+      %12 = krnl.load %8[] : memref<f32>
+      %13 = krnl.load %10[] : memref<f32>
       %14 = addf %12, %13 : f32
       %15 = alloc(%dim2) : memref<?xi8>
       %16 = "krnl.getref"(%15, %c0_i64) : (memref<?xi8>, i64) -> memref<f32>
-      affine.store %14, %16[] : memref<f32>
-      %17 = affine.load %16[] : memref<f32>
+      krnl.store %14, %16[] : memref<f32>
+      %17 = krnl.load %16[] : memref<f32>
       %18 = subf %cst, %17 : f32
       %19 = exp %17 : f32
       %20 = exp %18 : f32
       %21 = subf %19, %20 : f32
       %22 = addf %19, %20 : f32
       %23 = divf %21, %22 : f32
-      affine.store %23, %5[] : memref<f32>
-      %24 = affine.load %5[] : memref<f32>
-      affine.store %24, %0[0, symbol(%arg4), symbol(%arg5)] : memref<1x3x?xf32>
+      krnl.store %23, %5[] : memref<f32>
+      %24 = krnl.load %5[] : memref<f32>
+      krnl.store %24, %0[%c0, %arg4, %arg5] : memref<1x3x?xf32>
       dealloc %15 : memref<?xi8>
       dealloc %9 : memref<?xi8>
       dealloc %7 : memref<?xi8>
@@ -455,11 +459,11 @@ func @test_dynamic_pool_rnn(%arg0: memref<1x3x2xf32>, %arg1: memref<1x4x2xf32>, 
   // CHECK: [[OFFSET3:%.+]] = index_cast [[ADD2]] : index to i64
   // CHECK: [[DYNAMIC_MEMORY_POOL:%.+]] = alloc([[ADD3]]) : memref<?xi8>
   // CHECK: [[DATA2:%.+]] = "krnl.getref"([[DYNAMIC_MEMORY_POOL]], [[OFFSET3]]) : (memref<?xi8>, i64) -> memref<f32>
-  // CHECK: affine.load
+  // CHECK: krnl.load
   // CHECK: [[DATA3:%.+]] = "krnl.getref"([[DYNAMIC_MEMORY_POOL]], [[OFFSET2]]) : (memref<?xi8>, i64) -> memref<f32>
-  // CHECK: affine.store
+  // CHECK: krnl.store
   // CHECK: [[DATA4:%.+]] = "krnl.getref"([[DYNAMIC_MEMORY_POOL]], [[OFFSET1]]) : (memref<?xi8>, i64) -> memref<f32>
-  // CHECK: affine.store
+  // CHECK: krnl.store
   // CHECK: krnl.define_loops
   // CHECK: krnl.iterate
   // CHECK: [[DATA1:%.+]] = "krnl.getref"([[DYNAMIC_MEMORY_POOL]], [[C0]]) : (memref<?xi8>, i64) -> memref<f32>

--- a/test/mlir/krnl/krnl_optimize_memory_pool.mlir
+++ b/test/mlir/krnl/krnl_optimize_memory_pool.mlir
@@ -17,63 +17,63 @@ func @single_chain_dataflow(%arg0: memref<10x10xf32>, %arg1: memref<10x10xf32>) 
   %6 = "krnl.getref"(%1, %c0_i64) : (memref<2000xi8>, i64) -> memref<10x10xf32>
   %7:2 = krnl.define_loops 2
   krnl.iterate(%7#0, %7#1) with (%7#0 -> %arg2 = 0 to 10, %7#1 -> %arg3 = 0 to 10) {
-    affine.store %cst, %6[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %cst, %6[%arg2, %arg3] : memref<10x10xf32>
     %13 = krnl.define_loops 1
     krnl.iterate(%13) with (%13 -> %arg4 = 0 to 10) {
-      %14 = affine.load %arg0[symbol(%arg2), symbol(%arg4)] : memref<10x10xf32>
-      %15 = affine.load %arg1[symbol(%arg4), symbol(%arg3)] : memref<10x10xf32>
-      %16 = affine.load %6[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      %14 = krnl.load %arg0[%arg2, %arg4] : memref<10x10xf32>
+      %15 = krnl.load %arg1[%arg4, %arg3] : memref<10x10xf32>
+      %16 = krnl.load %6[%arg2, %arg3] : memref<10x10xf32>
       %17 = mulf %14, %15 : f32
       %18 = addf %16, %17 : f32
-      affine.store %18, %6[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      krnl.store %18, %6[%arg2, %arg3] : memref<10x10xf32>
     }
   }
   %8:2 = krnl.define_loops 2
   krnl.iterate(%8#0, %8#1) with (%8#0 -> %arg2 = 0 to 10, %8#1 -> %arg3 = 0 to 10) {
-    %13 = affine.load %arg0[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
-    %14 = affine.load %6[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    %13 = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+    %14 = krnl.load %6[%arg2, %arg3] : memref<10x10xf32>
     %15 = addf %13, %14 : f32
-    affine.store %15, %5[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %15, %5[%arg2, %arg3] : memref<10x10xf32>
   }
   %9:2 = krnl.define_loops 2
   krnl.iterate(%9#0, %9#1) with (%9#0 -> %arg2 = 0 to 10, %9#1 -> %arg3 = 0 to 10) {
-    affine.store %cst, %4[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %cst, %4[%arg2, %arg3] : memref<10x10xf32>
     %13 = krnl.define_loops 1
     krnl.iterate(%13) with (%13 -> %arg4 = 0 to 10) {
-      %14 = affine.load %arg0[symbol(%arg2), symbol(%arg4)] : memref<10x10xf32>
-      %15 = affine.load %5[symbol(%arg4), symbol(%arg3)] : memref<10x10xf32>
-      %16 = affine.load %4[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      %14 = krnl.load %arg0[%arg2, %arg4] : memref<10x10xf32>
+      %15 = krnl.load %5[%arg4, %arg3] : memref<10x10xf32>
+      %16 = krnl.load %4[%arg2, %arg3] : memref<10x10xf32>
       %17 = mulf %14, %15 : f32
       %18 = addf %16, %17 : f32
-      affine.store %18, %4[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      krnl.store %18, %4[%arg2, %arg3] : memref<10x10xf32>
     }
   }
   %10:2 = krnl.define_loops 2
   krnl.iterate(%10#0, %10#1) with (%10#0 -> %arg2 = 0 to 10, %10#1 -> %arg3 = 0 to 10) {
-    %13 = affine.load %4[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
-    %14 = affine.load %arg1[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    %13 = krnl.load %4[%arg2, %arg3] : memref<10x10xf32>
+    %14 = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
     %15 = addf %13, %14 : f32
-    affine.store %15, %3[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %15, %3[%arg2, %arg3] : memref<10x10xf32>
   }
   %11:2 = krnl.define_loops 2
   krnl.iterate(%11#0, %11#1) with (%11#0 -> %arg2 = 0 to 10, %11#1 -> %arg3 = 0 to 10) {
-    affine.store %cst, %2[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %cst, %2[%arg2, %arg3] : memref<10x10xf32>
     %13 = krnl.define_loops 1
     krnl.iterate(%13) with (%13 -> %arg4 = 0 to 10) {
-      %14 = affine.load %arg0[symbol(%arg2), symbol(%arg4)] : memref<10x10xf32>
-      %15 = affine.load %3[symbol(%arg4), symbol(%arg3)] : memref<10x10xf32>
-      %16 = affine.load %2[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      %14 = krnl.load %arg0[%arg2, %arg4] : memref<10x10xf32>
+      %15 = krnl.load %3[%arg4, %arg3] : memref<10x10xf32>
+      %16 = krnl.load %2[%arg2, %arg3] : memref<10x10xf32>
       %17 = mulf %14, %15 : f32
       %18 = addf %16, %17 : f32
-      affine.store %18, %2[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      krnl.store %18, %2[%arg2, %arg3] : memref<10x10xf32>
     }
   }
   %12:2 = krnl.define_loops 2
   krnl.iterate(%12#0, %12#1) with (%12#0 -> %arg2 = 0 to 10, %12#1 -> %arg3 = 0 to 10) {
-    %13 = affine.load %2[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
-    %14 = affine.load %arg1[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    %13 = krnl.load %2[%arg2, %arg3] : memref<10x10xf32>
+    %14 = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
     %15 = addf %13, %14 : f32
-    affine.store %15, %0[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %15, %0[%arg2, %arg3] : memref<10x10xf32>
   }
   dealloc %1 : memref<2000xi8>
   return %0 : memref<10x10xf32>
@@ -112,73 +112,73 @@ func @multiple_shaped_memrefs(%arg0: memref<10x5xf32>, %arg1: memref<5x5xf32>, %
     %8 = "krnl.getref"(%1, %c0_i64) : (memref<1400xi8>, i64) -> memref<10x5xf32>
     %9:2 = krnl.define_loops 2
     krnl.iterate(%9#0, %9#1) with (%9#0 -> %arg3 = 0 to 10, %9#1 -> %arg4 = 0 to 5) {
-      affine.store %cst, %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %cst, %8[%arg3, %arg4] : memref<10x5xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 5) {
-        %18 = affine.load %arg0[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
-        %19 = affine.load %arg1[symbol(%arg5), symbol(%arg4)] : memref<5x5xf32>
-        %20 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        %18 = krnl.load %arg0[%arg3, %arg5] : memref<10x5xf32>
+        %19 = krnl.load %arg1[%arg5, %arg4] : memref<5x5xf32>
+        %20 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        krnl.store %22, %8[%arg3, %arg4] : memref<10x5xf32>
       }
     }
     %10:2 = krnl.define_loops 2
     krnl.iterate(%10#0, %10#1) with (%10#0 -> %arg3 = 0 to 10, %10#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %7[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %7[%arg3, %arg4] : memref<10x5xf32>
     }
     %11:2 = krnl.define_loops 2
     krnl.iterate(%11#0, %11#1) with (%11#0 -> %arg3 = 0 to 10, %11#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %7[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      affine.store %17, %6[symbol(%arg4), symbol(%arg3)] : memref<5x10xf32>
+      %17 = krnl.load %7[%arg3, %arg4] : memref<10x5xf32>
+      krnl.store %17, %6[%arg4, %arg3] : memref<5x10xf32>
     }
     %12:2 = krnl.define_loops 2
     krnl.iterate(%12#0, %12#1) with (%12#0 -> %arg3 = 0 to 5, %12#1 -> %arg4 = 0 to 10) {
-      affine.store %cst, %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+      krnl.store %cst, %5[%arg3, %arg4] : memref<5x10xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 10) {
-        %18 = affine.load %6[symbol(%arg3), symbol(%arg5)] : memref<5x10xf32>
-        %19 = affine.load %arg2[symbol(%arg5), symbol(%arg4)] : memref<10x10xf32>
-        %20 = affine.load %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+        %18 = krnl.load %6[%arg3, %arg5] : memref<5x10xf32>
+        %19 = krnl.load %arg2[%arg5, %arg4] : memref<10x10xf32>
+        %20 = krnl.load %5[%arg3, %arg4] : memref<5x10xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+        krnl.store %22, %5[%arg3, %arg4] : memref<5x10xf32>
       }
     }
     %13:2 = krnl.define_loops 2
     krnl.iterate(%13#0, %13#1) with (%13#0 -> %arg3 = 0 to 5, %13#1 -> %arg4 = 0 to 10) {
-      %17 = affine.load %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
-      affine.store %17, %4[symbol(%arg4), symbol(%arg3)] : memref<10x5xf32>
+      %17 = krnl.load %5[%arg3, %arg4] : memref<5x10xf32>
+      krnl.store %17, %4[%arg4, %arg3] : memref<10x5xf32>
     }
     %14:2 = krnl.define_loops 2
     krnl.iterate(%14#0, %14#1) with (%14#0 -> %arg3 = 0 to 10, %14#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %4[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %4[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %3[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %3[%arg3, %arg4] : memref<10x5xf32>
     }
     %15:2 = krnl.define_loops 2
     krnl.iterate(%15#0, %15#1) with (%15#0 -> %arg3 = 0 to 10, %15#1 -> %arg4 = 0 to 5) {
-      affine.store %cst, %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %cst, %2[%arg3, %arg4] : memref<10x5xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 5) {
-        %18 = affine.load %3[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
-        %19 = affine.load %arg1[symbol(%arg5), symbol(%arg4)] : memref<5x5xf32>
-        %20 = affine.load %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        %18 = krnl.load %3[%arg3, %arg5] : memref<10x5xf32>
+        %19 = krnl.load %arg1[%arg5, %arg4] : memref<5x5xf32>
+        %20 = krnl.load %2[%arg3, %arg4] : memref<10x5xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        krnl.store %22, %2[%arg3, %arg4] : memref<10x5xf32>
       }
     }
     %16:2 = krnl.define_loops 2
     krnl.iterate(%16#0, %16#1) with (%16#0 -> %arg3 = 0 to 10, %16#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %2[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %0[%arg3, %arg4] : memref<10x5xf32>
     }
     dealloc %1 : memref<1400xi8>
     return %0 : memref<10x5xf32>
@@ -219,65 +219,65 @@ func @analysis_krnl_memcpy(%arg0: memref<10x5xf32>, %arg1: memref<5x5xf32>, %arg
     %8 = "krnl.getref"(%1, %c0_i64) : (memref<1400xi8>, i64) -> memref<10x5xf32>
     %9:2 = krnl.define_loops 2
     krnl.iterate(%9#0, %9#1) with (%9#0 -> %arg3 = 0 to 10, %9#1 -> %arg4 = 0 to 5) {
-      affine.store %cst, %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %cst, %8[%arg3, %arg4] : memref<10x5xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 5) {
-        %18 = affine.load %arg0[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
-        %19 = affine.load %arg1[symbol(%arg5), symbol(%arg4)] : memref<5x5xf32>
-        %20 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        %18 = krnl.load %arg0[%arg3, %arg5] : memref<10x5xf32>
+        %19 = krnl.load %arg1[%arg5, %arg4] : memref<5x5xf32>
+        %20 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        krnl.store %22, %8[%arg3, %arg4] : memref<10x5xf32>
       }
     }
     %10:2 = krnl.define_loops 2
     krnl.iterate(%10#0, %10#1) with (%10#0 -> %arg3 = 0 to 10, %10#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %7[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %7[%arg3, %arg4] : memref<10x5xf32>
     }
     "krnl.memcpy"(%6, %7, %c200_i64) : (memref<5x10xf32>, memref<10x5xf32>, i64) -> ()
     %12:2 = krnl.define_loops 2
     krnl.iterate(%12#0, %12#1) with (%12#0 -> %arg3 = 0 to 5, %12#1 -> %arg4 = 0 to 10) {
-      affine.store %cst, %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+      krnl.store %cst, %5[%arg3, %arg4] : memref<5x10xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 10) {
-        %18 = affine.load %6[symbol(%arg3), symbol(%arg5)] : memref<5x10xf32>
-        %19 = affine.load %arg2[symbol(%arg5), symbol(%arg4)] : memref<10x10xf32>
-        %20 = affine.load %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+        %18 = krnl.load %6[%arg3, %arg5] : memref<5x10xf32>
+        %19 = krnl.load %arg2[%arg5, %arg4] : memref<10x10xf32>
+        %20 = krnl.load %5[%arg3, %arg4] : memref<5x10xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+        krnl.store %22, %5[%arg3, %arg4] : memref<5x10xf32>
       }
     }
     "krnl.memcpy"(%4, %5, %c200_i64) : (memref<10x5xf32>, memref<5x10xf32>, i64) -> ()
     %14:2 = krnl.define_loops 2
     krnl.iterate(%14#0, %14#1) with (%14#0 -> %arg3 = 0 to 10, %14#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %4[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %4[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %3[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %3[%arg3, %arg4] : memref<10x5xf32>
     }
     %15:2 = krnl.define_loops 2
     krnl.iterate(%15#0, %15#1) with (%15#0 -> %arg3 = 0 to 10, %15#1 -> %arg4 = 0 to 5) {
-      affine.store %cst, %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %cst, %2[%arg3, %arg4] : memref<10x5xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 5) {
-        %18 = affine.load %3[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
-        %19 = affine.load %arg1[symbol(%arg5), symbol(%arg4)] : memref<5x5xf32>
-        %20 = affine.load %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        %18 = krnl.load %3[%arg3, %arg5] : memref<10x5xf32>
+        %19 = krnl.load %arg1[%arg5, %arg4] : memref<5x5xf32>
+        %20 = krnl.load %2[%arg3, %arg4] : memref<10x5xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        krnl.store %22, %2[%arg3, %arg4] : memref<10x5xf32>
       }
     }
     %16:2 = krnl.define_loops 2
     krnl.iterate(%16#0, %16#1) with (%16#0 -> %arg3 = 0 to 10, %16#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %2[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %0[%arg3, %arg4] : memref<10x5xf32>
     }
     dealloc %1 : memref<1400xi8>
     return %0 : memref<10x5xf32>
@@ -321,70 +321,70 @@ func @analysis_krnl_memcpy(%arg0: memref<10x5xf32>, %arg1: memref<5x5xf32>, %arg
     %8 = "krnl.getref"(%1, %c0_i64) : (memref<1400xi8>, i64) -> memref<10x5xf32>
     %9:2 = krnl.define_loops 2
     krnl.iterate(%9#0, %9#1) with (%9#0 -> %arg3 = 0 to 10, %9#1 -> %arg4 = 0 to 5) {
-      affine.store %cst, %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %cst, %8[%arg3, %arg4] : memref<10x5xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 5) {
-        %18 = affine.load %arg0[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
-        %19 = affine.load %arg1[symbol(%arg5), symbol(%arg4)] : memref<5x5xf32>
-        %20 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        %18 = krnl.load %arg0[%arg3, %arg5] : memref<10x5xf32>
+        %19 = krnl.load %arg1[%arg5, %arg4] : memref<5x5xf32>
+        %20 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        krnl.store %22, %8[%arg3, %arg4] : memref<10x5xf32>
       }
     }
     %10:2 = krnl.define_loops 2
     krnl.iterate(%10#0, %10#1) with (%10#0 -> %arg3 = 0 to 10, %10#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %7[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %7[%arg3, %arg4] : memref<10x5xf32>
     }
     "krnl.memcpy"(%6, %7, %c200_i64) : (memref<5x10xf32>, memref<10x5xf32>, i64) -> ()
     %12:2 = krnl.define_loops 2
     krnl.iterate(%12#0, %12#1) with (%12#0 -> %arg3 = 0 to 5, %12#1 -> %arg4 = 0 to 10) {
-      affine.store %cst, %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+      krnl.store %cst, %5[%arg3, %arg4] : memref<5x10xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 10) {
-        %18 = affine.load %6[symbol(%arg3), symbol(%arg5)] : memref<5x10xf32>
-        %19 = affine.load %arg2[symbol(%arg5), symbol(%arg4)] : memref<10x10xf32>
-        %20 = affine.load %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+        %18 = krnl.load %6[%arg3, %arg5] : memref<5x10xf32>
+        %19 = krnl.load %arg2[%arg5, %arg4] : memref<10x10xf32>
+        %20 = krnl.load %5[%arg3, %arg4] : memref<5x10xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+        krnl.store %22, %5[%arg3, %arg4] : memref<5x10xf32>
       }
     }
     "krnl.memcpy"(%4, %5, %c200_i64) : (memref<10x5xf32>, memref<5x10xf32>, i64) -> ()
     %14:2 = krnl.define_loops 2
     krnl.iterate(%14#0, %14#1) with (%14#0 -> %arg3 = 0 to 10, %14#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %4[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %4[%arg3, %arg4] : memref<10x5xf32>
       /// Change this to use %8 instead of an arg argument.
-      %18 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %18 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %3[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %3[%arg3, %arg4] : memref<10x5xf32>
     }
     %15:2 = krnl.define_loops 2
     krnl.iterate(%15#0, %15#1) with (%15#0 -> %arg3 = 0 to 10, %15#1 -> %arg4 = 0 to 5) {
-      affine.store %cst, %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %cst, %2[%arg3, %arg4] : memref<10x5xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 5) {
-        %18 = affine.load %3[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
+        %18 = krnl.load %3[%arg3, %arg5] : memref<10x5xf32>
         /// Add new val that uses %8.
-        %newVal = affine.load %8[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
+        %newVal = krnl.load %8[%arg3, %arg5] : memref<10x5xf32>
         %newAdd = addf %18, %newVal : f32
-        %19 = affine.load %arg1[symbol(%arg5), symbol(%arg4)] : memref<5x5xf32>
-        %20 = affine.load %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        %19 = krnl.load %arg1[%arg5, %arg4] : memref<5x5xf32>
+        %20 = krnl.load %2[%arg3, %arg4] : memref<10x5xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
         %newStoreVal = addf %22, %newAdd : f32
-        affine.store %newStoreVal, %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        krnl.store %newStoreVal, %2[%arg3, %arg4] : memref<10x5xf32>
       }
     }
     %16:2 = krnl.define_loops 2
     krnl.iterate(%16#0, %16#1) with (%16#0 -> %arg3 = 0 to 10, %16#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %2[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %0[%arg3, %arg4] : memref<10x5xf32>
     }
     dealloc %1 : memref<1400xi8>
     return %0 : memref<10x5xf32>
@@ -430,71 +430,71 @@ func @multiple_shaped_memrefs(%arg0: memref<10x5xf32>, %arg1: memref<5x5xf32>, %
     %8 = "krnl.getref"(%1, %c0_i64) : (memref<1400xi8>, i64) -> memref<10x5xf32>
     %9:2 = krnl.define_loops 2
     krnl.iterate(%9#0, %9#1) with (%9#0 -> %arg3 = 0 to 10, %9#1 -> %arg4 = 0 to 5) {
-      affine.store %cst, %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %cst, %8[%arg3, %arg4] : memref<10x5xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 5) {
-        %18 = affine.load %arg0[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
-        %19 = affine.load %arg1[symbol(%arg5), symbol(%arg4)] : memref<5x5xf32>
-        %20 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        %18 = krnl.load %arg0[%arg3, %arg5] : memref<10x5xf32>
+        %19 = krnl.load %arg1[%arg5, %arg4] : memref<5x5xf32>
+        %20 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        krnl.store %22, %8[%arg3, %arg4] : memref<10x5xf32>
       }
     }
     %10:2 = krnl.define_loops 2
     krnl.iterate(%10#0, %10#1) with (%10#0 -> %arg3 = 0 to 10, %10#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %8[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %8[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %7[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %7[%arg3, %arg4] : memref<10x5xf32>
     }
     %11:2 = krnl.define_loops 2
     krnl.iterate(%11#0, %11#1) with (%11#0 -> %arg3 = 0 to 10, %11#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %7[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      affine.store %17, %6[symbol(%arg4), symbol(%arg3)] : memref<5x10xf32>
+      %17 = krnl.load %7[%arg3, %arg4] : memref<10x5xf32>
+      krnl.store %17, %6[%arg4, %arg3] : memref<5x10xf32>
     }
     %12:2 = krnl.define_loops 2
     krnl.iterate(%12#0, %12#1) with (%12#0 -> %arg3 = 0 to 5, %12#1 -> %arg4 = 0 to 10) {
-      affine.store %cst, %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+      krnl.store %cst, %5[%arg3, %arg4] : memref<5x10xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 10) {
-        %18 = affine.load %6[symbol(%arg3), symbol(%arg5)] : memref<5x10xf32>
-        %19 = affine.load %arg2[symbol(%arg5), symbol(%arg4)] : memref<10x10xf32>
-        %20 = affine.load %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+        %18 = krnl.load %6[%arg3, %arg5] : memref<5x10xf32>
+        %19 = krnl.load %arg2[%arg5, %arg4] : memref<10x10xf32>
+        %20 = krnl.load %5[%arg3, %arg4] : memref<5x10xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %5[symbol(%arg3), symbol(%arg4)] : memref<5x10xf32>
+        krnl.store %22, %5[%arg3, %arg4] : memref<5x10xf32>
       }
     }
     %14:2 = krnl.define_loops 2
     krnl.iterate(%14#0, %14#1) with (%14#0 -> %arg3 = 0 to 10, %14#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %5[symbol(%arg4), symbol(%arg3)] : memref<5x10xf32>
-      %18 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %5[%arg4, %arg3] : memref<5x10xf32>
+      %18 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %3[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %3[%arg3, %arg4] : memref<10x5xf32>
     }
     %15:2 = krnl.define_loops 2
     krnl.iterate(%15#0, %15#1) with (%15#0 -> %arg3 = 0 to 10, %15#1 -> %arg4 = 0 to 5) {
-      affine.store %cst, %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %cst, %2[%arg3, %arg4] : memref<10x5xf32>
       %17 = krnl.define_loops 1
       krnl.iterate(%17) with (%17 -> %arg5 = 0 to 5) {
-        %18 = affine.load %3[symbol(%arg3), symbol(%arg5)] : memref<10x5xf32>
-        %19 = affine.load %arg1[symbol(%arg5), symbol(%arg4)] : memref<5x5xf32>
-        %20 = affine.load %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        %18 = krnl.load %3[%arg3, %arg5] : memref<10x5xf32>
+        %19 = krnl.load %arg1[%arg5, %arg4] : memref<5x5xf32>
+        %20 = krnl.load %2[%arg3, %arg4] : memref<10x5xf32>
         %21 = mulf %18, %19 : f32
         %22 = addf %20, %21 : f32
-        affine.store %22, %2[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+        krnl.store %22, %2[%arg3, %arg4] : memref<10x5xf32>
       }
       /// Newly added code.
-      %newLoad = affine.load %3[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      affine.store %newLoad, %4[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %newLoad = krnl.load %3[%arg3, %arg4] : memref<10x5xf32>
+      krnl.store %newLoad, %4[%arg3, %arg4] : memref<10x5xf32>
     }
     %16:2 = krnl.define_loops 2
     krnl.iterate(%16#0, %16#1) with (%16#0 -> %arg3 = 0 to 10, %16#1 -> %arg4 = 0 to 5) {
-      %17 = affine.load %4[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
-      %18 = affine.load %arg0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      %17 = krnl.load %4[%arg3, %arg4] : memref<10x5xf32>
+      %18 = krnl.load %arg0[%arg3, %arg4] : memref<10x5xf32>
       %19 = addf %17, %18 : f32
-      affine.store %19, %0[symbol(%arg3), symbol(%arg4)] : memref<10x5xf32>
+      krnl.store %19, %0[%arg3, %arg4] : memref<10x5xf32>
     }
     dealloc %1 : memref<1400xi8>
     return %0 : memref<10x5xf32>
@@ -535,65 +535,65 @@ func @unknown_op_reuse(%arg0: memref<10x10xf32>, %arg1: memref<10x10xf32>) -> me
   %6 = "krnl.getref"(%1, %c0_i64) : (memref<2000xi8>, i64) -> memref<10x10xf32>
   %7:2 = krnl.define_loops 2
   krnl.iterate(%7#0, %7#1) with (%7#0 -> %arg2 = 0 to 10, %7#1 -> %arg3 = 0 to 10) {
-    affine.store %cst, %6[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %cst, %6[%arg2, %arg3] : memref<10x10xf32>
     %13 = krnl.define_loops 1
     krnl.iterate(%13) with (%13 -> %arg4 = 0 to 10) {
-      %14 = affine.load %arg0[symbol(%arg2), symbol(%arg4)] : memref<10x10xf32>
-      %15 = affine.load %arg1[symbol(%arg4), symbol(%arg3)] : memref<10x10xf32>
-      %16 = affine.load %6[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      %14 = krnl.load %arg0[%arg2, %arg4] : memref<10x10xf32>
+      %15 = krnl.load %arg1[%arg4, %arg3] : memref<10x10xf32>
+      %16 = krnl.load %6[%arg2, %arg3] : memref<10x10xf32>
       %17 = mulf %14, %15 : f32
       %18 = addf %16, %17 : f32
-      affine.store %18, %6[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      krnl.store %18, %6[%arg2, %arg3] : memref<10x10xf32>
     }
   }
   %8:2 = krnl.define_loops 2
   krnl.iterate(%8#0, %8#1) with (%8#0 -> %arg2 = 0 to 10, %8#1 -> %arg3 = 0 to 10) {
-    %13 = affine.load %arg0[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
-    %14 = affine.load %6[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    %13 = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+    %14 = krnl.load %6[%arg2, %arg3] : memref<10x10xf32>
     %15 = addf %13, %14 : f32
-    affine.store %15, %5[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %15, %5[%arg2, %arg3] : memref<10x10xf32>
   }
   %9:2 = krnl.define_loops 2
   krnl.iterate(%9#0, %9#1) with (%9#0 -> %arg2 = 0 to 10, %9#1 -> %arg3 = 0 to 10) {
-    affine.store %cst, %4[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %cst, %4[%arg2, %arg3] : memref<10x10xf32>
     %13 = krnl.define_loops 1
     krnl.iterate(%13) with (%13 -> %arg4 = 0 to 10) {
-      %14 = affine.load %arg0[symbol(%arg2), symbol(%arg4)] : memref<10x10xf32>
-      %15 = affine.load %5[symbol(%arg4), symbol(%arg3)] : memref<10x10xf32>
-      %16 = affine.load %4[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      %14 = krnl.load %arg0[%arg2, %arg4] : memref<10x10xf32>
+      %15 = krnl.load %5[%arg4, %arg3] : memref<10x10xf32>
+      %16 = krnl.load %4[%arg2, %arg3] : memref<10x10xf32>
       %17 = mulf %14, %15 : f32
       %18 = addf %16, %17 : f32
-      affine.store %18, %4[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      krnl.store %18, %4[%arg2, %arg3] : memref<10x10xf32>
     }
   }
   /// Newly added operation, unknown dialect and semantics.
   "unknown.newOp"(%4, %6) : (memref<10x10xf32>, memref<10x10xf32>) -> ()
   %10:2 = krnl.define_loops 2
   krnl.iterate(%10#0, %10#1) with (%10#0 -> %arg2 = 0 to 10, %10#1 -> %arg3 = 0 to 10) {
-    %13 = affine.load %4[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
-    %14 = affine.load %arg1[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    %13 = krnl.load %4[%arg2, %arg3] : memref<10x10xf32>
+    %14 = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
     %15 = addf %13, %14 : f32
-    affine.store %15, %3[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %15, %3[%arg2, %arg3] : memref<10x10xf32>
   }
   %11:2 = krnl.define_loops 2
   krnl.iterate(%11#0, %11#1) with (%11#0 -> %arg2 = 0 to 10, %11#1 -> %arg3 = 0 to 10) {
-    affine.store %cst, %2[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %cst, %2[%arg2, %arg3] : memref<10x10xf32>
     %13 = krnl.define_loops 1
     krnl.iterate(%13) with (%13 -> %arg4 = 0 to 10) {
-      %14 = affine.load %arg0[symbol(%arg2), symbol(%arg4)] : memref<10x10xf32>
-      %15 = affine.load %3[symbol(%arg4), symbol(%arg3)] : memref<10x10xf32>
-      %16 = affine.load %2[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      %14 = krnl.load %arg0[%arg2, %arg4] : memref<10x10xf32>
+      %15 = krnl.load %3[%arg4, %arg3] : memref<10x10xf32>
+      %16 = krnl.load %2[%arg2, %arg3] : memref<10x10xf32>
       %17 = mulf %14, %15 : f32
       %18 = addf %16, %17 : f32
-      affine.store %18, %2[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+      krnl.store %18, %2[%arg2, %arg3] : memref<10x10xf32>
     }
   }
   %12:2 = krnl.define_loops 2
   krnl.iterate(%12#0, %12#1) with (%12#0 -> %arg2 = 0 to 10, %12#1 -> %arg3 = 0 to 10) {
-    %13 = affine.load %2[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
-    %14 = affine.load %arg1[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    %13 = krnl.load %2[%arg2, %arg3] : memref<10x10xf32>
+    %14 = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
     %15 = addf %13, %14 : f32
-    affine.store %15, %0[symbol(%arg2), symbol(%arg3)] : memref<10x10xf32>
+    krnl.store %15, %0[%arg2, %arg3] : memref<10x10xf32>
   }
   dealloc %1 : memref<2000xi8>
   return %0 : memref<10x10xf32>

--- a/test/mlir/onnx/onnx_enable_memory_pool.mlir
+++ b/test/mlir/onnx/onnx_enable_memory_pool.mlir
@@ -13,10 +13,10 @@ func @test_enable_memory_pool(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
   // CHECK: [[GETREF:%.+]] = "krnl.getref"([[MEMPOOL]], [[CONST0]]) : (memref<400xi8>, i64) -> memref<10x10xf32>
   // CHECK: krnl.define_loops
   // CHECK: krnl.iterate
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<10x10xf32>
   // CHECK: [[ADDF1:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADDF1]], [[GETREF]][%arg1, %arg2] : memref<10x10xf32>
+  // CHECK: krnl.store [[ADDF1]], [[GETREF]][%arg1, %arg2] : memref<10x10xf32>
   // CHECK: krnl.define_loops
   // CHECK: krnl.iterate
   // CHECK: dealloc [[MEMPOOL]] : memref<400xi8>
@@ -42,24 +42,24 @@ func @test_enable_memory_pool_2(%arg0: tensor<10x10xf32>, %arg1: tensor<10x20xf3
   // CHECK: [[GETREF1:%.+]] = "krnl.getref"([[MEMPOOL1]], [[CONST0]]) : (memref<400xi8>, i64) -> memref<10x10xf32>
   // CHECK: krnl.define_loops
   // CHECK: krnl.iterate
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[ADDF1:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADDF1]], [[GETREF1]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[ADDF1]], [[GETREF1]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: krnl.define_loops
   // CHECK: krnl.iterate
-  // CHECK: [[LOAD3:%.+]] = affine.load [[GETREF1]][%arg2, %arg4] : memref<10x10xf32>
-  // CHECK: [[LOAD4:%.+]] = affine.load %arg1[%arg4, %arg3] : memref<10x20xf32>
-  // CHECK: [[LOAD5:%.+]] = affine.load [[GETREF0]][%arg2, %arg3] : memref<10x20xf32>
+  // CHECK: [[LOAD3:%.+]] = krnl.load [[GETREF1]][%arg2, %arg4] : memref<10x10xf32>
+  // CHECK: [[LOAD4:%.+]] = krnl.load %arg1[%arg4, %arg3] : memref<10x20xf32>
+  // CHECK: [[LOAD5:%.+]] = krnl.load [[GETREF0]][%arg2, %arg3] : memref<10x20xf32>
   // CHECK: [[MULF1:%.+]] = mulf [[LOAD3]], [[LOAD4]] : f32
   // CHECK: [[ADDF2:%.+]] = addf [[LOAD5]], [[MULF1]] : f32
-  // CHECK: affine.store [[ADDF2]], [[GETREF0]][%arg2, %arg3] : memref<10x20xf32>
+  // CHECK: krnl.store [[ADDF2]], [[GETREF0]][%arg2, %arg3] : memref<10x20xf32>
   // CHECK: krnl.define_loops
   // CHECK: krnl.iterate
-  // CHECK: [[LOAD6:%.+]] = affine.load [[GETREF0]][%arg2, %arg3] : memref<10x20xf32>
-  // CHECK: [[LOAD7:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x20xf32>
+  // CHECK: [[LOAD6:%.+]] = krnl.load [[GETREF0]][%arg2, %arg3] : memref<10x20xf32>
+  // CHECK: [[LOAD7:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x20xf32>
   // CHECK: [[ADDF3:%.+]] = addf [[LOAD6]], [[LOAD7]] : f32
-  // CHECK: affine.store [[ADDF3]], [[RES]][%arg2, %arg3] : memref<10x20xf32>
+  // CHECK: krnl.store [[ADDF3]], [[RES]][%arg2, %arg3] : memref<10x20xf32>
   // CHECK: dealloc [[MEMPOOL1]] : memref<400xi8>
   // CHECK: dealloc [[MEMPOOL0]] : memref<800xi8>
   // CHECK: return [[RES]] : memref<10x20xf32>
@@ -88,7 +88,7 @@ func @test_enable_memory_pool_3(%arg0: tensor<?x?xf32>, %arg1: tensor<?x10xf32>,
   // CHECK: [[DATA1:%.+]] = "krnl.getref"([[MEMPOOL1]], [[CONST0_I64]], [[DIM1]]) : (memref<?xi8>, i64, index) -> memref<?x10xf32>
   // CHECK: krnl.define_loops 2
   // CHECK: krnl.iterate
-  // CHECK: affine.store {{.*}}, [[DATA1]][%arg3, %arg4] : memref<?x10xf32>
+  // CHECK: krnl.store {{.*}}, [[DATA1]][%arg3, %arg4] : memref<?x10xf32>
   // CHECK: [[CMP1:%.+]] = affine.max {{.*}}([[DIM1]], [[DIM1]])
   // CHECK: [[TMP3:%.+]] = muli [[CMP1]], [[CONST4]] : index
   // CHECK: [[TMP4:%.+]] = muli [[TMP3]], [[CONST10]] : index
@@ -96,14 +96,14 @@ func @test_enable_memory_pool_3(%arg0: tensor<?x?xf32>, %arg1: tensor<?x10xf32>,
   // CHECK: [[DATA2:%.+]] = "krnl.getref"([[MEMPOOL2]], [[CONST0_I64]], [[CMP1]]) : (memref<?xi8>, i64, index) -> memref<?x10xf32>
   // CHECK: krnl.define_loops 2
   // CHECK: krnl.iterate
-  // CHECK: affine.store {{.*}}, [[DATA2]][%arg3, %arg4] : memref<?x10xf32>
+  // CHECK: krnl.store {{.*}}, [[DATA2]][%arg3, %arg4] : memref<?x10xf32>
   // CHECK: [[DATA3:%.+]] = alloc([[DIM1]]) : memref<?x10xf32>
   // CHECK: krnl.define_loops 2
   // CHECK: krnl.iterate
-  // CHECK: affine.store [[CST]], [[DATA3]][%arg3, %arg4] : memref<?x10xf32>
+  // CHECK: krnl.store [[CST]], [[DATA3]][%arg3, %arg4] : memref<?x10xf32>
   // CHECK: krnl.define_loops 1
   // CHECK: krnl.iterate
-  // CHECK: affine.store {{.*}}, [[DATA3]][%arg3, %arg4] : memref<?x10xf32>
+  // CHECK: krnl.store {{.*}}, [[DATA3]][%arg3, %arg4] : memref<?x10xf32>
   // CHECK: dealloc [[MEMPOOL2]] : memref<?xi8>
   // CHECK: dealloc [[MEMPOOL1]] : memref<?xi8>
   // CHECK: return [[DATA3]] : memref<?x10xf32>

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -27,9 +27,9 @@ func private @test_elementwise_op_with_scalar_values_1(%arg0 : tensor<f32>) -> t
 
   // CHECK-LABEL: test_elementwise_op_with_scalar_values_1
   // CHECK: [[RES:%.+]] = alloc() : memref<f32>
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[] : memref<f32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[] : memref<f32>
   // CHECK: [[EXP:%.+]] = exp [[LOAD]] : f32
-  // CHECK: affine.store [[EXP]], [[RES]][] : memref<f32>
+  // CHECK: krnl.store [[EXP]], [[RES]][] : memref<f32>
   // CHECK: return [[RES]] : memref<f32>
 }
 
@@ -41,10 +41,10 @@ func private @test_elementwise_op_with_scalar_values_2(%arg0 : tensor<f32>, %arg
 
   // CHECK-LABEL: test_elementwise_op_with_scalar_values_2
   // CHECK: [[RES:%.+]] = alloc() : memref<f32>
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[] : memref<f32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[] : memref<f32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[] : memref<f32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[] : memref<f32>
   // CHECK: [[ADD:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADD]], [[RES]][] : memref<f32>
+  // CHECK: krnl.store [[ADD]], [[RES]][] : memref<f32>
   // CHECK: return [[RES]] : memref<f32>
 }
 
@@ -56,12 +56,12 @@ func private @test_elementwise_op_with_scalar_values_3(%arg0 : tensor<f32>, %arg
 
   // CHECK-LABEL: test_elementwise_op_with_scalar_values_3
   // CHECK: [[RES:%.+]] = alloc() : memref<f32>
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[] : memref<f32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[] : memref<f32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[] : memref<f32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[] : memref<f32>
   // CHECK: [[ADD1:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: [[LOAD3:%.+]] = affine.load %arg2[] : memref<f32>
+  // CHECK: [[LOAD3:%.+]] = krnl.load %arg2[] : memref<f32>
   // CHECK: [[ADD2:%.+]] = addf [[ADD1]], [[LOAD3]] : f32
-  // CHECK: affine.store [[ADD2]], [[RES]][] : memref<f32>
+  // CHECK: krnl.store [[ADD2]], [[RES]][] : memref<f32>
   // CHECK: return [[RES]] : memref<f32>
 }
 
@@ -75,10 +75,10 @@ func private @test_add(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> 
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[ADDF:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADDF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[ADDF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
@@ -92,10 +92,10 @@ func private @test_mul(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> 
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MULF:%.+]] = mulf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[MULF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[MULF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
@@ -109,10 +109,10 @@ func private @test_div(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> 
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[DIVF:%.+]] = divf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[DIVF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[DIVF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
@@ -126,10 +126,10 @@ func private @test_sub(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> 
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[SUBF:%.+]] = subf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[SUBF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[SUBF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
@@ -143,10 +143,10 @@ func private @test_and(%arg0 : tensor<10x10xi1>, %arg1 : tensor<10x10xi1>) -> te
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xi1>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[AND:%.+]] = and [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[AND]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[AND]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
   // CHECK: return [[RES]] : memref<10x10xi1>
 }
 
@@ -160,10 +160,10 @@ func private @test_or(%arg0 : tensor<10x10xi1>, %arg1 : tensor<10x10xi1>) -> ten
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xi1>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[OR:%.+]] = or [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[OR]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[OR]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
   // CHECK: return [[RES]] : memref<10x10xi1>
 }
 
@@ -177,10 +177,10 @@ func private @test_xor(%arg0 : tensor<10x10xi1>, %arg1 : tensor<10x10xi1>) -> te
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xi1>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[XOR:%.+]] = xor [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[XOR]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[XOR]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
   // CHECK: return [[RES]] : memref<10x10xi1>
 }
 
@@ -198,9 +198,9 @@ func private @test_exp(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[EXP:%.+]] = exp [[LOAD]] : f32
-  // CHECK: affine.store [[EXP]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[EXP]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -218,7 +218,7 @@ func private @test_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[X:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[X:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ONE:%.+]] = constant 1.000000e+00 : f32
   // CHECK: [[TWO:%.+]] = constant 2.000000e+00 : f32
   // CHECK: [[X_MUL_2:%.+]] = mulf [[X]], [[TWO]] : f32
@@ -234,7 +234,7 @@ func private @test_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[ZERO:%.+]] = constant 0.000000e+00 : f32
   // CHECK: [[CMP:%.+]] = cmpf "oge", [[X]], [[ZERO]] : f32
   // CHECK: [[TANH:%.+]] = select [[CMP]], [[DIV_1]], [[DIV_2]] : f32
-  // CHECK: affine.store [[TANH]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[TANH]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -252,7 +252,7 @@ func private @test_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[TWO:%.+]] = constant {{2.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
@@ -260,7 +260,7 @@ func private @test_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVIDEND:%.+]] = subf [[EXP]], [[NEXP]] : f32
   // CHECK: [[SINH_RES:%.+]] = divf [[DIVIDEND]], [[TWO]] : f32
-  // CHECK: affine.store [[SINH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SINH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -278,7 +278,7 @@ func private @test_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[TWO:%.+]] = constant {{2.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
@@ -286,7 +286,7 @@ func private @test_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVIDEND:%.+]] = addf [[EXP]], [[NEXP]] : f32
   // CHECK: [[COSH_RES:%.+]] = divf [[DIVIDEND]], [[TWO]] : f32
-  // CHECK: affine.store [[COSH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[COSH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -304,9 +304,9 @@ func private @test_cos(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[COS:%.+]] = cos [[LOAD]] : f32
-  // CHECK: affine.store [[COS]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[COS]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -324,9 +324,9 @@ func private @test_sin(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[SIN:%.+]] = sin [[LOAD]] : f32
-  // CHECK: affine.store [[SIN]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SIN]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -344,9 +344,9 @@ func private @test_log(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[LOG:%.+]] = log [[LOAD]] : f32
-  // CHECK: affine.store [[LOG]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[LOG]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -364,14 +364,14 @@ func private @test_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVISOR:%.+]] = addf [[ONE]], [[NEXP]] : f32
   // CHECK: [[SIGMOID_RES:%.+]] = divf [[ONE]], [[DIVISOR]] : f32
-  // CHECK: affine.store [[SIGMOID_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SIGMOID_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -389,11 +389,11 @@ func private @test_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[LTZERO:%.+]] = cmpf "olt", [[LOAD]], [[ZERO]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[LTZERO]], [[ZERO]], [[LOAD]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -414,7 +414,7 @@ func private @test_reshape(%arg0 : tensor<?x10xf32>, %arg1 : tensor<4xi64>) -> t
 
   // CHECK: [[TYPE_IN_BYTES_1:%.+]] = constant 4 : i64
   // CHECK: %[[CONSTANT_1:.+]] = constant 0 : index
-  // CHECK: [[LOAD_0:%.+]] = affine.load %arg1[%[[CONSTANT_1]]] : memref<4xi64>
+  // CHECK: [[LOAD_0:%.+]] = krnl.load %arg1[%[[CONSTANT_1]]] : memref<4xi64>
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_1:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: [[DIM_1_CAST:%.+]] = index_cast [[DIM_1]] : index to i64
@@ -424,7 +424,7 @@ func private @test_reshape(%arg0 : tensor<?x10xf32>, %arg1 : tensor<4xi64>) -> t
   // CHECK: [[MUL_1:%.+]] = muli [[TYPE_IN_BYTES_1]], [[SELECT_0]] : i64
 
   // CHECK: %[[CONSTANT_3:.+]] = constant 1 : index
-  // CHECK: [[LOAD_1:%.+]] = affine.load %arg1[%[[CONSTANT_3]]] : memref<4xi64>
+  // CHECK: [[LOAD_1:%.+]] = krnl.load %arg1[%[[CONSTANT_3]]] : memref<4xi64>
   // CHECK: [[CONSTANT_3:%.+]] = constant 10 : i64
   // CHECK: [[CONSTANT_4:%.+]] = constant 0 : i64
   // CHECK: [[CMP_1:%.+]] = cmpi "eq", [[LOAD_1]], [[CONSTANT_4]] : i64
@@ -432,11 +432,11 @@ func private @test_reshape(%arg0 : tensor<?x10xf32>, %arg1 : tensor<4xi64>) -> t
   // CHECK: [[MUL_2:%.+]] = muli [[MUL_1]], [[SELECT_1]] : i64
 
   // CHECK: %[[CONSTANT_5:.+]] = constant 2 : index
-  // CHECK: [[LOAD_2:%.+]] = affine.load %arg1[%[[CONSTANT_5]]] : memref<4xi64>
+  // CHECK: [[LOAD_2:%.+]] = krnl.load %arg1[%[[CONSTANT_5]]] : memref<4xi64>
   // CHECK: [[MUL_3:%.+]] = muli [[MUL_2]], [[LOAD_2]] : i64
 
   // CHECK: %[[CONSTANT_6:.+]] = constant 3 : index
-  // CHECK: [[LOAD_3:%.+]] = affine.load %arg1[%[[CONSTANT_6]]] : memref<4xi64>
+  // CHECK: [[LOAD_3:%.+]] = krnl.load %arg1[%[[CONSTANT_6]]] : memref<4xi64>
   // CHECK: [[MUL_4:%.+]] = muli [[MUL_3]], [[LOAD_3]] : i64
 
   // CHECK: [[CONSTANT_7:%.+]] = constant 0 : i64
@@ -478,10 +478,10 @@ func private @test_sum(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> 
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[ADD:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADD]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[ADD]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
@@ -495,11 +495,11 @@ func private @test_max(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> 
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MAX:%.+]] = cmpf "ogt", [[LOAD1]], [[LOAD2]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[MAX]], [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
@@ -513,11 +513,11 @@ func private @test_min(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> 
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MIN:%.+]] = cmpf "olt", [[LOAD1]], [[LOAD2]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[MIN]], [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   // CHECK: return [[RES]] : memref<10x10xf32>
 }
 
@@ -535,7 +535,7 @@ func private @test_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[ALPHA:%.+]] = constant {{2.+}} : f32
@@ -544,7 +544,7 @@ func private @test_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SUB:%.+]] = subf [[EXP]], [[ONE]] : f32
   // CHECK: [[MUL:%.+]] = mulf [[ALPHA]], [[SUB]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[MUL]], [[LOAD]] : f32
-  // CHECK: affine.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -562,13 +562,13 @@ func private @test_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32
   // CHECK: [[CMP:%.+]] = cmpf "olt", [[LOAD]], [[ZERO]] : f32
   // CHECK: [[MUL:%.+]] = mulf [[ALPHA]], [[LOAD]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[MUL]], [[LOAD]] : f32
-  // CHECK: affine.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -586,7 +586,7 @@ func private @test_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32
   // CHECK: [[GAMMA:%.+]] = constant {{2.+}} : f32
@@ -596,7 +596,7 @@ func private @test_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SUB:%.+]] = subf [[MUL]], [[ALPHA]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[LOAD]], [[SUB]] : f32
   // CHECK: [[SELU_RES:%.+]] = mulf [[GAMMA]], [[SELECT]] : f32
-  // CHECK: affine.store [[SELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -614,7 +614,7 @@ func private @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32
@@ -625,7 +625,7 @@ func private @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SELECT1:%.+]] = select [[CMP1]], [[ADD]], [[ZERO]] : f32
   // CHECK: [[CMP2:%.+]] = cmpf "olt", [[SELECT1]], [[ONE]] : f32
   // CHECK: [[SELECT2:%.+]] = select [[CMP2]], [[SELECT1]], [[ONE]] : f32
-  // CHECK: affine.store [[SELECT2]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT2]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -643,10 +643,10 @@ func private @test_reciprocal(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[RECIPROCAL_RES:%.+]] = divf [[ONE]], [[LOAD]] : f32
-  // CHECK: affine.store [[RECIPROCAL_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[RECIPROCAL_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -664,12 +664,12 @@ func private @test_softplus(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[EXP:%.+]] = exp [[LOAD]] : f32
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[ADD:%.+]] = addf [[EXP]], [[ONE]] : f32
   // CHECK: [[SOFTPLUS_RES:%.+]] = log [[ADD]] : f32
-  // CHECK: affine.store [[SOFTPLUS_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SOFTPLUS_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -687,12 +687,12 @@ func private @test_softsign(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ABS:%.+]] = absf [[LOAD]] : f32
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[ADD:%.+]] = addf [[ABS]], [[ONE]] : f32
   // CHECK: [[SOFTSIGN_RES:%.+]] = divf [[LOAD]], [[ADD]] : f32
-  // CHECK: affine.store [[SOFTSIGN_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SOFTSIGN_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -707,15 +707,15 @@ func private @test_reducemax(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 2) {
   // CHECK: [[IDENTITY:%.+]] = constant 0xFF800000 : f32
-  // CHECK: affine.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK: krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
 
   // CHECK: [[DEF_LOOPS2:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1, [[DEF_LOOPS2]]#2) with ([[DEF_LOOPS2]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS2]]#1 -> %arg2 = 0 to 2, [[DEF_LOOPS2]]#2 -> %arg3 = 0 to 2) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: [[CMP:%.+]] = cmpf "ogt", [[LOAD2]], [[LOAD1]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[LOAD2]], [[LOAD1]] : f32
-  // CHECK: store [[SELECT]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: krnl.store [[SELECT]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
@@ -731,15 +731,15 @@ func private @test_reducemin(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 2) {
   // CHECK: [[IDENTITY:%.+]] = constant 0x7F800000 : f32
-  // CHECK: affine.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK: krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
 
   // CHECK: [[DEF_LOOPS2:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1, [[DEF_LOOPS2]]#2) with ([[DEF_LOOPS2]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS2]]#1 -> %arg2 = 0 to 2, [[DEF_LOOPS2]]#2 -> %arg3 = 0 to 2) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: [[CMP:%.+]] = cmpf "olt", [[LOAD2]], [[LOAD1]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[LOAD2]], [[LOAD1]] : f32
-  // CHECK: affine.store [[SELECT]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: krnl.store [[SELECT]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
@@ -755,14 +755,14 @@ func private @test_reduceprod(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 2) {
   // CHECK: [[IDENTITY:%.+]] = constant 1.000000e+00 : f32
-  // CHECK: affine.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK: krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
 
   // CHECK: [[DEF_LOOPS2:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1, [[DEF_LOOPS2]]#2) with ([[DEF_LOOPS2]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS2]]#1 -> %arg2 = 0 to 2, [[DEF_LOOPS2]]#2 -> %arg3 = 0 to 2) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: [[REDUCE:%.+]] = mulf [[LOAD2]], [[LOAD1]] : f32
-  // CHECK: affine.store [[REDUCE]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: krnl.store [[REDUCE]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
@@ -778,14 +778,14 @@ func private @test_reducesum(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 2) {
   // CHECK: [[IDENTITY:%.+]] = constant 0.000000e+00 : f32
-  // CHECK: affine.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK: krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
 
   // CHECK: [[DEF_LOOPS2:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1, [[DEF_LOOPS2]]#2) with ([[DEF_LOOPS2]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS2]]#1 -> %arg2 = 0 to 2, [[DEF_LOOPS2]]#2 -> %arg3 = 0 to 2) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: [[REDUCE:%.+]] = addf [[LOAD2]], [[LOAD1]] : f32
-  // CHECK: affine.store [[REDUCE]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: krnl.store [[REDUCE]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
@@ -802,14 +802,14 @@ func private @test_reducemean_f32(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 2) {
   // CHECK: [[IDENTITY:%.+]] = constant 0.000000e+00 : f32
-  // CHECK: affine.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK: krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
 
   // CHECK: [[DEF_LOOPS2:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1, [[DEF_LOOPS2]]#2) with ([[DEF_LOOPS2]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS2]]#1 -> %arg2 = 0 to 2, [[DEF_LOOPS2]]#2 -> %arg3 = 0 to 2) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: [[REDUCE:%.+]] = addf [[LOAD2]], [[LOAD1]] : f32
-  // CHECK: affine.store [[REDUCE]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
+  // CHECK: krnl.store [[REDUCE]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: }
 
   // CHECK: [[DIVISOR_INDEX:%.+]] = constant 2 : index 
@@ -817,9 +817,9 @@ func private @test_reducemean_f32(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: [[DIVISOR:%.+]] = uitofp [[DIVISOR_i64]] : i64 to f32
   // CHECK: [[DEF_MEAN_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_MEAN_LOOPS]]#0, [[DEF_MEAN_LOOPS]]#1) with ([[DEF_MEAN_LOOPS]]#0 -> %arg1 = 0 to 3, [[DEF_MEAN_LOOPS]]#1 -> %arg2 = 0 to 2) {
-  // CHECK:   [[LOAD3:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK:   [[LOAD3:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<3x2xf32>
   // CHECK:   [[MEAN:%.+]] = divf [[LOAD3]], [[DIVISOR]] : f32
-  // CHECK:   affine.store [[MEAN]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK:   krnl.store [[MEAN]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
@@ -836,23 +836,23 @@ func private @test_reducemean_i32(%arg0 : tensor<3x2x2xi32>) -> tensor<*xi32> {
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 2) {
   // CHECK: [[IDENTITY:%.+]] = constant 0 : i32
-  // CHECK: affine.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xi32>
+  // CHECK: krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2] : memref<3x2xi32>
 
   // CHECK: [[DEF_LOOPS2:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1, [[DEF_LOOPS2]]#2) with ([[DEF_LOOPS2]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS2]]#1 -> %arg2 = 0 to 2, [[DEF_LOOPS2]]#2 -> %arg3 = 0 to 2) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xi32>
-  // CHECK: [[LOAD2:%.+]] = affine.load [[RES]][%arg1, %arg3] : memref<3x2xi32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3] : memref<3x2x2xi32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load [[RES]][%arg1, %arg3] : memref<3x2xi32>
   // CHECK: [[REDUCE:%.+]] = addi [[LOAD2]], [[LOAD1]] : i32
-  // CHECK: affine.store [[REDUCE]], [[RES]][%arg1, %arg3] : memref<3x2xi32>
+  // CHECK: krnl.store [[REDUCE]], [[RES]][%arg1, %arg3] : memref<3x2xi32>
   // CHECK: }
 
   // CHECK: [[DIVISOR_INDEX:%.+]] = constant 2 : index 
   // CHECK: [[DIVISOR:%.+]] = index_cast [[DIVISOR_INDEX]] : index to i32
   // CHECK: [[DEF_MEAN_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_MEAN_LOOPS]]#0, [[DEF_MEAN_LOOPS]]#1) with ([[DEF_MEAN_LOOPS]]#0 -> %arg1 = 0 to 3, [[DEF_MEAN_LOOPS]]#1 -> %arg2 = 0 to 2) {
-  // CHECK:   [[LOAD3:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<3x2xi32>
+  // CHECK:   [[LOAD3:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<3x2xi32>
   // CHECK:   [[MEAN:%.+]] = divi_signed [[LOAD3]], [[DIVISOR]] : i32
-  // CHECK:   affine.store [[MEAN]], [[RES]][%arg1, %arg2] : memref<3x2xi32>
+  // CHECK:   krnl.store [[MEAN]], [[RES]][%arg1, %arg2] : memref<3x2xi32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xi32>
 }
@@ -871,30 +871,30 @@ func private @test_softmax(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
   // CHECK: [[CST_0:%.+]] = constant 0xFF800000 : f32
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to 10) {
-  // CHECK: affine.store [[CST]], [[SUM]][] : memref<f32>
-  // CHECK: affine.store [[CST_0]], [[MAX]][] : memref<f32>
+  // CHECK: krnl.store [[CST]], [[SUM]][] : memref<f32>
+  // CHECK: krnl.store [[CST_0]], [[MAX]][] : memref<f32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK:   [[LOAD1:%.+]] = affine.load [[MAX]][] : memref<f32>
-  // CHECK:   [[LOAD2:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<10x10xf32>
+  // CHECK:   [[LOAD1:%.+]] = krnl.load [[MAX]][] : memref<f32>
+  // CHECK:   [[LOAD2:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<10x10xf32>
   // CHECK:   [[COND:%.+]] = cmpf "ogt", [[LOAD1]], [[LOAD2]] : f32
   // CHECK:   [[SELECT:%.+]] = select [[COND]], [[LOAD1]], [[LOAD2]] : f32
-  // CHECK:   affine.store [[SELECT]], [[MAX]][] : memref<f32>
+  // CHECK:   krnl.store [[SELECT]], [[MAX]][] : memref<f32>
   // CHECK: }
-  // CHECK: [[LOAD_MAX:%.+]] = affine.load [[MAX]][] : memref<f32>
+  // CHECK: [[LOAD_MAX:%.+]] = krnl.load [[MAX]][] : memref<f32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK:   [[LOAD1]] = affine.load [[SUM]][] : memref<f32>
-  // CHECK:   [[LOAD2]] = affine.load %arg0[%arg1, %arg2] : memref<10x10xf32>
+  // CHECK:   [[LOAD1]] = krnl.load [[SUM]][] : memref<f32>
+  // CHECK:   [[LOAD2]] = krnl.load %arg0[%arg1, %arg2] : memref<10x10xf32>
   // CHECK:   [[SUB:%.+]] = subf [[LOAD2]], [[LOAD_MAX]] : f32
   // CHECK:   [[EXP:%.+]] = exp [[SUB]] : f32
   // CHECK:   [[ADD:%.+]] = addf [[LOAD1]], [[EXP]] : f32
-  // CHECK:   affine.store [[ADD]], [[SUM]][] : memref<f32>
-  // CHECK:   affine.store [[EXP]], [[RES]][%arg1, %arg2] : memref<10x10xf32>
+  // CHECK:   krnl.store [[ADD]], [[SUM]][] : memref<f32>
+  // CHECK:   krnl.store [[EXP]], [[RES]][%arg1, %arg2] : memref<10x10xf32>
   // CHECK: }
-  // CHECK: [[LOAD_SUM:%.+]] = affine.load [[SUM]][] : memref<f32>
+  // CHECK: [[LOAD_SUM:%.+]] = krnl.load [[SUM]][] : memref<f32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK:   [[LOAD1]] = affine.load [[RES]][%arg1, %arg2] : memref<10x10xf32>
+  // CHECK:   [[LOAD1]] = krnl.load [[RES]][%arg1, %arg2] : memref<10x10xf32>
   // CHECK:   [[DIV:%.+]] = divf [[LOAD1]], [[LOAD_SUM]] : f32
-  // CHECK:   affine.store [[DIV]], [[RES]][%arg1, %arg2] : memref<10x10xf32>
+  // CHECK:   krnl.store [[DIV]], [[RES]][%arg1, %arg2] : memref<10x10xf32>
   // CHECK: }
   // CHECK: }
   // CHECK: dealloc [[SUM]] : memref<f32>
@@ -916,9 +916,9 @@ func private @test_sqrt(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[SQRT:%.+]] = sqrt [[LOAD]] : f32
-  // CHECK: affine.store [[SQRT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SQRT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -956,13 +956,13 @@ func private @test_transpose(%arg0 : tensor<10x20x30x40xf32>) -> tensor<*xf32> {
 
   // CHECK: [[DEF_LOOPS:%.+]]:4 = krnl.define_loops 4
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1, [[DEF_LOOPS]]#2, [[DEF_LOOPS]]#3) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg2 = 0 to 20, [[DEF_LOOPS]]#2 -> %arg3 = 0 to 30, [[DEF_LOOPS]]#3 -> %arg4 = 0 to 40) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3, %arg4] : memref<10x20x30x40xf32>
-  // CHECK: affine.store [[LOAD]], [[RES1]][%arg4, %arg3, %arg2, %arg1] : memref<40x30x20x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3, %arg4] : memref<10x20x30x40xf32>
+  // CHECK: krnl.store [[LOAD]], [[RES1]][%arg4, %arg3, %arg2, %arg1] : memref<40x30x20x10xf32>
 
   // CHECK: [[DEF_LOOPS:%.+]]:4 = krnl.define_loops 4
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1, [[DEF_LOOPS]]#2, [[DEF_LOOPS]]#3) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to 40, [[DEF_LOOPS]]#1 -> %arg2 = 0 to 30, [[DEF_LOOPS]]#2 -> %arg3 = 0 to 20, [[DEF_LOOPS]]#3 -> %arg4 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES1]][%arg1, %arg2, %arg3, %arg4] : memref<40x30x20x10xf32>
-  // CHECK: affine.store [[LOAD]], [[RES0]][%arg1, %arg4, %arg2, %arg3] : memref<40x10x30x20xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES1]][%arg1, %arg2, %arg3, %arg4] : memref<40x30x20x10xf32>
+  // CHECK: krnl.store [[LOAD]], [[RES0]][%arg1, %arg4, %arg2, %arg3] : memref<40x10x30x20xf32>
 
   // CHECK: dealloc [[RES1]] : memref<40x30x20x10xf32>
   // CHECK: return [[RES0]] : memref<40x10x30x20xf32>
@@ -983,8 +983,8 @@ func private @test_transpose_dynamic_dims(%arg0 : tensor<10x?x30x40xf32>) -> ten
   // CHECK-DAG:       [[CST_1_1_:%.+]] = constant 1 : index
   // CHECK:           [[DIM_1_:%.+]] = dim [[PARAM_0_]], [[CST_1_1_]] : memref<10x?x30x40xf32>
   // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to [[DIM_1_]], [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 30, [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 40) {
-  // CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = affine.load [[PARAM_0_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<10x?x30x40xf32>
-  // CHECK:             affine.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_3_]], [[I_1_]], [[I_2_]]{{.}} : memref<10x40x?x30xf32>
+  // CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<10x?x30x40xf32>
+  // CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_3_]], [[I_1_]], [[I_2_]]{{.}} : memref<10x40x?x30xf32>
   // CHECK:           }
   // CHECK:           return [[RES_]] : memref<10x40x?x30xf32>
   // CHECK:         }
@@ -1014,7 +1014,7 @@ func private @test_sign_f(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[MINUS_ONE:%.+]] = constant {{-1.+}} : f32
@@ -1022,7 +1022,7 @@ func private @test_sign_f(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SELECT_PLUS:%.+]] = select [[GTZERO]], [[ONE]], [[MINUS_ONE]] : f32
   // CHECK: [[EQZERO:%.+]] = cmpf "oeq", [[LOAD]], [[ZERO]] : f32
   // CHECK: [[SIGN_RES:%.+]] = select [[EQZERO]], [[ZERO]], [[SELECT_PLUS]] : f32
-  // CHECK: affine.store [[SIGN_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SIGN_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -1040,7 +1040,7 @@ func private @test_sign_i(%arg0 : tensor<?x10xi32>) -> tensor<*xi32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xi32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xi32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xi32>
   // CHECK: [[ZERO:%.+]] = constant 0 : i32
   // CHECK: [[ONE:%.+]] = constant 1 : i32
   // CHECK: [[MINUS_ONE:%.+]] = constant -1 : i32
@@ -1048,7 +1048,7 @@ func private @test_sign_i(%arg0 : tensor<?x10xi32>) -> tensor<*xi32> {
   // CHECK: [[SELECT_PLUS:%.+]] = select [[GTZERO]], [[ONE]], [[MINUS_ONE]] : i32
   // CHECK: [[EQZERO:%.+]] = cmpi "eq", [[LOAD]], [[ZERO]] : i32
   // CHECK: [[SIGN_RES:%.+]] = select [[EQZERO]], [[ZERO]], [[SELECT_PLUS]] : i32
-  // CHECK: affine.store [[SIGN_RES]], [[RES]][%arg1, %arg2] : memref<?x10xi32>
+  // CHECK: krnl.store [[SIGN_RES]], [[RES]][%arg1, %arg2] : memref<?x10xi32>
   // CHECK: return [[RES]] : memref<?x10xi32>
 }
 
@@ -1065,15 +1065,15 @@ func private @test_matmul1(%arg0 : tensor<10x5xf32>, %arg1 : tensor<5x10xf32>) -
 //CHECK:           [[VAR_cst_:%.+]] = constant 0.000000e+00 : f32
 //CHECK:           [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 //CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10) {
-//CHECK:             affine.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+//CHECK:             krnl.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 //CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 //CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 5) {
-//CHECK:               [[LOAD_A_MEM_:%.+]] = affine.load [[A_]]{{.}}[[I_0_]], [[I_2_]]{{.}} : memref<10x5xf32>
-//CHECK:               [[LOAD_B_MEM_:%.+]] = affine.load [[B_]]{{.}}[[I_2_]], [[I_1_]]{{.}} : memref<5x10xf32>
-//CHECK:               [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+//CHECK:               [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[I_0_]], [[I_2_]]{{.}} : memref<10x5xf32>
+//CHECK:               [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[I_2_]], [[I_1_]]{{.}} : memref<5x10xf32>
+//CHECK:               [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 //CHECK:               [[VAR_6_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
 //CHECK:               [[VAR_7_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_6_]] : f32
-//CHECK:               affine.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+//CHECK:               krnl.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 //CHECK:             }
 //CHECK:           }
 //CHECK:           return [[RES_]] : memref<10x10xf32>
@@ -1093,15 +1093,15 @@ func private @test_matmul2(%arg0 : tensor<10x5xf32>, %arg1 : tensor<2x3x5x10xf32
 //CHECK:           [[VAR_cst_:%.+]] = constant 0.000000e+00 : f32
 //CHECK:           [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
 //CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 10, [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 10) {
-//CHECK:             affine.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
+//CHECK:             krnl.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
 //CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 //CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_4_:%.+]] = 0 to 5) {
-//CHECK:               [[LOAD_A_MEM_:%.+]] = affine.load [[A_]]{{.}}[[I_2_]], [[I_4_]]{{.}} : memref<10x5xf32>
-//CHECK:               [[LOAD_B_MEM_:%.+]] = affine.load [[B_]]{{.}}[[I_0_]], [[I_1_]], [[I_4_]], [[I_3_]]{{.}} : memref<2x3x5x10xf32>
-//CHECK:               [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
+//CHECK:               [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[I_2_]], [[I_4_]]{{.}} : memref<10x5xf32>
+//CHECK:               [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[I_0_]], [[I_1_]], [[I_4_]], [[I_3_]]{{.}} : memref<2x3x5x10xf32>
+//CHECK:               [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
 //CHECK:               [[VAR_6_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
 //CHECK:               [[VAR_7_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_6_]] : f32
-//CHECK:               affine.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
+//CHECK:               krnl.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
 //CHECK:             }
 //CHECK:           }
 //CHECK:           return [[RES_]] : memref<2x3x10x10xf32>
@@ -1121,15 +1121,15 @@ func private @test_matmul3(%arg0 : tensor<2x3x10x5xf32>, %arg1 : tensor<2x3x5x10
 //CHECK:           [[VAR_cst_:%.+]] = constant 0.000000e+00 : f32
 //CHECK:           [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
 //CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 10, [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 10) {
-//CHECK:             affine.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
+//CHECK:             krnl.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
 //CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 //CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_4_:%.+]] = 0 to 5) {
-//CHECK:               [[LOAD_A_MEM_:%.+]] = affine.load [[A_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_4_]]{{.}} : memref<2x3x10x5xf32>
-//CHECK:               [[LOAD_B_MEM_:%.+]] = affine.load [[B_]]{{.}}[[I_0_]], [[I_1_]], [[I_4_]], [[I_3_]]{{.}} : memref<2x3x5x10xf32>
-//CHECK:               [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
+//CHECK:               [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_4_]]{{.}} : memref<2x3x10x5xf32>
+//CHECK:               [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[I_0_]], [[I_1_]], [[I_4_]], [[I_3_]]{{.}} : memref<2x3x5x10xf32>
+//CHECK:               [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
 //CHECK:               [[VAR_6_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
 //CHECK:               [[VAR_7_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_6_]] : f32
-//CHECK:               affine.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
+//CHECK:               krnl.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<2x3x10x10xf32>
 //CHECK:             }
 //CHECK:           }
 //CHECK:           return [[RES_]] : memref<2x3x10x10xf32>
@@ -1149,15 +1149,15 @@ func private @test_matmul4(%arg0 : tensor<5xf32>, %arg1 : tensor<5x10xf32>) -> t
 //CHECK:           [[VAR_cst_:%.+]] = constant 0.000000e+00 : f32
 //CHECK:           [[LOOP_0_:%.+]] = krnl.define_loops 1
 //CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 10) {
-//CHECK:             affine.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<10xf32>
+//CHECK:             krnl.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<10xf32>
 //CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 //CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_1_:%.+]] = 0 to 5) {
-//CHECK:               [[LOAD_A_MEM_:%.+]] = affine.load [[A_]]{{.}}[[I_1_]]{{.}} : memref<5xf32>
-//CHECK:               [[LOAD_B_MEM_:%.+]] = affine.load [[B_]]{{.}}[[I_1_]], [[I_0_]]{{.}} : memref<5x10xf32>
-//CHECK:               [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]]{{.}}[[I_0_]]{{.}} : memref<10xf32>
+//CHECK:               [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[I_1_]]{{.}} : memref<5xf32>
+//CHECK:               [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[I_1_]], [[I_0_]]{{.}} : memref<5x10xf32>
+//CHECK:               [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]]{{.}} : memref<10xf32>
 //CHECK:               [[VAR_6_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
 //CHECK:               [[VAR_7_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_6_]] : f32
-//CHECK:               affine.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<10xf32>
+//CHECK:               krnl.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<10xf32>
 //CHECK:             }
 //CHECK:           }
 //CHECK:           return [[RES_]] : memref<10xf32>
@@ -1179,15 +1179,15 @@ func private @test_matmul5(%arg0 : tensor<5xf32>, %arg1 : tensor<?x5x10xf32>) ->
 //CHECK:           [[VAR_cst_:%.+]] = constant 0.000000e+00 : f32
 //CHECK:           [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 //CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_0_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10) {
-//CHECK:             affine.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
+//CHECK:             krnl.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
 //CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 //CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 5) {
-//CHECK:               [[LOAD_A_MEM_:%.+]] = affine.load [[A_]]{{.}}[[I_2_]]{{.}} : memref<5xf32>
-//CHECK:               [[LOAD_B_MEM_:%.+]] = affine.load [[B_]]{{.}}[[I_0_]], [[I_2_]], [[I_1_]]{{.}} : memref<?x5x10xf32>
-//CHECK:               [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
+//CHECK:               [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[I_2_]]{{.}} : memref<5xf32>
+//CHECK:               [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[I_0_]], [[I_2_]], [[I_1_]]{{.}} : memref<?x5x10xf32>
+//CHECK:               [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
 //CHECK:               [[VAR_7_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
 //CHECK:               [[VAR_8_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_7_]] : f32
-//CHECK:               affine.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
+//CHECK:               krnl.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
 //CHECK:             }
 //CHECK:           }
 //CHECK:           return [[RES_]] : memref<?x10xf32>
@@ -1209,15 +1209,15 @@ func private @test_matmul6(%arg0 : tensor<?x10x5xf32>, %arg1 : tensor<5xf32>) ->
 //CHECK:           [[VAR_cst_:%.+]] = constant 0.000000e+00 : f32
 //CHECK:           [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 //CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_0_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10) {
-//CHECK:             affine.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
+//CHECK:             krnl.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
 //CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 //CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 5) {
-//CHECK:               [[LOAD_A_MEM_:%.+]] = affine.load [[A_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x10x5xf32>
-//CHECK:               [[LOAD_B_MEM_:%.+]] = affine.load [[B_]]{{.}}[[I_2_]]{{.}} : memref<5xf32>
-//CHECK:               [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
+//CHECK:               [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x10x5xf32>
+//CHECK:               [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[I_2_]]{{.}} : memref<5xf32>
+//CHECK:               [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
 //CHECK:               [[VAR_7_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
 //CHECK:               [[VAR_8_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_7_]] : f32
-//CHECK:               affine.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
+//CHECK:               krnl.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x10xf32>
 //CHECK:             }
 //CHECK:           }
 //CHECK:           return [[RES_]] : memref<?x10xf32>
@@ -1237,15 +1237,15 @@ func private @test_matmul7(%arg0 : tensor<5xf32>, %arg1 : tensor<5xf32>) -> tens
 //CHECK:           [[VAR_cst_:%.+]] = constant 0.000000e+00 : f32
 //CHECK:           [[LOOP_0_:%.+]] = krnl.define_loops 1
 //CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 1) {
-//CHECK:             affine.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<1xf32>
+//CHECK:             krnl.store [[VAR_cst_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<1xf32>
 //CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 //CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_1_:%.+]] = 0 to 5) {
-//CHECK:               [[LOAD_A_MEM_:%.+]] = affine.load [[A_]]{{.}}[[I_1_]]{{.}} : memref<5xf32>
-//CHECK:               [[LOAD_B_MEM_:%.+]] = affine.load [[B_]]{{.}}[[I_1_]]{{.}} : memref<5xf32>
-//CHECK:               [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]]{{.}}[[I_0_]]{{.}} : memref<1xf32>
+//CHECK:               [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[I_1_]]{{.}} : memref<5xf32>
+//CHECK:               [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[I_1_]]{{.}} : memref<5xf32>
+//CHECK:               [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]]{{.}} : memref<1xf32>
 //CHECK:               [[VAR_6_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
 //CHECK:               [[VAR_7_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_6_]] : f32
-//CHECK:               affine.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<1xf32>
+//CHECK:               krnl.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<1xf32>
 //CHECK:             }
 //CHECK:           }
 //CHECK:           return [[RES_]] : memref<1xf32>
@@ -1270,18 +1270,18 @@ func private @test_conv_no_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : te
   // CHECK: [[SPATIAL_LOOPS:%.+]]:2 = krnl.define_loops 2
 
   // CHECK: krnl.iterate([[SPATIAL_LOOPS]]#0, [[SPATIAL_LOOPS]]#1) with ([[SPATIAL_LOOPS]]#0 -> %arg4 = 0 to 27, [[SPATIAL_LOOPS]]#1 -> %arg5 = 0 to 58) {
-  // CHECK: affine.store [[CONST1]], [[RES]][%arg2, %arg3, %arg4, %arg5] : memref<1x5x27x58xf32>
+  // CHECK: krnl.store [[CONST1]], [[RES]][%arg2, %arg3, %arg4, %arg5] : memref<1x5x27x58xf32>
   // CHECK: [[INNER_LOOPS:%.+]]:3 = krnl.define_loops 3
 
   // CHECK: krnl.iterate([[INNER_LOOPS]]#0, [[INNER_LOOPS]]#1, [[INNER_LOOPS]]#2) with ([[INNER_LOOPS]]#0 -> %arg6 = 0 to 2, [[INNER_LOOPS]]#1 -> %arg7 = 0 to 6, [[INNER_LOOPS]]#2 -> %arg8 = 0 to 7) {
   // CHECK: [[R1PLUSK1:%.+]] = affine.apply #{{.*}}(%arg4, %arg7)
   // CHECK: [[R2PLUSK2:%.+]] = affine.apply #{{.*}}(%arg5, %arg8)
-  // CHECK: [[DATA:%.+]] = affine.load %arg0[%arg2, %arg6, [[R1PLUSK1]], [[R2PLUSK2]]] : memref<1x2x32x64xf32>
-  // CHECK: [[KERNEL:%.+]] = affine.load %arg1[%arg3, %arg6, %arg7, %arg8] : memref<5x2x6x7xf32>
-  // CHECK: [[ACC_RES:%.+]] = affine.load %0[%arg2, %arg3, %arg4, %arg5] : memref<1x5x27x58xf32>
+  // CHECK: [[DATA:%.+]] = krnl.load %arg0[%arg2, %arg6, [[R1PLUSK1]], [[R2PLUSK2]]] : memref<1x2x32x64xf32>
+  // CHECK: [[KERNEL:%.+]] = krnl.load %arg1[%arg3, %arg6, %arg7, %arg8] : memref<5x2x6x7xf32>
+  // CHECK: [[ACC_RES:%.+]] = krnl.load %0[%arg2, %arg3, %arg4, %arg5] : memref<1x5x27x58xf32>
   // CHECK: [[MUL:%.+]] = mulf [[DATA]], [[KERNEL]] : f32
   // CHECK: [[ADD:%.+]] = addf [[ACC_RES]], [[MUL]] : f32
-  // CHECK: affine.store [[ADD]], [[RES]][%arg2, %arg3, %arg4, %arg5] : memref<1x5x27x58xf32>
+  // CHECK: krnl.store [[ADD]], [[RES]][%arg2, %arg3, %arg4, %arg5] : memref<1x5x27x58xf32>
   // CHECK: }
   // CHECK: }
   // CHECK: }
@@ -1306,23 +1306,23 @@ func private @test_conv_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tenso
   // CHECK: [[SPATIAL_LOOPS:%.+]]:2 = krnl.define_loops 2
 
   // CHECK: krnl.iterate([[SPATIAL_LOOPS]]#0, [[SPATIAL_LOOPS]]#1) with ([[SPATIAL_LOOPS]]#0 -> %arg5 = 0 to 27, [[SPATIAL_LOOPS]]#1 -> %arg6 = 0 to 58) {
-  // CHECK: affine.store [[CONST1]], [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
+  // CHECK: krnl.store [[CONST1]], [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
   // CHECK: [[INNER_LOOPS:%.+]]:3 = krnl.define_loops 3
 
   // CHECK: krnl.iterate([[INNER_LOOPS]]#0, [[INNER_LOOPS]]#1, [[INNER_LOOPS]]#2) with ([[INNER_LOOPS]]#0 -> %arg7 = 0 to 2, [[INNER_LOOPS]]#1 -> %arg8 = 0 to 6, [[INNER_LOOPS]]#2 -> %arg9 = 0 to 7) {
   // CHECK: [[R1PLUSK1:%.+]] = affine.apply #{{.*}}(%arg5, %arg8)
   // CHECK: [[R2PLUSK2:%.+]] = affine.apply #{{.*}}(%arg6, %arg9)
-  // CHECK: [[DATA:%.+]] = affine.load %arg0[%arg3, %arg7, [[R1PLUSK1]], [[R2PLUSK2]]] : memref<1x2x32x64xf32>
-  // CHECK: [[KERNEL:%.+]] = affine.load %arg1[%arg4, %arg7, %arg8, %arg9] : memref<5x2x6x7xf32>
-  // CHECK: [[ACC_RES:%.+]] = affine.load %0[%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
+  // CHECK: [[DATA:%.+]] = krnl.load %arg0[%arg3, %arg7, [[R1PLUSK1]], [[R2PLUSK2]]] : memref<1x2x32x64xf32>
+  // CHECK: [[KERNEL:%.+]] = krnl.load %arg1[%arg4, %arg7, %arg8, %arg9] : memref<5x2x6x7xf32>
+  // CHECK: [[ACC_RES:%.+]] = krnl.load %0[%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
   // CHECK: [[MUL:%.+]] = mulf [[DATA]], [[KERNEL]] : f32
   // CHECK: [[ADD:%.+]] = addf [[ACC_RES]], [[MUL]] : f32
-  // CHECK: affine.store [[ADD]], [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
+  // CHECK: krnl.store [[ADD]], [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
   // CHECK: }
-  // CHECK: [[BIAS1:%.+]] = affine.load [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
-  // CHECK: [[BIAS2:%.+]] = affine.load %arg2[%arg4] : memref<5xf32>
+  // CHECK: [[BIAS1:%.+]] = krnl.load [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
+  // CHECK: [[BIAS2:%.+]] = krnl.load %arg2[%arg4] : memref<5xf32>
   // CHECK: [[BIAS3:%.+]] = addf [[BIAS1]], [[BIAS2]] : f32
-  // CHECK: affine.store [[BIAS3]], [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
+  // CHECK: krnl.store [[BIAS3]], [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<1x5x27x58xf32>
   // CHECK: }
   // CHECK: }
   // CHECK: return [[RES]] : memref<1x5x27x58xf32>
@@ -1347,19 +1347,19 @@ func private @test_conv_no_bias_no_pad_w_group(%arg0 : tensor<1x9x32x64xf32>, %a
   // CHECK: [[SPATIAL_LOOPS:%.+]]:2 = krnl.define_loops 2
 
   // CHECK: krnl.iterate([[SPATIAL_LOOPS]]#0, [[SPATIAL_LOOPS]]#1) with ([[SPATIAL_LOOPS]]#0 -> %arg5 = 0 to 27, [[SPATIAL_LOOPS]]#1 -> %arg6 = 0 to 58) {
-  // CHECK: affine.store [[CONST1]], [[RES]][%arg2, %[[ADD1]], %arg5, %arg6] : memref<1x5x27x58xf32>
+  // CHECK: krnl.store [[CONST1]], [[RES]][%arg2, %[[ADD1]], %arg5, %arg6] : memref<1x5x27x58xf32>
   // CHECK: [[INNER_LOOPS:%.+]]:3 = krnl.define_loops 3
 
   // CHECK: krnl.iterate([[INNER_LOOPS]]#0, [[INNER_LOOPS]]#1, [[INNER_LOOPS]]#2) with ([[INNER_LOOPS]]#0 -> %arg7 = 0 to 3, [[INNER_LOOPS]]#1 -> %arg8 = 0 to 6, [[INNER_LOOPS]]#2 -> %arg9 = 0 to 7) {
   // CHECK: [[ADD2:%.+]] = affine.apply #{{.*}}(%arg3, %arg7)[%c3]
   // CHECK: [[R1PLUSK1:%.+]] = affine.apply #{{.*}}(%arg5, %arg8)
   // CHECK: [[R2PLUSK2:%.+]] = affine.apply #{{.*}}(%arg6, %arg9)
-  // CHECK: [[DATA:%.+]] = affine.load %arg0[%arg2, [[ADD2]], [[R1PLUSK1]], [[R2PLUSK2]]] : memref<1x9x32x64xf32>
-  // CHECK: [[KERNEL:%.+]] = affine.load %arg1[%[[ADD1]], %arg7, %arg8, %arg9] : memref<5x3x6x7xf32>
-  // CHECK: [[ACC_RES:%.+]] = affine.load %0[%arg2, %[[ADD1]], %arg5, %arg6] : memref<1x5x27x58xf32>
+  // CHECK: [[DATA:%.+]] = krnl.load %arg0[%arg2, [[ADD2]], [[R1PLUSK1]], [[R2PLUSK2]]] : memref<1x9x32x64xf32>
+  // CHECK: [[KERNEL:%.+]] = krnl.load %arg1[%[[ADD1]], %arg7, %arg8, %arg9] : memref<5x3x6x7xf32>
+  // CHECK: [[ACC_RES:%.+]] = krnl.load %0[%arg2, %[[ADD1]], %arg5, %arg6] : memref<1x5x27x58xf32>
   // CHECK: [[MUL:%.+]] = mulf [[DATA]], [[KERNEL]] : f32
   // CHECK: [[ADD:%.+]] = addf [[ACC_RES]], [[MUL]] : f32
-  // CHECK: affine.store [[ADD]], [[RES]][%arg2, %[[ADD1]], %arg5, %arg6] : memref<1x5x27x58xf32>
+  // CHECK: krnl.store [[ADD]], [[RES]][%arg2, %[[ADD1]], %arg5, %arg6] : memref<1x5x27x58xf32>
   // CHECK: }
   // CHECK: }
   // CHECK: }
@@ -1385,18 +1385,18 @@ func private @test_conv_no_bias_no_pad_w_strides(%arg0 : tensor<1x9x32x64xf32>, 
   // CHECK: [[SPATIAL_LOOPS:%.+]]:2 = krnl.define_loops 2
 
   // CHECK: krnl.iterate([[SPATIAL_LOOPS]]#0, [[SPATIAL_LOOPS]]#1) with ([[SPATIAL_LOOPS]]#0 -> %arg4 = 0 to 14, [[SPATIAL_LOOPS]]#1 -> %arg5 = 0 to 29) {
-  // CHECK: affine.store [[CONST1]], [[RES]][%arg2, %arg3, %arg4, %arg5] : memref<1x5x14x29xf32>
+  // CHECK: krnl.store [[CONST1]], [[RES]][%arg2, %arg3, %arg4, %arg5] : memref<1x5x14x29xf32>
   // CHECK: [[INNER_LOOPS:%.+]]:3 = krnl.define_loops 3
 
   // CHECK: krnl.iterate([[INNER_LOOPS]]#0, [[INNER_LOOPS]]#1, [[INNER_LOOPS]]#2) with ([[INNER_LOOPS]]#0 -> %arg6 = 0 to 9, [[INNER_LOOPS]]#1 -> %arg7 = 0 to 6, [[INNER_LOOPS]]#2 -> %arg8 = 0 to 7) {
   // CHECK: [[R1PLUSK1:%.+]] = affine.apply #{{.*}}(%arg4, %arg7)
   // CHECK: [[R2PLUSK2:%.+]] = affine.apply #{{.*}}(%arg5, %arg8)
-  // CHECK: [[DATA:%.+]] = affine.load %arg0[%arg2, %arg6, [[R1PLUSK1]], [[R2PLUSK2]]] : memref<1x9x32x64xf32>
-  // CHECK: [[KERNEL:%.+]] = affine.load %arg1[%arg3, %arg6, %arg7, %arg8] : memref<5x9x6x7xf32>
-  // CHECK: [[ACC_RES:%.+]] = affine.load %0[%arg2, %arg3, %arg4, %arg5] : memref<1x5x14x29xf32>
+  // CHECK: [[DATA:%.+]] = krnl.load %arg0[%arg2, %arg6, [[R1PLUSK1]], [[R2PLUSK2]]] : memref<1x9x32x64xf32>
+  // CHECK: [[KERNEL:%.+]] = krnl.load %arg1[%arg3, %arg6, %arg7, %arg8] : memref<5x9x6x7xf32>
+  // CHECK: [[ACC_RES:%.+]] = krnl.load %0[%arg2, %arg3, %arg4, %arg5] : memref<1x5x14x29xf32>
   // CHECK: [[MUL:%.+]] = mulf [[DATA]], [[KERNEL]] : f32
   // CHECK: [[ADD:%.+]] = addf [[ACC_RES]], [[MUL]] : f32
-  // CHECK: affine.store [[ADD]], [[RES]][%arg2, %arg3, %arg4, %arg5] : memref<1x5x14x29xf32>
+  // CHECK: krnl.store [[ADD]], [[RES]][%arg2, %arg3, %arg4, %arg5] : memref<1x5x14x29xf32>
   // CHECK: }
   // CHECK: }
   // CHECK: }
@@ -1415,19 +1415,19 @@ func private @test_batchnorm_testmode_Nd(%arg0: tensor<1x2x1x3xf32>, %arg1: tens
   // CHECK: [[EPSILON:%.+]] = constant 9.99999974E-6 : f32
   // CHECK: [[DEF_LOOPS:%.+]]:4 = krnl.define_loops 4
   // CHECK: krnl.iterate([[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#1 -> %arg5 = 0 to 2) {
-  // CHECK:   [[SCALE:%.+]] = affine.load %arg1[%arg5] : memref<2xf32>
-  // CHECK:   [[BIAS:%.+]] = affine.load %arg2[%arg5] : memref<2xf32>
-  // CHECK:   [[MEAN:%.+]] = affine.load %arg3[%arg5] : memref<2xf32>
-  // CHECK:   [[VARIANCE:%.+]] = affine.load %arg4[%arg5] : memref<2xf32>
+  // CHECK:   [[SCALE:%.+]] = krnl.load %arg1[%arg5] : memref<2xf32>
+  // CHECK:   [[BIAS:%.+]] = krnl.load %arg2[%arg5] : memref<2xf32>
+  // CHECK:   [[MEAN:%.+]] = krnl.load %arg3[%arg5] : memref<2xf32>
+  // CHECK:   [[VARIANCE:%.+]] = krnl.load %arg4[%arg5] : memref<2xf32>
   // CHECK:   krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#2, [[DEF_LOOPS]]#3) with ([[DEF_LOOPS]]#0 -> %arg6 = 0 to 1, [[DEF_LOOPS]]#2 -> %arg7 = 0 to 1, [[DEF_LOOPS]]#3 -> %arg8 = 0 to 3) {
-  // CHECK:     [[LOADED_VAL:%.+]] = affine.load %arg0[%arg6, %arg5, %arg7, %arg8] : memref<1x2x1x3xf32>
+  // CHECK:     [[LOADED_VAL:%.+]] = krnl.load %arg0[%arg6, %arg5, %arg7, %arg8] : memref<1x2x1x3xf32>
   // CHECK:     [[DIVIDEND:%.+]] = subf [[LOADED_VAL]], [[MEAN]] : f32
   // CHECK:     [[ADJUSTED_VARIANCE:%.+]] = addf [[VARIANCE]], [[EPSILON]] : f32
   // CHECK:     [[DIVISOR:%.+]] = sqrt [[ADJUSTED_VARIANCE]] : f32
   // CHECK:     [[NORM:%.+]] = divf [[DIVIDEND]], [[DIVISOR]] : f32
   // CHECK:     [[SCALE_NORM:%.+]] = mulf [[SCALE]], [[NORM]] : f32
   // CHECK:     [[SHIFT_SCALE_NORM:%.+]] = addf [[SCALE_NORM]], [[BIAS]] : f32
-  // CHECK:     affine.store [[SHIFT_SCALE_NORM]], [[RES]][%arg6, %arg5, %arg7, %arg8] : memref<1x2x1x3xf32>
+  // CHECK:     krnl.store [[SHIFT_SCALE_NORM]], [[RES]][%arg6, %arg5, %arg7, %arg8] : memref<1x2x1x3xf32>
   // CHECK:   }
   // CHECK: }
   // CHECK: return [[RES]] : memref<1x2x1x3xf32>
@@ -1444,19 +1444,19 @@ func private @test_batchnorm_testmode_1d(%arg0: tensor<10xf32>, %arg1: tensor<1x
   // CHECK: [[EPSILON:%.+]] = constant 9.99999974E-6 : f32
   // CHECK: [[DEF_LOOPS:%.+]] = krnl.define_loops 1
   // CHECK: %[[ZERO_INDEX:.+]] = constant 0 : index
-  // CHECK: [[SCALE:%.+]] = affine.load %arg1[%[[ZERO_INDEX]]] : memref<1xf32>
-  // CHECK: [[BIAS:%.+]] = affine.load %arg2[%[[ZERO_INDEX]]] : memref<1xf32>
-  // CHECK: [[MEAN:%.+]] = affine.load %arg3[%[[ZERO_INDEX]]] : memref<1xf32>
-  // CHECK: [[VARIANCE:%.+]] = affine.load %arg4[%[[ZERO_INDEX]]] : memref<1xf32>
+  // CHECK: [[SCALE:%.+]] = krnl.load %arg1[%[[ZERO_INDEX]]] : memref<1xf32>
+  // CHECK: [[BIAS:%.+]] = krnl.load %arg2[%[[ZERO_INDEX]]] : memref<1xf32>
+  // CHECK: [[MEAN:%.+]] = krnl.load %arg3[%[[ZERO_INDEX]]] : memref<1xf32>
+  // CHECK: [[VARIANCE:%.+]] = krnl.load %arg4[%[[ZERO_INDEX]]] : memref<1xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]) with ([[DEF_LOOPS]] -> %arg5 = 0 to 10) {
-  // CHECK:   [[LOADED_VAL:%.+]] = affine.load %arg0[%arg5] : memref<10xf32>
+  // CHECK:   [[LOADED_VAL:%.+]] = krnl.load %arg0[%arg5] : memref<10xf32>
   // CHECK:   [[DIVIDEND:%.+]] = subf [[LOADED_VAL]], [[MEAN]] : f32
   // CHECK:   [[ADJUSTED_VARIANCE:%.+]] = addf [[VARIANCE]], [[EPSILON]] : f32
   // CHECK:   [[DIVISOR:%.+]] = sqrt [[ADJUSTED_VARIANCE]] : f32
   // CHECK:   [[NORM:%.+]] = divf [[DIVIDEND]], [[DIVISOR]] : f32
   // CHECK:   [[SCALE_NORM:%.+]] = mulf [[SCALE]], [[NORM]] : f32
   // CHECK:   [[SHIFT_SCALE_NORM:%.+]] = addf [[SCALE_NORM]], [[BIAS]] : f32
-  // CHECK:   affine.store [[SHIFT_SCALE_NORM]], [[RES]][%arg5] : memref<10xf32>
+  // CHECK:   krnl.store [[SHIFT_SCALE_NORM]], [[RES]][%arg5] : memref<10xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<10xf32>
 }
@@ -1472,19 +1472,19 @@ func private @test_batchnorm_testmode_2d(%arg0: tensor<10x3xf32>, %arg1: tensor<
   // CHECK: [[EPSILON:%.+]] = constant 9.99999974E-6 : f32
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#1 -> %arg5 = 0 to 3) {
-  // CHECK:   [[SCALE:%.+]] = affine.load %arg1[%arg5] : memref<3xf32>
-  // CHECK:   [[BIAS:%.+]] = affine.load %arg2[%arg5] : memref<3xf32>
-  // CHECK:   [[MEAN:%.+]] = affine.load %arg3[%arg5] : memref<3xf32>
-  // CHECK:   [[VARIANCE:%.+]] = affine.load %arg4[%arg5] : memref<3xf32>
+  // CHECK:   [[SCALE:%.+]] = krnl.load %arg1[%arg5] : memref<3xf32>
+  // CHECK:   [[BIAS:%.+]] = krnl.load %arg2[%arg5] : memref<3xf32>
+  // CHECK:   [[MEAN:%.+]] = krnl.load %arg3[%arg5] : memref<3xf32>
+  // CHECK:   [[VARIANCE:%.+]] = krnl.load %arg4[%arg5] : memref<3xf32>
   // CHECK:   krnl.iterate([[DEF_LOOPS]]#0) with ([[DEF_LOOPS]]#0 -> %arg6 = 0 to 10) {
-  // CHECK:     [[LOADED_VAL:%.+]] = affine.load %arg0[%arg6, %arg5] : memref<10x3xf32>
+  // CHECK:     [[LOADED_VAL:%.+]] = krnl.load %arg0[%arg6, %arg5] : memref<10x3xf32>
   // CHECK:     [[DIVIDEND:%.+]] = subf [[LOADED_VAL]], [[MEAN]] : f32
   // CHECK:     [[ADJUSTED_VARIANCE:%.+]] = addf [[VARIANCE]], [[EPSILON]] : f32
   // CHECK:     [[DIVISOR:%.+]] = sqrt [[ADJUSTED_VARIANCE]] : f32
   // CHECK:     [[NORM:%.+]] = divf [[DIVIDEND]], [[DIVISOR]] : f32
   // CHECK:     [[SCALE_NORM:%.+]] = mulf [[SCALE]], [[NORM]] : f32
   // CHECK:     [[SHIFT_SCALE_NORM:%.+]] = addf [[SCALE_NORM]], [[BIAS]] : f32
-  // CHECK:     affine.store [[SHIFT_SCALE_NORM]], [[RES]][%arg6, %arg5] : memref<10x3xf32>
+  // CHECK:     krnl.store [[SHIFT_SCALE_NORM]], [[RES]][%arg6, %arg5] : memref<10x3xf32>
   // CHECK:   }
   // CHECK: }
   // CHECK: return [[RES]] : memref<10x3xf32>
@@ -1504,9 +1504,9 @@ func private @test_abs_float(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ABS:%.+]] = absf [[LOAD]] : f32
-  // CHECK: affine.store [[ABS]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[ABS]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -1524,12 +1524,12 @@ func private @test_abs_int(%arg0 : tensor<?x10xi32>) -> tensor<*xi32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xi32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xi32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xi32>
   // CHECK: [[ZERO:%.+]] = constant 0 : i32
   // CHECK: [[LESS_THAN_ZERO:%.+]] = cmpi "slt", [[LOAD]], [[ZERO]] : i32
   // CHECK: [[NEGATIVE_LOAD:%.+]] = subi [[ZERO]], [[LOAD]] : i32
   // CHECK: [[SELECT:%.+]] = select [[LESS_THAN_ZERO]], [[NEGATIVE_LOAD]], [[LOAD]] : i32
-  // CHECK: affine.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xi32>
+  // CHECK: krnl.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xi32>
   // CHECK: return [[RES]] : memref<?x10xi32>
 }
 
@@ -1543,13 +1543,13 @@ func private @test_constant_pad1(%arg0: tensor<16x16xf32>) -> tensor<18x20xf32> 
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 18, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 20) {
   // CHECK: [[CST:%.+]] = constant 0.000000e+00 : f32
-  // CHECK: affine.store [[CST]], [[RES]][%arg1, %arg2] : memref<18x20xf32>
+  // CHECK: krnl.store [[CST]], [[RES]][%arg1, %arg2] : memref<18x20xf32>
   // CHECK: }
   // CHECK: [[DEF_LOOPS2:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1) with ([[DEF_LOOPS2]]#0 -> %arg1 = 0 to 16, [[DEF_LOOPS2]]#1 -> %arg2 = 0 to 16) {
   // CHECK: [[ADD:%.+]] = affine.apply #{{.*}}(%arg2)
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<16x16xf32>
-  // CHECK: affine.store [[LOAD]], [[RES]][%arg1, [[ADD]]] : memref<18x20xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<16x16xf32>
+  // CHECK: krnl.store [[LOAD]], [[RES]][%arg1, [[ADD]]] : memref<18x20xf32>
   // CHECK: }
 }
 
@@ -1562,13 +1562,13 @@ func private @test_pad1(%arg0: tensor<16x16xf32>) -> tensor<18x20xf32> {
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 18, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 20) {
   // CHECK: [[CST:%.+]] = constant 0.000000e+00 : f32
-  // CHECK: affine.store [[CST]], [[RES]][%arg1, %arg2] : memref<18x20xf32>
+  // CHECK: krnl.store [[CST]], [[RES]][%arg1, %arg2] : memref<18x20xf32>
   // CHECK: }
   // CHECK: [[DEF_LOOPS2:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1) with ([[DEF_LOOPS2]]#0 -> %arg1 = 0 to 16, [[DEF_LOOPS2]]#1 -> %arg2 = 0 to 16) {
   // CHECK: [[ADD:%.+]] = affine.apply #{{.*}}(%arg2)
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<16x16xf32>
-  // CHECK: affine.store [[LOAD]], [[RES]][%arg1, [[ADD]]] : memref<18x20xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<16x16xf32>
+  // CHECK: krnl.store [[LOAD]], [[RES]][%arg1, [[ADD]]] : memref<18x20xf32>
   // CHECK: }
 }
 
@@ -1597,20 +1597,20 @@ func private @test_concat_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x3
   // CHECK: [[RES:%.+]] = alloc() : memref<5x5x9x32xf32>
   // CHECK: [[DEF_LOOPS0:%.+]]:4 = krnl.define_loops 4
   // CHECK: krnl.iterate([[DEF_LOOPS0]]#0, [[DEF_LOOPS0]]#1, [[DEF_LOOPS0]]#2, [[DEF_LOOPS0]]#3) with ([[DEF_LOOPS0]]#0 -> %arg3 = 0 to 5, [[DEF_LOOPS0]]#1 -> %arg4 = 0 to 5, [[DEF_LOOPS0]]#2 -> %arg5 = 0 to 1, [[DEF_LOOPS0]]#3 -> %arg6 = 0 to 32) {
-  // CHECK: [[LOAD0:%.+]] = affine.load %arg0[%arg3, %arg4, %arg5, %arg6] :  memref<5x5x1x32xf32>
-  // CHECK: affine.store [[LOAD0]], [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<5x5x9x32xf32>
+  // CHECK: [[LOAD0:%.+]] = krnl.load %arg0[%arg3, %arg4, %arg5, %arg6] :  memref<5x5x1x32xf32>
+  // CHECK: krnl.store [[LOAD0]], [[RES]][%arg3, %arg4, %arg5, %arg6] : memref<5x5x9x32xf32>
 
   // CHECK: [[DEF_LOOPS1:%.+]]:4 = krnl.define_loops 4
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1, [[DEF_LOOPS1]]#2, [[DEF_LOOPS1]]#3) with ([[DEF_LOOPS1]]#0 -> %arg3 = 0 to 5, [[DEF_LOOPS1]]#1 -> %arg4 = 0 to 5, [[DEF_LOOPS1]]#2 -> %arg5 = 0 to 3, [[DEF_LOOPS1]]#3 -> %arg6 = 0 to 32) {
   // CHECK: [[AFFINE_APPLY1:%.+]] = affine.apply #{{.*}}(%arg5)
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg1[%arg3, %arg4, %arg5, %arg6] :  memref<5x5x3x32xf32>
-  // CHECK: affine.store [[LOAD1]], [[RES]][%arg3, %arg4, [[AFFINE_APPLY1]], %arg6] : memref<5x5x9x32xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg1[%arg3, %arg4, %arg5, %arg6] :  memref<5x5x3x32xf32>
+  // CHECK: krnl.store [[LOAD1]], [[RES]][%arg3, %arg4, [[AFFINE_APPLY1]], %arg6] : memref<5x5x9x32xf32>
 
   // CHECK: [[DEF_LOOPS2:%.+]]:4 = krnl.define_loops 4
   // CHECK: krnl.iterate([[DEF_LOOPS2]]#0, [[DEF_LOOPS2]]#1, [[DEF_LOOPS2]]#2, [[DEF_LOOPS2]]#3) with ([[DEF_LOOPS2]]#0 -> %arg3 = 0 to 5, [[DEF_LOOPS2]]#1 -> %arg4 = 0 to 5, [[DEF_LOOPS2]]#2 -> %arg5 = 0 to 5, [[DEF_LOOPS2]]#3 -> %arg6 = 0 to 32) {
   // CHECK: [[AFFINE_APPLY2:%.+]] = affine.apply #{{.*}}(%arg5)
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg2[%arg3, %arg4, %arg5, %arg6] :  memref<5x5x5x32xf32>
-  // CHECK: affine.store [[LOAD2]], [[RES]][%arg3, %arg4, [[AFFINE_APPLY2]], %arg6] : memref<5x5x9x32xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg2[%arg3, %arg4, %arg5, %arg6] :  memref<5x5x5x32xf32>
+  // CHECK: krnl.store [[LOAD2]], [[RES]][%arg3, %arg4, [[AFFINE_APPLY2]], %arg6] : memref<5x5x9x32xf32>
 
   // CHECK: return [[RES]] :  memref<5x5x9x32xf32>
 }
@@ -1633,17 +1633,17 @@ func private @test_pool_general_computation(%arg0 : tensor<1x3x32x32xf32>) -> te
   // CHECK: [[OUTPUT_LOOPS:%.+]]:4 = krnl.define_loops 4
   // CHECK: krnl.iterate([[OUTPUT_LOOPS]]#0, [[OUTPUT_LOOPS]]#1, [[OUTPUT_LOOPS]]#2, [[OUTPUT_LOOPS]]#3) with ([[OUTPUT_LOOPS]]#0 -> %arg1 = 0 to 1, [[OUTPUT_LOOPS]]#1 -> %arg2 = 0 to 3, [[OUTPUT_LOOPS]]#2 -> %arg3 = 0 to 31, [[OUTPUT_LOOPS]]#3 -> %arg4 = 0 to 31) {
 
-  // CHECK:   affine.store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
 
   // CHECK:   [[POOL_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK:   krnl.iterate([[POOL_LOOPS]]#0, [[POOL_LOOPS]]#1) with ([[POOL_LOOPS]]#0 -> %arg5 = 0 to min #{{.*}}(%arg3)[%c32, %c2, %c0, %c1, %c1_0], [[POOL_LOOPS]]#1 -> %arg6 = 0 to min #{{.*}}(%arg4)[%c32_1, %c2_2, %c0_3, %c1_4, %c1_5]) {
-  // CHECK:     {{.*}} = load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
-  // CHECK:     {{.*}} = affine.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
-  // CHECK:     affine.store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     {{.*}} = krnl.load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
+  // CHECK:     {{.*}} = krnl.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     krnl.store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK:   }
 
-  // CHECK:   {{.*}} = affine.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
-  // CHECK:   affine.store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   {{.*}} = krnl.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   krnl.store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK: }
 }
 
@@ -1674,7 +1674,7 @@ func private @test_averagepool_identity_value(%arg0 : tensor<1x3x32x32xf32>) -> 
   // CHECK-LABEL: @test_averagepool_identity_value
   // CHECK: [[RES:%.+]] = alloc() : memref<1x3x31x31xf32>
   // CHECK: [[IDENTITY:%.+]] = constant 0.000000e+00 : f32
-  // CHECK: affine.store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK: krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
 }
 
 // -----
@@ -1686,7 +1686,7 @@ func private @test_maxpool_identity_value(%arg0 : tensor<1x3x32x32xf32>) -> tens
   // CHECK-LABEL: @test_maxpool_identity_value
   // CHECK: [[RES:%.+]] = alloc() : memref<1x3x31x31xf32>
   // CHECK: [[IDENTITY:%.+]] = constant 0xFF800000 : f32
-  // CHECK: affine.store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK: krnl.store [[IDENTITY]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
 }
 
 // -----
@@ -1704,15 +1704,15 @@ func private @test_averagepool_pooling_operation(%arg0 : tensor<1x3x32x32xf32>) 
   // CHECK:   [[POOL_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK:   krnl.iterate([[POOL_LOOPS]]#0, [[POOL_LOOPS]]#1) with ([[POOL_LOOPS]]#0 -> %arg5 = 0 to min #{{.*}}(%arg3)[%c32, %c2, %c0, %c1, %c1_0], [[POOL_LOOPS]]#1 -> %arg6 = 0 to min #{{.*}}(%arg4)[%c32_1, %c2_2, %c0_3, %c1_4, %c1_5]) {
 
-  // CHECK:     [[INPUT_LOAD:%.+]] = load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
-  // CHECK:     [[OUTPUT_LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     [[INPUT_LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
+  // CHECK:     [[OUTPUT_LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK:     [[SUM:%.+]] = addf [[OUTPUT_LOAD]], [[INPUT_LOAD]] : f32
-  // CHECK:     affine.store [[SUM]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     krnl.store [[SUM]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK:   }
 
-  // CHECK:   [[NUMERATOR:%.+]] = affine.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   [[NUMERATOR:%.+]] = krnl.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK:   [[AVERAGE:%.+]] = divf [[NUMERATOR]], {{.*}} : f32
-  // CHECK:   affine.store [[AVERAGE]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:   krnl.store [[AVERAGE]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK: }
 }
 
@@ -1731,15 +1731,15 @@ func private @test_maxpool_pooling_operation(%arg0 : tensor<1x3x32x32xf32>) -> t
   // CHECK:   [[POOL_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK:   krnl.iterate([[POOL_LOOPS]]#0, [[POOL_LOOPS]]#1) with ([[POOL_LOOPS]]#0 -> %arg5 = 0 to min #{{.*}}(%arg3)[%c32, %c2, %c0, %c1, %c1_0], [[POOL_LOOPS]]#1 -> %arg6 = 0 to min #{{.*}}(%arg4)[%c32_1, %c2_2, %c0_3, %c1_4, %c1_5]) {
 
-  // CHECK:     [[INPUT_LOAD:%.+]] = load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
-  // CHECK:     [[OUTPUT_LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     [[INPUT_LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2, {{.*}}, {{.*}}] : memref<1x3x32x32xf32>
+  // CHECK:     [[OUTPUT_LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK:     [[GREATER:%.+]] = cmpf "ogt", [[OUTPUT_LOAD]], [[INPUT_LOAD]] : f32
   // CHECK:     [[SELECT:%.+]] = select [[GREATER]], [[OUTPUT_LOAD]], [[INPUT_LOAD]] : f32
-  // CHECK:     affine.store [[SELECT]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK:     krnl.store [[SELECT]], [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK:   }
 
-  // CHECK-NOT:   {{.*}} = affine.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
-  // CHECK-NOT:   affine.store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK-NOT:   {{.*}} = krnl.load [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
+  // CHECK-NOT:   krnl.store {{.*}}, [[RES]][%arg1, %arg2, %arg3, %arg4] : memref<1x3x31x31xf32>
   // CHECK: }
 }
 
@@ -1759,7 +1759,7 @@ func private @test_gru_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK: [[INITIAL_VAL:%.+]] = constant 0.000000e+00 : f32
   // CHECK: [[DEF_LOOPS_INIT:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS_INIT]]#0, [[DEF_LOOPS_INIT]]#1, [[DEF_LOOPS_INIT]]#2) with ([[DEF_LOOPS_INIT]]#0 -> %arg3 = 0 to 1, [[DEF_LOOPS_INIT]]#1 -> %arg4 = 0 to 3, [[DEF_LOOPS_INIT]]#2 -> %arg5 = 0 to 3) {
-  // CHECK:   affine.store [[INITIAL_VAL]], [[RES]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:   krnl.store [[INITIAL_VAL]], [[RES]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK: }
 
   /// Check main loop.
@@ -1782,43 +1782,43 @@ func private @test_gru_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
 
   // CHECK:     [[INITIAL_VAL_0:%.+]] = constant 0.000000e+00 : f32
   // CHECK:     [[XWZt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[XWZt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[XWZt]][] : memref<f32>
   // CHECK:     [[HRZt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[HRZt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[HRZt]][] : memref<f32>
   // CHECK:     [[XWRt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[XWRt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[XWRt]][] : memref<f32>
   // CHECK:     [[HRRt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[HRRt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[HRRt]][] : memref<f32>
 
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[xwHMemRef]][%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[xwHMemRef]][%arg4, %arg5] : memref<3x3xf32>
 
   // CHECK:     [[REDUCTION_LOOPS:%.+]] = krnl.define_loops 1
   // CHECK:     krnl.iterate([[REDUCTION_LOOPS]]) with ([[REDUCTION_LOOPS]] -> %arg6 = 0 to 2) {
   // CHECK:       [[BIAS_MAP_FOR_Z:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_0]], [[INDEX_3]]]
   // CHECK:       [[BIAS_MAP_FOR_R:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_1]], [[INDEX_3]]]
   // CHECK:       [[BIAS_MAP_FOR_H:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_2]], [[INDEX_3]]]
-  // CHECK:       [[Xt:%.+]] = affine.load %arg0[%arg3, %arg4, %arg6] : memref<4x3x2xf32>
+  // CHECK:       [[Xt:%.+]] = krnl.load %arg0[%arg3, %arg4, %arg6] : memref<4x3x2xf32>
 
   /// compute Xt*(Wz^T)
-  // CHECK:       [[WZt:%.+]] = affine.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_Z]], %arg6] : memref<1x9x2xf32>
+  // CHECK:       [[WZt:%.+]] = krnl.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_Z]], %arg6] : memref<1x9x2xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[Xt]], [[WZt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[XWZt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[XWZt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[XWZt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[XWZt]][] : memref<f32>
 
   /// compute Xt*(Wr^T)
-  // CHECK:       [[WRt:%.+]] = affine.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_R]], %arg6] : memref<1x9x2xf32>
+  // CHECK:       [[WRt:%.+]] = krnl.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_R]], %arg6] : memref<1x9x2xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[Xt]], [[WRt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[XWRt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[XWRt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[XWRt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[XWRt]][] : memref<f32>
 
   /// compute Xt*(Wh^T)
-  // CHECK:       [[WHt:%.+]] = affine.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_H]], %arg6] : memref<1x9x2xf32>
+  // CHECK:       [[WHt:%.+]] = krnl.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_H]], %arg6] : memref<1x9x2xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[Xt]], [[WHt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[xwHMemRef]][%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[xwHMemRef]][%arg4, %arg5] : memref<3x3xf32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[xwHMemRef]][%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:       krnl.store [[ADD]], [[xwHMemRef]][%arg4, %arg5] : memref<3x3xf32>
   // CHECK:     }
 
   // CHECK:     [[REDUCTION_LOOPS:%.+]] = krnl.define_loops 1
@@ -1826,60 +1826,60 @@ func private @test_gru_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:       [[BIAS_MAP_FOR_Z:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_0]], [[INDEX_3]]]
   // CHECK:       [[BIAS_MAP_FOR_R:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_1]], [[INDEX_3]]]
   // CHECK:       [[BIAS_MAP_FOR_H:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_2]], [[INDEX_3]]]
-  // CHECK:       [[PREVIOUS_Ht:%.+]] = affine.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg6] : memref<1x3x3xf32>
+  // CHECK:       [[PREVIOUS_Ht:%.+]] = krnl.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg6] : memref<1x3x3xf32>
   /// compute Ht-1*(Rz^T)
-  // CHECK:       [[RZt:%.+]] = affine.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_Z]], %arg6] : memref<1x9x3xf32>
+  // CHECK:       [[RZt:%.+]] = krnl.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_Z]], %arg6] : memref<1x9x3xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[PREVIOUS_Ht]], [[RZt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[HRZt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[HRZt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[HRZt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[HRZt]][] : memref<f32>
 
   /// compute Ht-1*(Rr^T)
-  // CHECK:       [[RRt:%.+]] = affine.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_R]], %arg6] : memref<1x9x3xf32>
+  // CHECK:       [[RRt:%.+]] = krnl.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_R]], %arg6] : memref<1x9x3xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[PREVIOUS_Ht]], [[RRt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[HRRt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[HRRt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[HRRt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[HRRt]][] : memref<f32>
   // CHECK:     }
 
   /// compute zt = f(Xt*(Wz^T) + Ht-1*(Rz^T) + Wbz + Rbz)
-  // CHECK:     [[LOAD_XWZt:%.+]] = affine.load [[XWZt]][] : memref<f32>
-  // CHECK:     [[LOAD_HRZt:%.+]] = affine.load [[HRZt]][] : memref<f32>
+  // CHECK:     [[LOAD_XWZt:%.+]] = krnl.load [[XWZt]][] : memref<f32>
+  // CHECK:     [[LOAD_HRZt:%.+]] = krnl.load [[HRZt]][] : memref<f32>
   // CHECK:     [[ADD:%.+]] = addf [[LOAD_XWZt]], [[LOAD_HRZt]] : f32
   /// apply activation f = sigmoid
   // CHECK:     {{.*}} = alloc() : memref<f32>
-  // CHECK:     affine.store [[ADD]], {{.*}}[] : memref<f32>
-  // CHECK:     {{.*}} = affine.load {{.*}}[] : memref<f32>
+  // CHECK:     krnl.store [[ADD]], {{.*}}[] : memref<f32>
+  // CHECK:     {{.*}} = krnl.load {{.*}}[] : memref<f32>
   // CHECK:     {{.*}} = constant 0.000000e+00 : f32
   // CHECK:     {{.*}} = constant 1.000000e+00 : f32
   // CHECK:     {{.*}} = subf {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = exp {{.*}} : f32
   // CHECK:     {{.*}} = addf {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = divf {{.*}}, {{.*}} : f32
-  // CHECK:     affine.store {{.*}}, [[zt]][] : memref<f32>
-  // CHECK:     affine.store {{.*}}, [[ztMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     krnl.store {{.*}}, [[zt]][] : memref<f32>
+  // CHECK:     krnl.store {{.*}}, [[ztMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
   /// compute rt = f(Xt*(Wr^T) + Ht-1*(Rr^T) + Wbr + Rbr)
-  // CHECK:     [[LOAD_XWRt:%.+]] = affine.load [[XWRt]][] : memref<f32>
-  // CHECK:     [[LOAD_HRRt:%.+]] = affine.load [[HRRt]][] : memref<f32>
+  // CHECK:     [[LOAD_XWRt:%.+]] = krnl.load [[XWRt]][] : memref<f32>
+  // CHECK:     [[LOAD_HRRt:%.+]] = krnl.load [[HRRt]][] : memref<f32>
   // CHECK:     [[ADD:%.+]] = addf [[LOAD_XWRt]], [[LOAD_HRRt]] : f32
   /// apply activation f = sigmoid
   // CHECK:     {{.*}} = alloc() : memref<f32>
-  // CHECK:     affine.store [[ADD]], {{.*}}[] : memref<f32>
-  // CHECK:     {{.*}} = affine.load {{.*}}[] : memref<f32>
+  // CHECK:     krnl.store [[ADD]], {{.*}}[] : memref<f32>
+  // CHECK:     {{.*}} = krnl.load {{.*}}[] : memref<f32>
   // CHECK:     {{.*}} = constant 0.000000e+00 : f32
   // CHECK:     {{.*}} = constant 1.000000e+00 : f32
   // CHECK:     {{.*}} = subf {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = exp {{.*}} : f32
   // CHECK:     {{.*}} = addf {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = divf {{.*}}, {{.*}} : f32
-  // CHECK:     affine.store {{.*}}, [[rt]][] : memref<f32>
-  // CHECK:     [[LOAD_rt:%.+]] = affine.load [[rt]][] : memref<f32>
+  // CHECK:     krnl.store {{.*}}, [[rt]][] : memref<f32>
+  // CHECK:     [[LOAD_rt:%.+]] = krnl.load [[rt]][] : memref<f32>
 
   // COM: 'rt (.) Ht-1'
-  // CHECK:     [[LOAD_ht:%.+]] = affine.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:     [[LOAD_ht:%.+]] = krnl.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK:     [[RtHt:%.+]] = mulf [[LOAD_rt]], [[LOAD_ht]] : f32
-  // CHECK:     affine.store [[RtHt]], [[rhMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     krnl.store [[RtHt]], [[rhMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
   // CHECK:     dealloc [[XWZt]] : memref<f32>
   // CHECK:     dealloc [[XWRt]] : memref<f32>
@@ -1892,15 +1892,15 @@ func private @test_gru_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:   krnl.iterate([[HT_LOOPS]]#0, [[HT_LOOPS]]#1) with ([[HT_LOOPS]]#0 -> %arg4 = 0 to 3, [[HT_LOOPS]]#1 -> %arg5 = 0 to 3) {
   // CHECK:     [[BIAS_MAP_FOR_H:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_2]], [[INDEX_3]]]
   // CHECK:     [[INITIAL_VAL:%.+]] = constant 0.000000e+00 : f32
-  // CHECK:     affine.store [[INITIAL_VAL]], [[rhrHMemRef]][%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     krnl.store [[INITIAL_VAL]], [[rhrHMemRef]][%arg4, %arg5] : memref<3x3xf32>
   // CHECK:     [[REDUCTION_LOOPS_1:%.+]] = krnl.define_loops 1
   // CHECK:     krnl.iterate([[REDUCTION_LOOPS_1]]) with ([[REDUCTION_LOOPS_1]] -> %arg6 = 0 to 3) {
-  // CHECK:       [[LOAD_RtHt:%.+]] = affine.load [[rhMemRef]][%arg4, %arg6] : memref<3x3xf32>
-  // CHECK:       [[LOAD_RHt:%.+]] = affine.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_H]], %arg6] : memref<1x9x3xf32>
+  // CHECK:       [[LOAD_RtHt:%.+]] = krnl.load [[rhMemRef]][%arg4, %arg6] : memref<3x3xf32>
+  // CHECK:       [[LOAD_RHt:%.+]] = krnl.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_H]], %arg6] : memref<1x9x3xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[LOAD_RtHt]], [[LOAD_RHt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[rhrHMemRef]][%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[rhrHMemRef]][%arg4, %arg5] : memref<3x3xf32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[rhrHMemRef]][%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:       krnl.store [[ADD]], [[rhrHMemRef]][%arg4, %arg5] : memref<3x3xf32>
   // CHECK:     }
   // CHECK:   }
 
@@ -1909,12 +1909,12 @@ func private @test_gru_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
 
   // COM: compute  ht = g(Xt*(Wh^T) + (rt (.) Ht-1)*(Rh^T) + Rbh + Wbh) since linear_before_reset = 0 (default)
   // CHECK:     [[ht:%.+]] = alloc() : memref<f32>
-  // CHECK:     [[LOAD_XWHt:%.+]] = affine.load [[xwHMemRef]][%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:     [[LOAD_HRHt:%.+]] = affine.load [[rhrHMemRef]][%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     [[LOAD_XWHt:%.+]] = krnl.load [[xwHMemRef]][%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     [[LOAD_HRHt:%.+]] = krnl.load [[rhrHMemRef]][%arg4, %arg5] : memref<3x3xf32>
   // CHECK:     [[ADD:%.+]] = addf [[LOAD_XWHt]], [[LOAD_HRHt]] : f32
   /// apply activation g = tanh
-  // CHECK:     affine.store [[ADD]], {{.*}}[] : memref<f32>
-  // CHECK:     {{.*}} = affine.load {{.*}}[] : memref<f32>
+  // CHECK:     krnl.store [[ADD]], {{.*}}[] : memref<f32>
+  // CHECK:     {{.*}} = krnl.load {{.*}}[] : memref<f32>
   // CHECK:     {{.*}} = constant 1.000000e+00 : f32
   // CHECK:     {{.*}} = constant 2.000000e+00 : f32
   // CHECK:     {{.*}} = mulf {{.*}}, {{.*}} : f32
@@ -1930,18 +1930,18 @@ func private @test_gru_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:     {{.*}} = constant 0.000000e+00 : f32
   // CHECK:     {{.*}} = cmpf "oge", {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = select {{.*}}, {{.*}}, {{.*}} : f32
-  // CHECK:     affine.store {{.*}}, [[ht]][] : memref<f32>
-  // CHECK:     [[LOAD_ht:%.+]] = affine.load [[ht]][] : memref<f32>
+  // CHECK:     krnl.store {{.*}}, [[ht]][] : memref<f32>
+  // CHECK:     [[LOAD_ht:%.+]] = krnl.load [[ht]][] : memref<f32>
 
   // COM: compute  Ht = (1 - zt) (.) ht + zt (.) Ht-1
-  // CHECK:     [[LOAD_zt:%.+]] = affine.load [[ztMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:     [[PREVIOUS_Ht:%.+]] = affine.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:     [[LOAD_zt:%.+]] = krnl.load [[ztMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     [[PREVIOUS_Ht:%.+]] = krnl.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK:     [[ONE:%.+]] = constant 1.000000e+00 : f32
   // CHECK:     [[SUB:%.+]] = subf [[ONE]], [[LOAD_zt]] : f32
   // CHECK:     [[MUL:%.+]] = mulf [[SUB]], [[LOAD_ht]] : f32
   // CHECK:     [[MUL_1:%.+]] = mulf [[LOAD_zt]], [[PREVIOUS_Ht]] : f32
   // CHECK:     [[ADD:%.+]] = addf [[MUL]], [[MUL_1]] : f32
-  // CHECK:     affine.store [[ADD]], [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:     krnl.store [[ADD]], [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK:   }
   // CHECK:   dealloc [[htMemRef]] : memref<3x3xf32>
   // CHECK:   dealloc [[ztMemRef]] : memref<3x3xf32>
@@ -1968,7 +1968,7 @@ func private @test_gru_linear_before_reset(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK: [[INITIAL_VAL:%.+]] = constant 0.000000e+00 : f32
   // CHECK: [[DEF_LOOPS_INIT:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS_INIT]]#0, [[DEF_LOOPS_INIT]]#1, [[DEF_LOOPS_INIT]]#2) with ([[DEF_LOOPS_INIT]]#0 -> %arg3 = 0 to 1, [[DEF_LOOPS_INIT]]#1 -> %arg4 = 0 to 3, [[DEF_LOOPS_INIT]]#2 -> %arg5 = 0 to 3) {
-  // CHECK:   affine.store [[INITIAL_VAL]], [[RES]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:   krnl.store [[INITIAL_VAL]], [[RES]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK: }
 
   /// Check main loop.
@@ -1989,45 +1989,45 @@ func private @test_gru_linear_before_reset(%arg0: tensor<4x3x2xf32>, %arg1: tens
 
   // CHECK:     [[INITIAL_VAL_0:%.+]] = constant 0.000000e+00 : f32
   // CHECK:     [[XWZt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[XWZt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[XWZt]][] : memref<f32>
   // CHECK:     [[HRZt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[HRZt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[HRZt]][] : memref<f32>
   // CHECK:     [[XWRt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[XWRt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[XWRt]][] : memref<f32>
   // CHECK:     [[HRRt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[HRRt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[HRRt]][] : memref<f32>
   // CHECK:     [[XWHt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[XWHt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[XWHt]][] : memref<f32>
   // CHECK:     [[HRHt:%.+]] = alloc() : memref<f32>
-  // CHECK:     affine.store [[INITIAL_VAL_0]], [[HRHt]][] : memref<f32>
+  // CHECK:     krnl.store [[INITIAL_VAL_0]], [[HRHt]][] : memref<f32>
 
   // CHECK:     [[REDUCTION_LOOPS:%.+]] = krnl.define_loops 1
   // CHECK:     krnl.iterate([[REDUCTION_LOOPS]]) with ([[REDUCTION_LOOPS]] -> %arg6 = 0 to 2) {
   // CHECK:       [[BIAS_MAP_FOR_Z:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_0]], [[INDEX_3]]]
   // CHECK:       [[BIAS_MAP_FOR_R:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_1]], [[INDEX_3]]]
   // CHECK:       [[BIAS_MAP_FOR_H:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_2]], [[INDEX_3]]]
-  // CHECK:       [[Xt:%.+]] = affine.load %arg0[%arg3, %arg4, %arg6] : memref<4x3x2xf32>
+  // CHECK:       [[Xt:%.+]] = krnl.load %arg0[%arg3, %arg4, %arg6] : memref<4x3x2xf32>
 
   /// compute Xt*(Wz^T)
-  // CHECK:       [[WZt:%.+]] = affine.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_Z]], %arg6] : memref<1x9x2xf32>
+  // CHECK:       [[WZt:%.+]] = krnl.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_Z]], %arg6] : memref<1x9x2xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[Xt]], [[WZt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[XWZt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[XWZt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[XWZt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[XWZt]][] : memref<f32>
 
   /// compute Xt*(Wr^T)
-  // CHECK:       [[WRt:%.+]] = affine.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_R]], %arg6] : memref<1x9x2xf32>
+  // CHECK:       [[WRt:%.+]] = krnl.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_R]], %arg6] : memref<1x9x2xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[Xt]], [[WRt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[XWRt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[XWRt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[XWRt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[XWRt]][] : memref<f32>
 
   /// compute Xt*(Wh^T)
-  // CHECK:       [[WHt:%.+]] = affine.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_H]], %arg6] : memref<1x9x2xf32>
+  // CHECK:       [[WHt:%.+]] = krnl.load %arg1{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_H]], %arg6] : memref<1x9x2xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[Xt]], [[WHt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[XWHt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[XWHt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[XWHt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[XWHt]][] : memref<f32>
   // CHECK:     }
 
   // CHECK:     [[REDUCTION_LOOPS:%.+]] = krnl.define_loops 1
@@ -2035,72 +2035,72 @@ func private @test_gru_linear_before_reset(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:       [[BIAS_MAP_FOR_Z:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_0]], [[INDEX_3]]]
   // CHECK:       [[BIAS_MAP_FOR_R:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_1]], [[INDEX_3]]]
   // CHECK:       [[BIAS_MAP_FOR_H:%.+]] = affine.apply {{.*}}(%arg5){{\[}}[[INDEX_2]], [[INDEX_3]]]
-  // CHECK:       [[PREVIOUS_Ht:%.+]] = affine.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg6] : memref<1x3x3xf32>
+  // CHECK:       [[PREVIOUS_Ht:%.+]] = krnl.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg6] : memref<1x3x3xf32>
   /// compute Ht-1*(Rz^T)
-  // CHECK:       [[RZt:%.+]] = affine.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_Z]], %arg6] : memref<1x9x3xf32>
+  // CHECK:       [[RZt:%.+]] = krnl.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_Z]], %arg6] : memref<1x9x3xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[PREVIOUS_Ht]], [[RZt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[HRZt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[HRZt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[HRZt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[HRZt]][] : memref<f32>
 
   /// compute Ht-1*(Rr^T)
-  // CHECK:       [[RRt:%.+]] = affine.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_R]], %arg6] : memref<1x9x3xf32>
+  // CHECK:       [[RRt:%.+]] = krnl.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_R]], %arg6] : memref<1x9x3xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[PREVIOUS_Ht]], [[RRt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[HRRt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[HRRt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[HRRt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[HRRt]][] : memref<f32>
 
   /// compute Ht-1*(Rh^T)
-  // CHECK:       [[RHt:%.+]] = affine.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_H]], %arg6] : memref<1x9x3xf32>
+  // CHECK:       [[RHt:%.+]] = krnl.load %arg2{{\[}}[[ZERO_INDEX]], [[BIAS_MAP_FOR_H]], %arg6] : memref<1x9x3xf32>
   // CHECK:       [[MUL:%.+]] = mulf [[PREVIOUS_Ht]], [[RHt]] : f32
-  // CHECK:       [[LOAD:%.+]] = affine.load [[HRHt]][] : memref<f32>
+  // CHECK:       [[LOAD:%.+]] = krnl.load [[HRHt]][] : memref<f32>
   // CHECK:       [[ADD:%.+]] = addf [[LOAD]], [[MUL]] : f32
-  // CHECK:       affine.store [[ADD]], [[HRHt]][] : memref<f32>
+  // CHECK:       krnl.store [[ADD]], [[HRHt]][] : memref<f32>
   // CHECK:     }
 
   /// compute zt = f(Xt*(Wz^T) + Ht-1*(Rz^T) + Wbz + Rbz)
-  // CHECK:     [[LOAD_XWZt:%.+]] = affine.load [[XWZt]][] : memref<f32>
-  // CHECK:     [[LOAD_HRZt:%.+]] = affine.load [[HRZt]][] : memref<f32>
+  // CHECK:     [[LOAD_XWZt:%.+]] = krnl.load [[XWZt]][] : memref<f32>
+  // CHECK:     [[LOAD_HRZt:%.+]] = krnl.load [[HRZt]][] : memref<f32>
   // CHECK:     [[ADD:%.+]] = addf [[LOAD_XWZt]], [[LOAD_HRZt]] : f32
   /// apply activation f = sigmoid
   // CHECK:     {{.*}} = alloc() : memref<f32>
-  // CHECK:     affine.store [[ADD]], {{.*}}[] : memref<f32>
-  // CHECK:     {{.*}} = affine.load {{.*}}[] : memref<f32>
+  // CHECK:     krnl.store [[ADD]], {{.*}}[] : memref<f32>
+  // CHECK:     {{.*}} = krnl.load {{.*}}[] : memref<f32>
   // CHECK:     {{.*}} = constant 0.000000e+00 : f32
   // CHECK:     {{.*}} = constant 1.000000e+00 : f32
   // CHECK:     {{.*}} = subf {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = exp {{.*}} : f32
   // CHECK:     {{.*}} = addf {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = divf {{.*}}, {{.*}} : f32
-  // CHECK:     affine.store {{.*}}, [[zt]][] : memref<f32>
-  // CHECK:     affine.store {{.*}}, [[ztMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     krnl.store {{.*}}, [[zt]][] : memref<f32>
+  // CHECK:     krnl.store {{.*}}, [[ztMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
   /// compute rt = f(Xt*(Wr^T) + Ht-1*(Rr^T) + Wbr + Rbr)
-  // CHECK:     [[LOAD_XWRt:%.+]] = affine.load [[XWRt]][] : memref<f32>
-  // CHECK:     [[LOAD_HRRt:%.+]] = affine.load [[HRRt]][] : memref<f32>
+  // CHECK:     [[LOAD_XWRt:%.+]] = krnl.load [[XWRt]][] : memref<f32>
+  // CHECK:     [[LOAD_HRRt:%.+]] = krnl.load [[HRRt]][] : memref<f32>
   // CHECK:     [[ADD:%.+]] = addf [[LOAD_XWRt]], [[LOAD_HRRt]] : f32
   /// apply activation f = sigmoid
   // CHECK:     {{.*}} = alloc() : memref<f32>
-  // CHECK:     affine.store [[ADD]], {{.*}}[] : memref<f32>
-  // CHECK:     {{.*}} = affine.load {{.*}}[] : memref<f32>
+  // CHECK:     krnl.store [[ADD]], {{.*}}[] : memref<f32>
+  // CHECK:     {{.*}} = krnl.load {{.*}}[] : memref<f32>
   // CHECK:     {{.*}} = constant 0.000000e+00 : f32
   // CHECK:     {{.*}} = constant 1.000000e+00 : f32
   // CHECK:     {{.*}} = subf {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = exp {{.*}} : f32
   // CHECK:     {{.*}} = addf {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = divf {{.*}}, {{.*}} : f32
-  // CHECK:     affine.store {{.*}}, [[rt]][] : memref<f32>
-  // CHECK:     [[LOAD_rt:%.+]] = affine.load [[rt]][] : memref<f32>
+  // CHECK:     krnl.store {{.*}}, [[rt]][] : memref<f32>
+  // CHECK:     [[LOAD_rt:%.+]] = krnl.load [[rt]][] : memref<f32>
 
   /// compute ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*(Rh^T) + Rbh)) + Wbh) since linear_before_reset != 0
-  // CHECK:     [[LOAD_XWHt:%.+]] = affine.load [[XWHt]][] : memref<f32>
-  // CHECK:     [[LOAD_HRHt:%.+]] = affine.load [[HRHt]][] : memref<f32>
+  // CHECK:     [[LOAD_XWHt:%.+]] = krnl.load [[XWHt]][] : memref<f32>
+  // CHECK:     [[LOAD_HRHt:%.+]] = krnl.load [[HRHt]][] : memref<f32>
   // CHECK:     [[MUL_rt_HRHt:%.+]] = mulf [[LOAD_rt]], [[LOAD_HRHt]] : f32
   // CHECK:     [[ADD:%.+]] = addf [[LOAD_XWHt]], [[MUL_rt_HRHt]] : f32
   /// apply activation g = tanh
   // CHECK:     {{.*}} = alloc() : memref<f32>
-  // CHECK:     affine.store [[ADD]], {{.*}}[] : memref<f32>
-  // CHECK:     {{.*}} = affine.load {{.*}}[] : memref<f32>
+  // CHECK:     krnl.store [[ADD]], {{.*}}[] : memref<f32>
+  // CHECK:     {{.*}} = krnl.load {{.*}}[] : memref<f32>
   // CHECK:     {{.*}} = constant 1.000000e+00 : f32
   // CHECK:     {{.*}} = constant 2.000000e+00 : f32
   // CHECK:     {{.*}} = mulf {{.*}}, {{.*}} : f32
@@ -2116,9 +2116,9 @@ func private @test_gru_linear_before_reset(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:     {{.*}} = constant 0.000000e+00 : f32
   // CHECK:     {{.*}} = cmpf "oge", {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = select {{.*}}, {{.*}}, {{.*}} : f32
-  // CHECK:     affine.store {{.*}}, [[ht]][] : memref<f32>
-  // CHECK:     [[LOAD_ht:%.+]] = affine.load [[ht]][] : memref<f32>
-  // CHECK:     affine.store [[LOAD_ht]], [[htMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     krnl.store {{.*}}, [[ht]][] : memref<f32>
+  // CHECK:     [[LOAD_ht:%.+]] = krnl.load [[ht]][] : memref<f32>
+  // CHECK:     krnl.store [[LOAD_ht]], [[htMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
   // CHECK:     dealloc [[XWZt]] : memref<f32>
   // CHECK:     dealloc [[XWRt]] : memref<f32>
@@ -2134,15 +2134,15 @@ func private @test_gru_linear_before_reset(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:   [[GATE_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK:   krnl.iterate([[GATE_LOOPS]]#0, [[GATE_LOOPS]]#1) with ([[GATE_LOOPS]]#0 -> %arg4 = 0 to 3, [[GATE_LOOPS]]#1 -> %arg5 = 0 to 3) {
   /// compute  Ht = (1 - zt) (.) ht + zt (.) Ht-1
-  // CHECK:     [[LOAD_ht:%.+]] = affine.load [[htMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:     [[LOAD_zt:%.+]] = affine.load [[ztMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:     [[PREVIOUS_Ht:%.+]] = affine.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:     [[LOAD_ht:%.+]] = krnl.load [[htMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     [[LOAD_zt:%.+]] = krnl.load [[ztMemRef]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     [[PREVIOUS_Ht:%.+]] = krnl.load [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK:     [[ONE:%.+]] = constant 1.000000e+00 : f32
   // CHECK:     [[SUB:%.+]] = subf [[ONE]], [[LOAD_zt]] : f32
   // CHECK:     [[MUL:%.+]] = mulf [[SUB]], [[LOAD_ht]] : f32
   // CHECK:     [[MUL_1:%.+]] = mulf [[LOAD_zt]], [[PREVIOUS_Ht]] : f32
   // CHECK:     [[ADD:%.+]] = addf [[MUL]], [[MUL_1]] : f32
-  // CHECK:     affine.store [[ADD]], [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:     krnl.store [[ADD]], [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK:   }
   // CHECK:    dealloc [[htMemRef]] : memref<3x3xf32>
   // CHECK:    dealloc [[ztMemRef]] : memref<3x3xf32>
@@ -2160,19 +2160,19 @@ func private @test_gru_with_bias(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf
 
   // CHECK-LABEL: test_gru_with_bias
 
-  // CHECK: [[LOAD_WZ_BIAS:%.+]] = affine.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
+  // CHECK: [[LOAD_WZ_BIAS:%.+]] = krnl.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
   // CHECK: {{.*}} = addf {{.*}}, [[LOAD_WZ_BIAS]] : f32
-  // CHECK: [[LOAD_RZ_BIAS:%.+]] = affine.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
+  // CHECK: [[LOAD_RZ_BIAS:%.+]] = krnl.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
   // CHECK: {{.*}} = addf {{.*}}, [[LOAD_RZ_BIAS]] : f32
 
-  // CHECK: [[LOAD_WR_BIAS:%.+]] = affine.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
+  // CHECK: [[LOAD_WR_BIAS:%.+]] = krnl.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
   // CHECK: {{.*}} = addf {{.*}}, [[LOAD_WR_BIAS]] : f32
-  // CHECK: [[LOAD_RR_BIAS:%.+]] = affine.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
+  // CHECK: [[LOAD_RR_BIAS:%.+]] = krnl.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
   // CHECK: {{.*}} = addf {{.*}}, [[LOAD_RR_BIAS]] : f32
 
-  // CHECK: [[LOAD_WH_BIAS:%.+]] = affine.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
+  // CHECK: [[LOAD_WH_BIAS:%.+]] = krnl.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
   // CHECK: {{.*}} = addf {{.*}}, [[LOAD_WH_BIAS]] : f32
-  // CHECK: [[LOAD_RH_BIAS:%.+]] = affine.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
+  // CHECK: [[LOAD_RH_BIAS:%.+]] = krnl.load %arg3[{{.*}}, {{.*}}] : memref<1x18xf32>
   // CHECK: {{.*}} = addf {{.*}}, [[LOAD_RH_BIAS]] : f32
 }
 
@@ -2212,8 +2212,8 @@ func private @test_lstm_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: ten
   // CHECK:  [[INITIAL_VALUE:%.+]] = constant 0.000000e+00 : f32
   // CHECK:  [[INITIALIZE_LOOPS:%.+]]:3 = krnl.define_loops 3
   // CHECK:  krnl.iterate([[INITIALIZE_LOOPS]]#0, [[INITIALIZE_LOOPS]]#1, [[INITIALIZE_LOOPS]]#2) with ([[INITIALIZE_LOOPS]]#0 -> %arg3 = 0 to 1, [[INITIALIZE_LOOPS]]#1 -> %arg4 = 0 to 3, [[INITIALIZE_LOOPS]]#2 -> %arg5 = 0 to 3) {
-  // CHECK:    affine.store [[INITIAL_VALUE]], [[HIDDEN_STATE]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
-  // CHECK:    affine.store [[INITIAL_VALUE]], [[CELL_STATE]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:    krnl.store [[INITIAL_VALUE]], [[HIDDEN_STATE]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:    krnl.store [[INITIAL_VALUE]], [[CELL_STATE]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK:  }
 
   // CHECK:  [[SEQUENCE_LOOPS:%.+]] = krnl.define_loops 1
@@ -2241,14 +2241,14 @@ func private @test_lstm_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: ten
   // CHECK:    [[MATRIX_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK:    krnl.iterate([[MATRIX_LOOPS]]#0, [[MATRIX_LOOPS]]#1) with ([[MATRIX_LOOPS]]#0 -> %arg4 = 0 to 3, [[MATRIX_LOOPS]]#1 -> %arg5 = 0 to 3) {
   // CHECK:      [[CST0:%.+]] = constant 0.000000e+00 : f32
-  // CHECK:      affine.store [[CST0]], [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      affine.store [[CST0]], [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      affine.store [[CST0]], [[XtWo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      affine.store [[CST0]], [[HtRo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      affine.store [[CST0]], [[XtWf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      affine.store [[CST0]], [[HtRf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      affine.store [[CST0]], [[XtWc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      affine.store [[CST0]], [[HtRc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      krnl.store [[CST0]], [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      krnl.store [[CST0]], [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      krnl.store [[CST0]], [[XtWo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      krnl.store [[CST0]], [[HtRo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      krnl.store [[CST0]], [[XtWf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      krnl.store [[CST0]], [[HtRf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      krnl.store [[CST0]], [[XtWc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      krnl.store [[CST0]], [[HtRc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:      [[XW_LOOPS:%.+]] = krnl.define_loops 1
   // CHECK:      krnl.iterate([[XW_LOOPS]]) with ([[XW_LOOPS]] -> %arg6 = 0 to 2) {
   // CHECK:        [[INPUT_HIDDEN_INDEX:%.+]] = affine.apply #{{.*}}(%arg5)[{{.*}}, {{.*}}]
@@ -2256,30 +2256,30 @@ func private @test_lstm_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: ten
   // CHECK:        [[FORGET_HIDDEN_INDEX:%.+]] = affine.apply #{{.*}}(%arg5)[{{.*}}, {{.*}}]
   // CHECK:        [[CELL_HIDDEN_INDEX:%.+]] = affine.apply #{{.*}}(%arg5)[{{.*}}, {{.*}}]
 
-  // CHECK:        [[Xt_LOAD:%.+]] = affine.load %arg0[%arg3, %arg4, %arg6] : memref<4x3x2xf32>
-  // CHECK:        [[Wi_LOAD:%.+]] = affine.load %arg1{{\[}}[[C0_INDEX]], [[INPUT_HIDDEN_INDEX]], %arg6] : memref<1x12x2xf32>
+  // CHECK:        [[Xt_LOAD:%.+]] = krnl.load %arg0[%arg3, %arg4, %arg6] : memref<4x3x2xf32>
+  // CHECK:        [[Wi_LOAD:%.+]] = krnl.load %arg1{{\[}}[[C0_INDEX]], [[INPUT_HIDDEN_INDEX]], %arg6] : memref<1x12x2xf32>
   // CHECK:        {{.*}} = mulf [[Xt_LOAD]], [[Wi_LOAD]] : f32
-  // CHECK:        {{.*}} = affine.load [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        {{.*}} = krnl.load [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:        {{.*}} = addf {{.*}}, {{.*}} : f32
-  // CHECK:        affine.store {{.*}}, [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        krnl.store {{.*}}, [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
-  // CHECK:        [[Wo_LOAD:%.+]] = affine.load %arg1{{\[}}[[C0_INDEX]], [[OUTPUT_HIDDEN_INDEX]], %arg6] : memref<1x12x2xf32>
+  // CHECK:        [[Wo_LOAD:%.+]] = krnl.load %arg1{{\[}}[[C0_INDEX]], [[OUTPUT_HIDDEN_INDEX]], %arg6] : memref<1x12x2xf32>
   // CHECK:        {{.*}} = mulf [[Xt_LOAD]], [[Wo_LOAD]] : f32
-  // CHECK:        {{.*}} = affine.load [[XtWo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        {{.*}} = krnl.load [[XtWo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:        {{.*}} = addf {{.*}}, %26 : f32
-  // CHECK:        affine.store {{.*}}, [[XtWo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        krnl.store {{.*}}, [[XtWo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
-  // CHECK:        [[Wf_LOAD:%.+]] = affine.load %arg1{{\[}}[[C0_INDEX]], [[FORGET_HIDDEN_INDEX]], %arg6] : memref<1x12x2xf32>
+  // CHECK:        [[Wf_LOAD:%.+]] = krnl.load %arg1{{\[}}[[C0_INDEX]], [[FORGET_HIDDEN_INDEX]], %arg6] : memref<1x12x2xf32>
   // CHECK:        {{.*}} = mulf [[Xt_LOAD]], [[Wf_LOAD]] : f32
-  // CHECK:        {{.*}} = affine.load [[XtWf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        {{.*}} = krnl.load [[XtWf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:        {{.*}} = addf {{.*}}, %30 : f32
-  // CHECK:        affine.store {{.*}}, [[XtWf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        krnl.store {{.*}}, [[XtWf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
-  // CHECK:        [[Wc_LOAD:%.+]] = affine.load %arg1{{\[}}[[C0_INDEX]], [[CELL_HIDDEN_INDEX]], %arg6] : memref<1x12x2xf32>
+  // CHECK:        [[Wc_LOAD:%.+]] = krnl.load %arg1{{\[}}[[C0_INDEX]], [[CELL_HIDDEN_INDEX]], %arg6] : memref<1x12x2xf32>
   // CHECK:        {{.*}} = mulf [[Xt_LOAD]], [[Wc_LOAD]] : f32
-  // CHECK:        {{.*}} = affine.load [[XtWc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        {{.*}} = krnl.load [[XtWc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:        {{.*}} = addf {{.*}}, %34 : f32
-  // CHECK:        affine.store {{.*}}, [[XtWc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        krnl.store {{.*}}, [[XtWc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:      }
   // CHECK:      [[HR_LOOPS:%.+]] = krnl.define_loops 1
   // CHECK:      krnl.iterate([[HR_LOOPS]]) with ([[HR_LOOPS]] -> %arg6 = 0 to 3) {
@@ -2288,31 +2288,31 @@ func private @test_lstm_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: ten
   // CHECK:        [[FORGET_HIDDEN_INDEX:%.+]] = affine.apply #{{.*}}(%arg5)[{{.*}}, {{.*}}]
   // CHECK:        [[CELL_HIDDEN_INDEX:%.+]] = affine.apply #{{.*}}(%arg5)[{{.*}}, {{.*}}]
 
-  // CHECK:        [[Ht_LOAD:%.+]] = affine.load %1{{\[}}[[C0_INDEX]], %arg4, %arg6] : memref<1x3x3xf32>
+  // CHECK:        [[Ht_LOAD:%.+]] = krnl.load %1{{\[}}[[C0_INDEX]], %arg4, %arg6] : memref<1x3x3xf32>
 
-  // CHECK:        [[Ri_LOAD:%.+]] = affine.load %arg2{{\[}}[[C0_INDEX]], [[INPUT_HIDDEN_INDEX]], %arg6] : memref<1x12x3xf32>
+  // CHECK:        [[Ri_LOAD:%.+]] = krnl.load %arg2{{\[}}[[C0_INDEX]], [[INPUT_HIDDEN_INDEX]], %arg6] : memref<1x12x3xf32>
   // CHECK:        {{.*}} = mulf [[Ht_LOAD]], [[Ri_LOAD]] : f32
-  // CHECK:        {{.*}} = affine.load [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        {{.*}} = krnl.load [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:        {{.*}} = addf {{.*}}, {{.*}} : f32
-  // CHECK:        affine.store {{.*}}, [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        krnl.store {{.*}}, [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
-  // CHECK:        [[Ro_LOAD:%.+]] = affine.load %arg2{{\[}}[[C0_INDEX]], [[OUTPUT_HIDDEN_INDEX]], %arg6] : memref<1x12x3xf32>
+  // CHECK:        [[Ro_LOAD:%.+]] = krnl.load %arg2{{\[}}[[C0_INDEX]], [[OUTPUT_HIDDEN_INDEX]], %arg6] : memref<1x12x3xf32>
   // CHECK:        {{.*}} = mulf [[Ht_LOAD]], [[Ro_LOAD]] : f32
-  // CHECK:        {{.*}} = affine.load [[HtRo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        {{.*}} = krnl.load [[HtRo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:        {{.*}} = addf {{.*}}, {{.*}} : f32
-  // CHECK:        affine.store {{.*}}, [[HtRo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        krnl.store {{.*}}, [[HtRo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
-  // CHECK:        [[Rf_LOAD:%.+]] = affine.load %arg2{{\[}}[[C0_INDEX]], [[FORGET_HIDDEN_INDEX]], %arg6] : memref<1x12x3xf32>
+  // CHECK:        [[Rf_LOAD:%.+]] = krnl.load %arg2{{\[}}[[C0_INDEX]], [[FORGET_HIDDEN_INDEX]], %arg6] : memref<1x12x3xf32>
   // CHECK:        {{.*}} = mulf [[Ht_LOAD]], [[Rf_LOAD]] : f32
-  // CHECK:        {{.*}} = affine.load [[HtRf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        {{.*}} = krnl.load [[HtRf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:        {{.*}} = addf {{.*}}, {{.*}} : f32
-  // CHECK:        affine.store {{.*}}, [[HtRf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        krnl.store {{.*}}, [[HtRf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
 
-  // CHECK:        [[Rc_LOAD:%.+]] = affine.load %arg2{{\[}}[[C0_INDEX]], [[CELL_HIDDEN_INDEX]], %arg6] : memref<1x12x3xf32>
+  // CHECK:        [[Rc_LOAD:%.+]] = krnl.load %arg2{{\[}}[[C0_INDEX]], [[CELL_HIDDEN_INDEX]], %arg6] : memref<1x12x3xf32>
   // CHECK:        {{.*}} = mulf [[Ht_LOAD]], [[Rc_LOAD]] : f32
-  // CHECK:        {{.*}} = affine.load [[HtRc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        {{.*}} = krnl.load [[HtRc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:        {{.*}} = addf {{.*}}, {{.*}} : f32
-  // CHECK:        affine.store {{.*}}, [[HtRc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:        krnl.store {{.*}}, [[HtRc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:      } 
   // CHECK:    }
 
@@ -2324,46 +2324,46 @@ func private @test_lstm_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: ten
   // CHECK:      [[Ft:%.+]] = alloc() : memref<f32>
   // CHECK:      [[It:%.+]] = alloc() : memref<f32>
 
-  // CHECK:      [[Ct1_LOAD:%.+]] = affine.load [[CELL_STATE]]{{\[}}[[C0_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
-  // CHECK:      [[XtWi_LOAD:%.+]] = affine.load [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      [[HtRi_LOAD:%.+]] = affine.load [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      [[Ct1_LOAD:%.+]] = krnl.load [[CELL_STATE]]{{\[}}[[C0_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:      [[XtWi_LOAD:%.+]] = krnl.load [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      [[HtRi_LOAD:%.+]] = krnl.load [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:      [[It_OUTPUT:%.+]] = addf [[XtWi_LOAD]], [[HtRi_LOAD]] : f32
 
   // CHECK:      [[SIGMOID_INPUT:%.+]] = alloc() : memref<f32>
-  // CHECK:      affine.store [[It_OUTPUT]], [[SIGMOID_INPUT]][] : memref<f32>
-  // CHECK:      {{.*}} = affine.load [[SIGMOID_INPUT]][] : memref<f32>
+  // CHECK:      krnl.store [[It_OUTPUT]], [[SIGMOID_INPUT]][] : memref<f32>
+  // CHECK:      {{.*}} = krnl.load [[SIGMOID_INPUT]][] : memref<f32>
   // CHECK:      {{.*}} = constant 0.000000e+00 : f32
   // CHECK:      {{.*}} = constant 1.000000e+00 : f32
   // CHECK:      {{.*}} = subf {{.*}}, {{.*}}: f32
   // CHECK:      {{.*}} = exp {{.*}} : f32
   // CHECK:      {{.*}} = addf {{.*}}, {{.*}} : f32
   // CHECK:      {{.*}} = divf {{.*}}, {{.*}} : f32
-  // CHECK:      affine.store {{.*}}, [[It]][] : memref<f32>
-  // CHECK:      [[It_LOAD:%.+]] = affine.load [[It]][] : memref<f32>
+  // CHECK:      krnl.store {{.*}}, [[It]][] : memref<f32>
+  // CHECK:      [[It_LOAD:%.+]] = krnl.load [[It]][] : memref<f32>
 
-  // CHECK:      [[XtWf_LOAD:%.+]] = affine.load [[XtWf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      [[HtRf_LOAD:%.+]] = affine.load [[HtRf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      [[XtWf_LOAD:%.+]] = krnl.load [[XtWf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      [[HtRf_LOAD:%.+]] = krnl.load [[HtRf_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:      [[Ft_OUTPUT:%.+]] = addf [[XtWf_LOAD]], [[HtRf_LOAD]] : f32
 
   // CHECK:      [[SIGMOID_FORGET:%.+]] = alloc() : memref<f32>
-  // CHECK:      affine.store [[Ft_OUTPUT]], [[SIGMOID_FORGET]][] : memref<f32>
-  // CHECK:      {{.*}} = affine.load [[SIGMOID_FORGET]][] : memref<f32>
+  // CHECK:      krnl.store [[Ft_OUTPUT]], [[SIGMOID_FORGET]][] : memref<f32>
+  // CHECK:      {{.*}} = krnl.load [[SIGMOID_FORGET]][] : memref<f32>
   // CHECK:      {{.*}} = constant 0.000000e+00 : f32
   // CHECK:      {{.*}} = constant 1.000000e+00 : f32
   // CHECK:      {{.*}} = subf {{.*}}, {{.*}}: f32
   // CHECK:      {{.*}} = exp {{.*}} : f32
   // CHECK:      {{.*}} = addf {{.*}}, {{.*}} : f32
   // CHECK:      {{.*}} = divf {{.*}}, {{.*}} : f32
-  // CHECK:      affine.store {{.*}}, [[Ft]][] : memref<f32>
-  // CHECK:      [[Ft_LOAD:%.+]] = affine.load [[Ft]][] : memref<f32>
+  // CHECK:      krnl.store {{.*}}, [[Ft]][] : memref<f32>
+  // CHECK:      [[Ft_LOAD:%.+]] = krnl.load [[Ft]][] : memref<f32>
 
-  // CHECK:      [[XtWc_LOAD:%.+]] = affine.load [[XtWc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      [[HtRc_LOAD:%.+]] = affine.load [[HtRc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      [[XtWc_LOAD:%.+]] = krnl.load [[XtWc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      [[HtRc_LOAD:%.+]] = krnl.load [[HtRc_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:      [[ct_OUTPUT:%.+]] = addf [[XtWc_LOAD]], [[HtRc_LOAD]] : f32
 
   // CHECK:      [[TANH_CELL:%.+]] = alloc() : memref<f32>
-  // CHECK:      affine.store [[ct_OUTPUT]], [[TANH_CELL]][] : memref<f32>
-  // CHECK:      {{.*}} = affine.load [[TANH_CELL]][] : memref<f32>
+  // CHECK:      krnl.store [[ct_OUTPUT]], [[TANH_CELL]][] : memref<f32>
+  // CHECK:      {{.*}} = krnl.load [[TANH_CELL]][] : memref<f32>
   // CHECK:      {{.*}} = constant 1.000000e+00 : f32
   // CHECK:      {{.*}} = constant 2.000000e+00 : f32
   // CHECK:      {{.*}} = mulf {{.*}}, {{.*}} : f32
@@ -2379,33 +2379,33 @@ func private @test_lstm_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: ten
   // CHECK:      {{.*}} = constant 0.000000e+00 : f32
   // CHECK:      {{.*}} = cmpf "oge", {{.*}}, {{.*}} : f32
   // CHECK:      {{.*}} = select {{.*}}, {{.*}}, {{.*}} : f32
-  // CHECK:      affine.store {{.*}}, [[ct]][] : memref<f32>
-  // CHECK:      [[ct_LOAD:%.+]] = affine.load [[ct]][] : memref<f32>
+  // CHECK:      krnl.store {{.*}}, [[ct]][] : memref<f32>
+  // CHECK:      [[ct_LOAD:%.+]] = krnl.load [[ct]][] : memref<f32>
 
   // CHECK:      [[FtCt1:%.+]] = mulf [[Ft_LOAD]], [[Ct1_LOAD]] : f32
   // CHECK:      [[Itct:%.+]] = mulf [[It_LOAD]], [[ct_LOAD]] : f32
   // CHECK:      [[Ct:%.+]] = addf [[FtCt1]], [[Itct]] : f32
-  // CHECK:      affine.store [[Ct]], [[CELL_STATE]]{{\[}}[[C0_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:      krnl.store [[Ct]], [[CELL_STATE]]{{\[}}[[C0_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
 
-  // CHECK:      [[XtWo_LOAD:%.+]] = affine.load [[XtWo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:      [[HtRo_LOAD:%.+]] = affine.load [[HtRo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      [[XtWo_LOAD:%.+]] = krnl.load [[XtWo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:      [[HtRo_LOAD:%.+]] = krnl.load [[HtRo_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:      [[Ot_OUTPUT:%.+]] = addf [[XtWo_LOAD]], [[HtRo_LOAD]] : f32
 
   // CHECK:      [[SIGMOID_OUTPUT:%.+]] = alloc() : memref<f32>
-  // CHECK:      affine.store [[Ot_OUTPUT]], [[SIGMOID_OUTPUT]][] : memref<f32>
-  // CHECK:      {{.*}} = affine.load [[SIGMOID_OUTPUT]][] : memref<f32>
+  // CHECK:      krnl.store [[Ot_OUTPUT]], [[SIGMOID_OUTPUT]][] : memref<f32>
+  // CHECK:      {{.*}} = krnl.load [[SIGMOID_OUTPUT]][] : memref<f32>
   // CHECK:      {{.*}} = constant 0.000000e+00 : f32
   // CHECK:      {{.*}} = constant 1.000000e+00 : f32
   // CHECK:      {{.*}} = subf {{.*}}, {{.*}}: f32
   // CHECK:      {{.*}} = exp {{.*}} : f32
   // CHECK:      {{.*}} = addf {{.*}}, {{.*}} : f32
   // CHECK:      {{.*}} = divf {{.*}}, {{.*}} : f32
-  // CHECK:      affine.store {{.*}}, [[Ot]][] : memref<f32>
-  // CHECK:      [[Ot_LOAD:%.+]] = affine.load [[Ot]][] : memref<f32>
+  // CHECK:      krnl.store {{.*}}, [[Ot]][] : memref<f32>
+  // CHECK:      [[Ot_LOAD:%.+]] = krnl.load [[Ot]][] : memref<f32>
 
   // CHECK:      [[TANH_HIDDEN:%.+]] = alloc() : memref<f32>
-  // CHECK:      affine.store [[Ct]], [[TANH_HIDDEN]][] : memref<f32>
-  // CHECK:      {{.*}} = affine.load [[TANH_HIDDEN]][] : memref<f32>
+  // CHECK:      krnl.store [[Ct]], [[TANH_HIDDEN]][] : memref<f32>
+  // CHECK:      {{.*}} = krnl.load [[TANH_HIDDEN]][] : memref<f32>
   // CHECK:      {{.*}} = constant 1.000000e+00 : f32
   // CHECK:      {{.*}} = constant 2.000000e+00 : f32
   // CHECK:      {{.*}} = mulf {{.*}}, {{.*}} : f32
@@ -2421,11 +2421,11 @@ func private @test_lstm_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: ten
   // CHECK:      {{.*}} = constant 0.000000e+00 : f32
   // CHECK:      {{.*}} = cmpf "oge", {{.*}}, {{.*}} : f32
   // CHECK:      {{.*}} = select {{.*}}, {{.*}}, {{.*}} : f32
-  // CHECK:      affine.store {{.*}}, [[hCt]][] : memref<f32>
-  // CHECK:      [[hCt_LOAD:%.+]] = affine.load [[hCt]][] : memref<f32>
+  // CHECK:      krnl.store {{.*}}, [[hCt]][] : memref<f32>
+  // CHECK:      [[hCt_LOAD:%.+]] = krnl.load [[hCt]][] : memref<f32>
 
   // CHECK:      [[Ht:%.+]] = mulf [[Ot_LOAD]], [[hCt_LOAD]] : f32
-  // CHECK:      affine.store [[Ht]], [[HIDDEN_STATE]]{{\[}}[[C0_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:      krnl.store [[Ht]], [[HIDDEN_STATE]]{{\[}}[[C0_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
 
   // CHECK:      dealloc [[It]] : memref<f32>
   // CHECK:      dealloc [[Ft]] : memref<f32>
@@ -2461,7 +2461,7 @@ func private @test_lstm_reverse_mode(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x1
   // CHECK:  krnl.iterate([[REVERSE_SEQUENCE_LOOPS]]) with ([[REVERSE_SEQUENCE_LOOPS]] -> %arg3 = 0 to 4) {
   // CHECK:  %[[SEQUENCE_LEN:.+]] = constant 4 : index
   // CHECK:  %[[REVERSE_SEQUENCE_IV:.+]] = affine.apply [[REVERSE_IV_MAP]](%arg3)[%[[SEQUENCE_LEN]]{{]}}
-  // CHECK:  [[Xt_LOAD:%.+]] = affine.load %arg0[%[[REVERSE_SEQUENCE_IV]], {{.*}}, {{.*}}] : memref<4x3x2xf32>
+  // CHECK:  [[Xt_LOAD:%.+]] = krnl.load %arg0[%[[REVERSE_SEQUENCE_IV]], {{.*}}, {{.*}}] : memref<4x3x2xf32>
 }
 
 // -----
@@ -2478,7 +2478,7 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:  krnl.iterate([[SEQUENCE_LOOPS]]) with ([[SEQUENCE_LOOPS]] -> %arg3 = 0 to 4) {
   // CHECK:  {{.*}} = krnl.define_loops 2
   // CHECK:  {{.*}} = krnl.define_loops 1
-  // CHECK:  [[Xt_LOAD:%.+]] = affine.load %arg0[%arg3, {{.*}}, {{.*}}] : memref<4x3x2xf32>
+  // CHECK:  [[Xt_LOAD:%.+]] = krnl.load %arg0[%arg3, {{.*}}, {{.*}}] : memref<4x3x2xf32>
   // CHECK:  {{.*}} = krnl.define_loops 1
   // CHECK:  {{.*}} = krnl.define_loops 2
 
@@ -2488,7 +2488,7 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:  %[[REVERSE_SEQUENCE_IV:.+]] = affine.apply [[REVERSE_IV_MAP]](%arg3)[%[[SEQUENCE_LEN]]{{]}}
   // CHECK:  {{.*}} = krnl.define_loops 2
   // CHECK:  {{.*}} = krnl.define_loops 1
-  // CHECK:  [[Xt_LOAD:%.+]] = affine.load %arg0[%[[REVERSE_SEQUENCE_IV]], {{.*}}, {{.*}}] : memref<4x3x2xf32>
+  // CHECK:  [[Xt_LOAD:%.+]] = krnl.load %arg0[%[[REVERSE_SEQUENCE_IV]], {{.*}}, {{.*}}] : memref<4x3x2xf32>
   // CHECK:  {{.*}} = krnl.define_loops 1
   // CHECK:  {{.*}} = krnl.define_loops 2
 }
@@ -2543,7 +2543,7 @@ func private @test_rnn_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK: [[INITIAL_VAL:%.+]] = constant 0.000000e+00 : f32
   // CHECK: [[DEF_LOOPS_INIT:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS_INIT]]#0, [[DEF_LOOPS_INIT]]#1, [[DEF_LOOPS_INIT]]#2) with ([[DEF_LOOPS_INIT]]#0 -> %arg3 = 0 to 1, [[DEF_LOOPS_INIT]]#1 -> %arg4 = 0 to 3, [[DEF_LOOPS_INIT]]#2 -> %arg5 = 0 to 3) {
-  // CHECK:   affine.store [[INITIAL_VAL]], [[RES]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:   krnl.store [[INITIAL_VAL]], [[RES]][%arg3, %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK: }
 
   /// Check main loop.
@@ -2560,25 +2560,25 @@ func private @test_rnn_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:   [[MATRIX_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK:   krnl.iterate([[MATRIX_LOOPS]]#0, [[MATRIX_LOOPS]]#1) with ([[MATRIX_LOOPS]]#0 -> %arg4 = 0 to 3, [[MATRIX_LOOPS]]#1 -> %arg5 = 0 to 3) {
   // CHECK:     [[CST0:%.+]] = constant 0.000000e+00 : f32
-  // CHECK:     affine.store [[CST0]], [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:     affine.store [[CST0]], [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     krnl.store [[CST0]], [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     krnl.store [[CST0]], [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:     [[XW_LOOPS:%.+]] = krnl.define_loops 1
   // CHECK:     krnl.iterate([[XW_LOOPS]]) with ([[XW_LOOPS]] -> %arg6 = 0 to 2) {
-  // CHECK:       [[Xt_LOAD:%.+]] = affine.load %arg0[%arg3, %arg4, %arg6] : memref<4x3x2xf32>
-  // CHECK:       [[Wi_LOAD:%.+]] = affine.load %arg1{{\[}}[[ZERO_INDEX]], %arg5, %arg6] : memref<1x3x2xf32>
+  // CHECK:       [[Xt_LOAD:%.+]] = krnl.load %arg0[%arg3, %arg4, %arg6] : memref<4x3x2xf32>
+  // CHECK:       [[Wi_LOAD:%.+]] = krnl.load %arg1{{\[}}[[ZERO_INDEX]], %arg5, %arg6] : memref<1x3x2xf32>
   // CHECK:       {{.*}} = mulf [[Xt_LOAD]], [[Wi_LOAD]] : f32
-  // CHECK:       {{.*}} = affine.load [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:       {{.*}} = krnl.load [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:       {{.*}} = addf {{.*}}, {{.*}} : f32
-  // CHECK:       affine.store {{.*}}, [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:       krnl.store {{.*}}, [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:     }
   // CHECK:     [[HR_LOOPS:%.+]] = krnl.define_loops 1
   // CHECK:     krnl.iterate([[HR_LOOPS]]) with ([[HR_LOOPS]] -> %arg6 = 0 to 3) {
-  // CHECK:       [[Ht_LOAD:%.+]] = affine.load %0{{\[}}[[ZERO_INDEX]], %arg4, %arg6] : memref<1x3x3xf32>
-  // CHECK:       [[Ri_LOAD:%.+]] = affine.load %arg2{{\[}}[[ZERO_INDEX]], %arg5, %arg6] : memref<1x3x3xf32>
+  // CHECK:       [[Ht_LOAD:%.+]] = krnl.load %0{{\[}}[[ZERO_INDEX]], %arg4, %arg6] : memref<1x3x3xf32>
+  // CHECK:       [[Ri_LOAD:%.+]] = krnl.load %arg2{{\[}}[[ZERO_INDEX]], %arg5, %arg6] : memref<1x3x3xf32>
   // CHECK:       {{.*}} = mulf [[Ht_LOAD]], [[Ri_LOAD]] : f32
-  // CHECK:       {{.*}} = affine.load [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:       {{.*}} = krnl.load [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:       {{.*}} = addf {{.*}}, {{.*}} : f32
-  // CHECK:       affine.store {{.*}}, [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:       krnl.store {{.*}}, [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:     }
   // CHECK:   }
  
@@ -2587,14 +2587,14 @@ func private @test_rnn_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:     [[Ht:%.+]] = alloc() : memref<f32>
 
   /// Check 'Xt*(Wi^T) + Ht-1*(Ri^T)'
-  // CHECK:     [[LOAD_XWi:%.+]] = affine.load [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
-  // CHECK:     [[LOAD_HRi:%.+]] = affine.load [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     [[LOAD_XWi:%.+]] = krnl.load [[XtWi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
+  // CHECK:     [[LOAD_HRi:%.+]] = krnl.load [[HtRi_GEMM]]{{\[}}%arg4, %arg5] : memref<3x3xf32>
   // CHECK:     [[XWi_PLUS_HRi:%.+]] = addf [[LOAD_XWi]], [[LOAD_HRi]] : f32
 
   /// Check calling 'Tanh'
   // CHECK:     {{.*}} = alloc() : memref<f32>
-  // CHECK:     affine.store [[XWi_PLUS_HRi]], {{.*}} : memref<f32>
-  // CHECK:     {{.*}} = affine.load {{.*}}[] : memref<f32>
+  // CHECK:     krnl.store [[XWi_PLUS_HRi]], {{.*}} : memref<f32>
+  // CHECK:     {{.*}} = krnl.load {{.*}}[] : memref<f32>
   // CHECK:     {{.*}} = constant 1.000000e+00 : f32
   // CHECK:     {{.*}} = constant 2.000000e+00 : f32
   // CHECK:     {{.*}} = mulf {{.*}}, {{.*}} : f32
@@ -2610,11 +2610,11 @@ func private @test_rnn_general_computation(%arg0: tensor<4x3x2xf32>, %arg1: tens
   // CHECK:     {{.*}} = constant 0.000000e+00 : f32
   // CHECK:     {{.*}} = cmpf "oge", {{.*}}, {{.*}} : f32
   // CHECK:     {{.*}} = select {{.*}}, {{.*}}, {{.*}} : f32
-  // CHECK:     affine.store {{.*}}, [[Ht]][] : memref<f32>
+  // CHECK:     krnl.store {{.*}}, [[Ht]][] : memref<f32>
 
   /// Check storing the result.
-  // CHECK:     [[NEW_Ht_LOAD:%.+]] = affine.load [[Ht]][] : memref<f32>
-  // CHECK:     affine.store [[NEW_Ht_LOAD]], [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
+  // CHECK:     [[NEW_Ht_LOAD:%.+]] = krnl.load [[Ht]][] : memref<f32>
+  // CHECK:     krnl.store [[NEW_Ht_LOAD]], [[RES]]{{\[}}[[ZERO_INDEX]], %arg4, %arg5] : memref<1x3x3xf32>
   // CHECK:     dealloc [[Ht]] : memref<f32>
   // CHECK:   }
   // CHECK:   dealloc [[XtWi_GEMM]] : memref<3x3xf32>
@@ -2632,9 +2632,9 @@ func private @test_rnn_with_bias(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf
   return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_rnn_with_bias
-  // CHECK: [[LOAD_W_BIAS:%.+]] = affine.load %arg3[{{.*}}, {{.*}}] : memref<1x6xf32>
+  // CHECK: [[LOAD_W_BIAS:%.+]] = krnl.load %arg3[{{.*}}, {{.*}}] : memref<1x6xf32>
   // CHECK: {{.*}} = addf {{.*}}, [[LOAD_W_BIAS]] : f32
-  // CHECK: [[LOAD_R_BIAS:%.+]] = affine.load %arg3[{{.*}}, {{.*}}] : memref<1x6xf32>
+  // CHECK: [[LOAD_R_BIAS:%.+]] = krnl.load %arg3[{{.*}}, {{.*}}] : memref<1x6xf32>
   // CHECK: {{.*}} = addf {{.*}}, [[LOAD_R_BIAS]] : f32
 }
 
@@ -2701,14 +2701,14 @@ func private @test_split_equal(%arg0 : tensor<16x32x64xf32>) -> (tensor<*xf32>, 
   // CHECK: [[RES_0:%.+]] = alloc() : memref<8x32x64xf32>
   // CHECK: [[DEF_LOOP_0:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOP_0]]#0, [[DEF_LOOP_0]]#1, [[DEF_LOOP_0]]#2) with ([[DEF_LOOP_0]]#0 -> %arg1 = 0 to 8, [[DEF_LOOP_0]]#1 -> %arg2 = 0 to 32, [[DEF_LOOP_0]]#2 -> %arg3 = 0 to 64) {
-  // CHECK:   [[LOAD_0:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3] : memref<16x32x64xf32>
-  // CHECK:   affine.store [[LOAD_0]], [[RES_0]][%arg1, %arg2, %arg3] : memref<8x32x64xf32>
+  // CHECK:   [[LOAD_0:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3] : memref<16x32x64xf32>
+  // CHECK:   krnl.store [[LOAD_0]], [[RES_0]][%arg1, %arg2, %arg3] : memref<8x32x64xf32>
   // CHECK: }
   // CHECK: [[DEF_LOOP_1:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOP_1]]#0, [[DEF_LOOP_1]]#1, [[DEF_LOOP_1]]#2) with ([[DEF_LOOP_1]]#0 -> %arg1 = 0 to 8, [[DEF_LOOP_1]]#1 -> %arg2 = 0 to 32, [[DEF_LOOP_1]]#2 -> %arg3 = 0 to 64) {
   // CHECK:   %[[INDEX:.+]] = affine.apply [[INDEX_MAP]](%arg1)
-  // CHECK:   [[LOAD_1:%.+]] = affine.load %arg0[%[[INDEX]], %arg2, %arg3] : memref<16x32x64xf32>
-  // CHECK:   affine.store [[LOAD_1]], [[RES_1]][%arg1, %arg2, %arg3] : memref<8x32x64xf32>
+  // CHECK:   [[LOAD_1:%.+]] = krnl.load %arg0[%[[INDEX]], %arg2, %arg3] : memref<16x32x64xf32>
+  // CHECK:   krnl.store [[LOAD_1]], [[RES_1]][%arg1, %arg2, %arg3] : memref<8x32x64xf32>
   // CHECK: }
   // CHECK: return [[RES_0]], [[RES_1]] : memref<8x32x64xf32>, memref<8x32x64xf32>
 }
@@ -2726,14 +2726,14 @@ func private @test_split_variable(%arg0 : tensor<16x32x64xf32>) -> (tensor<*xf32
   // CHECK: [[RES_0:%.+]] = alloc() : memref<16x2x64xf32>
   // CHECK: [[DEF_LOOP_0:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOP_0]]#0, [[DEF_LOOP_0]]#1, [[DEF_LOOP_0]]#2) with ([[DEF_LOOP_0]]#0 -> %arg1 = 0 to 16, [[DEF_LOOP_0]]#1 -> %arg2 = 0 to 2, [[DEF_LOOP_0]]#2 -> %arg3 = 0 to 64) {
-  // CHECK:   [[LOAD_0:%.+]] = affine.load %arg0[%arg1, %arg2, %arg3] : memref<16x32x64xf32>
-  // CHECK:   affine.store [[LOAD_0]], [[RES_0]][%arg1, %arg2, %arg3] : memref<16x2x64xf32>
+  // CHECK:   [[LOAD_0:%.+]] = krnl.load %arg0[%arg1, %arg2, %arg3] : memref<16x32x64xf32>
+  // CHECK:   krnl.store [[LOAD_0]], [[RES_0]][%arg1, %arg2, %arg3] : memref<16x2x64xf32>
   // CHECK: }
   // CHECK: [[DEF_LOOP_1:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOP_1]]#0, [[DEF_LOOP_1]]#1, [[DEF_LOOP_1]]#2) with ([[DEF_LOOP_1]]#0 -> %arg1 = 0 to 16, [[DEF_LOOP_1]]#1 -> %arg2 = 0 to 30, [[DEF_LOOP_1]]#2 -> %arg3 = 0 to 64) {
   // CHECK:   %[[INDEX:.+]] = affine.apply [[INDEX_MAP]](%arg2)
-  // CHECK:   [[LOAD_1:%.+]] = affine.load %arg0[%arg1, %[[INDEX]], %arg3] : memref<16x32x64xf32>
-  // CHECK:   affine.store [[LOAD_1]], [[RES_1]][%arg1, %arg2, %arg3] : memref<16x30x64xf32>
+  // CHECK:   [[LOAD_1:%.+]] = krnl.load %arg0[%arg1, %[[INDEX]], %arg3] : memref<16x32x64xf32>
+  // CHECK:   krnl.store [[LOAD_1]], [[RES_1]][%arg1, %arg2, %arg3] : memref<16x30x64xf32>
   // CHECK: }
   // CHECK: return [[RES_0]], [[RES_1]] : memref<16x2x64xf32>, memref<16x30x64xf32>
 }
@@ -2746,8 +2746,8 @@ func private @cast_lowering_sametype(%arg0: tensor<f32>) -> tensor<f32> {
 
   // CHECK-LABEL: cast_lowering_sametype
   // CHECK: [[RES:%.+]] = alloc() : memref<f32>
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[] : memref<f32>
-  // CHECK: affine.store [[LOAD]], [[RES]][] : memref<f32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[] : memref<f32>
+  // CHECK: krnl.store [[LOAD]], [[RES]][] : memref<f32>
   // CHECK: return [[RES]] : memref<f32>
 }
 
@@ -2759,9 +2759,9 @@ func private @cast_lowering_intfloat(%arg0: tensor<i64>) -> tensor<f32> {
 
   // CHECK-LABEL: cast_lowering_intfloat
   // CHECK: [[RES:%.+]] = alloc() : memref<f32>
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[] : memref<i64>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[] : memref<i64>
   // CHECK: [[VAL:%.+]] = sitofp [[LOAD]] : i64 to f32
-  // CHECK: affine.store [[VAL]], [[RES]][] : memref<f32>
+  // CHECK: krnl.store [[VAL]], [[RES]][] : memref<f32>
   // CHECK: return [[RES]] : memref<f32>
 }
 
@@ -2773,9 +2773,9 @@ func private @cast_lowering_floatint(%arg0: tensor<f32>) -> tensor<i64> {
 
   // CHECK-LABEL: cast_lowering_floatint
   // CHECK: [[RES:%.+]] = alloc() : memref<i64>
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[] : memref<f32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[] : memref<f32>
   // CHECK: [[VAL:%.+]] = fptosi [[LOAD]] : f32 to i64
-  // CHECK: affine.store [[VAL]], [[RES]][] : memref<i64>
+  // CHECK: krnl.store [[VAL]], [[RES]][] : memref<i64>
   // CHECK: return [[RES]] : memref<i64>
 }
 
@@ -2787,9 +2787,9 @@ func private @cast_lowering_f16f32(%arg0: tensor<f16>) -> tensor<f32> {
 
   // CHECK-LABEL: cast_lowering_f16f32
   // CHECK: [[RES:%.+]] = alloc() : memref<f32>
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[] : memref<f16>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[] : memref<f16>
   // CHECK: [[VAL:%.+]] = fpext [[LOAD]] : f16 to f32
-  // CHECK: affine.store [[VAL]], [[RES]][] : memref<f32>
+  // CHECK: krnl.store [[VAL]], [[RES]][] : memref<f32>
   // CHECK: return [[RES]] : memref<f32>
 }
 
@@ -2801,9 +2801,9 @@ func private @cast_lowering_f64f32(%arg0: tensor<f64>) -> tensor<f32> {
 
   // CHECK-LABEL: cast_lowering_f64f32
   // CHECK: [[RES:%.+]] = alloc() : memref<f32>
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[] : memref<f64>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[] : memref<f64>
   // CHECK: [[VAL:%.+]] = fptrunc [[LOAD]] : f64 to f32
-  // CHECK: affine.store [[VAL]], [[RES]][] : memref<f32>
+  // CHECK: krnl.store [[VAL]], [[RES]][] : memref<f32>
   // CHECK: return [[RES]] : memref<f32>
 }
 
@@ -2817,9 +2817,9 @@ func private @cast_lowering_f64f32_10(%arg0: tensor<10xf64>) -> tensor<*xf32> {
   // CHECK: [[RES:%.+]] = alloc() : memref<10xf32>
   // CHECK: [[DEF_LOOPS:%.+]] = krnl.define_loops 1
   // CHECK: krnl.iterate([[DEF_LOOPS]]) with ([[DEF_LOOPS]] -> %arg1 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg1] : memref<10xf64>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg1] : memref<10xf64>
   // CHECK: [[FPTRUNC:%.+]] = fptrunc [[LOAD1]] : f64 to f32
-  // CHECK: affine.store [[FPTRUNC]], [[RES]][%arg1] : memref<10xf32>
+  // CHECK: krnl.store [[FPTRUNC]], [[RES]][%arg1] : memref<10xf32>
   // CHECK: return [[RES]] : memref<10xf32>
 }
 
@@ -2831,9 +2831,9 @@ func private @cast_lowering_int_wider_int(%arg0: tensor<i32>) -> tensor<i64> {
 
   // CHECK-LABEL: cast_lowering_int_wider_int
   // CHECK: [[RES:%.+]] = alloc() : memref<i64>
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[] : memref<i32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[] : memref<i32>
   // CHECK: [[CAST:%.+]] = sexti [[LOAD]] : i32 to i64
-  // CHECK: affine.store [[CAST]], [[RES]][] : memref<i64>
+  // CHECK: krnl.store [[CAST]], [[RES]][] : memref<i64>
   // CHECK: return [[RES]] : memref<i64>
 }
 
@@ -2845,9 +2845,9 @@ func private @cast_lowering_int_narrow_int(%arg0: tensor<i64>) -> tensor<i32> {
 
   // CHECK-LABEL: cast_lowering_int_narrow_int
   // CHECK: [[RES:%.+]] = alloc() : memref<i32>
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[] : memref<i64>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[] : memref<i64>
   // CHECK: [[CAST:%.+]] = trunci [[LOAD]] : i64 to i32
-  // CHECK: affine.store [[CAST]], [[RES]][] : memref<i32>
+  // CHECK: krnl.store [[CAST]], [[RES]][] : memref<i32>
   // CHECK: return [[RES]] : memref<i32>
 }
 
@@ -2860,7 +2860,7 @@ func private @test_size_known(%arg0: tensor<2x2xf32>) -> tensor<i64> {
   // CHECK-LABEL: test_size_known
   // CHECK:      [[RES:%.+]] = alloc() : memref<i64>
   // CHECK-NEXT  [[SIZE:%.+]] = constant 4 : i64
-  // CHECK-NEXT  affine.store [[SIZE]], [[RES]][] : memref<i64>
+  // CHECK-NEXT  krnl.store [[SIZE]], [[RES]][] : memref<i64>
   // CHECK-NEXT  return [[RES]] : memref<i64>
 
 }
@@ -2880,7 +2880,7 @@ func private @test_size_unknown(%arg0 : tensor<?x2x?xf32>) -> tensor<i64> {
   // CHECK-NEXT:  [[DIM2:%.+]] = dim %arg0, [[IND2]] : memref<?x2x?xf32>
   // CHECK-NEXT:  [[IND3:%.+]] = index_cast [[DIM2]] : index to i64
   // CHECK-NEXT:  [[SIZE:%.+]] = muli [[TMP1]], [[IND3]] : i64
-  // CHECK-NEXT:  affine.store [[SIZE]], [[RES]][] : memref<i64>
+  // CHECK-NEXT:  krnl.store [[SIZE]], [[RES]][] : memref<i64>
   // CHECK-NEXT:  return [[RES]] : memref<i64>
 
   %1 = "onnx.Size"(%arg0)  : (tensor<?x2x?xf32>) -> tensor<i64>
@@ -2902,7 +2902,7 @@ func private @test_constant_of_shape_empty_tensor(%arg0 : tensor<0xi64>) -> tens
   // CHECK-LABEL: test_constant_of_shape_empty_tensor
   // CHECK: [[RES:%.+]] = alloc() : memref<f32>
   // CHECK: [[CST_VALUE:%.+]] = constant 0.000000e+00 : f32
-  // CHECK: affine.store [[CST_VALUE]], [[RES]][] : memref<f32>
+  // CHECK: krnl.store [[CST_VALUE]], [[RES]][] : memref<f32>
   // CHECK: return [[RES]] : memref<f32>
 }
 
@@ -2919,13 +2919,13 @@ func private @test_constant_of_shape_dynamic_dims(%arg0 : tensor<3xi64>) -> tens
 
   // CHECK-LABEL: test_constant_of_shape_dynamic_dims
   // CHECK: [[CST0:%.+]] = constant 0 : index
-  // CHECK: [[LOAD_DIM_0:%.+]] = affine.load %arg0{{\[}}[[CST0]]{{\]}} : memref<3xi64>
+  // CHECK: [[LOAD_DIM_0:%.+]] = krnl.load %arg0{{\[}}[[CST0]]{{\]}} : memref<3xi64>
   // CHECK: [[DIM_0:%.+]] = index_cast [[LOAD_DIM_0]] : i64 to index
   // CHECK: [[CST1:%.+]] = constant 1 : index
-  // CHECK: [[LOAD_DIM_1:%.+]] = affine.load %arg0{{\[}}[[CST1]]{{\]}} : memref<3xi64>
+  // CHECK: [[LOAD_DIM_1:%.+]] = krnl.load %arg0{{\[}}[[CST1]]{{\]}} : memref<3xi64>
   // CHECK: [[DIM_1:%.+]] = index_cast [[LOAD_DIM_1]] : i64 to index
   // CHECK: [[CST2:%.+]] = constant 2 : index
-  // CHECK: [[LOAD_DIM_2:%.+]] = affine.load %arg0{{\[}}[[CST2]]{{\]}} : memref<3xi64>
+  // CHECK: [[LOAD_DIM_2:%.+]] = krnl.load %arg0{{\[}}[[CST2]]{{\]}} : memref<3xi64>
   // CHECK: [[DIM_2:%.+]] = index_cast [[LOAD_DIM_2]] : i64 to index
   // CHECK: [[RES:%.+]] = alloc([[DIM_0]], [[DIM_1]], [[DIM_2]]) : memref<?x?x?xf32>
 
@@ -2938,7 +2938,7 @@ func private @test_constant_of_shape_dynamic_dims(%arg0 : tensor<3xi64>) -> tens
   // CHECK: [[CST22:%.+]] = constant 2 : index
   // CHECK: [[RES_DIM_2:%.+]] = dim [[RES]], [[CST22]] : memref<?x?x?xf32>
   // CHECK: krnl.iterate([[LOOP_DEF]]#0, [[LOOP_DEF]]#1, [[LOOP_DEF]]#2) with ([[LOOP_DEF]]#0 -> %arg1 = 0 to [[RES_DIM_0]], [[LOOP_DEF]]#1 -> %arg2 = 0 to [[RES_DIM_1]], [[LOOP_DEF]]#2 -> %arg3 = 0 to [[RES_DIM_2]]) {
-  // CHECK:   affine.store [[CST_VALUE]], [[RES]][%arg1, %arg2, %arg3] : memref<?x?x?xf32>
+  // CHECK:   krnl.store [[CST_VALUE]], [[RES]][%arg1, %arg2, %arg3] : memref<?x?x?xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<?x?x?xf32>
 }
@@ -2961,7 +2961,7 @@ func private @test_constant_of_shape_static_dims() -> tensor<*xf32> {
   // CHECK: [[CST_VALUE:%.+]] = constant 1.000000e+00 : f32
   // CHECK: [[LOOP_DEF:%.+]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[LOOP_DEF]]#0, [[LOOP_DEF]]#1, [[LOOP_DEF]]#2) with ([[LOOP_DEF]]#0 -> %arg0 = 0 to 3, [[LOOP_DEF]]#1 -> %arg1 = 0 to 4, [[LOOP_DEF]]#2 -> %arg2 = 0 to 5) {
-  // CHECK:   affine.store [[CST_VALUE]], [[RES]][%arg0, %arg1, %arg2] : memref<3x4x5xf32>
+  // CHECK:   krnl.store [[CST_VALUE]], [[RES]][%arg0, %arg1, %arg2] : memref<3x4x5xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x4x5xf32>
 }
@@ -2977,7 +2977,7 @@ func private @test_flatten0(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf32> {
   // CHECK:  [[ALLOC:%.+]] = alloc() : memref<1x24xf32>
   // CHECK:  [[LOOP:%.+]]:3 = krnl.define_loops 3
   // CHECK:  krnl.iterate([[LOOP]]#0, [[LOOP]]#1, [[LOOP]]#2) with ([[LOOP]]#0 -> [[LOOPARG1:%.+]] = 0 to 2, [[LOOP]]#1 -> [[LOOPARG2:%.+]] = 0 to 3, [[LOOP]]#2 -> [[LOOPARG3:%.+]] = 0 to 4) {
-  // CHECK:    [[LOAD:%.+]] = affine.load %arg0{{\[}}[[LOOPARG1]], [[LOOPARG2]], [[LOOPARG3]]{{\]}} : memref<2x3x4xf32>
+  // CHECK:    [[LOAD:%.+]] = krnl.load %arg0{{\[}}[[LOOPARG1]], [[LOOPARG2]], [[LOOPARG3]]{{\]}} : memref<2x3x4xf32>
   // CHECK:    [[FIRSTDIM:%.+]] = affine.apply [[MAP_FIRST]]()
   // CHECK:    [[C0:%.+]] = constant 0 : index
   // CHECK:    [[R4:%.+]] = dim %arg0, [[C0]] : memref<2x3x4xf32>
@@ -2986,7 +2986,7 @@ func private @test_flatten0(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf32> {
   // CHECK:    [[C2:%.+]] = constant 2 : index
   // CHECK:    [[R6:%.+]] = dim %arg0, [[C2]] : memref<2x3x4xf32>
   // CHECK:    [[SECONDDIM:%.+]] = affine.apply [[MAP_SECOND]]([[LOOPARG1]], [[LOOPARG2]], [[LOOPARG3]]){{\[}}[[R4]], [[R5]], [[R6]]{{\]}}
-  // CHECK:    affine.store [[LOAD]], [[ALLOC]]{{\[}}[[FIRSTDIM]], [[SECONDDIM]]{{\]}} : memref<1x24xf32>
+  // CHECK:    krnl.store [[LOAD]], [[ALLOC]]{{\[}}[[FIRSTDIM]], [[SECONDDIM]]{{\]}} : memref<1x24xf32>
 }
 
 // -----
@@ -3011,7 +3011,7 @@ func private @test_flatten1(%arg0 : tensor<2x?x4xf32>) -> tensor<*xf32> {
   // CHECK:  [[C1_1:%.+]] = constant 1 : index
   // CHECK:  [[R6:%.+]] = dim %arg0, [[C1_1]] : memref<2x?x4xf32>
   // CHECK:  krnl.iterate([[R5]]#0, [[R5]]#1, [[R5]]#2) with ([[R5]]#0 -> [[ARG1:%.+]] = 0 to 2, [[R5]]#1 -> [[ARG2:%.+]] = 0 to [[R6]], [[R5]]#2 -> [[ARG3:%.+]] = 0 to 4) {
-  // CHECK:    [[R7:%.+]] = affine.load %arg0{{\[}}[[ARG1]], [[ARG2]], [[ARG3]]{{\]}} : memref<2x?x4xf32>
+  // CHECK:    [[R7:%.+]] = krnl.load %arg0{{\[}}[[ARG1]], [[ARG2]], [[ARG3]]{{\]}} : memref<2x?x4xf32>
   // CHECK:    [[C0_2:%.+]] = constant 0 : index
   // CHECK:    [[R8:%.+]] = dim %arg0, [[C0_2]] : memref<2x?x4xf32>
   // CHECK:    [[C1_3:%.+]] = constant 1 : index
@@ -3020,7 +3020,7 @@ func private @test_flatten1(%arg0 : tensor<2x?x4xf32>) -> tensor<*xf32> {
   // CHECK:    [[C2:%.+]] = constant 2 : index
   // CHECK:    [[R11:%.+]] = dim %arg0, [[C2]] : memref<2x?x4xf32>
   // CHECK:    [[R12:%.+]] = affine.apply [[MAP2]]([[ARG3]]){{\[}}[[R11]]{{\]}}
-  // CHECK:    store [[R7]], [[R4]]{{\[}}[[R10]], [[R12]]{{\]}} : memref<?x4xf32>
+  // CHECK:    krnl.store [[R7]], [[R4]]{{\[}}[[R10]], [[R12]]{{\]}} : memref<?x4xf32>
 
 }
 
@@ -3034,10 +3034,10 @@ func private @test_less(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> t
   // CHECK: [[RES:%.+]] = alloc() : memref<3x4x5xi1>
   // CHECK: [[DEF_LOOPS]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1, [[DEF_LOOPS]]#2) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 3, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 4, [[DEF_LOOPS]]#2 -> %arg4 = 0 to 5) {
-  // CHECK:   [[LHS:%.+]] = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
-  // CHECK:   [[RHS:%.+]] = affine.load %arg1[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK:   [[LHS:%.+]] = krnl.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK:   [[RHS:%.+]] = krnl.load %arg1[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
   // CHECK:   [[LESS:%.+]] = cmpf "olt", [[LHS]], [[RHS]] : f32
-  // CHECK:   affine.store [[LESS]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xi1>
+  // CHECK:   krnl.store [[LESS]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xi1>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x4x5xi1>
 }
@@ -3052,10 +3052,10 @@ func private @test_less_broadcast(%arg0: tensor<3x4x5xf32>, %arg1: tensor<5xf32>
   // CHECK: [[RES:%.+]] = alloc() : memref<3x4x5xi1>
   // CHECK: [[DEF_LOOPS]]:3 = krnl.define_loops 3
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1, [[DEF_LOOPS]]#2) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 3, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 4, [[DEF_LOOPS]]#2 -> %arg4 = 0 to 5) {
-  // CHECK:   [[LHS:%.+]] = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
-  // CHECK:   [[RHS:%.+]] = affine.load %arg1[%arg4] : memref<5xf32>
+  // CHECK:   [[LHS:%.+]] = krnl.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
+  // CHECK:   [[RHS:%.+]] = krnl.load %arg1[%arg4] : memref<5xf32>
   // CHECK:   [[LESS:%.+]] = cmpf "olt", [[LHS]], [[RHS]] : f32
-  // CHECK:   affine.store [[LESS]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xi1>
+  // CHECK:   krnl.store [[LESS]], [[RES]][%arg2, %arg3, %arg4] : memref<3x4x5xi1>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x4x5xi1>
 }
@@ -3074,9 +3074,9 @@ func private @test_floor(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[FLOOR:%.+]] = floorf [[LOAD]] : f32
-  // CHECK: affine.store [[FLOOR]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[FLOOR]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -3094,9 +3094,9 @@ func private @test_ceil(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[CEIL:%.+]] = ceilf [[LOAD]] : f32
-  // CHECK: affine.store [[CEIL]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[CEIL]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -3114,9 +3114,9 @@ func private @test_atan(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ATAN:%.+]] = atan [[LOAD]] : f32
-  // CHECK: affine.store [[ATAN]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[ATAN]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
 
@@ -3131,14 +3131,14 @@ func private @test_clip(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<3xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 3) {
-// CHECK-DAG:         [[LOAD_INPUT_MEM_:%.+]] = affine.load [[INPUT_]]{{.}}[[I_0_]]{{.}} : memref<3xf32>
-// CHECK-DAG:         [[LOAD_MIN_MEM_:%.+]] = affine.load [[MIN_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_INPUT_MEM_:%.+]] = krnl.load [[INPUT_]]{{.}}[[I_0_]]{{.}} : memref<3xf32>
+// CHECK-DAG:         [[LOAD_MIN_MEM_:%.+]] = krnl.load [[MIN_]][] : memref<f32>
 // CHECK:             [[VAR_4_:%.+]] = cmpf "olt", [[LOAD_INPUT_MEM_]], [[LOAD_MIN_MEM_]] : f32
 // CHECK-DAG:         [[VAR_5_:%.+]] = select [[VAR_4_]], [[LOAD_MIN_MEM_]], [[LOAD_INPUT_MEM_]] : f32
-// CHECK-DAG:         [[LOAD_MAX_MEM_:%.+]] = affine.load [[MAX_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_MAX_MEM_:%.+]] = krnl.load [[MAX_]][] : memref<f32>
 // CHECK:             [[VAR_7_:%.+]] = cmpf "olt", [[VAR_5_]], [[LOAD_MAX_MEM_]] : f32
 // CHECK:             [[VAR_8_:%.+]] = select [[VAR_7_]], [[VAR_5_]], [[LOAD_MAX_MEM_]] : f32
-// CHECK:             affine.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<3xf32>
+// CHECK:             krnl.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<3xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<3xf32>
 // CHECK:         }
@@ -3156,11 +3156,11 @@ func private @test_clip_default_min(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %a
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<3xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 3) {
-// CHECK-DAG:         [[LOAD_INPUT_MEM_:%.+]] = affine.load [[INPUT_]]{{.}}[[I_0_]]{{.}} : memref<3xf32>
-// CHECK-DAG:         [[LOAD_MAX_MEM_:%.+]] = affine.load [[MAX_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_INPUT_MEM_:%.+]] = krnl.load [[INPUT_]]{{.}}[[I_0_]]{{.}} : memref<3xf32>
+// CHECK-DAG:         [[LOAD_MAX_MEM_:%.+]] = krnl.load [[MAX_]][] : memref<f32>
 // CHECK:             [[VAR_7_:%.+]] = cmpf "olt", [[LOAD_INPUT_MEM_]], [[LOAD_MAX_MEM_]] : f32
 // CHECK:             [[VAR_8_:%.+]] = select [[VAR_7_]], [[LOAD_INPUT_MEM_]], [[LOAD_MAX_MEM_]] : f32
-// CHECK:             affine.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<3xf32>
+// CHECK:             krnl.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<3xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<3xf32>
 // CHECK:         }
@@ -3176,10 +3176,10 @@ func private @test_pown(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> t
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<3x4x5xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
-// CHECK-DAG:         [[LOAD_INPUT_MEM_:%.+]] = affine.load [[INPUT_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<3x4x5xf32>
-// CHECK-DAG:         [[LOAD_POWER_MEM_:%.+]] = affine.load [[POWER_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<3x4x5xf32>
+// CHECK-DAG:         [[LOAD_INPUT_MEM_:%.+]] = krnl.load [[INPUT_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<3x4x5xf32>
+// CHECK-DAG:         [[LOAD_POWER_MEM_:%.+]] = krnl.load [[POWER_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<3x4x5xf32>
 // CHECK:             [[VAR_4_:%.+]] = powf [[LOAD_INPUT_MEM_]], [[LOAD_POWER_MEM_]] : f32
-// CHECK:             affine.store [[VAR_4_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<3x4x5xf32>
+// CHECK:             krnl.store [[VAR_4_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<3x4x5xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<3x4x5xf32>
 // CHECK:         }

--- a/test/mlir/onnx/onnx_lowering_loop.mlir
+++ b/test/mlir/onnx/onnx_lowering_loop.mlir
@@ -17,29 +17,29 @@ func private @test_loop_simple_main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>,
   // CHECK:           [[VAR_1:%.+]] = alloc() : memref<1xi64>
   // CHECK:           [[VAR_2:%.+]] = krnl.define_loops 1
   // CHECK:           krnl.iterate([[VAR_2]]) with ([[VAR_2]] -> [[VAR_arg3:%.+]] = 0 to 1) {
-  // CHECK:             [[VAR_7:%.+]] = affine.load [[VAR_arg2]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
-  // CHECK:             affine.store [[VAR_7]], [[VAR_1]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
+  // CHECK:             [[VAR_7:%.+]] = knrl.load [[VAR_arg2]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
+  // CHECK:             knrl.store [[VAR_7]], [[VAR_1]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
   // CHECK:           }
-  // CHECK:           [[VAR_3:%.+]] = affine.load [[VAR_arg1]][] : memref<i1>
-  // CHECK:           affine.store [[VAR_3]], [[VAR_0]][] : memref<i1>
+  // CHECK:           [[VAR_3:%.+]] = knrl.load [[VAR_arg1]][] : memref<i1>
+  // CHECK:           knrl.store [[VAR_3]], [[VAR_0]][] : memref<i1>
   // CHECK:           [[VAR_4:%.+]] = krnl.define_loops 1
-  // CHECK:           [[VAR_5:%.+]] = load [[VAR_arg0]][] : memref<i64>
+  // CHECK:           [[VAR_5:%.+]] = krnl.load [[VAR_arg0]][] : memref<i64>
   // CHECK:           [[VAR_6:%.+]] = index_cast [[VAR_5]] : i64 to index
   // CHECK:           krnl.iterate([[VAR_4]]) with ([[VAR_4]] -> [[VAR_arg3:%.+]] = 0 to [[VAR_6]]) {
-  // CHECK:             [[VAR_7:%.+]] = affine.load [[VAR_0]][] : memref<i1>
+  // CHECK:             [[VAR_7:%.+]] = knrl.load [[VAR_0]][] : memref<i1>
   // CHECK:             scf.if [[VAR_7]] {
   // CHECK:               [[VAR_8:%.+]] = index_cast [[VAR_arg3]] : index to i64
   // CHECK:               [[VAR_9:%.+]] = alloc() : memref<i64>
-  // CHECK:               store [[VAR_8]], [[VAR_9]][] : memref<i64>
+  // CHECK:               krnl.store [[VAR_8]], [[VAR_9]][] : memref<i64>
   // CHECK:               [[VAR_10:%.+]]:2 = call @loop_body([[VAR_9]], [[VAR_arg1]], [[VAR_1]]) : (memref<i64>, memref<i1>, memref<1xi64>) -> (memref<i1>, memref<1xi64>)
   // CHECK:               [[VAR_11:%.+]] = krnl.dummy_cast [[VAR_10]]#0 : (memref<i1>) -> memref<i1>
   // CHECK:               [[VAR_12:%.+]] = krnl.dummy_cast [[VAR_10]]#1 : (memref<1xi64>) -> memref<1xi64>
-  // CHECK:               [[VAR_13:%.+]] = affine.load [[VAR_11]][] : memref<i1>
-  // CHECK:               affine.store [[VAR_13]], [[VAR_0]][] : memref<i1>
+  // CHECK:               [[VAR_13:%.+]] = knrl.load [[VAR_11]][] : memref<i1>
+  // CHECK:               knrl.store [[VAR_13]], [[VAR_0]][] : memref<i1>
   // CHECK:               [[VAR_14:%.+]] = krnl.define_loops 1
   // CHECK:               krnl.iterate([[VAR_14]]) with ([[VAR_14]] -> [[VAR_arg4:%.+]] = 0 to 1) {
-  // CHECK:                 [[VAR_15:%.+]] = affine.load [[VAR_12]]{{.}}[[VAR_arg4]]{{.}} : memref<1xi64>
-  // CHECK:                 affine.store [[VAR_15]], [[VAR_1]]{{.}}[[VAR_arg4]]{{.}} : memref<1xi64>
+  // CHECK:                 [[VAR_15:%.+]] = knrl.load [[VAR_12]]{{.}}[[VAR_arg4]]{{.}} : memref<1xi64>
+  // CHECK:                 knrl.store [[VAR_15]], [[VAR_1]]{{.}}[[VAR_arg4]]{{.}} : memref<1xi64>
   // CHECK:               }
   // CHECK:             }
   // CHECK:           }
@@ -56,10 +56,10 @@ func private @loop_body(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<1xi
   // CHECK:           [[VAR_0:%.+]] = alloc() : memref<1xi64>
   // CHECK:           [[VAR_1:%.+]] = krnl.define_loops 1
   // CHECK:           krnl.iterate([[VAR_1]]) with ([[VAR_1]] -> [[VAR_arg3:%.+]] = 0 to 1) {
-  // CHECK:             [[VAR_2:%.+]] = affine.load [[VAR_arg2]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
-  // CHECK:             [[VAR_3:%.+]] = affine.load [[VAR_arg0]][] : memref<i64>
+  // CHECK:             [[VAR_2:%.+]] = knrl.load [[VAR_arg2]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
+  // CHECK:             [[VAR_3:%.+]] = knrl.load [[VAR_arg0]][] : memref<i64>
   // CHECK:             [[VAR_4:%.+]] = addi [[VAR_2]], [[VAR_3]] : i64
-  // CHECK:             affine.store [[VAR_4]], [[VAR_0]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
+  // CHECK:             knrl.store [[VAR_4]], [[VAR_0]]{{.}}[[VAR_arg3]]{{.}} : memref<1xi64>
   // CHECK:           }
   // CHECK:           return [[VAR_arg1]], [[VAR_0]] : memref<i1>, memref<1xi64>
   // CHECK:         }

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -15,15 +15,18 @@ func @test_slice_constant_default_axes(%arg0 : tensor<2x4xf32>) -> tensor<*xf32>
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_slice_constant_default_axes
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<1x2xf32>
-// CHECK-DAG:       [[START_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[END_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[2, 3]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[STEP_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[1, 2]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[2, 3]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[1, 2]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2) {
-// CHECK:             [[LOAD_DATA_MEM_:%.+]] = affine.load [[DATA_]][symbol([[I_0_]]) + 1, symbol([[I_1_]]) * 2] : memref<2x4xf32>
-// CHECK:             affine.store [[LOAD_DATA_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<1x2xf32>
+// CHECK-DAG:         [[VAR_6_:%.+]] = affine.apply #map0([[I_0_]])
+// CHECK-DAG:         [[VAR_7_:%.+]] = affine.apply #map1([[I_1_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<1x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x2xf32>
 // CHECK:         }
@@ -40,15 +43,17 @@ func @test_slice_constant_default_steps(%arg0 : tensor<2x4xf32>) -> tensor<*xf32
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_slice_constant_default_steps
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<2x4xf32>) -> memref<1x3xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4xf32>) -> memref<1x3xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<1x3xf32>
-// CHECK-DAG:       [[START_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[END_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[STEP_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[2, 3]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[2, 3]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<1> : tensor<2xi64>} : () -> memref<2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3) {
-// CHECK:             [[LOAD_DATA_MEM_:%.+]] = affine.load [[DATA_]][symbol([[I_0_]]) + 1, symbol([[I_1_]])] : memref<2x4xf32>
-// CHECK:             affine.store [[LOAD_DATA_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<1x3xf32>
+// CHECK:             [[VAR_6_:%.+]] = affine.apply #map([[I_0_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_6_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<1x3xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x3xf32>
 // CHECK:         }
@@ -65,16 +70,18 @@ func @test_slice_all_constant(%arg0 : tensor<2x4xf32>) -> tensor<*xf32> {
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_slice_all_constant
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<1x2xf32>
-// CHECK-DAG:       [[AXES_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[START_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[END_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[2, 3]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[STEP_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[1, 2]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[2, 3]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[1, 2]> : tensor<2xi64>} : () -> memref<2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2) {
-// CHECK:             [[LOAD_DATA_MEM_:%.+]] = affine.load [[DATA_]][symbol([[I_0_]]) + 1, symbol([[I_1_]]) * 2] : memref<2x4xf32>
-// CHECK:             affine.store [[LOAD_DATA_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<1x2xf32>
+// CHECK-DAG:         [[VAR_6_:%.+]] = affine.apply #map0([[I_0_]])
+// CHECK-DAG:         [[VAR_7_:%.+]] = affine.apply #map1([[I_1_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<1x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x2xf32>
 // CHECK:         }
@@ -91,16 +98,18 @@ func @test_slice_all_constant_negative(%arg0 : tensor<2x4xf32>) -> tensor<*xf32>
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_slice_all_constant_negative
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<1x2xf32>
-// CHECK-DAG:       [[AXES_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, -1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[START_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[END_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[2, -1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[STEP_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[1, 2]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, -1]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[2, -1]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[1, 2]> : tensor<2xi64>} : () -> memref<2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2) {
-// CHECK:             [[LOAD_DATA_MEM_:%.+]] = affine.load [[DATA_]][symbol([[I_0_]]) + 1, symbol([[I_1_]]) * 2] : memref<2x4xf32>
-// CHECK:             affine.store [[LOAD_DATA_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<1x2xf32>
+// CHECK-DAG:         [[VAR_6_:%.+]] = affine.apply #map0([[I_0_]])
+// CHECK-DAG:         [[VAR_7_:%.+]] = affine.apply #map1([[I_1_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<1x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x2xf32>
 // CHECK:         }
@@ -117,16 +126,18 @@ func @test_slice_all_constant_end_outofbound(%arg0 : tensor<2x4xf32>) -> tensor<
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_slice_all_constant_end_outofbound
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<1x2xf32>
-// CHECK-DAG:       [[AXES_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[START_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[END_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[5, 3]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[STEP_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[1, 2]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 0]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[5, 3]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[1, 2]> : tensor<2xi64>} : () -> memref<2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2) {
-// CHECK:             [[LOAD_DATA_MEM_:%.+]] = affine.load [[DATA_]][symbol([[I_0_]]) + 1, symbol([[I_1_]]) * 2] : memref<2x4xf32>
-// CHECK:             affine.store [[LOAD_DATA_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<1x2xf32>
+// CHECK-DAG:         [[VAR_6_:%.+]] = affine.apply #map0([[I_0_]])
+// CHECK-DAG:         [[VAR_7_:%.+]] = affine.apply #map1([[I_1_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<1x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x2xf32>
 // CHECK:         }
@@ -143,16 +154,18 @@ func @test_slice_all_constant_negative_steps(%arg0 : tensor<2x4xf32>) -> tensor<
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_slice_all_constant_negative_steps
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4xf32>) -> memref<1x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<1x2xf32>
-// CHECK-DAG:       [[AXES_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[START_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 3]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[END_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[2, 0]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[STEP_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[1, -2]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1, 3]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<[2, 0]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<[1, -2]> : tensor<2xi64>} : () -> memref<2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2) {
-// CHECK:             [[LOAD_DATA_MEM_:%.+]] = affine.load [[DATA_]][symbol([[I_0_]]) + 1, symbol([[I_1_]]) * -2 + 3] : memref<2x4xf32>
-// CHECK:             affine.store [[LOAD_DATA_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<1x2xf32>
+// CHECK-DAG:         [[VAR_6_:%.+]] = affine.apply #map0([[I_0_]])
+// CHECK-DAG:         [[VAR_7_:%.+]] = affine.apply #map1([[I_1_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_6_]], [[VAR_7_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<1x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x2xf32>
 // CHECK:         }
@@ -172,18 +185,20 @@ func @dyntest_slice_constant_dynshape_not_spliced(%arg0 : tensor<?x4x5xf32>) -> 
   "std.return"(%res) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @dyntest_slice_constant_dynshape_not_spliced
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<?x4x5xf32>) -> memref<?x2x3xf32> {
-// CHECK:           [[CST_0_:%.+]] = constant 0 : index
-// CHECK:           [[AXIS_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[2, 1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK:           [[START_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<1> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK:           [[END_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<-1> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK:           [[STEP_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<1> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK:           [[VAR_4_:%.+]] = dim [[DATA_]], [[CST_0_]] : memref<?x4x5xf32>
-// CHECK:           [[RES_:%.+]] = alloc([[VAR_4_]]) : memref<?x2x3xf32>
-// CHECK:           [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_4_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 3) {
-// CHECK:             [[LOAD_DATA_MEM_:%.+]] = affine.load [[DATA_]][symbol([[I_0_]]), symbol([[I_1_]]) + 1, symbol([[I_2_]]) + 1] : memref<?x4x5xf32>
-// CHECK:             affine.store [[LOAD_DATA_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x2x3xf32>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x4x5xf32>) -> memref<?x2x3xf32> {
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[VAR_0_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[2, 1]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<1> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_2", shape = [2], value = dense<-1> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_3", shape = [2], value = dense<1> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK:           [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x4x5xf32>
+// CHECK-DAG:       [[RES_:%.+]] = alloc([[DIM_0_]]) : memref<?x2x3xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[DIM_0_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 3) {
+// CHECK-DAG:         [[VAR_7_:%.+]] = affine.apply #map([[I_1_]])
+// CHECK-DAG:         [[VAR_8_:%.+]] = affine.apply #map([[I_2_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_0_]], [[VAR_7_]], [[VAR_8_]]{{.}} : memref<?x4x5xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x2x3xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x2x3xf32>
 // CHECK:         }
@@ -202,26 +217,27 @@ func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %arg2 
   %axes = "onnx.Constant"() {value = dense<[2, 1]> : tensor<2xi64> } : () -> tensor<2xi64>
   %res = "onnx.Slice"(%data, %arg0, %arg1, %axes, %arg2) : (tensor<3x4x5xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<3x?x?xi64>
   return
+
 // CHECK-LABEL:  func @compute_slice_all_dyn
-// CHECK-SAME:   ([[START_:%.+]]: memref<2xi64>, [[END_:%.+]]: memref<2xi64>, [[STEP_:%.+]]: memref<2xi64>) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2xi64>, [[PARAM_1_:%.+]]: memref<2xi64>, [[PARAM_2_:%.+]]: memref<2xi64>) {
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
 // CHECK-DAG:       [[CST_5_:%.+]] = constant 5 : index
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = constant -1 : index
 // CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
 // CHECK-DAG:       [[CST_minus_2147483648_:%.+]] = constant -2147483648 : index
 // CHECK-DAG:       [[CST_2147483647_:%.+]] = constant 2147483647 : index
-// CHECK-DAG:       [[CST_minus_1_:%.+]] = constant -1 : index
-// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
-// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = "krnl.global"() {name = "constant_0", shape = [3, 4, 5], value = dense<{{.}}{{.}}[0, 1, 2, 3, 4], [10, 11, 12, 13, 14], [20, 21, 22, 23, 24], [30, 31, 32, 33, 34]{{.}}, {{.}}[100, 101, 102, 103, 104], [110, 111, 112, 113, 114], [120, 121, 122, 123, 124], [130, 131, 132, 133, 134]{{.}}, {{.}}[200, 201, 202, 203, 204], [210, 211, 212, 213, 214], [220, 221, 222, 223, 224], [230, 231, 232, 233, 234]{{.}}{{.}}> : tensor<3x4x5xi64>} : () -> memref<3x4x5xi64>
-// CHECK-DAG:       [[AXES_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[2, 1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[LOAD_START_MEM_:%.+]] = affine.load [[START_]][0] : memref<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[2, 1]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[LOAD_PARAM_0_MEM_:%.+]] = affine.load [[PARAM_0_]][0] : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = index_cast [[LOAD_START_MEM_]] : i64 to index
-// CHECK-DAG:       [[LOAD_END_MEM_:%.+]] = affine.load [[END_]][0] : memref<2xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = index_cast [[LOAD_PARAM_0_MEM_]] : i64 to index
+// CHECK-DAG:       [[LOAD_PARAM_1_MEM_:%.+]] = affine.load [[PARAM_1_]][0] : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_:%.+]] = index_cast [[LOAD_END_MEM_]] : i64 to index
-// CHECK-DAG:       [[LOAD_STEP_MEM_:%.+]] = affine.load [[STEP_]][0] : memref<2xi64>
+// CHECK-DAG:       [[VAR_5_:%.+]] = index_cast [[LOAD_PARAM_1_MEM_]] : i64 to index
+// CHECK-DAG:       [[LOAD_PARAM_2_MEM_:%.+]] = affine.load [[PARAM_2_]][0] : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_7_:%.+]] = index_cast [[LOAD_STEP_MEM_]] : i64 to index
+// CHECK-DAG:       [[VAR_7_:%.+]] = index_cast [[LOAD_PARAM_2_MEM_]] : i64 to index
 // CHECK-DAG:       [[VAR_8_:%.+]] = cmpi "slt", [[VAR_3_]], [[CST_0_]] : index
 // CHECK-DAG:       [[VAR_9_:%.+]] = affine.apply #map0(){{.}}[[VAR_3_]]{{.}}
 // CHECK:           [[VAR_10_:%.+]] = select [[VAR_8_]], [[VAR_9_]], [[VAR_3_]] : index
@@ -259,15 +275,15 @@ func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %arg2 
 // CHECK:           [[VAR_39_:%.+]] = ceildivi_signed [[VAR_38_]], [[VAR_7_]] : index
 // CHECK:           [[VAR_40_:%.+]] = cmpi "slt", [[VAR_39_]], [[CST_0_]] : index
 // CHECK-DAG:       [[VAR_41_:%.+]] = select [[VAR_40_]], [[CST_0_]], [[VAR_39_]] : index
-// CHECK-DAG:       [[LOAD_START_MEM_1_:%.+]] = affine.load [[START_]][1] : memref<2xi64>
+// CHECK-DAG:       [[LOAD_PARAM_0_MEM_1_:%.+]] = affine.load [[PARAM_0_]][1] : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_43_:%.+]] = index_cast [[LOAD_START_MEM_1_]] : i64 to index
-// CHECK-DAG:       [[LOAD_END_MEM_1_:%.+]] = affine.load [[END_]][1] : memref<2xi64>
+// CHECK-DAG:       [[VAR_43_:%.+]] = index_cast [[LOAD_PARAM_0_MEM_1_]] : i64 to index
+// CHECK-DAG:       [[LOAD_PARAM_1_MEM_1_:%.+]] = affine.load [[PARAM_1_]][1] : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_45_:%.+]] = index_cast [[LOAD_END_MEM_1_]] : i64 to index
-// CHECK-DAG:       [[LOAD_STEP_MEM_1_:%.+]] = affine.load [[STEP_]][1] : memref<2xi64>
+// CHECK-DAG:       [[VAR_45_:%.+]] = index_cast [[LOAD_PARAM_1_MEM_1_]] : i64 to index
+// CHECK-DAG:       [[LOAD_PARAM_2_MEM_1_:%.+]] = affine.load [[PARAM_2_]][1] : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_47_:%.+]] = index_cast [[LOAD_STEP_MEM_1_]] : i64 to index
+// CHECK-DAG:       [[VAR_47_:%.+]] = index_cast [[LOAD_PARAM_2_MEM_1_]] : i64 to index
 // CHECK-DAG:       [[VAR_48_:%.+]] = cmpi "slt", [[VAR_43_]], [[CST_0_]] : index
 // CHECK-DAG:       [[VAR_49_:%.+]] = affine.apply #map1(){{.}}[[VAR_43_]]{{.}}
 // CHECK:           [[VAR_50_:%.+]] = select [[VAR_48_]], [[VAR_49_]], [[VAR_43_]] : index
@@ -312,8 +328,8 @@ func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %arg2 
 // CHECK-DAG:         [[VAR_85_:%.+]] = addi [[VAR_84_]], [[VAR_60_]] : index
 // CHECK-DAG:         [[VAR_86_:%.+]] = muli [[VAR_7_]], [[I_2_]] : index
 // CHECK:             [[VAR_87_:%.+]] = addi [[VAR_86_]], [[VAR_20_]] : index
-// CHECK:             [[VAR_88_:%.+]] = load [[VAR_0_]]{{.}}[[I_0_]], [[VAR_85_]], [[VAR_87_]]{{.}} : memref<3x4x5xi64>
-// CHECK:             affine.store [[VAR_88_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<3x?x?xi64>
+// CHECK:             [[LOAD_VAR_0_MEM_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[I_0_]], [[VAR_85_]], [[VAR_87_]]{{.}} : memref<3x4x5xi64>
+// CHECK:             krnl.store [[LOAD_VAR_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<3x?x?xi64>
 // CHECK:           }
 // CHECK:           dealloc [[RES_]] : memref<3x?x?xi64>
 // CHECK:           return
@@ -328,29 +344,29 @@ func @test_gemm(%arg0 : tensor<5x10xf32>, %arg1 : tensor<5x10xf32>, %arg2: tenso
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_gemm
-// CHECK-SAME:   ([[A_:%.+]]: memref<5x10xf32>, [[B_:%.+]]: memref<5x10xf32>, [[C_:%.+]]: memref<10xf32>) -> memref<10x10xf32> {
-// CHECK-DAG:       [[ALPHA_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:       [[BETA_:%.+]] = constant 5.000000e+00 : f32
-// CHECK-DAG:       [[ZERO_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<5x10xf32>, [[PARAM_1_:%.+]]: memref<5x10xf32>, [[PARAM_2_:%.+]]: memref<10xf32>) -> memref<10x10xf32> {
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_5_dot_000000_:%.+]] = constant 5.000000e+00 : f32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<10x10xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10) {
-// CHECK:             affine.store [[ZERO_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 5) {
-// CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = affine.load [[A_]][symbol([[I_2_]]), symbol([[I_0_]])] : memref<5x10xf32>
-// CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = affine.load [[B_]][symbol([[I_2_]]), symbol([[I_1_]])] : memref<5x10xf32>
-// CHECK-DAG:           [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
-// CHECK:               [[VAR_11_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[I_0_]]{{.}} : memref<5x10xf32>
+// CHECK-DAG:           [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[I_2_]], [[I_1_]]{{.}} : memref<5x10xf32>
+// CHECK-DAG:           [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+// CHECK:               [[VAR_11_:%.+]] = mulf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
 // CHECK:               [[VAR_12_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_11_]] : f32
-// CHECK:               affine.store [[VAR_12_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:               krnl.store [[VAR_12_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:             }
-// CHECK:             [[LOAD_RES_MEM_1_:%.+]] = affine.load [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
-// CHECK-DAG:         [[VAR_4_:%.+]] = mulf [[ALPHA_]], [[LOAD_RES_MEM_1_]] : f32
-// CHECK-DAG:         [[LOAD_C_MEM_:%.+]] = affine.load [[C_]][symbol([[I_1_]])] : memref<10xf32>
-// CHECK:             [[VAR_6_:%.+]] = mulf [[BETA_]], [[LOAD_C_MEM_]] : f32
+// CHECK:             [[LOAD_RES_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+// CHECK-DAG:         [[VAR_4_:%.+]] = mulf [[CST_1_dot_000000_]], [[LOAD_RES_MEM_1_]] : f32
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[I_1_]]{{.}} : memref<10xf32>
+// CHECK:             [[VAR_6_:%.+]] = mulf [[CST_5_dot_000000_]], [[LOAD_PARAM_2_MEM_]] : f32
 // CHECK:             [[VAR_7_:%.+]] = addf [[VAR_4_]], [[VAR_6_]] : f32
-// CHECK:             affine.store [[VAR_7_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:             krnl.store [[VAR_7_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<10x10xf32>
 // CHECK:         }
@@ -364,40 +380,40 @@ func @test_gemm_all_dyn(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2:
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_gemm_all_dyn
-// CHECK-SAME:   ([[A_:%.+]]: memref<?x?xf32>, [[B_:%.+]]: memref<?x?xf32>, [[C_:%.+]]: memref<?xf32>) -> memref<?x?xf32> {
-// CHECK-DAG:       [[ALPHA_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:       [[BETA_:%.+]] = constant 5.000000e+00 : f32
-// CHECK-DAG:       [[ZERO_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?xf32>, [[PARAM_1_:%.+]]: memref<?x?xf32>, [[PARAM_2_:%.+]]: memref<?xf32>) -> memref<?x?xf32> {
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_5_dot_000000_:%.+]] = constant 5.000000e+00 : f32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[A_]], [[CST_1_]] : memref<?x?xf32>
-// CHECK-DAG:       [[DIM_1_:%.+]] = dim [[A_]], [[CST_0_]] : memref<?x?xf32>
-// CHECK-DAG:       [[DIM_2_:%.+]] = dim [[B_]], [[CST_1_]] : memref<?x?xf32>
-// CHECK-DAG:       [[DIM_3_:%.+]] = dim [[C_]], [[CST_0_]] : memref<?xf32>
+// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_1_]] : memref<?x?xf32>
+// CHECK-DAG:       [[DIM_1_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x?xf32>
+// CHECK-DAG:       [[DIM_2_:%.+]] = dim [[PARAM_1_]], [[CST_1_]] : memref<?x?xf32>
+// CHECK-DAG:       [[DIM_3_:%.+]] = dim [[PARAM_2_]], [[CST_0_]] : memref<?xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[RES_:%.+]] = alloc([[DIM_0_]], [[DIM_2_]]) : memref<?x?xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[DIM_0_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to [[DIM_2_]]) {
-// CHECK:             affine.store [[ZERO_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<?x?xf32>
+// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x?xf32>
 // CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to [[DIM_1_]]) {
-// CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = affine.load [[A_]][symbol([[I_2_]]), symbol([[I_0_]])] : memref<?x?xf32>
-// CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = affine.load [[B_]][symbol([[I_2_]]), symbol([[I_1_]])] : memref<?x?xf32>
-// CHECK-DAG:           [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<?x?xf32>
-// CHECK:               [[VAR_17_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[I_0_]]{{.}} : memref<?x?xf32>
+// CHECK-DAG:           [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[I_2_]], [[I_1_]]{{.}} : memref<?x?xf32>
+// CHECK-DAG:           [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x?xf32>
+// CHECK:               [[VAR_17_:%.+]] = mulf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
 // CHECK:               [[VAR_18_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_17_]] : f32
-// CHECK:               affine.store [[VAR_18_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<?x?xf32>
+// CHECK:               krnl.store [[VAR_18_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x?xf32>
 // CHECK:             }
 // CHECK:             [[VAR_7_:%.+]] = cmpi "sgt", [[DIM_3_]], [[CST_1_]] : index
 // CHECK-DAG:         [[VAR_8_:%.+]] = select [[VAR_7_]], [[I_1_]], [[CST_0_]] : index
-// CHECK-DAG:         [[LOAD_RES_MEM_1_:%.+]] = affine.load [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<?x?xf32>
+// CHECK-DAG:         [[LOAD_RES_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x?xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_10_:%.+]] = mulf [[ALPHA_]], [[LOAD_RES_MEM_1_]] : f32
-// CHECK-DAG:         [[VAR_11_:%.+]] = load [[C_]]{{.}}[[VAR_8_]]{{.}} : memref<?xf32>
-// CHECK:             [[VAR_12_:%.+]] = mulf [[BETA_]], [[VAR_11_]] : f32
+// CHECK-DAG:         [[VAR_10_:%.+]] = mulf [[CST_1_dot_000000_]], [[LOAD_RES_MEM_1_]] : f32
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[VAR_8_]]{{.}} : memref<?xf32>
+// CHECK:             [[VAR_12_:%.+]] = mulf [[CST_5_dot_000000_]], [[LOAD_PARAM_2_MEM_]] : f32
 // CHECK:             [[VAR_13_:%.+]] = addf [[VAR_10_]], [[VAR_12_]] : f32
-// CHECK:             affine.store [[VAR_13_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<?x?xf32>
+// CHECK:             krnl.store [[VAR_13_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x?xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x?xf32>
 // CHECK:         }
@@ -409,33 +425,34 @@ func @test_gemm_all_dyn(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2:
 func @test_gemm_k_dyn(%arg0 : tensor<?x10xf32>, %arg1 : tensor<?x10xf32>, %arg2: tensor<10xf32>) -> tensor<*xf32> {
   %0 ="onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.0 : f32, beta = 5.0 : f32, transA = 1 : si64, transB = 0 : si64} : (tensor<?x10xf32>, tensor<?x10xf32>, tensor<10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
+
 // CHECK-LABEL:  func @test_gemm_k_dyn
-// CHECK-SAME:   ([[A_:%.+]]: memref<?x10xf32>, [[B_:%.+]]: memref<?x10xf32>, [[C_:%.+]]: memref<10xf32>) -> memref<10x10xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x10xf32>, [[PARAM_1_:%.+]]: memref<?x10xf32>, [[PARAM_2_:%.+]]: memref<10xf32>) -> memref<10x10xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[ALPHA_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:       [[BETA_:%.+]] = constant 5.000000e+00 : f32
-// CHECK-DAG:       [[ZERO_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_5_dot_000000_:%.+]] = constant 5.000000e+00 : f32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<10x10xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[A_]], [[CST_0_]] : memref<?x10xf32>
+// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x10xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10) {
-// CHECK:             affine.store [[ZERO_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to [[DIM_0_]]) {
-// CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = affine.load [[A_]][symbol([[I_2_]]), symbol([[I_0_]])] : memref<?x10xf32>
-// CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = affine.load [[B_]][symbol([[I_2_]]), symbol([[I_1_]])] : memref<?x10xf32>
-// CHECK-DAG:           [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
-// CHECK:               [[VAR_12_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[I_0_]]{{.}} : memref<?x10xf32>
+// CHECK-DAG:           [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[I_2_]], [[I_1_]]{{.}} : memref<?x10xf32>
+// CHECK-DAG:           [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+// CHECK:               [[VAR_12_:%.+]] = mulf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
 // CHECK:               [[VAR_13_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_12_]] : f32
-// CHECK:               affine.store [[VAR_13_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:               krnl.store [[VAR_13_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:             }
-// CHECK:             [[LOAD_RES_MEM_1_:%.+]] = affine.load [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
-// CHECK-DAG:         [[VAR_5_:%.+]] = mulf [[ALPHA_]], [[LOAD_RES_MEM_1_]] : f32
-// CHECK-DAG:         [[LOAD_C_MEM_:%.+]] = affine.load [[C_]][symbol([[I_1_]])] : memref<10xf32>
-// CHECK:             [[VAR_7_:%.+]] = mulf [[BETA_]], [[LOAD_C_MEM_]] : f32
+// CHECK:             [[LOAD_RES_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+// CHECK-DAG:         [[VAR_5_:%.+]] = mulf [[CST_1_dot_000000_]], [[LOAD_RES_MEM_1_]] : f32
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[I_1_]]{{.}} : memref<10xf32>
+// CHECK:             [[VAR_7_:%.+]] = mulf [[CST_5_dot_000000_]], [[LOAD_PARAM_2_MEM_]] : f32
 // CHECK:             [[VAR_8_:%.+]] = addf [[VAR_5_]], [[VAR_7_]] : f32
-// CHECK:             affine.store [[VAR_8_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:             krnl.store [[VAR_8_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<10x10xf32>
 // CHECK:         }
@@ -449,36 +466,36 @@ func @test_gemm_c_dyn(%arg0 : tensor<5x10xf32>, %arg1 : tensor<5x10xf32>, %arg2:
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func @test_gemm_c_dyn
-// CHECK-SAME:   ([[A_:%.+]]: memref<5x10xf32>, [[B_:%.+]]: memref<5x10xf32>, [[C_:%.+]]: memref<?xf32>) -> memref<10x10xf32> {
-// CHECK-DAG:       [[ALPHA_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:       [[BETA_:%.+]] = constant 5.000000e+00 : f32
-// CHECK-DAG:       [[ZERO_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<5x10xf32>, [[PARAM_1_:%.+]]: memref<5x10xf32>, [[PARAM_2_:%.+]]: memref<?xf32>) -> memref<10x10xf32> {
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_5_dot_000000_:%.+]] = constant 5.000000e+00 : f32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<10x10xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[C_]], [[CST_0_]] : memref<?xf32>
+// CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_2_]], [[CST_0_]] : memref<?xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10) {
-// CHECK:             affine.store [[ZERO_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 5) {
-// CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = affine.load [[A_]][symbol([[I_2_]]), symbol([[I_0_]])] : memref<5x10xf32>
-// CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = affine.load [[B_]][symbol([[I_2_]]), symbol([[I_1_]])] : memref<5x10xf32>
-// CHECK-DAG:           [[LOAD_RES_MEM_:%.+]] = affine.load [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
-// CHECK:               [[VAR_14_:%.+]] = mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[I_0_]]{{.}} : memref<5x10xf32>
+// CHECK-DAG:           [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[I_2_]], [[I_1_]]{{.}} : memref<5x10xf32>
+// CHECK-DAG:           [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+// CHECK:               [[VAR_14_:%.+]] = mulf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
 // CHECK:               [[VAR_15_:%.+]] = addf [[LOAD_RES_MEM_]], [[VAR_14_]] : f32
-// CHECK:               affine.store [[VAR_15_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:               krnl.store [[VAR_15_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:             }
 // CHECK:             [[VAR_4_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
 // CHECK-DAG:         [[VAR_5_:%.+]] = select [[VAR_4_]], [[I_1_]], [[CST_0_]] : index
-// CHECK-DAG:         [[LOAD_RES_MEM_1_:%.+]] = affine.load [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK-DAG:         [[LOAD_RES_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_7_:%.+]] = mulf [[ALPHA_]], [[LOAD_RES_MEM_1_]] : f32
-// CHECK-DAG:         [[LOAD_C_MEM_:%.+]] = load [[C_]]{{.}}[[VAR_5_]]{{.}} : memref<?xf32>
-// CHECK:             [[VAR_9_:%.+]] = mulf [[BETA_]], [[LOAD_C_MEM_]] : f32
+// CHECK-DAG:         [[VAR_7_:%.+]] = mulf [[CST_1_dot_000000_]], [[LOAD_RES_MEM_1_]] : f32
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[VAR_5_]]{{.}} : memref<?xf32>
+// CHECK:             [[VAR_9_:%.+]] = mulf [[CST_5_dot_000000_]], [[LOAD_PARAM_2_MEM_]] : f32
 // CHECK:             [[VAR_10_:%.+]] = addf [[VAR_7_]], [[VAR_9_]] : f32
-// CHECK:             affine.store [[VAR_10_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<10x10xf32>
+// CHECK:             krnl.store [[VAR_10_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<10x10xf32>
 // CHECK:         }
@@ -491,18 +508,20 @@ func @test_tile1(%arg0 : tensor<4x8xf32>) -> tensor<*xf32> {
   %0 = "onnx.Constant"() { value = dense<[3, 2]> : tensor<2xi64>} : () -> tensor<2xi64>
   %1 = "onnx.Tile"(%arg0, %0) : (tensor<4x8xf32>, tensor<2xi64>) -> tensor<*xf32>
   return %1 : tensor<*xf32>
-// CHECK-LABEL:       func @test_tile1
-// CHECK-SAME:     ([[VAR_arg0:%.+]]: memref<4x8xf32>) -> memref<12x16xf32> {
-// CHECK-DAG:       [[VAR_0:%.+]] = alloc() : memref<12x16xf32>
-// CHECK-DAG:       [[VAR_1:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[3, 2]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[VAR_2:%.+]]:2 = krnl.define_loops 2
-// CHECK:           krnl.iterate([[VAR_2]]#0, [[VAR_2]]#1) with ([[VAR_2]]#0 -> [[VAR_arg1:%.+]] = 0 to 12, [[VAR_2]]#1 -> [[VAR_arg2:%.+]] = 0 to 16) {
-// CHECK:             [[VAR_3:%.+]] = affine.load [[VAR_arg0]][symbol([[VAR_arg1]]) mod 4, symbol([[VAR_arg2]]) mod 8] : memref<4x8xf32>
-// CHECK:             affine.store [[VAR_3]], [[VAR_0]][symbol([[VAR_arg1]]), symbol([[VAR_arg2]])] : memref<12x16xf32>
+
+// CHECK-LABEL:  func @test_tile1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<4x8xf32>) -> memref<12x16xf32> {
+// CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<12x16xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2], value = dense<[3, 2]> : tensor<2xi64>} : () -> memref<2xi64>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 12, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 16) {
+// CHECK-DAG:         [[VAR_3_:%.+]] = affine.apply #map0([[I_0_]])
+// CHECK-DAG:         [[VAR_4_:%.+]] = affine.apply #map1([[I_1_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_3_]], [[VAR_4_]]{{.}} : memref<4x8xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<12x16xf32>
 // CHECK:           }
-// CHECK:           return [[VAR_0]] : memref<12x16xf32>
+// CHECK:           return [[RES_]] : memref<12x16xf32>
 // CHECK:         }
-// CHECK:       }
 }
 
 // -----
@@ -511,18 +530,20 @@ func @test_tile1(%arg0 : tensor<4x8xf32>) -> tensor<*xf32> {
 func @test_tile2(%arg0 : tensor<8xf32>, %arg1 : tensor<1xi64>) -> tensor<*xf32> {
   %1 = "onnx.Tile"(%arg0, %arg1) : (tensor<8xf32>, tensor<1xi64>) -> tensor<*xf32>
   return %1 : tensor<*xf32>
-// CHECK-LABEL:       func @test_tile2
-// CHECK-SAME:     ([[VAR_arg0:%.+]]: memref<8xf32>, [[VAR_arg1:%.+]]: memref<1xi64>) -> memref<?xf32> {
-// CHECK:           [[VAR_0:%.+]] = affine.load [[VAR_arg1]][0] : memref<1xi64>
-// CHECK:           [[VAR_1:%.+]] = index_cast [[VAR_0]] : i64 to index
-// CHECK:           [[VAR_2:%.+]] = affine.apply #map(){{.}}[[VAR_1]]{{.}}
-// CHECK-DAG:       [[VAR_3:%.+]] = alloc([[VAR_2]]) : memref<?xf32>
-// CHECK-DAG:       [[VAR_4:%.+]] = krnl.define_loops 1
-// CHECK:           krnl.iterate([[VAR_4]]) with ([[VAR_4]] -> [[VAR_arg2:%.+]] = 0 to [[VAR_2]]) {
-// CHECK:             [[VAR_6:%.+]] = affine.load [[VAR_arg0]][symbol([[VAR_arg2]]) mod 8] : memref<8xf32>
-// CHECK:             affine.store [[VAR_6]], [[VAR_3]][symbol([[VAR_arg2]])] : memref<?xf32>
+
+// CHECK-LABEL:  func @test_tile2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<8xf32>, [[PARAM_1_:%.+]]: memref<1xi64>) -> memref<?xf32> {
+// CHECK:           [[LOAD_PARAM_1_MEM_:%.+]] = affine.load [[PARAM_1_]][0] : memref<1xi64>
+// CHECK:           [[VAR_1_:%.+]] = index_cast [[LOAD_PARAM_1_MEM_]] : i64 to index
+// CHECK:           [[VAR_2_:%.+]] = affine.apply #map0(){{.}}[[VAR_1_]]{{.}}
+// CHECK-DAG:       [[RES_:%.+]] = alloc([[VAR_2_]]) : memref<?xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to [[VAR_2_]]) {
+// CHECK:             [[VAR_5_:%.+]] = affine.apply #map1([[I_0_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_5_]]{{.}} : memref<8xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]]{{.}} : memref<?xf32>
 // CHECK:           }
-// CHECK:           return [[VAR_3]] : memref<?xf32>
+// CHECK:           return [[RES_]] : memref<?xf32>
 // CHECK:         }
 }
 
@@ -535,15 +556,15 @@ func @test_gather_axis0(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
   "std.return"(%0) : (tensor<2x2x2xf32>) -> ()
 
 // CHECK-LABEL:  func @test_gather_axis0
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<3x2xf32>) -> memref<2x2x2xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3x2xf32>) -> memref<2x2x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<2x2x2xf32>
-// CHECK-DAG:       [[INDICES_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2, 2], value = dense<{{.}}[0, 1], [1, 2]{{.}}> : tensor<2x2xi64>} : () -> memref<2x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2, 2], value = dense<{{.}}[0, 1], [1, 2]{{.}}> : tensor<2x2xi64>} : () -> memref<2x2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 2) {
-// CHECK:             [[LOAD_INDICES_MEM_:%.+]] = affine.load [[INDICES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<2x2xi64>
-// CHECK:             [[VAR_4_:%.+]] = index_cast [[LOAD_INDICES_MEM_]] : i64 to index
-// CHECK:             [[VAR_5_:%.+]] = load [[DATA_]]{{.}}[[VAR_4_]], [[I_2_]]{{.}} : memref<3x2xf32>
-// CHECK:             affine.store [[VAR_5_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<2x2x2xf32>
+// CHECK:             [[LOAD_VAR_1_MEM_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x2xi64>
+// CHECK:             [[VAR_4_:%.+]] = index_cast [[LOAD_VAR_1_MEM_]] : i64 to index
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_4_]], [[I_2_]]{{.}} : memref<3x2xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<2x2x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<2x2x2xf32>
 // CHECK:         }
@@ -558,20 +579,20 @@ func @test_gather_axis0neg(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
   "std.return"(%0) : (tensor<2x2x2xf32>) -> ()
 
 // CHECK-LABEL:  func @test_gather_axis0neg
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<3x2xf32>) -> memref<2x2x2xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3x2xf32>) -> memref<2x2x2xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
 // CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<2x2x2xf32>
-// CHECK-DAG:       [[INDICES_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2, 2], value = dense<{{.}}[0, -1], [1, 2]{{.}}> : tensor<2x2xi64>} : () -> memref<2x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2, 2], value = dense<{{.}}[0, -1], [1, 2]{{.}}> : tensor<2x2xi64>} : () -> memref<2x2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 2) {
-// CHECK:             [[LOAD_INDICES_MEM_:%.+]] = affine.load [[INDICES_]][symbol([[I_0_]]), symbol([[I_1_]])] : memref<2x2xi64>
-// CHECK:             [[VAR_4_:%.+]] = index_cast [[LOAD_INDICES_MEM_]] : i64 to index
+// CHECK:             [[LOAD_VAR_1_MEM_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x2xi64>
+// CHECK:             [[VAR_4_:%.+]] = index_cast [[LOAD_VAR_1_MEM_]] : i64 to index
 // CHECK-DAG:         [[VAR_5_:%.+]] = cmpi "slt", [[VAR_4_]], [[CST_0_]] : index
 // CHECK-DAG:         [[VAR_6_:%.+]] = addi [[VAR_4_]], [[CST_3_]] : index
 // CHECK:             [[VAR_7_:%.+]] = select [[VAR_5_]], [[VAR_6_]], [[VAR_4_]] : index
-// CHECK:             [[VAR_8_:%.+]] = load [[DATA_]]{{.}}[[VAR_7_]], [[I_2_]]{{.}} : memref<3x2xf32>
-// CHECK:             affine.store [[VAR_8_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<2x2x2xf32>
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_7_]], [[I_2_]]{{.}} : memref<3x2xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<2x2x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<2x2x2xf32>
 // CHECK:         }
@@ -586,15 +607,15 @@ func @test_gather_axis1(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
   "std.return"(%0) : (tensor<3x1x2xf32>) -> ()
 
 // CHECK-LABEL:  func @test_gather_axis1
-// CHECK-SAME:   ([[DATA_:%.+]]: memref<3x3xf32>) -> memref<3x1x2xf32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3x3xf32>) -> memref<3x1x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = alloc() : memref<3x1x2xf32>
-// CHECK-DAG:       [[INDICES_:%.+]] = "krnl.global"() {name = "constant_0", shape = [1, 2], value = dense<{{.}}[0, 2]{{.}}> : tensor<1x2xi64>} : () -> memref<1x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [1, 2], value = dense<{{.}}[0, 2]{{.}}> : tensor<1x2xi64>} : () -> memref<1x2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 1, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 2) {
-// CHECK:             [[LOAD_INDICES_MEM_:%.+]] = affine.load [[INDICES_]][symbol([[I_1_]]), symbol([[I_2_]])] : memref<1x2xi64>
-// CHECK:             [[VAR_4_:%.+]] = index_cast [[LOAD_INDICES_MEM_]] : i64 to index
-// CHECK:             [[VAR_5_:%.+]] = load [[DATA_]]{{.}}[[I_0_]], [[VAR_4_]]{{.}} : memref<3x3xf32>
-// CHECK:             affine.store [[VAR_5_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<3x1x2xf32>
+// CHECK:             [[LOAD_VAR_1_MEM_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[I_1_]], [[I_2_]]{{.}} : memref<1x2xi64>
+// CHECK:             [[VAR_4_:%.+]] = index_cast [[LOAD_VAR_1_MEM_]] : i64 to index
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_0_]], [[VAR_4_]]{{.}} : memref<3x3xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<3x1x2xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<3x1x2xf32>
 // CHECK:         }
@@ -617,13 +638,14 @@ func @test_split_unknown_dimension(%arg0 : tensor<?x?x64xf32>) -> (tensor<*xf32>
 // CHECK-DAG:       [[RES_1_:%.+]] = alloc([[DIM_1_]]) : memref<?x30x64xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[DIM_0_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 64) {
-// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = affine.load [[PARAM_0_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x?x64xf32>
-// CHECK:             affine.store [[LOAD_PARAM_0_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x2x64xf32>
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x?x64xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x2x64xf32>
 // CHECK:           }
 // CHECK:           [[LOOP_1_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2) with ([[LOOP_1_]]#0 -> [[I_3_:%.+]] = 0 to [[DIM_1_]], [[LOOP_1_]]#1 -> [[I_4_:%.+]] = 0 to 30, [[LOOP_1_]]#2 -> [[I_5_:%.+]] = 0 to 64) {
-// CHECK:             [[LOAD_PARAM_0_MEM_1_:%.+]] = affine.load [[PARAM_0_]][symbol([[I_3_]]), symbol([[I_4_]]) + 2, symbol([[I_5_]])] : memref<?x?x64xf32>
-// CHECK:             affine.store [[LOAD_PARAM_0_MEM_1_]], [[RES_1_]][symbol([[I_3_]]), symbol([[I_4_]]), symbol([[I_5_]])] : memref<?x30x64xf32>
+// CHECK:             [[LOAD_PARAM_0_MEM_1_:%.+]] = affine.apply #map([[I_4_]])
+// CHECK:             [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_3_]], [[LOAD_PARAM_0_MEM_1_]], [[I_5_]]{{.}} : memref<?x?x64xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_2_]], [[RES_1_]]{{.}}[[I_3_]], [[I_4_]], [[I_5_]]{{.}} : memref<?x30x64xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]], [[RES_1_]] : memref<?x2x64xf32>, memref<?x30x64xf32>
 // CHECK:         }
@@ -644,20 +666,21 @@ func @test_split_unknown_dimension_equal_split(%arg0 : tensor<?x?x64xf32>) -> (t
 // CHECK-DAG:       [[DIM_0_:%.+]] = dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x64xf32>
 // CHECK-DAG:       [[DIM_1_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x?x64xf32>
 // CHECK-DAG:       [[DIM_2_:%.+]] = dim [[PARAM_0_]], [[CST_0_]] : memref<?x?x64xf32>
-// CHECK:           [[VAR_3_:%.+]] = affine.apply #map(){{.}}[[DIM_0_]]{{.}}
+// CHECK:           [[VAR_3_:%.+]] = affine.apply #map0(){{.}}[[DIM_0_]]{{.}}
 // CHECK-DAG:       [[RES_:%.+]] = alloc([[DIM_1_]], [[VAR_3_]]) : memref<?x?x64xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = affine.apply #map(){{.}}[[DIM_0_]]{{.}}
+// CHECK-DAG:       [[VAR_5_:%.+]] = affine.apply #map0(){{.}}[[DIM_0_]]{{.}}
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[RES_1_:%.+]] = alloc([[DIM_2_]], [[VAR_5_]]) : memref<?x?x64xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[DIM_1_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to [[VAR_3_]], [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 64) {
-// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = affine.load [[PARAM_0_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x?x64xf32>
-// CHECK:             affine.store [[LOAD_PARAM_0_MEM_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x?x64xf32>
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x?x64xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]]{{.}} : memref<?x?x64xf32>
 // CHECK:           }
 // CHECK:           [[LOOP_1_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2) with ([[LOOP_1_]]#0 -> [[I_3_:%.+]] = 0 to [[DIM_2_]], [[LOOP_1_]]#1 -> [[I_4_:%.+]] = 0 to [[VAR_5_]], [[LOOP_1_]]#2 -> [[I_5_:%.+]] = 0 to 64) {
-// CHECK:             [[LOAD_PARAM_0_MEM_1_:%.+]] = affine.load [[PARAM_0_]][symbol([[I_3_]]), symbol([[I_4_]]) + symbol([[DIM_0_]]) ceildiv 2, symbol([[I_5_]])] : memref<?x?x64xf32>
-// CHECK:             affine.store [[LOAD_PARAM_0_MEM_1_]], [[RES_1_]][symbol([[I_3_]]), symbol([[I_4_]]), symbol([[I_5_]])] : memref<?x?x64xf32>
+// CHECK:             [[LOAD_PARAM_0_MEM_1_:%.+]] = affine.apply #map1([[I_4_]]){{.}}[[DIM_0_]]{{.}}
+// CHECK:             [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_3_]], [[LOAD_PARAM_0_MEM_1_]], [[I_5_]]{{.}} : memref<?x?x64xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_2_]], [[RES_1_]]{{.}}[[I_3_]], [[I_4_]], [[I_5_]]{{.}} : memref<?x?x64xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]], [[RES_1_]] : memref<?x?x64xf32>, memref<?x?x64xf32>
 // CHECK:         }
@@ -713,12 +736,12 @@ func @test_binary_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5xf32>,
 // CHECK-DAG:       [[RES_:%.+]] = alloc([[VAR_2_]]) : memref<?x4x5xi1>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_2_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = affine.load [[PARAM_0_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x4x5xf32>
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{\[}}[[I_0_]], [[I_1_]], [[I_2_]]] : memref<?x4x5xf32>
 // CHECK-DAG:         [[VAR_6_:%.+]] = cmpi "sgt", [[DIM_1_]], [[CST_1_]] : index
 // CHECK:             [[VAR_7_:%.+]] = select [[VAR_6_]], [[I_1_]], [[CST_0_]] : index
-// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = load [[PARAM_1_]]{{.}}[[CST_0_]], [[VAR_7_]], [[CST_0_]]{{.}} : memref<1x?x1xf32>
+// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[CST_0_]], [[VAR_7_]], [[CST_0_]]{{.}} : memref<1x?x1xf32>
 // CHECK:             [[VAR_9_:%.+]] = cmpf "olt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
-// CHECK:             affine.store [[VAR_9_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x4x5xi1>
+// CHECK:             krnl.store [[VAR_9_]], [[RES_]]{{\[}}[[I_0_]], [[I_1_]], [[I_2_]]{{\]}} : memref<?x4x5xi1>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x4x5xi1>
 // CHECK:         }
@@ -745,21 +768,21 @@ func @test_variadic_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x1xf32
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_4_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5) {
 // CHECK:             [[VAR_7_:%.+]] = cmpi "sgt", [[DIM_0_]], [[CST_1_]] : index
 // CHECK:             [[VAR_8_:%.+]] = select [[VAR_7_]], [[I_0_]], [[CST_0_]] : index
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = load [[PARAM_0_]]{{.}}[[VAR_8_]], [[I_1_]], [[CST_0_]]{{.}} : memref<?x4x1xf32>
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_8_]], [[I_1_]], [[CST_0_]]{{.}} : memref<?x4x1xf32>
 // CHECK-DAG:         [[VAR_10_:%.+]] = cmpi "sgt", [[DIM_1_]], [[CST_1_]] : index
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_11_:%.+]] = select [[VAR_10_]], [[I_0_]], [[CST_0_]] : index
 // CHECK-DAG:         [[VAR_12_:%.+]] = cmpi "sgt", [[DIM_2_]], [[CST_1_]] : index
 // CHECK:             [[VAR_13_:%.+]] = select [[VAR_12_]], [[I_1_]], [[CST_0_]] : index
-// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = load [[PARAM_1_]]{{.}}[[VAR_11_]], [[VAR_13_]], [[I_2_]]{{.}} : memref<?x?x5xf32>
+// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[VAR_11_]], [[VAR_13_]], [[I_2_]]{{.}} : memref<?x?x5xf32>
 // CHECK:             [[VAR_15_:%.+]] = cmpf "ogt", [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
 // CHECK-DAG:         [[VAR_16_:%.+]] = select [[VAR_15_]], [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
 // CHECK-DAG:         [[VAR_17_:%.+]] = cmpi "sgt", [[DIM_3_]], [[CST_1_]] : index
 // CHECK:             [[VAR_18_:%.+]] = select [[VAR_17_]], [[I_0_]], [[CST_0_]] : index
-// CHECK:             [[LOAD_PARAM_2_MEM_:%.+]] = load [[PARAM_2_]]{{.}}[[VAR_18_]], [[CST_0_]], [[I_2_]]{{.}} : memref<?x1x5xf32>
+// CHECK:             [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[VAR_18_]], [[CST_0_]], [[I_2_]]{{.}} : memref<?x1x5xf32>
 // CHECK:             [[VAR_20_:%.+]] = cmpf "ogt", [[VAR_16_]], [[LOAD_PARAM_2_MEM_]] : f32
 // CHECK:             [[VAR_21_:%.+]] = select [[VAR_20_]], [[VAR_16_]], [[LOAD_PARAM_2_MEM_]] : f32
-// CHECK:             affine.store [[VAR_21_]], [[RES_]][symbol([[I_0_]]), symbol([[I_1_]]), symbol([[I_2_]])] : memref<?x4x5xf32>
+// CHECK:             krnl.store [[VAR_21_]], [[RES_]]{{\[}}[[I_0_]], [[I_1_]], [[I_2_]]{{\]}} : memref<?x4x5xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x4x5xf32>
 // CHECK:         }

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -221,6 +221,7 @@ func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %arg2 
 // CHECK-LABEL:  func @compute_slice_all_dyn
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2xi64>, [[PARAM_1_:%.+]]: memref<2xi64>, [[PARAM_2_:%.+]]: memref<2xi64>) {
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
 // CHECK-DAG:       [[CST_5_:%.+]] = constant 5 : index
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = constant -1 : index
 // CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
@@ -229,13 +230,13 @@ func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %arg2 
 // CHECK-DAG:       [[CST_2147483647_:%.+]] = constant 2147483647 : index
 // CHECK-DAG:       [[VAR_0_:%.+]] = "krnl.global"() {name = "constant_0", shape = [3, 4, 5], value = dense<{{.}}{{.}}[0, 1, 2, 3, 4], [10, 11, 12, 13, 14], [20, 21, 22, 23, 24], [30, 31, 32, 33, 34]{{.}}, {{.}}[100, 101, 102, 103, 104], [110, 111, 112, 113, 114], [120, 121, 122, 123, 124], [130, 131, 132, 133, 134]{{.}}, {{.}}[200, 201, 202, 203, 204], [210, 211, 212, 213, 214], [220, 221, 222, 223, 224], [230, 231, 232, 233, 234]{{.}}{{.}}> : tensor<3x4x5xi64>} : () -> memref<3x4x5xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[2, 1]> : tensor<2xi64>} : () -> memref<2xi64>
-// CHECK-DAG:       [[LOAD_PARAM_0_MEM_:%.+]] = affine.load [[PARAM_0_]][0] : memref<2xi64>
+// CHECK-DAG:       [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{\[}}[[CST_0_]]{{\]}} : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = index_cast [[LOAD_PARAM_0_MEM_]] : i64 to index
-// CHECK-DAG:       [[LOAD_PARAM_1_MEM_:%.+]] = affine.load [[PARAM_1_]][0] : memref<2xi64>
+// CHECK-DAG:       [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{\[}}[[CST_0_]]{{\]}} : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_5_:%.+]] = index_cast [[LOAD_PARAM_1_MEM_]] : i64 to index
-// CHECK-DAG:       [[LOAD_PARAM_2_MEM_:%.+]] = affine.load [[PARAM_2_]][0] : memref<2xi64>
+// CHECK-DAG:       [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{\[}}[[CST_0_]]{{\]}} : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_7_:%.+]] = index_cast [[LOAD_PARAM_2_MEM_]] : i64 to index
 // CHECK-DAG:       [[VAR_8_:%.+]] = cmpi "slt", [[VAR_3_]], [[CST_0_]] : index
@@ -275,13 +276,13 @@ func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %arg2 
 // CHECK:           [[VAR_39_:%.+]] = ceildivi_signed [[VAR_38_]], [[VAR_7_]] : index
 // CHECK:           [[VAR_40_:%.+]] = cmpi "slt", [[VAR_39_]], [[CST_0_]] : index
 // CHECK-DAG:       [[VAR_41_:%.+]] = select [[VAR_40_]], [[CST_0_]], [[VAR_39_]] : index
-// CHECK-DAG:       [[LOAD_PARAM_0_MEM_1_:%.+]] = affine.load [[PARAM_0_]][1] : memref<2xi64>
+// CHECK-DAG:       [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{\[}}[[CST_1_]]{{\]}} : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_43_:%.+]] = index_cast [[LOAD_PARAM_0_MEM_1_]] : i64 to index
-// CHECK-DAG:       [[LOAD_PARAM_1_MEM_1_:%.+]] = affine.load [[PARAM_1_]][1] : memref<2xi64>
+// CHECK-DAG:       [[LOAD_PARAM_1_MEM_1_:%.+]] = krnl.load [[PARAM_1_]]{{\[}}[[CST_1_]]{{\]}} : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_45_:%.+]] = index_cast [[LOAD_PARAM_1_MEM_1_]] : i64 to index
-// CHECK-DAG:       [[LOAD_PARAM_2_MEM_1_:%.+]] = affine.load [[PARAM_2_]][1] : memref<2xi64>
+// CHECK-DAG:       [[LOAD_PARAM_2_MEM_1_:%.+]] = krnl.load [[PARAM_2_]]{{\[}}[[CST_1_]]{{\]}} : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_47_:%.+]] = index_cast [[LOAD_PARAM_2_MEM_1_]] : i64 to index
 // CHECK-DAG:       [[VAR_48_:%.+]] = cmpi "slt", [[VAR_43_]], [[CST_0_]] : index
@@ -533,7 +534,8 @@ func @test_tile2(%arg0 : tensor<8xf32>, %arg1 : tensor<1xi64>) -> tensor<*xf32> 
 
 // CHECK-LABEL:  func @test_tile2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<8xf32>, [[PARAM_1_:%.+]]: memref<1xi64>) -> memref<?xf32> {
-// CHECK:           [[LOAD_PARAM_1_MEM_:%.+]] = affine.load [[PARAM_1_]][0] : memref<1xi64>
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK:           [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{\[}}[[CST_0_]]{{\]}} : memref<1xi64>
 // CHECK:           [[VAR_1_:%.+]] = index_cast [[LOAD_PARAM_1_MEM_]] : i64 to index
 // CHECK:           [[VAR_2_:%.+]] = affine.apply #map0(){{.}}[[VAR_1_]]{{.}}
 // CHECK-DAG:       [[RES_:%.+]] = alloc([[VAR_2_]]) : memref<?xf32>

--- a/test/mlir/onnx/onnx_lowering_with_dealloc.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_dealloc.mlir
@@ -13,18 +13,18 @@ func @test_add_add(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[ADDF:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADDF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[ADDF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Second Add
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[ADDF:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADDF]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[ADDF]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xf32>
@@ -46,18 +46,18 @@ func @test_mul_mul(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MULF:%.+]] = mulf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[MULF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[MULF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Second Mul
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MULF:%.+]] = mulf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[MULF]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[MULF]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xf32>
@@ -79,18 +79,18 @@ func @test_div_div(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[DIVF:%.+]] = divf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[DIVF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[DIVF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Second Div
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[DIVF:%.+]] = divf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[DIVF]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[DIVF]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xf32>
@@ -112,18 +112,18 @@ func @test_sub_sub(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[SUBF:%.+]] = subf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[SUBF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[SUBF]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Second Sub
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[SUBF:%.+]] = subf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[SUBF]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[SUBF]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xf32>
@@ -145,18 +145,18 @@ func @test_and_and(%arg0 : tensor<10x10xi1>, %arg1 : tensor<10x10xi1>) -> tensor
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xi1>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[AND:%.+]] = and [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[AND]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[AND]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
 
   /// Second And
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[AND:%.+]] = and [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[AND]], [[RET_RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[AND]], [[RET_RES]][%arg2, %arg3] : memref<10x10xi1>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xi1>
@@ -178,18 +178,18 @@ func @test_or_or(%arg0 : tensor<10x10xi1>, %arg1 : tensor<10x10xi1>) -> tensor<*
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xi1>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[OR:%.+]] = or [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[OR]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[OR]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
 
   /// Second Or
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[OR:%.+]] = or [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[OR]], [[RET_RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[OR]], [[RET_RES]][%arg2, %arg3] : memref<10x10xi1>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xi1>
@@ -211,18 +211,18 @@ func @test_xor_xor(%arg0 : tensor<10x10xi1>, %arg1 : tensor<10x10xi1>) -> tensor
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xi1>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[XOR:%.+]] = xor [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[XOR]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[XOR]], [[RES]][%arg2, %arg3] : memref<10x10xi1>
 
   /// Second Xor
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xi1>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xi1>
   // CHECK: [[XOR:%.+]] = xor [[LOAD1]], [[LOAD2]] : i1
-  // CHECK: affine.store [[XOR]], [[RET_RES]][%arg2, %arg3] : memref<10x10xi1>
+  // CHECK: krnl.store [[XOR]], [[RET_RES]][%arg2, %arg3] : memref<10x10xi1>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xi1>
@@ -247,9 +247,9 @@ func @test_exp_exp(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[EXP:%.+]] = exp [[LOAD]] : f32
-  // CHECK: affine.store [[EXP]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[EXP]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   
   /// Second Exp
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -259,9 +259,9 @@ func @test_exp_exp(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[EXP:%.+]] = exp [[LOAD]] : f32
-  // CHECK: affine.store [[EXP]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[EXP]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
   
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -286,7 +286,7 @@ func @test_tanh_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[X:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[X:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ONE:%.+]] = constant 1.000000e+00 : f32
   // CHECK: [[TWO:%.+]] = constant 2.000000e+00 : f32
   // CHECK: [[X_MUL_2:%.+]] = mulf [[X]], [[TWO]] : f32
@@ -302,7 +302,7 @@ func @test_tanh_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[ZERO:%.+]] = constant 0.000000e+00 : f32
   // CHECK: [[CMP:%.+]] = cmpf "oge", [[X]], [[ZERO]] : f32
   // CHECK: [[TANH:%.+]] = select [[CMP]], [[DIV_1]], [[DIV_2]] : f32
-  // CHECK: affine.store [[TANH]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[TANH]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   
   /// Second Tanh
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -312,7 +312,7 @@ func @test_tanh_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[X:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[X:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ONE:%.+]] = constant 1.000000e+00 : f32
   // CHECK: [[TWO:%.+]] = constant 2.000000e+00 : f32
   // CHECK: [[X_MUL_2:%.+]] = mulf [[X]], [[TWO]] : f32
@@ -328,7 +328,7 @@ func @test_tanh_tanh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[ZERO:%.+]] = constant 0.000000e+00 : f32
   // CHECK: [[CMP:%.+]] = cmpf "oge", [[X]], [[ZERO]] : f32
   // CHECK: [[TANH_RES:%.+]] = select [[CMP]], [[DIV_1]], [[DIV_2]] : f32
-  // CHECK: affine.store [[TANH_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[TANH_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -353,7 +353,7 @@ func @test_sinh_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[TWO:%.+]] = constant {{2.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
@@ -361,7 +361,7 @@ func @test_sinh_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVIDEND:%.+]] = subf [[EXP]], [[NEXP]] : f32
   // CHECK: [[SINH_RES:%.+]] = divf [[DIVIDEND]], [[TWO]] : f32
-  // CHECK: affine.store [[SINH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SINH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   
   /// Second Sinh
   // CHECK: [[C0_0:%.+]] = constant 0 : index
@@ -371,7 +371,7 @@ func @test_sinh_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[TWO:%.+]] = constant {{2.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
@@ -379,7 +379,7 @@ func @test_sinh_sinh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVIDEND:%.+]] = subf [[EXP]], [[NEXP]] : f32
   // CHECK: [[SINH_RES:%.+]] = divf [[DIVIDEND]], [[TWO]] : f32
-  // CHECK: affine.store [[SINH_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SINH_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -404,7 +404,7 @@ func @test_cosh_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[TWO:%.+]] = constant {{2.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
@@ -412,7 +412,7 @@ func @test_cosh_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVIDEND:%.+]] = addf [[EXP]], [[NEXP]] : f32
   // CHECK: [[COSH_RES:%.+]] = divf [[DIVIDEND]], [[TWO]] : f32
-  // CHECK: affine.store [[COSH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[COSH_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   
   /// Second Cosh
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -421,7 +421,7 @@ func @test_cosh_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[TWO:%.+]] = constant {{2.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
@@ -429,7 +429,7 @@ func @test_cosh_cosh(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVIDEND:%.+]] = addf [[EXP]], [[NEXP]] : f32
   // CHECK: [[COSH_RES:%.+]] = divf [[DIVIDEND]], [[TWO]] : f32
-  // CHECK: affine.store [[COSH_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[COSH_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -454,14 +454,14 @@ func @test_sigmoid_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVISOR:%.+]] = addf [[ONE]], [[NEXP]] : f32
   // CHECK: [[SIGMOID_RES:%.+]] = divf [[ONE]], [[DIVISOR]] : f32
-  // CHECK: affine.store [[SIGMOID_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SIGMOID_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   
   /// Second Sigmoid
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -471,14 +471,14 @@ func @test_sigmoid_sigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[NLOAD:%.+]] = subf [[ZERO]], [[LOAD]] : f32
   // CHECK: [[NEXP:%.+]] = exp [[NLOAD]] : f32
   // CHECK: [[DIVISOR:%.+]] = addf [[ONE]], [[NEXP]] : f32
   // CHECK: [[SIGMOID_RES:%.+]] = divf [[ONE]], [[DIVISOR]] : f32
-  // CHECK: affine.store [[SIGMOID_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SIGMOID_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -503,11 +503,11 @@ func @test_relu_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[LTZERO:%.+]] = cmpf "olt", [[LOAD]], [[ZERO]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[LTZERO]], [[ZERO]], [[LOAD]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Second Relu
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -517,11 +517,11 @@ func @test_relu_relu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32
   // CHECK: [[LTZERO:%.+]] = cmpf "olt", [[LOAD]], [[ZERO]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[LTZERO]], [[ZERO]], [[LOAD]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -543,18 +543,18 @@ func @test_sum_sum(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[ADD:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADD]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[ADD]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Second Sum
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[ADD:%.+]] = addf [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[ADD]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[ADD]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xf32>
@@ -576,20 +576,20 @@ func @test_max_max(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MAX:%.+]] = cmpf "ogt", [[LOAD1]], [[LOAD2]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[MAX]], [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   
   /// Second Max
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MAX:%.+]] = cmpf "ogt", [[LOAD1]], [[LOAD2]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[MAX]], [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
   
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xf32>
@@ -611,20 +611,20 @@ func @test_min_min(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tens
   // CHECK: [[RES:%.+]] = alloc() : memref<10x10xf32>
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load %arg0[%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MIN:%.+]] = cmpf "olt", [[LOAD1]], [[LOAD2]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[MIN]], [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RES]][%arg2, %arg3] : memref<10x10xf32>
   
   /// Second Min
   // CHECK: [[DEF_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg2 = 0 to 10, [[DEF_LOOPS]]#1 -> %arg3 = 0 to 10) {
-  // CHECK: [[LOAD1:%.+]] = affine.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
-  // CHECK: [[LOAD2:%.+]] = affine.load %arg1[%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD1:%.+]] = krnl.load [[RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: [[LOAD2:%.+]] = krnl.load %arg1[%arg2, %arg3] : memref<10x10xf32>
   // CHECK: [[MIN:%.+]] = cmpf "olt", [[LOAD1]], [[LOAD2]] : f32
   // CHECK: [[RELU_RES:%.+]] = select [[MIN]], [[LOAD1]], [[LOAD2]] : f32
-  // CHECK: affine.store [[RELU_RES]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
+  // CHECK: krnl.store [[RELU_RES]], [[RET_RES]][%arg2, %arg3] : memref<10x10xf32>
   
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<10x10xf32>
@@ -649,7 +649,7 @@ func @test_elu_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32 
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32 
   // CHECK: [[ALPHA:%.+]] = constant {{2.+}} : f32 
@@ -658,7 +658,7 @@ func @test_elu_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SUB:%.+]] = subf [[EXP]], [[ONE]] : f32
   // CHECK: [[MUL:%.+]] = mulf [[ALPHA]], [[SUB]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[MUL]], [[LOAD]] : f32
-  // CHECK: affine.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Second Elu
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -668,7 +668,7 @@ func @test_elu_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32 
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32 
   // CHECK: [[ALPHA:%.+]] = constant {{2.+}} : f32 
@@ -677,7 +677,7 @@ func @test_elu_elu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SUB:%.+]] = subf [[EXP]], [[ONE]] : f32
   // CHECK: [[MUL:%.+]] = mulf [[ALPHA]], [[SUB]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[MUL]], [[LOAD]] : f32
-  // CHECK: affine.store [[SELECT]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -702,13 +702,13 @@ func @test_leakyrelu_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32 
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32 
   // CHECK: [[CMP:%.+]] = cmpf "olt", [[LOAD]], [[ZERO]] : f32
   // CHECK: [[MUL:%.+]] = mulf [[ALPHA]], [[LOAD]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[MUL]], [[LOAD]] : f32
-  // CHECK: affine.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Second LeakyRelu
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -718,13 +718,13 @@ func @test_leakyrelu_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32 
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32 
   // CHECK: [[CMP:%.+]] = cmpf "olt", [[LOAD]], [[ZERO]] : f32
   // CHECK: [[MUL:%.+]] = mulf [[ALPHA]], [[LOAD]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[MUL]], [[LOAD]] : f32
-  // CHECK: affine.store [[SELECT]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -749,7 +749,7 @@ func @test_selu_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32 
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32 
   // CHECK: [[GAMMA:%.+]] = constant {{2.+}} : f32 
@@ -759,7 +759,7 @@ func @test_selu_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SUB:%.+]] = subf [[MUL]], [[ALPHA]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[LOAD]], [[SUB]] : f32
   // CHECK: [[SELU_RES:%.+]] = mulf [[GAMMA]], [[SELECT]] : f32
-  // CHECK: affine.store [[SELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELU_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Second Selu
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -769,7 +769,7 @@ func @test_selu_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32 
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32 
   // CHECK: [[GAMMA:%.+]] = constant {{2.+}} : f32 
@@ -779,7 +779,7 @@ func @test_selu_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SUB:%.+]] = subf [[MUL]], [[ALPHA]] : f32
   // CHECK: [[SELECT:%.+]] = select [[CMP]], [[LOAD]], [[SUB]] : f32
   // CHECK: [[SELU_RES:%.+]] = mulf [[GAMMA]], [[SELECT]] : f32
-  // CHECK: affine.store [[SELU_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELU_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -804,7 +804,7 @@ func @test_hardsigmoid_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32 
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32 
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32 
@@ -815,7 +815,7 @@ func @test_hardsigmoid_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SELECT1:%.+]] = select [[CMP1]], [[ADD]], [[ZERO]] : f32
   // CHECK: [[CMP2:%.+]] = cmpf "olt", [[SELECT1]], [[ONE]] : f32
   // CHECK: [[SELECT2:%.+]] = select [[CMP2]], [[SELECT1]], [[ONE]] : f32
-  // CHECK: affine.store [[SELECT2]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT2]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
   
   /// Second HardSigmoid
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -825,7 +825,7 @@ func @test_hardsigmoid_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ZERO:%.+]] = constant {{0.+}} : f32 
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32 
   // CHECK: [[ALPHA:%.+]] = constant {{1.+}} : f32 
@@ -836,7 +836,7 @@ func @test_hardsigmoid_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[SELECT1:%.+]] = select [[CMP1]], [[ADD]], [[ZERO]] : f32
   // CHECK: [[CMP2:%.+]] = cmpf "olt", [[SELECT1]], [[ONE]] : f32
   // CHECK: [[SELECT2:%.+]] = select [[CMP2]], [[SELECT1]], [[ONE]] : f32
-  // CHECK: affine.store [[SELECT2]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[SELECT2]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>
@@ -861,10 +861,10 @@ func @test_reciprocal_reciprocal(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_0:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim %arg0, [[C0_0]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load %arg0[%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load %arg0[%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[RECIPROCAL_RES:%.+]] = divf [[ONE]], [[LOAD]] : f32
-  // CHECK: affine.store [[RECIPROCAL_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[RECIPROCAL_RES]], [[RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Second Reciprocal
   // CHECK: [[C0_1:%.+]] = constant 0 : index
@@ -874,10 +874,10 @@ func @test_reciprocal_reciprocal(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: [[C0_2:%.+]] = constant 0 : index
   // CHECK: [[DIM_2:%.+]] = dim [[RES]], [[C0_2]] : memref<?x10xf32>
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to [[DIM_2]], [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10) {
-  // CHECK: [[LOAD:%.+]] = affine.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: [[LOAD:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<?x10xf32>
   // CHECK: [[ONE:%.+]] = constant {{1.+}} : f32
   // CHECK: [[RECIPROCAL_RES:%.+]] = divf [[ONE]], [[LOAD]] : f32
-  // CHECK: affine.store [[RECIPROCAL_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
+  // CHECK: krnl.store [[RECIPROCAL_RES]], [[RET_RES]][%arg1, %arg2] : memref<?x10xf32>
 
   /// Dealloc of first result.
   // CHECK: dealloc [[RES]] : memref<?x10xf32>


### PR DESCRIPTION
This patch introduces krnl.load and krnl.store  ops. These ops will replace std.load/store or affine.load/store when we lower ONNX ops to krnl dialect. 

With krnl.load/store, we don't need to care about whether access indices are affine or not. The lowering of krnl.load/store to affine and std dialects will automatically check access indices and decide which one to use.

Also, we can remove the dependency of the krnl.iterate op to affine (say, no need of AffineScope trait in the krnl.iterate definition). affine.load/store will be emitted at the same time affine.for is emitted, which avoids potential errors related to affine related optimization passes.