### PR TITLE
Remove quotes when posting github status and comment

### DIFF
--- a/.buildbot/Jenkinsfile
+++ b/.buildbot/Jenkinsfile
@@ -202,14 +202,22 @@ def call_build_script(script) {
 /* Set build status appearing on the GitHub pull request page */
 def post_build_status(event, state) {
     def status   = (state == 'aborted') ? 'failure' : state
-    /* Commit message may have newline so replace it to avoid invalid JSON */
-    def title    = "${ONNX_MLIR_PR_COMMIT_MESSAGE}".replace('\n', ' ')
+    /* Commit message may have newline so replace it to avoid invalid JSON.
+     * Also remove single and double quotes since the first MAXLEN characters
+     * may end in the middle of a quoted phrase.
+     *
+     * replace vs replaceAll: both will replace all occurrences of the 1st
+     * string with the 2nd string. But for replace the 1st string is a normal
+     * string while for replaceAll the 1st string is a regex.
+     */
+    def MAXLEN   = 24
+    def title    = "${ONNX_MLIR_PR_COMMIT_MESSAGE}".replace('\n', ' ').replace('\'', '').replace('"', '')
     def phrase   = (event == 'issue_comment') ?
                    "${ONNX_MLIR_PR_PHRASE}" : "${ONNX_MLIR_PR_ACTION}"
     def desc     = ("${ONNX_MLIR_PR_ACTION}" == 'push' ?
                     "Build [#${BUILD_NUMBER}](${BUILD_URL}) " :
                     "Build #${BUILD_NUMBER} ") + "[${phrase}] " +
-                   title.substring(0,Math.min(title.length(),24)) + '...'
+                   title.substring(0,Math.min(title.length(),MAXLEN)) + '...'
     def action   = (state == 'success') ? 'passed'  :
                    (state == 'failure') ? 'failed'  :
                    (state == 'aborted') ? 'aborted' : 'started'

--- a/docker/Dockerfile.onnx-mlir
+++ b/docker/Dockerfile.onnx-mlir
@@ -35,7 +35,7 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
        LLVM_PROJ_BUILD=${LLVM_PROJECT_ROOT}/build \
        cmake -DCMAKE_INSTALL_MESSAGE=NEVER .. \
     && make -j$(nproc) \
-    && make -j$(nproc) check-onnx-lit \
+    && LIT_OPTS=-v make -j$(nproc) check-onnx-lit \
     && make check-onnx-backend \
     && make check-onnx-backend-dynamic \
     && make ARGS=-j$(nproc) test \

--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -31,7 +31,7 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
        LLVM_PROJ_BUILD=${LLVM_PROJECT_ROOT}/build \
        cmake .. \
     && make -j$(nproc) \
-    && make -j$(nproc) check-onnx-lit \
+    && LIT_OPTS=-v make -j$(nproc) check-onnx-lit \
     && make check-onnx-backend \
     && make check-onnx-backend-dynamic \
     && make ARGS=-j$(nproc) test \


### PR DESCRIPTION
'A quoted commit message that is longer than MAXLEN (24) characters'

When posting github status or comment, we take the first MAXLEN characters
to construct a one-liner, which might end in the middle of a quoted phrase
and cause JSON error in the REST call. This patch should fix that.

Signed-off-by: Gong Su <gong_su@hotmail.com>