### PR TITLE
Change the equation for validating calculation results in numerical tests

### DIFF
--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -473,7 +473,7 @@ inline bool omTensorAreTwoOmtsClose(
   // (rtol * b + atol) - abs(a - b)
   std::transform(eqAllclose.begin(), eqAllclose.end(), absoluteDiff.begin(),
       eqAllclose.begin(), std::minus<>());
-  bool satisfied = all_of(
+  bool satisfied = std::all_of(
       eqAllclose.begin(), eqAllclose.end(), [&](T eq) { return eq >= 0; });
 
   if (satisfied) {

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -445,24 +445,38 @@ inline bool omTensorAreTwoOmtsClose(
     return false;
   }
 
-  // Compute absolute difference, verify it's within tolerable range.
+  // Compute difference, verify it's within tolerable range.
+  // rtol * b + atol >= abs(a - b)
   auto anum = omTensorGetNumElems(a);
+  auto bnum = omTensorGetNumElems(b);
+  auto rtolT = omTensorCreateWithShape<T>(aShape);
+  auto atolT = omTensorCreateWithShape<T>(aShape);
+  for (const auto &idx : omTensorComputeIndexSet(rtolT)) {
+    omTensorGetElem<T>(rtolT, idx) = rtol;
+    omTensorGetElem<T>(atolT, idx) = atol;
+  }
   std::vector<T> absoluteDiff(anum);
+  std::vector<T> eqAllclose(anum);
+  // abs(a - b)
   std::transform((T *)a->_allocatedPtr, (T *)a->_allocatedPtr + anum,
       (T *)b->_allocatedPtr, absoluteDiff.begin(), std::minus<>());
   std::transform(absoluteDiff.begin(), absoluteDiff.end(), absoluteDiff.begin(),
       static_cast<T (*)(T)>(&std::abs));
-  bool atolSatisfied = std::all_of(
-      absoluteDiff.begin(), absoluteDiff.end(), [&](T a) { return a < atol; });
+  // rtol * abs(b)
+  std::transform((T *)b->_allocatedPtr, (T *)b->_allocatedPtr + bnum,
+      (T *)b->_allocatedPtr, static_cast<T (*)(T)>(&std::abs));
+  std::transform((T *)b->_allocatedPtr, (T *)b->_allocatedPtr + bnum,
+      (T *)rtolT->_allocatedPtr, eqAllclose.begin(), std::multiplies<>());
+  // rtol * abs(b) + atol
+  std::transform(eqAllclose.begin(), eqAllclose.end(),
+      (T *)atolT->_allocatedPtr, eqAllclose.begin(), std::plus<>());
+  // (rtol * b + atol) - abs(a - b)
+  std::transform(eqAllclose.begin(), eqAllclose.end(), absoluteDiff.begin(),
+      eqAllclose.begin(), std::minus<>());
+  bool satisfied = all_of(
+      eqAllclose.begin(), eqAllclose.end(), [&](T eq) { return eq >= 0; });
 
-  // Compute relative difference, verify it's within tolerable range.
-  std::vector<T> relativeDiff(anum);
-  std::transform(absoluteDiff.begin(), absoluteDiff.end(),
-      (T *)a->_allocatedPtr, relativeDiff.begin(), std::divides<>());
-  bool rtolSatisfied = all_of(
-      relativeDiff.begin(), relativeDiff.end(), [&](T a) { return a < rtol; });
-
-  if (atolSatisfied && rtolSatisfied) {
+  if (satisfied) {
     return true;
   } else {
     // Figure out where and what went wrong, this can be slow; but hopefully we


### PR DESCRIPTION
The equation for validating calculation results in numerical tests is different from onnx backend test. This PR changes the equation to use the same one with onnx backend test. I think this equation is generally used, but is there any specific reason to use current one?

Onnx backend test uses `absolute(a - b) <= (atol + rtol * absolute(b))` by using [`testing.assert_allclose`](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_allclose.html) . Source code is [here.](https://github.com/onnx/onnx/blob/v1.7.0/onnx/backend/test/runner/__init__.py#L174) Equation is written [here]( https://numpy.org/doc/stable/reference/generated/numpy.allclose.html)

When I changed ATOL and RTOL both in onnx backend test and numerical test to meet my requirement, I got errors only in numerical test. So, I found this difference. 



Signed-off-by: Haruki Imai <imaihal@jp.ibm.com>