### PR TITLE
Remove variant

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "third_party/pybind11"]
 	path = third_party/pybind11
 	url = https://github.com/pybind/pybind11.git
-[submodule "third_party/variant"]
-	path = third_party/variant
-	url = https://github.com/mpark/variant.git
 [submodule "third_party/rapidcheck"]
 	path = third_party/rapidcheck
 	url = https://github.com/emil-e/rapidcheck.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ endif()
 add_subdirectory(third_party/onnx)
 
 add_subdirectory(third_party/pybind11)
-add_subdirectory(third_party/variant)
 add_subdirectory(third_party/rapidcheck)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/src/Builder/CMakeLists.txt
+++ b/src/Builder/CMakeLists.txt
@@ -19,12 +19,10 @@ endif()
 # when building onnx such as -DONNX_ML=1 -DONNX_NAMESPACE=onnx will be carried over
 # when compiling FrontendDialectHelper.cpp, etc.
 target_link_libraries(OMBuilder
-        onnx
-        mpark_variant)
+        onnx)
 target_include_directories(OMBuilder
                            PUBLIC
                            ${ONNX_MLIR_SRC_ROOT}/third_party/onnx
-                           ${ONNX_MLIR_SRC_ROOT}/third_party/variant
                            ${ONNX_MLIR_SRC_ROOT})
 
 # If you add onnx here, it will also cause onnx to be built. However, some

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -19,10 +19,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <type_traits>
-// Using backported variant.
-// bstd = backported standard library.
-#include <mpark/variant.hpp>
-namespace bstd = mpark;
 
 #include "mlir/IR/BuiltinOps.h"
 #include "onnx/defs/schema.h"


### PR DESCRIPTION
This submodule is currently unused, so it can be removed. The header and lib are referenced (as in the header is included and the lib is linked against), however, they are never actually used in code.