### PR TITLE
Index Expression interface update

### DIFF
--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -759,14 +759,14 @@ struct ONNXElementwiseBinaryOpLowering : public ConversionPattern {
     // Load the first value.
     SmallVector<IndexExpr, 4> lhsAccessExprs;
     LogicalResult res = shapeHelper.GetAccessExprs(
-        outerScope, operands[0], 0, outputAccessExprs, lhsAccessExprs);
+        operands[0], 0, outputAccessExprs, lhsAccessExprs);
     assert(res.succeeded());
     Value lhs = krnl_load(operands[0], lhsAccessExprs);
 
     // Load the second value.
     SmallVector<IndexExpr, 4> rhsAccessExprs;
     res = shapeHelper.GetAccessExprs(
-        outerScope, operands[1], 1, outputAccessExprs, rhsAccessExprs);
+        operands[1], 1, outputAccessExprs, rhsAccessExprs);
     assert(res.succeeded());
     Value rhs = krnl_load(operands[1], rhsAccessExprs);
 
@@ -829,17 +829,16 @@ struct ONNXElementwiseVariadicOpLowering : public ConversionPattern {
     // Obtain the first operand.
     SmallVector<IndexExpr, 4> oprdAccessExprs;
     LogicalResult res = shapeHelper.GetAccessExprs(
-        outerScope, operands[0], 0, outputAccessExprs, oprdAccessExprs);
+        operands[0], 0, outputAccessExprs, oprdAccessExprs);
     assert(res.succeeded());
-    Value accumulated =
-        krnl_load(operands[0], oprdAccessExprs);
+    Value accumulated = krnl_load(operands[0], oprdAccessExprs);
 
     // Iterate over the remaining operands.
     for (unsigned i = 1; i < numArgs; i++) {
       // Obtain the next operand.
       SmallVector<IndexExpr, 4> oprdAccessExprs;
       LogicalResult res = shapeHelper.GetAccessExprs(
-          outerScope, operands[i], i, outputAccessExprs, oprdAccessExprs);
+          operands[i], i, outputAccessExprs, oprdAccessExprs);
       assert(res.succeeded());
       Value next = krnl_load(operands[i], oprdAccessExprs);
       // Fold.

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -57,8 +57,8 @@ struct ONNXGemmOpLowering : public ConversionPattern {
     rewriter.setInsertionPointToStart(outputLoops.getIterateBlock());
 
     // Compute the access functions for res[n,m].
-    IndexExpr n = DimIndexExpr(outputLoops.getInductionVar(0));
-    IndexExpr m = DimIndexExpr(outputLoops.getInductionVar(1));
+    DimIndexExpr n(outputLoops.getInductionVar(0));
+    DimIndexExpr m(outputLoops.getInductionVar(1));
     SmallVector<IndexExpr, 4> resAccessFct({n, m});
 
     // Insert res[n,m] = 0.
@@ -77,7 +77,7 @@ struct ONNXGemmOpLowering : public ConversionPattern {
     auto ipOuterLoopRegion = rewriter.saveInsertionPoint();
     rewriter.setInsertionPointToStart(innerLoops.getIterateBlock());
     {
-      IndexExpr k = DimIndexExpr(innerLoops.getInductionVar(0));
+      DimIndexExpr k(innerLoops.getInductionVar(0));
       SmallVector<IndexExpr, 4> aAccessFct, bAccessFct;
       if (gemmOp.transA() != 0)
         aAccessFct = {k, n};
@@ -109,7 +109,7 @@ struct ONNXGemmOpLowering : public ConversionPattern {
     if (shapeHelper.hasBias) {
       for (int x = 2 - shapeHelper.cRank; x < 2; ++x) {
         // If dim > 1, use loop index, otherwise broadcast on 0's element.
-        IndexExpr dim = SymbolIndexExpr(shapeHelper.cDims[x]);
+        SymbolIndexExpr dim(shapeHelper.cDims[x]);
         cAccessFct.emplace_back(IndexExpr::select(dim > 1, resAccessFct[x], 0));
       }
     }

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -88,10 +88,8 @@ struct ONNXGemmOpLowering : public ConversionPattern {
       else
         bAccessFct = {k, m};
       // Add mat mul operation.
-      Value loadedA =
-          outerScope.createKrnlLoadOp(operandAdaptor.A(), aAccessFct);
-      Value loadedB =
-          outerScope.createKrnlLoadOp(operandAdaptor.B(), bAccessFct);
+      Value loadedA = krnl_load(operandAdaptor.A(), aAccessFct);
+      Value loadedB = krnl_load(operandAdaptor.B(), bAccessFct);
       Value loadedY =
           rewriter.create<KrnlLoadOp>(loc, reductionVal, ArrayRef<Value>{});
       Value AB = rewriter.create<MulFOp>(loc, loadedA, loadedB);
@@ -118,14 +116,13 @@ struct ONNXGemmOpLowering : public ConversionPattern {
     Value alphaAB = rewriter.create<MulFOp>(loc, alpha, loadedAB);
     if (shapeHelper.hasBias) {
       // Res = AB*alpha + beta * C.
-      Value loadedC =
-          outerScope.createKrnlLoadOp(operandAdaptor.C(), cAccessFct);
+      Value loadedC = krnl_load(operandAdaptor.C(), cAccessFct);
       auto betaC = rewriter.create<MulFOp>(loc, beta, loadedC);
       auto Y = rewriter.create<AddFOp>(loc, alphaAB, betaC);
-      outerScope.createKrnlStoreOp(Y, alloc, resAccessFct);
+      krnl_store(Y, alloc, resAccessFct);
     } else {
       // No bias, just store alphaAB into res.
-      outerScope.createKrnlStoreOp(alphaAB, alloc, resAccessFct);
+      krnl_store(alphaAB, alloc, resAccessFct);
     }
 
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/Math/LRN.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LRN.cpp
@@ -65,24 +65,22 @@ struct ONNXLRNOpLowering : public ConversionPattern {
     // and i<= min(C - 1, c + ceil((size - 1) / 2)).
 
     // Get a child IndexExpr context.
-    IndexExprContext childContext(shapeHelper.context);
+    IndexExprScope childScope(shapeHelper.scope);
 
     // Compute the lower bound and upper bound for square_sum.
     const int loopIndexForC = 1;
     Value cValue = outputLoops.getInductionVar(loopIndexForC);
-    IndexExpr cIE = childContext.createLoopInductionIndex(cValue);
-    IndexExpr sizeIE =
-        childContext.createDimIndexFromShapedType(input, loopIndexForC);
+    IndexExpr cIE = DimIndexExpr(cValue);
+    MemRefBoundIndexCapture inputBounds(input);
+    IndexExpr sizeIE = inputBounds.getDim(loopIndexForC);
 
     SmallVector<IndexExpr, 2> lbMaxList;
-    lbMaxList.emplace_back(childContext.createLiteralIndex(0));
-    lbMaxList.emplace_back(
-        cIE - (sizeIE - 1).floorDiv(childContext.createLiteralIndex(2)));
+    lbMaxList.emplace_back(LiteralIndexExpr(0));
+    lbMaxList.emplace_back(cIE - (sizeIE - 1).floorDiv(LiteralIndexExpr(2)));
 
     SmallVector<IndexExpr, 2> ubMinList;
     ubMinList.emplace_back(sizeIE);
-    ubMinList.emplace_back(
-        cIE + 1 + (sizeIE - 1).ceilDiv(childContext.createLiteralIndex(2)));
+    ubMinList.emplace_back(cIE + 1 + (sizeIE - 1).ceilDiv(LiteralIndexExpr(2)));
 
     // Initialize sum
     MemRefType scalarMemRefType = MemRefType::get({}, elementType, {}, 0);

--- a/src/Conversion/ONNXToKrnl/Math/LRN.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LRN.cpp
@@ -70,9 +70,9 @@ struct ONNXLRNOpLowering : public ConversionPattern {
     // Compute the lower bound and upper bound for square_sum.
     const int loopIndexForC = 1;
     Value cValue = outputLoops.getInductionVar(loopIndexForC);
-    IndexExpr cIE = DimIndexExpr(cValue);
+    DimIndexExpr cIE(cValue);
     MemRefBoundIndexCapture inputBounds(input);
-    IndexExpr sizeIE = inputBounds.getDim(loopIndexForC);
+    DimIndexExpr sizeIE(inputBounds.getDim(loopIndexForC));
 
     SmallVector<IndexExpr, 2> lbMaxList;
     lbMaxList.emplace_back(LiteralIndexExpr(0));

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -54,8 +54,6 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     // Access function for the output, and set it to zero.
     SmallVector<IndexExpr, 4> resAccessFct;
     bool res = getIndexExprListFrom<DimIndexExpr>(outputLoops.getAllInductionVar(), resAccessFct);
-    //outerContext.createLoopInductionIndicesFromArrayValues(
-    //xxx    outputLoops.getAllInductionVar(), resAccessFct);
     // Insert res[...] = 0.
     // Create a local reduction value for res[...].
     Value reductionVal =
@@ -106,9 +104,9 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
 
     // Add mat mul operation.
     Value loadedA =
-        outerScope.createKrnlLoadOp(operandAdaptor.A(), aAccessFct);
+        krnl_load(operandAdaptor.A(), aAccessFct);
     Value loadedB =
-        outerScope.createKrnlLoadOp(operandAdaptor.B(), bAccessFct);
+        krnl_load(operandAdaptor.B(), bAccessFct);
     Value loadedY =
         rewriter.create<KrnlLoadOp>(loc, reductionVal, ArrayRef<Value>{});
     Value AB = rewriter.create<MulFOp>(loc, loadedA, loadedB);
@@ -119,7 +117,7 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     rewriter.restoreInsertionPoint(ipOuterLoopRegion);
     accumulated =
         rewriter.create<KrnlLoadOp>(loc, reductionVal, ArrayRef<Value>{});
-    outerScope.createKrnlStoreOp(accumulated, alloc, resAccessFct);
+    krnl_store(accumulated, alloc, resAccessFct);
 
     // Done.
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -74,7 +74,7 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     auto ipOuterLoopRegion = rewriter.saveInsertionPoint();
     rewriter.setInsertionPointToStart(innerLoops.getIterateBlock());
 
-    IndexExpr k = DimIndexExpr(innerLoops.getInductionVar(0));
+    DimIndexExpr k(innerLoops.getInductionVar(0));
     SmallVector<IndexExpr, 4> aAccessFct, bAccessFct;
     for (int i = 0; i < aRank; ++i) {
       // Add index if dim is not a padded dimension.

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -53,7 +53,8 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
 
     // Access function for the output, and set it to zero.
     SmallVector<IndexExpr, 4> resAccessFct;
-    bool res = getIndexExprListFrom<DimIndexExpr>(outputLoops.getAllInductionVar(), resAccessFct);
+    bool res = getIndexExprListFrom<DimIndexExpr>(
+        outputLoops.getAllInductionVar(), resAccessFct);
     // Insert res[...] = 0.
     // Create a local reduction value for res[...].
     Value reductionVal =
@@ -103,10 +104,8 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     }
 
     // Add mat mul operation.
-    Value loadedA =
-        krnl_load(operandAdaptor.A(), aAccessFct);
-    Value loadedB =
-        krnl_load(operandAdaptor.B(), bAccessFct);
+    Value loadedA = krnl_load(operandAdaptor.A(), aAccessFct);
+    Value loadedB = krnl_load(operandAdaptor.B(), bAccessFct);
     Value loadedY =
         rewriter.create<KrnlLoadOp>(loc, reductionVal, ArrayRef<Value>{});
     Value AB = rewriter.create<MulFOp>(loc, loadedA, loadedB);

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -276,19 +276,21 @@ struct ONNXReductionOpLowering : public ConversionPattern {
 
     // 3. Define an Krnl loop to compute mean (optional).
     rewriter.restoreInsertionPoint(ipMainRegion);
+    MemRefBoundIndexCapture inputBounds(input);
+    MemRefBoundIndexCapture allocBounds(alloc);
     if (computeMean) {
       Type elementType = memRefOutType.getElementType();
       // Compute the divisor that is the number of elements participated in
       // reduction, i.e., 'divisor = size of input / size of output'.
-      IndexExprContext context(&rewriter, loc);
-      IndexExpr inputSizeExpr = context.createLiteralIndex(1);
+      IndexExprScope context(&rewriter, loc);
+      IndexExpr inputSizeExpr = LiteralIndexExpr(1);
       for (unsigned i = 0; i < inRank; i++) {
-        IndexExpr dimExpr = context.createDimIndexFromShapedType(input, i);
+        IndexExpr dimExpr = inputBounds.getDim(i);
         inputSizeExpr = inputSizeExpr * dimExpr;
       }
-      IndexExpr outputSizeExpr = context.createLiteralIndex(1);
+      IndexExpr outputSizeExpr = LiteralIndexExpr(1);
       for (unsigned i = 0; i < outRank; i++) {
-        IndexExpr dimExpr = context.createDimIndexFromShapedType(alloc, i);
+        IndexExpr dimExpr = allocBounds.getDim(i);
         outputSizeExpr = outputSizeExpr * dimExpr;
       }
       IndexExpr divisorExpr = inputSizeExpr.floorDiv(outputSizeExpr);

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -285,12 +285,12 @@ struct ONNXReductionOpLowering : public ConversionPattern {
       IndexExprScope context(&rewriter, loc);
       IndexExpr inputSizeExpr = LiteralIndexExpr(1);
       for (unsigned i = 0; i < inRank; i++) {
-        IndexExpr dimExpr = inputBounds.getDim(i);
+        DimIndexExpr dimExpr(inputBounds.getDim(i));
         inputSizeExpr = inputSizeExpr * dimExpr;
       }
       IndexExpr outputSizeExpr = LiteralIndexExpr(1);
       for (unsigned i = 0; i < outRank; i++) {
-        IndexExpr dimExpr = allocBounds.getDim(i);
+        DimIndexExpr dimExpr(allocBounds.getDim(i));
         outputSizeExpr = outputSizeExpr * dimExpr;
       }
       IndexExpr divisorExpr = inputSizeExpr.floorDiv(outputSizeExpr);

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -282,7 +282,7 @@ struct ONNXReductionOpLowering : public ConversionPattern {
       Type elementType = memRefOutType.getElementType();
       // Compute the divisor that is the number of elements participated in
       // reduction, i.e., 'divisor = size of input / size of output'.
-      IndexExprScope context(&rewriter, loc);
+      IndexExprScope scope(&rewriter, loc);
       IndexExpr inputSizeExpr = LiteralIndexExpr(1);
       for (unsigned i = 0; i < inRank; i++) {
         DimIndexExpr dimExpr(inputBounds.getDim(i));

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -254,7 +254,7 @@ struct ONNXConvOpLowering : public ConversionPattern {
         SmallVector<IndexExpr, 4> windowStartExprs, kernelOffsetExprs;
         for (int i = 0; i < nSpatialLoops; ++i) {
           std::vector<mlir::IndexExpr> exprs = getIndexExprsForConvWindow(
-              ieScope, IVExprs[i], /*ceilMode=*/true, isDilated);
+              IVExprs[i], /*ceilMode=*/true, isDilated);
           windowStartExprs.emplace_back(exprs[0]);
           kernelOffsetExprs.emplace_back(exprs[2]);
         }
@@ -340,8 +340,7 @@ struct ONNXConvOpLowering : public ConversionPattern {
 
           // 4.3 Compute convolution.
           auto loadData = krnl_load(inputOperand, dataIndices);
-          auto loadKernel =
-              krnl_load(kernelOperand, kernelIndices);
+          auto loadKernel = krnl_load(kernelOperand, kernelIndices);
           auto loadPartialSum =
               rewriter.create<KrnlLoadOp>(loc, reductionVal, ArrayRef<Value>{});
           Value result = rewriter.create<AddFOp>(loc, loadPartialSum,

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -394,8 +394,8 @@ struct ONNXPoolOpLowering : public ConversionPattern {
       //   endH = min(H, ho * sH + (kH - 1) * dH  + 1 - pbH)
       SmallVector<IndexExpr, 4> windowStartExprs, windowEndExprs;
       for (int i = 0; i < kernelShape.size(); ++i) {
-        std::vector<mlir::IndexExpr> exprs = getIndexExprsForConvWindow(
-            ieScope, IVExprs[i], ceilMode, isDilated);
+        std::vector<mlir::IndexExpr> exprs =
+            getIndexExprsForConvWindow(IVExprs[i], ceilMode, isDilated);
         windowStartExprs.emplace_back(exprs[0]);
         windowEndExprs.emplace_back(exprs[1]);
       }

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -234,7 +234,7 @@ struct ONNXPoolOpLowering : public ConversionPattern {
     // Kernel offset in the input shape.
     int kernelOffset = inputShape.size() - kernelShape.size();
 
-    // Context for IndexExpr.
+    // Scope for IndexExpr.
     IndexExprScope ieScope(&rewriter, loc);
 
     // Insert an allocation and deallocation for the output of this operation.
@@ -475,7 +475,7 @@ struct ONNXPoolOpLowering : public ConversionPattern {
         // Apply pooling operation.
         //      output[n][c][ho][wo] =
         //        emitScalarOpFor(output[n][c][ho][wo], input[n, c, hi, wi]);
-        Value loadInput = ieScope.createKrnlLoadOp(inputOperand, inputIndices);
+        Value loadInput = krnl_load(inputOperand, inputIndices);
         Value loadPartialOutput =
             rewriter.create<KrnlLoadOp>(loc, reductionVal, ArrayRef<Value>{});
         Value output = emitScalarOpFor<PoolOp>(rewriter, loc, op,
@@ -486,7 +486,7 @@ struct ONNXPoolOpLowering : public ConversionPattern {
       rewriter.restoreInsertionPoint(ipOuterLoopRegion);
       Value output =
           rewriter.create<KrnlLoadOp>(loc, reductionVal, ArrayRef<Value>{});
-      ieScope.createKrnlStoreOp(output, alloc, outputIndices);
+      krnl_store(output, alloc, outputIndices);
 
       // 2.5 Post-processing for the pooling window, e.g. taking average.
       SmallVector<Value, 4> outputIndicesInValue;

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -459,7 +459,7 @@ struct ONNXPoolOpLowering : public ConversionPattern {
             inputIndices.emplace_back(outputIndices[i]);
           for (int i = kernelOffset; i < inputShape.size(); ++i) {
             int j = i - kernelOffset;
-            IndexExpr hp = DimIndexExpr(poolingLoops.getInductionVar(j));
+            DimIndexExpr hp(poolingLoops.getInductionVar(j));
             IndexExpr startH = windowStartExprs[j];
             if (isDilated) {
               // hi = hp * dH + startH

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -68,12 +68,11 @@ struct ONNXConcatOpLowering : public ConversionPattern {
         if (r != axis || i == 0) {
           writeIndices.emplace_back(inputLoops.getInductionVar(r));
         } else {
-          IndexExprContext IEContext(&rewriter, loc);
-          IndexExpr writeOffset =
-              IEContext.createLoopInductionIndex(inputLoops.getInductionVar(r));
+          IndexExprScope IEContext(&rewriter, loc);
+          IndexExpr writeOffset = DimIndexExpr(inputLoops.getInductionVar(r));
           for (int j = 0; j < i; j++) {
-            writeOffset = writeOffset + IEContext.createDimIndexFromShapedType(
-                                            operands[j], r);
+            MemRefBoundIndexCapture operandJBounds(operands[j]);
+            writeOffset = writeOffset + operandJBounds.getDim(r);
           }
           writeIndices.emplace_back(writeOffset.getValue());
         }

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -67,7 +67,7 @@ struct ONNXConcatOpLowering : public ConversionPattern {
         if (r != axis || i == 0) {
           writeIndices.emplace_back(inputLoops.getInductionVar(r));
         } else {
-          IndexExprScope IEContext(&rewriter, loc);
+          IndexExprScope IEScope(&rewriter, loc);
           IndexExpr writeOffset = DimIndexExpr(inputLoops.getInductionVar(r));
           for (int j = 0; j < i; j++) {
             MemRefBoundIndexCapture operandJBounds(operands[j]);

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -47,7 +47,6 @@ struct ONNXConcatOpLowering : public ConversionPattern {
     ;
 
     // Creates loops, one for each input.
-    // IndexExpr writeOffset = IEContext.createLiteralIndex(0);
     for (int i = 0; i < inputNum; ++i) {
       OpBuilder::InsertionGuard insertGuard(rewriter);
       // Operand info.

--- a/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
@@ -65,9 +65,9 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     int kIndexStart = jIndexStart + indicesRank - (axisLit + 1);
 
     // Load the constants for the tests
-    IndexExpr zero = LiteralIndexExpr(0);
-    IndexExpr axis = LiteralIndexExpr(axisLit);
-    IndexExpr axisDim = SymbolIndexExpr(shapeHelper.dataDims[axisLit]);
+    LiteralIndexExpr zero(0);
+    LiteralIndexExpr axis(axisLit);
+    SymbolIndexExpr axisDim(shapeHelper.dataDims[axisLit]);
     rewriter.setInsertionPointToStart(outputLoops.getIterateBlock());
 
     // compute the loop indices for the output

--- a/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
@@ -80,7 +80,7 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     for (int j = 0; j < indicesRank; ++j)
       indicesAccessFct.emplace_back(outputAccessFct[jIndexStart + j]);
     Value indexVal =
-        outerScope.createKrnlLoadOp(operandAdaptor.indices(), indicesAccessFct);
+        krnl_load(operandAdaptor.indices(), indicesAccessFct);
     // Loaded value is an index that is not affine
     IndexExpr index = NonAffineIndexExpr(indexVal);
     // When index may be negative, add axis Dim to it.
@@ -99,10 +99,10 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     for (int k = axisLit + 1; k < dataRank; ++k)
       dataAccessFct.emplace_back(outputAccessFct[kIndexStart + k]);
     Value data =
-        outerScope.createKrnlLoadOp(operandAdaptor.data(), dataAccessFct);
+        krnl_load(operandAdaptor.data(), dataAccessFct);
 
     // Save data into output
-    outerScope.createKrnlStoreOp(data, alloc, outputAccessFct);
+    krnl_store(data, alloc, outputAccessFct);
     rewriter.replaceOp(op, alloc);
     return success();
   }

--- a/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
@@ -79,8 +79,7 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     SmallVector<IndexExpr, 4> indicesAccessFct;
     for (int j = 0; j < indicesRank; ++j)
       indicesAccessFct.emplace_back(outputAccessFct[jIndexStart + j]);
-    Value indexVal =
-        krnl_load(operandAdaptor.indices(), indicesAccessFct);
+    Value indexVal = krnl_load(operandAdaptor.indices(), indicesAccessFct);
     // Loaded value is an index that is not affine
     IndexExpr index = NonAffineIndexExpr(indexVal);
     // When index may be negative, add axis Dim to it.
@@ -98,8 +97,7 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     // Then add kks.
     for (int k = axisLit + 1; k < dataRank; ++k)
       dataAccessFct.emplace_back(outputAccessFct[kIndexStart + k]);
-    Value data =
-        krnl_load(operandAdaptor.data(), dataAccessFct);
+    Value data = krnl_load(operandAdaptor.data(), dataAccessFct);
 
     // Save data into output
     krnl_store(data, alloc, outputAccessFct);

--- a/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
@@ -45,9 +45,10 @@ struct ONNXShapeOpLowering : public ConversionPattern {
 
     // Iterate along the data shape storing dim value to result.
     for (int i = 0; i < dataRank; i++) {
-      IndexExprContext IEContext(&rewriter, loc);
-      IndexExpr storeIndex = IEContext.createLiteralIndex(i);
-      IndexExpr shapeVal = IEContext.createDimIndexFromShapedType(data, i);
+      IndexExprScope scope(&rewriter, loc);
+      IndexExpr storeIndex = LiteralIndexExpr(i);
+      MemRefBoundIndexCapture dataBounds(data);
+      IndexExpr shapeVal = dataBounds.getDim(i);
       Value storeVal = rewriter.create<IndexCastOp>(
           loc, shapeVal.getValue(), outputMemRefType.getElementType());
       rewriter.create<KrnlStoreOp>(loc, storeVal, alloc, storeIndex.getValue());

--- a/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
@@ -46,9 +46,9 @@ struct ONNXShapeOpLowering : public ConversionPattern {
     // Iterate along the data shape storing dim value to result.
     for (int i = 0; i < dataRank; i++) {
       IndexExprScope scope(&rewriter, loc);
-      IndexExpr storeIndex = LiteralIndexExpr(i);
+      LiteralIndexExpr storeIndex(i);
       MemRefBoundIndexCapture dataBounds(data);
-      IndexExpr shapeVal = dataBounds.getDim(i);
+      DimIndexExpr shapeVal(dataBounds.getDim(i));
       Value storeVal = rewriter.create<IndexCastOp>(
           loc, shapeVal.getValue(), outputMemRefType.getElementType());
       rewriter.create<KrnlStoreOp>(loc, storeVal, alloc, storeIndex.getValue());

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -61,8 +61,8 @@ struct ONNXSliceOpLowering : public ConversionPattern {
     }
     // Load data and store in alloc data.
     Value loadVal =
-        childScope.createKrnlLoadOp(operandAdaptor.data(), loadIndices);
-    childScope.createKrnlStoreOp(loadVal, alloc, storeIndices);
+        krnl_load(operandAdaptor.data(), loadIndices);
+    krnl_store(loadVal, alloc, storeIndices);
 
     rewriter.replaceOp(op, alloc);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -53,7 +53,7 @@ struct ONNXSliceOpLowering : public ConversionPattern {
     SmallVector<IndexExpr, 4> storeIndices;
     for (int ii = 0; ii < outputRank; ++ii) {
       Value inductionVal = outputLoops.getInductionVar(ii);
-      IndexExpr inductionIndex = DimIndexExpr(inductionVal);
+      DimIndexExpr inductionIndex(inductionVal);
       IndexExpr start = SymbolIndexExpr(shapeHelper.starts[ii]);
       IndexExpr step = SymbolIndexExpr(shapeHelper.steps[ii]);
       loadIndices.emplace_back((step * inductionIndex) + start);

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -60,8 +60,7 @@ struct ONNXSliceOpLowering : public ConversionPattern {
       storeIndices.emplace_back(inductionIndex);
     }
     // Load data and store in alloc data.
-    Value loadVal =
-        krnl_load(operandAdaptor.data(), loadIndices);
+    Value loadVal = krnl_load(operandAdaptor.data(), loadIndices);
     krnl_store(loadVal, alloc, storeIndices);
 
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -55,7 +55,7 @@ struct ONNXSplitOpLowering : public ConversionPattern {
       outputLoops.createDefineAndIterateOp(allocs[i]);
       rewriter.setInsertionPointToStart(outputLoops.getIterateBlock());
 
-      IndexExprContext childContext(shapeHelper.context);
+      IndexExprScope childScope(shapeHelper.scope);
 
       // Indices for the read and write.
       SmallVector<IndexExpr, 4> readIndices;
@@ -63,14 +63,13 @@ struct ONNXSplitOpLowering : public ConversionPattern {
       for (int r = 0; r < rank; ++r) {
         Value readVal = outputLoops.getInductionVar(r);
         // If not the split axis, same index for read and write
-        IndexExpr readIndex = childContext.createLoopInductionIndex(readVal);
-        IndexExpr writeIndex = childContext.createLoopInductionIndex(readVal);
+        IndexExpr readIndex = DimIndexExpr(readVal);
+        IndexExpr writeIndex = DimIndexExpr(readVal);
         // If the split axis, compute read index for the split axis.
         if (r == axis) {
           for (int k = 0; k < i; ++k) {
             IndexExpr splitDim =
-                childContext.createSymbolIndexFromParentContext(
-                    shapeHelper.dimsForOutput(k)[r]);
+                SymbolIndexExpr(shapeHelper.dimsForOutput(k)[r]);
             readIndex = readIndex + splitDim;
           }
         }
@@ -79,8 +78,8 @@ struct ONNXSplitOpLowering : public ConversionPattern {
       }
       // Insert copy.
       Value loadData =
-          childContext.createKrnlLoadOp(operandAdaptor.input(), readIndices);
-      childContext.createKrnlStoreOp(loadData, allocs[i], writeIndices);
+          childScope.createKrnlLoadOp(operandAdaptor.input(), readIndices);
+      childScope.createKrnlStoreOp(loadData, allocs[i], writeIndices);
     }
     rewriter.replaceOp(op, allocs);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -78,8 +78,8 @@ struct ONNXSplitOpLowering : public ConversionPattern {
       }
       // Insert copy.
       Value loadData =
-          childScope.createKrnlLoadOp(operandAdaptor.input(), readIndices);
-      childScope.createKrnlStoreOp(loadData, allocs[i], writeIndices);
+          krnl_load(operandAdaptor.input(), readIndices);
+      krnl_store(loadData, allocs[i], writeIndices);
     }
     rewriter.replaceOp(op, allocs);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -64,7 +64,7 @@ struct ONNXSplitOpLowering : public ConversionPattern {
         Value readVal = outputLoops.getInductionVar(r);
         // If not the split axis, same index for read and write
         IndexExpr readIndex = DimIndexExpr(readVal);
-        IndexExpr writeIndex = DimIndexExpr(readVal);
+        DimIndexExpr writeIndex(readVal);
         // If the split axis, compute read index for the split axis.
         if (r == axis) {
           for (int k = 0; k < i; ++k) {

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -77,8 +77,7 @@ struct ONNXSplitOpLowering : public ConversionPattern {
         writeIndices.emplace_back(writeIndex);
       }
       // Insert copy.
-      Value loadData =
-          krnl_load(operandAdaptor.input(), readIndices);
+      Value loadData = krnl_load(operandAdaptor.input(), readIndices);
       krnl_store(loadData, allocs[i], writeIndices);
     }
     rewriter.replaceOp(op, allocs);

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -98,10 +98,11 @@ struct ONNXTileOpLowering : public ConversionPattern {
 
     for (int i = 0; i < outputRank; i++) {
       // Context is created for each dimension because they are independent
-      IndexExprContext IEContext(&rewriter, loc);
+      IndexExprScope IEContext(&rewriter, loc);
       Value loopVal = outputLoops.getInductionVar(i);
-      IndexExpr index = IEContext.createLoopInductionIndex(loopVal);
-      IndexExpr dimSize = IEContext.createDimIndexFromShapedType(input, i);
+      IndexExpr index = DimIndexExpr(loopVal);
+      MemRefBoundIndexCapture inputBounds(input);
+      IndexExpr dimSize = inputBounds.getDim(i);
       IndexExpr exprVal = index % dimSize;
       if (!exprVal.isAffine()) {
         isAffineLoad = false;

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -93,7 +93,7 @@ struct ONNXTileOpLowering : public ConversionPattern {
     // The store has simple affine subscript expression.
     // Alternative implementation is to iterate the input tensor and repeats.
     // The load of elements in input tensor can be reused explicitly.
-    // But the subscript of store is not contigous, or even not affine.
+    // But the subscript of store is not contigious, or even not affine.
     // Alternative implementation can be found at the end of this file.
 
     for (int i = 0; i < outputRank; i++) {

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -97,8 +97,8 @@ struct ONNXTileOpLowering : public ConversionPattern {
     // Alternative implementation can be found at the end of this file.
 
     for (int i = 0; i < outputRank; i++) {
-      // Context is created for each dimension because they are independent
-      IndexExprScope IEContext(&rewriter, loc);
+      // Scope is created for each dimension because they are independent
+      IndexExprScope IEScope(&rewriter, loc);
       DimIndexExpr index(outputLoops.getInductionVar(i));
       MemRefBoundIndexCapture inputBounds(input);
       DimIndexExpr dimSize(inputBounds.getDim(i));

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -99,10 +99,9 @@ struct ONNXTileOpLowering : public ConversionPattern {
     for (int i = 0; i < outputRank; i++) {
       // Context is created for each dimension because they are independent
       IndexExprScope IEContext(&rewriter, loc);
-      Value loopVal = outputLoops.getInductionVar(i);
-      IndexExpr index = DimIndexExpr(loopVal);
+      DimIndexExpr index(outputLoops.getInductionVar(i));
       MemRefBoundIndexCapture inputBounds(input);
-      IndexExpr dimSize = inputBounds.getDim(i);
+      DimIndexExpr dimSize(inputBounds.getDim(i));
       IndexExpr exprVal = index % dimSize;
       if (!exprVal.isAffine()) {
         isAffineLoad = false;

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -65,8 +65,8 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
       }
 
       // Copy data.
-      Value loadData = childScope.createKrnlLoadOp(data, readIndices);
-      childScope.createKrnlStoreOp(loadData, alloc, writeIndices);
+      Value loadData = krnl_load(data, readIndices);
+      krnl_store(loadData, alloc, writeIndices);
     }
 
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -60,10 +60,8 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
         Value readVal = inputLoops.getInductionVar(i);
         Value writeVal =
             inputLoops.getInductionVar(ArrayAttrIntVal(permAttr, i));
-        IndexExpr readIndex = DimIndexExpr(readVal);
-        IndexExpr writeIndex = DimIndexExpr(writeVal);
-        readIndices.emplace_back(readIndex);
-        writeIndices.emplace_back(writeIndex);
+        readIndices.emplace_back(DimIndexExpr(readVal));
+        writeIndices.emplace_back(DimIndexExpr(writeVal));
       }
 
       // Copy data.

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -51,7 +51,7 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
     rewriter.setInsertionPointToStart(inputLoops.getIterateBlock());
     {
       // Get a child IndexExpr context.
-      IndexExprContext childContext(shapeHelper.context);
+      IndexExprScope childScope(shapeHelper.scope);
 
       // Get read/write indices.
       SmallVector<IndexExpr, 4> readIndices;
@@ -60,15 +60,15 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
         Value readVal = inputLoops.getInductionVar(i);
         Value writeVal =
             inputLoops.getInductionVar(ArrayAttrIntVal(permAttr, i));
-        IndexExpr readIndex = childContext.createLoopInductionIndex(readVal);
-        IndexExpr writeIndex = childContext.createLoopInductionIndex(writeVal);
+        IndexExpr readIndex = DimIndexExpr(readVal);
+        IndexExpr writeIndex = DimIndexExpr(writeVal);
         readIndices.emplace_back(readIndex);
         writeIndices.emplace_back(writeIndex);
       }
 
       // Copy data.
-      Value loadData = childContext.createKrnlLoadOp(data, readIndices);
-      childContext.createKrnlStoreOp(loadData, alloc, writeIndices);
+      Value loadData = childScope.createKrnlLoadOp(data, readIndices);
+      childScope.createKrnlStoreOp(loadData, alloc, writeIndices);
     }
 
     rewriter.replaceOp(op, alloc);

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -167,12 +167,12 @@ void KrnlIterateOperandPack::pushIndexExprBound(IndexExpr expr) {
   if (expr.isLiteral()) {
     pushConstantBound(expr.getLiteral());
   } else if (expr.isAffine() && !expr.isPredType()) {
-    int dimNum = expr.getContext().getNumDims();
-    int symNum = expr.getContext().getNumSymbols();
+    int dimNum = expr.getScope().getNumDims();
+    int symNum = expr.getScope().getNumSymbols();
     AffineMap map = AffineMap::get(dimNum, symNum, {expr.getAffineExpr()},
         expr.getRewriter().getContext());
     SmallVector<Value, 4> list;
-    expr.getContext().getDimAndSymbolList(list);
+    expr.getScope().getDimAndSymbolList(list);
     pushAffineMapBound(map, list);
   } else {
     // Assume the expr is loop invariant if there is any outer loop
@@ -188,12 +188,12 @@ void KrnlIterateOperandPack::pushIndexExprsBound(
     AEVector.push_back(expr.getAffineExpr());
   }
   IndexExpr expr = exprVector.front();
-  int dimNum = expr.getContext().getNumDims();
-  int symNum = expr.getContext().getNumSymbols();
+  int dimNum = expr.getScope().getNumDims();
+  int symNum = expr.getScope().getNumSymbols();
   AffineMap map =
       AffineMap::get(dimNum, symNum, AEVector, builder.getContext());
   SmallVector<Value, 4> list;
-  expr.getContext().getDimAndSymbolList(list);
+  expr.getScope().getDimAndSymbolList(list);
   pushAffineMapBound(map, list);
 }
 

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -14,7 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 // both debug variables will be removed once debugging is complete.
-#define DEBUG 0
+#define DEBUG 1
 
 #include "src/Dialect/ONNX/IndexExpr.hpp"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -1078,14 +1078,15 @@ NonAffineIndexExpr::NonAffineIndexExpr(IndexExpr const otherIndexExpr) {
   // Depending on what kind of index expr we got, take different actions.
   switch (otherIndexExpr.getKind()) {
   case IndexExprKind::Questionmark: {
-    assert("cannot make a non-affine from a Questionmark");
+    indexExprObj->initAsQuestionmark();
+    return;
   }
   case IndexExprKind::NonAffine: {
     indexExprObj->copy(otherIndexExpr.getObjPtr());
     return;
   }
   case IndexExprKind::Predicate: {
-    assert("cannot make a non-affine from a predicate");
+    llvm_unreachable("cannot make a non-affine from a predicate");
   }
   case IndexExprKind::Affine: {
     indexExprObj->initAsKind(
@@ -1158,14 +1159,15 @@ AffineIndexExpr::AffineIndexExpr(IndexExpr const otherIndexExpr) {
   bool isSameScope = otherIndexExpr.isInCurrentScope();
   switch (otherIndexExpr.getKind()) {
   case IndexExprKind::Questionmark: {
-    assert("cannot make an affine from a Questionmark");
+    indexExprObj->initAsQuestionmark();
+    return;
   }
   case IndexExprKind::NonAffine: {
-    assert("cannot make an affine from an non affine, affine are made of "
-           "literals, dims, and symbols");
+    llvm_unreachable("cannot make an affine from an non affine, affine are "
+                     "made of literals, dims, and symbols");
   }
   case IndexExprKind::Predicate: {
-    assert("cannot make an affine from a predicate");
+    llvm_unreachable("cannot make an affine from a predicate");
   }
   case IndexExprKind::Affine: {
     assert(isSameScope && "cannot can only import literals, dims and symbols "
@@ -1205,14 +1207,15 @@ DimIndexExpr::DimIndexExpr(IndexExpr const otherIndexExpr) {
   bool isSameScope = otherIndexExpr.isInCurrentScope();
   switch (otherIndexExpr.getKind()) {
   case IndexExprKind::Questionmark: {
-    assert("cannot make a dim from a Questionmark");
+    indexExprObj->initAsQuestionmark();
+    return;
   }
   case IndexExprKind::NonAffine: {
     indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Dim);
     return;
   }
   case IndexExprKind::Predicate: {
-    assert("cannot make an dim from a predicate");
+    llvm_unreachable("cannot make an dim from a predicate");
   }
   case IndexExprKind::Affine: {
     indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Dim);
@@ -1253,14 +1256,15 @@ SymbolIndexExpr::SymbolIndexExpr(IndexExpr const otherIndexExpr) {
   bool isSameScope = otherIndexExpr.isInCurrentScope();
   switch (otherIndexExpr.getKind()) {
   case IndexExprKind::Questionmark: {
-    assert("cannot make a symbol from a Questionmark");
+    indexExprObj->initAsQuestionmark();
+    return;
   }
   case IndexExprKind::NonAffine: {
     indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Symbol);
     return;
   }
   case IndexExprKind::Predicate: {
-    assert("cannot make an symbol from a predicate");
+    llvm_unreachable("cannot make an symbol from a predicate");
   }
   case IndexExprKind::Affine: {
     indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Symbol);
@@ -1344,7 +1348,7 @@ bool ArrayValueIndexCapture::getSymbolList(
   symbolList.clear();
   bool successful = true;
   for (int i = 0; i < num; ++i) {
-    IndexExpr index = getSymbol(i);
+    SymbolIndexExpr index = getSymbol(i);
     if (index.isUndefined())
       successful = false;
     symbolList.emplace_back(index);

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -275,7 +275,7 @@ IndexExpr IndexExpr::deepCopy() const {
 // IndexExpr list queries.
 //===----------------------------------------------------------------------===//
 bool IndexExpr::isDefined() const {
-  assert(!getObj().defined || hasContext());
+  assert(!getObj().defined || hasScope());
   return getObj().defined;
 }
 
@@ -319,7 +319,7 @@ bool IndexExpr::isShapeInferencePass() const {
   return getScope().isShapeInferencePass();
 }
 
-bool IndexExpr::hasContext() const { return getObj().scope != nullptr; }
+bool IndexExpr::hasScope() const { return getObj().scope != nullptr; }
 
 bool IndexExpr::hasAffineExpr() const {
   assert(isDefined());
@@ -438,7 +438,7 @@ Value IndexExpr::getValue() const {
 }
 
 IndexExprScope *IndexExpr::getScopePtr() const {
-  assert(hasContext());
+  assert(hasScope());
   return getObj().scope;
 }
 
@@ -836,9 +836,12 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
 
 /*static*/ IndexExpr IndexExpr::select(IndexExpr const compare,
     IndexExpr const trueVal, IndexExpr const falseVal) {
-  assert(compare.canBeUsedInScope() && "compare cannot be used in current scope");
-  assert(trueVal.canBeUsedInScope() && "trueVal cannot be used in current scope");
-  assert(falseVal.canBeUsedInScope() && "falseVal cannot be used in current scope");
+  assert(
+      compare.canBeUsedInScope() && "compare cannot be used in current scope");
+  assert(
+      trueVal.canBeUsedInScope() && "trueVal cannot be used in current scope");
+  assert(falseVal.canBeUsedInScope() &&
+         "falseVal cannot be used in current scope");
   // When compare result is literal, just feed forward the right value.
   if (compare.isLiteral()) {
     if (compare.getLiteral())

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -14,7 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 // both debug variables will be removed once debugging is complete.
-#define DEBUG 1
+#define DEBUG 0
 
 #include "src/Dialect/ONNX/IndexExpr.hpp"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -246,31 +246,6 @@ void IndexExprImpl::copy(IndexExprImpl const *other) {
 }
 
 //===----------------------------------------------------------------------===//
-// IndexExpr constructors
-//===----------------------------------------------------------------------===//
-
-IndexExpr::IndexExpr(int64_t const val) {
-  indexExprObj = new IndexExprImpl();
-  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
-  indexExprObj->initAsLiteral(val);
-}
-
-IndexExpr::IndexExpr(Value const value)
-    : IndexExpr(value, IndexExprKind::NonAffine) {}
-
-IndexExpr::IndexExpr(AffineExpr const value) {
-  indexExprObj = new IndexExprImpl();
-  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
-  indexExprObj->initAsAffineExpr(value);
-}
-
-IndexExpr::IndexExpr(Value const value, IndexExprKind newKind) {
-  indexExprObj = new IndexExprImpl();
-  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
-  indexExprObj->initAsKind(value, newKind);
-}
-
-//===----------------------------------------------------------------------===//
 // IndexExpr copy and setters.
 //===----------------------------------------------------------------------===//
 
@@ -465,19 +440,26 @@ void IndexExpr::debugPrint(const std::string &msg) const {
   if (isAffine())
     printf(" is affine");
   switch (getKind()) {
-    case IndexExprKind::NonAffine : printf(" kind(non-affine)");
+  case IndexExprKind::NonAffine:
+    printf(" kind(non-affine)");
     break;
-    case IndexExprKind::Questionmark :  printf(" kind(questionmark)");
+  case IndexExprKind::Questionmark:
+    printf(" kind(questionmark)");
     break;
-    case IndexExprKind::Predicate :  printf(" kind(predicate)");
+  case IndexExprKind::Predicate:
+    printf(" kind(predicate)");
     break;
-    case IndexExprKind::Affine :printf(" kind(affine)");
+  case IndexExprKind::Affine:
+    printf(" kind(affine)");
     break;
-    case IndexExprKind::Dim :printf(" kind(dim)");
+  case IndexExprKind::Dim:
+    printf(" kind(dim)");
     break;
-    case IndexExprKind::Symbol :printf(" kind(symbol)");
+  case IndexExprKind::Symbol:
+    printf(" kind(symbol)");
     break;
-    default :printf(" kind(unknown)");
+  default:
+    printf(" kind(unknown)");
     break;
   }
   printf(" scope(0x%llx)\n", (long long unsigned)getScopePtr());
@@ -1004,7 +986,11 @@ IndexExpr IndexExpr::selectOrSelf(
 
 UndefinedIndexExpr::UndefinedIndexExpr() : IndexExpr() {}
 
-LiteralIndexExpr::LiteralIndexExpr(int64_t const value) : IndexExpr(value) {}
+LiteralIndexExpr::LiteralIndexExpr(int64_t const value) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsLiteral(value);
+}
 
 LiteralIndexExpr::LiteralIndexExpr(IndexExpr const otherIndexExpr) {
   assert(
@@ -1015,7 +1001,11 @@ LiteralIndexExpr::LiteralIndexExpr(IndexExpr const otherIndexExpr) {
   return;
 }
 
-NonAffineIndexExpr::NonAffineIndexExpr(Value const value) : IndexExpr(value) {}
+NonAffineIndexExpr::NonAffineIndexExpr(Value const value) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsKind(value, IndexExprKind::NonAffine);
+}
 
 NonAffineIndexExpr::NonAffineIndexExpr(IndexExpr const otherIndexExpr) {
   // Create new IndexExpr implementation object.
@@ -1070,8 +1060,11 @@ QuestionmarkIndexExpr::QuestionmarkIndexExpr(IndexExpr const otherIndexExpr)
   // Don't care about otherIndexExpr as questionmarks have no real data.
 }
 
-PredicateIndexExpr::PredicateIndexExpr(Value const value)
-    : IndexExpr(value, IndexExprKind::Predicate) {}
+PredicateIndexExpr::PredicateIndexExpr(Value const value) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsKind(value, IndexExprKind::Predicate);
+}
 
 PredicateIndexExpr::PredicateIndexExpr(IndexExpr const otherIndexExpr) {
   // Create new IndexExpr implementation object.
@@ -1087,7 +1080,11 @@ PredicateIndexExpr::PredicateIndexExpr(IndexExpr const otherIndexExpr) {
   indexExprObj->copy(otherIndexExpr.getObjPtr());
 }
 
-AffineIndexExpr::AffineIndexExpr(AffineExpr const value) : IndexExpr(value) {}
+AffineIndexExpr::AffineIndexExpr(AffineExpr const value) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsAffineExpr(value);
+}
 
 AffineIndexExpr::AffineIndexExpr(IndexExpr const otherIndexExpr) {
   // Create new IndexExpr implementation object.
@@ -1130,8 +1127,11 @@ AffineIndexExpr::AffineIndexExpr(IndexExpr const otherIndexExpr) {
   llvm_unreachable("bad path");
 }
 
-DimIndexExpr::DimIndexExpr(Value const value)
-    : IndexExpr(value, IndexExprKind::Dim) {}
+DimIndexExpr::DimIndexExpr(Value const value) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsKind(value, IndexExprKind::Dim);
+}
 
 DimIndexExpr::DimIndexExpr(IndexExpr const otherIndexExpr) {
   // Create new IndexExpr implementation object.
@@ -1175,8 +1175,11 @@ DimIndexExpr::DimIndexExpr(IndexExpr const otherIndexExpr) {
   llvm_unreachable("bad path");
 }
 
-SymbolIndexExpr::SymbolIndexExpr(Value const value)
-    : IndexExpr(value, IndexExprKind::Symbol) {}
+SymbolIndexExpr::SymbolIndexExpr(Value const value) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsKind(value, IndexExprKind::Symbol);
+}
 
 SymbolIndexExpr::SymbolIndexExpr(IndexExpr const otherIndexExpr) {
   // Create new IndexExpr implementation object.
@@ -1332,4 +1335,3 @@ bool MemRefBoundIndexCapture::getDimList(SmallVectorImpl<IndexExpr> &dimList) {
   }
   return successful;
 }
-

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -395,6 +395,10 @@ int64_t IndexExpr::getLiteral() const {
 AffineExpr IndexExpr::getAffineExpr() const {
   assert(!isShapeInferencePass() && "cannot get affine during shape inference");
   assert(!isPredType() && "no affine support for predicate type");
+  if (hasAffineExpr() ) {
+    // Already computed it, use it.
+    return getObj().affineExpr;
+  }
   if (isLiteral()) {
     // Create a literal.
     getObj().affineExpr = getRewriter().getAffineConstantExpr(getObj().intLit);
@@ -413,6 +417,7 @@ AffineExpr IndexExpr::getAffineExpr() const {
     int id = getScope().addDim(getObj().value);
     getObj().affineExpr = getRewriter().getAffineDimExpr(id);
   } else {
+    llvm_unreachable("requesting affine expr of incompatible InexeExpr");
     assert(
         hasAffineExpr() && "requesting affine expr of incompatible IndexExpr");
   }

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -1160,7 +1160,7 @@ DimIndexExpr::DimIndexExpr(IndexExpr const otherIndexExpr) {
     return;
   }
   case IndexExprKind::Dim: {
-    assert(!isSameScope && "should not replicate dims in the same scope");
+    // If replicated in the same scope, its not great but will not gen errors.
     indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Dim);
     return;
   }
@@ -1213,7 +1213,7 @@ SymbolIndexExpr::SymbolIndexExpr(IndexExpr const otherIndexExpr) {
     return;
   }
   case IndexExprKind::Symbol: {
-    assert(!isSameScope && "should not replicate dims at the same scope");
+    // If replicated in the same scope, its not great but will not gen errors.
     indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Symbol);
     return;
   }

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -102,26 +102,6 @@ IndexExprScope::~IndexExprScope() {
 }
 
 //===----------------------------------------------------------------------===//
-// IndexExprScope support for creating krnl load and store ops.
-//===----------------------------------------------------------------------===//
-
-Value IndexExprScope::createKrnlLoadOp(
-    Value memref, SmallVectorImpl<IndexExpr> &indices) {
-  SmallVector<Value, 4> loadIndices;
-  for (IndexExpr ie : indices)
-    loadIndices.emplace_back(ie.getValue());
-  return getRewriter().create<KrnlLoadOp>(getLoc(), memref, loadIndices);
-}
-
-void IndexExprScope::createKrnlStoreOp(
-    Value val, Value memref, SmallVectorImpl<IndexExpr> &indices) {
-  SmallVector<Value, 4> storeIndices;
-  for (IndexExpr ie : indices)
-    storeIndices.emplace_back(ie.getValue());
-  getRewriter().create<KrnlStoreOp>(getLoc(), val, memref, storeIndices);
-}
-
-//===----------------------------------------------------------------------===//
 // IndexExprScope builder for IndexExpr.
 //===----------------------------------------------------------------------===//
 
@@ -395,7 +375,7 @@ int64_t IndexExpr::getLiteral() const {
 AffineExpr IndexExpr::getAffineExpr() const {
   assert(!isShapeInferencePass() && "cannot get affine during shape inference");
   assert(!isPredType() && "no affine support for predicate type");
-  if (hasAffineExpr() ) {
+  if (hasAffineExpr()) {
     // Already computed it, use it.
     return getObj().affineExpr;
   }
@@ -1377,4 +1357,28 @@ bool MemRefBoundIndexCapture::getDimList(SmallVectorImpl<IndexExpr> &dimList) {
     dimList.emplace_back(index);
   }
   return successful;
+}
+
+//===----------------------------------------------------------------------===//
+// Generating Krnl Load / Store
+//===----------------------------------------------------------------------===//
+
+krnl_load::krnl_load(Value memref, SmallVectorImpl<IndexExpr> &indices) {
+  IndexExprScope *currScope = IndexExprScope::getCurrentScopePtr();
+  assert(currScope && "expected an existing scope");
+  SmallVector<Value, 4> loadIndices;
+  for (IndexExpr ie : indices)
+    loadIndices.emplace_back(ie.getValue());
+  result = currScope->getRewriter().create<KrnlLoadOp>(
+      currScope->getLoc(), memref, loadIndices);
+}
+
+krnl_store::krnl_store(Value val, Value memref, SmallVectorImpl<IndexExpr> &indices) {
+  IndexExprScope *currScope = IndexExprScope::getCurrentScopePtr();
+  assert(currScope && "expected an existing scope");
+  SmallVector<Value, 4> storeIndices;
+  for (IndexExpr ie : indices)
+    storeIndices.emplace_back(ie.getValue());
+  currScope->getRewriter().create<KrnlStoreOp>(
+      currScope->getLoc(), val, memref, storeIndices);
 }

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -549,7 +549,8 @@ IndexExprImpl *IndexExpr::getObjPtr() const {
 // Used for add/sub/mult/ceilDiv/floorDiv
 IndexExpr IndexExpr::binaryOp(IndexExpr const b, bool affineWithLitB,
     bool canBeAffine, F2 litFct, F2 affineExprFct, F2 valueFct) const {
-  assert(getScopePtr() == b.getScopePtr() && "incompatible contexts");
+  assert(canBeUsedInScope() && "a cannot be used in current scope");
+  assert(b.canBeUsedInScope() && "b cannot be used in current scope");
   // Literal integer if a and b are literals. Affine if canBeAffine is true,
   // both a and b are affine, and possibly a and/or b are also constant.
   bool resIsLit = isLiteral() && b.isLiteral();
@@ -639,8 +640,7 @@ IndexExpr IndexExpr::compareOp(
       resIsLit = false;
     if (!vals[i].isAffine())
       resIsAffine = false;
-    assert(vals[0].getScopePtr() == vals[i].getScopePtr() &&
-           "incompatible contexts");
+    assert(vals[i].canBeUsedInScope() && "incompatible contexts");
   }
   if (resIsLit) {
     // Process int literals, if we only have literal values.
@@ -814,8 +814,10 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
     return res2;
   };
 
-  assert(getScopePtr() == min.getScopePtr() &&
-         getScopePtr() == max.getScopePtr() && "incompatible contexts");
+  assert(canBeUsedInScope() && "cannot be used in current scope");
+  assert(min.canBeUsedInScope() && "min cannot be used in current scope");
+  assert(max.canBeUsedInScope() && "max cannot be used in current scope");
+
   // Literal integer if a, b, and c are literals. Output is not affine (unless
   // all 3 are literals).
   bool resIsLit = isLiteral() && min.isLiteral() && max.isLiteral();
@@ -834,9 +836,9 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
 
 /*static*/ IndexExpr IndexExpr::select(IndexExpr const compare,
     IndexExpr const trueVal, IndexExpr const falseVal) {
-  assert(compare.getScopePtr() == trueVal.getScopePtr() &&
-         compare.getScopePtr() == falseVal.getScopePtr() &&
-         "incompatible contexts");
+  assert(compare.canBeUsedInScope() && "compare cannot be used in current scope");
+  assert(trueVal.canBeUsedInScope() && "trueVal cannot be used in current scope");
+  assert(falseVal.canBeUsedInScope() && "falseVal cannot be used in current scope");
   // When compare result is literal, just feed forward the right value.
   if (compare.isLiteral()) {
     if (compare.getLiteral())

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -14,7 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 // both debug variables will be removed once debugging is complete.
-#define DEBUG 0
+#define DEBUG 1
 
 #include "src/Dialect/ONNX/IndexExpr.hpp"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -31,245 +31,48 @@
 using namespace mlir;
 
 //===----------------------------------------------------------------------===//
-// IndexExprContext constructors.
+// IndexExprScope constructors.
 //===----------------------------------------------------------------------===//
 
-IndexExprContext::IndexExprContext(
+IndexExprScope::IndexExprScope(
     ConversionPatternRewriter *rewriter, Location loc)
-    : rewriter(rewriter), loc(loc), dims(), symbols(), parentContext(nullptr),
-      zero(nullptr), one(nullptr), minusOne(nullptr) {}
-
-IndexExprContext::IndexExprContext(IndexExprContext &newParentContext)
-    : rewriter(newParentContext.rewriter), loc(newParentContext.loc), dims(),
-      symbols(), parentContext(nullptr), zero(nullptr), one(nullptr),
-      minusOne(nullptr) {
-  // We reuse the parent context, and in particuliar its affine
-  // functions. Now because the affine functions of the parent context have
-  // "ids" embedded in the AffineExpr, we must reuse the same mix of Dims and
-  // Symbols here. I don't believe there is any sideeffects in considering a Dim
-  // from the parent's context as a Dim in the child's context, even though the
-  // parent's dim is supposed to be constant in the child's context.
-  for (Value parentDim : newParentContext.dims)
-    addDim(parentDim);
-  for (Value parentSymbol : newParentContext.symbols)
-    addSymbol(parentSymbol);
-  // Save reference to parent context so that we may detect the reuse.
-  parentContext = &newParentContext;
+    : dims(), symbols(), rewriter(rewriter), loc(loc),
+      parentScope(getCurrentScopePtr()), container() {
+  getCurrentScopePtr() = this;
 }
 
-IndexExprContext::~IndexExprContext() {
-  // Free the memory of each IndexExprImpl in context's container.
+IndexExprScope::IndexExprScope()
+    : dims(), symbols(), rewriter(getCurrentScope().rewriter),
+      loc(getCurrentScope().loc), parentScope(getCurrentScopePtr()),
+      container() {
+  getCurrentScopePtr() = this;
+}
+
+IndexExprScope::IndexExprScope(IndexExprScope &explicitParentScope)
+    : IndexExprScope() {
+  assert(&explicitParentScope == parentScope &&
+         "provided parent scope was not the previously active scope");
+}
+
+IndexExprScope::~IndexExprScope() {
+  // Free the memory of each IndexExprImpl in scope's container.
   for (IndexExprImpl *obj : container)
     delete obj;
   container.clear();
+  getCurrentScopePtr() = parentScope;
+}
+
+/*static*/ IndexExprScope &IndexExprScope::getCurrentScope() {
+  IndexExprScope *currScope = getCurrentScopePtr();
+  assert(currScope != nullptr && "expected nonnull scope");
+  return *currScope;
 }
 
 //===----------------------------------------------------------------------===//
-// IndexExprContext builder for IndexExpr.
+// IndexExprScope support for creating krnl load and store ops.
 //===----------------------------------------------------------------------===//
 
-IndexExprImpl *IndexExprContext::createIndexExprImpl() {
-  // Create implementation object.
-  IndexExprImpl *obj = new IndexExprImpl(this);
-  assert(obj && "failed to allocate object");
-  // Record implementation object in container, so that the context may free
-  // them upon context destruction.
-  container.emplace_back(obj);
-  return obj;
-}
-
-IndexExpr IndexExprContext::createUndefinedIndex() {
-  IndexExprImpl *obj = createIndexExprImpl();
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createQuestionmarkIndex() {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsQuestionmark(*this);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createLiteralIndex(int64_t const val) {
-  IndexExprImpl *obj;
-
-  // Provide reuse for 0/1/-1.
-  if (val == 0) {
-    if (zero)
-      return IndexExpr(zero);
-    zero = obj = createIndexExprImpl();
-  } else if (val == 1) {
-    if (one)
-      return IndexExpr(one);
-    one = obj = createIndexExprImpl();
-  } else if (val == -1) {
-    if (minusOne)
-      return IndexExpr(minusOne);
-    minusOne = obj = createIndexExprImpl();
-  } else {
-    obj = createIndexExprImpl();
-  }
-  obj->initAsLiteral(*this, val);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createAffineIndex(AffineExpr const val) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsAffineExpr(*this, val);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createDimIndex(Value const val) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsType(*this, val, IndexExprType::Dim);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createLoopInductionIndex(Value const val) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsType(*this, val, IndexExprType::LoopInduction);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createSymbolIndex(Value const val) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsType(*this, val, IndexExprType::Symbol);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createNonAffineIndex(Value const val) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsType(*this, val, IndexExprType::NonAffine);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createPredicateIndex(Value const val) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsType(*this, val, IndexExprType::Predicate);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createIndex(IndexExpr const other) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->copy(other.getObjPtr());
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createDimIndexFromShapedType(
-    Value tensorOrMemref, int index) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsDimFromShapedType(*this, tensorOrMemref, index);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createSymbolIndexFromArrayValueAtIndex(
-    Operation *op, Value array, uint64_t indexInArray) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsSymbolFromArrayAtIndex(*this, op, array, indexInArray);
-  return IndexExpr(obj);
-}
-
-IndexExpr IndexExprContext::createSymbolIndexFromArrayValueAtIndex(
-    Operation *op, Value array, uint64_t indexInArray, int64_t defaultLiteral) {
-  IndexExprImpl *obj = createIndexExprImpl();
-  obj->initAsSymbolFromArrayAtIndex(
-      *this, op, array, indexInArray, defaultLiteral);
-  return IndexExpr(obj);
-}
-
-// Additional builder for re-purposing IndexExpr from parent context.
-IndexExpr IndexExprContext::createSymbolIndexFromParentContext(
-    IndexExpr const parentIndexExpr) {
-  // Make sure that we are using the propper parent context
-  assert(parentIndexExpr.getContextPtr() == parentContext &&
-         "parent index is not from the parent's context");
-  // Make sure that the parent index expr is defined and not question mark
-  assert(parentIndexExpr.isDefined() &&
-         "expected defined parent index expression here");
-  assert(!parentIndexExpr.isQuestionmark() &&
-         "expected defined parent index expression here");
-  // Do not expect predicate expression here either
-  assert(!parentIndexExpr.isPredType() &&
-         "expect non-predicate index expressions here");
-  // When the parent expression is already affine in the outer context, it
-  // will remain affine in the child's context as wee. So we keep it as
-  // such, to get as expressive affine expressions as possible. We could
-  // restrict reuse for literal only.
-  if (parentIndexExpr.isAffine()) {
-    // Reuse affine expression.
-    IndexExprImpl *obj = createIndexExprImpl();
-    obj->copy(parentIndexExpr.getObjPtr());
-    return IndexExpr(obj);
-  }
-  // Non affine, create a symbol.
-  return createSymbolIndex(parentIndexExpr.getValue());
-}
-
-//===----------------------------------------------------------------------===//
-// IndexExprContext builder for lists of IndexExpr.
-//===----------------------------------------------------------------------===//
-
-bool IndexExprContext::createDimIndicesFromShapedType(
-    Value tensorOrMemref, SmallVectorImpl<IndexExpr> &dimIndices) {
-  // Clear output.
-  dimIndices.clear();
-  // Scan type and shape, bail if incompatible.
-  ShapedType type = tensorOrMemref.getType().cast<ShapedType>();
-  int size = type.getShape().size();
-  // Scan tensor or memref.
-  bool successful = true;
-  for (int i = 0; i < size; ++i) {
-    IndexExpr index = createDimIndexFromShapedType(tensorOrMemref, i);
-    if (index.isUndefined())
-      successful = false;
-    dimIndices.emplace_back(index);
-  }
-  return successful;
-}
-
-bool IndexExprContext::createSymbolIndicesFromArrayValues(Operation *op,
-    Value array, int arraySize, SmallVectorImpl<IndexExpr> &symbolIndices) {
-  // Clear output.
-  symbolIndices.clear();
-  bool successful = true;
-  for (int i = 0; i < arraySize; ++i) {
-    IndexExpr index = createSymbolIndexFromArrayValueAtIndex(op, array, i);
-    if (index.isUndefined())
-      successful = false;
-    symbolIndices.emplace_back(index);
-  }
-  return successful;
-}
-
-bool IndexExprContext::createSymbolIndicesFromArrayValues(Operation *op,
-    Value array, int arraySize, int64_t defaultLiteral,
-    SmallVectorImpl<IndexExpr> &symbolIndices) {
-  // Clear output.
-  symbolIndices.clear();
-  bool successful = true;
-  for (int i = 0; i < arraySize; ++i) {
-    IndexExpr index =
-        createSymbolIndexFromArrayValueAtIndex(op, array, i, defaultLiteral);
-    if (index.isUndefined())
-      successful = false;
-    symbolIndices.emplace_back(index);
-  }
-  return successful;
-}
-
-void IndexExprContext::createLoopInductionIndicesFromArrayValues(
-    ArrayRef<BlockArgument> inductionVarArray,
-    SmallVectorImpl<IndexExpr> &loopInductionIndices) {
-  // Clear output.
-  loopInductionIndices.clear();
-  for (BlockArgument b : inductionVarArray)
-    loopInductionIndices.emplace_back(createLoopInductionIndex(b));
-}
-
-//===----------------------------------------------------------------------===//
-// IndexExprContext support for creating krnl load and store ops.
-//===----------------------------------------------------------------------===//
-
-Value IndexExprContext::createKrnlLoadOp(
+Value IndexExprScope::createKrnlLoadOp(
     Value memref, SmallVectorImpl<IndexExpr> &indices) {
   SmallVector<Value, 4> loadIndices;
   for (IndexExpr ie : indices)
@@ -277,7 +80,7 @@ Value IndexExprContext::createKrnlLoadOp(
   return getRewriter().create<KrnlLoadOp>(getLoc(), memref, loadIndices);
 }
 
-void IndexExprContext::createKrnlStoreOp(
+void IndexExprScope::createKrnlStoreOp(
     Value val, Value memref, SmallVectorImpl<IndexExpr> &indices) {
   SmallVector<Value, 4> storeIndices;
   for (IndexExpr ie : indices)
@@ -286,24 +89,43 @@ void IndexExprContext::createKrnlStoreOp(
 }
 
 //===----------------------------------------------------------------------===//
-// IndexExprContext support for dim and symbol lists in affine exprs.
+// IndexExprScope builder for IndexExpr.
 //===----------------------------------------------------------------------===//
 
-int IndexExprContext::addDim(Value const value) {
+void IndexExprScope::addIndexExprImpl(IndexExprImpl *obj) {
+  container.emplace_back(obj);
+}
+
+//===----------------------------------------------------------------------===//
+// IndexExprScope support for dim and symbol lists in affine exprs.
+//===----------------------------------------------------------------------===//
+
+int IndexExprScope::addDim(Value const value) {
   dims.emplace_back(value);
   return dims.size() - 1;
   ;
 }
-int IndexExprContext::addSymbol(Value const value) {
+int IndexExprScope::addSymbol(Value const value) {
   symbols.emplace_back(value);
   return symbols.size() - 1;
 }
 
 //===----------------------------------------------------------------------===//
-// IndexExprContext getters.
+// IndexExprScope getters.
 //===----------------------------------------------------------------------===//
 
-void IndexExprContext::getDimAndSymbolList(SmallVectorImpl<Value> &list) const {
+bool IndexExprScope::isCurrentScope() { return getCurrentScopePtr() == this; }
+
+bool IndexExprScope::isParentOfCurrentScope() {
+  for (IndexExprScope *s = getCurrentScopePtr()->parentScope; s;
+       s = s->parentScope) {
+    if (s == this)
+      return true;
+  }
+  return false;
+}
+
+void IndexExprScope::getDimAndSymbolList(SmallVectorImpl<Value> &list) const {
   list.clear();
   for (auto dim : dims)
     list.emplace_back(dim);
@@ -311,242 +133,141 @@ void IndexExprContext::getDimAndSymbolList(SmallVectorImpl<Value> &list) const {
     list.emplace_back(sym);
 }
 
-ConversionPatternRewriter &IndexExprContext::getRewriter() const {
+ConversionPatternRewriter &IndexExprScope::getRewriter() const {
   assert(rewriter);
   return *rewriter;
-}
-
-//===----------------------------------------------------------------------===//
-// IndexExprContext static helper functions.
-//===----------------------------------------------------------------------===//
-
-/*static*/ bool IndexExprContext::areAllLiteral(
-    SmallVectorImpl<IndexExpr> &list) {
-  for (auto index : list) {
-    if (!index.isLiteral())
-      return false;
-  }
-  return true;
-}
-
-/*static*/ bool IndexExprContext::areAllAffine(
-    SmallVectorImpl<IndexExpr> &list) {
-  for (auto index : list) {
-    if (!index.isAffine())
-      return false;
-  }
-  return true;
-}
-
-/*static*/ void IndexExprContext::getOutputDimsForType(
-    SmallVectorImpl<IndexExpr> &outputIndices,
-    SmallVectorImpl<int64_t> &outputDims) {
-  outputDims.clear();
-  for (IndexExpr &outputIndex : outputIndices) {
-    if (outputIndex.isLiteral()) {
-      int64_t val = outputIndex.getLiteral();
-      assert(val >= 0 && "expected positive values only");
-      outputDims.emplace_back(val);
-    } else
-      outputDims.emplace_back(-1);
-  }
 }
 
 //===----------------------------------------------------------------------===//
 // IndexExprImpl constructors, initializers
 //===----------------------------------------------------------------------===//
 
-IndexExprImpl::IndexExprImpl(IndexExprContext *indexExprContext)
-    : defined(false), literal(false), type(IndexExprType::NonAffine), intLit(0),
-      affineExpr(nullptr), value(nullptr), context(indexExprContext) {}
+IndexExprImpl::IndexExprImpl()
+    : defined(false), literal(false), kind(IndexExprKind::NonAffine), intLit(0),
+      affineExpr(nullptr), value(nullptr) {
+  // Set scope from thread private global.
+  scope = IndexExprScope::getCurrentScopePtr();
+  assert(scope && "expected IndexExpr Scope to be defined");
+  // Record the new index expr implementation.
+  scope->addIndexExprImpl(this);
+}
 
 void IndexExprImpl::initAsUndefined() {
-  init(/*context*/ nullptr, /*isDefined*/ false, /*literal*/ false,
-      IndexExprType::NonAffine, 0, AffineExpr(nullptr), Value(nullptr));
+  init(/*isDefined*/ false, /*literal*/ false, IndexExprKind::NonAffine, 0,
+      AffineExpr(nullptr), Value(nullptr));
 }
 
-void IndexExprImpl::initAsQuestionmark(IndexExprContext &newContext) {
-  init(&newContext, /*isDefined*/ true, /*literal*/ false,
-      IndexExprType::QuestionMark, 0, AffineExpr(nullptr), Value(nullptr));
+void IndexExprImpl::initAsQuestionmark() {
+  init(/*isDefined*/ true, /*literal*/ false, IndexExprKind::Questionmark, 0,
+      AffineExpr(nullptr), Value(nullptr));
 }
 
-void IndexExprImpl::initAsLiteral(
-    IndexExprContext &newContext, int64_t const val) {
-  init(&newContext, /*isDefined*/ true, /*literal*/ true, IndexExprType::Affine,
-      val, AffineExpr(nullptr), Value(nullptr));
+void IndexExprImpl::initAsLiteral(int64_t const val) {
+  init(/*isDefined*/ true, /*literal*/ true, IndexExprKind::Affine, val,
+      AffineExpr(nullptr), Value(nullptr));
 }
 
-void IndexExprImpl::initAsType(
-    IndexExprContext &newContext, Value const val, IndexExprType newType) {
-  if (newType == IndexExprType::QuestionMark) {
-    initAsQuestionmark(newContext);
+void IndexExprImpl::initAsKind(Value const val, IndexExprKind const newKind) {
+  if (newKind == IndexExprKind::Questionmark) {
+    initAsQuestionmark();
     return;
   }
   // Val should exist, because we come here only when passing an actual val, but
   // we might consider checking.
-
+  assert(val != nullptr && "expected a defined value");
   // Do we have a literal integer, if we do, handle it now.
   int64_t valIntLit;
   if (getIntegerLiteralFromValue(val, valIntLit)) {
     // We have an integer. No need for symbol or dim. It is by default affine.
     // Ignore the predicate type as we treat all literal int as untyped.
-    initAsLiteral(newContext, valIntLit);
+    initAsLiteral(valIntLit);
     return;
   }
   // We have a value that is not a literal.
-  if (newContext.isShapeInferencePass()) {
-    initAsQuestionmark(newContext);
+  if (scope->isShapeInferencePass()) {
+    initAsQuestionmark();
     return;
   }
   // Check that the value is of the right type.
   auto type = val.getType();
   Value newVal = val;
   if (type.isa<IntegerType>()) {
-    if (newType != IndexExprType::Predicate) {
+    if (newKind != IndexExprKind::Predicate) {
       // We need to convert the int into an index, since we are dealing with
       // index expressions.
-      newVal = newContext.getRewriter().create<IndexCastOp>(
-          newContext.getLoc(), newContext.getRewriter().getIndexType(), newVal);
+      newVal = scope->getRewriter().create<IndexCastOp>(
+          scope->getLoc(), scope->getRewriter().getIndexType(), newVal);
     }
   } else if (type.isa<IndexType>()) {
-    if (newType == IndexExprType::Predicate) {
+    if (newKind == IndexExprKind::Predicate) {
       // We need to convert the int into an index, since we are dealing with
       // index expressions.
-      newVal = newContext.getRewriter().create<IndexCastOp>(
-          newContext.getLoc(), newContext.getRewriter().getI1Type(), newVal);
+      newVal = scope->getRewriter().create<IndexCastOp>(
+          scope->getLoc(), scope->getRewriter().getI1Type(), newVal);
     }
   } else {
     llvm_unreachable("unsupported element type");
   }
   // Now record the value. Affine Expr will be created on demand by
   // getAffineExpr.
-  init(&newContext, /*isDefined*/ true, /*literal*/ false, newType, 0,
-      AffineExpr(nullptr), newVal);
+  init(/*isDefined*/ true, /*literal*/ false, newKind, 0, AffineExpr(nullptr),
+      newVal);
 }
 
-void IndexExprImpl::initAsAffineExpr(
-    IndexExprContext &newContext, AffineExpr const val) {
-  // TODO: check that val exists.
+void IndexExprImpl::initAsAffineExpr(AffineExpr const val) {
   // Check if the affine expression is reduced to a constant expr.
-  AffineExpr simpleVal = simplifyAffineExpr(
-      val, newContext.getNumDims(), newContext.getNumSymbols());
+  AffineExpr simpleVal =
+      simplifyAffineExpr(val, scope->getNumDims(), scope->getNumSymbols());
   AffineConstantExpr constAffineExpr = simpleVal.dyn_cast<AffineConstantExpr>();
   if (constAffineExpr) {
-    initAsLiteral(newContext, constAffineExpr.getValue());
+    initAsLiteral(constAffineExpr.getValue());
   } else {
-    init(&newContext, /*isDefined*/ true, /*literal*/ false,
-        IndexExprType::Affine, 0, AffineExpr(val), Value(nullptr));
+    init(/*isDefined*/ true, /*literal*/ false, IndexExprKind::Affine, 0,
+        AffineExpr(val), Value(nullptr));
   }
 }
 
-void IndexExprImpl::init(IndexExprContext *newContext, bool newIsDefined,
-    bool newIsIntLit, IndexExprType newType, int64_t const newIntLit,
+void IndexExprImpl::init(bool newIsDefined, bool newIsIntLit,
+    IndexExprKind newKind, int64_t const newIntLit,
     AffineExpr const newAffineExpr, Value const newValue) {
-  context = newContext;
   defined = newIsDefined;
   literal = newIsIntLit;
-  type = newType;
+  kind = newKind;
   intLit = newIntLit;
   affineExpr = newAffineExpr;
   value = newValue;
 }
 
-//===----------------------------------------------------------------------===//
-// IndexExprImpl initializers that extract info
-//===----------------------------------------------------------------------===//
-
-void IndexExprImpl::initAsDimFromShapedType(
-    IndexExprContext &newContext, Value tensorOrMemref, int index) {
-  // Get shape from tensor or memref value.
-  ArrayRef<int64_t> shape =
-      tensorOrMemref.getType().cast<ShapedType>().getShape();
-  if (shape[index] >= 0) {
-    // We have a constant dimension.
-    int64_t intVal = shape[index];
-    initAsLiteral(newContext, intVal);
-    return;
-  }
-  // We have a dynamic dimension.
-  if (newContext.isShapeInferencePass()) {
-    initAsQuestionmark(newContext);
-  } else {
-    Value dynVal = newContext.getRewriter().create<DimOp>(
-        newContext.getLoc(), tensorOrMemref, index);
-    initAsType(newContext, dynVal, IndexExprType::Dim);
-  }
-}
-
-void IndexExprImpl::initAsSymbolFromArrayAtIndex(IndexExprContext &newContext,
-    Operation *op, Value array, uint64_t indexInArray) {
-  if (auto attrArray = getDenseElementAttributeFromValue(array)) {
-    // We extracted an dense attribute from definition of operand.
-    if (indexInArray >= attrArray.getType().getDimSize(0)) {
-      printf("error 1\n");
-      op->emitError("operand literal has wrong shape");
-      initAsUndefined();
-      return;
-    }
-    auto attrVal = attrArray.getValue(ArrayRef<uint64_t>({indexInArray}));
-    int64_t attrInt = attrVal.cast<IntegerAttr>().getInt();
-    initAsLiteral(newContext, attrInt);
-    return;
-  }
-  // We must read value from an array.
-  if (newContext.isShapeInferencePass()) {
-    // Not a constant; don't add code.
-    initAsQuestionmark(newContext);
-    return;
-  }
-  // Emit code to read array.
-  Value indexVal = emitConstantOp(newContext.getRewriter(), newContext.getLoc(),
-      newContext.getRewriter().getIndexType(), indexInArray);
-  SmallVector<Value, 1> memrefVal = {indexVal};
-  Value loadVal = newContext.getRewriter().create<KrnlLoadOp>(
-      newContext.getLoc(), array, memrefVal);
-  initAsType(newContext, loadVal, IndexExprType::Symbol);
-}
-
-void IndexExprImpl::initAsSymbolFromArrayAtIndex(IndexExprContext &newContext,
-    Operation *op, Value array, uint64_t indexInArray, int64_t defaultLiteral) {
-  // Check if we have an operand.
-  if (array.getType().isa<NoneType>()) {
-    // Operand undefined, we use the default value.
-    initAsLiteral(newContext, defaultLiteral);
-    return;
-  }
-  if (auto attrArray = getDenseElementAttributeFromValue(array)) {
-    // We extracted an dense attribute from definition of operand.
-    if (indexInArray > attrArray.getType().getDimSize(0)) {
-      // Not enough attributes for this index, return the default value.
-      initAsLiteral(newContext, defaultLiteral);
-      return;
-    }
-    // We have enough attributes for this index, get the value.
-    Attribute attrVal = attrArray.getValue(ArrayRef<uint64_t>({indexInArray}));
-    int64_t attrInt = attrVal.cast<IntegerAttr>().getInt();
-    initAsLiteral(newContext, attrInt);
-    return;
-  }
-  // Read the value from an array.
-  if (newContext.isShapeInferencePass()) {
-    // Not a constant; don't add code.
-    initAsQuestionmark(newContext);
-    return;
-  }
-  // Emit the code to read array.
-  Value indexVal = emitConstantOp(newContext.getRewriter(), newContext.getLoc(),
-      newContext.getRewriter().getIndexType(), indexInArray);
-  SmallVector<Value, 1> memrefVal = {indexVal};
-  Value loadVal = newContext.getRewriter().create<KrnlLoadOp>(
-      newContext.getLoc(), array, memrefVal);
-  initAsType(newContext, loadVal, IndexExprType::Symbol);
-}
-
 void IndexExprImpl::copy(IndexExprImpl const *other) {
-  assert(context && "all index expr must have a defined context");
-  // Preserve this context, copy the remaining attributes from other.
-  init(context, other->defined, other->literal, other->type, other->intLit,
+  assert(scope && "all index expr must have a defined scope");
+  // Preserve this scope, copy the remaining attributes from other.
+  init(other->defined, other->literal, other->kind, other->intLit,
       other->affineExpr, other->value);
+}
+
+//===----------------------------------------------------------------------===//
+// IndexExpr constructors
+//===----------------------------------------------------------------------===//
+
+IndexExpr::IndexExpr(int64_t const val) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsLiteral(val);
+}
+
+IndexExpr::IndexExpr(Value const value)
+    : IndexExpr(value, IndexExprKind::NonAffine) {}
+
+IndexExpr::IndexExpr(AffineExpr const value) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsAffineExpr(value);
+}
+
+IndexExpr::IndexExpr(Value const value, IndexExprKind newKind) {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsKind(value, newKind);
 }
 
 //===----------------------------------------------------------------------===//
@@ -554,10 +275,12 @@ void IndexExprImpl::copy(IndexExprImpl const *other) {
 //===----------------------------------------------------------------------===//
 
 IndexExpr IndexExpr::deepCopy() const {
-  // If we go to a model like Values & AffineExpr with a pointer to the actual
-  // data, we should just make the indirection here. copy info in the
-  // meanwhile.
-  return getContext().createIndex(*this);
+  // Create new implementation and set scope to current scope (don't copy it).
+  IndexExprImpl *newImplObj = new IndexExprImpl();
+  assert(newImplObj && "failed to allocate IndexExpr implemtation");
+  // Copy all of hte other fields (preserving current scope).
+  newImplObj->copy(getObjPtr());
+  return IndexExpr(newImplObj);
 }
 
 //===----------------------------------------------------------------------===//
@@ -580,35 +303,35 @@ bool IndexExpr::isLiteral() const {
 
 bool IndexExpr::isQuestionmark() const {
   assert(isDefined());
-  return getObj().type == IndexExprType::QuestionMark;
+  return getKind() == IndexExprKind::Questionmark;
 }
 
 bool IndexExpr::isAffine() const {
   assert(isDefined());
   // Note that we do bitvector and to check affine properties.
-  return (int)getObj().type & (int)IndexExprType::Affine;
+  return (int)getKind() & (int)IndexExprKind::Affine;
 }
 
 bool IndexExpr::isSymbol() const {
   assert(isDefined());
-  return getObj().type == IndexExprType::Symbol;
+  return getKind() == IndexExprKind::Symbol;
 }
 
 bool IndexExpr::isDim() const {
   assert(isDefined());
-  return getObj().type == IndexExprType::Dim;
+  return getKind() == IndexExprKind::Dim;
 }
 
 bool IndexExpr::isPredType() const {
   assert(isDefined());
-  return getObj().type == IndexExprType::Predicate;
+  return getKind() == IndexExprKind::Predicate;
 }
 
 bool IndexExpr::isShapeInferencePass() const {
-  return getContext().isShapeInferencePass();
+  return getScope().isShapeInferencePass();
 }
 
-bool IndexExpr::hasContext() const { return getObj().context != nullptr; }
+bool IndexExpr::hasContext() const { return getObj().scope != nullptr; }
 
 bool IndexExpr::hasAffineExpr() const {
   assert(isDefined());
@@ -657,7 +380,7 @@ bool IndexExpr::isLiteralAndDifferentThan(IndexExpr const b) const {
 //===----------------------------------------------------------------------===//
 
 int64_t IndexExpr::getLiteral() const {
-  assert(isLiteral());
+  assert(isLiteral() && "expected a literal index expression");
   return getObj().intLit;
 }
 
@@ -672,15 +395,15 @@ AffineExpr IndexExpr::getAffineExpr() const {
     // array of symbols. Has value because symbols are gen on demand from
     // values.
     assert(hasValue());
-    int id = getContext().addSymbol(getObj().value);
-    getObj().affineExpr = getContext().getRewriter().getAffineSymbolExpr(id);
+    int id = getScope().addSymbol(getObj().value);
+    getObj().affineExpr = getRewriter().getAffineSymbolExpr(id);
   } else if (isDim()) {
     // Create a dim/index value expr and register its value in the
     // array of dims/indices. Has value because dims are gen on demand from
     // values.
     assert(hasValue());
-    int id = getContext().addDim(getObj().value);
-    getObj().affineExpr = getContext().getRewriter().getAffineDimExpr(id);
+    int id = getScope().addDim(getObj().value);
+    getObj().affineExpr = getRewriter().getAffineDimExpr(id);
   } else {
     assert(
         hasAffineExpr() && "requesting affine expr of incompatible IndexExpr");
@@ -692,7 +415,7 @@ Value IndexExpr::getValue() const {
   assert(!isShapeInferencePass() && "cannot get affine during shape inference");
 
   // If we already have a value, no need to recompute it as all values must be
-  // in the same scope.
+  // in the same scope->
   if (hasValue())
     return getObj().value;
 
@@ -706,14 +429,14 @@ Value IndexExpr::getValue() const {
     // Has an affine expression: need to build a map, and then perform an
     // affine.apply.
     assert(!isPredType() && "no affine support for predicate type");
-    int dimNum = getContext().getNumDims();
-    int symNum = getContext().getNumSymbols();
+    int dimNum = getScope().getNumDims();
+    int symNum = getScope().getNumSymbols();
     AffineMap map = AffineMap::get(
         dimNum, symNum, {getObj().affineExpr}, getRewriter().getContext());
     // We need to concatenate the dims and symbol into a single
     // list, and then use the apply.
     SmallVector<Value, 4> list;
-    getContext().getDimAndSymbolList(list);
+    getScope().getDimAndSymbolList(list);
     getObj().value = getRewriter().create<AffineApplyOp>(getLoc(), map, list);
   } else {
     llvm_unreachable("bad path");
@@ -721,13 +444,13 @@ Value IndexExpr::getValue() const {
   return getObj().value;
 }
 
-IndexExprContext *IndexExpr::getContextPtr() const {
+IndexExprScope *IndexExpr::getScopePtr() const {
   assert(hasContext());
-  return getObj().context;
+  return getObj().scope;
 }
 
 ConversionPatternRewriter &IndexExpr::getRewriter() const {
-  return getContext().getRewriter();
+  return getScope().getRewriter();
 }
 
 void IndexExpr::debugPrint(const std::string &msg) const {
@@ -741,7 +464,23 @@ void IndexExpr::debugPrint(const std::string &msg) const {
     printf(" hasValue");
   if (isAffine())
     printf(" is affine");
-  printf(" context(0x%llx)\n", (long long unsigned)getContextPtr());
+  switch (getKind()) {
+    case IndexExprKind::NonAffine : printf(" kind(non-affine)");
+    break;
+    case IndexExprKind::Questionmark :  printf(" kind(questionmark)");
+    break;
+    case IndexExprKind::Predicate :  printf(" kind(predicate)");
+    break;
+    case IndexExprKind::Affine :printf(" kind(affine)");
+    break;
+    case IndexExprKind::Dim :printf(" kind(dim)");
+    break;
+    case IndexExprKind::Symbol :printf(" kind(symbol)");
+    break;
+    default :printf(" kind(unknown)");
+    break;
+  }
+  printf(" scope(0x%llx)\n", (long long unsigned)getScopePtr());
 #endif
 }
 
@@ -752,6 +491,26 @@ IndexExprImpl *IndexExpr::getObjPtr() const {
   return indexExprObj;
 }
 
+IndexExprKind IndexExpr::getKind() const { return getObj().kind; }
+
+//===----------------------------------------------------------------------===//
+// Helpers for IndexExpressions
+//===----------------------------------------------------------------------===//
+
+/* static */ void IndexExpr::convertListOfIndexExprToIntegerDim(
+    SmallVectorImpl<IndexExpr> &indexExprList,
+    SmallVectorImpl<int64_t> &intDimList) {
+  intDimList.clear();
+  for (IndexExpr &expr : indexExprList) {
+    if (expr.isLiteral()) {
+      int64_t val = expr.getLiteral();
+      assert(val >= 0 && "expected positive values only");
+      intDimList.emplace_back(val);
+    } else
+      intDimList.emplace_back(-1);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // IndexExpr Op Support.
 //===----------------------------------------------------------------------===//
@@ -759,7 +518,7 @@ IndexExprImpl *IndexExpr::getObjPtr() const {
 // Used for add/sub/mult/ceilDiv/floorDiv
 IndexExpr IndexExpr::binaryOp(IndexExpr const b, bool affineWithLitB,
     bool canBeAffine, F2 litFct, F2 affineExprFct, F2 valueFct) const {
-  assert(getContextPtr() == b.getContextPtr() && "incompatible contexts");
+  assert(getScopePtr() == b.getScopePtr() && "incompatible contexts");
   // Literal integer if a and b are literals. Affine if canBeAffine is true,
   // both a and b are affine, and possibly a and/or b are also constant.
   bool resIsLit = isLiteral() && b.isLiteral();
@@ -774,7 +533,7 @@ IndexExpr IndexExpr::binaryOp(IndexExpr const b, bool affineWithLitB,
   if (isShapeInferencePass())
     // In shape analysis, if not constant: do noting, aka leave Values &
     // Affine expr undefined.
-    return getContext().createQuestionmarkIndex();
+    return QuestionmarkIndexExpr();
   if (resIsAffine)
     // Use affine values.
     return affineExprFct(*this, b);
@@ -790,37 +549,37 @@ IndexExpr IndexExpr::compareOp(
     switch (comparePred) {
     case CmpIPredicate::eq:
       if (aaa == bbb)
-        return aa.getContext().createLiteralIndex(1);
+        return LiteralIndexExpr(1);
       break;
     case CmpIPredicate::ne:
       if (aaa != bbb)
-        return aa.getContext().createLiteralIndex(1);
+        return LiteralIndexExpr(1);
       break;
     case CmpIPredicate::slt:
       if (aaa < bbb)
-        return aa.getContext().createLiteralIndex(1);
+        return LiteralIndexExpr(1);
       break;
     case CmpIPredicate::sle:
       if (aaa <= bbb)
-        return aa.getContext().createLiteralIndex(1);
+        return LiteralIndexExpr(1);
       break;
     case CmpIPredicate::sgt:
       if (aaa > bbb)
-        return aa.getContext().createLiteralIndex(1);
+        return LiteralIndexExpr(1);
       break;
     case CmpIPredicate::sge:
       if (aaa >= bbb)
-        return aa.getContext().createLiteralIndex(1);
+        return LiteralIndexExpr(1);
       break;
     default:
       llvm_unreachable("unknown or illegal (unsigned) compare operator");
     }
-    return aa.getContext().createLiteralIndex(0);
+    return LiteralIndexExpr(0);
   };
   F2 valueFct = [&](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     Value compare = aa.getRewriter().create<CmpIOp>(
         aa.getLoc(), comparePred, aa.getValue(), bb.getValue());
-    return aa.getContext().createPredicateIndex(compare);
+    return PredicateIndexExpr(compare);
   };
   // Cannot have affine results, disable and pass null lambda function.
   return binaryOp(b, false, false, litFct, nullptr, valueFct);
@@ -833,7 +592,7 @@ IndexExpr IndexExpr::compareOp(
   // If no values, result is undefined.
   int size = vals.size();
   if (size == 0) {
-    return vals[0].getContext().createUndefinedIndex();
+    return UndefinedIndexExpr();
   }
   // Set the output to the first value.
   IndexExpr res = vals[0].deepCopy();
@@ -849,7 +608,7 @@ IndexExpr IndexExpr::compareOp(
       resIsLit = false;
     if (!vals[i].isAffine())
       resIsAffine = false;
-    assert(vals[0].getContextPtr() == vals[i].getContextPtr() &&
+    assert(vals[0].getScopePtr() == vals[i].getScopePtr() &&
            "incompatible contexts");
   }
   if (resIsLit) {
@@ -863,8 +622,7 @@ IndexExpr IndexExpr::compareOp(
   }
   if (vals[0].isShapeInferencePass()) {
     // Just set as undefined
-    res.getObj().initAsQuestionmark(res.getContext());
-    return res;
+    return QuestionmarkIndexExpr();
   }
   if (resIsAffine) {
     // Affine handles the hole list
@@ -883,15 +641,13 @@ IndexExpr IndexExpr::compareOp(
 
 IndexExpr IndexExpr::operator+(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return aa.getContext().createLiteralIndex(
-        aa.getLiteral() + bb.getLiteral());
+    return LiteralIndexExpr(aa.getLiteral() + bb.getLiteral());
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return aa.getContext().createAffineIndex(
-        aa.getAffineExpr() + bb.getAffineExpr());
+    return AffineIndexExpr(aa.getAffineExpr() + bb.getAffineExpr());
   };
   F2 valueFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return aa.getContext().createNonAffineIndex(aa.getRewriter().create<AddIOp>(
+    return NonAffineIndexExpr(aa.getRewriter().create<AddIOp>(
         aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   return binaryOp(b, false, true, litFct, affineExprFct, valueFct);
@@ -899,15 +655,13 @@ IndexExpr IndexExpr::operator+(IndexExpr const b) const {
 
 IndexExpr IndexExpr::operator-(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return aa.getContext().createLiteralIndex(
-        aa.getLiteral() - bb.getLiteral());
+    return LiteralIndexExpr(aa.getLiteral() - bb.getLiteral());
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return aa.getContext().createAffineIndex(
-        aa.getAffineExpr() - bb.getAffineExpr());
+    return AffineIndexExpr(aa.getAffineExpr() - bb.getAffineExpr());
   };
   F2 valueFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return aa.getContext().createNonAffineIndex(aa.getRewriter().create<SubIOp>(
+    return NonAffineIndexExpr(aa.getRewriter().create<SubIOp>(
         aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   return binaryOp(b, false, true, litFct, affineExprFct, valueFct);
@@ -915,17 +669,15 @@ IndexExpr IndexExpr::operator-(IndexExpr const b) const {
 
 IndexExpr IndexExpr::operator*(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return aa.getContext().createLiteralIndex(
-        aa.getLiteral() * bb.getLiteral());
+    return LiteralIndexExpr(aa.getLiteral() * bb.getLiteral());
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return aa.getContext().createAffineIndex(
-        aa.getAffineExpr() * bb.getAffineExpr());
+    return AffineIndexExpr(aa.getAffineExpr() * bb.getAffineExpr());
   };
   F2 valueFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     if (bb.isLiteral() && bb.getLiteral() == 1)
       return aa.deepCopy();
-    return aa.getContext().createNonAffineIndex(aa.getRewriter().create<MulIOp>(
+    return NonAffineIndexExpr(aa.getRewriter().create<MulIOp>(
         aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   // Literal should be place in second argument; do so if a is a lit.
@@ -937,7 +689,7 @@ IndexExpr IndexExpr::operator*(IndexExpr const b) const {
 IndexExpr IndexExpr::floorDiv(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     int64_t rval = floor((1.0 * aa.getLiteral()) / (1.0 * bb.getLiteral()));
-    return aa.getContext().createLiteralIndex(rval);
+    return LiteralIndexExpr(rval);
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     // Operand bb must be a literal.
@@ -945,19 +697,16 @@ IndexExpr IndexExpr::floorDiv(IndexExpr const b) const {
     if (bval == 1)
       return aa.deepCopy();
     if (bval > 1)
-      return aa.getContext().createAffineIndex(
-          aa.getAffineExpr().floorDiv(bval));
-    return aa.getContext().createNonAffineIndex(
-        aa.getRewriter().create<SignedFloorDivIOp>(
-            aa.getLoc(), aa.getValue(), bb.getValue()));
+      return AffineIndexExpr(aa.getAffineExpr().floorDiv(bval));
+    return NonAffineIndexExpr(aa.getRewriter().create<SignedFloorDivIOp>(
+        aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   F2 valueFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     if (bb.isLiteral() && bb.getLiteral() == 1) {
       return aa.deepCopy();
     }
-    return aa.getContext().createNonAffineIndex(
-        aa.getRewriter().create<SignedFloorDivIOp>(
-            aa.getLoc(), aa.getValue(), bb.getValue()));
+    return NonAffineIndexExpr(aa.getRewriter().create<SignedFloorDivIOp>(
+        aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   // Index b must be a literal.
   return binaryOp(b, true, true, litFct, affineExprFct, valueFct);
@@ -966,7 +715,7 @@ IndexExpr IndexExpr::floorDiv(IndexExpr const b) const {
 IndexExpr IndexExpr::ceilDiv(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     int64_t rval = ceil((1.0 * aa.getLiteral()) / (1.0 * bb.getLiteral()));
-    return aa.getContext().createLiteralIndex(rval);
+    return LiteralIndexExpr(rval);
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     // Operand bb must be a literal.
@@ -974,19 +723,16 @@ IndexExpr IndexExpr::ceilDiv(IndexExpr const b) const {
     if (bval == 1)
       return aa.deepCopy();
     if (bval > 1)
-      return aa.getContext().createAffineIndex(
-          aa.getAffineExpr().ceilDiv(bval));
-    return aa.getContext().createNonAffineIndex(
-        aa.getRewriter().create<SignedCeilDivIOp>(
-            aa.getLoc(), aa.getValue(), bb.getValue()));
+      return AffineIndexExpr(aa.getAffineExpr().ceilDiv(bval));
+    return NonAffineIndexExpr(aa.getRewriter().create<SignedCeilDivIOp>(
+        aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   F2 valueFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     if (bb.isLiteral() && bb.getLiteral() == 1) {
       return aa.deepCopy();
     }
-    return aa.getContext().createNonAffineIndex(
-        aa.getRewriter().create<SignedCeilDivIOp>(
-            aa.getLoc(), aa.getValue(), bb.getValue()));
+    return NonAffineIndexExpr(aa.getRewriter().create<SignedCeilDivIOp>(
+        aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   // Index b must be a literal.
   return binaryOp(b, true, true, litFct, affineExprFct, valueFct);
@@ -995,24 +741,22 @@ IndexExpr IndexExpr::ceilDiv(IndexExpr const b) const {
 IndexExpr IndexExpr::operator%(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     int64_t rval = mlir::mod(aa.getLiteral(), bb.getLiteral());
-    return aa.getContext().createLiteralIndex(rval);
+    return LiteralIndexExpr(rval);
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     // Operand bb must be a literal.
     int64_t bval = bb.getLiteral();
     if (bval >= 0)
-      return aa.getContext().createAffineIndex(aa.getAffineExpr() % bval);
-    return aa.getContext().createNonAffineIndex(
-        aa.getRewriter().create<SignedRemIOp>(
-            aa.getLoc(), aa.getValue(), bb.getValue()));
+      return AffineIndexExpr(aa.getAffineExpr() % bval);
+    return NonAffineIndexExpr(aa.getRewriter().create<SignedRemIOp>(
+        aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   F2 valueFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     if (bb.isLiteral() && bb.getLiteral() == 1) {
       return aa.deepCopy();
     }
-    return aa.getContext().createNonAffineIndex(
-        aa.getRewriter().create<SignedRemIOp>(
-            aa.getLoc(), aa.getValue(), bb.getValue()));
+    return NonAffineIndexExpr(aa.getRewriter().create<SignedRemIOp>(
+        aa.getLoc(), aa.getValue(), bb.getValue()));
   };
   // Index b must be a literal.
   return binaryOp(b, true, true, litFct, affineExprFct, valueFct);
@@ -1030,7 +774,7 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
       res = smin;
     if (res > smax)
       res = smax;
-    return val.getContext().createLiteralIndex(res);
+    return LiteralIndexExpr(res);
   };
   F3 valueFct = [](IndexExpr const val, IndexExpr const min,
                     IndexExpr const max) {
@@ -1039,8 +783,8 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
     return res2;
   };
 
-  assert(getContextPtr() == min.getContextPtr() &&
-         getContextPtr() == max.getContextPtr() && "incompatible contexts");
+  assert(getScopePtr() == min.getScopePtr() &&
+         getScopePtr() == max.getScopePtr() && "incompatible contexts");
   // Literal integer if a, b, and c are literals. Output is not affine (unless
   // all 3 are literals).
   bool resIsLit = isLiteral() && min.isLiteral() && max.isLiteral();
@@ -1052,15 +796,15 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
   if (isShapeInferencePass())
     // In shape analysis, if not constant: do noting, aka leave Values &
     // Affine expr undefined.
-    return getContext().createQuestionmarkIndex();
+    return QuestionmarkIndexExpr();
   // Use values.
   return valueFct(*this, min, max);
 }
 
 /*static*/ IndexExpr IndexExpr::select(IndexExpr const compare,
     IndexExpr const trueVal, IndexExpr const falseVal) {
-  assert(compare.getContextPtr() == trueVal.getContextPtr() &&
-         compare.getContextPtr() == falseVal.getContextPtr() &&
+  assert(compare.getScopePtr() == trueVal.getScopePtr() &&
+         compare.getScopePtr() == falseVal.getScopePtr() &&
          "incompatible contexts");
   // When compare result is literal, just feed forward the right value.
   if (compare.isLiteral()) {
@@ -1070,11 +814,11 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
   }
   // Dynamic value, just set as undefined during shape inference pass.
   if (compare.isShapeInferencePass())
-    return compare.getContext().createQuestionmarkIndex();
+    return QuestionmarkIndexExpr();
   // Generate code for the select.
   Value results = compare.getRewriter().create<SelectOp>(compare.getLoc(),
       compare.getValue(), trueVal.getValue(), falseVal.getValue());
-  return compare.getContext().createNonAffineIndex(results);
+  return NonAffineIndexExpr(results);
 }
 
 /*static*/ IndexExpr IndexExpr::min(SmallVectorImpl<IndexExpr> &vals) {
@@ -1095,27 +839,26 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
       affineExprs.emplace_back(vv.getAffineExpr());
     }
     // Compute a map including the list of affine expressions.
-    IndexExprContext &context = vvals[0].getContext();
-    int dimNum = context.getNumDims();
-    int symNum = context.getNumSymbols();
-    auto mapContext = context.getRewriter().getContext();
+    IndexExprScope &scope = vvals[0].getScope();
+    int dimNum = scope.getNumDims();
+    int symNum = scope.getNumSymbols();
+    auto mapContext = scope.getRewriter().getContext();
     AffineMap map = AffineMap::get(dimNum, symNum, affineExprs, mapContext);
     // Compute the min value out of this map.
     SmallVector<Value, 4> dimAndSymList;
-    context.getDimAndSymbolList(dimAndSymList);
-    Value minVal = context.getRewriter().create<AffineMinOp>(
+    scope.getDimAndSymbolList(dimAndSymList);
+    Value minVal = scope.getRewriter().create<AffineMinOp>(
         vvals[0].getLoc(), map, dimAndSymList);
-    res.getObj().initAsType(context, minVal, IndexExprType::NonAffine);
+    res.getObj().initAsKind(minVal, IndexExprKind::NonAffine);
     return res;
   };
   // Res is already defined, we are reducing into it.
   F2Self valueFct = [](IndexExpr res, IndexExpr const aa) {
     Value compareVal = res.getRewriter().create<CmpIOp>(
         aa.getLoc(), CmpIPredicate::slt, aa.getValue(), res.getValue());
-    Value resVal = aa.getContext().getRewriter().create<SelectOp>(
+    Value resVal = aa.getRewriter().create<SelectOp>(
         aa.getLoc(), compareVal, aa.getValue(), res.getValue());
-    res.getObj().initAsType(
-        res.getContext(), res.getValue(), IndexExprType::NonAffine);
+    res.getObj().initAsKind(res.getValue(), IndexExprKind::NonAffine);
     return res;
   };
   return reductionOp(vals, litFct, affineExprFct, valueFct);
@@ -1139,27 +882,26 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
       affineExprs.emplace_back(vv.getAffineExpr());
     }
     // Compute a map including the list of affine expressions.
-    IndexExprContext &context = vvals[0].getContext();
-    int dimNum = context.getNumDims();
-    int symNum = context.getNumSymbols();
-    auto mapContext = context.getRewriter().getContext();
+    IndexExprScope &scope = vvals[0].getScope();
+    int dimNum = scope.getNumDims();
+    int symNum = scope.getNumSymbols();
+    auto mapContext = scope.getRewriter().getContext();
     AffineMap map = AffineMap::get(dimNum, symNum, affineExprs, mapContext);
     // Compute the min value out of this map.
     SmallVector<Value, 4> dimAndSymList;
-    context.getDimAndSymbolList(dimAndSymList);
-    Value minVal = context.getRewriter().create<AffineMaxOp>(
+    scope.getDimAndSymbolList(dimAndSymList);
+    Value minVal = scope.getRewriter().create<AffineMaxOp>(
         vvals[0].getLoc(), map, dimAndSymList);
-    res.getObj().initAsType(context, minVal, IndexExprType::NonAffine);
+    res.getObj().initAsKind(minVal, IndexExprKind::NonAffine);
     return res;
   };
   // Res is already defined, we are reducing into it.
   F2Self valueFct = [](IndexExpr res, IndexExpr const aa) {
     Value compareVal = res.getRewriter().create<CmpIOp>(
         aa.getLoc(), CmpIPredicate::sgt, aa.getValue(), res.getValue());
-    Value resVal = aa.getContext().getRewriter().create<SelectOp>(
+    Value resVal = aa.getRewriter().create<SelectOp>(
         aa.getLoc(), compareVal, aa.getValue(), res.getValue());
-    res.getObj().initAsType(
-        res.getContext(), res.getValue(), IndexExprType::NonAffine);
+    res.getObj().initAsKind(res.getValue(), IndexExprKind::NonAffine);
     return res;
   };
   return reductionOp(vals, litFct, affineExprFct, valueFct);
@@ -1170,18 +912,15 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
 //===----------------------------------------------------------------------===//
 
 IndexExpr IndexExpr::operator+(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this + bIndex;
+  return *this + LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::operator-(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this - bIndex;
+  return *this - LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::operator*(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this * bIndex;
+  return *this * LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::operator==(IndexExpr const b) const {
@@ -1189,8 +928,7 @@ IndexExpr IndexExpr::operator==(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator==(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this == bIndex;
+  return *this == LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::operator!=(IndexExpr const b) const {
@@ -1198,8 +936,7 @@ IndexExpr IndexExpr::operator!=(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator!=(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this != bIndex;
+  return *this != LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::operator<=(IndexExpr const b) const {
@@ -1207,8 +944,7 @@ IndexExpr IndexExpr::operator<=(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator<=(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this <= bIndex;
+  return *this <= LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::operator<(IndexExpr const b) const {
@@ -1216,8 +952,7 @@ IndexExpr IndexExpr::operator<(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator<(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this < bIndex;
+  return *this < LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::operator>=(IndexExpr const b) const {
@@ -1225,8 +960,7 @@ IndexExpr IndexExpr::operator>=(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator>=(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this >= bIndex;
+  return *this >= LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::operator>(IndexExpr const b) const {
@@ -1234,30 +968,24 @@ IndexExpr IndexExpr::operator>(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator>(int64_t const b) const {
-  IndexExpr bIndex = getContext().createLiteralIndex(b);
-  return *this > bIndex;
+  return *this > LiteralIndexExpr(b);
 }
 
 IndexExpr IndexExpr::clamp(int64_t min, IndexExpr max) {
-  IndexExpr minIndex = getContext().createLiteralIndex(min);
-  return clamp(minIndex, max);
+  return clamp(LiteralIndexExpr(min), max);
 }
 
 /*static*/ IndexExpr IndexExpr::select(
     IndexExpr const compare, int64_t const trueVal, IndexExpr const falseVal) {
-  IndexExpr trueValIndex = compare.getContext().createLiteralIndex(trueVal);
-  return select(compare, trueValIndex, falseVal);
+  return select(compare, LiteralIndexExpr(trueVal), falseVal);
 }
 /*static*/ IndexExpr IndexExpr::select(
     IndexExpr const compare, IndexExpr const trueVal, int64_t const falseVal) {
-  IndexExpr falseValIndex = compare.getContext().createLiteralIndex(falseVal);
-  return select(compare, trueVal, falseValIndex);
+  return select(compare, trueVal, LiteralIndexExpr(falseVal));
 }
 /*static*/ IndexExpr IndexExpr::select(
     IndexExpr const compare, int64_t const trueVal, int64_t const falseVal) {
-  IndexExpr trueValIndex = compare.getContext().createLiteralIndex(trueVal);
-  IndexExpr falseValIndex = compare.getContext().createLiteralIndex(falseVal);
-  return select(compare, trueValIndex, falseValIndex);
+  return select(compare, LiteralIndexExpr(trueVal), LiteralIndexExpr(falseVal));
 }
 
 IndexExpr IndexExpr::selectOrSelf(
@@ -1269,3 +997,339 @@ IndexExpr IndexExpr::selectOrSelf(
     IndexExpr const compare, int64_t const trueVal) const {
   return select(compare, trueVal, *this);
 }
+
+//===----------------------------------------------------------------------===//
+// IndexExpr Subclasses for constructing specific IndexExpr kinds.
+//===----------------------------------------------------------------------===//
+
+UndefinedIndexExpr::UndefinedIndexExpr() : IndexExpr() {}
+
+LiteralIndexExpr::LiteralIndexExpr(int64_t const value) : IndexExpr(value) {}
+
+LiteralIndexExpr::LiteralIndexExpr(IndexExpr const otherIndexExpr) {
+  assert(
+      otherIndexExpr.isLiteral() && "cannot make a literal from non literal");
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implementation");
+  indexExprObj->initAsLiteral(otherIndexExpr.getLiteral());
+  return;
+}
+
+NonAffineIndexExpr::NonAffineIndexExpr(Value const value) : IndexExpr(value) {}
+
+NonAffineIndexExpr::NonAffineIndexExpr(IndexExpr const otherIndexExpr) {
+  // Create new IndexExpr implementation object.
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implementation");
+  // If the index expression is a literal,  just copy it.
+  if (otherIndexExpr.isLiteral()) {
+    indexExprObj->initAsLiteral(otherIndexExpr.getLiteral());
+    return;
+  }
+  // Depending on what kind of index expr we got, take different actions.
+  switch (otherIndexExpr.getKind()) {
+  case IndexExprKind::Questionmark: {
+    assert("cannot make a non-affine from a Questionmark");
+  }
+  case IndexExprKind::NonAffine: {
+    indexExprObj->copy(otherIndexExpr.getObjPtr());
+    return;
+  }
+  case IndexExprKind::Predicate: {
+    assert("cannot make a non-affine from a predicate");
+  }
+  case IndexExprKind::Affine: {
+    indexExprObj->initAsKind(
+        otherIndexExpr.getValue(), IndexExprKind::NonAffine);
+    return;
+  }
+  case IndexExprKind::Dim: {
+    indexExprObj->initAsKind(
+        otherIndexExpr.getValue(), IndexExprKind::NonAffine);
+    return;
+  }
+  case IndexExprKind::Symbol: {
+    indexExprObj->initAsKind(
+        otherIndexExpr.getValue(), IndexExprKind::NonAffine);
+    return;
+  }
+  default:
+    break;
+  }
+  llvm_unreachable("bad path");
+}
+
+QuestionmarkIndexExpr::QuestionmarkIndexExpr() {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implemtation");
+  indexExprObj->initAsQuestionmark();
+}
+
+QuestionmarkIndexExpr::QuestionmarkIndexExpr(IndexExpr const otherIndexExpr)
+    : QuestionmarkIndexExpr() {
+  // Don't care about otherIndexExpr as questionmarks have no real data.
+}
+
+PredicateIndexExpr::PredicateIndexExpr(Value const value)
+    : IndexExpr(value, IndexExprKind::Predicate) {}
+
+PredicateIndexExpr::PredicateIndexExpr(IndexExpr const otherIndexExpr) {
+  // Create new IndexExpr implementation object.
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implementation");
+  // If the index expression is a literal,  just copy it.
+  if (otherIndexExpr.isLiteral()) {
+    indexExprObj->initAsLiteral(otherIndexExpr.getLiteral());
+    return;
+  }
+  assert(otherIndexExpr.getKind() == IndexExprKind::Predicate &&
+         "can only make a predicate from another predicate");
+  indexExprObj->copy(otherIndexExpr.getObjPtr());
+}
+
+AffineIndexExpr::AffineIndexExpr(AffineExpr const value) : IndexExpr(value) {}
+
+AffineIndexExpr::AffineIndexExpr(IndexExpr const otherIndexExpr) {
+  // Create new IndexExpr implementation object.
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implementation");
+  // If the index expression is a literal,  just copy it.
+  if (otherIndexExpr.isLiteral()) {
+    indexExprObj->initAsLiteral(otherIndexExpr.getLiteral());
+    return;
+  }
+  // Depending on what kind of index expr we got, take different actions.
+  bool isSameScope = otherIndexExpr.getScope().isCurrentScope();
+  switch (otherIndexExpr.getKind()) {
+  case IndexExprKind::Questionmark: {
+    assert("cannot make an affine from a Questionmark");
+  }
+  case IndexExprKind::NonAffine: {
+    assert("cannot make an affine from an non affine, affine are made of "
+           "literals, dims, and symbols");
+  }
+  case IndexExprKind::Predicate: {
+    assert("cannot make an affine from a predicate");
+  }
+  case IndexExprKind::Affine: {
+    assert(isSameScope && "cannot can only import literals, dims and symbols "
+                          "from different scopes");
+    indexExprObj->copy(otherIndexExpr.getObjPtr());
+    return;
+  }
+  case IndexExprKind::Dim:
+  case IndexExprKind::Symbol: {
+    assert(isSameScope && "cannot can only import literals, dims and symbols "
+                          "from different scopes");
+    indexExprObj->initAsAffineExpr(otherIndexExpr.getAffineExpr());
+    return;
+  }
+  default:
+    break;
+  }
+  llvm_unreachable("bad path");
+}
+
+DimIndexExpr::DimIndexExpr(Value const value)
+    : IndexExpr(value, IndexExprKind::Dim) {}
+
+DimIndexExpr::DimIndexExpr(IndexExpr const otherIndexExpr) {
+  // Create new IndexExpr implementation object.
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implementation");
+  // If the index expression is a literal,  just copy it.
+  if (otherIndexExpr.isLiteral()) {
+    indexExprObj->initAsLiteral(otherIndexExpr.getLiteral());
+    return;
+  }
+  // Depending on what kind of index expr we got, take different actions.
+  bool isSameScope = otherIndexExpr.getScope().isCurrentScope();
+  switch (otherIndexExpr.getKind()) {
+  case IndexExprKind::Questionmark: {
+    assert("cannot make a dim from a Questionmark");
+  }
+  case IndexExprKind::NonAffine: {
+    indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Dim);
+    return;
+  }
+  case IndexExprKind::Predicate: {
+    assert("cannot make an dim from a predicate");
+  }
+  case IndexExprKind::Affine: {
+    indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Dim);
+    return;
+  }
+  case IndexExprKind::Dim: {
+    assert(!isSameScope && "should not replicate dims in the same scope");
+    indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Dim);
+    return;
+  }
+  case IndexExprKind::Symbol: {
+    assert(!isSameScope && "cannot make a dim from a symbol at the same scope");
+    indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Dim);
+    return;
+  }
+  default:
+    break;
+  }
+  llvm_unreachable("bad path");
+}
+
+SymbolIndexExpr::SymbolIndexExpr(Value const value)
+    : IndexExpr(value, IndexExprKind::Symbol) {}
+
+SymbolIndexExpr::SymbolIndexExpr(IndexExpr const otherIndexExpr) {
+  // Create new IndexExpr implementation object.
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implementation");
+  // If the index expression is a literal,  just copy it.
+  if (otherIndexExpr.isLiteral()) {
+    indexExprObj->initAsLiteral(otherIndexExpr.getLiteral());
+    return;
+  }
+  // Depending on what kind of index expr we got, take different actions.
+  bool isSameScope = otherIndexExpr.getScope().isCurrentScope();
+  switch (otherIndexExpr.getKind()) {
+  case IndexExprKind::Questionmark: {
+    assert("cannot make a symbol from a Questionmark");
+  }
+  case IndexExprKind::NonAffine: {
+    indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Symbol);
+    return;
+  }
+  case IndexExprKind::Predicate: {
+    assert("cannot make an symbol from a predicate");
+  }
+  case IndexExprKind::Affine: {
+    indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Symbol);
+    return;
+  }
+  case IndexExprKind::Dim: {
+    assert(!isSameScope && "cannot make a symbol from a dim in the same scope");
+    indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Symbol);
+    return;
+  }
+  case IndexExprKind::Symbol: {
+    assert(!isSameScope && "should not replicate dims at the same scope");
+    indexExprObj->initAsKind(otherIndexExpr.getValue(), IndexExprKind::Symbol);
+    return;
+  }
+  default:
+    break;
+  }
+  llvm_unreachable("bad path");
+}
+
+//===----------------------------------------------------------------------===//
+// Capturing Index Expressions: Array of values
+//===----------------------------------------------------------------------===//
+
+ArrayValueIndexCapture::ArrayValueIndexCapture(Operation *op, Value array)
+    : op(op), array(array), hasDefault(false) {
+  assert(op && "expected an op");
+}
+
+ArrayValueIndexCapture::ArrayValueIndexCapture(
+    Operation *op, Value array, int64_t defaultLiteral)
+    : op(op), array(array), defaultLiteral(defaultLiteral), hasDefault(true) {
+  assert(op && "expected an op");
+}
+
+IndexExpr ArrayValueIndexCapture::getSymbol(uint64_t i) {
+  // Check if we have an operand.
+  if (array.getType().isa<NoneType>()) {
+    // Operand undefined, we use the default value if there is one.
+    if (hasDefault)
+      return LiteralIndexExpr(defaultLiteral);
+    // Has no default: error
+    op->emitError("array value has no values");
+    return UndefinedIndexExpr();
+  }
+  // Check if we have an array of literals.
+  if (auto attrArray = getDenseElementAttributeFromValue(array)) {
+    // We extracted an dense attribute from definition of operand.
+    if (i >= attrArray.getType().getDimSize(0)) {
+      // Request beyond available size.
+      if (hasDefault)
+        return LiteralIndexExpr(defaultLiteral);
+      // Has no default: error
+      op->emitError("request past array size");
+      return UndefinedIndexExpr();
+    }
+    auto attrVal = attrArray.getValue(ArrayRef<uint64_t>({i}));
+    int64_t attrInt = attrVal.cast<IntegerAttr>().getInt();
+    return LiteralIndexExpr(attrInt);
+  }
+
+  // We must read value from an array.
+  IndexExprScope &scope = IndexExprScope::getCurrentScope();
+  if (scope.isShapeInferencePass()) {
+    // Not a constant; don't add code.
+    return QuestionmarkIndexExpr();
+  }
+  // Emit code to read array.
+  Value indexVal = emitConstantOp(scope.getRewriter(), scope.getLoc(),
+      scope.getRewriter().getIndexType(), i);
+  SmallVector<Value, 1> memrefVal = {indexVal};
+  Value loadVal =
+      scope.getRewriter().create<KrnlLoadOp>(scope.getLoc(), array, memrefVal);
+  return SymbolIndexExpr(loadVal);
+}
+
+bool ArrayValueIndexCapture::getSymbolList(
+    int num, SmallVectorImpl<IndexExpr> &symbolList) {
+  // Clear output.
+  symbolList.clear();
+  bool successful = true;
+  for (int i = 0; i < num; ++i) {
+    IndexExpr index = getSymbol(i);
+    if (index.isUndefined())
+      successful = false;
+    symbolList.emplace_back(index);
+  }
+  return successful;
+}
+
+//===----------------------------------------------------------------------===//
+// Capturing Index Expressions: MemRef Bounds
+//===----------------------------------------------------------------------===//
+
+MemRefBoundIndexCapture::MemRefBoundIndexCapture(Value tensorOrMemref)
+    : tensorOrMemref(tensorOrMemref) {}
+
+IndexExpr MemRefBoundIndexCapture::getDim(uint64_t i) {
+  ArrayRef<int64_t> shape =
+      tensorOrMemref.getType().cast<ShapedType>().getShape();
+  if (shape[i] >= 0) {
+    // We have a constant dimension.
+    int64_t intVal = shape[i];
+    return LiteralIndexExpr(intVal);
+  }
+  // We have a dynamic dimension.
+  IndexExprScope &scope = IndexExprScope::getCurrentScope();
+  if (scope.isShapeInferencePass()) {
+    // Not a constant; don't add code.
+    return QuestionmarkIndexExpr();
+  }
+  Value dynVal =
+      scope.getRewriter().create<DimOp>(scope.getLoc(), tensorOrMemref, i);
+  return DimIndexExpr(dynVal);
+}
+
+bool MemRefBoundIndexCapture::getDimList(SmallVectorImpl<IndexExpr> &dimList) {
+  // Clear output.
+  dimList.clear();
+  // Scan type and shape, bail if incompatible.
+  ShapedType type = tensorOrMemref.getType().cast<ShapedType>();
+  int size = type.getShape().size();
+  // Scan tensor or memref.
+  bool successful = true;
+  for (int i = 0; i < size; ++i) {
+    IndexExpr index = getDim(i);
+    if (index.isUndefined())
+      successful = false;
+    dimList.emplace_back(index);
+  }
+  return successful;
+}
+

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -339,15 +339,9 @@ public:
 
   // Default and shallow copy constructors.
   IndexExpr() : indexExprObj(nullptr) {} // Undefined index expression.
-  IndexExpr(IndexExprImpl *implObj) : indexExprObj(implObj) {}
-  IndexExpr(IndexExpr const &obj) : IndexExpr(obj.getObjPtr()) {}
-
-  // Constructor for new IndexExpr (xxx should they be made protected?)
-  IndexExpr(int64_t const value);    // Build literal index expression.
-  IndexExpr(Value const value);      // Build non-affine index expression.
-  IndexExpr(AffineExpr const value); // Build affine index expression.
-  IndexExpr(Value const val, IndexExprKind kind); // Build kind expression.
-
+  IndexExpr(IndexExprImpl *implObj) : indexExprObj(implObj) {}    // Shallow.
+  IndexExpr(IndexExpr const &obj) : IndexExpr(obj.getObjPtr()) {} // Shallow.
+  // To construct meaningful IndexExpr, use subclasses constructors.
   IndexExpr deepCopy() const;
 
   // Shape inference queries.

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -570,9 +570,10 @@ public:
   UndefinedIndexExpr();
 };
 
-// Subclass to explicitly create non affine IndexExpr
+// Subclass to explicitly create non affine IndexExpr.
 class LiteralIndexExpr : public IndexExpr {
 public:
+  LiteralIndexExpr() : IndexExpr() {} // Make undefined.
   LiteralIndexExpr(int64_t const value);
   LiteralIndexExpr(IndexExpr const otherIndexExpr);
 
@@ -580,47 +581,62 @@ private:
   void init(int64_t const value);
 };
 
-// Subclass to explicitly create non affine IndexExpr
+// Subclass to explicitly create non affine IndexExpr.
 class NonAffineIndexExpr : public IndexExpr {
 public:
+  NonAffineIndexExpr() : IndexExpr() {} // Make undefined.
   NonAffineIndexExpr(Value const value);
   NonAffineIndexExpr(IndexExpr const otherIndexExpr);
 };
 
-// Subclass to explicitly create Questionmark IndexExpr
+// Subclass to explicitly create Questionmark IndexExpr.
 class QuestionmarkIndexExpr : public IndexExpr {
 public:
   QuestionmarkIndexExpr();
   QuestionmarkIndexExpr(IndexExpr const otherIndexExpr);
 };
 
-// Subclass to explicitly create Predicate IndexExpr
+// Subclass to explicitly create Predicate IndexExpr.
 class PredicateIndexExpr : public IndexExpr {
 public:
+  PredicateIndexExpr() : IndexExpr() {} // Make undefined.
   PredicateIndexExpr(Value const value);
   PredicateIndexExpr(IndexExpr const otherIndexExpr);
 };
 
-// Subclass to explicitly create Affine IndexExpr
+// Subclass to explicitly create Affine IndexExpr.
 class AffineIndexExpr : public IndexExpr {
 public:
+  AffineIndexExpr() : IndexExpr() {} // Make undefined.
   AffineIndexExpr(AffineExpr const value);
   AffineIndexExpr(IndexExpr const otherIndexExpr);
 };
 
-// Subclass to explicitly create Dim IndexExpr
+// Subclass to explicitly create Dim IndexExpr.
 class DimIndexExpr : public IndexExpr {
 public:
+  DimIndexExpr() : IndexExpr() {} // Make undefined.
   DimIndexExpr(Value const value);
   DimIndexExpr(IndexExpr const otherIndexExpr);
 };
 
-// Subclass to explicitly create IndexExpr
+// Subclass to explicitly create IndexExpr.
 class SymbolIndexExpr : public IndexExpr {
 public:
+  SymbolIndexExpr() : IndexExpr() {} // Make undefined.
   SymbolIndexExpr(Value const value);
   SymbolIndexExpr(IndexExpr const otherIndexExpr);
 };
+
+//===----------------------------------------------------------------------===//
+// Additional operators with integer values in first position
+//===----------------------------------------------------------------------===//
+
+inline IndexExpr operator+(int64_t const a, const IndexExpr b) { return b + a; }
+inline IndexExpr operator*(int64_t const a, const IndexExpr b) { return b * a; }
+inline IndexExpr operator-(int64_t const a, const IndexExpr b) {
+  return LiteralIndexExpr(a) - b;
+}
 
 //===----------------------------------------------------------------------===//
 // Capturing Index Expressions
@@ -654,13 +670,6 @@ private:
   MemRefBoundIndexCapture() { llvm_unreachable("forbidden constructor"); };
   Value tensorOrMemref;
 };
-
-// Additional operators with integer values in first position.
-inline IndexExpr operator+(int64_t const a, const IndexExpr b) { return b + a; }
-inline IndexExpr operator*(int64_t const a, const IndexExpr b) { return b * a; }
-inline IndexExpr operator-(int64_t const a, const IndexExpr b) {
-  return LiteralIndexExpr(a) - b;
-}
 
 //===----------------------------------------------------------------------===//
 // Processing lists

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -360,7 +360,7 @@ public:
   bool isPredType() const;
   bool isIndexType() const { return !isPredType(); }
   bool isShapeInferencePass() const;
-  bool hasContext() const;
+  bool hasContext() const; //xxx needed?
   bool hasAffineExpr() const;
   bool hasValue() const;
 

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -233,9 +233,14 @@ public:
 
   // Add a new IndexExprImpl in the scope's container.
   void addIndexExprImpl(IndexExprImpl *obj);
+
   // Support functions for AffineExpr.
   int addDim(Value const value);
   int addSymbol(Value const value);
+
+  // Support for cached literals.
+  static IndexExprImpl *hasCachedLiteralIndexExp(int64_t value);
+  static void cacheLiteralIndexExp(int64_t value, IndexExprImpl *obj);
 
   // Queries and getters.
   bool isShapeInferencePass() const { return !rewriter; }
@@ -260,6 +265,8 @@ private:
   // Container of all index expr implementation records, to simplify
   // live range analysis. ALl will be deleted upon scope destruction.
   SmallVector<IndexExprImpl *, 20> container;
+  // Cached literals.
+  IndexExprImpl *zero, *minusOne, *one;
 };
 
 //===----------------------------------------------------------------------===//
@@ -467,6 +474,9 @@ class LiteralIndexExpr : public IndexExpr {
 public:
   LiteralIndexExpr(int64_t const value);
   LiteralIndexExpr(IndexExpr const otherIndexExpr);
+
+private:
+  void init(int64_t const value);
 };
 
 // Subclass to explicitly create non affine IndexExpr

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -217,13 +217,6 @@ public:
   // Destructor which release all IndexExpr associated with this scope.
   ~IndexExprScope();
 
-  // Code Create for Krnl load and store. Memref shape is expected to be of the
-  // same dimension than the indices array size. Each index expression will be
-  // transformed to a value to be used as indices to the memref.
-  Value createKrnlLoadOp(Value memref, SmallVectorImpl<IndexExpr> &indices);
-  void createKrnlStoreOp(
-      Value val, Value memref, SmallVectorImpl<IndexExpr> &indices);
-
   // Get current scope.
   static IndexExprScope *&getCurrentScopePtr() {
     thread_local IndexExprScope *scope = nullptr; // Thread local, null init.
@@ -578,5 +571,19 @@ bool getIndexExprListFrom(
   }
   return successful;
 }
+
+//===----------------------------------------------------------------------===//
+// Generating Krnl Load / Store
+//===----------------------------------------------------------------------===//
+
+struct krnl_load {
+  krnl_load(Value memref, SmallVectorImpl<IndexExpr> &indices);
+  Value result;
+  operator Value() { return result; }
+};
+
+struct krnl_store {
+  krnl_store(Value val, Value memref, SmallVectorImpl<IndexExpr> &indices);
+};
 
 } // namespace mlir

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -132,8 +132,8 @@ the same scope for Dim, Symbol, and Affine. Literal and non-affine can be from
 enclosing scopes as well.
 
 Note that the current scope is kept in a thread private variable and does not
-need to be explicitly passed. It will be retrieved from the environment. Which also
-means that one can only geneate code in one index scope at a time.
+need to be explicitly passed. It will be retrieved from the environment. Which
+also means that one can only geneate code in one index scope at a time.
 
 
 3) Code Sample
@@ -193,7 +193,7 @@ Dim variable.
   getResult().setType(RankedTensorType::get(outputDims, elementType));
 
 In this code, we convert the IndexExpressions back to integer dims (with >=0 for
-compile time sizes, -1 for runtime sizes). 
+compile time sizes, -1 for runtime sizes).
 
 3d) Look at Slice.cpp on how to use IndexExpr for lowering.
 
@@ -224,6 +224,21 @@ compile time sizes, -1 for runtime sizes).
       loadIndices.emplace_back((step * inductionIndex) + start);
       storeIndices.emplace_back(inductionIndex);
     }
+
+  4) Additional infrastructure
+
+   ArrayValueIndexCapture allows us to read 1D arrays and generate symbols out
+of them expressions that are either literals or runtime values (symbols).
+
+   MemRefBoundIndexCapture allows us to read memref or tensor 1D descriptors and
+generate out of them expressions that are either literals or runtime values
+(dims).
+
+Note that in both case, runtime values may be "questionmarks" during the shape
+inference part as no code may be generated during such phases.
+
+krnl_load / krnl_store allow us to generate kernel loads or store where the
+indices are represented by index expressions.
 
 */
 

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -3020,7 +3020,7 @@ LogicalResult ONNXArgMaxOp::inferShapes(
     return emitError("Failed to scan ArgMax parameters successfully");
 
   SmallVector<int64_t, 4> outputDims;
-  IndexExprContext::getOutputDimsForType(
+  IndexExpr::convertListOfIndexExprToIntegerDim(
       shapeHelper.dimsForOutput(0), outputDims);
 
   // ONNX spec specifies the reduced type as an int64

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -49,7 +49,7 @@ LogicalResult shapeHelperInferShapes(OP *op, Value typeOper) {
     return op->emitError("Failed to scan " + OP::getOperationName() +
                          " parameters successfully");
   SmallVector<int64_t, 4> outputDims;
-  IndexExprContext::getOutputDimsForType(
+  IndexExpr::convertListOfIndexExprToIntegerDim(
       shapeHelper.dimsForOutput(0), outputDims);
   auto elementType = typeOper.getType().cast<ShapedType>().getElementType();
   op->getResult().setType(RankedTensorType::get(outputDims, elementType));
@@ -68,12 +68,12 @@ LogicalResult shapeHelperInferMultipleShapes(OP *op, Value typeOper) {
     return op->emitError("Failed to scan " + OP::getOperationName() +
                          " parameters successfully");
   SmallVector<int64_t, 4> outputDims;
-  IndexExprContext::getOutputDimsForType(
+  IndexExpr::convertListOfIndexExprToIntegerDim(
       shapeHelper.dimsForOutput(0), outputDims);
   auto elementType = typeOper.getType().cast<ShapedType>().getElementType();
   for (int i = 0; i < op->getNumResults(); ++i) {
     SmallVector<int64_t, 4> outputDims;
-    IndexExprContext::getOutputDimsForType(
+    IndexExpr::convertListOfIndexExprToIntegerDim(
         shapeHelper.dimsForOutput(i), outputDims);
     op->getResults()[i].setType(RankedTensorType::get(outputDims, elementType));
   }
@@ -1448,7 +1448,7 @@ LogicalResult ONNXTransposeOp::inferShapes(
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan Transpose parameters successfully");
   SmallVector<int64_t, 4> outputDims;
-  IndexExprContext::getOutputDimsForType(
+  IndexExpr::convertListOfIndexExprToIntegerDim(
       shapeHelper.dimsForOutput(0), outputDims);
   getResult().setType(RankedTensorType::get(outputDims, elementType));
 
@@ -1624,7 +1624,8 @@ LogicalResult ONNXConvOp::inferShapes(
   }
 
   // Process strides, dilations, and pads.
-  processConvTypeParams<>(this, X());
+  LogicalResult res = processConvTypeParams<>(this, X());
+  assert(res.succeeded());
   auto dilationsOpt = dilations();
   auto stridesOpt = strides();
   auto padsOpt = pads();
@@ -1754,7 +1755,8 @@ LogicalResult ONNXConvTransposeOp::inferShapes(
   }
 
   // Process strides, dilations, and pads.
-  processConvTypeParams<>(this, X());
+  LogicalResult res = processConvTypeParams<>(this, X());
+  assert(res.succeeded());
   auto dilationsOpt = dilations();
   auto stridesOpt = strides();
   auto padsOpt = pads();
@@ -1872,7 +1874,8 @@ LogicalResult ONNXQLinearConvOp::inferShapes(
   }
 
   // Process strides, dilations, and pads.
-  processConvTypeParams<>(this, x());
+  LogicalResult res = processConvTypeParams<>(this, x());
+  assert(res.succeeded());
   auto dilationsOpt = dilations();
   auto stridesOpt = strides();
   auto padsOpt = pads();
@@ -1979,7 +1982,8 @@ LogicalResult ONNXMaxPoolSingleOutOp::inferShapes(
     return emitError("column major storage order not supported at this time");
 
   // Process strides, dilations, and pads.
-  processConvTypeParams<>(this, X());
+  LogicalResult res = processConvTypeParams<>(this, X());
+  assert(res.succeeded());
   auto dilationsOpt = dilations();
   auto stridesOpt = strides();
   auto padsOpt = pads();
@@ -2366,7 +2370,7 @@ LogicalResult ONNXConcatOp::inferShapes(
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan Tile parameters successfully");
   SmallVector<int64_t, 4> outputDims;
-  IndexExprContext::getOutputDimsForType(
+  IndexExpr::convertListOfIndexExprToIntegerDim(
       shapeHelper.dimsForOutput(0), outputDims);
   getResult().setType(
       RankedTensorType::get(outputDims, commonType.getElementType()));
@@ -2636,7 +2640,8 @@ LogicalResult ONNXConvIntegerOp::inferShapes(
   }
 
   // Process strides, dilations, and pads.
-  processConvTypeParams<>(this, x());
+  LogicalResult res = processConvTypeParams<>(this, x());
+  assert(res.succeeded());
   auto dilationsOpt = dilations();
   auto stridesOpt = strides();
   auto padsOpt = pads();
@@ -2843,7 +2848,7 @@ LogicalResult ONNXSliceOp::inferShapes(
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan Slice parameters successfully");
   SmallVector<int64_t, 4> outputDims;
-  IndexExprContext::getOutputDimsForType(
+  IndexExpr::convertListOfIndexExprToIntegerDim(
       shapeHelper.dimsForOutput(0), outputDims);
   getResult().setType(RankedTensorType::get(outputDims, elementType));
 
@@ -3156,7 +3161,7 @@ LogicalResult ONNXLRNOp::inferShapes(
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan LRN parameters successfully");
   SmallVector<int64_t, 4> outputDims;
-  IndexExprContext::getOutputDimsForType(
+  IndexExpr::convertListOfIndexExprToIntegerDim(
       shapeHelper.dimsForOutput(0), outputDims);
   getResult().setType(RankedTensorType::get(outputDims, elementType));
 

--- a/src/Dialect/ONNX/ONNXOpsHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.cpp
@@ -79,7 +79,7 @@ AffineMap getConvDimMap(Builder &builder, bool ceilMode) {
 ///
 /// This function returns {startH, endH, kernelOffset}.
 
-std::vector<IndexExpr> getIndexExprsForConvWindow(IndexExprContext &context,
+std::vector<IndexExpr> getIndexExprsForConvWindow(IndexExprScope &context,
     SmallVectorImpl<IndexExpr> &inputExprs, bool ceilMode, bool isDilated) {
   assert(inputExprs.size() == 6 && "Not enought inputs");
   IndexExpr windowStartExpr, windowEndExpr, kernelOffsetExpr;
@@ -104,7 +104,7 @@ std::vector<IndexExpr> getIndexExprsForConvWindow(IndexExprContext &context,
   windowEndExpr = IndexExpr::min(endExprs);
   // kernelOffsetExpr
   SmallVector<mlir::IndexExpr, 2> kernelExprs = {
-      context.createLiteralIndex(0), start2};
+      LiteralIndexExpr(0), start2};
   kernelOffsetExpr = IndexExpr::min(kernelExprs);
 
   return std::vector<IndexExpr>{

--- a/src/Dialect/ONNX/ONNXOpsHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.cpp
@@ -79,7 +79,7 @@ AffineMap getConvDimMap(Builder &builder, bool ceilMode) {
 ///
 /// This function returns {startH, endH, kernelOffset}.
 
-std::vector<IndexExpr> getIndexExprsForConvWindow(IndexExprScope &context,
+std::vector<IndexExpr> getIndexExprsForConvWindow(
     SmallVectorImpl<IndexExpr> &inputExprs, bool ceilMode, bool isDilated) {
   assert(inputExprs.size() == 6 && "Not enought inputs");
   IndexExpr windowStartExpr, windowEndExpr, kernelOffsetExpr;
@@ -103,8 +103,7 @@ std::vector<IndexExpr> getIndexExprsForConvWindow(IndexExprScope &context,
   SmallVector<mlir::IndexExpr, 2> endExprs = {end1, end2};
   windowEndExpr = IndexExpr::min(endExprs);
   // kernelOffsetExpr
-  SmallVector<mlir::IndexExpr, 2> kernelExprs = {
-      LiteralIndexExpr(0), start2};
+  SmallVector<mlir::IndexExpr, 2> kernelExprs = {LiteralIndexExpr(0), start2};
   kernelOffsetExpr = IndexExpr::min(kernelExprs);
 
   return std::vector<IndexExpr>{

--- a/src/Dialect/ONNX/ONNXOpsHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.hpp
@@ -70,7 +70,7 @@ AffineMap getConvDimMap(Builder &builder, bool ceilMode);
 ///   thus the first valid pixel location is 'ceil(pH / dH) * dH- pH'.
 ///
 /// This function returns {startH, endH, kernelOffset}.
-std::vector<IndexExpr> getIndexExprsForConvWindow(IndexExprContext &context,
+std::vector<IndexExpr> getIndexExprsForConvWindow(IndexExprScope &context,
     SmallVectorImpl<IndexExpr> &inputExprs, bool ceilMode, bool isDilated);
 
 /// The conv/pooling window can be smaller than the kernel when slicing it over

--- a/src/Dialect/ONNX/ONNXOpsHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.hpp
@@ -70,7 +70,7 @@ AffineMap getConvDimMap(Builder &builder, bool ceilMode);
 ///   thus the first valid pixel location is 'ceil(pH / dH) * dH- pH'.
 ///
 /// This function returns {startH, endH, kernelOffset}.
-std::vector<IndexExpr> getIndexExprsForConvWindow(IndexExprScope &context,
+std::vector<IndexExpr> getIndexExprsForConvWindow(
     SmallVectorImpl<IndexExpr> &inputExprs, bool ceilMode, bool isDilated);
 
 /// The conv/pooling window can be smaller than the kernel when slicing it over

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -468,7 +468,7 @@ LogicalResult ONNXMatMulOpShapeHelper::Compute(
   // positions, prepended by 1s to fit the paddedRankSize.
   // (1,1,1... 1, aDim[0]...aDim[aRank-1])
 
-  IndexExpr one = LiteralIndexExpr(1);
+  LiteralIndexExpr one(1);
   MemRefBoundIndexCapture ABounds(A);
   int aOffset = paddedRank - aRank;
   for (int i = 0; i < aOffset; ++i) {
@@ -595,14 +595,14 @@ LogicalResult ONNXSplitOpShapeHelper::Compute(
     if (ArrayAttrSize(splitAttribute) != numOfResults)
       return op->emitError("Split size not equal to the number of results");
     for (int i = 0; i < numOfResults; ++i) {
-      IndexExpr dim = LiteralIndexExpr(ArrayAttrIntVal(splitAttribute, i));
+      LiteralIndexExpr dim(ArrayAttrIntVal(splitAttribute, i));
       splitDims.emplace_back(dim);
     }
   } else {
     // If split parameter is not specified, the dimension is split to
     // equal-sized parts.
     IndexExpr splitInputDim(inputBounds.getDim(axisIndex));
-    IndexExpr numOfPartitions = LiteralIndexExpr(numOfResults);
+    LiteralIndexExpr numOfPartitions(numOfResults);
     if (splitInputDim.isLiteral() &&
         (splitInputDim.getLiteral() % numOfResults != 0))
       return op->emitError("The dimension at the split axis is "

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -75,21 +75,21 @@ LogicalResult ONNXArgMaxOpShapeHelper::Compute(
 
   // Compute outputDims
   DimsExpr outputDims;
-
+  MemRefBoundIndexCapture dataBounds(data);
   int reducedRank = isKeepdims ? dataRank : dataRank - 1;
   outputDims.resize(reducedRank);
   for (auto i = 0; i < reducedRank; i++) {
-    IndexExpr dimOutput = nullptr;
+    DimIndexExpr dimOutput;
     if (isKeepdims) {
       if (i != axisValue)
-        dimOutput = context.createDimIndexFromShapedType(data, i);
+        dimOutput = dataBounds.getDim(i);
       else
-        dimOutput = context.createLiteralIndex(1);
+        dimOutput = LiteralIndexExpr(1);
     } else {
       if (i < axisValue)
-        dimOutput = context.createDimIndexFromShapedType(data, i);
+        dimOutput = dataBounds.getDim(i);
       else
-        dimOutput = context.createDimIndexFromShapedType(data, i + 1);
+        dimOutput = dataBounds.getDim(i + 1);
     }
     outputDims[i] = dimOutput;
   }

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -135,7 +135,7 @@ LogicalResult ONNXOpBroadcastedShapeHelper::Compute(ArrayRef<Value> operands) {
 }
 
 LogicalResult ONNXOpBroadcastedShapeHelper::GetAccessExprs(
-    IndexExprScope &outerContext, Value operand, unsigned operandIndex,
+    IndexExprScope &outerScope, Value operand, unsigned operandIndex,
     const SmallVectorImpl<IndexExpr> &outputAccessExprs,
     SmallVectorImpl<IndexExpr> &operandAccessExprs) {
   if (isUniBroadcasting && operandIndex == 0) {

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -222,8 +222,6 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
   ends.resize(dataRank);
   outputDims.resize(dataRank);
 
-  printf("hi alex 1\n");
-
   // SmallVector<uint64_t, 1> index1D(1, 0);
   ArrayValueIndexCapture startsCapture(genericOp, operandAdaptor.starts());
   ArrayValueIndexCapture endsCapture(genericOp, operandAdaptor.ends());
@@ -251,23 +249,14 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
     // Get dim.
     IndexExpr dimInput(dataBounds.getDim(ii));
 
-    printf("hi alex 1.1\n");
-
     // Now proceed with the computations for start/end/dim.
     // Calculation for start: start < 0 ? start + dim : start.
-    startInput.debugPrint("start input");
     IndexExpr startPos =
         IndexExpr::select(startInput < 0, startInput + dimInput, startInput);
-    startPos.debugPrint("start pos");
     // Step < 0: clamp(0, start, dim -1) else clamp(0, start, dim)
     IndexExpr neg = startPos.clamp(0, dimInput - 1);
     IndexExpr pos = startPos.clamp(0, dimInput);
-    neg.debugPrint("neg");
-    neg.debugPrint("pos");
-    stepInput.debugPrint("stepInput");
     IndexExpr startFinal = IndexExpr::select(stepInput < 0, neg, pos);
-
-    printf("hi alex 1.2\n");
 
     // Calculation for end: end<0 -> end + dim else -> end;
     // special case end <= -inf -> -1;  end >= inf -> dim;
@@ -282,16 +271,10 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
     pos = endPos.clamp(0, dimInput);
     IndexExpr endFinal = IndexExpr::select(stepInput < 0, neg, pos);
 
-    printf("hi alex 1.3\n");
-    endFinal.debugPrint("end final");
-    startFinal.debugPrint("start final");
-    stepInput.debugPrint("step input");
     // Calculation for output size.
     IndexExpr dimOutputFinal = (endFinal - startFinal).ceilDiv(stepInput);
     // should use a max
     dimOutputFinal = dimOutputFinal.selectOrSelf(dimOutputFinal < 0, 0);
-
-    printf("hi alex 1.4\n");
 
     // Save results
     starts[ii] = startFinal;
@@ -299,8 +282,6 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
     ends[ii] = endFinal;
     outputDims[ii] = dimOutputFinal;
   }
-
-  printf("hi alex 2\n");
 
   // Handle the default for the non-axis arrays; they are detected with 0 steps
   // (illegal value).
@@ -316,8 +297,6 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
       outputDims[i] = dimInput;
     }
   }
-
-  printf("hi alex 3\n");
 
   // Save the final result.
   dimsForOutput(0) = outputDims;

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -134,9 +134,8 @@ LogicalResult ONNXOpBroadcastedShapeHelper::Compute(ArrayRef<Value> operands) {
   return success();
 }
 
-LogicalResult ONNXOpBroadcastedShapeHelper::GetAccessExprs(
-    IndexExprScope &outerScope, Value operand, unsigned operandIndex,
-    const SmallVectorImpl<IndexExpr> &outputAccessExprs,
+LogicalResult ONNXOpBroadcastedShapeHelper::GetAccessExprs(Value operand,
+    unsigned operandIndex, const SmallVectorImpl<IndexExpr> &outputAccessExprs,
     SmallVectorImpl<IndexExpr> &operandAccessExprs) {
   if (isUniBroadcasting && operandIndex == 0) {
     for (IndexExpr ie : outputAccessExprs)
@@ -233,7 +232,7 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
     int ii = axesIntLit[i];
     // Get start, end, step, and dim index expressions.
     // Get start.
-    IndexExpr startInput(startsCapture.getSymbol(i));
+    SymbolIndexExpr startInput(startsCapture.getSymbol(i));
     if (startInput.isUndefined())
       return op->emitError("start input parameter could not be processed");
     // Get end.

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -37,7 +37,7 @@ ONNXConstantOp getONNXConstantOp(Value value) {
 template <class OP>
 ONNXOpShapeHelper<OP>::ONNXOpShapeHelper(
     OP *newOp, ConversionPatternRewriter *rewriter)
-    : op(newOp), context(rewriter, newOp->getLoc()), outputsDims() {
+    : op(newOp), scope(rewriter, newOp->getLoc()), outputsDims() {
   setNumberOfOutputs(op->getOperation()->getNumResults());
 }
 
@@ -47,7 +47,7 @@ ONNXOpShapeHelper<OP>::ONNXOpShapeHelper(
 
 ONNXOpBroadcastedShapeHelper::ONNXOpBroadcastedShapeHelper(
     ConversionPatternRewriter *rewriter, Location loc, bool uniBroadcasting)
-    : context(rewriter, loc), isUniBroadcasting(uniBroadcasting) {}
+    : scope(rewriter, loc), isUniBroadcasting(uniBroadcasting) {}
 
 LogicalResult ONNXOpBroadcastedShapeHelper::Compute(ArrayRef<Value> operands) {
   // A temporary IndexExpr vector for the output.
@@ -67,13 +67,13 @@ LogicalResult ONNXOpBroadcastedShapeHelper::Compute(ArrayRef<Value> operands) {
   for (int64_t i = 0; i < numOfInputs; ++i) {
     DimsExpr dims;
     int64_t r = operands[i].getType().cast<ShapedType>().getRank();
+    MemRefBoundIndexCapture bounds(operands[i]);
     // Prepend 1s.
     for (int64_t k = 0; k < outputRank - r; ++k)
-      dims.emplace_back(context.createLiteralIndex(1));
+      dims.emplace_back(LiteralIndexExpr(1));
     // Get from the input.
     for (int64_t k = outputRank - r; k < outputRank; ++k)
-      dims.emplace_back(context.createDimIndexFromShapedType(
-          operands[i], k - outputRank + r));
+      dims.emplace_back(bounds.getDim(k - outputRank + r));
     inputsDims.emplace_back(dims);
   }
 
@@ -135,7 +135,7 @@ LogicalResult ONNXOpBroadcastedShapeHelper::Compute(ArrayRef<Value> operands) {
 }
 
 LogicalResult ONNXOpBroadcastedShapeHelper::GetAccessExprs(
-    IndexExprContext &outerContext, Value operand, unsigned operandIndex,
+    IndexExprScope &outerContext, Value operand, unsigned operandIndex,
     const SmallVectorImpl<IndexExpr> &outputAccessExprs,
     SmallVectorImpl<IndexExpr> &operandAccessExprs) {
   if (isUniBroadcasting && operandIndex == 0) {
@@ -148,8 +148,7 @@ LogicalResult ONNXOpBroadcastedShapeHelper::GetAccessExprs(
   for (decltype(operandRank) i = 0; i < operandRank; ++i) {
     // Shape helper may pretend 1s, thus adjust dimension index accordingly.
     auto dimIndex = outputRank - operandRank + i;
-    IndexExpr dim = outerContext.createSymbolIndexFromParentContext(
-        inputsDims[operandIndex][dimIndex]);
+    SymbolIndexExpr dim(inputsDims[operandIndex][dimIndex]);
 
     // Compute access index based on broadcasting rules.
     // If all other operand dims are 1, just use the output access index.
@@ -223,40 +222,52 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
   ends.resize(dataRank);
   outputDims.resize(dataRank);
 
+  printf("hi alex 1\n");
+
   // SmallVector<uint64_t, 1> index1D(1, 0);
+  ArrayValueIndexCapture startsCapture(genericOp, operandAdaptor.starts());
+  ArrayValueIndexCapture endsCapture(genericOp, operandAdaptor.ends());
+  ArrayValueIndexCapture stepsCapture(genericOp, operandAdaptor.steps());
+  MemRefBoundIndexCapture dataBounds(data);
   for (uint64_t i = 0; i < sliceRank; i++) {
     // i is index in start/step/end/output
     // ii is logical index in mem/loop bounds
     int ii = axesIntLit[i];
     // Get start, end, step, and dim index expressions.
     // Get start.
-    IndexExpr startInput = context.createSymbolIndexFromArrayValueAtIndex(
-        genericOp, operandAdaptor.starts(), i);
+    IndexExpr startInput(startsCapture.getSymbol(i));
     if (startInput.isUndefined())
       return op->emitError("start input parameter could not be processed");
     // Get end.
-    IndexExpr endInput = context.createSymbolIndexFromArrayValueAtIndex(
-        genericOp, operandAdaptor.ends(), i);
+    IndexExpr endInput(endsCapture.getSymbol(i));
     if (endInput.isUndefined())
       return op->emitError("end input parameter could not be processed");
     // Get step.
-    IndexExpr stepInput = context.createSymbolIndexFromArrayValueAtIndex(
-        genericOp, operandAdaptor.steps(), i, 1);
+    IndexExpr stepInput(stepsCapture.getSymbol(i));
     if (stepInput.isUndefined())
       return op->emitError("step input parameter could not be processed");
     if (stepInput.isLiteral() && stepInput.getLiteral() == 0)
       return op->emitError("step input parameter cannot be zero");
     // Get dim.
-    IndexExpr dimInput = context.createDimIndexFromShapedType(data, ii);
+    IndexExpr dimInput(dataBounds.getDim(ii));
+
+    printf("hi alex 1.1\n");
 
     // Now proceed with the computations for start/end/dim.
     // Calculation for start: start < 0 ? start + dim : start.
+    startInput.debugPrint("start input");
     IndexExpr startPos =
         IndexExpr::select(startInput < 0, startInput + dimInput, startInput);
+    startPos.debugPrint("start pos");
     // Step < 0: clamp(0, start, dim -1) else clamp(0, start, dim)
     IndexExpr neg = startPos.clamp(0, dimInput - 1);
     IndexExpr pos = startPos.clamp(0, dimInput);
+    neg.debugPrint("neg");
+    neg.debugPrint("pos");
+    stepInput.debugPrint("stepInput");
     IndexExpr startFinal = IndexExpr::select(stepInput < 0, neg, pos);
+
+    printf("hi alex 1.2\n");
 
     // Calculation for end: end<0 -> end + dim else -> end;
     // special case end <= -inf -> -1;  end >= inf -> dim;
@@ -271,10 +282,16 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
     pos = endPos.clamp(0, dimInput);
     IndexExpr endFinal = IndexExpr::select(stepInput < 0, neg, pos);
 
+    printf("hi alex 1.3\n");
+    endFinal.debugPrint("end final");
+    startFinal.debugPrint("start final");
+    stepInput.debugPrint("step input");
     // Calculation for output size.
     IndexExpr dimOutputFinal = (endFinal - startFinal).ceilDiv(stepInput);
     // should use a max
     dimOutputFinal = dimOutputFinal.selectOrSelf(dimOutputFinal < 0, 0);
+
+    printf("hi alex 1.4\n");
 
     // Save results
     starts[ii] = startFinal;
@@ -283,6 +300,8 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
     outputDims[ii] = dimOutputFinal;
   }
 
+  printf("hi alex 2\n");
+
   // Handle the default for the non-axis arrays; they are detected with 0 steps
   // (illegal value).
   bool allOutputLit;
@@ -290,13 +309,15 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
     if (steps[i].isUndefined()) {
       // have one unset, put the defaults (start was already at zero, so we are
       // fine).
-      starts[i] = context.createLiteralIndex(0);
-      steps[i] = context.createLiteralIndex(1);
-      IndexExpr dimInput = context.createDimIndexFromShapedType(data, i);
+      starts[i] = LiteralIndexExpr(0);
+      steps[i] = LiteralIndexExpr(1);
+      IndexExpr dimInput(dataBounds.getDim(i));
       ends[i] = dimInput;
       outputDims[i] = dimInput;
     }
   }
+
+  printf("hi alex 3\n");
 
   // Save the final result.
   dimsForOutput(0) = outputDims;
@@ -325,10 +346,11 @@ LogicalResult ONNXTileOpShapeHelper::Compute(ONNXTileOpAdaptor operandAdaptor) {
   // Compute outputDims
   DimsExpr outputDims;
   outputDims.resize(inputRank);
+  MemRefBoundIndexCapture inputBounds(input);
+  ArrayValueIndexCapture repeatsCapture(genericOp, repeats);
   for (auto i = 0; i < inputRank; i++) {
-    IndexExpr dimInput = context.createDimIndexFromShapedType(input, i);
-    IndexExpr repeatsValue =
-        context.createSymbolIndexFromArrayValueAtIndex(genericOp, repeats, i);
+    IndexExpr dimInput(inputBounds.getDim(i));
+    IndexExpr repeatsValue(repeatsCapture.getSymbol(i));
     IndexExpr dimOutput = dimInput * repeatsValue;
     outputDims[i] = dimOutput;
   }
@@ -368,38 +390,41 @@ LogicalResult ONNXGemmOpShapeHelper::Compute(ONNXGemmOpAdaptor operandAdaptor) {
       return op->emitError("Gemm with C should be a 1D or 2D tensor");
   }
   // Scan dimensions of A with/without transpose.
+  MemRefBoundIndexCapture ABounds(A);
   if (op->transA() == 0) {
-    aDims.emplace_back(context.createDimIndexFromShapedType(A, 0));
-    aDims.emplace_back(context.createDimIndexFromShapedType(A, 1));
+    aDims.emplace_back(ABounds.getDim(0));
+    aDims.emplace_back(ABounds.getDim(1));
   } else {
-    aDims.emplace_back(context.createDimIndexFromShapedType(A, 1));
-    aDims.emplace_back(context.createDimIndexFromShapedType(A, 0));
+    aDims.emplace_back(ABounds.getDim(1));
+    aDims.emplace_back(ABounds.getDim(0));
   }
   // Scan dimensions of B with/without transpose.
+  MemRefBoundIndexCapture BBounds(B);
   if (op->transB() == 0) {
-    bDims.emplace_back(context.createDimIndexFromShapedType(B, 0));
-    bDims.emplace_back(context.createDimIndexFromShapedType(B, 1));
+    bDims.emplace_back(BBounds.getDim(0));
+    bDims.emplace_back(BBounds.getDim(1));
   } else {
-    bDims.emplace_back(context.createDimIndexFromShapedType(B, 1));
-    bDims.emplace_back(context.createDimIndexFromShapedType(B, 0));
+    bDims.emplace_back(BBounds.getDim(1));
+    bDims.emplace_back(BBounds.getDim(0));
   }
   // Set output dims of result, creating a copy of it to be safe.
-  outputDims.emplace_back(context.createIndex(aDims[0]));
-  outputDims.emplace_back(context.createIndex(bDims[1]));
+  outputDims.emplace_back(aDims[0].deepCopy());
+  outputDims.emplace_back(bDims[1].deepCopy());
   // Bias C can be a (unidirectional) broadcast.
+  MemRefBoundIndexCapture CBounds(C);
   if (hasBias) {
     if (cRank == 0) {
       // Broadcast for scalar: both dims are 1.
-      cDims.emplace_back(context.createLiteralIndex(1));
-      cDims.emplace_back(context.createLiteralIndex(1));
+      cDims.emplace_back(LiteralIndexExpr(1));
+      cDims.emplace_back(LiteralIndexExpr(1));
     } else if (cRank == 1) {
       // First dim is the one padded.
-      cDims.emplace_back(context.createLiteralIndex(1));
-      cDims.emplace_back(context.createDimIndexFromShapedType(C, 0));
+      cDims.emplace_back(LiteralIndexExpr(1));
+      cDims.emplace_back(CBounds.getDim(0));
     } else {
       assert(cRank == 2 && "illegal path");
-      cDims.emplace_back(context.createDimIndexFromShapedType(C, 0));
-      cDims.emplace_back(context.createDimIndexFromShapedType(C, 1));
+      cDims.emplace_back(CBounds.getDim(0));
+      cDims.emplace_back(CBounds.getDim(1));
     }
   }
   // Check static dimensions, if we can.
@@ -463,20 +488,23 @@ LogicalResult ONNXMatMulOpShapeHelper::Compute(
   // Add the dims of A. All of the aDim[0]...aDim[aRank-1] are in the rightmost
   // positions, prepended by 1s to fit the paddedRankSize.
   // (1,1,1... 1, aDim[0]...aDim[aRank-1])
-  IndexExpr one = context.createLiteralIndex(1);
+
+  IndexExpr one = LiteralIndexExpr(1);
+  MemRefBoundIndexCapture ABounds(A);
   int aOffset = paddedRank - aRank;
   for (int i = 0; i < aOffset; ++i) {
     aDims[i] = one;
     aPadDims[i] = true;
   }
   for (int i = 0; i < aRank; ++i) {
-    aDims[i + aOffset] = context.createDimIndexFromShapedType(A, i);
+    aDims[i + aOffset] = ABounds.getDim(i);
     aPadDims[i + aOffset] = false; // Pad false even if dim is sized 1.
   }
   // for B: two cases. If bRank = 1, we pad the rightmost position. Namely we
   // get (1...,1, bDim[0], 1). We use one padding credit for the rightmost
   // position. Otherwise, when bRank>1, we only pad the leading positions.
   // Namely we get (1,1,1...,1, bDim[0],.... bDim[bRank-1])
+  MemRefBoundIndexCapture BBounds(B);
   int bOffset = paddedRank - bRank;
   if (bRank == 1) {
     bDims[paddedRank - 1] = one;
@@ -488,7 +516,7 @@ LogicalResult ONNXMatMulOpShapeHelper::Compute(
     bPadDims[i] = true;
   }
   for (int i = 0; i < bRank; ++i) {
-    bDims[i + bOffset] = context.createDimIndexFromShapedType(B, i);
+    bDims[i + bOffset] = BBounds.getDim(i);
     bPadDims[i + bOffset] = false; // Pad false even if dim is sized 1.
   }
   assert(aDims.size() == bDims.size() && "padded A&B must have same size");
@@ -583,20 +611,19 @@ LogicalResult ONNXSplitOpShapeHelper::Compute(
   // Checking value of split parameter.
   auto splitAttribute = op->split();
   SmallVector<IndexExpr, 4> splitDims;
+  MemRefBoundIndexCapture inputBounds(operandAdaptor.input());
   if (splitAttribute.hasValue()) {
     if (ArrayAttrSize(splitAttribute) != numOfResults)
       return op->emitError("Split size not equal to the number of results");
     for (int i = 0; i < numOfResults; ++i) {
-      IndexExpr dim =
-          context.createLiteralIndex(ArrayAttrIntVal(splitAttribute, i));
+      IndexExpr dim = LiteralIndexExpr(ArrayAttrIntVal(splitAttribute, i));
       splitDims.emplace_back(dim);
     }
   } else {
     // If split parameter is not specified, the dimension is split to
     // equal-sized parts.
-    IndexExpr splitInputDim =
-        context.createDimIndexFromShapedType(operandAdaptor.input(), axisIndex);
-    IndexExpr numOfPartitions = context.createLiteralIndex(numOfResults);
+    IndexExpr splitInputDim(inputBounds.getDim(axisIndex));
+    IndexExpr numOfPartitions = LiteralIndexExpr(numOfResults);
     if (splitInputDim.isLiteral() &&
         (splitInputDim.getLiteral() % numOfResults != 0))
       return op->emitError("The dimension at the split axis is "
@@ -615,9 +642,7 @@ LogicalResult ONNXSplitOpShapeHelper::Compute(
       if (j == axisIndex) {
         outputDims[j] = splitDims[i];
       } else {
-        IndexExpr dim =
-            context.createDimIndexFromShapedType(operandAdaptor.input(), j);
-        outputDims[j] = dim;
+        outputDims[j] = inputBounds.getDim(j);
       }
     }
     dimsForOutput(i) = outputDims;
@@ -638,8 +663,10 @@ LogicalResult ONNXGatherOpShapeHelper::Compute(
     ONNXGatherOpAdaptor operandAdaptor) {
   // Shape inference indicated by passing a null rewriter pointer.
   // Read data and indices shapes as dim indices.
-  context.createDimIndicesFromShapedType(operandAdaptor.data(), dataDims);
-  context.createDimIndicesFromShapedType(operandAdaptor.indices(), indicesDims);
+  MemRefBoundIndexCapture dataBounds(operandAdaptor.data());
+  MemRefBoundIndexCapture indicesBounds(operandAdaptor.indices());
+  dataBounds.getDimList(dataDims);
+  indicesBounds.getDimList(indicesDims);
 
   // Read constant 'axis' attribute and normalize when negative.
   int64_t axisIndex = op->axis();
@@ -711,22 +738,22 @@ LogicalResult ONNXConcatOpShapeHelper::Compute(
     axisIndex = commonRank + axisIndex;
   }
 
-  IndexExpr cumulativeAxisSize = context.createLiteralIndex(0);
-
+  IndexExpr cumulativeAxisSize = LiteralIndexExpr(0);
   for (int i = 0; i < inputNum; ++i) {
     Value currentInput = operandAdaptor.getODSOperands(0)[i];
-    IndexExpr currentSize =
-        context.createDimIndexFromShapedType(currentInput, axisIndex);
+    MemRefBoundIndexCapture currInputBounds(currentInput);
+    IndexExpr currentSize(currInputBounds.getDim(axisIndex));
     cumulativeAxisSize = cumulativeAxisSize + currentSize;
   }
 
   DimsExpr outputDims;
+  MemRefBoundIndexCapture firstInputBounds(firstInput);
   outputDims.resize(commonRank);
   for (int i = 0; i < commonRank; i++) {
     if (i == axisIndex) {
       outputDims[i] = cumulativeAxisSize;
     } else {
-      outputDims[i] = context.createDimIndexFromShapedType(firstInput, i);
+      outputDims[i] = firstInputBounds.getDim(i);
     }
   }
 
@@ -767,11 +794,10 @@ LogicalResult ONNXTransposeOpShapeHelper::Compute(
 
   // Perform transposition according to perm attribute.
   DimsExpr transposedDims;
+  MemRefBoundIndexCapture dataBounds(operandAdaptor.data());
   for (decltype(rank) i = 0; i < rank; ++i) {
     int64_t inputIndex = ArrayAttrIntVal(permAttr, i);
-    IndexExpr inputDim =
-        context.createDimIndexFromShapedType(operandAdaptor.data(), inputIndex);
-    transposedDims.emplace_back(inputDim);
+    transposedDims.emplace_back(dataBounds.getDim(inputIndex));
   }
 
   // Set type for the first output.
@@ -796,10 +822,9 @@ LogicalResult ONNXLRNOpShapeHelper::Compute(ONNXLRNOpAdaptor operandAdaptor) {
 
   // Perform transposition according to perm attribute.
   DimsExpr outputDims;
+  MemRefBoundIndexCapture XBounds(operandAdaptor.X());
   for (decltype(rank) i = 0; i < rank; ++i) {
-    IndexExpr inputDim =
-        context.createDimIndexFromShapedType(operandAdaptor.X(), i);
-    outputDims.emplace_back(inputDim);
+    outputDims.emplace_back(XBounds.getDim(i));
   }
 
   // Set type for the first output.

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -83,13 +83,11 @@ struct ONNXOpBroadcastedShapeHelper {
   // Compute access indices to load/store value from/to a given 'operand'.
   // Used in a loop to access the operand.
   // Parameters:
-  //   - outerScope: shape helper scope obtained outside the loop.
   //   - operand: operand to access
   //   - operandIndex: index of the operand in 'inputsDims'
   //   - loopAccessExprs: IndexExprs for the loop's IVs
   //   - operandAccessExprs: access indices to access the operand.
-  LogicalResult GetAccessExprs(IndexExprScope &outerScope, Value operand,
-      unsigned operandIndex,
+  LogicalResult GetAccessExprs(Value operand, unsigned operandIndex,
       const SmallVectorImpl<IndexExpr> &outputAccessExprs,
       SmallVectorImpl<IndexExpr> &operandAccessExprs);
 

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -83,12 +83,12 @@ struct ONNXOpBroadcastedShapeHelper {
   // Compute access indices to load/store value from/to a given 'operand'.
   // Used in a loop to access the operand.
   // Parameters:
-  //   - outerContext: shape helper scope obtained outside the loop.
+  //   - outerScope: shape helper scope obtained outside the loop.
   //   - operand: operand to access
   //   - operandIndex: index of the operand in 'inputsDims'
   //   - loopAccessExprs: IndexExprs for the loop's IVs
   //   - operandAccessExprs: access indices to access the operand.
-  LogicalResult GetAccessExprs(IndexExprScope &outerContext, Value operand,
+  LogicalResult GetAccessExprs(IndexExprScope &outerScope, Value operand,
       unsigned operandIndex,
       const SmallVectorImpl<IndexExpr> &outputAccessExprs,
       SmallVectorImpl<IndexExpr> &operandAccessExprs);

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -57,11 +57,11 @@ struct ONNXOpShapeHelper {
   // Set the number of outputs.
   void setNumberOfOutputs(int n) { outputsDims.resize(n); }
 
-  // Data that must be present for every ShapeHelper operation. Op and context
+  // Data that must be present for every ShapeHelper operation. Op and scope
   // are initialized in the constructor, and outputsDims is computed by the
   // child's struct `Compute` function.
   OP *op;
-  IndexExprContext context;
+  IndexExprScope scope;
 
 private:
   SmallVector<DimsExpr, 1> outputsDims;
@@ -83,17 +83,17 @@ struct ONNXOpBroadcastedShapeHelper {
   // Compute access indices to load/store value from/to a given 'operand'.
   // Used in a loop to access the operand.
   // Parameters:
-  //   - outerContext: shape helper context obtained outside the loop.
+  //   - outerContext: shape helper scope obtained outside the loop.
   //   - operand: operand to access
   //   - operandIndex: index of the operand in 'inputsDims'
   //   - loopAccessExprs: IndexExprs for the loop's IVs
   //   - operandAccessExprs: access indices to access the operand.
-  LogicalResult GetAccessExprs(IndexExprContext &outerContext, Value operand,
+  LogicalResult GetAccessExprs(IndexExprScope &outerContext, Value operand,
       unsigned operandIndex,
       const SmallVectorImpl<IndexExpr> &outputAccessExprs,
       SmallVectorImpl<IndexExpr> &operandAccessExprs);
 
-  IndexExprContext context;
+  IndexExprScope scope;
   // A vector of input shapes where dimensions are padded with 1 if necessary,
   // so that all inputs have the same rank.
   SmallVector<DimsExpr, 4> inputsDims;

--- a/src/Transform/ONNX/ElideConstants.cpp
+++ b/src/Transform/ONNX/ElideConstants.cpp
@@ -72,7 +72,8 @@ public:
     OwningRewritePatternList patterns;
     patterns.insert<ConstantValueElision>(&getContext());
 
-    LogicalResult res = applyPatternsAndFoldGreedily(function, std::move(patterns));
+    LogicalResult res =
+        applyPatternsAndFoldGreedily(function, std::move(patterns));
   }
 };
 } // end anonymous namespace

--- a/src/Transform/ONNX/ElideConstants.cpp
+++ b/src/Transform/ONNX/ElideConstants.cpp
@@ -72,7 +72,7 @@ public:
     OwningRewritePatternList patterns;
     patterns.insert<ConstantValueElision>(&getContext());
 
-    applyPatternsAndFoldGreedily(function, std::move(patterns));
+    LogicalResult res = applyPatternsAndFoldGreedily(function, std::move(patterns));
   }
 };
 } // end anonymous namespace

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -1279,10 +1279,10 @@ func private @test_conv_no_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : te
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
-  // CHECK-DAG: #[[ZERO_MAP2:.+]] = affine_map<(d0, d1) -> (0, d0)>
-  // CHECK-DAG: #{{.*}} = affine_map<(d0, d1) -> (32, d1 + 6)>
-  // CHECK-DAG: #[[ZERO_MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (0, d2)>
-  // CHECK-DAG: #{{.*}} = affine_map<(d0, d1, d2, d3) -> (64, d3 + 7)>
+  // CHECK-DAG: #[[ZERO_MAP2:.+]] = affine_map<(d0) -> (0, d0)>
+  // CHECK-DAG: #{{.*}} = affine_map<(d0) -> (32, d0 + 6)>
+  // CHECK-DAG: #[[ZERO_MAP4:.+]] = affine_map<(d0, d1) -> (0, d1)>
+  // CHECK-DAG: #{{.*}} = affine_map<(d0, d1) -> (64, d1 + 7)>
   // CHECK-DAG: #[[BOUND:.+]] = affine_map<(d0)[s0, s1, s2, s3, s4] -> (s0 - ((s2 ceildiv s4) * s4 - s2), -(d0 * s3 - s2) + s0, d0 * s3 + (s1 - 1) * s4 - s2 - ((s2 ceildiv s4) * s4 - s2) + 1, d0 * s3 + (s1 - 1) * s4 - s2 - (d0 * s3 - s2) + 1)>
 
   // CHECK-LABEL: test_conv_no_bias_no_pad
@@ -1296,12 +1296,12 @@ func private @test_conv_no_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : te
   // CHECK: krnl.iterate([[SPATIAL_LOOPS]]#0, [[SPATIAL_LOOPS]]#1) with ([[SPATIAL_LOOPS]]#0 -> %arg4 = 0 to 27, [[SPATIAL_LOOPS]]#1 -> %arg5 = 0 to 58) {
   // CHECK: [[REDUCTION_VAL:%.+]] = alloca() : memref<f32>
   // CHECK: krnl.store [[CONST1]], [[REDUCTION_VAL]][] : memref<f32>
-  // CHECK: [[START1:%.+]] = affine.max #[[ZERO_MAP2]](%arg4, %arg4)
+  // CHECK: [[START1:%.+]] = affine.max #[[ZERO_MAP2]](%arg4)
   // CHECK: {{.*}} = affine.min {{.*}}
-  // CHECK: [[KERNEL_OFFSET1:%.+]] = affine.min #[[ZERO_MAP2]](%arg4, %arg4)
-  // CHECK: [[START2:%.+]] = affine.max #[[ZERO_MAP4]](%arg4, %arg4, %arg5, %arg5)
+  // CHECK: [[KERNEL_OFFSET1:%.+]] = affine.min #[[ZERO_MAP2]](%arg4)
+  // CHECK: [[START2:%.+]] = affine.max #[[ZERO_MAP4]](%arg4, %arg5)
   // CHECK: {{.*}} = affine.min {{.*}}
-  // CHECK: [[KERNEL_OFFSET2:%.+]] = affine.min #[[ZERO_MAP4]](%arg4, %arg4, %arg5, %arg5)
+  // CHECK: [[KERNEL_OFFSET2:%.+]] = affine.min #[[ZERO_MAP4]](%arg4, %arg5)
 
   // CHECK: [[INNER_LOOPS:%.+]]:3 = krnl.define_loops 3
 
@@ -1375,7 +1375,7 @@ func private @test_conv_no_bias_no_pad_w_group(%arg0 : tensor<1x9x32x64xf32>, %a
   // CHECK: [[INNER_LOOPS:%.+]]:3 = krnl.define_loops 3
 
   // CHECK: krnl.iterate([[INNER_LOOPS]]#0, [[INNER_LOOPS]]#1, [[INNER_LOOPS]]#2) with ([[INNER_LOOPS]]#0 -> %arg7 = 0 to 3, [[INNER_LOOPS]]#1 -> %arg8 = 0 to min #{{.*}}(%arg5)[{{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}], [[INNER_LOOPS]]#2 -> %arg9 = 0 to min #{{.*}}(%arg6)[{{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}]) {
-  // CHECK: [[GROUP:%.+]] = affine.apply #{{.*}}(%arg3, %arg4, %arg5, %arg5, %arg6, %arg6, %arg3, %arg7)
+  // CHECK: [[GROUP:%.+]] = affine.apply #{{.*}}(%arg3, %arg4, %arg5, %arg6, %arg3, %arg7)
   // CHECK: [[DATA:%.+]] = krnl.load %arg0[%arg2, [[GROUP]], {{.*}}, {{.*}}] : memref<1x9x32x64xf32>
   // CHECK: }
   // CHECK: }
@@ -1433,13 +1433,13 @@ func private @test_conv_bias_group_pad_stride_dilation(%arg0 : tensor<1x9x32x64x
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
-  // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (0, d2 * 2 - 2)>
-  // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (32, d3 * 2 + 9)>
-  // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (0, d4 * 2 - 2)>
-  // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (64, d5 * 2 + 11)>
-  // CHECK-DAG: #[[MAP6:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d8 * 2)>
-  // CHECK-DAG: #[[MAP7:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d9 * 2)>
-  // CHECK-DAG: #[[MAP8:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d6 * 3 + d7)>
+  // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (0, d2 * 2 - 2)>
+  // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (32, d2 * 2 + 9)>
+  // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (0, d3 * 2 - 2)>
+  // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (64, d3 * 2 + 11)>
+  // CHECK-DAG: #[[MAP6:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d6 * 2)>
+  // CHECK-DAG: #[[MAP7:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d7 * 2)>
+  // CHECK-DAG: #[[MAP8:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d4 * 3 + d5)>
   // CHECK-DAG: #[[BOUND:.+]] = affine_map<(d0)[s0, s1, s2, s3, s4] -> ((s0 - ((s2 ceildiv s4) * s4 - s2) + 1) ceildiv s4, (-(d0 * s3 - s2) + s0 + 1) ceildiv s4, (d0 * s3 + (s1 - 1) * s4 - s2 - ((s2 ceildiv s4) * s4 - s2) + 2) ceildiv s4, (d0 * s3 + (s1 - 1) * s4 - s2 - (d0 * s3 - s2) + 2) ceildiv s4)>
 
   // CHECK-LABEL: test_conv_bias_group_pad_stride_dilation
@@ -1456,12 +1456,12 @@ func private @test_conv_bias_group_pad_stride_dilation(%arg0 : tensor<1x9x32x64x
   // CHECK:     krnl.store [[INITIALIZE_VALUE]], [[RES]][%arg3, [[MAP0_APPLY]], %arg6, %arg7] : memref<1x5x13x28xf32>
   // CHECK:     [[REDUCTION_VAL:%.+]] = alloca() : memref<f32>
   // CHECK:     krnl.store [[INITIALIZE_VALUE]], [[REDUCTION_VAL]][] : memref<f32>
-  // CHECK:     [[START1:%.+]] = affine.max #[[MAP1]](%arg4, %arg5, %arg6, %arg6)
+  // CHECK:     [[START1:%.+]] = affine.max #[[MAP1]](%arg4, %arg5, %arg6)
   // CHECK:     {{.*}} = affine.min {{.*}}
-  // CHECK:     [[OFFSET1:%.+]] = affine.min #[[MAP1]](%arg4, %arg5, %arg6, %arg6)
-  // CHECK:     [[START2:%.+]] = affine.max #[[MAP3]](%arg4, %arg5, %arg6, %arg6, %arg7, %arg7)
+  // CHECK:     [[OFFSET1:%.+]] = affine.min #[[MAP1]](%arg4, %arg5, %arg6)
+  // CHECK:     [[START2:%.+]] = affine.max #[[MAP3]](%arg4, %arg5, %arg6, %arg7)
   // CHECK:     {{.*}} = affine.min {{.*}}
-  // CHECK:     [[OFFSET2:%.+]] = affine.min #[[MAP3]](%arg4, %arg5, %arg6, %arg6, %arg7, %arg7)
+  // CHECK:     [[OFFSET2:%.+]] = affine.min #[[MAP3]](%arg4, %arg5, %arg6, %arg7)
 
   // CHECK:     [[INNER_LOOPS:%.+]]:3 = krnl.define_loops 3
   // CHECK-DAG: [[C2:%.+]] = constant 2 : index
@@ -1475,13 +1475,13 @@ func private @test_conv_bias_group_pad_stride_dilation(%arg0 : tensor<1x9x32x64x
   // CHECK-DAG: [[C2_3:%.+]] = constant 2 : index
   // CHECK-DAG: [[C2_4:%.+]] = constant 2 : index
   // CHECK:     krnl.iterate([[INNER_LOOPS]]#0, [[INNER_LOOPS]]#1, [[INNER_LOOPS]]#2) with ([[INNER_LOOPS]]#0 -> %arg8 = 0 to 3, [[INNER_LOOPS]]#1 -> %arg9 = 0 to min #[[BOUND]](%arg6){{\[}}[[C32]], [[C6]], [[C2]], [[C2_0]], [[C2_1]]{{\]}}, [[INNER_LOOPS]]#2 -> %arg10 = 0 to min #[[BOUND]](%arg7){{\[}}[[C64]], [[C7]], [[C2_2]], [[C2_3]], [[C2_4]]{{\]}}) {
-  // CHECK:       [[DILATION_SCALE1:%.+]] = affine.apply #[[MAP6]](%arg4, %arg5, %arg6, %arg6, %arg7, %arg7, %arg4, %arg8, %arg9)
+  // CHECK:       [[DILATION_SCALE1:%.+]] = affine.apply #[[MAP6]](%arg4, %arg5, %arg6, %arg7, %arg4, %arg8, %arg9)
   // CHECK:       [[R1:%.+]] = addi [[DILATION_SCALE1]], [[START1]] : index
-  // CHECK:       [[DILATION_SCALE2:%.+]] = affine.apply #[[MAP7]](%arg4, %arg5, %arg6, %arg6, %arg7, %arg7, %arg4, %arg8, %arg9, %arg10)
+  // CHECK:       [[DILATION_SCALE2:%.+]] = affine.apply #[[MAP7]](%arg4, %arg5, %arg6, %arg7, %arg4, %arg8, %arg9, %arg10)
   // CHECK:       [[R2:%.+]] = addi [[DILATION_SCALE2]], [[START2]] : index
   // CHECK:       [[K1:%.+]] = subi %arg9, [[OFFSET1]] : index
   // CHECK:       [[K2:%.+]] = subi %arg10, [[OFFSET2]] : index
-  // CHECK:       [[GROUP:%.+]] = affine.apply #[[MAP8]](%arg4, %arg5, %arg6, %arg6, %arg7, %arg7, %arg4, %arg8, %arg9, %arg10)
+  // CHECK:       [[GROUP:%.+]] = affine.apply #[[MAP8]](%arg4, %arg5, %arg6, %arg7, %arg4, %arg8, %arg9, %arg10)
 
   // CHECK:       [[DATA:%.+]] = krnl.load %arg0[%arg3, [[GROUP]], [[R1]], [[R2]]] : memref<1x9x32x64xf32>
   // CHECK:       [[KERNEL:%.+]] = krnl.load %arg1{{\[}}[[MAP0_APPLY]], %arg8, [[K1]], [[K2]]{{\]}} : memref<5x3x6x7xf32>
@@ -1716,10 +1716,10 @@ func private @test_pool_general_computation(%arg0 : tensor<1x3x32x32xf32>) -> te
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x32x32xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
-  // CHECK-DAG: #{{.*}} = affine_map<(d0, d1) -> (0, d0)>
+  // CHECK-DAG: #{{.*}} = affine_map<(d0) -> (0, d0)>
+  // CHECK-DAG: #{{.*}} = affine_map<(d0) -> (32, d0 + 2)>
+  // CHECK-DAG: #{{.*}} = affine_map<(d0, d1) -> (0, d1)>
   // CHECK-DAG: #{{.*}} = affine_map<(d0, d1) -> (32, d1 + 2)>
-  // CHECK-DAG: #{{.*}} = affine_map<(d0, d1, d2, d3) -> (0, d2)>
-  // CHECK-DAG: #{{.*}} = affine_map<(d0, d1, d2, d3) -> (32, d3 + 2)>
   // CHECK-DAG: #[[BOUND:.+]] = affine_map<(d0)[s0, s1, s2, s3, s4] -> (s0 - ((s2 ceildiv s4) * s4 - s2), -(d0 * s3 - s2) + s0, d0 * s3 + (s1 - 1) * s4 - s2 - ((s2 ceildiv s4) * s4 - s2) + 1, d0 * s3 + (s1 - 1) * s4 - s2 - (d0 * s3 - s2) + 1)>
 
   // CHECK-LABEL: @test_pool_general_computation

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1597,11 +1597,11 @@ func @test_less_unknown_dims_2(%arg0: tensor<?x?x5xf32>, %arg1: tensor<?x4x5xf32
 
 // -----
 
-func @test_clip(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func @test_clip2(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
   %0 = "onnx.Clip"(%arg0, %arg1, %arg2) : (tensor<3xf32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 
-// CHECK-LABEL:  func @test_clip
+// CHECK-LABEL:  func @test_clip2
 // CHECK-SAME:   ([[INPUT_:%.+]]: tensor<3xf32>, [[MIN_:%.+]]: tensor<f32>, [[MAX_:%.+]]: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
 // CHECK:           [[RES_:%.+]] = "onnx.Clip"([[INPUT_]], [[MIN_]], [[MAX_]]) : (tensor<3xf32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
 // CHECK:           return [[RES_]] : tensor<3xf32>


### PR DESCRIPTION
Updated the IndexExpr interface to be more like EDSC like. At the big picture level, I created two new data structure to capture memref bounds and array values as index expressions:

```mlir
  // Scan dimensions of A with/without transpose.
  MemRefBoundIndexCapture ABounds(A);
  if (op->transA() == 0) {
    aDims = {ABounds.getDim(0), ABounds.getDim(1)};
  } else {
    aDims = {ABounds.getDim(1), ABounds.getDim(0)};
  }
```

or 
```mlir
  ArrayValueIndexCapture startsCapture(genericOp, operandAdaptor.starts());
  for (uint64_t i = 0; i < sliceRank; i++) {
    int ii = axesIntLit[i];
    // Get start, end, step, and dim index expressions.
    // Get start.
    SymbolIndexExpr startInput(startsCapture.getSymbol(i));
   // ...
}
```

To create IndexExpr, we have now 5 subclasses of IndexExpr that are use solely to create Index Expressions. E.g.

``` mlir
    SymbolIndexExpr endInput(endsCapture.getSymbol(i));
    if (endInput.isUndefined())
      return op->emitError("end input parameter could not be processed");
    // Get step.
    SymbolIndexExpr stepInput(stepsCapture.getSymbol(i));
    if (stepInput.isUndefined())
      return op->emitError("step input parameter could not be processed");
    if (stepInput.isLiteral() && stepInput.getLiteral() == 0)
      return op->emitError("step input parameter cannot be zero");
    // Get dim.
    DimIndexExpr dimInput(dataBounds.getDim(ii));

   // create a literal
  LiteralIndexExpr three(3);
```

Scopes are now implicit, so they need to be created but don't need to be passed around. Internally, its a thread private.

``` mlir
  IndexExprScope outerScope; // outer scope 
  DimIndexExpr d1(dataBounds.getDim(2); // outer scope variable
  // ...
  {
     IndexExprScope innerScope;
     SymbolIndexExpr s1(d1); // in the inner scope, make a symbol out of the outer scope dim index expr d1.
    // ...
    // innerScope is deleted, and its enclosing scope becomes the active scope again.
}

// Back to the outer scope
```

In addition to the new interface, I also detected some redundant AffineExpr's dim and symbol being created. I changed the code to prevent the rewriting of these redundant symbols. Thus some lit tests were updated to reflect these changes. Otherwise, there were no changes in the code being produced as this PR is mainly about the IndexExpr interface. 



