### PR TITLE
Fix memory leak with C/C++ interface

### DIFF
--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -877,8 +877,10 @@ public:
     }
 
     // Create wrapped output.
+    auto one = rewriter.create<LLVM::ConstantOp>(
+        loc, int32Ty, rewriter.getI32IntegerAttr(1));
     auto wrappedOutput = callApi(rewriter, loc, apiRegistry,
-        API::CREATE_OMTENSOR_LIST, {outOmtPtrsArr, numOutput});
+        API::CREATE_OMTENSOR_LIST, {outOmtPtrsArr, numOutput, one});
 
     // Clean the global constant.
     auto globalBase = module.lookupSymbol<LLVM::GlobalOp>("packedConst");
@@ -916,7 +918,7 @@ private:
     // specifying its signature.
     // clang-format off
     std::vector<ApiSpec> apiSpecs = {
-        ApiSpec(API::CREATE_OMTENSOR_LIST, "omTensorListCreate", opaquePtrTy, {opaquePtrPtrTy, int32Ty}),
+        ApiSpec(API::CREATE_OMTENSOR_LIST, "omTensorListCreateWithOwnership", opaquePtrTy, {opaquePtrPtrTy, int32Ty, int32Ty}),
         ApiSpec(API::CREATE_OMTENSOR, "omTensorCreateEmptyDeprecated", opaquePtrTy, {int32Ty}),
         ApiSpec(API::GET_DATA, "omTensorGetDataPtr", opaquePtrTy, {opaquePtrTy}),
         ApiSpec(API::SET_DATA, "omTensorSetDataPtr", voidTy, {opaquePtrTy, int32Ty, opaquePtrTy, opaquePtrTy}),

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -158,6 +158,27 @@ static FlatSymbolRefAttr getOrInsertMalloc(
   return SymbolRefAttr::get("malloc", ctx);
 }
 
+static FlatSymbolRefAttr getOrInsertDealloc(
+    PatternRewriter &rewriter, ModuleOp module) {
+  // Insert the dealloc declaration if it is not already present.
+  auto deallocFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("free");
+  auto ctx = rewriter.getContext();
+  LLVMTypeConverter converter(ctx);
+  if (!deallocFunc) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(module.getBody());
+    auto voidPtrType = LLVM::LLVMPointerType::get(
+        IntegerType::get(&converter.getContext(), 8));
+    SmallVector<Type, 2> callArgTypes = {voidPtrType};
+    auto llvmVoidTy = LLVM::LLVMVoidType::get(&converter.getContext());
+    deallocFunc =
+        rewriter.create<LLVM::LLVMFuncOp>(rewriter.getUnknownLoc(), "free",
+            LLVM::LLVMFunctionType::get(llvmVoidTy, callArgTypes,
+                /*isVarArg=*/false));
+  }
+  return SymbolRefAttr::get("free", ctx);
+}
+
 // This function emits a declaration of the form:
 //
 // declare float <mathFuncName>(float)
@@ -858,6 +879,18 @@ public:
     // Create wrapped output.
     auto wrappedOutput = callApi(rewriter, loc, apiRegistry,
         API::CREATE_OMTENSOR_LIST, {outOmtPtrsArr, numOutput});
+
+    // Clean the global constant.
+    auto globalBase = module.lookupSymbol<LLVM::GlobalOp>("packedConst");
+    if (globalBase) {
+      Value basePtrAddr = rewriter.create<LLVM::AddressOfOp>(loc, globalBase);
+      Value alloc = rewriter.create<LLVM::LoadOp>(loc,
+          LLVM::LLVMPointerType::get(IntegerType::get(context, 8)),
+          basePtrAddr);
+      auto deallocSym = getOrInsertDealloc(rewriter, module);
+      auto dealloc = rewriter.create<LLVM::CallOp>(
+          loc, ArrayRef<Type>({}), deallocSym, ArrayRef<Value>(alloc));
+    }
 
     // Return wrapped output.
     rewriter.create<LLVM::ReturnOp>(

--- a/src/Runtime/OMTensorList.inc
+++ b/src/Runtime/OMTensorList.inc
@@ -31,7 +31,9 @@ struct OMTensorList {
    * Create an OMTensorList with specified OMTensor pointer array
    * and the size of the array
    */
-  OMTensorList(OMTensor *omts[], int n) : _omts(omts), _size(n){};
+  OMTensorList(OMTensor *omts[], int n) : _omts(omts), _size(n) {
+      _owning = false;
+  };
 
   /**
    * Constructor
@@ -60,6 +62,13 @@ struct OMTensorList {
   OMTensor **_omts; // OMTensor array
 
   size_t _size; // Number of elements in _omts.
+
+
+  int _owning; // indicates whether the OMTensorList owns the pointer to
+               // OMTensor array or not. OMTensorList struct will release the
+               // memory space referred to by '_omts' upon destruction if and
+               // only if it owns it.
+
 };
 
 /* OMTensorList creator */
@@ -69,6 +78,19 @@ OMTensorList *omTensorListCreate(OMTensor **tensors, int n) {
     return NULL;
   list->_omts = tensors;
   list->_size = n;
+  list->_owning = false;
+  return list;
+}
+
+/* OMTensorList creator with ownership */
+OMTensorList *omTensorListCreateWithOwnership(OMTensor **tensors, int n,
+    int owning) {
+  OMTensorList *list = (OMTensorList *)malloc(sizeof(struct OMTensorList));
+  if (!list)
+    return NULL;
+  list->_omts = tensors;
+  list->_size = n;
+  list->_owning = owning;
   return list;
 }
 
@@ -77,6 +99,8 @@ void omTensorListDestroy(OMTensorList *list) {
   for (int i = 0; i < list->_size; i++)
     if (list->_omts[i])
       omTensorDestroy(list->_omts[i]);
+  if (list->_owning)
+    free(list->_omts);
   free(list);
 }
 


### PR DESCRIPTION
Signed-off-by: Tung D. Le <tung@jp.ibm.com>

Memory leak issue was originally reported by @seroyer. Thanks, Steven!

Test program (for MNIST inference): 
```mlir
OMTensor *tensor = omTensorCreate(input, shape.data(), shape.size(), ONNX_TYPE_FLOAT);
OMTensor *tensorList[] = {tensor};
OMTensorList *tensorListIn = omTensorListCreate(tensorList, 1);

OMTensorList *tensorListOut = run_main_graph(tensorListIn);

omTensorListDestroy(tensorListOut);
omTensorListDestroy(tensorListIn);
```

Using valgrind to check memory leak: `valgrind --leak-check=full ./memcheck`
- run one inference:
```
==372468== LEAK SUMMARY:
==372468==    definitely lost: 8 bytes in 1 blocks
==372468==    indirectly lost: 0 bytes in 0 blocks
==372468==      possibly lost: 0 bytes in 0 blocks
==372468==    still reachable: 0 bytes in 0 blocks
==372468==         suppressed: 0 bytes in 0 blocks
```

- run 100 inferences, the leak grows by each call.
```
==372469== LEAK SUMMARY:
==372469==    definitely lost: 800 bytes in 100 blocks
==372469==    indirectly lost: 0 bytes in 0 blocks
==372469==      possibly lost: 0 bytes in 0 blocks
==372469==    still reachable: 0 bytes in 0 blocks
==372469==         suppressed: 0 bytes in 0 blocks
```

There are two issues that cause the leak:
1) Global constant
In the generated code, we malloc memory for global constant but not free.
```
llvm.mlir.global internal @packedConst() : !llvm.ptr<i8>
%17 = llvm.mlir.constant(0 : i64) : i64
%18 = llvm.call @getEmbeddedConstPool(%17) : (i64) -> !llvm.ptr<i8>
```
In particular, memory is allocated (by malloc) inside getEmbeddedConstPool and pointed to by `%18`, but there is no intrinsic to free `%18`.

2) OMTensorList
In the generated code, we malloc memory for the list of OMTensor pointers which is to store output OMTensorList.
```
%26 = llvm.call @malloc(%25) : (i64) -> !llvm.ptr<i8>
```
This memory is expected to be destroyed by `omTensorListDestroy`. Document for `omTensorListDestroy` said the memory will be released but there is no code for it.

This patch fixes the two above issues:
- for issue 1: Emit `free` for the global constant if the global constant exists.
- for issue 2: Add a member of OMTensorList to indicate the OMTensorList owns the pointer to OMTensor array or not, and the pointer will be freed if owning. By default, OMTensorList does not own the pointer.

With this patch, we do not see memory leak:
- run 100 inferences:
```
==373203== HEAP SUMMARY:
==373203==     in use at exit: 0 bytes in 0 blocks
==373203==   total heap usage: 1,625 allocs, 1,625 frees, 12,184,032 bytes allocated
==373203==
==373203== All heap blocks were freed -- no leaks are possible
```