### PR TITLE
Use -O2 in bitcode opt

### DIFF
--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -258,7 +258,7 @@ void genLLVMBitcode(const mlir::OwningModuleRef &module,
   // Use the LLVM's 'opt' command to optimize the bitcode.
   string optPath = getToolPath("opt");
   Command optBitcode(/*exePath=*/!optPath.empty() ? optPath : kOptPath);
-  optBitcode.appendStr("-O3")
+  optBitcode.appendStr("-O2")
       .appendStr(getTargetOptions())
       .appendList({"-o", optimizedBitcodePath})
       .appendStr(unoptimizedBitcodePath)


### PR DESCRIPTION
Using -O3 for opt causes unexpected behavior on BE machines. One issue was reported here: #600.

This patch changes to use -O2 for safety.
 
Signed-off-by: Tung D. Le <tung@jp.ibm.com>