### PR TITLE
Removing in IndexExpr any references to ONNX and KRNL, Removing in ONNX any references to KRNL

### DIFF
--- a/src/Builder/FrontendDialectHelper.cpp
+++ b/src/Builder/FrontendDialectHelper.cpp
@@ -15,7 +15,6 @@
 #include <llvm/Support/SwapByteOrder.h>
 
 #include "src/Builder/FrontendDialectHelper.hpp"
-#include "src/Dialect/ONNX/ONNXOps.hpp"
 
 namespace onnx_mlir {
 

--- a/src/Builder/FrontendDialectHelper.hpp
+++ b/src/Builder/FrontendDialectHelper.hpp
@@ -36,6 +36,7 @@
 
 #include "onnx/onnx_pb.h"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
 #if INCLUDE_ONNX_ML == 1
 #include "src/Dialect/MLONNX/MLONNXOps.hpp"
 #endif

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -73,7 +73,7 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   // krnl.load/store will be lowered to std.load/store and affine.load/store by
   // `convert-krnl-to-affine` pass.
   target.addIllegalOp<mlir::memref::LoadOp>();
-  target.addIllegalOp<mlir::AffineLoadOp>();
+  //target.addIllegalOp<mlir::AffineLoadOp>();
   target.addIllegalOp<mlir::memref::StoreOp>();
   target.addIllegalOp<mlir::AffineStoreOp>();
 

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -73,7 +73,7 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   // krnl.load/store will be lowered to std.load/store and affine.load/store by
   // `convert-krnl-to-affine` pass.
   target.addIllegalOp<mlir::memref::LoadOp>();
-  //target.addIllegalOp<mlir::AffineLoadOp>();
+  target.addIllegalOp<mlir::AffineLoadOp>();
   target.addIllegalOp<mlir::memref::StoreOp>();
   target.addIllegalOp<mlir::AffineStoreOp>();
 

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -319,7 +319,9 @@ struct ONNXGemmOpLowering : public ConversionPattern {
     ONNXGemmOpAdaptor operandAdaptor(operands);
     ONNXGemmOp gemmOp = llvm::cast<ONNXGemmOp>(op);
     Location loc = op->getLoc();
-    ONNXGemmOpShapeHelper shapeHelper(&gemmOp, &rewriter);
+    ONNXGemmOpShapeHelper shapeHelper(&gemmOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     assert(succeeded(shapecomputed));
     // Scope for krnl EDSC ops

--- a/src/Conversion/ONNXToKrnl/Math/LRN.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LRN.cpp
@@ -27,7 +27,9 @@ struct ONNXLRNOpLowering : public ConversionPattern {
     ONNXLRNOp lrnOp = llvm::cast<ONNXLRNOp>(op);
     auto loc = op->getLoc();
 
-    ONNXLRNOpShapeHelper shapeHelper(&lrnOp, &rewriter);
+    ONNXLRNOpShapeHelper shapeHelper(&lrnOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
 
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     (void)shapecomputed;

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -176,7 +176,9 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     ONNXMatMulOpAdaptor operandAdaptor(operands);
     ONNXMatMulOp matMulOp = llvm::cast<ONNXMatMulOp>(op);
     Location loc = ONNXLoc<ONNXMatMulOp>(op);
-    ONNXMatMulOpShapeHelper shapeHelper(&matMulOp, &rewriter);
+    ONNXMatMulOpShapeHelper shapeHelper(&matMulOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
     LogicalResult shapecomputed = shapeHelper.Compute(operandAdaptor);
     assert(succeeded(shapecomputed));
     IndexExprScope outerScope(shapeHelper.scope);

--- a/src/Conversion/ONNXToKrnl/Tensor/ArgMax.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ArgMax.cpp
@@ -22,7 +22,9 @@ struct ONNXArgMaxOpLowering : public ConversionPattern {
     ONNXArgMaxOp argMaxOp = llvm::cast<ONNXArgMaxOp>(op);
 
     // shape helper
-    ONNXArgMaxOpShapeHelper shapeHelper(&argMaxOp, &rewriter);
+    ONNXArgMaxOpShapeHelper shapeHelper(&argMaxOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
 
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     (void)shapecomputed;

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -28,7 +28,9 @@ struct ONNXConcatOpLowering : public ConversionPattern {
 
     ONNXConcatOpAdaptor operandAdaptor(operands);
     ONNXConcatOp concatOp = llvm::cast<ONNXConcatOp>(op);
-    ONNXConcatOpShapeHelper shapeHelper(&concatOp, &rewriter);
+    ONNXConcatOpShapeHelper shapeHelper(&concatOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     (void)shapecomputed;
     assert(succeeded(shapecomputed));

--- a/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
@@ -27,7 +27,9 @@ struct ONNXGatherOpLowering : public ConversionPattern {
     ONNXGatherOp gatherOp = llvm::cast<ONNXGatherOp>(op);
     auto loc = op->getLoc();
 
-    ONNXGatherOpShapeHelper shapeHelper(&gatherOp, &rewriter);
+    ONNXGatherOpShapeHelper shapeHelper(&gatherOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     assert(succeeded(shapecomputed));
     // Scope for krnl EDSC ops

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -27,7 +27,9 @@ struct ONNXSliceOpLowering : public ConversionPattern {
     ONNXSliceOp sliceOp = llvm::cast<ONNXSliceOp>(op);
     Location loc = op->getLoc();
 
-    ONNXSliceOpShapeHelper shapeHelper(&sliceOp, &rewriter);
+    ONNXSliceOpShapeHelper shapeHelper(&sliceOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     assert(succeeded(shapecomputed));
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -32,7 +32,9 @@ struct ONNXSplitOpLowering : public ConversionPattern {
     auto axis = splitOp.axis();
 
     // Get a shape helper.
-    ONNXSplitOpShapeHelper shapeHelper(&splitOp, &rewriter);
+    ONNXSplitOpShapeHelper shapeHelper(&splitOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     assert(succeeded(shapecomputed));
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -63,7 +63,9 @@ struct ONNXTileOpLowering : public ConversionPattern {
     ONNXTileOp tileOp = llvm::cast<ONNXTileOp>(op);
     auto loc = op->getLoc();
 
-    ONNXTileOpShapeHelper shapeHelper(&tileOp, &rewriter);
+    ONNXTileOpShapeHelper shapeHelper(&tileOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
 
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     (void)shapecomputed;

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -36,7 +36,9 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
     int64_t rank = memRefType.getShape().size();
 
     // Get a shape helper.
-    ONNXTransposeOpShapeHelper shapeHelper(&transposeOp, &rewriter);
+    ONNXTransposeOpShapeHelper shapeHelper(&transposeOp, rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
     auto shapecomputed = shapeHelper.Compute(operandAdaptor);
     (void)shapecomputed;
     assert(succeeded(shapecomputed));

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -355,24 +355,23 @@ ArrayRef<BlockArgument> BuildKrnlLoop::getAllInductionVar() {
 
 // This function satisfies the ArrayValueIndexCapture::DenseElementsAttr lambda
 // type, using ONNX and Krnl operations.
-DenseElementsAttr getDenseElementAttributeFromONNXAndKrnlValue(Value value) {
+DenseElementsAttr getDenseElementAttributeFromKrnlValue(Value value) {
   auto definingOp = value.getDefiningOp();
-  if (auto constantOp = dyn_cast_or_null<mlir::ONNXConstantOp>(definingOp))
-    return constantOp.valueAttr().dyn_cast<DenseElementsAttr>();
-  else if (auto globalOp = dyn_cast_or_null<mlir::KrnlGlobalOp>(definingOp))
+  if (auto globalOp = dyn_cast_or_null<mlir::KrnlGlobalOp>(definingOp)) {
     if (globalOp.value().hasValue())
       return globalOp.valueAttr().dyn_cast<DenseElementsAttr>();
+  }
   return nullptr;
 }
 
 // This function satisfies the ArrayValueIndexCapture::LoadVal lambda
 // type, using Krnl operations.
 Value loadDenseElementArrayValueAtIndex(
-    OpBuilder &rewriter, Value array, int64_t index) {
+    OpBuilder &rewriter, Location loc, Value array, int64_t index) {
   Attribute constAttr = rewriter.getIntegerAttr(rewriter.getIndexType(), index);
-  Value indexVal = rewriter.create<ConstantOp>(scope.getLoc(), constAttr);
+  Value indexVal = rewriter.create<ConstantOp>(loc, constAttr);
   SmallVector<Value, 1> memrefVal = {indexVal};
-  return rewriter.create<KrnlLoadOp>(scope.getLoc(), array, memrefVal);
+  return rewriter.create<KrnlLoadOp>(loc, array, memrefVal);
 }
 
 //====---------------- Support for simple transpose ----------------------===//

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -251,6 +251,15 @@ private:
   Block *iterBlock;
 };
 
+// This function satisfies the ArrayValueIndexCapture::DenseElementsAttr lambda
+// type, using ONNX and Krnl operations.
+DenseElementsAttr getDenseElementAttributeFromONNXAndKrnlValue(Value value);
+
+// This function satisfies the ArrayValueIndexCapture::LoadVal lambda
+// type, using Krnl operations.
+Value loadDenseElementArrayValueAtIndex(
+    OpBuilder &rewriter, Value array, int64_t index);
+
 //====---------------- Support for simple transpose ----------------------===//
 
 void generateIndexMap(

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -253,12 +253,12 @@ private:
 
 // This function satisfies the ArrayValueIndexCapture::DenseElementsAttr lambda
 // type, using ONNX and Krnl operations.
-DenseElementsAttr getDenseElementAttributeFromONNXAndKrnlValue(Value value);
+DenseElementsAttr getDenseElementAttributeFromKrnlValue(Value value);
 
 // This function satisfies the ArrayValueIndexCapture::LoadVal lambda
 // type, using Krnl operations.
 Value loadDenseElementArrayValueAtIndex(
-    OpBuilder &rewriter, Value array, int64_t index);
+    OpBuilder &rewriter, Location loc, Value array, int64_t index);
 
 //====---------------- Support for simple transpose ----------------------===//
 

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -1260,15 +1260,9 @@ IndexExpr ArrayValueIndexCapture::getSymbol(uint64_t i) {
     return QuestionmarkIndexExpr();
   }
   // Emit code to read array.
-  OpBuilder &rewriter = scope.getRewriter();
-  // Attribute constAttr =
-  //    rewriter.getIntegerAttr(rewriter.getIndexType(), (int64_t)i);
-  // Value indexVal = rewriter.create<ConstantOp>(scope.getLoc(), constAttr);
-  // SmallVector<Value, 1> memrefVal = {indexVal};
-  // Value loadVal =
-  //    rewriter.create<AffineLoadOp>(scope.getLoc(), array, memrefVal);
   assert(fLoadVallFromArrayAtIndex && "expected method to load an array value");
-  Value loadVal = fLoadVallFromArrayAtIndex(rewriter, array, i);
+  Value loadVal =
+      fLoadVallFromArrayAtIndex(scope.getRewriter(), scope.getLoc(), array, i);
   return SymbolIndexExpr(loadVal);
 }
 

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -629,11 +629,17 @@ inline IndexExpr operator-(int64_t const a, const IndexExpr b) {
 // Capture array of values given by an operand. Will find its definitition and
 // use it locate its constant values, or load dynamically if they are not
 // constant.
-template<typename LOAD_OP>
 class ArrayValueIndexCapture {
 public:
-  ArrayValueIndexCapture(Operation *op, Value array);
-  ArrayValueIndexCapture(Operation *op, Value array, int64_t defaultLiteral);
+  // Lambda functions to extract/generate info.
+  typedef std::function<DenseElementsAttr(Value array)> GetDenseVal;
+  typedef std::function<Value(OpBuilder &rewriter, Value array, int64_t index)>
+      LoadVal;
+
+  ArrayValueIndexCapture(
+      Operation *op, Value array, GetDenseVal fGetDenseVal, LoadVal fLoadVal);
+  ArrayValueIndexCapture(Operation *op, Value array, int64_t defaultLiteral,
+      GetDenseVal fGetDenseVal, LoadVal fLoadVal);
 
   IndexExpr getSymbol(uint64_t i);
   void getSymbolList(int num, SmallVectorImpl<IndexExpr> &symbolList);
@@ -645,6 +651,8 @@ private:
   Value array;
   int64_t defaultLiteral;
   bool hasDefault;
+  GetDenseVal fGetDenseArrayAttr;
+  LoadVal fLoadVallFromArrayAtIndex;
 };
 
 // Capture array of values given by attributes.

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -629,6 +629,7 @@ inline IndexExpr operator-(int64_t const a, const IndexExpr b) {
 // Capture array of values given by an operand. Will find its definitition and
 // use it locate its constant values, or load dynamically if they are not
 // constant.
+template<typename LOAD_OP>
 class ArrayValueIndexCapture {
 public:
   ArrayValueIndexCapture(Operation *op, Value array);

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -631,9 +631,17 @@ inline IndexExpr operator-(int64_t const a, const IndexExpr b) {
 // constant.
 class ArrayValueIndexCapture {
 public:
-  // Lambda functions to extract/generate info.
+  // Lambda functions to extract/generate info. No code is provided in order to
+  // keep the IndexExpr and their support operations generic.
+
+  // GetDenseVal locate a DenseElementAttr by looking at the definition of the
+  // array value. Return null if this definition is not generating a dense
+  // array.
   typedef std::function<DenseElementsAttr(Value array)> GetDenseVal;
-  typedef std::function<Value(OpBuilder &rewriter, Value array, int64_t index)>
+  // LoadVal will load the value at array[i] where array is a single dimensional
+  // array.
+  typedef std::function<Value(
+      OpBuilder &rewriter, Location loc, Value array, int64_t index)>
       LoadVal;
 
   ArrayValueIndexCapture(

--- a/src/Dialect/ONNX/IndexExprDetail.cpp
+++ b/src/Dialect/ONNX/IndexExprDetail.cpp
@@ -20,8 +20,6 @@
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/MathExtras.h"
-#include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
-#include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/ONNX/ONNXShapeHelper.hpp"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Sequence.h"

--- a/src/Dialect/ONNX/IndexExprDetail.hpp
+++ b/src/Dialect/ONNX/IndexExprDetail.hpp
@@ -18,13 +18,6 @@
 
 #include "src/Dialect/ONNX/IndexExpr.hpp"
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
-#include "mlir/IR/AffineExpr.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Value.h"
-#include "mlir/Transforms/DialectConversion.h"
-
 namespace mlir {
 
 // Implementation of the IndexExpr. In nearly all cases, the value described by

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -25,8 +25,9 @@
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/FormatVariadic.h"
 
-#include "ONNXOps.hpp"
-#include "ONNXShapeHelper.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
+#include "src/Dialect/ONNX/ONNXShapeHelper.hpp"
 
 #include <string>
 
@@ -42,7 +43,7 @@ using namespace mlir::onnxmlir;
 template <class SHAPE_HELPER, class OP, class ADAPTOR>
 LogicalResult shapeHelperInferShapes(OP *op, Value typeOper) {
 
-  SHAPE_HELPER shapeHelper(op, nullptr);
+  SHAPE_HELPER shapeHelper(op);
 
   ADAPTOR operandAdaptor(*op);
   if (failed(shapeHelper.Compute(operandAdaptor)))
@@ -60,7 +61,7 @@ LogicalResult shapeHelperInferShapes(OP *op, Value typeOper) {
 template <class SHAPE_HELPER, class OP, class ADAPTOR>
 LogicalResult shapeHelperInferMultipleShapes(OP *op, Value typeOper) {
 
-  SHAPE_HELPER shapeHelper(op, nullptr);
+  SHAPE_HELPER shapeHelper(op);
 
   ADAPTOR operandAdaptor(*op);
   if (failed(shapeHelper.Compute(operandAdaptor)))
@@ -1444,7 +1445,7 @@ LogicalResult ONNXTransposeOp::inferShapes(
 
   auto elementType = data().getType().cast<ShapedType>().getElementType();
   ONNXTransposeOpAdaptor operandAdaptor(*this);
-  ONNXTransposeOpShapeHelper shapeHelper(this, nullptr);
+  ONNXTransposeOpShapeHelper shapeHelper(this);
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan Transpose parameters successfully");
   SmallVector<int64_t, 4> outputDims;
@@ -2300,7 +2301,7 @@ LogicalResult ONNXConcatOp::inferShapes(
   }
 
   ONNXConcatOpAdaptor operandAdaptor(*this);
-  ONNXConcatOpShapeHelper shapeHelper(this, nullptr);
+  ONNXConcatOpShapeHelper shapeHelper(this);
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan Tile parameters successfully");
   SmallVector<int64_t, 4> outputDims;
@@ -2777,7 +2778,7 @@ LogicalResult ONNXSliceOp::inferShapes(
 
   auto elementType = data().getType().cast<ShapedType>().getElementType();
   ONNXSliceOpAdaptor operandAdaptor(*this);
-  ONNXSliceOpShapeHelper shapeHelper(this, nullptr);
+  ONNXSliceOpShapeHelper shapeHelper(this);
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan Slice parameters successfully");
   SmallVector<int64_t, 4> outputDims;
@@ -2946,7 +2947,7 @@ LogicalResult ONNXArgMaxOp::inferShapes(
   if (!data().getType().isa<RankedTensorType>())
     return emitError("Input tensor not ranked");
 
-  ONNXArgMaxOpShapeHelper shapeHelper(this, nullptr);
+  ONNXArgMaxOpShapeHelper shapeHelper(this);
   ONNXArgMaxOpAdaptor operandAdaptor(*this);
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan ArgMax parameters successfully");
@@ -3104,7 +3105,7 @@ LogicalResult ONNXLRNOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
   auto elementType = X().getType().cast<ShapedType>().getElementType();
   ONNXLRNOpAdaptor operandAdaptor(*this);
-  ONNXLRNOpShapeHelper shapeHelper(this, nullptr);
+  ONNXLRNOpShapeHelper shapeHelper(this);
   if (failed(shapeHelper.Compute(operandAdaptor)))
     return emitError("Failed to scan LRN parameters successfully");
   SmallVector<int64_t, 4> outputDims;

--- a/src/Dialect/ONNX/ONNXOps.hpp
+++ b/src/Dialect/ONNX/ONNXOps.hpp
@@ -28,8 +28,6 @@
 #include "src/Interface/ResultTypeInferenceOpInterface.hpp"
 #include "src/Interface/ShapeInferenceOpInterface.hpp"
 
-#include "ONNXOpsHelper.hpp"
-
 namespace mlir {
 
 class ONNXOpsDialect : public Dialect {

--- a/src/Dialect/ONNX/ONNXOpsHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.cpp
@@ -169,13 +169,13 @@ int64_t ArrayAttrIntVal(Optional<ArrayAttr> a, int i) {
   return (a.getValue().getValue()[i]).cast<IntegerAttr>().getInt();
 }
 
-DenseElementsAttr getDenseElementAttributeFromValue(Value value) {
+DenseElementsAttr getDenseElementAttributeFromONNXValue(Value value) {
   auto definingOp = value.getDefiningOp();
   if (auto constantOp = dyn_cast_or_null<mlir::ONNXConstantOp>(definingOp))
     return constantOp.valueAttr().dyn_cast<DenseElementsAttr>();
-  else if (auto globalOp = dyn_cast_or_null<mlir::KrnlGlobalOp>(definingOp))
-    if (globalOp.value().hasValue())
-      return globalOp.valueAttr().dyn_cast<DenseElementsAttr>();
+  //else if (auto globalOp = dyn_cast_or_null<mlir::KrnlGlobalOp>(definingOp))
+  //  if (globalOp.value().hasValue())
+  //     return globalOp.valueAttr().dyn_cast<DenseElementsAttr>();
   return nullptr;
 }
 

--- a/src/Dialect/ONNX/ONNXOpsHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.hpp
@@ -84,7 +84,10 @@ size_t ArrayAttrSize(Optional<ArrayAttr> a);
 int64_t ArrayAttrIntVal(ArrayAttr a, int i);
 int64_t ArrayAttrIntVal(Optional<ArrayAttr> a, int i);
 
-DenseElementsAttr getDenseElementAttributeFromValue(Value value);
+// This function satisfies the ArrayValueIndexCapture::DenseElementsAttr lambda
+// type, using ONNX operations only.
+DenseElementsAttr getDenseElementAttributeFromONNXValue(Value value);
+
 Value getONNXConstantOpFromDenseAttr(
     PatternRewriter &rewriter, Location loc, Attribute dense);
 bool getIntegerLiteralFromValue(Value value, int64_t &intLit);

--- a/src/Dialect/ONNX/ONNXOpsHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.hpp
@@ -20,6 +20,7 @@
 #include "mlir/IR/Value.h"
 
 #include "src/Dialect/ONNX/IndexExpr.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
 
 using namespace mlir;
 
@@ -88,7 +89,7 @@ int64_t ArrayAttrIntVal(Optional<ArrayAttr> a, int i);
 // type, using ONNX operations only.
 DenseElementsAttr getDenseElementAttributeFromONNXValue(Value value);
 
+ONNXConstantOp getONNXConstantOp(Value value);
 Value getONNXConstantOpFromDenseAttr(
     PatternRewriter &rewriter, Location loc, Attribute dense);
-bool getIntegerLiteralFromValue(Value value, int64_t &intLit);
 Type getBroadcastedRankedType(Type type1, Type type2);

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -259,7 +259,7 @@ LogicalResult ONNXSliceOpShapeHelper::Compute(
     // If `axes` are omitted, they are set to `[0, ..., nDim-1]`."
     for (int i = 0; i < dataRank; ++i)
       axesIntLit.emplace_back(i);
-  } else if (auto valueAttribute = getDenseElementAttributeFromValue(axes)) {
+  } else if (auto valueAttribute = getDenseElementAttributeFromONNXValue(axes)) {
     // If `axes` are constants, read them."
     for (IntegerAttr value : valueAttribute.getValues<IntegerAttr>()) {
       int64_t axis = value.cast<IntegerAttr>().getInt();
@@ -714,7 +714,7 @@ LogicalResult ONNXGatherOpShapeHelper::Compute(
   // If 'indices' is a constant tensor, check whether its values are valid.
   if (dataDims[axisIndex].isLiteral()) {
     auto valueAttribute =
-        getDenseElementAttributeFromValue(operandAdaptor.indices());
+        getDenseElementAttributeFromONNXValue(operandAdaptor.indices());
     if (valueAttribute) {
       int64_t dataDimAtAxis = dataDims[axisIndex].getLiteral();
       positiveConstantIndices = true;

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -210,13 +210,12 @@ struct ONNXLRNOpShapeHelper : public ONNXOpShapeHelper<ONNXLRNOp> {
 // Low Level Helpers
 //===----------------------------------------------------------------------===//
 
+// aee: needed here?
 size_t ArrayAttrSize(ArrayAttr a);
 size_t ArrayAttrSize(Optional<ArrayAttr> a);
 int64_t ArrayAttrIntVal(ArrayAttr a, int i);
 int64_t ArrayAttrIntVal(Optional<ArrayAttr> a, int i);
 // Returns the ConstantOp which defines an MLIR Value or null.
 ONNXConstantOp getONNXConstantOp(Value value);
-
-DenseElementsAttr getDenseElementAttributeFromValue(Value value);
 
 bool getIntegerLiteralFromValue(Value value, int64_t &intLit);

--- a/src/Dialect/ONNX/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.hpp
@@ -43,7 +43,12 @@ typedef SmallVector<IndexExpr, 4> DimsExpr;
 /// be used to generate code.
 template <class OP>
 struct ONNXOpShapeHelper {
-  ONNXOpShapeHelper(OP *newOp, ConversionPatternRewriter *rewriter);
+  // Constructor for shape inference.
+  ONNXOpShapeHelper(OP *newOp);
+  // Constructor when code can be generated.
+  ONNXOpShapeHelper(OP *newOp, ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   // Define in every children. Use op to get attributes, and operandAdaptor
   // to get the input/output parameters.
@@ -62,6 +67,12 @@ struct ONNXOpShapeHelper {
   // child's struct `Compute` function.
   OP *op;
   IndexExprScope scope;
+
+protected:
+  // Function to get a dense value from an attribute.
+  ArrayValueIndexCapture::GetDenseVal fGetDenseVal;
+  // Function to load a value from an array.
+  ArrayValueIndexCapture::LoadVal fLoadVal;
 
 private:
   SmallVector<DimsExpr, 1> outputsDims;
@@ -107,24 +118,33 @@ private:
 
 // Shape for ArgMax
 struct ONNXArgMaxOpShapeHelper : public ONNXOpShapeHelper<ONNXArgMaxOp> {
-  ONNXArgMaxOpShapeHelper(
-      ONNXArgMaxOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXArgMaxOpShapeHelper(ONNXArgMaxOp *newOp);
+  ONNXArgMaxOpShapeHelper(ONNXArgMaxOp *newOp,
+      ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXArgMaxOpAdaptor operandAdaptor);
 };
 
 // Shape for concat
 struct ONNXConcatOpShapeHelper : public ONNXOpShapeHelper<ONNXConcatOp> {
-  ONNXConcatOpShapeHelper(
-      ONNXConcatOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXConcatOpShapeHelper(ONNXConcatOp *newOp);
+  ONNXConcatOpShapeHelper(ONNXConcatOp *newOp,
+      ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXConcatOpAdaptor operandAdaptor);
 };
 
 // Shape for SliceOp.
 struct ONNXSliceOpShapeHelper : public ONNXOpShapeHelper<ONNXSliceOp> {
-  ONNXSliceOpShapeHelper(
-      ONNXSliceOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXSliceOpShapeHelper(ONNXSliceOp *newOp);
+  ONNXSliceOpShapeHelper(ONNXSliceOp *newOp,
+      ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXSliceOpAdaptor operandAdaptor);
 
@@ -136,7 +156,10 @@ struct ONNXSliceOpShapeHelper : public ONNXOpShapeHelper<ONNXSliceOp> {
 
 // Shape for Tile.
 struct ONNXTileOpShapeHelper : public ONNXOpShapeHelper<ONNXTileOp> {
-  ONNXTileOpShapeHelper(ONNXTileOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXTileOpShapeHelper(ONNXTileOp *newOp);
+  ONNXTileOpShapeHelper(ONNXTileOp *newOp, ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXTileOpAdaptor operandAdaptor);
 };
@@ -145,7 +168,10 @@ struct ONNXTileOpShapeHelper : public ONNXOpShapeHelper<ONNXTileOp> {
 // of the dimensions of C can have 1 (broadcast) or many (same size as position
 // requires).
 struct ONNXGemmOpShapeHelper : public ONNXOpShapeHelper<ONNXGemmOp> {
-  ONNXGemmOpShapeHelper(ONNXGemmOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXGemmOpShapeHelper(ONNXGemmOp *newOp);
+  ONNXGemmOpShapeHelper(ONNXGemmOp *newOp, ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXGemmOpAdaptor operandAdaptor);
 
@@ -159,12 +185,15 @@ struct ONNXGemmOpShapeHelper : public ONNXOpShapeHelper<ONNXGemmOp> {
 
 // Shape for MatMulOp.
 struct ONNXMatMulOpShapeHelper : public ONNXOpShapeHelper<ONNXMatMulOp> {
-  ONNXMatMulOpShapeHelper(
-      ONNXMatMulOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXMatMulOpShapeHelper(ONNXMatMulOp *newOp);
+  ONNXMatMulOpShapeHelper(ONNXMatMulOp *newOp,
+      ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXMatMulOpAdaptor operandAdaptor);
 
-  // Additional data for MatMulOp: output = a * b.
+  // Additional data for MatMulOp: output = a & b.
   SmallVector<IndexExpr, 4> aDims; // Dim of A, after applying padding.
   SmallVector<IndexExpr, 4> bDims; // Dim of B, after applying padding.
   llvm::BitVector aPadDims;        // When true, that dim was padded.
@@ -173,8 +202,11 @@ struct ONNXMatMulOpShapeHelper : public ONNXOpShapeHelper<ONNXMatMulOp> {
 
 // Shape for Gather.
 struct ONNXGatherOpShapeHelper : public ONNXOpShapeHelper<ONNXGatherOp> {
-  ONNXGatherOpShapeHelper(
-      ONNXGatherOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXGatherOpShapeHelper(ONNXGatherOp *newOp);
+  ONNXGatherOpShapeHelper(ONNXGatherOp *newOp,
+      ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXGatherOpAdaptor operandAdaptor);
 
@@ -185,37 +217,32 @@ struct ONNXGatherOpShapeHelper : public ONNXOpShapeHelper<ONNXGatherOp> {
 
 // Shape for SplitOp.
 struct ONNXSplitOpShapeHelper : public ONNXOpShapeHelper<ONNXSplitOp> {
-  ONNXSplitOpShapeHelper(
-      ONNXSplitOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXSplitOpShapeHelper(ONNXSplitOp *newOp);
+  ONNXSplitOpShapeHelper(ONNXSplitOp *newOp,
+      ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXSplitOpAdaptor operandAdaptor);
 };
 
 // Shape for TransposeOp.
 struct ONNXTransposeOpShapeHelper : public ONNXOpShapeHelper<ONNXTransposeOp> {
-  ONNXTransposeOpShapeHelper(
-      ONNXTransposeOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXTransposeOpShapeHelper(ONNXTransposeOp *newOp);
+  ONNXTransposeOpShapeHelper(ONNXTransposeOp *newOp,
+      ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXTransposeOpAdaptor operandAdaptor);
 };
 
 // Shape for LRN.
 struct ONNXLRNOpShapeHelper : public ONNXOpShapeHelper<ONNXLRNOp> {
-  ONNXLRNOpShapeHelper(ONNXLRNOp *newOp, ConversionPatternRewriter *rewriter);
+  ONNXLRNOpShapeHelper(ONNXLRNOp *newOp);
+  ONNXLRNOpShapeHelper(ONNXLRNOp *newOp, ConversionPatternRewriter &rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
 
   LogicalResult Compute(ONNXLRNOpAdaptor operandAdaptor);
 };
-
-//===----------------------------------------------------------------------===//
-// Low Level Helpers
-//===----------------------------------------------------------------------===//
-
-// aee: needed here?
-size_t ArrayAttrSize(ArrayAttr a);
-size_t ArrayAttrSize(Optional<ArrayAttr> a);
-int64_t ArrayAttrIntVal(ArrayAttr a, int i);
-int64_t ArrayAttrIntVal(Optional<ArrayAttr> a, int i);
-// Returns the ConstantOp which defines an MLIR Value or null.
-ONNXConstantOp getONNXConstantOp(Value value);
-
-bool getIntegerLiteralFromValue(Value value, int64_t &intLit);

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
 #include "src/Pass/Passes.hpp"
 
 using namespace mlir;

--- a/src/Transform/ONNX/Rewrite.cpp
+++ b/src/Transform/ONNX/Rewrite.cpp
@@ -17,6 +17,7 @@
 #include "mlir/IR/PatternMatch.h"
 
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
 
 using namespace mlir;
 


### PR DESCRIPTION
As the title say. The most "difficult" was that ONNX Shape Helper need to generate some code, which for us is KRNL ops. So I added two lambda functions that are passed as parameters to the ONNX shape helper to retrieve and generate KRNL ops, so that ONNX may be deployed (for shape inference) totally free of KRNL, and when we want to use it with KRNL, we just passed the appropriate functions. Similar functions are trivial to generate using affine dialect, if need be.

Lots of tedious small changes