### PR TITLE
Fix for Issue #619

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -821,10 +821,11 @@ private:
     // Data input is imported but starts, ends, axes, and steps may come from
     // attributes, and need to be created as constant ops.
     const auto elementType = builder_.getIntegerType(64);
-    const auto tensorType = RankedTensorType::get({1}, elementType);
     const auto attributes = ImportNodeAttributes(node);
     for (auto attr : attributes) {
       if (auto arrayAttr = attr.second.dyn_cast<ArrayAttr>()) {
+        const auto tensorType =
+            RankedTensorType::get({(int64_t)arrayAttr.size()}, elementType);
         auto constantDenseAttribute =
             DenseElementsAttr::get(tensorType, arrayAttr.getValue());
         auto constantOp = builder_.create<ONNXConstantOp>(


### PR DESCRIPTION
When converting Slice op attrs to constant inputs, we need to use the size of the attribute as the shape of the constant.

Signed-off-by: aman <alachapelle@apple.com>