### PR TITLE
Remove squeeze/unsqueeze pairs

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -5223,6 +5223,7 @@ def ONNXSqrtOp:ONNX_Op<"Sqrt",
 
 def ONNXSqueezeOp:ONNX_Op<"Squeeze",
   [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Squeeze operation";
   let description = [{
   "Remove single-dimensional entries from the shape of a tensor."
@@ -5679,6 +5680,7 @@ def ONNXUniqueOp:ONNX_Op<"Unique",
 
 def ONNXUnsqueezeOp:ONNX_Op<"Unsqueeze",
   [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Unsqueeze operation";
   let description = [{
   "Insert single-dimensional entries to the shape of an input tensor (`data`)."

--- a/src/Transform/ONNX/Combine.td
+++ b/src/Transform/ONNX/Combine.td
@@ -37,6 +37,10 @@ def HasSameElementType : Constraint<
           "$1.cast<::mlir::TypeAttr>().getValue())">,
     "has same element type">;
 
+def AreTheSameAxisArray: Constraint<
+    CPred<"AreTheSameAxisArray($0.getType().cast<ShapedType>().getRank(), $1, $2)">,
+    "Two axis arrays are the same">;
+
 //===----------------------------------------------------------------------===//
 // Pattern-Match and Rewrite
 //===----------------------------------------------------------------------===//
@@ -97,5 +101,25 @@ def RemoveIdentityTransposePattern:  Pat<
   // Check that we have indeed a identity transpose pattern.
   [(IsIdentityPermuteAttribute:$p)]>;
 
+
+/// Combine squeeze and unsqueeze.
+/// Squeeze {axes = [a, b, c]} (Unsqueeze {axes = [a, b, c]} (%X)) = %X
+def RemoveSqueezeUnsqueezePattern:  Pat<
+  // Squeeze and the unsqueeze with the same axes.
+  (ONNXSqueezeOp (ONNXUnsqueezeOp $val, $u_axes), $s_axes),
+  // Remove the transpose.
+  (replaceWithValue $val),
+  // Check that both ops use the same `axes`.
+  [(AreTheSameAxisArray $val, $u_axes, $s_axes)]>;
+
+/// Combine unsqueeze and squeeze.
+/// Unsqueeze {axes = [a, b, c]} (Squeeze {axes = [a, b, c]} (%X)) = %X
+def RemoveUnsqueezeSqueezePattern:  Pat<
+  // Squeeze and the unsqueeze with the same axes.
+  (ONNXUnsqueezeOp (ONNXSqueezeOp:$res $val, $s_axes), $u_axes),
+  // Remove the transpose.
+  (replaceWithValue $val),
+  // Check that both ops use the same `axes`.
+  [(AreTheSameAxisArray $res, $u_axes, $s_axes)]>;
 
 #endif // ONNX_COMBINE

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -287,3 +287,67 @@ func @test_global_average_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tensor<1x
   // CHECK: [[RES:%.+]] = "onnx.ReduceMax"(%arg0) {axes = [2, 3]} : (tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32>
   // CHECK: return [[RES]] : tensor<1x?x?x1xf32>
 }
+
+// -----
+
+// COM: Test removing squeeze/unsqueeze pairs when they use the same axes.
+
+func @test_remove_unsqueeze_squeeze(%arg0 : tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %0 = "onnx.Unsqueeze"(%arg0) {axes=[0, 2]} : (tensor<10x10xf32>) -> tensor<1x10x1x10xf32>
+  %1 = "onnx.Squeeze"(%0) {axes=[0, -2]} : (tensor<1x10x1x10xf32>) -> tensor<10x10xf32>
+  return %1: tensor<10x10xf32>
+
+  // CHECK-LABEL: test_remove_unsqueeze_squeeze
+  // CHECK: return {{.*}}
+  // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
+  // CHECK-NOT: {{.*}} = onnx.Squeeze"{{.*}}
+
+}
+
+// -----
+
+func @test_should_not_remove_unsqueeze_squeeze(%arg0 : tensor<10x10xf32>) -> tensor<10x1x10xf32> {
+  %0 = "onnx.Unsqueeze"(%arg0) {axes=[0, 2]} : (tensor<10x10xf32>) -> tensor<1x10x1x10xf32>
+  %1 = "onnx.Squeeze"(%0) {axes=[0]} : (tensor<1x10x1x10xf32>) -> tensor<10x1x10xf32>
+  return %1: tensor<10x1x10xf32>
+  // CHECK-LABEL: test_should_not_remove_unsqueeze_squeeze
+  // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
+  // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
+  // CHECK: return {{.*}}
+}
+
+// -----
+
+func @test_remove_squeeze_unsqueeze(%arg0 : tensor<10x1x10xf32>) -> tensor<10x1x10xf32> {
+  %0 = "onnx.Squeeze"(%arg0) {axes=[1]} : (tensor<10x1x10xf32>) -> tensor<10x10xf32>
+  %1 = "onnx.Unsqueeze"(%0) {axes=[1]} : (tensor<10x10xf32>) -> tensor<10x1x10xf32>
+  return %1: tensor<10x1x10xf32>
+  // CHECK-LABEL: test_remove_squeeze_unsqueeze
+  // CHECK: return {{.*}}
+  // CHECK-NOT: {{.*}} = "onnx.Squeeze"{{.*}}
+  // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
+}
+
+// -----
+
+func @test_should_not_remove_squeeze_unsqueeze(%arg0 : tensor<1x10x1x10xf32>) -> tensor<10x1x10x1xf32> {
+  %0 = "onnx.Squeeze"(%arg0) {axes=[0]} : (tensor<1x10x1x10xf32>) -> tensor<10x1x10xf32>
+  %1 = "onnx.Unsqueeze"(%0) {axes=[3]} : (tensor<10x1x10xf32>) -> tensor<10x1x10x1xf32>
+  return %1: tensor<10x1x10x1xf32>
+  // CHECK-LABEL: test_should_not_remove_squeeze_unsqueeze
+  // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
+  // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
+  // CHECK: return {{.*}}
+}
+
+// -----
+
+func @test_should_not_remove_null_axes_squeeze_unsqueeze(%arg0 : tensor<1x10x1x10xf32>) -> tensor<10x1x10x1xf32> {
+  %0 = "onnx.Squeeze"(%arg0) : (tensor<1x10x1x10xf32>) -> tensor<10x10xf32>
+  %1 = "onnx.Unsqueeze"(%0) {axes=[1, 3]} : (tensor<10x10xf32>) -> tensor<10x1x10x1xf32>
+  return %1: tensor<10x1x10x1xf32>
+  // CHECK-LABEL: test_should_not_remove_null_axes_squeeze_unsqueeze
+  // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
+  // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
+  // CHECK: return {{.*}}
+}

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -335,7 +335,7 @@ OpsWithShapeInference=[
 # Operations supporting canonicalization.
 OpsWithCanonicalizer = ['Add', 'Identity', 'Gemm', 'Cast', 'Transpose',
                         'Dropout', 'Shape', 'Size', 'GlobalAveragePool',
-                        'GlobalMaxPool']
+                        'GlobalMaxPool', 'Squeeze', 'Unsqueeze']
 
 # Operations who have operands that, if produced by constant operations, should
 # be promoted to become an attribute (via attribute promotion).


### PR DESCRIPTION
This patch adds DDR rules for removing squeeze/unsqueeze pairs.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>