### PR TITLE
Hoist invariant instructions from krnl.iterate before lowering

### DIFF
--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -1377,7 +1377,7 @@ void ConvertKrnlToAffinePass::runOnFunction() {
   FuncOp funcOp = getFunction();
 
   // Move invariant instructions outside of the loops as many as possible. This
-  // helps make loops perfectly nested, which faciliates transformations. 
+  // helps make loops perfectly nested, which faciliates transformations.
   funcOp.walk([&](KrnlIterateOp loopOp) {
     moveLoopInvariantCode(cast<LoopLikeOpInterface>(loopOp.getOperation()));
   });

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -303,6 +303,18 @@ ParseResult parseKrnlIterateOp(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
+Region &KrnlIterateOp::getLoopBody() { return bodyRegion(); }
+
+LogicalResult KrnlIterateOp::moveOutOfLoop(ArrayRef<Operation *> ops) {
+  for (auto *op : ops)
+    op->moveBefore(*this);
+  return success();
+}
+
+bool KrnlIterateOp::isDefinedOutsideOfLoop(Value value) {
+  return !bodyRegion().isAncestor(value.getParentRegion());
+}
+
 static LogicalResult verify(KrnlIterateOp op) {
   // TODO: Verify number of induction variable bounds matches the number of
   // input loops.

--- a/src/Dialect/Krnl/KrnlOps.hpp
+++ b/src/Dialect/Krnl/KrnlOps.hpp
@@ -15,13 +15,13 @@
 #pragma once
 
 #include "mlir/Dialect/Shape/IR/Shape.h"
-#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "src/Interface/SpecializedKernelOpInterface.hpp"
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/src/Dialect/Krnl/KrnlOps.hpp
+++ b/src/Dialect/Krnl/KrnlOps.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -10,6 +10,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Dialect/Shape/IR/ShapeBase.td"
+include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "src/Interface/SpecializedKernelOpInterface.td"
 
@@ -50,7 +51,8 @@ def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
 }];
 }
 
-def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator]> {
+def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator,
+    DeclareOpInterfaceMethods<LoopLikeOpInterface>]> {
   let summary = "iterate operation";
   let description = [{
     The "krnl.iterate" operation is conceptually equivalent to a nested for loops.

--- a/test/mlir/krnl/get_induction_var_value.mlir
+++ b/test/mlir/krnl/get_induction_var_value.mlir
@@ -29,7 +29,8 @@ func @test_2d_tiling_imperfectly_nested() {
 
     %alloc = memref.alloc() : memref<10 x f32>
     krnl.iterate(%il, %jl) with () {
-      %foo = addi %i, %j : index
+      %il_idx, %jl_idx = krnl.get_induction_var_value(%il, %jl) : (!krnl.loop, !krnl.loop) -> (index, index)
+      %foo = addi %il_idx, %jl_idx : index
     }
     memref.dealloc %alloc : memref<10 x f32>
   }

--- a/test/mlir/krnl/hoisting.mlir
+++ b/test/mlir/krnl/hoisting.mlir
@@ -1,0 +1,27 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-affine %s -split-input-file | FileCheck %s
+
+// Hoist invariant instructions outside of the loop.
+func @simple_block(%arg0 : memref<?xf32>) {
+  // CHECK-LABEL: simple_block
+  // CHECK-NEXT:  constant
+  // CHECK-NEXT:  memref.dim 
+  // CHECK-NEXT:  affine.for
+  // CHECK-NEXT:    affine.for
+  // CHECK-NEXT:      affine.for
+  // CHECK-NEXT:        addi
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  %c0 = constant 0 : index
+  %ii = krnl.define_loops 1
+  krnl.iterate(%ii) with (%ii -> %i = 0 to 1) {
+    %0 = memref.dim %arg0, %c0 : memref<?xf32>
+    %jj = krnl.define_loops 1
+    %jb, %jl = krnl.block %jj 2 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+    krnl.iterate(%jb, %jl) with (%jj -> %j = 0 to %0) {
+      %foo = addi %j, %j : index
+    }
+  }
+  return
+}
+

--- a/test/mlir/krnl/imperfectly_nested_stmts.mlir
+++ b/test/mlir/krnl/imperfectly_nested_stmts.mlir
@@ -6,7 +6,8 @@ func @simple_imperfectly_nested() {
   krnl.iterate(%ib) with (%ii -> %i = 0 to 10) {
     %alloc = memref.alloc() : memref<10 x f32>
     krnl.iterate(%il) with () {
-      %v0 = krnl.load %alloc[%i] : memref<10xf32>
+      %il_idx = krnl.get_induction_var_value(%il) : (!krnl.loop) -> (index)
+      %v0 = krnl.load %alloc[%il_idx] : memref<10xf32>
       %foo = addf %v0, %v0 : f32
     }
     memref.dealloc %alloc : memref<10 x f32>
@@ -38,7 +39,8 @@ func @test_2d_tiling_imperfectly_nested() {
   krnl.iterate(%ib, %jb) with (%ii -> %i = 0 to 10, %ij -> %j = 0 to 20) {
     %alloc = memref.alloc() : memref<10 x f32>
     krnl.iterate(%il, %jl) with () {
-      %foo = addi %i, %j : index
+      %il_idx, %jl_idx = krnl.get_induction_var_value(%il, %jl) : (!krnl.loop, !krnl.loop) -> (index, index)
+      %foo = addi %il_idx, %jl_idx : index
     }
     memref.dealloc %alloc : memref<10 x f32>
   }


### PR DESCRIPTION
Before lowering krnl op, move invariant instructions outside of the loops as many as possible. This helps make loops perfectly nested, which facilitates transformations.

resolves #697 

Signed-off-by: Tung D. Le <tung@jp.ibm.com>