### PR TITLE
Fix J9 crash (llvm-12-release-branch)

### DIFF
--- a/.buildbot/Jenkinsfile
+++ b/.buildbot/Jenkinsfile
@@ -53,13 +53,15 @@ def call() {
       JENKINS_REST_API_URL = sh(returnStdout: true,
                                 script: """#!/bin/bash +x
         declare -A url=([s390x]="http://localhost:8080/jenkins"
-                        [amd64]="http://localhost:8080/jenkinx")
+                        [amd64]="http://localhost:8080/jenkinx"
+                        [ppc64le]="http://localhost:8080/jenkinp")
         echo \${url[${CPU_ARCH}]}""").trim()
 
       JENKINS_REST_API_USER = sh(returnStdout: true,
                                  script: """#!/bin/bash +x
         declare -A user=([s390x]="jenkins"
-                         [amd64]="jenkins")
+                         [amd64]="jenkins"
+                         [ppc64le]="jenkins")
         echo \${user[${CPU_ARCH}]}""").trim()
 
       /* The rest of the environment variables need not to be changed for
@@ -109,6 +111,9 @@ def call() {
           echo "JENKINS_SCRIPTSPACE_AT   = ${JENKINS_SCRIPTSPACE_AT}"
           echo "JENKINS_WORKSPACE        = ${JENKINS_WORKSPACE}"
           echo "JENKINS_WORKSPACE_AT     = ${JENKINS_WORKSPACE_AT}"
+	  echo "JENKINS_START_TIME       = ${JENKINS_START_TIME}"
+	  echo "JENKINS_REST_API_URL     = ${JENKINS_REST_API_URL}"
+	  echo "JENKINS_REST_API_USER    = ${JENKINS_REST_API_USER}"
           echo "CPU_ARCH                 = ${CPU_ARCH}"
           echo "GITHUB_CONTEXT           = ${GITHUB_CONTEXT}"
           echo "GITHUB_EVENT             = ${GITHUB_EVENT}"
@@ -124,8 +129,11 @@ def call() {
           echo "GITHUB_PR_TITLE          = ${GITHUB_PR_TITLE}"
           echo "GITHUB_PR_REQUEST_URL    = ${GITHUB_PR_REQUEST_URL}"
           echo "GITHUB_PR_COMMENT_URL    = ${GITHUB_PR_COMMENT_URL}"
-          echo "GITHUB_PR_STATUS_URL     = ${GITHUB_PR_STATUS_URL}"
+	  echo "GITHUB_PR_BASEREF        = ${GITHUB_PR_BASEREF}"
+          echo "GITHUB_PR_COMMIT_SHA1    = ${GITHUB_PR_COMMIT_SHA1}"
+          echo "GITHUB_PR_COMMIT_URL     = ${GITHUB_PR_COMMIT_URL}"
           echo "GITHUB_PR_COMMIT_MESSAGE = ${GITHUB_PR_COMMIT_MESSAGE}"
+          echo "GITHUB_PR_STATUS_URL     = ${GITHUB_PR_STATUS_URL}"
           echo "GITHUB_PR_MERGED         = ${GITHUB_PR_MERGED}"
 
           checkout_pr_source("${GITHUB_PR_REPO_URL}",
@@ -143,10 +151,13 @@ def call() {
             env.JENKINS_BUILD_RESULT = 'UNKNOWN'
           }
 
+          /* The stopped build will post github status with 'aborted'.
+           * However, the status has already been updated with the new
+           * commit sha with 'pending' by the frontend script. So the
+           * 'aborted' status will not appear on the pull request page.
+           */
           sh "${JENKINS_STOP_PREVIOUS_BUILD}"
           sh "${JENKINS_CLEANUP_BUILD_STATES}"
-
-          post_build_status("${GITHUB_EVENT}", 'pending')
         }
       }
 
@@ -210,7 +221,6 @@ def call() {
 
 /* Set build status appearing on the GitHub pull request page */
 def post_build_status(event, state) {
-    def status   = (state == 'aborted') ? 'failure' : state
     /* Commit message may have newline so replace it to avoid invalid JSON.
      * Also remove single and double quotes since the first MAXLEN characters
      * may end in the middle of a quoted phrase.
@@ -230,9 +240,9 @@ def post_build_status(event, state) {
     def action   = (state == 'success') ? 'passed'  :
                    (state == 'failure') ? 'failed'  :
                    (state == 'aborted') ? 'aborted' : 'started'
-    def start    = (new Date("${currentBuild.startTimeInMillis}".toLong())).format('HH:mm')
     def duration = (state == 'pending') ?
-        "at ${start}" : "after ${currentBuild.durationString.replace(' and counting','')}"
+        "at ${JENKINS_START_TIME}" : "after ${currentBuild.durationString.replace(' and counting','')}"
+    def status   = (state == 'aborted') ? 'failure' : state
 
     /* If the action is "push", it's for merging into master. The GitHub page
      * for the pull request is already closed and commit status is no longer

--- a/.buildbot/ONNX-MLIR-Pipeline-Docker-Build.xml
+++ b/.buildbot/ONNX-MLIR-Pipeline-Docker-Build.xml
@@ -35,7 +35,7 @@ The &quot;head&quot; branch is the actual branch that is to be merged. The &quot
 The GitHub Plugin has a &quot;bug&quot; that it would use the SHA we are building to post the commit status. So if we build the &quot;merge&quot; branch, it would post to the wrong &quot;merge&quot; SHA. The GitHub Pull Request Builder Plugin handles building either branch correctly.</description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.2"/>
+    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.2.1"/>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.33.1">
       <projectUrl>https://github.com/onnx/onnx-mlir/</projectUrl>
       <displayName></displayName>
@@ -123,7 +123,7 @@ The GitHub Plugin has a &quot;bug&quot; that it would use the SHA we are buildin
             </org.jenkinsci.plugins.gwt.GenericVariable>
           </genericVariables>
           <regexpFilterText>${x_github_event}:${github_webhook_payload_action}:${github_webhook_payload_issue_pull_request_url}:${github_webhook_payload_comment_body}:${GITHUB_PR_NUMBER_PUSH}</regexpFilterText>
-          <regexpFilterExpression>(pull_request:(opened|reopened|synchronize|closed):.*:.*:.*)|(issue_comment:created:.*pull.*:.*(test|publish) this please.*:.*)|(push:.*:.*:.*:master)</regexpFilterExpression>
+          <regexpFilterExpression>(pull_request:(opened|reopened|synchronize|closed):.*:.*:.*)|(issue_comment:created:.*pull.*:.*@jenkins-droid (test|publish) this please.*:.*)|(push:.*:.*:.*:(master|llvm-12-release-branch))</regexpFilterExpression>
           <genericHeaderVariables>
             <org.jenkinsci.plugins.gwt.GenericHeaderVariable>
               <key>x-github-delivery</key>
@@ -154,74 +154,89 @@ The GitHub Plugin has a &quot;bug&quot; that it would use the SHA we are buildin
  */
 def jenkinsfile
 def auth_ok
+def errmsg
 
 node {
-    /* In order to checkout the PR source to load the Jenkinsfile,
-     * we need to find out various bits about the PR depending on
-     * the webhook event received.
-     */
-    set_environ_vars(&quot;${x_github_event}&quot;)
-    set_build_name(&quot;${x_github_event}&quot;)
-
-    /* Check for authorization, i.e., where the user triggered
-     * the event is one of the admins.
-     */
     auth_ok = true
     withCredentials([
         string(credentialsId: &apos;ONNX-MLIR-GitHub-Admins&apos;,
                variable:      &apos;GITHUB_REPO_ADMINS&apos;),
         string(credentialsId: &apos;jenkins-buildbot-access-token&apos;,
-               variable:      &apos;GITHUB_REOP_ACCESS_TOKEN&apos;) ]) {
-        /* User triggering the event is not one of the admins */
-        if (GITHUB_REPO_ADMINS.indexOf(GITHUB_PR_SENDER) &lt; 0) {
-            /* Just post the comment once */
-            if (CPU_ARCH == &apos;s390x&apos;)
-                post_pr_comment(&quot;${GITHUB_PR_COMMENT_URL}&quot;,
-                                &quot;${GITHUB_REOP_ACCESS_TOKEN}&quot;,
-                                &apos;Can one of the admins verify this patch?&apos;)
+               variable:      &apos;GITHUB_REPO_ACCESS_TOKEN&apos;) ]) {
+
+        /* In order to checkout the PR source to load the Jenkinsfile,
+         * we need to find out various bits about the PR depending on
+         * the webhook event received.
+         */
+        set_environ_vars(&quot;${x_github_event}&quot;)
+        set_build_name(&quot;${x_github_event}&quot;)
+
+        try {
+            /* User triggering the event is not one of the admins */
+            if (GITHUB_REPO_ADMINS.indexOf(GITHUB_PR_SENDER) &lt; 0) {
+                /* Just post the comment once */
+                if (CPU_ARCH == &apos;s390x&apos;)
+                    post_pr_comment(&quot;${GITHUB_PR_COMMENT_URL}&quot;,
+                                    &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;,
+                                    &apos;Can one of the admins verify this patch?&apos;)
+                throw new Exception(&apos;admin authentication failed&apos;)
+            }
+            else {
+                /* Update github status as early as possible so we can get a
+                 * link to the build job even if we fail early.
+                 */
+                env.JENKINS_START_TIME = (new Date(&quot;${currentBuild.startTimeInMillis}&quot;.toLong())).format(&apos;HH:mm&apos;)
+                post_build_status(&quot;${GITHUB_EVENT}&quot;, &apos;pending&apos;)
+
+                /* We ask for this directory */
+                env.JENKINS_SCRIPTSPACE = &quot;${JENKINS_HOME}/workspace/${JOB_NAME}@script/pr_${GITHUB_PR_NUMBER}&quot;
+                ws(&quot;${JENKINS_SCRIPTSPACE}&quot;) {
+                    /* We may get one with @2, @3, etc. appended */
+                    env.JENKINS_SCRIPTSPACE_AT = &quot;${WORKSPACE}&quot;
+        
+                    /* Checkout the PR source */
+                    checkout_pr_source(&quot;${GITHUB_PR_REPO_URL}&quot;,
+                                       &quot;${GITHUB_PR_REMOTE}&quot;,
+                                       &quot;${GITHUB_PR_REFSPEC}&quot;,
+                                       &quot;${GITHUB_PR_BRANCH}&quot;,
+                                       false)
+
+                    /* debug only */
+                    set_environ_vars2(&quot;${x_github_event}&quot;)
+
+                    /* Load the Jenkinsfile in the source code repo but do not
+                     * run it yet. Since we are still inside the current node
+                     * block so running the loaded Jenkinsfile immediately will
+                     * consume another executor.
+                     *
+                     * For the assignment to work, the loaded Jenkinsfile must
+                     * have the &quot;return this&quot; statement after all the function
+                     * definitions.
+                     */
+                    jenkinsfile = load &quot;.buildbot/Jenkinsfile&quot;
+        
+                    /* We no longer need the script directory once the Jenkinsfile
+                     * is loaded so cleanup
+                     */
+                    deleteDir()
+                    dir(&quot;${JENKINS_SCRIPTSPACE_AT}@tmp&quot;) {
+                        deleteDir()
+                    }
+                } /* ws() */
+            } /* else */
+        } catch (Exception e) {
+            post_build_status(&quot;${GITHUB_EVENT}&quot;, &apos;failure&apos;)
+            errmsg = &apos;Exception: &apos; + e.toString()
             auth_ok = false
         }
-    }
-    if (!auth_ok) return
-    
-    /* We ask for this directory */
-    env.JENKINS_SCRIPTSPACE = &quot;${JENKINS_HOME}/workspace/${JOB_NAME}@script/pr_${GITHUB_PR_NUMBER}&quot;
-    ws(&quot;${JENKINS_SCRIPTSPACE}&quot;) {
-        /* We may get one with @2, @3, etc. appended */
-        env.JENKINS_SCRIPTSPACE_AT = &quot;${WORKSPACE}&quot;
-        
-        /* Checkout the PR source */
-        checkout_pr_source(GITHUB_PR_REPO_URL,
-                           GITHUB_PR_REMOTE,
-                           GITHUB_PR_REFSPEC,
-                           GITHUB_PR_BRANCH,
-                           false)
-
-        set_environ_vars2(&quot;${x_github_event}&quot;)
-
-        /* Load the Jenkinsfile in the source code repo but do not
-         * run it yet. Since we are still inside the current node
-         * block so running the loaded Jenkinsfile immediately will
-         * consume another executor.
-         *
-         * For the assignment to work, the loaded Jenkinsfile must
-         * have the &quot;return this&quot; statement after all the function
-         * definitions.
-         */
-        jenkinsfile = load &quot;.buildbot/Jenkinsfile&quot;
-        
-        /* We no longer need the script directory once the Jenkinsfile
-         * is loaded so cleanup
-         */
-        deleteDir()
-        dir(&quot;${JENKINS_SCRIPTSPACE_AT}@tmp&quot;) {
-            deleteDir()
-        }
-    }
-}
+    } /* withCredentials() */
+} /* node */
 
 /* Run the loaded Jenkinsfile by calling its special &quot;call&quot; function */
-if (auth_ok) jenkinsfile()
+if (auth_ok)
+	jenkinsfile()
+else
+	error(errmsg)
 
 /* Set various environment variables related to the pull request.
  * These are derived from the GitHub webhook payload without 
@@ -236,86 +251,66 @@ def set_environ_vars(event) {
     
     switch(event) {
         case &apos;pull_request&apos;:
-            env.GITHUB_PR_SENDER      = &quot;${github_webhook_payload_sender_login}&quot;
-            env.GITHUB_PR_NUMBER      = &quot;${github_webhook_payload_number}&quot;
-            env.GITHUB_PR_NUMBER2     = &quot;${github_webhook_payload_number}&quot;
-            env.GITHUB_PR_REPO_URL    = &quot;${github_webhook_payload_repository_clone_url}&quot;
-            env.GITHUB_PR_REMOTE      = &apos;origin&apos;
-            env.GITHUB_PR_REFSPEC     = &apos;+refs/pull/*:refs/remotes/origin/pr/*&apos;
-            env.GITHUB_PR_BRANCH      = &quot;origin/pr/${GITHUB_PR_NUMBER}/head&quot;
-            env.GITHUB_PR_ACTION      = &quot;${github_webhook_payload_action}&quot;
-            env.GITHUB_PR_PHRASE      = &apos;none&apos;
-            env.GITHUB_PR_TITLE       = &quot;${github_webhook_payload_pull_request_title}&quot;
-            env.GITHUB_PR_REQUEST_URL = &quot;${github_webhook_payload_pull_request_url}&quot;
-            env.GITHUB_PR_COMMENT_URL = &quot;${github_webhook_payload_pull_request_comments_url}&quot;
-            env.GITHUB_PR_MERGED      = &quot;${github_webhook_payload_pull_request_merged}&quot;
+            env.GITHUB_PR_SENDER         = &quot;${github_webhook_payload_sender_login}&quot;
+            env.GITHUB_PR_NUMBER         = &quot;${github_webhook_payload_number}&quot;
+            env.GITHUB_PR_NUMBER2        = &quot;${github_webhook_payload_number}&quot;
+            env.GITHUB_PR_REPO_URL       = &quot;${github_webhook_payload_repository_clone_url}&quot;
+            env.GITHUB_PR_REMOTE         = &apos;origin&apos;
+            env.GITHUB_PR_REFSPEC        = &apos;+refs/pull/*:refs/remotes/origin/pr/*&apos;
+            env.GITHUB_PR_BRANCH         = &quot;origin/pr/${GITHUB_PR_NUMBER}/head&quot;
+            env.GITHUB_PR_ACTION         = &quot;${github_webhook_payload_action}&quot;
+            env.GITHUB_PR_PHRASE         = &apos;none&apos;
+            env.GITHUB_PR_TITLE          = &quot;${github_webhook_payload_pull_request_title}&quot;
+            env.GITHUB_PR_REQUEST_URL    = &quot;${github_webhook_payload_pull_request_url}&quot;
+            env.GITHUB_PR_COMMENT_URL    = &quot;${github_webhook_payload_pull_request_comments_url}&quot;
+            env.GITHUB_PR_BASEREF        = &quot;${github_webhook_payload_pull_request_base_ref}&quot;
+            env.GITHUB_PR_COMMIT_SHA1    = &quot;${github_webhook_payload_pull_request_head_sha}&quot;
+            env.GITHUB_PR_COMMIT_URL     = &quot;${github_webhook_payload_pull_request_head_repo_commits_url}&quot;.replace(&apos;{/sha}&apos;, &quot;/${GITHUB_PR_COMMIT_SHA1}&quot;)
+            env.GITHUB_PR_COMMIT_MESSAGE = get_commit_data(&quot;${GITHUB_PR_COMMIT_URL}&quot;, &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;, &apos;.commit.message&apos;)
+            env.GITHUB_PR_STATUS_URL     = &quot;${github_webhook_payload_repository_statuses_url}&quot;.replace(&apos;{sha}&apos;, &quot;${GITHUB_PR_COMMIT_SHA1}&quot;)
+            env.GITHUB_PR_MERGED         = &quot;${github_webhook_payload_pull_request_merged}&quot;
             break
         case &apos;issue_comment&apos;:
-            env.GITHUB_PR_SENDER      = &quot;${github_webhook_payload_sender_login}&quot;
-            env.GITHUB_PR_NUMBER      = &quot;${github_webhook_payload_issue_number}&quot;
-            env.GITHUB_PR_NUMBER2     = &quot;${github_webhook_payload_issue_number}&quot;
-            env.GITHUB_PR_REPO_URL    = &quot;${github_webhook_payload_repository_clone_url}&quot;
-            env.GITHUB_PR_REMOTE      = &apos;origin&apos;
-            env.GITHUB_PR_REFSPEC     = &apos;+refs/pull/*:refs/remotes/origin/pr/*&apos;
-            env.GITHUB_PR_BRANCH      = &quot;origin/pr/${GITHUB_PR_NUMBER}/head&quot;
-            env.GITHUB_PR_ACTION      = &quot;${github_webhook_payload_action}&quot;
-            env.GITHUB_PR_PHRASE      = (&quot;${github_webhook_payload_comment_body}&quot; =~ /.*(test|publish) this please.*/)[0][1]
-            env.GITHUB_PR_TITLE       = &quot;${github_webhook_payload_issue_title}&quot;
-            env.GITHUB_PR_REQUEST_URL = &quot;${github_webhook_payload_issue_pull_request_url}&quot;
-            env.GITHUB_PR_COMMENT_URL = &quot;${github_webhook_payload_issue_comments_url}&quot;
-            env.GITHUB_PR_MERGED      = &apos;none&apos;
+            env.GITHUB_PR_SENDER         = &quot;${github_webhook_payload_sender_login}&quot;
+            env.GITHUB_PR_NUMBER         = &quot;${github_webhook_payload_issue_number}&quot;
+            env.GITHUB_PR_NUMBER2        = &quot;${github_webhook_payload_issue_number}&quot;
+            env.GITHUB_PR_REPO_URL       = &quot;${github_webhook_payload_repository_clone_url}&quot;
+            env.GITHUB_PR_REMOTE         = &apos;origin&apos;
+            env.GITHUB_PR_REFSPEC        = &apos;+refs/pull/*:refs/remotes/origin/pr/*&apos;
+            env.GITHUB_PR_BRANCH         = &quot;origin/pr/${GITHUB_PR_NUMBER}/head&quot;
+            env.GITHUB_PR_ACTION         = &quot;${github_webhook_payload_action}&quot;
+            env.GITHUB_PR_PHRASE         = (&quot;${github_webhook_payload_comment_body}&quot; =~ /.*@jenkins-droid (test|publish) this please.*/)[0][1]
+            env.GITHUB_PR_TITLE          = &quot;${github_webhook_payload_issue_title}&quot;
+            env.GITHUB_PR_REQUEST_URL    = &quot;${github_webhook_payload_issue_pull_request_url}&quot;
+            env.GITHUB_PR_COMMENT_URL    = &quot;${github_webhook_payload_issue_comments_url}&quot;
+            env.GITHUB_PR_BASEREF        = get_commit_data(&quot;${github_webhook_payload_issue_pull_request_url}&quot;, &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;, &apos;.base.ref&apos;)
+            env.GITHUB_PR_COMMIT_SHA1    = get_commit_data(&quot;${github_webhook_payload_issue_pull_request_url}&quot;, &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;, &apos;.head.sha&apos;)
+            env.GITHUB_PR_COMMIT_URL     = &quot;${github_webhook_payload_repository_commits_url}&quot;.replace(&apos;{/sha}&apos;, &quot;/${GITHUB_PR_COMMIT_SHA1}&quot;)
+            env.GITHUB_PR_COMMIT_MESSAGE = get_commit_data(&quot;${GITHUB_PR_COMMIT_URL}&quot;, &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;, &apos;.commit.message&apos;)
+            env.GITHUB_PR_STATUS_URL     = &quot;${github_webhook_payload_repository_statuses_url}&quot;.replace(&apos;{sha}&apos;, &quot;${GITHUB_PR_COMMIT_SHA1}&quot;)
+            env.GITHUB_PR_MERGED         = &apos;none&apos;
             break
         case &apos;push&apos;:
-            env.GITHUB_PR_SENDER      = &quot;${github_webhook_payload_sender_login}&quot;
-            env.GITHUB_PR_NUMBER      = &quot;${GITHUB_PR_NUMBER_PUSH}&quot;
-            def match = &quot;${github_webhook_payload_head_commit_message}&quot; =~ /.*#(\d+)( from.*|\)\n+|\)$)/
-            env.GITHUB_PR_NUMBER2     = match ? match[0][1] : &apos;none&apos;
-            env.GITHUB_PR_REPO_URL    = &quot;${github_webhook_payload_repository_clone_url}&quot;
-            env.GITHUB_PR_REMOTE      = &apos;&apos;
-            env.GITHUB_PR_REFSPEC     = &apos;&apos;
-            env.GITHUB_PR_BRANCH      = &quot;${github_webhook_payload_ref}&quot;
-            env.GITHUB_PR_ACTION      = &apos;push&apos;
-            env.GITHUB_PR_PHRASE      = &apos;push&apos;
-            env.GITHUB_PR_TITLE       = &quot;${github_webhook_payload_head_commit_message}&quot;
-            env.GITHUB_PR_REQUEST_URL = &apos;none&apos;
-            env.GITHUB_PR_COMMENT_URL = &quot;${github_webhook_payload_repository_issue_comment_url}&quot;.replace(&apos;comments{/number}&apos;, &quot;${GITHUB_PR_NUMBER2}/comments&quot;)
-            env.GITHUB_PR_MERGED      = &apos;none&apos;
+            env.GITHUB_PR_SENDER         = &quot;${github_webhook_payload_sender_login}&quot;
+            env.GITHUB_PR_NUMBER         = &quot;${GITHUB_PR_NUMBER_PUSH}&quot;
+            env.GITHUB_PR_NUMBER2        = get_pr_number(&quot;${github_webhook_payload_head_commit_message}&quot;)
+            env.GITHUB_PR_REPO_URL       = &quot;${github_webhook_payload_repository_clone_url}&quot;
+            env.GITHUB_PR_REMOTE         = &apos;&apos;
+            env.GITHUB_PR_REFSPEC        = &apos;&apos;
+            env.GITHUB_PR_BRANCH         = &quot;${github_webhook_payload_ref}&quot;
+            env.GITHUB_PR_ACTION         = &apos;push&apos;
+            env.GITHUB_PR_PHRASE         = &apos;push&apos;
+            env.GITHUB_PR_TITLE          = &quot;${github_webhook_payload_head_commit_message}&quot;
+            env.GITHUB_PR_REQUEST_URL    = &quot;${github_webhook_payload_repository_pulls_url}&quot;.replace(&apos;{/number}&apos;, &quot;/${GITHUB_PR_NUMBER2}&quot;)
+            env.GITHUB_PR_COMMENT_URL    = &quot;${github_webhook_payload_repository_issue_comment_url}&quot;.replace(&apos;comments{/number}&apos;, &quot;${GITHUB_PR_NUMBER2}/comments&quot;)
+            env.GITHUB_PR_BASEREF        = get_commit_data(&quot;${GITHUB_PR_REQUEST_URL}&quot;, &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;, &apos;.base.ref&apos;)
+            env.GITHUB_PR_COMMIT_SHA1    = &quot;${github_webhook_payload_head_commit_id}&quot;
+            env.GITHUB_PR_COMMIT_URL     = &quot;${github_webhook_payload_repository_commits_url}&quot;.replace(&apos;{/sha}&apos;, &quot;/${GITHUB_PR_COMMIT_SHA1}&quot;)
+            env.GITHUB_PR_COMMIT_MESSAGE = get_commit_data(&quot;${GITHUB_PR_COMMIT_URL}&quot;, &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;, &apos;.commit.message&apos;)
+            env.GITHUB_PR_STATUS_URL     = &quot;${github_webhook_payload_repository_statuses_url}&quot;.replace(&apos;{sha}&apos;, &quot;${GITHUB_PR_COMMIT_SHA1}&quot;)
+            env.GITHUB_PR_MERGED         = &apos;none&apos;
             break
     }
-
-    println &quot;CPU_ARCH                 = ${CPU_ARCH}&quot;
-    println &quot;GITHUB_REPO_NAME         = ${GITHUB_REPO_NAME}&quot;
-    println &quot;GITHUB_CONTEXT           = ${GITHUB_CONTEXT}&quot;
-    println &quot;GITHUB_EVENT             = ${GITHUB_EVENT}&quot;
-    println &quot;GITHUB_PR_SENDER         = ${GITHUB_PR_SENDER}&quot;
-    println &quot;GITHUB_PR_NUMBER         = ${GITHUB_PR_NUMBER}&quot;
-    println &quot;GITHUB_PR_NUMBER2        = ${GITHUB_PR_NUMBER2}&quot;
-    println &quot;GITHUB_PR_REPO_URL       = ${GITHUB_PR_REPO_URL}&quot;
-    println &quot;GITHUB_PR_REMOTE         = ${GITHUB_PR_REMOTE}&quot;
-    println &quot;GITHUB_PR_REFSPEC        = ${GITHUB_PR_REFSPEC}&quot;
-    println &quot;GITHUB_PR_BRANCH         = ${GITHUB_PR_BRANCH}&quot;
-    println &quot;GITHUB_PR_ACTION         = ${GITHUB_PR_ACTION}&quot;
-    println &quot;GITHUB_PR_PHRASE         = ${GITHUB_PR_PHRASE}&quot;
-    println &quot;GITHUB_PR_TITLE          = ${GITHUB_PR_TITLE}&quot;
-    println &quot;GITHUB_PR_REQUEST_URL    = ${GITHUB_PR_REQUEST_URL}&quot;
-    println &quot;GITHUB_PR_COMMENT_URL    = ${GITHUB_PR_COMMENT_URL}&quot;
-    println &quot;GITHUB_PR_MERGED         = ${GITHUB_PR_MERGED}&quot;
-    
-    /* Backward compatibility, remove when generalized scripts merged */
-    env.X_GITHUB_EVENT           = GITHUB_EVENT
-    env.ONNX_MLIR_PR_SENDER      = GITHUB_PR_SENDER
-    env.ONNX_MLIR_PR_NUMBER      = GITHUB_PR_NUMBER
-    env.ONNX_MLIR_PR_NUMBER2     = GITHUB_PR_NUMBER2
-    env.ONNX_MLIR_PR_REPO_URL    = GITHUB_PR_REPO_URL
-    env.ONNX_MLIR_PR_REMOTE      = GITHUB_PR_REMOTE
-    env.ONNX_MLIR_PR_REFSPEC     = GITHUB_PR_REFSPEC
-    env.ONNX_MLIR_PR_BRANCH      = GITHUB_PR_BRANCH
-    env.ONNX_MLIR_PR_ACTION      = GITHUB_PR_ACTION
-    env.ONNX_MLIR_PR_PHRASE      = GITHUB_PR_PHRASE
-    env.ONNX_MLIR_PR_TITLE       = GITHUB_PR_TITLE
-    env.ONNX_MLIR_PR_REQUEST_URL = GITHUB_PR_REQUEST_URL
-    env.ONNX_MLIR_PR_COMMENT_URL = GITHUB_PR_COMMENT_URL
-    env.ONNX_MLIR_PR_MERGED      = GITHUB_PR_MERGED
 }
 
 /* Set various environment variables related to the pull request.
@@ -332,33 +327,26 @@ def set_environ_vars2(event) {
     * So if we want bash specific interpretation such as $(git ...),
     * we need to escape the $ sign.
     */
-    env.GITHUB_PR_COMMIT_MESSAGE = sh(returnStdout: true, script: &quot;&quot;&quot;#!/bin/bash +x
-        git -C ${JENKINS_SCRIPTSPACE_AT} log --oneline --format=%B -n 1 HEAD&quot;&quot;&quot;).trim()
-
     switch(event) {
         case &apos;pull_request&apos;:
-            env.GITHUB_PR_COMMIT_SHA1 = sh(returnStdout: true, script: &quot;&quot;&quot;#!/bin/bash +x
+            env.XGITHUB_PR_COMMIT_SHA1 = sh(returnStdout: true, script: &quot;&quot;&quot;#!/bin/bash +x
                 git -C ${JENKINS_SCRIPTSPACE_AT} rev-parse HEAD&quot;&quot;&quot;).trim()
             break
         case &apos;issue_comment&apos;:
-            env.GITHUB_PR_COMMIT_SHA1 = sh(returnStdout: true, script: &quot;&quot;&quot;#!/bin/bash +x
+            env.XGITHUB_PR_COMMIT_SHA1 = sh(returnStdout: true, script: &quot;&quot;&quot;#!/bin/bash +x
                 git -C ${JENKINS_SCRIPTSPACE_AT} rev-parse HEAD&quot;&quot;&quot;).trim()
             break
         case &apos;push&apos;:
-            env.GITHUB_PR_COMMIT_SHA1 = &quot;${github_webhook_payload_commits_0_id}&quot;
+            env.XGITHUB_PR_COMMIT_SHA1 = &quot;${github_webhook_payload_head_commit_id}&quot;
             break
     }
-    
-    env.GITHUB_PR_STATUS_URL = &quot;${github_webhook_payload_repository_statuses_url}&quot;.replace(&apos;{sha}&apos;, &quot;${GITHUB_PR_COMMIT_SHA1}&quot;)
+    env.XGITHUB_PR_COMMIT_MESSAGE = sh(returnStdout: true, script: &quot;&quot;&quot;#!/bin/bash +x
+        git -C ${JENKINS_SCRIPTSPACE_AT} log --oneline --format=%B -n 1 HEAD&quot;&quot;&quot;).trim()
+    env.XGITHUB_PR_STATUS_URL = &quot;${github_webhook_payload_repository_statuses_url}&quot;.replace(&apos;{sha}&apos;, &quot;${XGITHUB_PR_COMMIT_SHA1}&quot;)
 
-    println &quot;GITHUB_PR_COMMIT_MESSAGE = ${GITHUB_PR_COMMIT_MESSAGE}&quot;
-    println &quot;GITHUB_PR_COMMIT_SHA1    = ${GITHUB_PR_COMMIT_SHA1}&quot;
-    println &quot;GITHUB_PR_STATUS_URL     = ${GITHUB_PR_STATUS_URL}&quot;
-    
-    /* Backward compatibility, remove when generalized scripts merged */
-    env.ONNX_MLIR_PR_COMMIT_MESSAGE = GITHUB_PR_COMMIT_MESSAGE
-    env.ONNX_MLIR_PR_COMMIT_SHA1    = GITHUB_PR_COMMIT_SHA1
-    env.ONNX_MLIR_PR_STATUS_URL     = GITHUB_PR_STATUS_URL
+    println &quot;XGITHUB_PR_COMMIT_SHA1    = ${XGITHUB_PR_COMMIT_SHA1}&quot;
+    println &quot;XGITHUB_PR_COMMIT_MESSAGE = ${XGITHUB_PR_COMMIT_MESSAGE}&quot;
+    println &quot;XGITHUB_PR_STATUS_URL     = ${XGITHUB_PR_STATUS_URL}&quot;
 }
 
 /* Set build name appearing on the build history */
@@ -373,6 +361,66 @@ def set_build_name(event) {
                                &quot;[${phrase}] &quot; +
                                title.substring(0,Math.min(title.length(),32)) +
                                (title.length() &gt; 32 ? &apos;...&apos; : &apos;&apos;)
+}
+
+/* Set build status appearing on the GitHub pull request page */
+def post_build_status(event, state) {
+    /* Commit message may have newline so replace it to avoid invalid JSON.
+     * Also remove single and double quotes since the first MAXLEN characters
+     * may end in the middle of a quoted phrase.
+     *
+     * replace vs replaceAll: both will replace all occurrences of the 1st
+     * string with the 2nd string. But for replace the 1st string is a normal
+     * string while for replaceAll the 1st string is a regex.
+     */
+    def MAXLEN   = 24
+    def title    = &quot;${GITHUB_PR_COMMIT_MESSAGE}&quot;.replace(&apos;\n&apos;, &apos; &apos;).replace(&apos;\&apos;&apos;, &apos;&apos;).replace(&apos;&quot;&apos;, &apos;&apos;)
+    def phrase   = (event == &apos;issue_comment&apos;) ?
+                   &quot;${GITHUB_PR_PHRASE}&quot; : &quot;${GITHUB_PR_ACTION}&quot;
+    def desc     = (&quot;${GITHUB_PR_ACTION}&quot; == &apos;push&apos; ?
+                    &quot;Build [#${BUILD_NUMBER}](${BUILD_URL}) &quot; : &quot;Build #${BUILD_NUMBER} &quot;) +
+                   &quot;[${phrase}] &quot; + title.substring(0,Math.min(title.length(),MAXLEN)) + &apos;...&apos;
+    def action   = (state == &apos;success&apos;) ? &apos;passed&apos;  :
+                   (state == &apos;failure&apos;) ? &apos;failed&apos;  :
+                   (state == &apos;aborted&apos;) ? &apos;aborted&apos; : &apos;started&apos;
+    def duration = (state == &apos;pending&apos;) ?
+        &quot;at ${JENKINS_START_TIME}&quot; : &quot;after ${currentBuild.durationString.replace(&apos; and counting&apos;,&apos;&apos;)}&quot;
+    def status   = (state == &apos;aborted&apos;) ? &apos;failure&apos; : state
+
+    /* If the action is &quot;push&quot;, it&apos;s for merging into master. The GitHub page
+     * for the pull request is already closed and commit status is no longer
+     * updated. So we post the build status as a comment.
+     */
+    if (&quot;${GITHUB_PR_ACTION}&quot; == &apos;push&apos;)
+        post_pr_comment(&quot;${GITHUB_PR_COMMENT_URL}&quot;,
+                        &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;,
+                        &quot;**${GITHUB_CONTEXT}** ${desc} ${action} ${duration}&quot;)
+    else
+        post_pr_status(&quot;${GITHUB_PR_STATUS_URL}&quot;,
+                       &quot;${GITHUB_REPO_ACCESS_TOKEN}&quot;,
+                       &quot;${status}&quot;,
+                       &quot;${GITHUB_CONTEXT}&quot;,
+                       &quot;${desc} ${action} ${duration}&quot;,
+                       &quot;${BUILD_URL}&quot;)
+}
+
+/* Post a status to the pull request page */
+def post_pr_status(url, token, status, context, description, target_url) {
+    def data = &quot;&quot;&quot;
+        { &quot;state&quot;: &quot;${status}&quot;, \
+          &quot;context&quot;: &quot;${context}&quot;, \
+          &quot;description&quot;: &quot;${description}&quot;, \
+          &quot;target_url&quot;: &quot;${target_url}&quot; }
+    &quot;&quot;&quot;
+
+    sh &apos;&apos;&apos;#!/bin/bash +x
+        curl -s &apos;&apos;&apos; + url + &apos;&apos;&apos; \
+             -X POST \
+             -H &quot;Accept: application/vnd.github.v3+json&quot; \
+             -H &quot;Authorization: token &apos;&apos;&apos; + token + &apos;&apos;&apos;&quot; \
+             -d \&apos; &apos;&apos;&apos; + data + &apos;&apos;&apos; \&apos; | \
+        jq &apos;{url: .url, state: .state, description: .description, context: .context, message: .message}&apos;
+    &apos;&apos;&apos;
 }
 
 /* Post a comment on the pull request issue page when an event
@@ -393,6 +441,23 @@ def post_pr_comment(url, token, msg) {
              -d \&apos; &apos;&apos;&apos; + data + &apos;&apos;&apos; \&apos; | \
         jq &apos;{url: .url, created_at: .created_at, updated_at: .updated_at, body: .body}&apos;
     &apos;&apos;&apos;
+}
+
+/* Get JSON data from url */
+def get_commit_data(url, token, data) {
+    return sh(returnStdout: true, script: &apos;&apos;&apos;#!/bin/bash +x
+        curl -s &apos;&apos;&apos; + url + &apos;&apos;&apos; \
+             -X GET \
+             -H &quot;Accept: application/json&quot; \
+             -H &quot;Authorization: token &apos;&apos;&apos; + token + &apos;&apos;&apos;&quot; | \
+        jq -r &apos;&apos;&apos; + data + &apos;&apos;&apos;
+    &apos;&apos;&apos;).trim()
+}
+
+/* Parse commit message to get pull request number */
+def get_pr_number(message) {
+    def match = message =~ /.*#(\d+)( from.*|\)\n)/
+    return match ? match[0][1] : &apos;none&apos;
 }
 
 /* Checkout pull request source without submodules for the purpose

--- a/.buildbot/jenkins-build-llvm-project.py
+++ b/.buildbot/jenkins-build-llvm-project.py
@@ -26,15 +26,23 @@ docker_registry_login_token = os.getenv('DOCKER_REGISTRY_LOGIN_TOKEN')
 github_repo_access_token    = os.getenv('GITHUB_REPO_ACCESS_TOKEN')
 github_repo_name            = os.getenv('GITHUB_REPO_NAME')
 github_repo_name2           = os.getenv('GITHUB_REPO_NAME').replace('-', '_')
+github_pr_baseref           = os.getenv('GITHUB_PR_BASEREF')
 github_pr_number            = os.getenv('GITHUB_PR_NUMBER')
 github_pr_number2           = os.getenv('GITHUB_PR_NUMBER2')
+
+docker_static_image_name    = (github_repo_name + '-llvm-static' +
+                               ('.' + github_pr_baseref
+                                if github_pr_baseref != 'master' else ''))
+docker_shared_image_name    = (github_repo_name + '-llvm-shared' +
+                               ('.' + github_pr_baseref
+                                if github_pr_baseref != 'master' else ''))
 
 LLVM_PROJECT_SHA1_FILE      = 'utils/clone-mlir.sh'
 LLVM_PROJECT_SHA1_REGEX     = 'git checkout ([0-9a-f]+)'
 LLVM_PROJECT_DOCKERFILE     = 'docker/Dockerfile.llvm-project'
 LLVM_PROJECT_GITHUB_URL     = 'https://api.github.com/repos/llvm/llvm-project'
-LLVM_PROJECT_IMAGE          = { 'static': github_repo_name + '-llvm-static',
-                                'shared': github_repo_name + '-llvm-shared' }
+LLVM_PROJECT_IMAGE          = { 'static': docker_static_image_name,
+                                'shared': docker_shared_image_name }
 BUILD_SHARED_LIBS           = { 'static': 'off',
                                 'shared': 'on' }
 LLVM_PROJECT_LABELS         = [ 'llvm_project_sha1',

--- a/src/Runtime/jni/jnilog.c
+++ b/src/Runtime/jni/jnilog.c
@@ -15,6 +15,7 @@
 
 #include <errno.h>
 #include <libgen.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -23,13 +24,47 @@
 
 #include "jnilog.h"
 
-static int log_initd = 0;
-static int log_level;
-static FILE *log_fp;
+static __thread int log_inited = 0;
+static __thread int log_level;
+static __thread FILE *log_fp;
 
 /* Must match enum in log.h */
 static char *log_level_name[] = {
     "trace", "debug", "info", "warning", "error", "fatal"};
+
+/* Generic log routine */
+void log_printf(
+    int level, char *file, const char *func, int line, char *fmt, ...) {
+
+  if (level < log_level)
+    return;
+
+  time_t now;
+  struct tm *tm;
+  char buf[LOG_MAX_LEN];
+
+  /* Get local time and format as 2020-07-03 05:17:42 -0400 */
+  if (time(&now) == -1 || (tm = localtime(&now)) == NULL ||
+      strftime(buf, sizeof(buf), "[%F %T %z]", tm) == 0)
+    sprintf(buf, "[-]");
+
+  /* Output thread ID, log level, file name, function number, and line number */
+  snprintf(buf + strlen(buf), LOG_MAX_LEN - strlen(buf), "[%lx][%s]%s:%s:%d ",
+      pthread_self(), log_level_name[level], basename(file), func, line);
+
+  /* Output actual log data */
+  va_list va_list;
+  va_start(va_list, fmt);
+  vsnprintf(buf + strlen(buf), LOG_MAX_LEN - strlen(buf), fmt, va_list);
+  va_end(va_list);
+
+  /* Add new line */
+  snprintf(buf + strlen(buf), LOG_MAX_LEN - strlen(buf), "\n");
+
+  /* Write out and flush the output buffer */
+  fputs(buf, log_fp);
+  fflush(log_fp);
+}
 
 /* Return numerical log level of give level name */
 static int get_log_level_by_name(char *name) {
@@ -50,16 +85,25 @@ static FILE *get_log_file_by_name(char *name) {
     fp = stdout;
   else if (!strcmp(name, "stderr"))
     fp = stderr;
-  else
-    fp = fopen(name, "w");
+  else {
+    char tname[strlen(name) + 32];
+    snprintf(tname, strlen(name) + 32, "%s.%lx", name, pthread_self());
+    fp = fopen(tname, "w");
+  }
   return fp;
 }
 
-/* Initialize log system. Set default log level and file or use environment
- * variables ONNX_MLIR_JNI_LOG_LEVEL and ONNX_MLIR_JNI_LOG_FILE, respectively.
+/* Initialize log system. Set log level and file from environment
+ * variables ONNX_MLIR_JNI_LOG_LEVEL and ONNX_MLIR_JNI_LOG_FILE,
+ * respectively if provided.
+ *
+ * When logging to stdout or stderr, output from multiple threads
+ * will be interleaved. When logging to a file, output from multiple
+ * threads go to separate files, suffixed with the thread ID.
  */
-static void log_init() {
-  if (log_initd)
+void log_init() {
+
+  if (log_inited)
     return;
 
   log_level = LOG_INFO;
@@ -75,35 +119,5 @@ static void log_init() {
     log_fp = fp;
 
   tzset();
-  log_initd = 1;
-}
-
-/* Generic log routine */
-void log_printf(
-    int level, char *file, const char *func, int line, char *fmt, ...) {
-  if (!log_initd)
-    log_init();
-  if (level < log_level)
-    return;
-
-  time_t now;
-  struct tm *tm;
-  char buf[80];
-
-  /* Get local time and format as 2020-07-03 05:17:42 -0400 */
-  if (time(&now) == -1 || (tm = localtime(&now)) == NULL ||
-      strftime(buf, sizeof(buf), "%F %T %z", tm) == 0)
-    sprintf(buf, "-");
-
-  /* Output log prefix */
-  fprintf(log_fp, "[%s][%s]%s:%s:%d ", buf, log_level_name[level],
-      basename(file), func, line);
-
-  /* Output actually log data */
-  va_list va_list;
-  va_start(va_list, fmt);
-  vfprintf(log_fp, fmt, va_list);
-  va_end(va_list);
-
-  fprintf(log_fp, "\n");
+  log_inited = 1;
 }

--- a/src/Runtime/jni/jnilog.c
+++ b/src/Runtime/jni/jnilog.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===----------- jnilog.c - JNI wrapper simple logging routines -----------===//
+/*===----------- jnilog.c - JNI wrapper simple logging routines -----------===//
 //
 // Copyright 2019-2020 The IBM Research Authors.
 //
@@ -11,7 +11,7 @@
 // This file contains implementation of simple logging routines used by the JNI
 // wrapper.
 //
-//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===*/
 
 #include <errno.h>
 #include <libgen.h>
@@ -33,8 +33,7 @@ static char *log_level_name[] = {
     "trace", "debug", "info", "warning", "error", "fatal"};
 
 /* Generic log routine */
-void log_printf(
-    int level, char *file, const char *func, int line, char *fmt, ...) {
+void log_printf(int level, char *file, char *func, int line, char *fmt, ...) {
 
   if (level < log_level)
     return;

--- a/src/Runtime/jni/jnilog.h
+++ b/src/Runtime/jni/jnilog.h
@@ -111,11 +111,12 @@ enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR, LOG_FATAL };
 
 /* Main macro for log output */
 #define LOG_PRINTF(level, ...)                                                 \
-  log_printf(level, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+  log_printf(level, (char *)__FILE__, (char *)__FUNCTION__, __LINE__,          \
+      (char *)__VA_ARGS__)
 
 /* Generic log routine */
 extern void log_init(void);
 extern void log_printf(
-    int level, char *file, const char *func, int line, char *fmt, ...);
+    int level, char *file, char *func, int line, char *fmt, ...);
 
 #endif

--- a/src/Runtime/jni/jnilog.h
+++ b/src/Runtime/jni/jnilog.h
@@ -20,7 +20,8 @@
 
 enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR, LOG_FATAL };
 
-#define LOG_MAX_NUM 128 /* max number of elements to output */
+#define LOG_MAX_LEN 4096 /* max number of chars to output    */
+#define LOG_MAX_NUM 128  /* max number of elements to output */
 
 #define MIN(x, y) ((x) > (y) ? y : x)
 
@@ -113,7 +114,8 @@ enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR, LOG_FATAL };
   log_printf(level, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 
 /* Generic log routine */
-void log_printf(
+extern void log_init(void);
+extern void log_printf(
     int level, char *file, const char *func, int line, char *fmt, ...);
 
 #endif

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -134,8 +134,6 @@ typedef struct {
   jmethodID jomtl_getOmtArray; /* OMTensorList getOmtArray method */
 } jniapi_t;
 
-jniapi_t jniapi;
-
 /* Find and initialize Java method IDs in struct jniapi */
 jniapi_t *fill_jniapi(JNIEnv *env, jniapi_t *japi) {
   /* Get Java Exception, Long, String, OMTensor, and OMTensorList classes
@@ -372,6 +370,14 @@ jobject omtl_native_to_java(
 JNIEXPORT jobject JNICALL Java_com_ibm_onnxmlir_OMModel_main_1graph_1jni(
     JNIEnv *env, jclass cls, jobject java_iomtl) {
 
+  /* Apparently J9 cannot have the return pointer of FindClass shared
+   * across threads. So move jniapi into stack so each thread has its
+   * own copy.
+   */
+  jniapi_t jniapi;
+
+  log_init();
+
   /* Find and initialize Java method IDs in struct jniapi */
   CHECK_CALL(jniapi_t *, japi, fill_jniapi(env, &jniapi), NULL);
 
@@ -395,6 +401,8 @@ JNIEXPORT jobject JNICALL Java_com_ibm_onnxmlir_OMModel_main_1graph_1jni(
 JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_input_1signature_1jni(
     JNIEnv *env, jclass cls) {
 
+  log_init();
+
   /* Call model input signature API */
   CHECK_CALL(const char *, jni_isig, omInputSignature(), NULL);
   HEX_DEBUG("isig", jni_isig, strlen(jni_isig));
@@ -408,6 +416,8 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_input_1signature_1jni(
 
 JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_output_1signature_1jni(
     JNIEnv *env, jclass cls) {
+
+  log_init();
 
   /* Call model output signature API */
   CHECK_CALL(const char *, jni_osig, omOutputSignature(), NULL);


### PR DESCRIPTION
- move jniapi into stack to avoid J9 crash, which apparently cannot share pointer returned by FindClass across threads
- make jnilog thread safe also

Signed-off-by: Gong Su <gong_su@hotmail.com>