### PR TITLE
Allow to change tolerance in numerical tests

### DIFF
--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -126,7 +126,10 @@ bool isOMConvTheSameAsNaiveImplFor(const int N, const int C, const int H,
   auto outputs = sess.run(move(inputs));
   auto &conv = outputs.at(0);
 
-  return omTensorAreTwoOmtsClose<float>(conv.get(), ref);
+  float rtol = getenv("TEST_RTOL") ? atof(getenv("TEST_RTOL")) : 1e-5;
+  float atol = getenv("TEST_ATOL") ? atof(getenv("TEST_ATOL")) : 1e-5;
+
+  return omTensorAreTwoOmtsClose<float>(conv.get(), ref, rtol, atol);
 }
 
 int main(int argc, char *argv[]) {

--- a/test/numerical/TestGRU.cpp
+++ b/test/numerical/TestGRU.cpp
@@ -282,8 +282,11 @@ bool isOMGRUTheSameAsNaiveImplFor(const int direction, const int S, const int B,
   auto &gruY = outputs.at(0);
   auto &gruYh = outputs.at(1);
 
-  return (omTensorAreTwoOmtsClose<float>(gruY.get(), refY) &&
-          omTensorAreTwoOmtsClose<float>(gruYh.get(), refYh));
+  float rtol = getenv("TEST_RTOL") ? atof(getenv("TEST_RTOL")) : 1e-5;
+  float atol = getenv("TEST_ATOL") ? atof(getenv("TEST_ATOL")) : 1e-5;
+
+  return (omTensorAreTwoOmtsClose<float>(gruY.get(), refY, rtol, atol) &&
+          omTensorAreTwoOmtsClose<float>(gruYh.get(), refYh, rtol, atol));
 }
 
 int main(int argc, char *argv[]) {

--- a/test/numerical/TestLSTM.cpp
+++ b/test/numerical/TestLSTM.cpp
@@ -290,9 +290,12 @@ bool isOMLSTMTheSameAsNaiveImplFor(const int direction, const int S,
   auto &lstmYh = outputs.at(1);
   auto &lstmYc = outputs.at(2);
 
-  return (omTensorAreTwoOmtsClose<float>(lstmY.get(), refY) &&
-          omTensorAreTwoOmtsClose<float>(lstmYh.get(), refYh) &&
-          omTensorAreTwoOmtsClose<float>(lstmYc.get(), refYc));
+  float rtol = getenv("TEST_RTOL") ? atof(getenv("TEST_RTOL")) : 1e-5;
+  float atol = getenv("TEST_ATOL") ? atof(getenv("TEST_ATOL")) : 1e-5;
+
+  return (omTensorAreTwoOmtsClose<float>(lstmY.get(), refY, rtol, atol) &&
+          omTensorAreTwoOmtsClose<float>(lstmYh.get(), refYh, rtol, atol) &&
+          omTensorAreTwoOmtsClose<float>(lstmYc.get(), refYc, rtol, atol));
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Allow to change tolerance in numerical tests by the "TEST_RTOL" and "TEST_ATOL" environments.
If they are not set, default values 1e-5 for rtol, and 1e-5 for atol, those are default values of omTensorAreTwoOmtsClose, are used.