### PR TITLE
Krnl operations support for broadcast

### DIFF
--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -697,17 +697,17 @@ public:
         kGlobalUB(operandAdaptor.kGlobalUB());
     // A[i, k]; B[k, j]; C[i, j]
     IndexExpr AStart0 =
-        iComputeStart - DimIndexExpr(operandAdaptor.aMemStart0());
+        iComputeStart - DimIndexExpr(operandAdaptor.aMemStart()[0]);
     IndexExpr AStart1 =
-        kComputeStart - DimIndexExpr(operandAdaptor.aMemStart1());
+        kComputeStart - DimIndexExpr(operandAdaptor.aMemStart()[1]);
     IndexExpr BStart0 =
-        kComputeStart - DimIndexExpr(operandAdaptor.bMemStart0());
+        kComputeStart - DimIndexExpr(operandAdaptor.bMemStart()[0]);
     IndexExpr BStart1 =
-        jComputeStart - DimIndexExpr(operandAdaptor.bMemStart1());
+        jComputeStart - DimIndexExpr(operandAdaptor.bMemStart()[0]);
     IndexExpr CStart0 =
-        iComputeStart - DimIndexExpr(operandAdaptor.cMemStart0());
+        iComputeStart - DimIndexExpr(operandAdaptor.cMemStart()[0]);
     IndexExpr CStart1 =
-        jComputeStart - DimIndexExpr(operandAdaptor.cMemStart1());
+        jComputeStart - DimIndexExpr(operandAdaptor.cMemStart()[1]);
 
     // Simdize along M for the full compute tile
     IndexExpr vectorLen = jComputeTileSize;

--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -818,7 +818,7 @@ private:
       ArrayRef<IndexExpr> aStart, ArrayRef<IndexExpr> bStart,
       ArrayRef<IndexExpr> cStart, IndexExpr I, IndexExpr J, IndexExpr K,
       bool unrollJam) const {
-    // Get operands.
+    // Get operands.Î
     KrnlMatMulOpAdaptor operandAdaptor(op);
     Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(operandAdaptor.C());
     int64_t aRank(aStart.size()), bRank(bStart.size()), cRank(cStart.size());

--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -639,30 +639,35 @@ public:
     SmallVector<IndexExpr, 2> aTileSize, bTileSize, cTileSize;
     Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(operandAdaptor.C());
     MemRefBoundIndexCapture aBounds(A), bBounds(B), cBounds(C);
+    int64_t aRank(aBounds.getRank()), bRank(bBounds.getRank()),
+        cRank(cBounds.getRank());
     // Tile sizes for A/B/C are determined by their memref unless explicitly
     // specified by an optional argument. That allows A/B/C memrefs to be
     // padded if needed for SIMD/unroll and jam, for example.
-    aBounds.getSymbolList(aTileSize);
-    ArrayAttributeIndexCapture ASizeCapture(op.aTileSizeAttr());
-    if (ASizeCapture.size())
-      aTileSize = {ASizeCapture.getLiteral(0), ASizeCapture.getLiteral(1)};
-    bBounds.getLiteralList(bTileSize);
-    ArrayAttributeIndexCapture BSizeCapture(op.bTileSizeAttr());
-    if (BSizeCapture.size())
-      bTileSize = {BSizeCapture.getLiteral(0), BSizeCapture.getLiteral(1)};
+    ArrayAttributeIndexCapture aSizeCapture(op.aTileSizeAttr());
+    if (aSizeCapture.size())
+      aTileSize = {aSizeCapture.getLiteral(0), aSizeCapture.getLiteral(1)};
+    else
+      aTileSize = {aBounds.getSymbol(aRank - 2), aBounds.getSymbol(aRank - 1)};
+    ArrayAttributeIndexCapture bSizeCapture(op.bTileSizeAttr());
+    if (bSizeCapture.size())
+      bTileSize = {bSizeCapture.getLiteral(0), bSizeCapture.getLiteral(1)};
+    else
+      bTileSize = {bBounds.getSymbol(bRank - 2), bBounds.getSymbol(bRank - 1)};
     cBounds.getLiteralList(cTileSize);
-    ArrayAttributeIndexCapture CSizeCapture(op.cTileSizeAttr());
-    if (CSizeCapture.size())
-      cTileSize = {CSizeCapture.getLiteral(0), CSizeCapture.getLiteral(1)};
+    ArrayAttributeIndexCapture cSizeCapture(op.cTileSizeAttr());
+    if (cSizeCapture.size())
+      cTileSize = {cSizeCapture.getLiteral(0), cSizeCapture.getLiteral(1)};
+    else
+      cTileSize = {cBounds.getSymbol(cRank - 2), cBounds.getSymbol(cRank - 1)};
+
     // Check consitency. If the dimensions were padded differently for
     // A, B, or C, and the optional A/B/C TileSize attributes were given,
     // we take the these optional sizes into consideration. Meaning, we
     // don't really care about the padded dimensions, we only care about
     // the actual data.
-    bool literalTileSizes = false;
     if (IndexExpr::isLiteral(aTileSize) && IndexExpr::isLiteral(bTileSize) &&
         IndexExpr::isLiteral(cTileSize)) {
-      literalTileSizes = true;
       assert(aTileSize[0].getLiteral() == cTileSize[0].getLiteral() &&
              "I dim mismatch");
       assert(aTileSize[1].getLiteral() == bTileSize[0].getLiteral() &&
@@ -695,19 +700,35 @@ public:
     SymbolIndexExpr iGlobalUB(operandAdaptor.iGlobalUB()),
         jGlobalUB(operandAdaptor.jGlobalUB()),
         kGlobalUB(operandAdaptor.kGlobalUB());
-    // A[i, k]; B[k, j]; C[i, j]
-    IndexExpr AStart0 =
-        iComputeStart - DimIndexExpr(operandAdaptor.aMemStart()[0]);
-    IndexExpr AStart1 =
-        kComputeStart - DimIndexExpr(operandAdaptor.aMemStart()[1]);
-    IndexExpr BStart0 =
-        kComputeStart - DimIndexExpr(operandAdaptor.bMemStart()[0]);
-    IndexExpr BStart1 =
-        jComputeStart - DimIndexExpr(operandAdaptor.bMemStart()[0]);
-    IndexExpr CStart0 =
-        iComputeStart - DimIndexExpr(operandAdaptor.cMemStart()[0]);
-    IndexExpr CStart1 =
-        jComputeStart - DimIndexExpr(operandAdaptor.cMemStart()[1]);
+    // A[i, k];
+    SmallVector<IndexExpr, 4> aStart, bStart, cStart;
+    for (int t = 0; t < aRank - 2; t++)
+      aStart.emplace_back(SymbolIndexExpr(operandAdaptor.aMemStart()[t]));
+    aStart.emplace_back(
+        iComputeStart - DimIndexExpr(operandAdaptor.aMemStart()[aRank - 2]));
+    aStart.emplace_back(
+        kComputeStart - DimIndexExpr(operandAdaptor.aMemStart()[aRank - 1]));
+    // B[k, j];
+    for (int t = 0; t < bRank - 2; t++)
+      bStart.emplace_back(SymbolIndexExpr(operandAdaptor.bMemStart()[t]));
+    bStart.emplace_back(
+        kComputeStart - DimIndexExpr(operandAdaptor.bMemStart()[bRank - 2]));
+    bStart.emplace_back(
+        jComputeStart - DimIndexExpr(operandAdaptor.bMemStart()[bRank - 1]));
+    // C[i, j]
+    for (int t = 0; t < cRank - 2; t++)
+      cStart.emplace_back(SymbolIndexExpr(operandAdaptor.cMemStart()[t]));
+    cStart.emplace_back(
+        iComputeStart - DimIndexExpr(operandAdaptor.cMemStart()[cRank - 2]));
+    cStart.emplace_back(
+        jComputeStart - DimIndexExpr(operandAdaptor.cMemStart()[cRank - 1]));
+
+    IndexExpr AStart0 = aStart[0];
+    IndexExpr AStart1 = aStart[1];
+    IndexExpr BStart0 = bStart[0];
+    IndexExpr BStart1 = bStart[1];
+    IndexExpr CStart0 = cStart[0];
+    IndexExpr CStart1 = cStart[1];
 
     // Simdize along M for the full compute tile
     IndexExpr vectorLen = jComputeTileSize;
@@ -752,27 +773,25 @@ public:
       // clang-format off
       genIfThenElseWithoutParams(rewriter, allFullTiles,
         /* then full */ [&](ValueRange) {
-        genSimd(rewriter, op, elementType, AStart0,  AStart1,  BStart0,
-          BStart1,  CStart0,  CStart1, iComputeTileSize, jComputeTileSize,
-          kComputeTileSize,  vectorLen, fullUnrollAndJam); 
+        genSimd(rewriter, op, elementType, aStart, bStart, cStart,
+          iComputeTileSize, jComputeTileSize, kComputeTileSize,
+          vectorLen, fullUnrollAndJam); 
       }, /* has some partial tiles */ [&](ValueRange) {
         // Trip regardless of full/partial for N & K
         // Test if SIMD dim (M) is full.
         genIfThenElseWithoutParams(rewriter, jFullTiles,
           /* full SIMD */ [&](ValueRange) {
-          genSimd(rewriter, op, elementType, AStart0,  AStart1,  BStart0,
-            BStart1,  CStart0,  CStart1, iTrip, jComputeTileSize, kTrip,
-            vectorLen, false);
+          genSimd(rewriter, op, elementType, aStart, bStart, cStart,
+            iTrip, jComputeTileSize, kTrip, vectorLen, false);
         }, /* else partial SIMD */ [&](ValueRange) {
           if (false && jPartialTrip.isLiteral() && jPartialTrip.getLiteral() >=2) {
             // has a known trip count along the simd dimension of at least 2
             // elements, use simd again.
-            genSimd(rewriter, op, elementType, AStart0,  AStart1,  BStart0,
-              BStart1,  CStart0,  CStart1, iTrip, jPartialTrip, kTrip,
-              vectorLen, false);
+            genSimd(rewriter, op, elementType, aStart, bStart, cStart,
+              iTrip, jPartialTrip, kTrip, vectorLen, false);
           } else {
-            genScalar(rewriter, op, elementType, AStart0,  AStart1,  BStart0,
-              BStart1,  CStart0,  CStart1, iTrip, jPartialTrip, kTrip, false);
+            genScalar(rewriter, op, elementType, aStart, bStart,  cStart,
+              iTrip, jPartialTrip, kTrip, false);
           }
         });
       });
@@ -782,12 +801,12 @@ public:
       // clang-format off
       genIfThenElseWithoutParams(rewriter, allFullTiles,
         /* then full */ [&](ValueRange) {
-        genScalar(rewriter, op, elementType, AStart0,  AStart1,  BStart0,
-          BStart1,  CStart0,  CStart1, iComputeTileSize, jComputeTileSize, 
-          kComputeTileSize, fullUnrollAndJam); 
+        genScalar(rewriter, op, elementType, aStart, bStart, cStart,
+          iComputeTileSize, jComputeTileSize, kComputeTileSize,
+          fullUnrollAndJam); 
       }, /* else partial */ [&](ValueRange) {
-        genScalar(rewriter, op, elementType, AStart0,  AStart1,  BStart0,
-          BStart1,  CStart0,  CStart1, iTrip, jTrip, kTrip, false);
+        genScalar(rewriter, op, elementType, aStart, bStart, cStart,
+          iTrip, jTrip, kTrip, false);
       });
       // clang-format on
     }
@@ -797,15 +816,13 @@ public:
 
 private:
   void genScalar(PatternRewriter &rewriter, KrnlMatMulOp op, Type elementType,
-      IndexExpr aStart0, IndexExpr aStart1, IndexExpr bStart0,
-      IndexExpr bStart1, IndexExpr cStart0, IndexExpr cStart1, IndexExpr I,
-      IndexExpr J, IndexExpr K, bool unrollJam) const {
+      ArrayRef<IndexExpr> aStart, ArrayRef<IndexExpr> bStart,
+      ArrayRef<IndexExpr> cStart, IndexExpr I, IndexExpr J, IndexExpr K,
+      bool unrollJam) const {
     // Get operands.
     KrnlMatMulOpAdaptor operandAdaptor(op);
     Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(operandAdaptor.C());
-
-    // Get the EDSC variables, and loop dimensions.
-    AffineIndexedValue AA(A), BB(B), CC(C); // Obj we can load and store into.
+    int64_t aRank(aStart.size()), bRank(bStart.size()), cRank(cStart.size());
     MemRefType CTmpType = MemRefType::get({}, elementType);
 
     // For i, j loops.
@@ -820,15 +837,29 @@ private:
         // Alloc and init temp c storage.
         Value TmpC = std_alloca(CTmpType);
         AffineIndexedValue TTmpC(TmpC);
-        TTmpC() = CC(i + cStart0.getValue(), j + cStart1.getValue());
+        SmallVector<Value, 4> cAccess;
+        // CC(i + cStart0.getValue(), j + cStart1.getValue());
+        IndexExpr::getValues(cStart, cAccess);
+        cAccess[cRank-2] = i + cAccess[cRank-2];
+        cAccess[cRank-1] = j + cAccess[cRank-1];
+        TTmpC() = affine_load(C, cAccess);
         // Sum over k.
         affineLoopBuilder(zero, K, 1, [&](Value k) {
-          TTmpC() = AA(i + aStart0.getValue(), k + aStart1.getValue()) *
-            BB(k + bStart0.getValue(), j + bStart1.getValue()) +
-            TTmpC();
+          SmallVector<Value, 4> aAccess, bAccess;
+          // AA(i + aStart0.getValue(), k + aStart1.getValue())
+          IndexExpr::getValues(aStart, aAccess);
+          aAccess[aRank-2] = i + aAccess[aRank-2];
+          aAccess[aRank-1] = k + aAccess[aRank-1];
+          Value a = affine_load(A, aAccess);
+          // BB(k + bStart0.getValue(), j + bStart1.getValue())
+          IndexExpr::getValues(bStart, bAccess);
+          bAccess[bRank-2] = k + bAccess[bRank-2];
+          bAccess[bRank-1] = j + bAccess[bRank-1];
+          Value b = affine_load(B, bAccess);
+          TTmpC() = a * b + TTmpC();
         });
         // Store temp result into C(i, j)
-        CC(i + cStart0.getValue(), j + cStart1.getValue()) = TTmpC();
+        affine_store(TTmpC(), C, cAccess);
       });
     });
     // clang-format on
@@ -841,25 +872,22 @@ private:
   }
 
   void genSimd(PatternRewriter &rewriter, KrnlMatMulOp op, Type elementType,
-      IndexExpr aStart0, IndexExpr aStart1, IndexExpr bStart0,
-      IndexExpr bStart1, IndexExpr cStart0, IndexExpr cStart1, IndexExpr I,
-      IndexExpr J, IndexExpr K, IndexExpr vectorLen, bool unrollJam) const {
+      ArrayRef<IndexExpr> aStart, ArrayRef<IndexExpr> bStart,
+      ArrayRef<IndexExpr> cStart, IndexExpr I, IndexExpr J, IndexExpr K,
+      IndexExpr vectorLen, bool unrollJam) const {
     // can simdize only if K is compile time
     assert(J.isLiteral() &&
            "can only simdize with compile time blocking factor on simd axis");
     // Get operands.
     KrnlMatMulOpAdaptor operandAdaptor = KrnlMatMulOpAdaptor(op);
-    Value A = operandAdaptor.A();
-    Value B = operandAdaptor.B();
-    Value C = operandAdaptor.C();
+    Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(operandAdaptor.C());
+    int64_t aRank(aStart.size()), bRank(bStart.size()), cRank(cStart.size());
 
     // Generate the vector type conversions.
     int64_t VL = vectorLen.getLiteral();
     VectorType vecType = VectorType::get({VL}, elementType);
     MemRefType CTmpType = MemRefType::get({}, vecType);
 
-    // Get the EDSC variables, and loop dimensions.
-    AffineIndexedValue AA(A), BB(B), CC(C);
     // Iterates over the I indices (j are simd dim).
     Value iSaved;
     using namespace edsc::op;
@@ -870,16 +898,26 @@ private:
       // Alloca temp vector TmpC and save C(i)/0.0 into it.
       Value TmpC = std_alloca(CTmpType);
       AffineIndexedValue TTmpC(TmpC);
-      SmallVector<Value, 4> cVecIndices = {i + cStart0.getValue(), cStart1.getValue()};
-      Value vc = rewriter.create<AffineVectorLoadOp>(op.getLoc(), vecType, C, cVecIndices);
-      TTmpC() = vc;
+      SmallVector<Value, 4> cAccess;
+      // cAccess = {i + cStart0.getValue(), cStart1.getValue()};
+      IndexExpr::getValues(cStart, cAccess);
+      cAccess[cRank-2] = i + cAccess[cRank-2];
+      TTmpC() = rewriter.create<AffineVectorLoadOp>(op.getLoc(), vecType,
+        C, cAccess);
       // Sum over k.
       affineLoopBuilder(zero, K, 1, [&](Value k) {
-        Value a = AA(i + aStart0.getValue(), k + aStart1.getValue());
+        // Value a = AA(i + aStart0.getValue(), k + aStart1.getValue());
+        SmallVector<Value, 4> aAccess, bAccess;
+        IndexExpr::getValues(aStart, aAccess);
+        aAccess[aRank-2] = i + aAccess[aRank-2];
+        aAccess[aRank-1] = k + aAccess[aRank-1];
+        Value a = affine_load(A, aAccess);
         Value va = vector_broadcast(vecType, a);
-        //Value vb = BBVec(k + BStart0.getValue(), BStart1.getValue());
-        SmallVector<Value, 4> bVecIndices = {k + bStart0.getValue(), bStart1.getValue()};
-        Value vb = rewriter.create<AffineVectorLoadOp>(op.getLoc(), vecType, B, bVecIndices);
+        // bAccess = {k + bStart0.getValue(), bStart1.getValue()};
+        IndexExpr::getValues(bStart, bAccess);
+        bAccess[bRank-2] = k + bAccess[bRank-2];
+        Value vb = rewriter.create<AffineVectorLoadOp>(op.getLoc(), vecType,
+          B, bAccess);
         TTmpC() = vector_fma(va, vb, TTmpC());
       });
       // Store temp result into C(i)
@@ -891,12 +929,13 @@ private:
         for(int64_t i=0; i<VL; i++)
           mask.emplace_back((i<JLit) ? i : VL+i);
         // permute
-        Value originalCvec = rewriter.create<AffineVectorLoadOp>(op.getLoc(), vecType, C, cVecIndices);
+        Value originalCvec = rewriter.create<AffineVectorLoadOp>(op.getLoc(), 
+          vecType, C, cAccess);
         tmpResults = rewriter.create<vector::ShuffleOp>(op.getLoc(),
           tmpResults, originalCvec, mask);
       }
       //CCvec(i + CStart0.getValue(), CStart1.getValue()) = tmpResults;
-      rewriter.create<AffineVectorStoreOp>(op.getLoc(), tmpResults, C, cVecIndices);
+      rewriter.create<AffineVectorStoreOp>(op.getLoc(), tmpResults, C, cAccess);
     });
     // clang-format on
     if (unrollJam && I.isLiteral()) {

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -115,7 +115,7 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
 
   // Handle the cases with 2x2 matrices both for A, B, and C without broadcast.
   // Implementation here uses the efficient 1d tiling plus kernel substitution.
-  void replace2x2Matmul2D(ONNXMatMulOp &matMulOp,
+  void replace2x2Matmul2d(ONNXMatMulOp &matMulOp,
       ONNXMatMulOpAdaptor &operandAdaptor, Type elementType,
       ONNXMatMulOpShapeHelper &shapeHelper, Value alloc, Value zeroVal,
       ConversionPatternRewriter &rewriter, Location loc) const {
@@ -142,61 +142,6 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
       SmallVector<Value> storeIndices({zii, zjj});
       krnl_store(zeroVal, alloc, storeIndices);
     });
-
-    // Compute.
-    // Define blocking, with simdization along the j axis.
-    const int64_t iRegTile(4), jRegTile(8), kRegTile(4);
-    // I, J, K loop.
-    ValueRange origLoop = krnl_define_loop(3);
-    Value ii(origLoop[0]), jj(origLoop[1]), kk(origLoop[2]);
-    // Define blocked loop and permute.
-    ValueRange iRegBlock = krnl_block(ii, iRegTile);
-    Value ii1(iRegBlock[0]), ii2(iRegBlock[1]);
-    ValueRange jRegBlock = krnl_block(jj, jRegTile);
-    Value jj1(jRegBlock[0]), jj2(jRegBlock[1]);
-    ValueRange kRegBlock = krnl_block(kk, kRegTile);
-    Value kk1(kRegBlock[0]), kk2(kRegBlock[1]);
-    krnl_permute({ii1, ii2, jj1, jj2, kk1, kk2}, {0, 3, 1, 4, 2, 5});
-
-    krnl_iterate({ii, jj, kk}, {ii1, jj1, kk1}, {zero, zero, zero}, {I, J, K},
-        {}, [&](ValueRange args) {
-          ValueRange indices = krnl_get_induction_var_value({ii1, jj1, kk1});
-          Value i1(indices[0]), j1(indices[1]), k1(indices[2]);
-          krnl_matmul(A, {zero, zero}, B, {zero, zero}, C, {zero, zero},
-              {ii2, jj2, kk2}, {i1, j1, k1}, {I, J, K},
-              {iRegTile, jRegTile, kRegTile}, {}, {}, {}, true, true, false);
-        });
-  }
-
-  // Handle the cases with 2x2 matrices both for A, B, and C with broadcast.
-  // Implementation here uses the efficient 1d tiling plus kernel substitution.
-  void replace2x2Matmul2dWithBroadcast(ONNXMatMulOp &matMulOp,
-      ONNXMatMulOpAdaptor &operandAdaptor, Type elementType,
-      ONNXMatMulOpShapeHelper &shapeHelper, Value alloc, Value zeroVal,
-      ConversionPatternRewriter &rewriter, Location loc) const {
-
-    using namespace mlir::edsc;
-    using namespace mlir::edsc::ops;
-    using namespace mlir::edsc::intrinsics;
-
-    // Define scopes
-    ScopedContext scope(rewriter, loc);
-
-    // Prepare: loop bounds and zero
-    Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(alloc);
-    MemRefBoundsCapture aBounds(A), bBounds(B), cBounds(C);
-    Value I(cBounds.ub(0)), J(cBounds.ub(1)), K(aBounds.ub(1));
-    Value zero = std_constant_index(0);
-    int64_t aRank(aBounds.rank()), bRank(bBounds.rank()), cRank(cBounds.rank());
-    assert(cRank == shapeHelper.dimsForOutput(0).size() && "just checking");
-
-    // Initialize alloc/C to zero.
-    ValueRange zLoop = krnl_define_loop(cRank);
-    krnl_iterate(zLoop, cBounds.getLbs(), cBounds.getUbs(), {},
-        [&](ValueRange args) {
-          ValueRange storeIndices = krnl_get_induction_var_value(zLoop);
-          krnl_store(zeroVal, alloc, storeIndices);
-        });
 
     // Compute.
     // Define blocking, with simdization along the j axis.
@@ -251,8 +196,8 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     MemRefBoundsIndexCapture aBounds(A), bBounds(B);
 
     if (aBounds.getRank() == 2 && bBounds.getRank() == 2) {
-      replace2x2Matmul2dWithBroadcast(matMulOp, operandAdaptor, elementType,
-          shapeHelper, alloc, zero, rewriter, loc);
+      replace2x2Matmul2d(matMulOp, operandAdaptor, elementType, shapeHelper,
+          alloc, zero, rewriter, loc);
     } else {
       replaceGenericMatmul(matMulOp, operandAdaptor, elementType, shapeHelper,
           alloc, zero, rewriter, loc);

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -357,24 +357,12 @@ Value krnl_load(Value memref, ValueRange indices) {
       ScopedContext::getLocation(), memref, indices);
 }
 
-#if 0
-Value krnl_load(Value memref, ArrayRef<Value> indices) {
-  return krnl_load(memref, ValueRange(indices));
-}
-#endif
-
 void krnl_store(Value val, Value memref, ValueRange indices) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
   ScopedContext::getBuilderRef().create<KrnlStoreOp>(
       ScopedContext::getLocation(), val, memref, indices);
 }
-
-#if 0
-void krnl_store(Value val, Value memref, ArrayRef<Value> indices) {
-  krnl_store(val, memref, ValueRange(indices));
-}
-#endif
 
 ValueRange krnl_define_loop(int64_t originalLoopNum) {
   using namespace mlir::edsc;
@@ -400,17 +388,6 @@ void krnl_permute(ArrayRef<Value> loops, ArrayRef<int64_t> map) {
       ScopedContext::getLocation(), loops, map);
 }
 
-#if 0
-ValueRange krnl_get_induction_var_value(ArrayRef<Value> loops) {
-  using namespace mlir::edsc;
-  assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
-  return ScopedContext::getBuilderRef()
-      .create<KrnlGetInductionVariableValueOp>(
-          ScopedContext::getLocation(), loops)
-      .getResults();
-}
-#endif
-
 ValueRange krnl_get_induction_var_value(ValueRange loops) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
@@ -420,40 +397,6 @@ ValueRange krnl_get_induction_var_value(ValueRange loops) {
       .getResults();
 }
 
-#if 0
-void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> optimizedLoop,
-    ArrayRef<Value> lb, ArrayRef<Value> ub, ArrayRef<Value> iterArgs,
-    function_ref<void(ArrayRef<Value>)> bodyBuilderFn) {
-  using namespace mlir::edsc;
-  assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
-  assert(lb.size() == ub.size() && "expected matching number of lb & ub");
-  OpBuilder &builder = ScopedContext::getBuilderRef();
-  Location loc = ScopedContext::getLocation();
-  KrnlIterateOperandPack pack(builder, originalLoop, optimizedLoop);
-  for (int i = 0; i < lb.size(); ++i) {
-    pack.pushOperandBound(lb[i]);
-    pack.pushOperandBound(ub[i]);
-  }
-  KrnlIterateOp iterateOp =
-      builder.create<KrnlIterateOp>(ScopedContext::getLocation(), pack);
-  // auto savedInsertionPoint = builder.saveInsertionPoint();
-  Block *iterBlock = &iterateOp.bodyRegion().front();
-
-  if (bodyBuilderFn) { // Scope for the scoped context of the loop.
-    ScopedContext nestedContext(builder, loc);
-    builder.setInsertionPointToStart(iterBlock);
-    bodyBuilderFn(iterArgs);
-  }
-}
-
-void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> lb,
-    ArrayRef<Value> ub, ArrayRef<Value> iterArgs,
-    function_ref<void(ArrayRef<Value>)> bodyBuilderFn) {
-  // When no optimized loops are given, use original for the optimized.
-  krnl_iterate(originalLoop, originalLoop, lb, ub, iterArgs, bodyBuilderFn);
-}
-#endif
-
 void krnl_iterate(ValueRange originalLoops, ValueRange optimizedLoops,
     ValueRange lbs, ValueRange ubs, ValueRange iterArgs,
     function_ref<void(ValueRange)> bodyBuilderFn) {
@@ -462,7 +405,7 @@ void krnl_iterate(ValueRange originalLoops, ValueRange optimizedLoops,
   assert(lbs.size() == ubs.size() && "expected matching number of lb & ub");
   OpBuilder &builder = ScopedContext::getBuilderRef();
   Location loc = ScopedContext::getLocation();
-  // May want to change KrnlIterateOperandPack to use ValueRanges...
+  // TODO: May want to change KrnlIterateOperandPack to use ValueRanges...
   SmallVector<Value, 4> origLoops, optLoops;
   for (auto org : originalLoops)
     origLoops.emplace_back(org);

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -381,7 +381,7 @@ ValueRange krnl_block(Value loop, int64_t blockSize) {
       .getResults();
 }
 
-void krnl_permute(ArrayRef<Value> loops, ArrayRef<int64_t> map) {
+void krnl_permute(ValueRange loops, ArrayRef<int64_t> map) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
   ScopedContext::getBuilderRef().create<KrnlPermuteOp>(
@@ -434,9 +434,8 @@ void krnl_iterate(ValueRange originalLoops, ValueRange lbs, ValueRange ubs,
   krnl_iterate(originalLoops, originalLoops, lbs, ubs, iterArgs, bodyBuilderFn);
 }
 
-void krnl_copy_to_buffer(Value bufferMemref, Value memref,
-    ArrayRef<Value> starts, Value padValue, ArrayRef<int64_t> tileSize,
-    ArrayRef<int64_t> padToNext) {
+void krnl_copy_to_buffer(Value bufferMemref, Value memref, ValueRange starts,
+    Value padValue, ArrayRef<int64_t> tileSize, ArrayRef<int64_t> padToNext) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
   ScopedContext::getBuilderRef().create<KrnlCopyToBufferOp>(
@@ -445,28 +444,27 @@ void krnl_copy_to_buffer(Value bufferMemref, Value memref,
 }
 
 void krnl_copy_to_buffer(
-    Value bufferMemref, Value memref, ArrayRef<Value> starts, Value padValue) {
+    Value bufferMemref, Value memref, ValueRange starts, Value padValue) {
   ArrayRef<int64_t> empty;
   krnl_copy_to_buffer(bufferMemref, memref, starts, padValue, empty, empty);
 }
 
-void krnl_copy_from_buffer(Value bufferMemref, Value memref,
-    ArrayRef<Value> starts, ArrayRef<int64_t> tileSize) {
+void krnl_copy_from_buffer(Value bufferMemref, Value memref, ValueRange starts,
+    ArrayRef<int64_t> tileSize) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
   ScopedContext::getBuilderRef().create<KrnlCopyFromBufferOp>(
       ScopedContext::getLocation(), bufferMemref, memref, starts, tileSize);
 }
 void krnl_copy_from_buffer(
-    Value bufferMemref, Value memref, ArrayRef<Value> starts) {
+    Value bufferMemref, Value memref, ValueRange starts) {
   ArrayRef<int64_t> empty;
   krnl_copy_from_buffer(bufferMemref, memref, starts, empty);
 }
 
-void krnl_matmul(Value A, ArrayRef<Value> aStart, Value B,
-    ArrayRef<Value> bStart, Value C, ArrayRef<Value> cStart,
-    ArrayRef<Value> loops, ArrayRef<Value> computeStarts,
-    ArrayRef<Value> globalUBs, ArrayRef<int64_t> computeTileSize,
+void krnl_matmul(Value A, ValueRange aStart, Value B, ValueRange bStart,
+    Value C, ValueRange cStart, ValueRange loops, ValueRange computeStarts,
+    ValueRange globalUBs, ArrayRef<int64_t> computeTileSize,
     ArrayRef<int64_t> aTileSize, ArrayRef<int64_t> bTileSize,
     ArrayRef<int64_t> cTileSize, bool simdize, bool unroll, bool overcompute) {
   using namespace mlir::edsc;
@@ -478,10 +476,9 @@ void krnl_matmul(Value A, ArrayRef<Value> aStart, Value B,
       cTileSize, simdize, unroll, overcompute);
 }
 
-void krnl_matmul(Value A, ArrayRef<Value> aStart, Value B,
-    ArrayRef<Value> bStart, Value C, ArrayRef<Value> cStart,
-    ArrayRef<Value> loops, ArrayRef<Value> computeStarts,
-    ArrayRef<Value> globalUBs, bool simdize, bool unroll, bool overcompute) {
+void krnl_matmul(Value A, ValueRange aStart, Value B, ValueRange bStart,
+    Value C, ValueRange cStart, ValueRange loops, ValueRange computeStarts,
+    ValueRange globalUBs, bool simdize, bool unroll, bool overcompute) {
   ArrayRef<int64_t> empty;
   krnl_matmul(A, aStart, B, bStart, C, cStart, loops, computeStarts, globalUBs,
       empty, empty, empty, empty, simdize, unroll, overcompute);

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -466,18 +466,11 @@ void krnl_matmul(Value A, ArrayRef<Value> aStart, Value B,
     ArrayRef<int64_t> cTileSize, bool simdize, bool unroll, bool overcompute) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
-  assert(aStart.size() == 2 && "A start needs 2 dim");
-  assert(bStart.size() == 2 && "B start needs 2 dim");
-  assert(cStart.size() == 2 && "C start needs 2 dim");
-  assert(loops.size() == 3 && "loops needs 3 dim");
-  assert(computeStarts.size() == 3 && "compute starts needs 3 dim");
-  assert(globalUBs.size() == 3 && "global UBs needs 3 dim");
   ScopedContext::getBuilderRef().create<KrnlMatMulOp>(
-      ScopedContext::getLocation(), A, aStart[0], aStart[1], B, bStart[0],
-      bStart[1], C, cStart[0], cStart[1], loops, computeStarts[0],
-      computeStarts[1], computeStarts[2], globalUBs[0], globalUBs[1],
-      globalUBs[2], computeTileSize, aTileSize, bTileSize, cTileSize, simdize,
-      unroll, overcompute);
+      ScopedContext::getLocation(), A, aStart, B, bStart, C, cStart, loops,
+      computeStarts[0], computeStarts[1], computeStarts[2], globalUBs[0],
+      globalUBs[1], globalUBs[2], computeTileSize, aTileSize, bTileSize,
+      cTileSize, simdize, unroll, overcompute);
 }
 
 void krnl_matmul(Value A, ArrayRef<Value> aStart, Value B,

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -350,19 +350,31 @@ ArrayRef<BlockArgument> BuildKrnlLoop::getAllInductionVar() {
 
 //====---------------- EDSC Support with Value ---------------------------===//
 
-Value krnl_load(Value memref, ArrayRef<Value> indices) {
+Value krnl_load(Value memref, ValueRange indices) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
   return ScopedContext::getBuilderRef().create<KrnlLoadOp>(
       ScopedContext::getLocation(), memref, indices);
 }
 
-void krnl_store(Value val, Value memref, ArrayRef<Value> indices) {
+#if 0
+Value krnl_load(Value memref, ArrayRef<Value> indices) {
+  return krnl_load(memref, ValueRange(indices));
+}
+#endif
+
+void krnl_store(Value val, Value memref, ValueRange indices) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
   ScopedContext::getBuilderRef().create<KrnlStoreOp>(
       ScopedContext::getLocation(), val, memref, indices);
 }
+
+#if 0
+void krnl_store(Value val, Value memref, ArrayRef<Value> indices) {
+  krnl_store(val, memref, ValueRange(indices));
+}
+#endif
 
 ValueRange krnl_define_loop(int64_t originalLoopNum) {
   using namespace mlir::edsc;
@@ -388,6 +400,7 @@ void krnl_permute(ArrayRef<Value> loops, ArrayRef<int64_t> map) {
       ScopedContext::getLocation(), loops, map);
 }
 
+#if 0
 ValueRange krnl_get_induction_var_value(ArrayRef<Value> loops) {
   using namespace mlir::edsc;
   assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
@@ -396,7 +409,18 @@ ValueRange krnl_get_induction_var_value(ArrayRef<Value> loops) {
           ScopedContext::getLocation(), loops)
       .getResults();
 }
+#endif
 
+ValueRange krnl_get_induction_var_value(ValueRange loops) {
+  using namespace mlir::edsc;
+  assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
+  return ScopedContext::getBuilderRef()
+      .create<KrnlGetInductionVariableValueOp>(
+          ScopedContext::getLocation(), loops)
+      .getResults();
+}
+
+#if 0
 void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> optimizedLoop,
     ArrayRef<Value> lb, ArrayRef<Value> ub, ArrayRef<Value> iterArgs,
     function_ref<void(ArrayRef<Value>)> bodyBuilderFn) {
@@ -427,6 +451,44 @@ void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> lb,
     function_ref<void(ArrayRef<Value>)> bodyBuilderFn) {
   // When no optimized loops are given, use original for the optimized.
   krnl_iterate(originalLoop, originalLoop, lb, ub, iterArgs, bodyBuilderFn);
+}
+#endif
+
+void krnl_iterate(ValueRange originalLoops, ValueRange optimizedLoops,
+    ValueRange lbs, ValueRange ubs, ValueRange iterArgs,
+    function_ref<void(ValueRange)> bodyBuilderFn) {
+  using namespace mlir::edsc;
+  assert(ScopedContext::getContext() && "EDSC ScopedContext not set up");
+  assert(lbs.size() == ubs.size() && "expected matching number of lb & ub");
+  OpBuilder &builder = ScopedContext::getBuilderRef();
+  Location loc = ScopedContext::getLocation();
+  // May want to change KrnlIterateOperandPack to use ValueRanges...
+  SmallVector<Value, 4> origLoops, optLoops;
+  for (auto org : originalLoops)
+    origLoops.emplace_back(org);
+  for (auto opt : optimizedLoops)
+    optLoops.emplace_back(opt);
+  KrnlIterateOperandPack pack(builder, origLoops, optLoops);
+  for (int i = 0; i < lbs.size(); ++i) {
+    pack.pushOperandBound(lbs[i]);
+    pack.pushOperandBound(ubs[i]);
+  }
+  KrnlIterateOp iterateOp =
+      builder.create<KrnlIterateOp>(ScopedContext::getLocation(), pack);
+  // auto savedInsertionPoint = builder.saveInsertionPoint();
+  Block *iterBlock = &iterateOp.bodyRegion().front();
+
+  if (bodyBuilderFn) { // Scope for the scoped context of the loop.
+    ScopedContext nestedContext(builder, loc);
+    builder.setInsertionPointToStart(iterBlock);
+    bodyBuilderFn(iterArgs);
+  }
+}
+
+void krnl_iterate(ValueRange originalLoops, ValueRange lbs, ValueRange ubs,
+    ValueRange iterArgs, function_ref<void(ValueRange)> bodyBuilderFn) {
+  // When no optimized loops are given, use original for the optimized.
+  krnl_iterate(originalLoops, originalLoops, lbs, ubs, iterArgs, bodyBuilderFn);
 }
 
 void krnl_copy_to_buffer(Value bufferMemref, Value memref,
@@ -487,13 +549,13 @@ void krnl_matmul(Value A, ArrayRef<Value> aStart, Value B,
 Value krnl_load(Value memref, ArrayRef<IndexExpr> indices) {
   SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
-  return krnl_load(memref, indexValues);
+  return krnl_load(memref, ValueRange(indexValues));
 }
 
 void krnl_store(Value val, Value memref, ArrayRef<IndexExpr> indices) {
   SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
-  krnl_store(val, memref, indexValues);
+  krnl_store(val, memref, ValueRange(indexValues));
 }
 
 void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> optimizedLoop,

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -258,8 +258,7 @@ void krnl_store(Value val, Value memref, ValueRange indices);
 
 ValueRange krnl_define_loop(int64_t originalLoopNum);
 ValueRange krnl_block(Value loop, int64_t blockSize);
-void krnl_permute(ArrayRef<Value> loops, ArrayRef<int64_t> map);
-// ValueRange krnl_get_induction_var_value(ArrayRef<Value> loops);
+void krnl_permute(ValueRange loops, ArrayRef<int64_t> map);
 ValueRange krnl_get_induction_var_value(ValueRange loops);
 
 void krnl_iterate(ValueRange originalLoops, ValueRange optimizedLoops,
@@ -268,28 +267,24 @@ void krnl_iterate(ValueRange originalLoops, ValueRange optimizedLoops,
 void krnl_iterate(ValueRange originalLoops, ValueRange lbs, ValueRange ubs,
     ValueRange iterArgs, function_ref<void(ValueRange args)> bodyBuilderFn);
 
-void krnl_copy_to_buffer(Value bufferMemref, Value memref,
-    ArrayRef<Value> starts, Value padValue, ArrayRef<int64_t> tileSize,
-    ArrayRef<int64_t> padToNext);
+void krnl_copy_to_buffer(Value bufferMemref, Value memref, ValueRange starts,
+    Value padValue, ArrayRef<int64_t> tileSize, ArrayRef<int64_t> padToNext);
 void krnl_copy_to_buffer(
-    Value bufferMemref, Value memref, ArrayRef<Value> starts, Value padValue);
+    Value bufferMemref, Value memref, ValueRange starts, Value padValue);
 
-void krnl_copy_from_buffer(Value bufferMemref, Value memref,
-    ArrayRef<Value> starts, ArrayRef<int64_t> tileSize);
-void krnl_copy_from_buffer(
-    Value bufferMemref, Value memref, ArrayRef<Value> starts);
+void krnl_copy_from_buffer(Value bufferMemref, Value memref, ValueRange starts,
+    ArrayRef<int64_t> tileSize);
+void krnl_copy_from_buffer(Value bufferMemref, Value memref, ValueRange starts);
 
-void krnl_matmul(Value A, ArrayRef<Value> aStart, Value B,
-    ArrayRef<Value> bStart, Value C, ArrayRef<Value> cStart,
-    ArrayRef<Value> loops, ArrayRef<Value> computeStarts,
-    ArrayRef<Value> globalUBs, ArrayRef<int64_t> computeTileSize,
+void krnl_matmul(Value A, ValueRange aStart, Value B, ValueRange bStart,
+    Value C, ValueRange cStart, ValueRange loops, ValueRange computeStarts,
+    ValueRange globalUBs, ArrayRef<int64_t> computeTileSize,
     ArrayRef<int64_t> aTileSize, ArrayRef<int64_t> bTileSize,
     ArrayRef<int64_t> cTileSize, bool simdize, bool unroll, bool overcompute);
 
-void krnl_matmul(Value A, ArrayRef<Value> aStart, Value B,
-    ArrayRef<Value> bStart, Value C, ArrayRef<Value> cStart,
-    ArrayRef<Value> loops, ArrayRef<Value> computeStarts,
-    ArrayRef<Value> globalUBs, bool simdize, bool unroll, bool overcompute);
+void krnl_matmul(Value A, ValueRange aStart, Value B, ValueRange bStart,
+    Value C, ValueRange cStart, ValueRange loops, ValueRange computeStarts,
+    ValueRange globalUBs, bool simdize, bool unroll, bool overcompute);
 
 //====---------------- EDSC Support with IndexExpr -----------------------===//
 

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -253,20 +253,30 @@ private:
 
 //====---------------- EDSC Support with Value ---------------------------===//
 
-Value krnl_load(Value memref, ArrayRef<Value> indices);
-void krnl_store(Value val, Value memref, ArrayRef<Value> indices);
+// Value krnl_load(Value memref, ArrayRef<Value> indices);
+Value krnl_load(Value memref, ValueRange indices);
+// void krnl_store(Value val, Value memref, ArrayRef<Value> indices);
+void krnl_store(Value val, Value memref, ValueRange indices);
 
 ValueRange krnl_define_loop(int64_t originalLoopNum);
 ValueRange krnl_block(Value loop, int64_t blockSize);
 void krnl_permute(ArrayRef<Value> loops, ArrayRef<int64_t> map);
-ValueRange krnl_get_induction_var_value(ArrayRef<Value> loops);
+// ValueRange krnl_get_induction_var_value(ArrayRef<Value> loops);
+ValueRange krnl_get_induction_var_value(ValueRange loops);
 
+#if 0
 void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> optimizedLoop,
     ArrayRef<Value> lb, ArrayRef<Value> ub, ArrayRef<Value> iterArgs,
     function_ref<void(ArrayRef<Value> args)> bodyBuilderFn);
 void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> lb,
     ArrayRef<Value> ub, ArrayRef<Value> iterArgs,
     function_ref<void(ArrayRef<Value> args)> bodyBuilderFn);
+#endif
+void krnl_iterate(ValueRange originalLoops, ValueRange optimizedLoops,
+    ValueRange lbs, ValueRange ubs, ValueRange iterArgs,
+    function_ref<void(ValueRange args)> bodyBuilderFn);
+void krnl_iterate(ValueRange originalLoops, ValueRange lbs, ValueRange ubs,
+    ValueRange iterArgs, function_ref<void(ValueRange args)> bodyBuilderFn);
 
 void krnl_copy_to_buffer(Value bufferMemref, Value memref,
     ArrayRef<Value> starts, Value padValue, ArrayRef<int64_t> tileSize,

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -291,12 +291,12 @@ void krnl_matmul(Value A, ValueRange aStart, Value B, ValueRange bStart,
 Value krnl_load(Value memref, ArrayRef<IndexExpr> indices);
 void krnl_store(Value val, Value memref, ArrayRef<IndexExpr> indices);
 
-void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> optimizedLoop,
-    ArrayRef<IndexExpr> lb, ArrayRef<IndexExpr> ub, ArrayRef<Value> iterArgs,
-    function_ref<void(ArrayRef<Value> args)> bodyBuilderFn);
-void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<IndexExpr> lb,
-    ArrayRef<IndexExpr> ub, ArrayRef<Value> iterArgs,
-    function_ref<void(ArrayRef<Value> args)> bodyBuilderFn);
+void krnl_iterate(ValueRange originalLoops, ValueRange optimizedLoops,
+    ArrayRef<IndexExpr> lbs, ArrayRef<IndexExpr> ubs, ValueRange iterArgs,
+    function_ref<void(ValueRange args)> bodyBuilderFn);
+void krnl_iterate(ValueRange originalLoops, ArrayRef<IndexExpr> lbs,
+    ArrayRef<IndexExpr> ubs, ValueRange iterArgs,
+    function_ref<void(ValueRange args)> bodyBuilderFn);
 
 void krnl_copy_to_buffer(Value bufferMemref, Value memref,
     ArrayRef<IndexExpr> starts, Value padValue, ArrayRef<int64_t> tileSize,
@@ -307,6 +307,6 @@ void krnl_copy_to_buffer(Value bufferMemref, Value memref,
 void krnl_copy_from_buffer(Value bufferMemref, Value memref,
     ArrayRef<IndexExpr> starts, ArrayRef<int64_t> tileSize);
 void krnl_copy_from_buffer(
-    Value bufferMemref, Value memref, ArrayRef<Value> starts);
+    Value bufferMemref, Value memref, ArrayRef<IndexExpr> starts);
 
 } // namespace mlir

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -253,9 +253,7 @@ private:
 
 //====---------------- EDSC Support with Value ---------------------------===//
 
-// Value krnl_load(Value memref, ArrayRef<Value> indices);
 Value krnl_load(Value memref, ValueRange indices);
-// void krnl_store(Value val, Value memref, ArrayRef<Value> indices);
 void krnl_store(Value val, Value memref, ValueRange indices);
 
 ValueRange krnl_define_loop(int64_t originalLoopNum);
@@ -264,14 +262,6 @@ void krnl_permute(ArrayRef<Value> loops, ArrayRef<int64_t> map);
 // ValueRange krnl_get_induction_var_value(ArrayRef<Value> loops);
 ValueRange krnl_get_induction_var_value(ValueRange loops);
 
-#if 0
-void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> optimizedLoop,
-    ArrayRef<Value> lb, ArrayRef<Value> ub, ArrayRef<Value> iterArgs,
-    function_ref<void(ArrayRef<Value> args)> bodyBuilderFn);
-void krnl_iterate(ArrayRef<Value> originalLoop, ArrayRef<Value> lb,
-    ArrayRef<Value> ub, ArrayRef<Value> iterArgs,
-    function_ref<void(ArrayRef<Value> args)> bodyBuilderFn);
-#endif
 void krnl_iterate(ValueRange originalLoops, ValueRange optimizedLoops,
     ValueRange lbs, ValueRange ubs, ValueRange iterArgs,
     function_ref<void(ValueRange args)> bodyBuilderFn);

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -491,6 +491,8 @@ static LogicalResult verify(KrnlMatMulOp op) {
       operandAdaptor.B().getType().cast<MemRefType>().getShape().size();
   int64_t cRank =
       operandAdaptor.C().getType().cast<MemRefType>().getShape().size();
+  if (!(aRank >= 2 && bRank >= 2 && cRank >= 2))
+    return op.emitOpError("currently only support ranks >=2");
   if (operandAdaptor.aMemStart().size() != aRank)
     return op.emitOpError("aMemStart should have same rank as memref A");
   if (operandAdaptor.bMemStart().size() != bRank)

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -460,13 +460,13 @@ MutableOperandRange KrnlSpecializedKernel::getLoopRefs() {
 
 void KrnlMatMulOp::build(::mlir::OpBuilder &odsBuilder,
     ::mlir::OperationState &odsState, Value odsA, ValueRange aOdsStart,
-    Value odsB, ValueRange bOdsStart, Value odsC,
-    ValueRange cOdsStart, ValueRange odsLoops, Value iOdsComputeStart,
-    Value jOdsComputeStart, Value kOdsComputeStart, Value iOdsGlobalUB,
-    Value jOdsGlobalUB, Value kOdsGlobalUB,
-    ArrayRef<int64_t> odsComputeTileSize, ArrayRef<int64_t> aOdsTileSize,
-    ArrayRef<int64_t> bOdsTileSize, ArrayRef<int64_t> cOdsTileSize,
-    bool odsSimdize, bool odsUnroll, bool odsOvercompute) {
+    Value odsB, ValueRange bOdsStart, Value odsC, ValueRange cOdsStart,
+    ValueRange odsLoops, Value iOdsComputeStart, Value jOdsComputeStart,
+    Value kOdsComputeStart, Value iOdsGlobalUB, Value jOdsGlobalUB,
+    Value kOdsGlobalUB, ArrayRef<int64_t> odsComputeTileSize,
+    ArrayRef<int64_t> aOdsTileSize, ArrayRef<int64_t> bOdsTileSize,
+    ArrayRef<int64_t> cOdsTileSize, bool odsSimdize, bool odsUnroll,
+    bool odsOvercompute) {
   // Massage types.
   ValueRange loopRange(odsLoops);
   ArrayAttr computeTileSizeAttr =

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -348,19 +348,8 @@ void KrnlPermuteOp::build(::mlir::OpBuilder &odsBuilder,
 }
 
 //===----------------------------------------------------------------------===//
-// KrnlDummyCastOp
+// KrnlGetInductionVariableValueOp
 //===----------------------------------------------------------------------===//
-
-void KrnlGetInductionVariableValueOp::build(::mlir::OpBuilder &odsBuilder,
-    ::mlir::OperationState &odsState, ArrayRef<Value> odsLoops) {
-  int64_t rank = odsLoops.size();
-  Type loopType = LoopType::get(odsBuilder.getContext());
-  SmallVector<Type, 6> types(rank, odsBuilder.getIndexType());
-  TypeRange typeRange(types);
-  ValueRange loopRange(odsLoops);
-  ArrayRef<NamedAttribute> noAttr({});
-  build(odsBuilder, odsState, typeRange, loopRange, noAttr);
-}
 
 void KrnlGetInductionVariableValueOp::build(::mlir::OpBuilder &odsBuilder,
     ::mlir::OperationState &odsState, ValueRange odsLoops) {
@@ -371,7 +360,6 @@ void KrnlGetInductionVariableValueOp::build(::mlir::OpBuilder &odsBuilder,
   ArrayRef<NamedAttribute> noAttr({});
   build(odsBuilder, odsState, typeRange, odsLoops, noAttr);
 }
-
 
 //===----------------------------------------------------------------------===//
 // KrnlDummyCastOp

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -331,7 +331,7 @@ void KrnlBlockOp::build(::mlir::OpBuilder &odsBuilder,
 //===----------------------------------------------------------------------===//
 
 void KrnlPermuteOp::build(::mlir::OpBuilder &odsBuilder,
-    ::mlir::OperationState &odsState, ArrayRef<Value> odsLoops,
+    ::mlir::OperationState &odsState, ValueRange odsLoops,
     ArrayRef<int64_t> odsMap) {
   int64_t rank = odsLoops.size();
   assert(rank >= 2 && "permute needs 2 or more loops");
@@ -459,9 +459,9 @@ MutableOperandRange KrnlSpecializedKernel::getLoopRefs() {
 //===----------------------------------------------------------------------===//
 
 void KrnlMatMulOp::build(::mlir::OpBuilder &odsBuilder,
-    ::mlir::OperationState &odsState, Value odsA, ArrayRef<Value> aOdsStart,
-    Value odsB, ArrayRef<Value> bOdsStart, Value odsC,
-    ArrayRef<Value> cOdsStart, ArrayRef<Value> odsLoops, Value iOdsComputeStart,
+    ::mlir::OperationState &odsState, Value odsA, ValueRange aOdsStart,
+    Value odsB, ValueRange bOdsStart, Value odsC,
+    ValueRange cOdsStart, ValueRange odsLoops, Value iOdsComputeStart,
     Value jOdsComputeStart, Value kOdsComputeStart, Value iOdsGlobalUB,
     Value jOdsGlobalUB, Value kOdsGlobalUB,
     ArrayRef<int64_t> odsComputeTileSize, ArrayRef<int64_t> aOdsTileSize,
@@ -523,7 +523,7 @@ MutableOperandRange KrnlMatMulOp::getLoopRefs() { return loopsMutable(); }
 
 void KrnlCopyToBufferOp::build(::mlir::OpBuilder &odsBuilder,
     ::mlir::OperationState &odsState, Value odsBufferMemref, Value odsMemref,
-    ArrayRef<Value> odsStarts, Value odsPadValue, ArrayRef<int64_t> odsTileSize,
+    ValueRange odsStarts, Value odsPadValue, ArrayRef<int64_t> odsTileSize,
     ArrayRef<int64_t> odsPadToNext) {
   // Validate input.
   auto memrefT = odsMemref.getType().dyn_cast<MemRefType>();
@@ -551,7 +551,7 @@ void KrnlCopyToBufferOp::build(::mlir::OpBuilder &odsBuilder,
 
 void KrnlCopyFromBufferOp::build(::mlir::OpBuilder &odsBuilder,
     ::mlir::OperationState &odsState, Value odsBufferMemref, Value odsMemref,
-    ArrayRef<Value> odsStarts, ArrayRef<int64_t> odsTileSize) {
+    ValueRange odsStarts, ArrayRef<int64_t> odsTileSize) {
   // Validate input.
   auto memrefT = odsMemref.getType().dyn_cast<MemRefType>();
   auto bufferT = odsBufferMemref.getType().dyn_cast<MemRefType>();

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -362,6 +362,17 @@ void KrnlGetInductionVariableValueOp::build(::mlir::OpBuilder &odsBuilder,
   build(odsBuilder, odsState, typeRange, loopRange, noAttr);
 }
 
+void KrnlGetInductionVariableValueOp::build(::mlir::OpBuilder &odsBuilder,
+    ::mlir::OperationState &odsState, ValueRange odsLoops) {
+  int64_t rank = odsLoops.size();
+  Type loopType = LoopType::get(odsBuilder.getContext());
+  SmallVector<Type, 6> types(rank, odsBuilder.getIndexType());
+  TypeRange typeRange(types);
+  ArrayRef<NamedAttribute> noAttr({});
+  build(odsBuilder, odsState, typeRange, odsLoops, noAttr);
+}
+
+
 //===----------------------------------------------------------------------===//
 // KrnlDummyCastOp
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -737,6 +737,17 @@ def KrnlMatMulOp : Op<Krnl_Dialect, "matmul", [AttrSizedOperandSegments,
     the I, J, and K computeTileSizes, in their respective
     dimensions (A: IxK], B: [KxJ], C: [IxJ]).
 
+    Note that the buffers A, B, and C can be of higher dimensionality than
+    the traditional 2D mentioned up to now, because of broadcasting rules.
+    At this time, we only support broadcast of arrays having ranks of 2 or
+    more. Because of the broadcast rules, the higher dimenstions have a
+    constant index during one matrix multiply. These fixed indices are
+    given as prefix dimensions in the starting indices for A, B, and C
+    as described above. E.g. if A has a rank of 3, and B has a rank of 2,
+    the starting indices for A are [d, i1, k1] where i1 and k1 are as
+    above, and d is index pointing to the current instance of the IxK
+    A matrix to be computed. B start indices would be unchanged at [k1, j1].
+
     Simdize is used to state if simdization is requested.
     Unrolling is used to unroll and jam loops as warrented.
 
@@ -759,36 +770,42 @@ def KrnlMatMulOp : Op<Krnl_Dialect, "matmul", [AttrSizedOperandSegments,
         !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, 
         !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop
     // Outer 2 for i, j.
-    krnl.iterate(%ib, %jb) with (%ii -> %i = 0 to 40, %jj -> %j = 0 to 80, %kk -> %k = 0 to 60) {
-        %i1, %j1 = krnl.get_induction_var_value(%ib, %jb) : (!krnl.loop,!krnl.loop) -> (index, index)
+    krnl.iterate(%ib, %jb) with (%ii -> %i = 0 to 40, 
+                                 %jj -> %j = 0 to 80, 
+                                 %kk -> %k = 0 to 60) {
+        %i1, %j1 = krnl.get_induction_var_value(%ib, %jb) : 
+          (!krnl.loop,!krnl.loop) -> (index, index)
         // Fill C buffer.
         %Cbuff = alloca(): memref<10x8xf32>  // n x m_simd
-        krnl.copy_to_tile_buffer %Cbuff, %C[%i1, %j1], %f0 : memref<10x8xf32>,  memref<40x80xf32>
+        krnl.copy_to_tile_buffer %Cbuff, %C[%i1, %j1], %f0 : 
+          memref<10x8xf32>, memref<40x80xf32>
         // Outer 1 for k.
         krnl.iterate(%kb) with () {
             %k1 = krnl.get_induction_var_value(%kb) : (!krnl.loop) -> (index)
             // Fill A and B buffer
-            %Abuff = alloca(): memref<10x10xf32> // n x k
-            %Bbuff = alloca(): memref<10x8xf32>  // k x m_simd     
-            krnl.copy_to_tile_buffer %Abuff, %A[%i1, %k1], %f0 : memref<10x10xf32>, memref<40x60xf32>
-            krnl.copy_to_tile_buffer %Bbuff, %B[%k1, %j1], %f0 : memref<10x8xf32>,  memref<60x80xf32>
+            %Abuff = alloca(): memref<10x10xf32> // i x k
+            %Bbuff = alloca(): memref<10x8xf32>  // k x j_simd     
+            krnl.copy_to_tile_buffer %Abuff, %A[%i1, %k1], %f0 :
+              memref<10x10xf32>, memref<40x60xf32>
+            krnl.copy_to_tile_buffer %Bbuff, %B[%k1, %j1], %f0 :
+              memref<10x8xf32>, memref<60x80xf32>
 
             // Inner iterations for subtiles.
             krnl.iterate(%ilb, %jlb, %klb) with () {
-                %i2, %j2, %k2 = krnl.get_induction_var_value(%ilb, %jlb, %klb) : 
+                %i2, %j2, %k2 = krnl.get_induction_var_value(%ilb, %jlb, %klb) :
                 (!krnl.loop,!krnl.loop,!krnl.loop) -> (index,index,index)
 
-                krnl.matmul %Abuff[%i1, %k1], %Bbuff[%k1, %j1], %Cbuff[%i1, %j1], 
-                    (%ill, %jll, %kll), (%i2, %j2, %k2), (%c40, %c80, %c60) 
-                    { computeTileSize=[5,4,5], simdize=false, unroll=false } : 
-                    memref<10x10xf32>, memref<10x8xf32>, memref<10x8xf32>, 
-                    (!krnl.loop,!krnl.loop,!krnl.loop)        
+                krnl.matmul %Abuff[%i1, %k1], %Bbuff[%k1, %j1], %Cbuff[%i1, %j1],
+                    (%ill, %jll, %kll), (%i2, %j2, %k2), (%c40, %c80, %c60)
+                    { computeTileSize=[5,4,5], simdize=false, unroll=false } :
+                    memref<10x10xf32>, memref<10x8xf32>, memref<10x8xf32>,
+                    (!krnl.loop,!krnl.loop,!krnl.loop)
             }
         }
         // Copy back the data into C.
-        krnl.copy_from_tile_buffer %Cbuff, %C[%i1, %j1] : memref<10x8xf32>, memref<40x80xf32>
+        krnl.copy_from_tile_buffer %Cbuff, %C[%i1, %j1] :
+          memref<10x8xf32>, memref<40x80xf32>
     }
-
   }];
 
   let arguments = (ins 
@@ -817,16 +834,16 @@ def KrnlMatMulOp : Op<Krnl_Dialect, "matmul", [AttrSizedOperandSegments,
     DefaultValuedAttr<BoolAttr, "false">:$overcompute);
 
   let builders = [ OpBuilderDAG<(ins 
-      "Value": $A, "ArrayRef<Value>": $aStart,
-      "Value": $B, "ArrayRef<Value>": $bStart,
-      "Value": $C, "ArrayRef<Value>": $cStart,
-      "ArrayRef<Value>": $loops,
+      "Value": $A, "ArrayRef<Value>": $aStart, // Both same rank.
+      "Value": $B, "ArrayRef<Value>": $bStart, // Both same rank.
+      "Value": $C, "ArrayRef<Value>": $cStart, // Both same rank.
+      "ArrayRef<Value>": $loops, // Rank 3: (i,j,k).
       "Value": $iComputeStart, "Value": $jComputeStart, "Value": $kComputeStart, 
       "Value": $iGlobalUB, "Value": $jGlobalUB, "Value": $kGlobalUB,
-      "ArrayRef<int64_t>": $computeTileSize,
-      "ArrayRef<int64_t>": $aTileSize,
-      "ArrayRef<int64_t>": $bTileSize,
-      "ArrayRef<int64_t>": $cTileSize, 
+      "ArrayRef<int64_t>": $computeTileSize, // Rank 3: (i,j,k).
+      "ArrayRef<int64_t>": $aTileSize, // Rank 2: (rightmost 2 dims).
+      "ArrayRef<int64_t>": $bTileSize, // Rank 2: (rightmost 2 dims).
+      "ArrayRef<int64_t>": $cTileSize, // Rank 2: (rightmost 2 dims).
       "bool": $simdize,
       "bool": $unroll, 
       "bool": $overcompute 

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -329,7 +329,7 @@ def KrnlPermuteOp : Op<Krnl_Dialect, "permute"> {
 
   let arguments = (ins Variadic<AnyType>:$loops, I64ArrayAttr:$map);
   let results = (outs);
-  let builders = [ OpBuilderDAG<(ins "ArrayRef<Value>": $loops, "ArrayRef<int64_t>":$map)> ];
+  let builders = [ OpBuilderDAG<(ins "ValueRange": $loops, "ArrayRef<int64_t>":$map)> ];
   let assemblyFormat = [{
       `(` $loops `)` $map attr-dict `:` type($loops)
   }];
@@ -834,10 +834,10 @@ def KrnlMatMulOp : Op<Krnl_Dialect, "matmul", [AttrSizedOperandSegments,
     DefaultValuedAttr<BoolAttr, "false">:$overcompute);
 
   let builders = [ OpBuilderDAG<(ins 
-      "Value": $A, "ArrayRef<Value>": $aStart, // Both same rank.
-      "Value": $B, "ArrayRef<Value>": $bStart, // Both same rank.
-      "Value": $C, "ArrayRef<Value>": $cStart, // Both same rank.
-      "ArrayRef<Value>": $loops, // Rank 3: (i,j,k).
+      "Value": $A, "ValueRange": $aStart, // Both same rank.
+      "Value": $B, "ValueRange": $bStart, // Both same rank.
+      "Value": $C, "ValueRange": $cStart, // Both same rank.
+      "ValueRange": $loops, // Rank 3: (i,j,k).
       "Value": $iComputeStart, "Value": $jComputeStart, "Value": $kComputeStart, 
       "Value": $iGlobalUB, "Value": $jGlobalUB, "Value": $kGlobalUB,
       "ArrayRef<int64_t>": $computeTileSize, // Rank 3: (i,j,k).
@@ -921,7 +921,7 @@ def KrnlCopyToBufferOp : Op<Krnl_Dialect, "copy_to_tile_buffer", [
     OptionalAttr<I64ArrayAttr>:$padToNext);
 
   let builders = [ OpBuilderDAG<(ins "Value": $bufferMemref, "Value": $memref, 
-      "ArrayRef<Value>": $starts, "Value": $padValue, 
+      "ValueRange": $starts, "Value": $padValue, 
       "ArrayRef<int64_t>": $tileSize, "ArrayRef<int64_t>": $padToNext
     )> ];
 
@@ -954,7 +954,7 @@ def KrnlCopyFromBufferOp : Op<Krnl_Dialect, "copy_from_tile_buffer",
     OptionalAttr<I64ArrayAttr>:$tileSize);
 
   let builders = [ OpBuilderDAG<(ins "Value": $bufferMemref, "Value": $memref, 
-      "ArrayRef<Value>": $starts, "ArrayRef<int64_t>": $tileSize
+      "ValueRange": $starts, "ArrayRef<int64_t>": $tileSize
     )> ];
 
   let parser = ?;

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -636,7 +636,8 @@ def KrnlGetInductionVariableValueOp : Op<Krnl_Dialect, "get_induction_var_value"
 
   let arguments = (ins Variadic<AnyType> : $loops);
   let results = (outs Variadic<AnyType> : $ind_var_vals);
-  let builders = [ OpBuilderDAG<(ins "ArrayRef<Value>": $loops)> ];
+  let builders = [ OpBuilderDAG<(ins "ArrayRef<Value>": $loops)>,
+   OpBuilderDAG<(ins "ValueRange": $loops)>];
 
   let assemblyFormat = [{
       `(` $loops `)` attr-dict `:` functional-type($loops, results)

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -636,8 +636,7 @@ def KrnlGetInductionVariableValueOp : Op<Krnl_Dialect, "get_induction_var_value"
 
   let arguments = (ins Variadic<AnyType> : $loops);
   let results = (outs Variadic<AnyType> : $ind_var_vals);
-  let builders = [ OpBuilderDAG<(ins "ArrayRef<Value>": $loops)>,
-   OpBuilderDAG<(ins "ValueRange": $loops)>];
+  let builders = [ OpBuilderDAG<(ins "ValueRange": $loops)>];
 
   let assemblyFormat = [{
       `(` $loops `)` attr-dict `:` functional-type($loops, results)

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -703,8 +703,8 @@ def KrnlSpecializedKernel : Op<Krnl_Dialect, "specialized_kernel",
 
 // =============================================================================
 
-def KrnlMatMulOp : Op<Krnl_Dialect, "matmul", 
-      [DeclareOpInterfaceMethods<SpecializedKernelOpInterface>]> {
+def KrnlMatMulOp : Op<Krnl_Dialect, "matmul", [AttrSizedOperandSegments, 
+       DeclareOpInterfaceMethods<SpecializedKernelOpInterface>]> {
   let summary = "Matmul operation for a single pannel.";
   let description = [{
     Perform a matrix multiplication A * B + C
@@ -795,11 +795,11 @@ def KrnlMatMulOp : Op<Krnl_Dialect, "matmul",
     // Buffer/memory used and indices that correspoond to the begining 
     // of each buffer/memory.
     Arg<AnyMemRef, "Mult A [NxK]", [MemRead]>:$A,
-    Index: $aMemStart0, Index: $aMemStart1,
+    Variadic<Index>: $aMemStart,
     Arg<AnyMemRef, "Mult B [KxM]", [MemRead]>:$B,
-    Index: $bMemStart0, Index: $bMemStart1,
+    Variadic<Index>: $bMemStart,
     Arg<AnyMemRef, "Add into C [NxM]", [MemRead, MemWrite]>:$C,
-    Index: $cMemStart0, Index: $cMemStart1,
+    Variadic<Index>: $cMemStart,
     // Loops involved, and indices pointing to the start of the compute
     // subtile. 
     Variadic<AnyType> : $loops,
@@ -817,9 +817,9 @@ def KrnlMatMulOp : Op<Krnl_Dialect, "matmul",
     DefaultValuedAttr<BoolAttr, "false">:$overcompute);
 
   let builders = [ OpBuilderDAG<(ins 
-      "Value": $A, "Value": $aStart0, "Value": $aStart1,
-      "Value": $B, "Value": $bStart0, "Value": $bStart1,
-      "Value": $C, "Value": $cStart0, "Value": $cStart1,
+      "Value": $A, "ArrayRef<Value>": $aStart,
+      "Value": $B, "ArrayRef<Value>": $bStart,
+      "Value": $C, "ArrayRef<Value>": $cStart,
       "ArrayRef<Value>": $loops,
       "Value": $iComputeStart, "Value": $jComputeStart, "Value": $kComputeStart, 
       "Value": $iGlobalUB, "Value": $jGlobalUB, "Value": $kGlobalUB,
@@ -834,10 +834,12 @@ def KrnlMatMulOp : Op<Krnl_Dialect, "matmul",
 
   let parser = ?;
   let printer = ?;
+  let verifier = [{ return ::verify(*this); }];
+
   let assemblyFormat = [{
-    $A `[` $aMemStart0 `,` $aMemStart1 `]` `,`
-    $B `[` $bMemStart0 `,` $bMemStart1 `]` `,`
-    $C `[` $cMemStart0 `,` $cMemStart1 `]` `,`
+    $A `[` $aMemStart `]` `,`
+    $B `[` $bMemStart `]` `,`
+    $C `[` $cMemStart `]` `,`
     `(` $loops `)` `,`
     `(` $iComputeStart `,` $jComputeStart `,` $kComputeStart `)` `,`
     `(` $iGlobalUB `,` $jGlobalUB `,` $kGlobalUB `)` 


### PR DESCRIPTION
Added support for Variadic parameter passing in MatMul, CopyFromBuffer, CopyToBuffer, in order to facilitate the use of broadcast in matrix multiplication. Before this, memrefs were restricted to 2D data structures.

EDSC and MLIR seems to use predominantly `ValueRange` instead of `ArrayRef<Value>` and having the Krnl EDSC rely on ArrayRefs was making the integration more difficult. This PR changes them to facilitate integration. 

Finally, moved asserts that were checking the validity of parameter for MatMul from the builder (which was limited to one specific builder) to a verify() function for more broad use.