### PR TITLE
Handle scalar attributes in constprop

### DIFF
--- a/src/Transform/ONNX/ConstPropHelper.cpp
+++ b/src/Transform/ONNX/ConstPropHelper.cpp
@@ -140,8 +140,15 @@ DenseElementsAttr createDenseElementsAttrFromArray(char *arr, Type outputType) {
   int64_t sizeInBytes = getSizeInBytes(outputType);
   RankedTensorType resType =
       constructRankedTensorType(outputType.cast<ShapedType>());
+  bool isSplat;
+  if (resType.getShape().size() == 0)
+    isSplat = true;
+  else if (resType.getShape().size() == 1 && resType.getShape()[0] == 1)
+    isSplat = true;
+  else
+    isSplat = false;
   return DenseElementsAttr::getFromRawBuffer(
-      resType, ArrayRef<char>(arr, sizeInBytes), /*isSplat=*/false);
+      resType, ArrayRef<char>(arr, sizeInBytes), /*isSplat=*/isSplat);
 }
 
 /// Create a dense ONNXConstantOp from a byte array.

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1,5 +1,53 @@
 // RUN: onnx-mlir-opt --shape-inference --constprop-onnx %s -split-input-file | FileCheck %s
 
+//===----------------------------------------------------------------------===//
+// Common tests. Use ONNXAddOp as example.
+
+// -----
+
+// CHECK-LABEL: @test_scalar_attr() -> tensor<f32>
+func @test_scalar_attr() -> tensor<f32> {
+  %0 = "onnx.Constant"() {value = dense<1.0> : tensor<f32>} : () -> tensor<f32>
+  %1 = "onnx.Constant"() {value = dense<2.0> : tensor<f32>} : () -> tensor<f32>
+  %2 = "onnx.Add"(%0, %1) : (tensor<f32> , tensor<f32>) -> tensor<f32>
+  "std.return"(%2) : (tensor<f32>) -> ()
+  // CHECK: [[CONST:%.+]] = "onnx.Constant"() {value = dense<3.000000e+00> : tensor<f32>} : () -> tensor<f32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_single_value_attr() -> tensor<1xf32>
+func @test_single_value_attr() -> tensor<1xf32> {
+  %0 = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %1 = "onnx.Constant"() {value = dense<[2.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %2 = "onnx.Add"(%0, %1) : (tensor<1xf32> , tensor<1xf32>) -> tensor<1xf32>
+  "std.return"(%2) : (tensor<1xf32>) -> ()
+  // CHECK: [[CONST:%.+]] = "onnx.Constant"() {value = dense<3.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_splat_attr() -> tensor<3xf32>
+func @test_splat_attr() -> tensor<3xf32> {
+  %0 = "onnx.Constant"() {value = dense<1.0> : tensor<3xf32>} : () -> tensor<3xf32>
+  %1 = "onnx.Constant"() {value = dense<2.0> : tensor<3xf32>} : () -> tensor<3xf32>
+  %2 = "onnx.Add"(%0, %1) : (tensor<3xf32> , tensor<3xf32>) -> tensor<3xf32>
+  "std.return"(%2) : (tensor<3xf32>) -> ()
+  // CHECK: [[CONST:%.+]] = "onnx.Constant"() {value = dense<3.000000e+00> : tensor<3xf32>} : () -> tensor<3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_splat_nonsplat_attrs() -> tensor<3xf32>
+func @test_splat_nonsplat_attrs() -> tensor<3xf32> {
+  %0 = "onnx.Constant"() {value = dense<1.0> : tensor<3xf32>} : () -> tensor<3xf32>
+  %1 = "onnx.Constant"() {value = dense<[0.0, 1.0, 2.0]> : tensor<3xf32>} : () -> tensor<3xf32>
+  %2 = "onnx.Add"(%0, %1) : (tensor<3xf32> , tensor<3xf32>) -> tensor<3xf32>
+  "std.return"(%2) : (tensor<3xf32>) -> ()
+  // CHECK: [[CONST:%.+]] = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>} : () -> tensor<3xf32>
+}
+
+// -----
 
 //===----------------------------------------------------------------------===//
 /// ADD tests 


### PR DESCRIPTION
This patch fixes an issue in constant propagation when creating a DenseElementsAttr whose type is scalar tensor using a raw buffer. For scalar tensor, we should mark the attribute with splat.

Resolves #733 

Signed-off-by: Tung D. Le <tung@jp.ibm.com>