### PR TITLE
Map ONNX operator names to instructions

### DIFF
--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -23,7 +23,9 @@ struct ONNXLoopOpLowering : public ConversionPattern {
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto loc = op->getLoc();
+    auto loc = NameLoc::get(
+        Identifier::get(ONNXLoopOp::getOperationName(), op->getContext()),
+        op->getLoc());
     auto loopOp = dyn_cast<ONNXLoopOp>(op);
     ONNXLoopOpAdaptor loopOpAdapter(operands, op->getAttrDictionary());
 

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -23,9 +23,7 @@ struct ONNXLoopOpLowering : public ConversionPattern {
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto loc = NameLoc::get(
-        Identifier::get(ONNXLoopOp::getOperationName(), op->getContext()),
-        op->getLoc());
+    auto loc = ONNXLoc<ONNXLoopOp>(op);
     auto loopOp = dyn_cast<ONNXLoopOp>(op);
     ONNXLoopOpAdaptor loopOpAdapter(operands, op->getAttrDictionary());
 

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -663,10 +663,7 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
       : ConversionPattern(ElementwiseUnaryOp::getOperationName(), 1, ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto loc =
-        NameLoc::get(Identifier::get(ElementwiseUnaryOp::getOperationName(),
-                         op->getContext()),
-            op->getLoc());
+    auto loc = ONNXLoc<ElementwiseUnaryOp>(op);
     auto X = operands[0];
 
     // Insert an allocation and deallocation for the result of this operation.

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -663,7 +663,10 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
       : ConversionPattern(ElementwiseUnaryOp::getOperationName(), 1, ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto loc = op->getLoc();
+    auto loc =
+        NameLoc::get(Identifier::get(ElementwiseUnaryOp::getOperationName(),
+                         op->getContext()),
+            op->getLoc());
     auto X = operands[0];
 
     // Insert an allocation and deallocation for the result of this operation.
@@ -721,7 +724,10 @@ struct ONNXElementwiseBinaryOpLowering : public ConversionPattern {
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto loc = op->getLoc();
+    auto loc =
+        NameLoc::get(Identifier::get(ElementwiseBinaryOp::getOperationName(),
+                         op->getContext()),
+            op->getLoc());
     auto numArgs = op->getNumOperands();
     auto outputMemRefType = convertToMemRefType(*op->result_type_begin());
     auto outputElementType = outputMemRefType.getElementType();
@@ -787,7 +793,10 @@ struct ONNXElementwiseVariadicOpLowering : public ConversionPattern {
       : ConversionPattern(ElementwiseVariadicOp::getOperationName(), 1, ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto loc = op->getLoc();
+    auto loc =
+        NameLoc::get(Identifier::get(ElementwiseVariadicOp::getOperationName(),
+                         op->getContext()),
+            op->getLoc());
     auto numArgs = op->getNumOperands();
     auto outputMemRefType = convertToMemRefType(*op->result_type_begin());
     auto outputElementType = outputMemRefType.getElementType();

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -27,10 +27,7 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     // Get shape.
     ONNXMatMulOpAdaptor operandAdaptor(operands);
     ONNXMatMulOp matMulOp = llvm::cast<ONNXMatMulOp>(op);
-    auto loc = NameLoc::get(
-        Identifier::get(ONNXMatMulOp::getOperationName(),
-                         op->getContext()),
-            op->getLoc());
+    auto loc = ONNXLoc<ONNXMatMulOp>(op);
     ONNXMatMulOpShapeHelper shapeHelper(&matMulOp, &rewriter);
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     (void)shapecomputed;

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -27,7 +27,10 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     // Get shape.
     ONNXMatMulOpAdaptor operandAdaptor(operands);
     ONNXMatMulOp matMulOp = llvm::cast<ONNXMatMulOp>(op);
-    Location loc = op->getLoc();
+    auto loc = NameLoc::get(
+        Identifier::get(ONNXMatMulOp::getOperationName(),
+                         op->getContext()),
+            op->getLoc());
     ONNXMatMulOpShapeHelper shapeHelper(&matMulOp, &rewriter);
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     (void)shapecomputed;

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -301,3 +301,15 @@ bool checkOpResultIsUsedByGetRef(AllocOp *allocOp);
 /// %d0, %d1 and %d2. Their indices 0, 1, 2 correspond to `index` values
 /// 1, 2 and 4 in the MemRef shape respectively
 int64_t getAllocArgIndex(AllocOp allocOp, int64_t index);
+
+/// This function returns a location with the corresponding ONNX operator name
+/// inside. This is useful when tracing what expanded MLIR instructions
+/// correspond to what ONNX operator.
+///
+///
+template <typename OP_TYPE>
+Location ONNXLoc(Operation *op) {
+  return NameLoc::get(
+      Identifier::get(OP_TYPE::getOperationName(), op->getContext()),
+      op->getLoc());
+}

--- a/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
@@ -40,7 +40,9 @@ struct ONNXConstantOpLowering : public ConversionPattern {
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto loc = op->getLoc();
+    auto loc = NameLoc::get(
+        Identifier::get(ONNXConstantOp::getOperationName(), op->getContext()),
+        op->getLoc());
     auto constantOp = llvm::dyn_cast<ONNXConstantOp>(op);
 
     if (constantOp.sparse_value().hasValue())

--- a/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
@@ -40,9 +40,7 @@ struct ONNXConstantOpLowering : public ConversionPattern {
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    auto loc = NameLoc::get(
-        Identifier::get(ONNXConstantOp::getOperationName(), op->getContext()),
-        op->getLoc());
+    auto loc = ONNXLoc<ONNXConstantOp>(op);
     auto constantOp = llvm::dyn_cast<ONNXConstantOp>(op);
 
     if (constantOp.sparse_value().hasValue())

--- a/test/mlir/onnx/onnx_location.mlir
+++ b/test/mlir/onnx/onnx_location.mlir
@@ -7,5 +7,5 @@
      return %0 : tensor<1x16xf32>
   }
 
-// PRESENT: loc("{{(/[[:alnum:]]+)+}}.onnx":1:0)
-// ABSENT-NOT: loc("{{(/[[:alnum:]]+)+}}.onnx":1:0)
+// PRESENT: loc("onnx.Add"("{{(/[[:alnum:]]+)+}}.onnx":1:0))
+// ABSENT-NOT: loc("{{("onnx.Add"(/[[:alnum:]]+)+}}.onnx":1:0))


### PR DESCRIPTION
This change maps the ONNX operator names (e.g. onnx.Add) to their corresponding MLIR instructions as  named location information.

Downstream, the operator names can be used to more accurately trace the kernel operations that were responsible for generating different MLIR instructions. To avoid extra code churn I only modified a subset of the common operators.