### PR TITLE
Add cmake tablegen functions

### DIFF
--- a/src/Dialect/Krnl/CMakeLists.txt
+++ b/src/Dialect/Krnl/CMakeLists.txt
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(LLVM_TARGET_DEFINITIONS KrnlOps.td)
-onnx_mlir_tablegen(KrnlOps.hpp.inc -gen-op-decls)
-onnx_mlir_tablegen(KrnlOps.cpp.inc -gen-op-defs)
-add_public_tablegen_target(OMKrnlOpsIncGen)
+add_onnx_mlir_dialect(KrnlOps)
 
 # Header dependencies target for KrnOps.hpp
 add_custom_target(OMKrnlOpsInc

--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -1,16 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(LLVM_TARGET_DEFINITIONS ONNXOps.td)
-onnx_mlir_tablegen(ONNXOps.hpp.inc -gen-op-decls "-I${ONNX_MLIR_SRC_ROOT}/compiler/pass")
-onnx_mlir_tablegen(ONNXOps.cpp.inc -gen-op-defs "-I${ONNX_MLIR_SRC_ROOT}/compiler/pass")
-set(GEN_DOC_FILE ${CMAKE_BINARY_DIR}/docs/Dialects/onnx.md)
-add_public_tablegen_target(OMONNXOpsIncGen)
+add_onnx_mlir_dialect(ONNXOps)
 
 # Header dependencies target for ONNXOps.hpp
 add_custom_target(OMONNXOpsInc
         DEPENDS OMONNXOpsIncGen
                 OMResultTypeInferenceOpInterfaceIncGen
-                ShapeInferenceOpInterfaceIncGen
+                OMShapeInferenceOpInterfaceIncGen
                 OMHasOnnxSubgraphOpInterfaceIncGen)
 
 add_library(OMONNXOps

--- a/src/Dialect/ONNX/ONNXOps.hpp
+++ b/src/Dialect/ONNX/ONNXOps.hpp
@@ -26,7 +26,7 @@
 
 #include "src/Interface/HasOnnxSubgraphOpInterface.hpp"
 #include "src/Interface/ResultTypeInferenceOpInterface.hpp"
-#include "src/Interface/ShapeInferenceInterface.hpp"
+#include "src/Interface/ShapeInferenceOpInterface.hpp"
 
 #include "ONNXOpsHelper.hpp"
 

--- a/src/Dialect/ONNX/ONNXOps.td
+++ b/src/Dialect/ONNX/ONNXOps.td
@@ -14,7 +14,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
-include "src/Interface/ShapeInferenceInterface.td"
+include "src/Interface/ShapeInferenceOpInterface.td"
 include "src/Interface/ResultTypeInferenceOpInterface.td"
 include "src/Interface/HasOnnxSubgraphOpInterface.td"
 

--- a/src/Interface/CMakeLists.txt
+++ b/src/Interface/CMakeLists.txt
@@ -1,22 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(LLVM_TARGET_DEFINITIONS ShapeInferenceInterface.td)
-onnx_mlir_tablegen(ShapeInference.hpp.inc -gen-op-interface-decls)
-onnx_mlir_tablegen(ShapeInference.cpp.inc -gen-op-interface-defs)
-add_public_tablegen_target(ShapeInferenceOpInterfaceIncGen)
+add_onnx_mlir_interface(ShapeInferenceOpInterface)
 
 add_library(OMShapeInferenceOpInterface
-        ShapeInferenceInterface.hpp
-        ShapeInferenceInterface.cpp)
+        ShapeInferenceOpInterface.hpp
+        ShapeInferenceOpInterface.cpp)
 target_include_directories(OMShapeInferenceOpInterface
         PRIVATE ${ONNX_MLIR_SRC_ROOT} ${ONNX_MLIR_BIN_ROOT}
         ${ONNX_MLIR_SRC_ROOT})
-add_dependencies(OMShapeInferenceOpInterface ShapeInferenceOpInterfaceIncGen)
+add_dependencies(OMShapeInferenceOpInterface OMShapeInferenceOpInterfaceIncGen)
 
-set(LLVM_TARGET_DEFINITIONS ResultTypeInferenceOpInterface.td)
-onnx_mlir_tablegen(ResultTypeInferenceOpInterface.hpp.inc -gen-op-interface-decls)
-onnx_mlir_tablegen(ResultTypeInferenceOpInterface.cpp.inc -gen-op-interface-defs)
-add_public_tablegen_target(OMResultTypeInferenceOpInterfaceIncGen)
+add_onnx_mlir_interface(ResultTypeInferenceOpInterface)
 
 add_library(OMResultTypeInferenceOpInterface
         ResultTypeInferenceOpInterface.hpp
@@ -27,10 +21,7 @@ target_include_directories(OMResultTypeInferenceOpInterface
 add_dependencies(OMResultTypeInferenceOpInterface
         OMResultTypeInferenceOpInterfaceIncGen)
 
-set(LLVM_TARGET_DEFINITIONS HasOnnxSubgraphOpInterface.td)
-onnx_mlir_tablegen(HasOnnxSubgraphOpInterface.hpp.inc -gen-op-interface-decls)
-onnx_mlir_tablegen(HasOnnxSubgraphOpInterface.cpp.inc -gen-op-interface-defs)
-add_public_tablegen_target(OMHasOnnxSubgraphOpInterfaceIncGen)
+add_onnx_mlir_interface(HasOnnxSubgraphOpInterface)
 
 add_library(OMHasOnnxSubgraphOpInterface
         HasOnnxSubgraphOpInterface.hpp
@@ -42,10 +33,7 @@ target_include_directories(OMHasOnnxSubgraphOpInterface
 add_dependencies(OMHasOnnxSubgraphOpInterface
         OMHasOnnxSubgraphOpInterfaceIncGen)
 
-set(LLVM_TARGET_DEFINITIONS SpecializedKernelOpInterface.td)
-onnx_mlir_tablegen(SpecializedKernelOpInterface.hpp.inc -gen-op-interface-decls)
-onnx_mlir_tablegen(SpecializedKernelOpInterface.cpp.inc -gen-op-interface-defs)
-add_public_tablegen_target(OMSpecializedKernelOpInterfaceIncGen)
+add_onnx_mlir_interface(SpecializedKernelOpInterface)
 
 add_library(OMSpecializedKernelOpInterface
         SpecializedKernelOpInterface.hpp

--- a/src/Interface/ShapeInferenceOpInterface.cpp
+++ b/src/Interface/ShapeInferenceOpInterface.cpp
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===---- ShapeInferenceInterface.cpp - Definition for ShapeInference -----===//
+//===---- ShapeInferenceOpInterface.cpp - Definition for ShapeInference ---===//
 //
 // Copyright 2019-2020 The IBM Research Authors.
 //
@@ -13,11 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/Interface/ShapeInferenceInterface.hpp"
+#include "src/Interface/ShapeInferenceOpInterface.hpp"
 
 namespace mlir {
 
 /// Include the auto-generated declarations.
-#include "src/Interface/ShapeInference.cpp.inc"
+#include "src/Interface/ShapeInferenceOpInterface.cpp.inc"
 
 } // end namespace mlir

--- a/src/Interface/ShapeInferenceOpInterface.hpp
+++ b/src/Interface/ShapeInferenceOpInterface.hpp
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===---- ShapeInferenceInterface.hpp - Definition for ShapeInference -----===//
+//===---- ShapeInferenceOpInterface.hpp - Definition for ShapeInference ---===//
 //
 // Copyright 2019-2020 The IBM Research Authors.
 //
@@ -21,6 +21,6 @@
 namespace mlir {
 
 /// Include the auto-generated declarations.
-#include "src/Interface/ShapeInference.hpp.inc"
+#include "src/Interface/ShapeInferenceOpInterface.hpp.inc"
 
 } // end namespace mlir

--- a/src/Interface/ShapeInferenceOpInterface.td
+++ b/src/Interface/ShapeInferenceOpInterface.td
@@ -8,9 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifdef SHAPE_INFERENCE_INTERFACE
+#ifdef SHAPE_INFERENCE_OP_INTERFACE
 #else
-#define SHAPE_INFERENCE_INTERFACE
+#define SHAPE_INFERENCE_OP_INTERFACE
 
 #ifdef OP_BASE
 #else
@@ -38,4 +38,4 @@ def ShapeInferenceOpInterface : OpInterface<"ShapeInference"> {
   ];
 }
 
-#endif // SHAPE_INFERENCE_INTERFACE
+#endif // SHAPE_INFERENCE_OP_INTERFACE

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -11,22 +11,10 @@ add_dependencies(OMElideConstants OMONNXOpsInc)
 # Linking dependencies
 add_dependencies(OMElideConstants OMONNXOps)
 
-
-set(LLVM_TARGET_DEFINITIONS Rewrite.td)
-onnx_mlir_tablegen(ONNXRewrite.inc -gen-rewriters)
-add_public_tablegen_target(OMONNXRewriteIncGen)
-
-set(LLVM_TARGET_DEFINITIONS Combine.td)
-onnx_mlir_tablegen(ONNXCombine.inc -gen-rewriters)
-add_public_tablegen_target(OMONNXCombineIncGen)
-
-set(LLVM_TARGET_DEFINITIONS Decompose.td)
-onnx_mlir_tablegen(ONNXDecompose.inc -gen-rewriters)
-add_public_tablegen_target(OMONNXDecomposeIncGen)
-
-set(LLVM_TARGET_DEFINITIONS ConstProp.td)
-onnx_mlir_tablegen(ONNXConstProp.inc -gen-rewriters)
-add_public_tablegen_target(OMONNXConstPropIncGen)
+add_onnx_mlir_rewriter(Rewrite)
+add_onnx_mlir_rewriter(Combine)
+add_onnx_mlir_rewriter(Decompose)
+add_onnx_mlir_rewriter(ConstProp)
 
 add_library(OMONNXRewrite
         Rewrite.cpp
@@ -53,7 +41,7 @@ target_include_directories(OMShapeInference
         PRIVATE ${ONNX_MLIR_SRC_ROOT} ${ONNX_MLIR_BIN_ROOT}
         ${ONNX_MLIR_SRC_ROOT})
 # Header dependencies
-add_dependencies(OMShapeInference ShapeInferenceOpInterfaceIncGen)
+add_dependencies(OMShapeInference OMShapeInferenceOpInterfaceIncGen)
 # Linking dependencies
 add_dependencies(OMShapeInference OMShapeInferenceOpInterface)
 

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -20,7 +20,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "src/Interface/ShapeInferenceInterface.hpp"
+#include "src/Interface/ShapeInferenceOpInterface.hpp"
 #include "src/Pass/Passes.hpp"
 
 using namespace mlir;


### PR DESCRIPTION
mlir (and llvm for that matter) use helper tablegen functions to simplify logic that is repetitive.
This is using the existing onnx_mlir_tablegen function to add a couple of helper functions similar to mlir and then use them.

As part of this change, a couple of inconsistencies in the naming of the generated targets and files were found and addressed as well.

Eventually, onnx_mlir_tablegen will replaced with mlir_tablegen (eventually = when using find_package(mlir)).

Signed-off-by: Stella Stamenova <stilis@microsoft.com>