### PR TITLE
[DO NOT COMMIT] Convert attributes to input tensor

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -500,15 +500,16 @@ private:
   }
 
   Value ConvertAttrToInput(const std::map<int, std::string> &attrToInputMap,
-      int i, const std::vector<NamedAttribute> &attributes) {
+      int i, std::vector<NamedAttribute> &attributes) {
     auto item = attrToInputMap.find(i);
     if (item == attrToInputMap.end())
       return nullptr;
     std::string name = item->second;
     ArrayAttr arrayAttr;
-    for (auto &t : attributes) {
-      if (t.first == name) {
-        arrayAttr = t.second.dyn_cast<ArrayAttr>();
+    for (auto it = attributes.begin(); it != attributes.end(); it++) {
+      if (it->first == name) {
+        arrayAttr = it->second.dyn_cast<ArrayAttr>();
+        attributes.erase(it);
         break;
       }
     }
@@ -531,7 +532,7 @@ private:
   template <typename T>
   void buildOutputAndOperation(const onnx::NodeProto &node,
       std::vector<Value> inputs, int expectedNumOperands,
-      int expectedNumResults, const std::vector<NamedAttribute> &attributes) {
+      int expectedNumResults, std::vector<NamedAttribute> &attributes) {
     bool variadicIn = expectedNumOperands == -1;
     bool variadicOut = expectedNumResults == -1;
 
@@ -862,7 +863,7 @@ private:
     // Data input is imported but starts, ends, axes, and steps may come from
     // attributes, and need to be created as constant ops.
     const auto elementType = builder_.getIntegerType(64);
-    const auto attributes = ImportNodeAttributes(node);
+    auto attributes = ImportNodeAttributes(node);
     for (auto attr : attributes) {
       if (auto arrayAttr = attr.second.dyn_cast<ArrayAttr>()) {
         const auto tensorType =

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -499,34 +499,35 @@ private:
     }
   }
 
-  Value ConvertAttrToInput(const std::map<int, std::string> &attrToInputMap, int i, const std::vector<NamedAttribute> &attributes) {
-   auto item = attrToInputMap.find(i);
-   if (item == attrToInputMap.end())
-     return nullptr;
-   std::string name = item->second;
-   ArrayAttr arrayAttr;
-   for (auto &t : attributes) {
-     if (t.first == name) {
-       arrayAttr = t.second.dyn_cast<ArrayAttr>();
-       break;
-     }
-   }
-   if (!arrayAttr) 
-     return nullptr;
-       
-    // ToFix: Duplicate the code from Decompose.cpp 
+  Value ConvertAttrToInput(const std::map<int, std::string> &attrToInputMap,
+      int i, const std::vector<NamedAttribute> &attributes) {
+    auto item = attrToInputMap.find(i);
+    if (item == attrToInputMap.end())
+      return nullptr;
+    std::string name = item->second;
+    ArrayAttr arrayAttr;
+    for (auto &t : attributes) {
+      if (t.first == name) {
+        arrayAttr = t.second.dyn_cast<ArrayAttr>();
+        break;
+      }
+    }
+    if (!arrayAttr)
+      return nullptr;
+
+    // ToFix: Duplicate the code from Decompose.cpp
     // Or the new format of constant can be used
     const auto elementType = builder_.getIntegerType(64);
     const auto tensorType =
-            RankedTensorType::get({(int64_t)arrayAttr.size()}, elementType);
+        RankedTensorType::get({(int64_t)arrayAttr.size()}, elementType);
     auto constantDenseAttribute =
-            DenseElementsAttr::get(tensorType, arrayAttr.getValue());
+        DenseElementsAttr::get(tensorType, arrayAttr.getValue());
     auto constantOp = builder_.create<ONNXConstantOp>(
-            UnknownLoc(), Attribute(), constantDenseAttribute);
+        UnknownLoc(), Attribute(), constantDenseAttribute);
     Value constantValue = constantOp.output();
-    return  constantValue;
+    return constantValue;
   }
- 
+
   template <typename T>
   void buildOutputAndOperation(const onnx::NodeProto &node,
       std::vector<Value> inputs, int expectedNumOperands,
@@ -542,14 +543,15 @@ private:
     // Here, we import optional inputs and outputs as NoneType.
 
     // Trailing optional inputs.
-    std::map<int, std::string> attrToInputMap ;
+    std::map<int, std::string> attrToInputMap;
+    // TOFIX: Should try to use the trait implementation.
     if constexpr (std::is_same<T, ONNXReduceSumOp>().value) {
       attrToInputMap = T::attrToInput();
-    } 
+    }
     if (!variadicIn) {
       for (auto i = inputs.size(); i < expectedNumOperands; i++) {
         // Convert the attribute to input due to the standard change
-        if (Value v = ConvertAttrToInput(attrToInputMap, i, attributes)) 
+        if (Value v = ConvertAttrToInput(attrToInputMap, i, attributes))
           inputs.emplace_back(v);
         else
           inputs.emplace_back(none());

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -4266,6 +4266,9 @@ def ONNXReduceSumOp:ONNX_Op<"ReduceSum",
       static std::vector<int> getTypeMap() {
         return {20};
       }
+      static std::map<int, std::string> attrToInput() {
+        return {{1, "axes"}};
+      }
     }];
 }
 


### PR DESCRIPTION
Signed-off-by: chentong <chentong@us.ibm.com>
One common change in onnx is that an attribute of an op is changed to input tensor in the new version. This PR is intended to handle that change so that the onnx-mlir is able to handle ops in old version with the new version op.
1. Specify which attribute is converted to which input in gen_onnx_mlir.py so that the op dialect has a mapping.
2. In frontend, convert the attributes according to the mapping