### PR TITLE
enable compiler options for test.py (necessary for SIMD on z)

### DIFF
--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -394,13 +394,11 @@ void addONNXToKrnlPasses(mlir::PassManager &pm) {
   pm.addNestedPass<FuncOp>(createDisconnectKrnlDimFromAllocPass());
 
   // TODO: make this pass optional:
-  if (true) {
-    pm.addNestedPass<FuncOp>(mlir::createKrnlEnableMemoryPoolPass());
-    pm.addNestedPass<FuncOp>(mlir::createKrnlBundleMemoryPoolsPass());
-    pm.addPass(mlir::createCanonicalizerPass());
-    pm.addNestedPass<FuncOp>(mlir::createKrnlOptimizeMemoryPoolsPass());
-    pm.addPass(mlir::createCanonicalizerPass());
-  }
+  pm.addNestedPass<FuncOp>(mlir::createKrnlEnableMemoryPoolPass());
+  pm.addNestedPass<FuncOp>(mlir::createKrnlBundleMemoryPoolsPass());
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addNestedPass<FuncOp>(mlir::createKrnlOptimizeMemoryPoolsPass());
+  pm.addPass(mlir::createCanonicalizerPass());
 }
 
 void addKrnlToAffinePasses(mlir::PassManager &pm) {

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -233,8 +233,11 @@ string getTargetOptions() {
   string targetOptions = "";
   if (mtriple != "")
     targetOptions = "--mtriple=" + mtriple;
+  // Comand cannot tolerate extra spaces. Add only when needed.
+  if (mtriple != "" && mcpu != "")
+    targetOptions += " ";
   if (mcpu != "")
-    targetOptions += " --mcpu=" + mcpu;
+    targetOptions += "--mcpu=" + mcpu;
   return targetOptions;
 }
 
@@ -391,11 +394,13 @@ void addONNXToKrnlPasses(mlir::PassManager &pm) {
   pm.addNestedPass<FuncOp>(createDisconnectKrnlDimFromAllocPass());
 
   // TODO: make this pass optional:
-  pm.addNestedPass<FuncOp>(mlir::createKrnlEnableMemoryPoolPass());
-  pm.addNestedPass<FuncOp>(mlir::createKrnlBundleMemoryPoolsPass());
-  pm.addPass(mlir::createCanonicalizerPass());
-  pm.addNestedPass<FuncOp>(mlir::createKrnlOptimizeMemoryPoolsPass());
-  pm.addPass(mlir::createCanonicalizerPass());
+  if (true) {
+    pm.addNestedPass<FuncOp>(mlir::createKrnlEnableMemoryPoolPass());
+    pm.addNestedPass<FuncOp>(mlir::createKrnlBundleMemoryPoolsPass());
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<FuncOp>(mlir::createKrnlOptimizeMemoryPoolsPass());
+    pm.addPass(mlir::createCanonicalizerPass());
+  }
 }
 
 void addKrnlToAffinePasses(mlir::PassManager &pm) {


### PR DESCRIPTION
…option in MainUtils.cpp

Options to set the cpu and triple were added on onnx-mlir, but not to the python test.py. In addition, onnx-mlir was not able to handle 2 options... this is now fixed. New options (last 2)

```
Options for test.py
usage: test.py [-h] [--dynamic] [-i INPUT] [-d DIM] [-v] [--mtriple MTRIPLE] [--mcpu MCPU] [unittest_args [unittest_args ...]]

with dynamic shape or not.

positional arguments:
  unittest_args

optional arguments:
  -h, --help            show this help message and exit
  --dynamic             enable dynamic shape tests (default: false if TEST_DYNAMIC env var not set)
  -i INPUT, --input INPUT
                        inputs whose dimensions to be changed to unknown (default: all inputs if TEST_INPUT env var not set)
  -d DIM, --dim DIM     dimensions to be changed to unknown (default: all dimensions if TEST_DIM env var not set)
  -v, --verbose         verbose output (default: false if VERBOSE env var not set)
  --mtriple MTRIPLE     triple to pass to the compiler
  --mcpu MCPU           target a specific cpu, passed to the compiler
```

They can be driven by TEST_MCPU and TEST_MTRIPLE env var also

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>