### PR TITLE
Resize Op with static shape and constant scales

### DIFF
--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -35,6 +35,7 @@ add_onnx_mlir_library(OMONNXToKrnl
   Tensor/Size.cpp
   Tensor/Flatten.cpp
   Tensor/Tile.cpp
+  Tensor/Resize.cpp
   ConvertONNXToKrnl.cpp
 
   LINK_LIBS PUBLIC

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -173,6 +173,7 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   populateLoweringONNXSizeOpPattern(patterns, &getContext());
   populateLoweringONNXTileOpPattern(patterns, &getContext());
   populateLoweringONNXFlattenOpPattern(patterns, &getContext());
+  populateLoweringONNXResizeOpPattern(patterns, &getContext());
   // Neural network
   populateLoweringONNXConvOpPattern(patterns, &getContext());
   populateLoweringONNXNormalizationOpPattern(patterns, &getContext());

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -323,6 +323,9 @@ void populateLoweringONNXTileOpPattern(
 void populateLoweringONNXFlattenOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx);
 
+void populateLoweringONNXResizeOpPattern(
+    RewritePatternSet &patterns, MLIRContext *ctx);
+
 bool checkOpResultIsUsedByGetRef(memref::AllocOp *allocOp);
 
 /// This function returns the index in the list of alloc arguments of the

--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -44,13 +44,14 @@ struct ONNXResizeOpLowering : public ConversionPattern {
     if (hasAllConstantDimensions(memRefType))
       alloc = insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc);
     else
-      llvm_unreachable("unknown shape for output");
+      // TODO: handle dynamic shape in alloc
+      return emitError(loc, "unknown shape for output");
 
     // Get the scales
     DenseElementsAttr scalesAttrs =
         getDenseElementAttributeFromONNXValue(resizeOp.scales());
     if (!scalesAttrs)
-      llvm_unreachable("Not implemented yet");
+      return emitError(loc, "Not implemented yet");
     SmallVector<float, 4> scalesConstant;
     for (auto scaleAttr : scalesAttrs.getValues<FloatAttr>()) {
       scalesConstant.emplace_back(scaleAttr.getValueAsDouble());

--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -62,12 +62,18 @@ struct ONNXResizeOpLowering : public ConversionPattern {
     SmallVector<Value, 4> writeIndices;
     for (decltype(rank) i = 0; i < rank; ++i) {
       Value outIndex = outputLoops.getInductionVar(i);
-      Value outIndexInteger = rewriter.create<IndexCastOp>(loc, outIndex, rewriter.getIntegerType(64));
-      Value outIndexFloat = rewriter.create<SIToFPOp>(loc, rewriter.getF32Type(), outIndexInteger);
-      Value scaleVal = emitConstantOp(rewriter, loc, rewriter.getF32Type(), scalesConstant[i]);
-      Value inIndexFloat = rewriter.create<DivFOp>(loc, outIndexFloat, scaleVal);
-      Value inIndexInteger = rewriter.create<FPToSIOp>(loc, rewriter.getIntegerType(64), inIndexFloat);
-      Value inIndex = rewriter.create<IndexCastOp>(loc, rewriter.getIndexType(), inIndexInteger);
+      Value outIndexInteger = rewriter.create<IndexCastOp>(
+          loc, outIndex, rewriter.getIntegerType(64));
+      Value outIndexFloat = rewriter.create<SIToFPOp>(
+          loc, rewriter.getF32Type(), outIndexInteger);
+      Value scaleVal = emitConstantOp(
+          rewriter, loc, rewriter.getF32Type(), scalesConstant[i]);
+      Value inIndexFloat =
+          rewriter.create<DivFOp>(loc, outIndexFloat, scaleVal);
+      Value inIndexInteger = rewriter.create<FPToSIOp>(
+          loc, rewriter.getIntegerType(64), inIndexFloat);
+      Value inIndex = rewriter.create<IndexCastOp>(
+          loc, rewriter.getIndexType(), inIndexInteger);
       readIndices.emplace_back(inIndex);
       writeIndices.emplace_back(outIndex);
     }

--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------------- Resize.cpp - Lowering Resize Op
+//-------------------===//
+//
+// Copyright 2019 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file lowers the ONNX Resize Operator to Krnl dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+
+using namespace mlir;
+
+struct ONNXResizeOpLowering : public ConversionPattern {
+  ONNXResizeOpLowering(MLIRContext *ctx)
+      : ConversionPattern(mlir::ONNXResizeOp::getOperationName(), 1, ctx) {}
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const final {
+    // Gather info.
+    Location loc = op->getLoc();
+    Value alloc;
+    bool insertDealloc = checkInsertDealloc(op);
+    ONNXResizeOp sizeOp = llvm::dyn_cast<ONNXResizeOp>(op);
+
+    ONNXResizeOpAdaptor operandAdaptor(operands);
+    Value data = operandAdaptor.X();
+    ArrayRef<int64_t> dataShape = data.getType().cast<MemRefType>().getShape();
+
+    MemRefType memRefType = convertToMemRefType(*op->result_type_begin());
+    int64_t rank = memRefType.getShape().size();
+
+    if (hasAllConstantDimensions(memRefType))
+      alloc = insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc);
+    else
+      llvm_unreachable("unknown shape for output");
+
+    // Get the scales
+    ONNXResizeOp resizeOp = llvm::cast<ONNXResizeOp>(op);
+    DenseElementsAttr scalesAttrs =
+        getDenseElementAttributeFromONNXValue(resizeOp.scales());
+    if (!scalesAttrs)
+      llvm_unreachable("Not implemented yet");
+    SmallVector<float, 4> scalesConstant;
+    for (auto scaleAttr : scalesAttrs.getValues<FloatAttr>()) {
+      scalesConstant.emplace_back(scaleAttr.getValueAsDouble());
+    }
+
+    // Create loops
+    BuildKrnlLoop outputLoops(rewriter, loc, rank);
+    outputLoops.createDefineAndIterateOp(alloc);
+    rewriter.setInsertionPointToStart(outputLoops.getIterateBlock());
+
+    // Loop body
+    SmallVector<Value, 4> readIndices;
+    SmallVector<Value, 4> writeIndices;
+    for (decltype(rank) i = 0; i < rank; ++i) {
+      Value outIndex = outputLoops.getInductionVar(i);
+      Value outIndexInteger = rewriter.create<IndexCastOp>(loc, outIndex, rewriter.getIntegerType(64));
+      Value outIndexFloat = rewriter.create<SIToFPOp>(loc, rewriter.getF32Type(), outIndexInteger);
+      Value scaleVal = emitConstantOp(rewriter, loc, rewriter.getF32Type(), scalesConstant[i]);
+      Value inIndexFloat = rewriter.create<DivFOp>(loc, outIndexFloat, scaleVal);
+      Value inIndexInteger = rewriter.create<FPToSIOp>(loc, rewriter.getIntegerType(64), inIndexFloat);
+      Value inIndex = rewriter.create<IndexCastOp>(loc, rewriter.getIndexType(), inIndexInteger);
+      readIndices.emplace_back(inIndex);
+      writeIndices.emplace_back(outIndex);
+    }
+    Value loadVal = rewriter.create<KrnlLoadOp>(loc, data, readIndices);
+    rewriter.create<KrnlStoreOp>(loc, loadVal, alloc, writeIndices);
+    loadVal.dump();
+
+    rewriter.replaceOp(op, alloc);
+    return success();
+  }
+};
+
+void populateLoweringONNXResizeOpPattern(
+    RewritePatternSet &patterns, MLIRContext *ctx) {
+  patterns.insert<ONNXResizeOpLowering>(ctx);
+}

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -2493,6 +2493,46 @@ LogicalResult ONNXFlattenOp::inferShapes(
 }
 
 //===----------------------------------------------------------------------===//
+// Resize
+//===----------------------------------------------------------------------===//
+
+LogicalResult ONNXResizeOp::inferShapes(
+    std::function<void(mlir::Region &)> doShapeInference) {
+  if (!X().getType().isa<RankedTensorType>()) {
+    return emitError("X tensor has to be ranked in current implementation");
+  }
+  auto inputTy = X().getType().cast<RankedTensorType>();
+
+  if (isFromNone(scales()) == isFromNone(sizes())) {
+    return emitError("scales() and sizes() can not both None/not None");
+  }
+
+  // Current implementation handles constant scales only
+  DenseElementsAttr scalesAttrs =
+      getDenseElementAttributeFromONNXValue(scales());
+  if (!scalesAttrs)
+    return emitError("Not implemented yet");
+
+  SmallVector<float, 4> scalesConstant;
+  for (auto scaleAttr : scalesAttrs.getValues<FloatAttr>()) {
+    scalesConstant.emplace_back(scaleAttr.getValueAsDouble());
+  }
+
+  SmallVector<int64_t, 4> dims;
+  for (int i = 0; i < inputTy.getRank(); i++) {
+    int newDim;
+    if (inputTy.getShape()[i] == -1)
+      newDim = -1;
+    else
+      newDim = inputTy.getShape()[i] * scalesConstant[i];
+    dims.emplace_back(newDim);
+  }
+
+  getResult().setType(RankedTensorType::get(dims, inputTy.getElementType()));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // DynamicQuantizeLinear
 //===----------------------------------------------------------------------===//
 
@@ -3324,11 +3364,6 @@ LogicalResult ONNXReduceLogSumExpOp::inferShapes(
 }
 
 LogicalResult ONNXReduceSumSquareOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
-  return emitError(NOT_IMPLEMENTED_MESSAGE);
-}
-
-LogicalResult ONNXResizeOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1747,3 +1747,24 @@ func @test_scan_simple_main_graph(%arg0: tensor<2xf32>, %arg1: tensor<3x2xf32>) 
 // CHECK:         }
 // CHECK:       }
 }
+
+
+// -----
+//===----------------------------------------------------------------------===//
+
+// Test Resize
+
+func @test_resize1(%arg0 : tensor<3x4x5x6xf32>) -> tensor<*xf32> {
+    %cst = constant unit
+    %0 = "onnx.Constant"() {value = dense<[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<8xf32>} : () -> tensor<8xf32>
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %cst) {coordinate_transformation_mode = "asymmetric", mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize1"} : (tensor<3x4x5x6xf32>, tensor<8xf32>, tensor<4xf32>, none) -> tensor<*xf32>
+    "std.return"(%2) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL: @test_resize1
+// CHECK-SAME: ([[ARG:%.+]]: tensor<3x4x5x6xf32>) -> tensor<3x4x10x12xf32> {
+// CHECK: [[CST:%.+]] = constant unit
+// CHECK: [[R0:%.+]] = "onnx.Constant"() {value = dense<[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<8xf32>} : () -> tensor<8xf32>
+// CHECK: [[R1:%.+]] = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+// CHECK: [[R2:%.+]] = "onnx.Resize"([[ARG]], [[R0]], [[R1]], [[CST]]) {coordinate_transformation_mode = "asymmetric", mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize1"} : (tensor<3x4x5x6xf32>, tensor<8xf32>, tensor<4xf32>, none) -> tensor<3x4x10x12xf32>
+}


### PR DESCRIPTION
This PR support shape inference and lowering for Resize Op with static shape and constant scales.  Only the nearest mode is supported. 

1. Shape inference. Use `output_dimension = floor(input_dimension * (roi_end - roi_start) * scale) if input "sizes" is not specified.` to compute the output_dimension. The standard says `It (roi) only takes effect when coordinate_transformation_mode is "tf_crop_and_resize"`. Current implementation is for "asymmetric" and rio_end and rio_start are ignored.
2. In lowering, the index is computed as 
```
if coordinate_transformation_mode is "asymmetric", 
x_original = x_resized / scale, 
```
3. examples from standard:
resize_downsample_scales_nearest and resize_upsample_scales_nearest
Please note that in resize_downsample_scales_nearest, for the last dimension, when x_resized = 1 and scale = 0.6, the x_original is 2, not 1. Need to figure out why.
4. The targeted model may have dynamic shape input tensor for Resize. It seems that IndexExpr should be used to handle the dynamic shape. @AlexandreEichenberger  There are float and integer type casting for index computation in Resize. Can IndexExpr handle those operations?
