### PR TITLE
Support lowering reshape when its input is promoted to attribute

### DIFF
--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -333,3 +333,19 @@ Value emitNegativeInfinityConstantOp(
 
   return rewriter.create<ConstantOp>(loc, constantAttr);
 }
+
+Value getDimOrConstant(ConversionPatternRewriter &rewriter, Location loc,
+    Value operand, int64_t axis, Type type) {
+  ArrayRef<int64_t> shape = operand.getType().cast<ShapedType>().getShape();
+  Value dimVal;
+  if (shape[axis] < 0) {
+    Value dim = rewriter.create<DimOp>(loc, operand, axis);
+    if (type.isa<IndexType>())
+      dimVal = dim;
+    else
+      dimVal = rewriter.create<IndexCastOp>(loc, dim, type);
+  } else {
+    dimVal = emitConstantOp(rewriter, loc, type, shape[axis]);
+  }
+  return dimVal;
+}

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -94,6 +94,13 @@ Value emitNegativeInfinityConstantOp(
 
 int64_t ArrayAttrIntVal(ArrayAttr a, int i);
 
+/// Get a dimension value from a memref. Emit a constant if the dimension is
+/// constant. Otherwise, emit a dim op.
+/// If the return type is different from IndexType, emit a cast op to cast the
+/// output of the dim op.
+Value getDimOrConstant(ConversionPatternRewriter &rewriter, Location loc,
+    Value operand, int64_t axis, Type type);
+
 //===----------------------------------------------------------------------===//
 // This is to get a scalar operation of a given type for a specific operation.
 //===----------------------------------------------------------------------===//

--- a/src/Conversion/ONNXToKrnl/Tensor/Reshape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Reshape.cpp
@@ -40,7 +40,7 @@ struct ONNXReshapeOpLowering : public ConversionPattern {
     Value data = operandAdaptor.data();
     Value shape = operandAdaptor.shape();
     auto dataShape = data.getType().cast<MemRefType>().getShape();
-    // If shape tensor was be promoted to attribute, get its values from the
+    // If shape input was promoted to attribute, get its values from the
     // attribute.
     SmallVector<int64_t, 4> shapeAttrValues;
     DenseElementsAttr shapeAttr =
@@ -104,8 +104,8 @@ struct ONNXReshapeOpLowering : public ConversionPattern {
           loadedVal = rewriter.create<KrnlLoadOp>(loc, shape, index);
         }
 
-        // The output dimension cannot be 0 if the output dimension position is
-        // out of the input dimension position.
+        // A dimension cannot be 0 if its position is out-of-bound, e.g. the
+        // output rank is greater than the input rank.
         if (i < dataShape.size()) {
           // If a dimension is 0, the actual dimension value is taken from the
           // input tensor.

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -439,27 +439,26 @@ func private @test_reshape(%arg0 : tensor<?x10xf32>, %arg1 : tensor<4xi64>) -> t
   // CHECK: [[LOAD_3:%.+]] = krnl.load %arg1[%[[CONSTANT_6]]] : memref<4xi64>
   // CHECK: [[MUL_4:%.+]] = muli [[MUL_3]], [[LOAD_3]] : i64
 
-  // CHECK: [[CONSTANT_7:%.+]] = constant 0 : i64
-  // CHECK: [[SUB_0:%.+]] = subi [[CONSTANT_7]], [[MUL_4]] : i64
-
   // CHECK: [[CONSTANT_8:%.+]] = constant -1 : i64
+  // CHECK: [[TENSOR_SIZE_FROM_SHAPE:%.+]] = muli [[MUL_4]], [[CONSTANT_8]] : i64
+
   // CHECK: [[CMP_2:%.+]] = cmpi "eq", [[SELECT_0]], [[CONSTANT_8]] : i64
-  // CHECK: [[DIVISIGNED_0:%.+]] = divi_signed [[TENSOR_SIZE]], [[SUB_0]] : i64
+  // CHECK: [[DIVISIGNED_0:%.+]] = divi_signed [[TENSOR_SIZE]], [[TENSOR_SIZE_FROM_SHAPE]] : i64
   // CHECK: [[SELECT_2:%.+]] = select [[CMP_2]], [[DIVISIGNED_0]], [[SELECT_0]] : i64
   // CHECK: [[CAST_0:%.+]] = index_cast [[SELECT_2]] : i64 to index
 
   // CHECK: [[CMP_3:%.+]] = cmpi "eq", [[SELECT_1]], [[CONSTANT_8]] : i64
-  // CHECK: [[DIVISIGNED_1:%.+]] = divi_signed [[TENSOR_SIZE]], [[SUB_0]] : i64
+  // CHECK: [[DIVISIGNED_1:%.+]] = divi_signed [[TENSOR_SIZE]], [[TENSOR_SIZE_FROM_SHAPE]] : i64
   // CHECK: [[SELECT_3:%.+]] = select [[CMP_3]], [[DIVISIGNED_1]], [[SELECT_1]] : i64
   // CHECK: [[CAST_1:%.+]] = index_cast [[SELECT_3]] : i64 to index
 
   // CHECK: [[CMP_4:%.+]] = cmpi "eq", [[LOAD_2]], [[CONSTANT_8]] : i64
-  // CHECK: [[DIVISIGNED_2:%.+]] = divi_signed [[TENSOR_SIZE]], [[SUB_0]] : i64
+  // CHECK: [[DIVISIGNED_2:%.+]] = divi_signed [[TENSOR_SIZE]], [[TENSOR_SIZE_FROM_SHAPE]] : i64
   // CHECK: [[SELECT_4:%.+]] = select [[CMP_4]], [[DIVISIGNED_2]], [[LOAD_2]] : i64
   // CHECK: [[CAST_2:%.+]] = index_cast [[SELECT_4]] : i64 to index
 
   // CHECK: [[CMP_5:%.+]] = cmpi "eq", [[LOAD_3]], [[CONSTANT_8]] : i64
-  // CHECK: [[DIVISIGNED_3:%.+]] = divi_signed [[TENSOR_SIZE]], [[SUB_0]] : i64
+  // CHECK: [[DIVISIGNED_3:%.+]] = divi_signed [[TENSOR_SIZE]], [[TENSOR_SIZE_FROM_SHAPE]] : i64
   // CHECK: [[SELECT_5:%.+]] = select [[CMP_5]], [[DIVISIGNED_3]], [[LOAD_3]] : i64
   // CHECK: [[CAST_3:%.+]] = index_cast [[SELECT_5]] : i64 to index
 

--- a/test/mlir/onnx/onnx_lowering_attribute_promotion_ops.mlir
+++ b/test/mlir/onnx/onnx_lowering_attribute_promotion_ops.mlir
@@ -1,0 +1,27 @@
+// RUN: onnx-mlir-opt --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
+
+// -----
+
+// COM: Test reshape lowering when its constant shape input is promoted to attribute
+func private @test_reshape_attribute_promotion(%arg0 : tensor<?x10xf32>) -> tensor<?x5xf32> {
+  %cst = constant unit
+  %0 = "onnx.Reshape"(%arg0, %cst) {shape = dense<[-1, 5]> : tensor<2xi64>}: (tensor<?x10xf32>, none) -> tensor<?x5xf32>
+  "std.return"(%0) : (tensor<?x5xf32>) -> ()
+
+  // CHECK-LABEL: test_reshape_attribute_promotion
+  // CHECK-DAG:   [[CST_0_:%.+]] = constant 0 : index
+  // CHECK-DAG:   [[CST_10_:%.+]] = constant 10 : i64
+  // CHECK-DAG:   [[FLOAT_SIZE:%.+]] = constant 4 : i64
+  // CHECK-DAG:   [[OUTPUT_SIZE:%.+]] = constant 20 : i64
+
+  // CHECK:       [[DIM_0_:%.+]] = dim %arg0, [[CST_0_]] : memref<?x10xf32>
+  // CHECK:       [[DIM_0_i64:%.+]] = index_cast [[DIM_0_]] : index to i64
+  // CHECK:       [[MUL:%.+]] = muli [[DIM_0_i64]], [[FLOAT_SIZE]] : i64
+  // CHECK:       [[INPUT_SIZE:%.+]] = muli [[MUL]], [[CST_10_]] : i64
+
+  // CHECK:       [[UNKNOWN_DIM_VALUE:%.+]] = divi_signed [[INPUT_SIZE]], [[OUTPUT_SIZE]] : i64
+  // CHECK:       [[UNKNOWN_DIM_VALUE_i64:%.+]] = index_cast [[UNKNOWN_DIM_VALUE]] : i64 to index
+  // CHECK:       [[RES_:%.+]] = alloc([[UNKNOWN_DIM_VALUE_i64]]) : memref<?x5xf32>
+  // CHECK:       "krnl.memcpy"([[RES_]], %arg0, [[INPUT_SIZE]]) : (memref<?x5xf32>, memref<?x10xf32>, i64) -> ()
+  // CHECK:       return [[RES_]] : memref<?x5xf32>
+}


### PR DESCRIPTION
This patch is to fix #490.

When the shape input of Reshape is constant, it is promoted to attribute. Thus, the lowering should read shape information from the attribute instead of the shape input (which became None after promotion).

For ops that have attribute promotion, we should handle two cases: an input is 1) promoted and 2) not promoted.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>