### PR TITLE
Fix dependency error with ShapeInferencePass

### DIFF
--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(OMShapeInference
         ${ONNX_MLIR_SRC_ROOT})
 # Header dependencies
 add_dependencies(OMShapeInference ShapeInferenceOpInterfaceIncGen)
+add_dependencies(OMShapeInference OMHasOnnxSubgraphOpInterfaceIncGen)
 # Linking dependencies
 add_dependencies(OMShapeInference OMShapeInferenceOpInterface)
 


### PR DESCRIPTION
A compile order dependency issue was introduced with commit
09259975200307925971b4cd51061d942f794868

```
In file included from /build/third_party/onnx-mlir/src/Dialect/ONNX/ONNXOps.hpp:27,
                 from /build/third_party/onnx-mlir/src/Transform/ONNX/ShapeInferencePass.cpp:23:
/build/third_party/onnx-mlir/src/Interface/HasOnnxSubgraphOpInterface.hpp:26:10: fatal error: src/Interface/HasOnnxSubgraphOpInterface.hpp.inc: No such file or directory
 #include "src/Interface/HasOnnxSubgraphOpInterface.hpp.inc"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Signed-off-by: Steven Royer <seroyer@us.ibm.com>