### PR TITLE
Handle dynamic input of Resize Op

### DIFF
--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -31,32 +31,49 @@ struct ONNXResizeOpLowering : public ConversionPattern {
     ONNXResizeOp resizeOp = llvm::cast<ONNXResizeOp>(op);
     ONNXResizeOpAdaptor operandAdaptor(operands);
     Value data = operandAdaptor.X();
+    Value scales = operandAdaptor.scales();
+    MemRefType memRefType = convertToMemRefType(*op->result_type_begin());
+    int64_t rank = memRefType.getShape().size();
 
+
+#if 0
     // Check implementation constraints
     if (resizeOp.mode() != "nearest" ||
         resizeOp.coordinate_transformation_mode() != "asymmetric" ||
         resizeOp.nearest_mode() != "floor")
       llvm_unreachable("not implemented yet");
+#endif
 
     // Get the scales
+    SmallVector<Value, 4> scaleValues;
     DenseElementsAttr scalesAttrs =
         getDenseElementAttributeFromONNXValue(resizeOp.scales());
-    if (!scalesAttrs)
-      return emitError(loc, "Not implemented yet");
     SmallVector<float, 4> scalesConstant;
-    for (auto scaleAttr : scalesAttrs.getValues<FloatAttr>()) {
-      scalesConstant.emplace_back(scaleAttr.getValueAsDouble());
+    if (scalesAttrs) {
+      for (auto scaleAttr : scalesAttrs.getValues<FloatAttr>()) {
+        Value scaleConstant = emitConstantOp(
+            rewriter, loc, rewriter.getF32Type(), scaleAttr.getValueAsDouble());
+        scaleValues.emplace_back(scaleConstant);
+      }
+    } else {
+      for (decltype(rank) i = 0; i < rank; i++) {
+        Value indexValue = emitConstantOp(
+            rewriter, loc, rewriter.getIndexType(), i);
+        SmallVector<Value, 1> loadIndex;
+        loadIndex.emplace_back(indexValue);
+        Value scaleVal = rewriter.create<KrnlLoadOp>(loc, scales, loadIndex);
+        scaleValues.emplace_back(scaleVal);
+      }
     }
 
-    MemRefType memRefType = convertToMemRefType(*op->result_type_begin());
-    int64_t rank = memRefType.getShape().size();
+    IndexExprScope outerloopContex(&rewriter, loc);
+    DimsExpr outputDims(rank);
+    MemRefBoundsIndexCapture dataBounds(data);
+    ArrayValueIndexCapture scaleIEs(op, resizeOp.scales(), getDenseElementAttributeFromKrnlValue, loadDenseElementArrayValueAtIndex);
 
     if (hasAllConstantDimensions(memRefType))
       alloc = insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc);
     else {
-      IndexExprScope outerloopContex(&rewriter, loc);
-      DimsExpr outputDims(rank);
-      MemRefBoundsIndexCapture dataBounds(data);
       for (decltype(rank) i = 0; i < rank; i++) {
         if (memRefType.getShape()[i] != -1) {
 	  outputDims[i] = LiteralIndexExpr(memRefType.getShape()[i]);
@@ -66,10 +83,8 @@ struct ONNXResizeOpLowering : public ConversionPattern {
               loc, inputDim, rewriter.getIntegerType(64));
           Value inputDimFloat = rewriter.create<SIToFPOp>(
               loc, rewriter.getF32Type(), inputDimInteger);
-          Value scaleVal = emitConstantOp(
-              rewriter, loc, rewriter.getF32Type(), scalesConstant[i]);
           Value outputDimFloat = rewriter.create<MulFOp>(
-              loc, inputDimFloat, scaleVal);         
+              loc, inputDimFloat, scaleValues[i]);         
           Value outputDimInteger = rewriter.create<FPToSIOp>(
               loc, rewriter.getIntegerType(64), outputDimFloat);
           Value outDim = rewriter.create<IndexCastOp>(
@@ -95,10 +110,8 @@ struct ONNXResizeOpLowering : public ConversionPattern {
           loc, outIndex, rewriter.getIntegerType(64));
       Value outIndexFloat = rewriter.create<SIToFPOp>(
           loc, rewriter.getF32Type(), outIndexInteger);
-      Value scaleVal = emitConstantOp(
-          rewriter, loc, rewriter.getF32Type(), scalesConstant[i]);
       Value inIndexFloat =
-          rewriter.create<DivFOp>(loc, outIndexFloat, scaleVal);
+          rewriter.create<DivFOp>(loc, outIndexFloat, scaleValues[i]);
       Value inIndexInteger = rewriter.create<FPToSIOp>(
           loc, rewriter.getIntegerType(64), inIndexFloat);
       Value inIndex = rewriter.create<IndexCastOp>(

--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -128,9 +128,8 @@ struct ONNXResizeOpLowering : public ConversionPattern {
               rewriter, loc, rewriter.getF32Type(), 0.4999999999);
           inIndexFloat =
               rewriter.create<AddFOp>(loc, inIndexFloat, deltaConstant);
-        } else if (resizeOp.nearest_mode() == "round_prefer_floor") {
-          inIndexFloat =
-              rewriter.create<FloorFOp>(loc, inIndexFloat);
+        } else if (resizeOp.nearest_mode() == "floor") {
+          inIndexFloat = rewriter.create<FloorFOp>(loc, inIndexFloat);
         }
         Value inIndexInteger = rewriter.create<FPToSIOp>(
             loc, rewriter.getIntegerType(64), inIndexFloat);
@@ -158,9 +157,8 @@ struct ONNXResizeOpLowering : public ConversionPattern {
               rewriter, loc, rewriter.getF32Type(), 0.4999999999);
           inIndexFloat =
               rewriter.create<AddFOp>(loc, inIndexFloat, deltaConstant);
-        } else if (resizeOp.nearest_mode() == "round_prefer_floor") {
-          inIndexFloat =
-              rewriter.create<FloorFOp>(loc, inIndexFloat);
+        } else if (resizeOp.nearest_mode() == "floor") {
+          inIndexFloat = rewriter.create<FloorFOp>(loc, inIndexFloat);
         }
         Value inIndexInteger = rewriter.create<FPToSIOp>(
             loc, rewriter.getIntegerType(64), inIndexFloat);

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -122,7 +122,7 @@ computations derived before the loop to compute the output bounds/shape of the
 loop iterations.
 
 When all the computations in a) are constant or affine, then the same
-IndexExprContext can be reused between a) and b). It is recommended as it
+IndexExprScope can be reused between a) and b). It is recommended as it
 enables bigger AffineExpr. But when the computations in a) are not affine, then
 a new scope can be started for the b) part. The non-affine parts of a)
 becomes symbols.
@@ -143,11 +143,11 @@ also means that one can only geneate code in one index scope at a time.
 
     // During shape inference: no rewriter.
 
-    IndexExprContext scope(nullptr, getLoc());
+    IndexExprScope scope(nullptr, getLoc());
 
     // During lowering.
 
-    IndexExprContext outerloopContex(&rewriter, sliceOp.getLoc());
+    IndexExprScope outerloopContex(&rewriter, sliceOp.getLoc());
 
 3b) Computations on IndexExpr (examples from processing of ONNXSliceOp)
 
@@ -212,7 +212,7 @@ compile time sizes, -1 for runtime sizes).
 
     // Create a sub-scope for computations inside the loop iteration.
 
-    IndexExprContext childContext(outerloopContex);
+    IndexExprScope childContext(outerloopContex);
 
     // Create indices with computations for a load.
 

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -2511,9 +2511,11 @@ LogicalResult ONNXResizeOp::inferShapes(
     return emitError("using sizes() not implemented yet");
   }
 
-  if (!(mode() == "nearest" && (coordinate_transformation_mode() == "half_pixel" 
-      || coordinate_transformation_mode() == "asymmetric"))) {
-    return emitError("these modes() or coordinate_transformation_mode() not supported yet");
+  if (!(mode() == "nearest" &&
+          (coordinate_transformation_mode() == "half_pixel" ||
+              coordinate_transformation_mode() == "asymmetric"))) {
+    return emitError(
+        "these modes() or coordinate_transformation_mode() not supported yet");
   }
 
   // Current implementation handles constant scales only

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -613,6 +613,8 @@ test_to_enable_static_dynamic = {
     "test_reshape_zero_dim_cpu": (test_static_dynamic,{0:{-1}}),
 
     # Resize
+    "test_resize_upsample_scales_nearest_cpu": (test_static_dynamic, {0:{-1}}),
+    "test_resize_downsample_scales_nearest_cpu": (test_static_dynamic, {0:{-1}}),
 
     # Reverse Sequence
 

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -2360,28 +2360,30 @@ func @test_resize1(%arg0 : tensor<3x4xf32>) -> tensor<*xf32> {
     %1 = "onnx.Constant"() {value = dense<[1.000000e+00,  3.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
     %2 = "onnx.Resize"(%arg0, %0, %1, %cst) {coordinate_transformation_mode = "asymmetric", mode = "nearest", nearest_mode = "floor"} : (tensor<3x4xf32>, tensor<4xf32>, tensor<2xf32>, none) -> tensor<*xf32>
     "std.return"(%2) : (tensor<*xf32>) -> ()
-// CHECK-LABEL:       func @test_resize1
+// CHECK-LABEL:       func @test_resize1       
 // CHECK-SAME:     ([[VAR_arg0:%.+]]: memref<3x4xf32>) -> memref<3x12xf32> {
 // CHECK:           [[VAR_0:%.+]] = memref.alloc() : memref<3x12xf32>
 // CHECK:           [[VAR_cst:%.+]] = constant unit
 // CHECK:           [[VAR_1:%.+]] = "krnl.global"() {name = "constant_0", shape = [4], value = dense<[0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
 // CHECK:           [[VAR_2:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1.000000e+00, 3.000000e+00]> : tensor<2xf32>} : () -> memref<2xf32>
+// CHECK:           [[VAR_cst_0:%.+]] = constant 1.000000e+00 : f32
+// CHECK:           [[VAR_cst_1:%.+]] = constant 3.000000e+00 : f32
 // CHECK:           [[VAR_3:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[VAR_3]]#0, [[VAR_3]]#1) with ([[VAR_3]]#0 -> [[VAR_arg1:%.+]] = 0 to 3, [[VAR_3]]#1 -> [[VAR_arg2:%.+]] = 0 to 12) {
 // CHECK:             [[VAR_4:%.+]] = index_cast [[VAR_arg1]] : index to i64
 // CHECK:             [[VAR_5:%.+]] = sitofp [[VAR_4]] : i64 to f32
-// CHECK:             [[VAR_cst_0:%.+]] = constant 1.000000e+00 : f32
 // CHECK:             [[VAR_6:%.+]] = divf [[VAR_5]], [[VAR_cst_0]] : f32
-// CHECK:             [[VAR_7:%.+]] = fptosi [[VAR_6]] : f32 to i64
-// CHECK:             [[VAR_8:%.+]] = index_cast [[VAR_7]] : i64 to index
-// CHECK:             [[VAR_9:%.+]] = index_cast [[VAR_arg2]] : index to i64
-// CHECK:             [[VAR_10:%.+]] = sitofp [[VAR_9]] : i64 to f32
-// CHECK:             [[VAR_cst_1:%.+]] = constant 3.000000e+00 : f32
-// CHECK:             [[VAR_11:%.+]] = divf [[VAR_10]], [[VAR_cst_1]] : f32
-// CHECK:             [[VAR_12:%.+]] = fptosi [[VAR_11]] : f32 to i64
-// CHECK:             [[VAR_13:%.+]] = index_cast [[VAR_12]] : i64 to index
-// CHECK:             [[VAR_14:%.+]] = krnl.load [[VAR_arg0]]{{.}}[[VAR_8]], [[VAR_13]]{{.}} : memref<3x4xf32>
-// CHECK:             krnl.store [[VAR_14]], [[VAR_0]]{{.}}[[VAR_arg1]], [[VAR_arg2]]{{.}} : memref<3x12xf32>
+// CHECK:             [[VAR_7:%.+]] = floorf [[VAR_6]] : f32
+// CHECK:             [[VAR_8:%.+]] = fptosi [[VAR_7]] : f32 to i64
+// CHECK:             [[VAR_9:%.+]] = index_cast [[VAR_8]] : i64 to index
+// CHECK:             [[VAR_10:%.+]] = index_cast [[VAR_arg2]] : index to i64
+// CHECK:             [[VAR_11:%.+]] = sitofp [[VAR_10]] : i64 to f32
+// CHECK:             [[VAR_12:%.+]] = divf [[VAR_11]], [[VAR_cst_1]] : f32
+// CHECK:             [[VAR_13:%.+]] = floorf [[VAR_12]] : f32
+// CHECK:             [[VAR_14:%.+]] = fptosi [[VAR_13]] : f32 to i64
+// CHECK:             [[VAR_15:%.+]] = index_cast [[VAR_14]] : i64 to index
+// CHECK:             [[VAR_16:%.+]] = krnl.load [[VAR_arg0]]{{.}}[[VAR_9]], [[VAR_15]]{{.}} : memref<3x4xf32>
+// CHECK:             krnl.store [[VAR_16]], [[VAR_0]]{{.}}[[VAR_arg1]], [[VAR_arg2]]{{.}} : memref<3x12xf32>
 // CHECK:           }
 // CHECK:           return [[VAR_0]] : memref<3x12xf32>
 }


### PR DESCRIPTION
This PR handles non-constant scales() and unknown size of input data X().
Extend the implementation to handle nearest_mode() == "round_prefer_floor" and coordinate_transformation_mode() == "half_pixel", the default value for the optional attributes. With these support, some backend test for resize in onnx can be passed. 
IndexExpr utilities are used and mixed with std ops due to the type conversions. The IndexExpr code is directly added in lowering currently. 