### PR TITLE
Add shape inference pass option to analyze all functions

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -232,13 +232,14 @@ private:
     return RankedTensorType::get(tensor_dims, elementType);
   }
 
-  Type ConvertOnnxType(const std::string &onnx_name) {
-    auto it = value_info_map.find(onnx_name);
-    if (it != value_info_map.end()) {
-      return ImportTensorType(it->second);
-    } else {
-      return builder_.getNoneType();
+  llvm::Optional<Type> ConvertOnnxType(const std::string &onnx_name) {
+    if (options_.useOnnxModelTypes) {
+      auto it = value_info_map.find(onnx_name);
+      if (it != value_info_map.end()) {
+        return llvm::Optional<Type>(ImportTensorType(it->second));
+      }
     }
+    return llvm::Optional<Type>();
   }
 
   /*!
@@ -531,8 +532,8 @@ private:
       // Optional outputs using empty string.
       if (node.output()[i].empty()) {
         outputTypes.emplace_back(builder_.getNoneType());
-      } else if (options_.useOnnxModelTypes) {
-        outputTypes.emplace_back(ConvertOnnxType(node.output(i)));
+      } else if (auto onnxModelType = ConvertOnnxType(node.output(i))) {
+        outputTypes.emplace_back(onnxModelType.getValue());
       } else {
         auto j = i;
         // Variadic output is a single ODS result.
@@ -589,13 +590,15 @@ private:
         }
       }
     }
-    if (!options_.useOnnxModelTypes)
-      if (auto opWithTypeInference =
-              dyn_cast<ResultTypeInferenceOpInterface>(genericOp)) {
-        auto outTypes = opWithTypeInference.resultTypeInference();
-        for (int i = 0; i < node.output().size(); i++)
+    if (auto opWithTypeInference =
+            dyn_cast<ResultTypeInferenceOpInterface>(genericOp)) {
+      auto outTypes = opWithTypeInference.resultTypeInference();
+      for (int i = 0; i < node.output().size(); i++) {
+        auto result = genericOp->getOpResult(i);
+        if (!options_.useOnnxModelTypes || result.getType().isa<NoneType>())
           genericOp->getOpResult(i).setType(outTypes[i]);
       }
+    }
 
     for (const auto &output : llvm::enumerate(node.output()))
       frontend_symbols_.AddMapping(

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -22,7 +22,8 @@ class Pass;
 /// Pass for rewriting inside frontend dialect.
 std::unique_ptr<Pass> createDecomposeONNXToONNXPass();
 
-std::unique_ptr<Pass> createShapeInferencePass();
+std::unique_ptr<Pass> createShapeInferencePass(
+    bool analyzeAllFunctions = false);
 
 std::unique_ptr<Pass> createConstPropONNXToONNXPass();
 

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -8,11 +8,17 @@
 
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
 
 #include "onnx/defs/function.h"
 #include "onnx/defs/schema.h"
 
 #include "src/Builder/FrontendDialectTransformer.hpp"
+
+#include "src/Interface/ShapeInferenceOpInterface.hpp"
+#include "src/Pass/Passes.hpp"
 
 using namespace std;
 using namespace ONNX_NAMESPACE;
@@ -56,10 +62,20 @@ void check(ModelProto &model) {
   options.useOnnxModelTypes = true;
   onnx_mlir::ImportFrontendModel(model, context, module, options);
 
-  // TODO: use result?
-  mlir::LogicalResult res = module->verify();
-  module->dump();
-  std::cerr << std::endl;
+  mlir::PassManager pm(&context, mlir::OpPassManager::Nesting::Implicit);
+  pm.addPass(mlir::createShapeInferencePass(true));
+  mlir::applyPassManagerCLOptions(pm);
+  if (mlir::failed(pm.run(*module))) {
+    module->dump();
+    std::cerr << "Error applying shape inference!\n";
+    return;
+  }
+
+  if (mlir::failed(module->verify())) {
+    module->dump();
+    std::cerr << "Error verifying module!\n";
+    return;
+  }
 }
 
 void testCustomFunTranslation() {
@@ -77,26 +93,23 @@ void testCustomFunTranslation() {
 
   auto *x = graph->add_input();
   x->set_name("x");
-  x->mutable_type()->mutable_tensor_type()->set_elem_type(elt_type);
+  auto *x_type = x->mutable_type()->mutable_tensor_type();
+  x_type->set_elem_type(elt_type);
+  auto *x_shape = x_type->mutable_shape();
+  x_shape->add_dim()->set_dim_value(10);
 
   auto *y = graph->add_output();
   y->set_name("y");
-  y->mutable_type()->mutable_tensor_type()->set_elem_type(elt_type);
+  auto *y_type = y->mutable_type()->mutable_tensor_type();
+  y_type->set_elem_type(elt_type);
+  auto *y_shape = y_type->mutable_shape();
+  y_shape->add_dim()->set_dim_value(10);
 
   auto *node = graph->add_node();
   node->add_input("x");
   node->add_output("y");
   node->set_op_type("SquareFn");
   node->set_name("node1");
-
-  auto *t = graph->add_value_info();
-  t->set_name("t");
-  t->mutable_type()->mutable_tensor_type()->set_elem_type(elt_type);
-
-  node = graph->add_node();
-  node->add_input("x");
-  node->add_output("t");
-  node->set_op_type("SquareFn");
 
   check(model_proto);
 }


### PR DESCRIPTION
(Closing PR #723 and recreating it due to signoff/DCO issues.)

A couple of fixes to enable the translation of ONNX functions using MLIR functions:

(a) The existing shape-inference pass has a hack that checks if the module contains any function with a name matching the pattern "[a-zA-Z0-9_]*main_graph" and, if so, restricts inference to those functions. Adding an option analyzeAllFunctions to skip this filter, since when translating ONNX functions into MLIR functions it is useful to apply shape-inference to all functions (even though it has a main_graph). Also, allow function-calls in code being checked.

(b) Refine the translation process when using the option useOnnxModelTypes (which enables the translator to use type-information contained in the input model during translation) to use the resultTypeInference method if the input model doesn't contain type information.