### PR TITLE
Add dependence for check-onnx-backend-dynamic

### DIFF
--- a/test/backend/CMakeLists.txt
+++ b/test/backend/CMakeLists.txt
@@ -54,3 +54,5 @@ add_custom_target(clean-onnx-backend
 
 add_dependencies(check-onnx-backend onnx-mlir)
 add_dependencies(check-onnx-backend PyRuntime)
+add_dependencies(check-onnx-backend-dynamic onnx-mlir)
+add_dependencies(check-onnx-backend-dynamic PyRuntime)


### PR DESCRIPTION
Signed-off-by: chentong <chentong@us.ibm.com>
Add dependence for target check-onnx-backend-dynamic, same as check-onnx-backend.