### PR TITLE
added use for the return value of passes

### DIFF
--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -1365,7 +1365,9 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
     vector::populateVectorToVectorCanonicalizationPatterns(patterns);
     vector::populateVectorSlicesLoweringPatterns(patterns);
     vector::populateVectorContractLoweringPatterns(patterns);
-    applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
   }
   // Define the target for this lowering i.e. the LLVM dialect.
   ConversionTarget target(getContext());

--- a/src/Transform/BundleMemoryPools.cpp
+++ b/src/Transform/BundleMemoryPools.cpp
@@ -517,7 +517,9 @@ public:
         &getContext(), &blockToDynamicPool);
     patterns.insert<KrnlMoveConstantsUp>(&getContext());
 
-    applyPatternsAndFoldGreedily(function, std::move(patterns));
+    // No need to test, its ok to fail the apply.
+    LogicalResult res =
+        applyPatternsAndFoldGreedily(function, std::move(patterns));
     BlockToMemPool::iterator it;
     for (it = blockToStaticPool.begin(); it != blockToStaticPool.end(); it++)
       free(it->second);

--- a/src/Transform/DisconnectKrnlDimFromAlloc.cpp
+++ b/src/Transform/DisconnectKrnlDimFromAlloc.cpp
@@ -137,7 +137,8 @@ public:
     RewritePatternSet patterns(&getContext());
     patterns.insert<DisconnectKrnlDimFromAlloc>(&getContext());
 
-    applyPatternsAndFoldGreedily(function, std::move(patterns));
+    if (failed(applyPatternsAndFoldGreedily(function, std::move(patterns))))
+      signalPassFailure();
   }
 };
 } // namespace

--- a/src/Transform/ElideKrnlGlobalConstants.cpp
+++ b/src/Transform/ElideKrnlGlobalConstants.cpp
@@ -89,8 +89,9 @@ public:
     RewritePatternSet patterns(&getContext());
     patterns.insert<KrnlConstGlobalValueElision>(
         &getContext(), KrnlConstGlobalValueElision::kDefaultElisionThreshold);
-
-    applyPatternsAndFoldGreedily(function, std::move(patterns));
+    // No need to test, its ok to fail the apply.
+    LogicalResult res =
+        applyPatternsAndFoldGreedily(function, std::move(patterns));
   }
 };
 

--- a/src/Transform/EnableMemoryPool.cpp
+++ b/src/Transform/EnableMemoryPool.cpp
@@ -157,7 +157,9 @@ public:
     patterns.insert<KrnlEnableMemoryPool>(&getContext());
     patterns.insert<KrnlEliminateOldDealloc>(&getContext());
 
-    applyPatternsAndFoldGreedily(function, std::move(patterns));
+    // No need to test, its ok to fail the apply.
+    LogicalResult res =
+        applyPatternsAndFoldGreedily(function, std::move(patterns));
   }
 };
 } // namespace

--- a/src/Transform/LowerKrnlShape.cpp
+++ b/src/Transform/LowerKrnlShape.cpp
@@ -87,7 +87,8 @@ public:
     RewritePatternSet patterns(&getContext());
     patterns.insert<LowerKrnlShape>(&getContext());
 
-    applyPatternsAndFoldGreedily(function, std::move(patterns));
+    if (failed(applyPatternsAndFoldGreedily(function, std::move(patterns))))
+      signalPassFailure();
   }
 };
 } // namespace

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -835,7 +835,8 @@ void ConstPropONNXToONNXPass::runOnFunction() {
   populateWithGenerated(patterns);
   patterns.insert<ConstPropSplitPattern>(&getContext());
 
-  applyPatternsAndFoldGreedily(function, std::move(patterns));
+  if (failed(applyPatternsAndFoldGreedily(function, std::move(patterns))))
+    signalPassFailure();
 
   // Create DenseElementsAttr and clean up helper attributes.
   function.walk([&](ONNXConstantOp constOp) {

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -50,7 +50,7 @@ static SmallVector<mlir::FuncOp, 4> lookUpFuncsMatching(
  * its output shape only after shape inference completes for the associated
  * (sub) graph.
  *
- * In the abscence of a main computation graph, we will treat every mlir
+ * In the absence of a main computation graph, we will treat every mlir
  * function as a main computation graph; this is mostly just for testing
  * purposes.
  */
@@ -62,8 +62,10 @@ public:
     auto matchedFuncs =
         lookUpFuncsMatching(module, std::regex("[a-zA-Z0-9_]*main_graph"));
     if (!matchedFuncs.empty()) {
-      for (auto func : matchedFuncs)
-        runShapeInferenceOn(func);
+      for (auto func : matchedFuncs) {
+        if (failed(runShapeInferenceOn(func)))
+          signalPassFailure();
+      }
     } else {
       auto result = module.walk([&](FuncOp funcOp) -> WalkResult {
         return runShapeInferenceOn(funcOp);

--- a/src/Transform/OptimizeMemoryPools.cpp
+++ b/src/Transform/OptimizeMemoryPools.cpp
@@ -792,7 +792,9 @@ public:
     patterns.insert<KrnlCompactStaticMemoryPools>(
         &getContext(), &blockToStaticPoolAlignments);
 
-    applyPatternsAndFoldGreedily(function, std::move(patterns));
+    // No need to test, its ok to fail the apply.
+    LogicalResult res =
+        applyPatternsAndFoldGreedily(function, std::move(patterns));
   }
 };
 } // namespace

--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -77,7 +77,10 @@ bool isOMConvTheSameAsNaiveImplFor(const int N, const int C, const int H,
 
   // Use the convOp shape inference method to compute output shape, and unset
   // the shape so that we don't leave IR in a inconsistent state.
-  convOp.inferShapes([](mlir::Region&) {});
+  LogicalResult res = convOp.inferShapes([](mlir::Region &) {});
+  if (failed(res)) {
+    return false;
+  }
   auto outputShape = convOp.getResult().getType().cast<ShapedType>().getShape();
   auto NOut = outputShape[0];
   auto COut = outputShape[1];
@@ -95,7 +98,7 @@ bool isOMConvTheSameAsNaiveImplFor(const int N, const int C, const int H,
   auto entryPoint = ONNXEntryPointOp::create(UnknownLoc::get(&ctx), funcOp,
       /*numInputs=*/2,
       /*numOutputs=*/1,
-      /*signature*/signature);
+      /*signature*/ signature);
   module.push_back(entryPoint);
 
   OwningModuleRef moduleRef(module);

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -56,7 +56,8 @@ void check(ModelProto &model) {
   options.useOnnxModelTypes = true;
   onnx_mlir::ImportFrontendModel(model, context, module, options);
 
-  module->verify();
+  // TODO: use result?
+  LogicalResult res = module->verify();
   module->dump();
   std::cerr << std::endl;
 }

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -57,7 +57,7 @@ void check(ModelProto &model) {
   onnx_mlir::ImportFrontendModel(model, context, module, options);
 
   // TODO: use result?
-  LogicalResult res = module->verify();
+  mlir::LogicalResult res = module->verify();
   module->dump();
   std::cerr << std::endl;
 }


### PR DESCRIPTION
Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>

MLIR requires the return value of passes to be tested. Most are now, with some where its ok to succeed or fail.