### PR TITLE
Investigate gemm small dim error, fixed now

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -38,7 +38,7 @@ IMPORTER_FORCE_DYNAMIC='0:-1|1:0,1' all dimensions of the first input and the 1s
 
 The Backus–Naur Form (BNF) for IMPORTER_FORCE_DYNAMIC is as follows.
 ```
-<ImportForceDymanicExpr> :== `'` <expr> `'`
+<ImportForceDynamicExpr> :== `'` <expr> `'`
                   <expr> ::= <inputString> | <inputString> `|` <expr>
             <inputString ::= <inputIndex> `:` <dimString>
              <dimString> ::= <dimIndex> | <dimIndex> `,` <dimString>
@@ -88,7 +88,7 @@ Numerical tests should be structured such that the following two components are 
 
 The motivation is that there are two ways we want to generate test case parameters:
 - Exhaustive generation of test case parameters. Where we want to exhaustively test the correctness of a small range
-of parameters (for instance, if we would like to test and verify that 3x3 convolution is correctly implmented for
+of parameters (for instance, if we would like to test and verify that 3x3 convolution is correctly implemented for
 all valid padding configurations.)
 - When the possible parameter space is extremely large, we can rely on RapidCheck to randomly generate test cases
 that becomes increasingly large as smaller test cases succeed. And it also automatically shrinks the test cases
@@ -98,7 +98,7 @@ test case parameters and invoke the value checking function `isOMConvTheSameAsNa
 
 ```cpp
   // RapidCheck test case generation.
-  rc::check("convolution implementation correctness", []() {
+  bool success = rc::check("convolution implementation correctness", []() {
     const auto N = *rc::gen::inRange(1, 10);
     const auto C = *rc::gen::inRange(1, 20);
     const auto H = *rc::gen::inRange(5, 20);
@@ -119,5 +119,7 @@ test case parameters and invoke the value checking function `isOMConvTheSameAsNa
     RC_ASSERT(isOMConvTheSameAsNaiveImplFor(
         N, C, H, W, kH, kW, pHBegin, pHEnd, pWBegin, pWEnd));
   });
+  assert(success && "error while performing RapidCheck tests");
 ```
   
+Sometimes it is convenient to be able to see the mlir files associated with a numerical tests. To do so, the easiest is to set the `KEEP_TEMP_FILES` variable in `src/MainUtils.cpp` to true. Then, no matter how you compile your model, input and output mlir files will be preserved, as well as unoptimized and optimized bytecode files as well as a few additional binaries.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -122,4 +122,9 @@ test case parameters and invoke the value checking function `isOMConvTheSameAsNa
   assert(success && "error while performing RapidCheck tests");
 ```
   
-Sometimes it is convenient to be able to see the mlir files associated with a numerical tests. To do so, the easiest is to set the `KEEP_TEMP_FILES` variable in `src/MainUtils.cpp` to true. Then, no matter how you compile your model, input and output mlir files will be preserved, as well as unoptimized and optimized bytecode files as well as a few additional binaries.
+Sometimes it is convenient to be able to see the mlir files associated with a
+numerical tests. To do so, the easiest is to set the `overridePreserveFiles`
+variable in `src/MainUtils.cpp` to the types of files that you want to
+preserve (e.g. `KeepFilesOfType::All`). Then, no matter how you compile
+your model, input and output mlir files will be preserved, as well as
+unoptimized and optimized bytecode files as well as a few additional binaries.

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -18,7 +18,7 @@
 #include "src/Dialect/ONNX/ONNXShapeHelper.hpp"
 
 // Used to trace which op are used, good for profiling apps.
-#define TRACE 0
+#define TRACE 1
 #define DEBUG_SIMD_OFF 0
 #define DEBUG_UNROLL_OFF 0
 #define DEBUG_OPTIMIZED_OFF 0
@@ -83,7 +83,7 @@ struct ONNXGemmOpLowering : public ConversionPattern {
             SmallVector<IndexExpr, 2> cAccess;
             for (int x = 2 - shapeHelper.cRank; x < 2; ++x) {
               // If dim > 1, use loop index, otherwise broadcast on 0's element.
-              SymbolIndexExpr dim(shapeHelper.cDims[x]);
+              DimIndexExpr dim(shapeHelper.cDims[x]);
               cAccess.emplace_back(
                   IndexExpr::select(dim > 1, DimIndexExpr(outerIndices[x]), 0));
             }

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -18,7 +18,7 @@
 #include "src/Dialect/ONNX/ONNXShapeHelper.hpp"
 
 // Used to trace which op are used, good for profiling apps.
-#define TRACE 1
+#define TRACE 0
 #define DEBUG_SIMD_OFF 0
 #define DEBUG_UNROLL_OFF 0
 #define DEBUG_OPTIMIZED_OFF 0

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -73,6 +73,10 @@ llvm::cl::opt<bool> preserveBitcode("preserveBitcode",
         "dont delete the bitcode files (optimized and unoptimized):"),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
 
+llvm::cl::opt<bool> preserveMLIR("preserveMLIR",
+    llvm::cl::desc("dont delete the MLIR files (input and llvm):"),
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
+
 llvm::cl::opt<bool> useOnnxModelTypes("useOnnxModelTypes",
     llvm::cl::desc("use types and shapes from ONNX model"),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
@@ -84,6 +88,30 @@ llvm::cl::opt<string> mtriple("mtriple", llvm::cl::desc("Target architecture"),
 llvm::cl::opt<string> mcpu("mcpu", llvm::cl::desc("Target cpu"),
     llvm::cl::value_desc("<llvm cpu value>"), llvm::cl::cat(OnnxMlirOptions),
     llvm::cl::ValueRequired);
+
+// Make a function that forces preserving all files using the runtime arguments
+// and/or the KEEP_TEMP_FILES define flag.
+
+enum class KeepFilesOfType { MLIR, Bitcode, Object };
+
+static bool keepFiles(KeepFilesOfType preserve) {
+  // When wanting to preserve all files, do it regardles of isBitcode.
+  if (KEEP_TEMP_FILES)
+    return true;
+  // When file is bitcode, check the runtime flag preserveBitcode.
+  switch (preserve) {
+  case KeepFilesOfType::Bitcode:
+    return preserveBitcode;
+  case KeepFilesOfType::MLIR:
+    return preserveMLIR;
+  case KeepFilesOfType::Object:
+    // Currently no option, enable using the KEEP_TEMP_FILES flag.
+    return false;
+  default:
+    llvm_unreachable("unkown keep file type enum");
+  }
+  return false;
+}
 
 // Runtime directory contains all the libraries, jars, etc. that are
 // necessary for running onnx-mlir. It's resolved in the following order:
@@ -263,7 +291,7 @@ void genLLVMBitcode(const mlir::OwningModuleRef &module,
   // Write bitcode to a file.
   string unoptimizedBitcodePath = outputBaseName + ".unoptimized.bc";
   llvm::FileRemover unoptimzedBitcodeRemover(
-      unoptimizedBitcodePath, !preserveBitcode);
+      unoptimizedBitcodePath, !keepFiles(KeepFilesOfType::Bitcode));
 
   llvm::raw_fd_ostream moduleBitcodeStream(
       unoptimizedBitcodePath, error, llvm::sys::fs::F_None);
@@ -281,8 +309,7 @@ void genLLVMBitcode(const mlir::OwningModuleRef &module,
   // Use the LLVM's 'opt' command to optimize the bitcode.
   string optPath = getToolPath("opt");
   Command optBitcode(/*exePath=*/!optPath.empty() ? optPath : kOptPath);
-  optBitcode
-      .appendStr("-O3") 
+  optBitcode.appendStr("-O3")
       .appendStr(getTargetTripleOption())
       .appendStr(getTargetCpuOption())
       .appendList({"-o", optimizedBitcodePath})
@@ -340,16 +367,49 @@ void genJniJar(const mlir::OwningModuleRef &module, string modelSharedLibPath,
   jar.appendList({"uf", modelJniJarPath}).appendStr(modelSharedLibPath).exec();
 }
 
+void outputCode(
+    mlir::OwningModuleRef &module, string filename, string extension) {
+  string tempFilename = filename + extension;
+  mlir::OpPrintingFlags flags;
+  if (preserveLocations)
+    flags.enableDebugInfo();
+
+#ifdef _WIN32
+  // copy original stderr file number
+  int stderrOrigin = _dup(_fileno(stderr));
+#else
+  int stderrOrigin = dup(fileno(stderr));
+#endif
+  // printf("hi alex in output code, print %s\n", tempFilename.c_str());
+  freopen(tempFilename.c_str(), "w", stderr);
+  module->print(llvm::errs(), flags);
+  fflush(stderr);
+  // set modified stderr as original stderr
+#ifdef _WIN32
+  _dup2(stderrOrigin, _fileno(stderr));
+#else
+  dup2(stderrOrigin, fileno(stderr));
+#endif
+  if (printIR)
+    module->print(llvm::outs(), flags);
+}
+
 void compileModuleToSharedLibrary(
-    const mlir::OwningModuleRef &module, std::string outputBaseName) {
+    mlir::OwningModuleRef &module, std::string outputBaseName) {
 
   string bitcodePath = outputBaseName + ".bc";
   genLLVMBitcode(module, bitcodePath, outputBaseName);
-  llvm::FileRemover bitcodeRemover(bitcodePath, !preserveBitcode);
+
+  if (keepFiles(KeepFilesOfType::MLIR))
+    outputCode(module, outputBaseName, ".llvm.mlir");
+
+  llvm::FileRemover bitcodeRemover(
+      bitcodePath, !keepFiles(KeepFilesOfType::Bitcode));
 
   string modelObjPath = outputBaseName + ".o";
   genModelObject(module, bitcodePath, modelObjPath);
-  llvm::FileRemover modelObjRemover(modelObjPath, !KEEP_TEMP_FILES);
+  llvm::FileRemover modelObjRemover(
+      modelObjPath, !keepFiles(KeepFilesOfType::Object));
 
   string modelSharedLibPath = outputBaseName + ".so";
   genSharedLib(module, modelSharedLibPath, {"-shared", "-fPIC"}, {modelObjPath},
@@ -361,22 +421,26 @@ void compileModuleToJniJar(
 
   string bitcodePath = outputBaseName + ".bc";
   genLLVMBitcode(module, bitcodePath, outputBaseName);
-  llvm::FileRemover bitcodeRemover(bitcodePath, !preserveBitcode);
+  llvm::FileRemover bitcodeRemover(
+      bitcodePath, !keepFiles(KeepFilesOfType::Bitcode));
 
   string modelObjPath = outputBaseName + ".o";
   genModelObject(module, bitcodePath, modelObjPath);
-  llvm::FileRemover modelObjRemover(modelObjPath, !KEEP_TEMP_FILES);
+  llvm::FileRemover modelObjRemover(
+      modelObjPath, !keepFiles(KeepFilesOfType::Object));
 
   string jniSharedLibPath = getRuntimeDir() + "/libjniruntime.a";
   string jniObjPath = "jnidummy.c.o";
   genJniObject(module, jniSharedLibPath, jniObjPath);
-  llvm::FileRemover jniObjRemover(jniObjPath, !KEEP_TEMP_FILES);
+  llvm::FileRemover jniObjRemover(
+      jniObjPath, !keepFiles(KeepFilesOfType::Object));
 
   string modelSharedLibPath = "libmodel.so";
   genSharedLib(module, modelSharedLibPath,
       {"-shared", "-fPIC", "-z", "noexecstack"}, {modelObjPath, jniObjPath},
       {"-ljniruntime", "-lcruntime"});
-  llvm::FileRemover modelSharedLibRemover(modelSharedLibPath, !KEEP_TEMP_FILES);
+  llvm::FileRemover modelSharedLibRemover(
+      modelSharedLibPath, !keepFiles(KeepFilesOfType::Object));
 
   string modelJniJarPath = outputBaseName + ".jar";
   genJniJar(module, modelSharedLibPath, modelJniJarPath);
@@ -457,32 +521,6 @@ void processInputFile(string inputFilename, EmissionTargetType emissionTarget,
   }
 }
 
-void outputCode(
-    mlir::OwningModuleRef &module, string filename, string extension) {
-  string tempFilename = filename + extension;
-  mlir::OpPrintingFlags flags;
-  if (preserveLocations)
-    flags.enableDebugInfo();
-
-#ifdef _WIN32
-  // copy original stderr file number
-  int stderrOrigin = _dup(_fileno(stderr));
-#else
-  int stderrOrigin = dup(fileno(stderr));
-#endif
-  freopen(tempFilename.c_str(), "w", stderr);
-  module->print(llvm::errs(), flags);
-  fflush(stderr);
-  // set modified stderr as original stderr
-#ifdef _WIN32
-  _dup2(stderrOrigin, _fileno(stderr));
-#else
-  dup2(stderrOrigin, fileno(stderr));
-#endif
-  if (printIR)
-    module->print(llvm::outs(), flags);
-}
-
 void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
     mlir::MLIRContext &context, mlir::OwningModuleRef &module) {
   // For EmitONNXIR and EmitMLIR the constant value are embedded in the code
@@ -541,6 +579,10 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
 int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
     std::string outputBaseName, EmissionTargetType emissionTarget) {
   mlir::PassManager pm(&context, mlir::OpPassManager::Nesting::Implicit);
+
+  if (keepFiles(KeepFilesOfType::MLIR)) {
+    outputCode(module, outputBaseName, ".input.mlir");
+  }
 
   if (emissionTarget >= EmitONNXIR) {
     addONNXToMLIRPasses(pm);

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -37,9 +37,6 @@
 #include <unistd.h>
 #endif
 
-// If need to inspect the temp files for debugging, set flag below to true.
-#define KEEP_TEMP_FILES false
-
 using namespace std;
 using namespace mlir;
 using namespace onnx_mlir;
@@ -90,25 +87,27 @@ llvm::cl::opt<string> mcpu("mcpu", llvm::cl::desc("Target cpu"),
     llvm::cl::ValueRequired);
 
 // Make a function that forces preserving all files using the runtime arguments
-// and/or the KEEP_TEMP_FILES define flag.
+// and/or the overridePreserveFiles enum.
+enum class KeepFilesOfType { All, MLIR, Bitcode, Object, None };
 
-enum class KeepFilesOfType { MLIR, Bitcode, Object };
+static const KeepFilesOfType overridePreserveFiles = KeepFilesOfType::All;
 
 static bool keepFiles(KeepFilesOfType preserve) {
   // When wanting to preserve all files, do it regardles of isBitcode.
-  if (KEEP_TEMP_FILES)
+  if (overridePreserveFiles == KeepFilesOfType::All)
     return true;
   // When file is bitcode, check the runtime flag preserveBitcode.
   switch (preserve) {
   case KeepFilesOfType::Bitcode:
-    return preserveBitcode;
+    return overridePreserveFiles == KeepFilesOfType::Bitcode || preserveBitcode;
   case KeepFilesOfType::MLIR:
-    return preserveMLIR;
+    return overridePreserveFiles == KeepFilesOfType::MLIR || preserveMLIR;
   case KeepFilesOfType::Object:
-    // Currently no option, enable using the KEEP_TEMP_FILES flag.
-    return false;
+    // Currently no option, enable using the overridePreserveFiles enum.
+    return overridePreserveFiles == KeepFilesOfType::Object;
   default:
-    llvm_unreachable("unkown keep file type enum");
+    // All, None should not be used in the parameter
+    llvm_unreachable("illegal KeepFilesOfType enum value");
   }
   return false;
 }
@@ -367,42 +366,11 @@ void genJniJar(const mlir::OwningModuleRef &module, string modelSharedLibPath,
   jar.appendList({"uf", modelJniJarPath}).appendStr(modelSharedLibPath).exec();
 }
 
-void outputCode(
-    mlir::OwningModuleRef &module, string filename, string extension) {
-  string tempFilename = filename + extension;
-  mlir::OpPrintingFlags flags;
-  if (preserveLocations)
-    flags.enableDebugInfo();
-
-#ifdef _WIN32
-  // copy original stderr file number
-  int stderrOrigin = _dup(_fileno(stderr));
-#else
-  int stderrOrigin = dup(fileno(stderr));
-#endif
-  // printf("hi alex in output code, print %s\n", tempFilename.c_str());
-  freopen(tempFilename.c_str(), "w", stderr);
-  module->print(llvm::errs(), flags);
-  fflush(stderr);
-  // set modified stderr as original stderr
-#ifdef _WIN32
-  _dup2(stderrOrigin, _fileno(stderr));
-#else
-  dup2(stderrOrigin, fileno(stderr));
-#endif
-  if (printIR)
-    module->print(llvm::outs(), flags);
-}
-
 void compileModuleToSharedLibrary(
-    mlir::OwningModuleRef &module, std::string outputBaseName) {
+    const mlir::OwningModuleRef &module, std::string outputBaseName) {
 
   string bitcodePath = outputBaseName + ".bc";
   genLLVMBitcode(module, bitcodePath, outputBaseName);
-
-  if (keepFiles(KeepFilesOfType::MLIR))
-    outputCode(module, outputBaseName, ".llvm.mlir");
-
   llvm::FileRemover bitcodeRemover(
       bitcodePath, !keepFiles(KeepFilesOfType::Bitcode));
 
@@ -521,6 +489,32 @@ void processInputFile(string inputFilename, EmissionTargetType emissionTarget,
   }
 }
 
+void outputCode(
+    mlir::OwningModuleRef &module, string filename, string extension) {
+  string tempFilename = filename + extension;
+  mlir::OpPrintingFlags flags;
+  if (preserveLocations)
+    flags.enableDebugInfo();
+
+#ifdef _WIN32
+  // copy original stderr file number
+  int stderrOrigin = _dup(_fileno(stderr));
+#else
+  int stderrOrigin = dup(fileno(stderr));
+#endif
+  freopen(tempFilename.c_str(), "w", stderr);
+  module->print(llvm::errs(), flags);
+  fflush(stderr);
+  // set modified stderr as original stderr
+#ifdef _WIN32
+  _dup2(stderrOrigin, _fileno(stderr));
+#else
+  dup2(stderrOrigin, fileno(stderr));
+#endif
+  if (printIR)
+    module->print(llvm::outs(), flags);
+}
+
 void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
     mlir::MLIRContext &context, mlir::OwningModuleRef &module) {
   // For EmitONNXIR and EmitMLIR the constant value are embedded in the code
@@ -543,9 +537,13 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
   if (emissionTarget == EmitLib) {
     // Write LLVM bitcode to disk, compile & link.
     compileModuleToSharedLibrary(module, outputBaseName);
+    if (keepFiles(KeepFilesOfType::MLIR))
+      outputCode(module, outputBaseName, ".llvm.mlir");
     printf("Shared library %s.so has been compiled.\n", outputBaseName.c_str());
   } else if (emissionTarget == EmitJNI) {
     compileModuleToJniJar(module, outputBaseName);
+    if (keepFiles(KeepFilesOfType::MLIR))
+      outputCode(module, outputBaseName, ".llvm.mlir");
     printf("JNI archive %s.jar has been compiled.\n", outputBaseName.c_str());
   } else {
     // Emit the version with all constants included.

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -90,7 +90,9 @@ llvm::cl::opt<string> mcpu("mcpu", llvm::cl::desc("Target cpu"),
 // and/or the overridePreserveFiles enum.
 enum class KeepFilesOfType { All, MLIR, Bitcode, Object, None };
 
-static const KeepFilesOfType overridePreserveFiles = KeepFilesOfType::All;
+// Value below override at compile time by effectively setting the requested
+// flags.
+static const KeepFilesOfType overridePreserveFiles = KeepFilesOfType::None;
 
 static bool keepFiles(KeepFilesOfType preserve) {
   // When wanting to preserve all files, do it regardles of isBitcode.

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -282,7 +282,7 @@ void genLLVMBitcode(const mlir::OwningModuleRef &module,
   string optPath = getToolPath("opt");
   Command optBitcode(/*exePath=*/!optPath.empty() ? optPath : kOptPath);
   optBitcode
-      .appendStr("-O3") // test_scan9_sum_cpu fails on z with O3.
+      .appendStr("-O3") 
       .appendStr(getTargetTripleOption())
       .appendStr(getTargetCpuOption())
       .appendList({"-o", optimizedBitcodePath})

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -96,6 +96,8 @@ struct OMTensor {
   void *_allocatedPtr; // data buffer
   void *_alignedPtr;   // aligned data buffer that the omt indexes.
 
+  // TODO: remove or use _offset. Currently only set to zero, never used. It
+  // may be in use in LLVM memrefs, so someone needs to look into this.
   int64_t _offset;   // offset of 1st element
   int64_t *_shape;   // shape array
   int64_t *_strides; // strides array
@@ -127,6 +129,7 @@ OMTensor *omTensorCreate(
       (tensor->_strides = (int64_t *)malloc(rank * sizeof(int64_t)))) {
     tensor->_allocatedPtr = data_ptr;
     tensor->_alignedPtr = data_ptr;
+    tensor->_offset = 0;
     tensor->_rank = rank;
     tensor->_dataType = dtype;
     tensor->_owning = false;
@@ -214,8 +217,9 @@ OMTensor *omTensorCreateEmpty(
 
 /* OMTensor destroyer */
 void omTensorDestroy(OMTensor *tensor) {
-  if (tensor->_owning)
+  if (tensor->_owning) {
     free(tensor->_allocatedPtr);
+  }
   free(tensor->_shape);
   free(tensor->_strides);
   free(tensor);
@@ -270,11 +274,11 @@ void omTensorSetStrides(OMTensor *tensor, int64_t *strides) {
 }
 
 /* OMTensor data strides setter with PyArray stride values */
-void omTensorSetStridesWithPyArrayStrides(OMTensor *tensor,
-  int64_t *stridesInBytes) {
+void omTensorSetStridesWithPyArrayStrides(
+    OMTensor *tensor, int64_t *stridesInBytes) {
   for (int i = 0; i < tensor->_rank; i++)
     tensor->_strides[i] =
-      stridesInBytes[i] / getDataTypeSize(tensor->_dataType);
+        stridesInBytes[i] / getDataTypeSize(tensor->_dataType);
 }
 
 /* OMTensor data type getter */
@@ -368,7 +372,6 @@ OMTensor *omTensorCreateWithShape(std::vector<int64_t> shape) {
 
   /* Set flag for destructor */
   omt->_owning = true;
-
   return omt;
 }
 
@@ -386,8 +389,8 @@ OMTensor *omTensorCreateWithRandomData(
   if (omt == NULL)
     return NULL;
 
-  std::generate((T *)omt->_allocatedPtr,
-      (T *)omt->_allocatedPtr + getNumElems(omt->_shape, omt->_rank),
+  std::generate((T *)omt->_alignedPtr,
+      (T *)omt->_alignedPtr + getNumElems(omt->_shape, omt->_rank),
       [&]() { return dis(gen); });
   return omt;
 }
@@ -396,13 +399,13 @@ OMTensor *omTensorCreateWithRandomData(
 template <typename T>
 T &omTensorGetElem(OMTensor *omt, std::vector<int64_t> indexes) {
   int64_t elemOffset = omTensorComputeElemOffset(omt, indexes);
-  return ((T *)omt->_allocatedPtr)[elemOffset];
+  return ((T *)omt->_alignedPtr)[elemOffset];
 }
 
 /* Access an element (by reference) at linear offset */
 template <typename T>
 T &omTensorGetElemByOffset(OMTensor *omt, int64_t index) {
-  return ((T *)omt->_allocatedPtr)[index];
+  return ((T *)omt->_alignedPtr)[index];
 }
 
 /* Compute strides vector from shape vector */
@@ -454,7 +457,9 @@ inline bool omTensorAreTwoOmtsClose(
   auto anum = omTensorGetNumElems(a);
   auto bnum = omTensorGetNumElems(b);
   auto rtolT = omTensorCreateWithShape<T>(aShape);
+  assert(rtolT && "failed to allocate memory");
   auto atolT = omTensorCreateWithShape<T>(aShape);
+  assert(atolT && "failed to allocate memory");
   for (const auto &idx : omTensorComputeIndexSet(rtolT)) {
     omTensorGetElem<T>(rtolT, idx) = rtol;
     omTensorGetElem<T>(atolT, idx) = atol;
@@ -462,27 +467,25 @@ inline bool omTensorAreTwoOmtsClose(
   std::vector<T> absoluteDiff(anum);
   std::vector<T> eqAllclose(anum);
   // abs(a - b)
-  std::transform((T *)a->_allocatedPtr, (T *)a->_allocatedPtr + anum,
-      (T *)b->_allocatedPtr, absoluteDiff.begin(), std::minus<>());
+  std::transform((T *)a->_alignedPtr, (T *)a->_alignedPtr + anum,
+      (T *)b->_alignedPtr, absoluteDiff.begin(), std::minus<>());
   std::transform(absoluteDiff.begin(), absoluteDiff.end(), absoluteDiff.begin(),
       static_cast<T (*)(T)>(&std::abs));
   // rtol * abs(b)
-  std::transform((T *)b->_allocatedPtr, (T *)b->_allocatedPtr + bnum,
-      (T *)b->_allocatedPtr, static_cast<T (*)(T)>(&std::abs));
-  std::transform((T *)b->_allocatedPtr, (T *)b->_allocatedPtr + bnum,
-      (T *)rtolT->_allocatedPtr, eqAllclose.begin(), std::multiplies<>());
+  std::transform((T *)b->_alignedPtr, (T *)b->_alignedPtr + bnum,
+      (T *)b->_alignedPtr, static_cast<T (*)(T)>(&std::abs));
+  std::transform((T *)b->_alignedPtr, (T *)b->_alignedPtr + bnum,
+      (T *)rtolT->_alignedPtr, eqAllclose.begin(), std::multiplies<>());
   // rtol * abs(b) + atol
-  std::transform(eqAllclose.begin(), eqAllclose.end(),
-      (T *)atolT->_allocatedPtr, eqAllclose.begin(), std::plus<>());
+  std::transform(eqAllclose.begin(), eqAllclose.end(), (T *)atolT->_alignedPtr,
+      eqAllclose.begin(), std::plus<>());
   // (rtol * b + atol) - abs(a - b)
   std::transform(eqAllclose.begin(), eqAllclose.end(), absoluteDiff.begin(),
       eqAllclose.begin(), std::minus<>());
   bool satisfied = std::all_of(
       eqAllclose.begin(), eqAllclose.end(), [&](T eq) { return eq >= 0; });
 
-  if (satisfied) {
-    return true;
-  } else {
+  if (!satisfied) {
     // Figure out where and what went wrong, this can be slow; but hopefully we
     // don't need this often.
     for (const auto &idx : omTensorComputeIndexSet(a)) {
@@ -500,8 +503,10 @@ inline bool omTensorAreTwoOmtsClose(
         std::cerr << "] = " << bElem << std::endl;
       }
     }
-    return false;
   }
+  omTensorDestroy(rtolT);
+  omTensorDestroy(atolT);
+  return satisfied;
 }
 
 // Explicit instantiation of all templated API functions.
@@ -520,8 +525,7 @@ template OMTensor *omTensorCreateWithRandomData<float>(
 template OMTensor *omTensorCreateWithRandomData<double>(
     std::vector<int64_t> shape, double lbound, double ubound);
 
-template bool &omTensorGetElem<bool>(
-    OMTensor *, std::vector<int64_t> indexes);
+template bool &omTensorGetElem<bool>(OMTensor *, std::vector<int64_t> indexes);
 template int32_t &omTensorGetElem<int32_t>(
     OMTensor *, std::vector<int64_t> indexes);
 template int64_t &omTensorGetElem<int64_t>(


### PR DESCRIPTION
Turns out that there was a mixup between allocated ptr and aligned in the runtime, and for some reason, small dimensions were triggering a tensor where the two pointers where not the same.

Fixed also a memory leak in `omTensorAreTwoOmtsClose`