### PR TITLE
[cmake] Allow pointing to LLVM without using environment variables

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -2,29 +2,33 @@
 
 # Path to LLVM source folder.
 if(DEFINED LLVM_PROJ_SRC)
+  # Just use it...
 elseif(DEFINED ENV{LLVM_PROJ_SRC})
   set(LLVM_PROJ_SRC $ENV{LLVM_PROJ_SRC})
 else()
-  message(FATAL_ERROR "env variable LLVM_PROJ_SRC not set")
+  message(FATAL_ERROR "LLVM_PROJ_SRC is not configured.  Please set the env variable "
+  "LLVM_PROJ_SRC or the corresponding cmake configuration option to reference an LLVM source tree.")
 endif()
 if(EXISTS ${LLVM_PROJ_SRC})
-message(STATUS "LLVM_PROJ_SRC           : " ${LLVM_PROJ_SRC})
+  message(STATUS "LLVM_PROJ_SRC           : " ${LLVM_PROJ_SRC})
 else()
-message(FATAL_ERROR "The path specified by LLVM_PROJ_SRC does not exist: "
+  message(FATAL_ERROR "The path specified by LLVM_PROJ_SRC does not exist: "
         ${LLVM_PROJ_SRC})
 endif()
 
 # Path to LLVM build folder
 if(DEFINED LLVM_PROJ_BUILD)
+  # Just use it...
 elseif(DEFINED ENV{LLVM_PROJ_BUILD})
   set(LLVM_PROJ_BUILD $ENV{LLVM_PROJ_BUILD})
 else()
-  message(FATAL_ERROR "env variable LLVM_PROJ_BUILD not set")
+  message(FATAL_ERROR "LLVM_PROJ_BUILD is not configured.  Please set the env variable "
+  "LLVM_PROJ_BUILD or the corresponding cmake configuration option to reference an LLVM build.")
 endif()
 if(EXISTS ${LLVM_PROJ_BUILD})
-message(STATUS "LLVM_PROJ_BUILD         : " ${LLVM_PROJ_BUILD})
+  message(STATUS "LLVM_PROJ_BUILD         : " ${LLVM_PROJ_BUILD})
 else()
-message(FATAL_ERROR "The path specified by LLVM_PROJ_BUILD does not exist: "
+  message(FATAL_ERROR "The path specified by LLVM_PROJ_BUILD does not exist: "
         ${LLVM_PROJ_BUILD})
 endif()
 

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -1,29 +1,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Path to LLVM source folder.
-if(DEFINED ENV{LLVM_PROJ_SRC})
+if(DEFINED LLVM_PROJ_SRC)
+elseif(DEFINED ENV{LLVM_PROJ_SRC})
   set(LLVM_PROJ_SRC $ENV{LLVM_PROJ_SRC})
-  if(EXISTS ${LLVM_PROJ_SRC})
-    message(STATUS "LLVM_PROJ_SRC           : " ${LLVM_PROJ_SRC})
-  else()
-    message(FATAL_ERROR "The path specified by LLVM_PROJ_SRC does not exist: "
-            ${LLVM_PROJ_SRC})
-  endif()
 else()
   message(FATAL_ERROR "env variable LLVM_PROJ_SRC not set")
 endif()
+if(EXISTS ${LLVM_PROJ_SRC})
+message(STATUS "LLVM_PROJ_SRC           : " ${LLVM_PROJ_SRC})
+else()
+message(FATAL_ERROR "The path specified by LLVM_PROJ_SRC does not exist: "
+        ${LLVM_PROJ_SRC})
+endif()
 
 # Path to LLVM build folder
-if(DEFINED ENV{LLVM_PROJ_BUILD})
+if(DEFINED LLVM_PROJ_BUILD)
+elseif(DEFINED ENV{LLVM_PROJ_BUILD})
   set(LLVM_PROJ_BUILD $ENV{LLVM_PROJ_BUILD})
-  if(EXISTS ${LLVM_PROJ_BUILD})
-    message(STATUS "LLVM_PROJ_BUILD         : " ${LLVM_PROJ_BUILD})
-  else()
-    message(FATAL_ERROR "The path specified by LLVM_PROJ_BUILD does not exist: "
-            ${LLVM_PROJ_BUILD})
-  endif()
 else()
   message(FATAL_ERROR "env variable LLVM_PROJ_BUILD not set")
+endif()
+if(EXISTS ${LLVM_PROJ_BUILD})
+message(STATUS "LLVM_PROJ_BUILD         : " ${LLVM_PROJ_BUILD})
+else()
+message(FATAL_ERROR "The path specified by LLVM_PROJ_BUILD does not exist: "
+        ${LLVM_PROJ_BUILD})
 endif()
 
 # LLVM project lib folder


### PR DESCRIPTION
When integrating as an external project, this becomes awkward.
It's generally preferable to use cmake variables to configure
things like this.  This patch extends the existing mechanism to
allow the use of cmake variables.