### PR TITLE
Added return of nonzero value when errors occur

### DIFF
--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -168,9 +168,8 @@ int main(int argc, char *argv[]) {
     RC_ASSERT(isOMConvTheSameAsNaiveImplFor(
         N, C, H, W, kH, kW, pHBegin, pHEnd, pWBegin, pWEnd));
   });
-  // Todo: fix the test and remove comment below
-  //if (!success)
-  //  return 1;
+  if (!success)
+    return 1;
 
   // Exhaustive test case generation.
   for (int pHBegin = 0; pHBegin < 3; pHBegin++)

--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
   llvm::FileRemover remover(SHARED_LIB_BASE + ".so");
 
   // RapidCheck test case generation.
-  rc::check("convolution implementation correctness", []() {
+  bool success = rc::check("convolution implementation correctness", []() {
     const auto N = *rc::gen::inRange(1, 10);
     const auto C = *rc::gen::inRange(1, 20);
     const auto H = *rc::gen::inRange(5, 20);
@@ -168,6 +168,9 @@ int main(int argc, char *argv[]) {
     RC_ASSERT(isOMConvTheSameAsNaiveImplFor(
         N, C, H, W, kH, kW, pHBegin, pHEnd, pWBegin, pWEnd));
   });
+  // Todo: fix the test
+  //if (!success)
+  //  return 1;
 
   // Exhaustive test case generation.
   for (int pHBegin = 0; pHBegin < 3; pHBegin++)

--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -168,7 +168,7 @@ int main(int argc, char *argv[]) {
     RC_ASSERT(isOMConvTheSameAsNaiveImplFor(
         N, C, H, W, kH, kW, pHBegin, pHEnd, pWBegin, pWEnd));
   });
-  // Todo: fix the test
+  // Todo: fix the test and remove comment below
   //if (!success)
   //  return 1;
 

--- a/test/numerical/TestGRU.cpp
+++ b/test/numerical/TestGRU.cpp
@@ -301,7 +301,7 @@ int main(int argc, char *argv[]) {
   llvm::FileRemover remover(SHARED_LIB_BASE + ".so");
 
   // RapidCheck test case generation.
-  rc::check("GRU implementation correctness", []() {
+  bool success = rc::check("GRU implementation correctness", []() {
     // The number of directions.
     // 1: forward, -1: reverse, 2: bidirectional
     const auto D = *rc::gen::element(1, -1, 2);
@@ -323,6 +323,8 @@ int main(int argc, char *argv[]) {
     RC_ASSERT(isOMGRUTheSameAsNaiveImplFor(
         D, S, B, I, H, L, isDynS == 0, isDynB == 0));
   });
+  if (!success)
+    return 1;
 
   // Exhaustive test case generation.
   for (int64_t s = 2; s < 5; s++)

--- a/test/numerical/TestGemm.cpp
+++ b/test/numerical/TestGemm.cpp
@@ -188,7 +188,7 @@ int main(int argc, char *argv[]) {
   llvm::FileRemover remover(SHARED_LIB_BASE + ".so");
 
   printf("RapidCheck test case generation.\n");
-  rc::check("Gemm implementation correctness", []() {
+  bool success = rc::check("Gemm implementation correctness", []() {
     const int maxRange = 50;
     const auto I = *rc::gen::inRange(1, maxRange);
     const auto J = *rc::gen::inRange(1, maxRange);
@@ -203,6 +203,8 @@ int main(int argc, char *argv[]) {
     RC_ASSERT(isOMGemmTheSameAsNaiveImplFor(
         I, J, K, aTrans, bTrans, cRank, alpha, beta));
   });
+  if (!success)
+    return 1;
 
   if (false) {
     // Was too slow on some machines, disable test.

--- a/test/numerical/TestGemm.cpp
+++ b/test/numerical/TestGemm.cpp
@@ -203,8 +203,9 @@ int main(int argc, char *argv[]) {
     RC_ASSERT(isOMGemmTheSameAsNaiveImplFor(
         I, J, K, aTrans, bTrans, cRank, alpha, beta));
   });
-  if (!success)
-    return 1;
+  // Todo: fix the test and remove comment below
+  // if (!success)
+  //  return 1;
 
   if (false) {
     // Was too slow on some machines, disable test.

--- a/test/numerical/TestLSTM.cpp
+++ b/test/numerical/TestLSTM.cpp
@@ -310,7 +310,7 @@ int main(int argc, char *argv[]) {
   llvm::FileRemover remover(SHARED_LIB_BASE + ".so");
 
   // RapidCheck test case generation.
-  rc::check("LSTM implementation correctness", []() {
+  bool success = rc::check("LSTM implementation correctness", []() {
     // The number of directions.
     // 1: forward, -1: reverse, 2: bidirectional
     const auto D = *rc::gen::element(1, -1, 2);
@@ -330,6 +330,8 @@ int main(int argc, char *argv[]) {
     RC_ASSERT(
         isOMLSTMTheSameAsNaiveImplFor(D, S, B, I, H, isDynS == 0, isDynB == 0));
   });
+  if (!success)
+    return 1;
 
   // Exhaustive test case generation.
   for (int64_t s = 2; s < 5; s++)

--- a/test/numerical/TestMatMul2D.cpp
+++ b/test/numerical/TestMatMul2D.cpp
@@ -31,7 +31,7 @@ bool isOMMatmulTheSameAsNaiveImplFor(const int I, const int J, const int K) {
   registerDialects(ctx);
   static int testNum = 0;
   printf("attempt %d with i %d, j %d, k %d\n", ++testNum, I, J, K);
-  
+
   auto module = ModuleOp::create(UnknownLoc::get(&ctx));
   OpBuilder builder(&ctx);
   llvm::SmallVector<int64_t, 4> aShape = {I, K};
@@ -69,7 +69,7 @@ bool isOMMatmulTheSameAsNaiveImplFor(const int I, const int J, const int K) {
   auto entryPoint = ONNXEntryPointOp::create(UnknownLoc::get(&ctx), funcOp,
       /*numInputs=*/2,
       /*numOutputs=*/1,
-      /*signature*/signature);
+      /*signature*/ signature);
   module.push_back(entryPoint);
 
   OwningModuleRef moduleRef(module);
@@ -113,13 +113,15 @@ int main(int argc, char *argv[]) {
   llvm::FileRemover remover(SHARED_LIB_BASE + ".so");
 
   printf("RapidCheck test case generation.\n");
-  rc::check("Matmul implementation correctness", []() {
+  bool success = rc::check("Matmul implementation correctness", []() {
     const auto I = *rc::gen::inRange(1, 50);
     const auto J = *rc::gen::inRange(1, 50);
     const auto K = *rc::gen::inRange(1, 50);
 
     RC_ASSERT(isOMMatmulTheSameAsNaiveImplFor(I, J, K));
   });
+  if (!success)
+    return 1;
 
   printf("\n\nExhaustive test case generation.\n");
   for (int I = 1; I < 9; I++)

--- a/test/numerical/TestRNN.cpp
+++ b/test/numerical/TestRNN.cpp
@@ -213,7 +213,7 @@ int main(int argc, char *argv[]) {
   llvm::FileRemover remover(SHARED_LIB_BASE + ".so");
 
   // RapidCheck test case generation.
-  rc::check("RNN implementation correctness", []() {
+  bool success = rc::check("RNN implementation correctness", []() {
     // The number of directions.
     // 1: forward, -1: reverse, 2: bidirectional
     const auto D = *rc::gen::element(1, -1, 2);
@@ -233,6 +233,8 @@ int main(int argc, char *argv[]) {
     RC_ASSERT(
         isOMRNNTheSameAsNaiveImplFor(D, S, B, I, H, isDynS == 0, isDynB == 0));
   });
+  if (!success)
+    return 1;
 
   // Exhaustive test case generation.
   for (int64_t s = 1; s < 5; s++)


### PR DESCRIPTION
Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>

Current numerical may assert in the `rc::check` silently using the `make test` check. The fix here enforce a return of a non-zero values on `rc::check` error.

It will be enabled also for TestGemm, which currently fails.