### PR TITLE
Put aligned constants on the heap instead of the stack

### DIFF
--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -350,6 +350,7 @@ public:
     auto loc = op->getLoc();
 
     auto krnlGlobalOp = llvm::dyn_cast<KrnlGlobalOp>(op);
+    auto alignmentAttr = krnlGlobalOp.alignmentAttr();
 
     // Get module.
     ModuleOp module = op->getParentOfType<ModuleOp>();
@@ -434,62 +435,85 @@ public:
 
     // Prepare data to be inserted into MemRef.
     // If global needs alignment, we need to allocate a new buffer that is
-    // aligned. This is a region of local memory and needs to be emitted as an
-    // alloca.
+    // aligned.
     // - Otherwise, no preparation is needed, directly use the global.
-
-    int alignment = 0;
-    if (krnlGlobalOp.alignmentAttr())
-      alignment = krnlGlobalOp.alignmentAttr().getValue().getSExtValue();
-    Value typedGlobal;
 
     // Get the address of the global.
     Value globalValue = rewriter.create<LLVM::AddressOfOp>(loc, global);
-    auto llvmConstantElementType = constantElementType.cast<Type>();
+    auto globalPtrType =
+        LLVM::LLVMPointerType::get(constantElementType.cast<Type>());
 
-    if (alignment != 0) {
+    Value localValue, alignedLocalValue;
+    if (alignmentAttr && alignmentAttr.getValue().getSExtValue() != 0) {
       // Some frequently used types.
+      auto llvmVoidTy = LLVM::LLVMVoidType::get(context);
       auto llvmI8PtrTy =
           LLVM::LLVMPointerType::get(IntegerType::get(context, 8));
-      auto llvmI64Ty = IntegerType::get(context, 64);
-      auto one = rewriter.create<LLVM::ConstantOp>(
-          loc, llvmI64Ty, rewriter.getI64IntegerAttr(1));
-      Value alloc = rewriter.create<LLVM::AllocaOp>(loc,
-          LLVM::LLVMPointerType::get(llvmGlobalType), one,
-          /*alignment=*/alignment);
 
-      // Copy constant value into the local alloca:
-      //  - Bitcast alloc to i8*
-      Value int8PtrAlloc =
-          rewriter.create<LLVM::BitcastOp>(loc, llvmI8PtrTy, alloc);
+      // Compute allocation size.
+      Value alignment = createIndexConstant(
+          rewriter, loc, alignmentAttr.getValue().getSExtValue());
+      Value sizeBytes = createIndexConstant(rewriter, loc, sizeInBytes);
+      // Adjust the allocation size to consider alignment.
+      Value sizeBytesWithAligment =
+          rewriter.create<LLVM::AddOp>(loc, sizeBytes, alignment);
+
+      // Allocate a local buffer for the constant.
+      FlatSymbolRefAttr mallocSym = getOrInsertMalloc(rewriter, module);
+      Value i8PtrLocal = rewriter
+                             .create<LLVM::CallOp>(loc, llvmI8PtrTy, mallocSym,
+                                 ArrayRef<Value>(sizeBytesWithAligment))
+                             .getResult(0);
+
+      // Bitcast the local buffer to the MemRefType's element type.
+      localValue =
+          rewriter.create<LLVM::BitcastOp>(loc, globalPtrType, i8PtrLocal);
+
+      // Compute alignedPtr.
+      Type intPtrType = getIntPtrType(memRefTy.getMemorySpaceAsInt());
+      Value intPtrLocal =
+          rewriter.create<LLVM::PtrToIntOp>(loc, intPtrType, localValue);
+      Value intAlignment = createAligned(rewriter, loc, intPtrLocal, alignment);
+      alignedLocalValue =
+          rewriter.create<LLVM::IntToPtrOp>(loc, globalPtrType, intAlignment);
+
+      // Copy constant value into the local aligned buffer:
+      //  - Bitcast alignedPtr to i8*
+      Value i8AlignedPtrLocal =
+          rewriter.create<LLVM::BitcastOp>(loc, llvmI8PtrTy, alignedLocalValue);
       //  - Bitcast global to i8*
       Value i8PtrGlobal =
           rewriter.create<LLVM::BitcastOp>(loc, llvmI8PtrTy, globalValue);
-      //  - Set size.
-      Value totalElementsSize = rewriter.create<LLVM::ConstantOp>(
-          loc, llvmI64Ty, rewriter.getI64IntegerAttr(sizeInBytes));
-      Value int64Size =
-          rewriter.create<LLVM::SExtOp>(loc, llvmI64Ty, totalElementsSize);
       //  - Set volatile.
       Value isVolatile =
           rewriter.create<LLVM::ConstantOp>(loc, IntegerType::get(context, 1),
               rewriter.getIntegerAttr(rewriter.getIntegerType(1), 0));
-      //  - Copy constant data into the alloca.
-      auto memcpyRef = getOrInsertMemcpy(rewriter, module);
+      //  - Copy constant data into the local buffer.
+      FlatSymbolRefAttr memcpyRef = getOrInsertMemcpy(rewriter, module);
       rewriter.create<CallOp>(loc, memcpyRef, ArrayRef<Type>({}),
-          ArrayRef<Value>({int8PtrAlloc, i8PtrGlobal, int64Size, isVolatile}));
-      //  - Use the allocated buffer.
-      typedGlobal = rewriter.create<LLVM::BitcastOp>(
-          loc, LLVM::LLVMPointerType::get(llvmConstantElementType), alloc);
+          ArrayRef<Value>(
+              {i8AlignedPtrLocal, i8PtrGlobal, sizeBytes, isVolatile}));
+
+      // Insert deallocation for the local buffer.
+      Block *parentBlock = i8PtrLocal.getDefiningOp()->getBlock();
+      FlatSymbolRefAttr deallocSym = getOrInsertDealloc(rewriter, module);
+      LLVM::CallOp dealloc = rewriter.create<LLVM::CallOp>(
+          loc, llvmVoidTy, deallocSym, ArrayRef<Value>(i8PtrLocal));
+      dealloc.getOperation()->moveBefore(&parentBlock->back());
     } else {
       // Bitcast the global to the MemRefType's element type.
-      typedGlobal = rewriter.create<LLVM::BitcastOp>(loc,
-          LLVM::LLVMPointerType::get(llvmConstantElementType), globalValue);
+      localValue =
+          rewriter.create<LLVM::BitcastOp>(loc, globalPtrType, globalValue);
     }
 
     // Create llvm MemRef from original MemRef and fill the data pointers.
     auto llvmMemRef = MemRefDescriptor::fromStaticShape(
-        rewriter, loc, *getTypeConverter(), memRefTy, typedGlobal);
+        rewriter, loc, *getTypeConverter(), memRefTy, localValue);
+
+    // If alignment, update alignedPtr.
+    if (alignedLocalValue) {
+      llvmMemRef.setAlignedPtr(rewriter, loc, alignedLocalValue);
+    }
 
     rewriter.replaceOp(op, {llvmMemRef});
     return success();
@@ -498,6 +522,20 @@ public:
 private:
   static int64_t ArrayAttrIntVal(ArrayAttr a, int i) {
     return (a.getValue()[i]).cast<IntegerAttr>().getInt();
+  }
+
+  // Copied from lib/Conversion/StandardToLLVM/StandardToLLVM.cpp
+  // Returns 'input' aligned up to 'alignment'. Computes
+  // bumped = input + alignement - 1
+  // aligned = bumped - bumped % alignment
+  static Value createAligned(ConversionPatternRewriter &rewriter, Location loc,
+      Value input, Value alignment) {
+    Value one = rewriter.create<LLVM::ConstantOp>(loc, alignment.getType(),
+        rewriter.getIntegerAttr(rewriter.getIndexType(), 1));
+    Value bump = rewriter.create<LLVM::SubOp>(loc, alignment, one);
+    Value bumped = rewriter.create<LLVM::AddOp>(loc, input, bump);
+    Value mod = rewriter.create<LLVM::URemOp>(loc, bumped, alignment);
+    return rewriter.create<LLVM::SubOp>(loc, bumped, mod);
   }
 };
 

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -469,7 +469,7 @@ public:
       localValue =
           rewriter.create<LLVM::BitcastOp>(loc, globalPtrType, i8PtrLocal);
 
-      // Compute alignedPtr.
+      // Compute the aligned pointer.
       Type intPtrType = getIntPtrType(memRefTy.getMemorySpaceAsInt());
       Value intPtrLocal =
           rewriter.create<LLVM::PtrToIntOp>(loc, intPtrType, localValue);
@@ -477,7 +477,7 @@ public:
       alignedLocalValue =
           rewriter.create<LLVM::IntToPtrOp>(loc, globalPtrType, intAlignment);
 
-      // Copy constant value into the local aligned buffer:
+      // Copy constant values into the local aligned buffer:
       //  - Bitcast alignedPtr to i8*
       Value i8AlignedPtrLocal =
           rewriter.create<LLVM::BitcastOp>(loc, llvmI8PtrTy, alignedLocalValue);
@@ -488,7 +488,7 @@ public:
       Value isVolatile =
           rewriter.create<LLVM::ConstantOp>(loc, IntegerType::get(context, 1),
               rewriter.getIntegerAttr(rewriter.getIntegerType(1), 0));
-      //  - Copy constant data into the local buffer.
+      //  - Call memcpy.
       FlatSymbolRefAttr memcpyRef = getOrInsertMemcpy(rewriter, module);
       rewriter.create<CallOp>(loc, memcpyRef, ArrayRef<Type>({}),
           ArrayRef<Value>(

--- a/test/mlir/krnl/krnl_global_with_alignment_lowering.mlir
+++ b/test/mlir/krnl/krnl_global_with_alignment_lowering.mlir
@@ -28,7 +28,7 @@ func @test_krnl_global_constant_alignment() -> memref<3xf32> {
 // CHECK:           %[[ALIGNED:.*]] = llvm.sub %[[BUMPED]], %[[REM]]  : i64
 // CHECK:           %[[ALIGNED_PTR_LOCAL:.*]] = llvm.inttoptr %[[ALIGNED]] : i64 to !llvm.ptr<f32>
 
-// COM: Compute constant values to the aligned buffer.
+// COM: Copy constant values to the aligned buffer.
 // CHECK:           %[[I8_ALIGNED_PTR_LOCAL:.*]] = llvm.bitcast %[[ALIGNED_PTR_LOCAL]] : !llvm.ptr<f32> to !llvm.ptr<i8>
 // CHECK:           %[[I8_ALIGNED_PTR_GLOBAL:.*]] = llvm.bitcast %[[GLOBAL_VALUE]] : !llvm.ptr<array<3 x f32>> to !llvm.ptr<i8>
 // CHECK:           %[[VOLATILE:.*]] = llvm.mlir.constant(false) : i1
@@ -45,7 +45,7 @@ func @test_krnl_global_constant_alignment() -> memref<3xf32> {
 // CHECK:           %[[CONSTANT_1:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK:           %[[MEMREF_5:.*]] = llvm.insertvalue %[[CONSTANT_1]], %[[MEMREF_4]][4, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
 
-// COM: Update the MemRef with a new aligned pointer.
+// COM: Update the MemRef with the new aligned pointer.
 // CHECK:           %[[RES:.*]] = llvm.insertvalue %[[ALIGNED_PTR_LOCAL]], %[[MEMREF_5]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
 // CHECK:           %[[DEALLOCATION:.*]] = llvm.call @free(%[[I8_PTR_LOCAL]]) : (!llvm.ptr<i8>) -> !llvm.void
 // CHECK:           llvm.return %[[RES]] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>

--- a/test/mlir/krnl/krnl_global_with_alignment_lowering.mlir
+++ b/test/mlir/krnl/krnl_global_with_alignment_lowering.mlir
@@ -1,0 +1,54 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
+
+func @test_krnl_global_constant_alignment() -> memref<3xf32> {
+  %0 = "krnl.global"() {name = "constant", alignment = 1024 : i64, shape = [3], value = dense<[0.0, 0.1, 0.2]> : tensor<3xf32>} : () -> memref<3xf32>
+  return %0 : memref<3xf32>
+
+// CHECK-LABEL:   llvm.func @free(!llvm.ptr<i8>)
+// CHECK:         llvm.func @llvm.memcpy.p0i8.p0i8.i64(!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1)
+// CHECK:         llvm.func @malloc(i64) -> !llvm.ptr<i8>
+// CHECK:         llvm.mlir.global internal constant @constant(dense<[0.000000e+00, 1.000000e-01, 2.000000e-01]> : tensor<3xf32>) : !llvm.array<3 x f32>
+
+// CHECK-LABEL:   llvm.func @test_krnl_global_constant_alignment() -> !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)> {
+// CHECK:           %[[GLOBAL_VALUE:.*]] = llvm.mlir.addressof @constant : !llvm.ptr<array<3 x f32>>
+// CHECK-DAG:       %[[CONSTANT_1024:.*]] = llvm.mlir.constant(1024 : index) : i64
+// CHECK-DAG:       %[[CONSTANT_12:.*]] = llvm.mlir.constant(12 : index) : i64
+// CHECK:           %[[ALLOCATION_SIZE:.*]] = llvm.add %[[CONSTANT_12]], %[[CONSTANT_1024]]  : i64
+
+// COM: Allocate a local buffer considering alignment.
+// CHECK:           %[[I8_PTR_LOCAL:.*]] = llvm.call @malloc(%[[ALLOCATION_SIZE]]) : (i64) -> !llvm.ptr<i8>
+// CHECK:           %[[F32_PTR_LOCAL:.*]] = llvm.bitcast %[[I8_PTR_LOCAL]] : !llvm.ptr<i8> to !llvm.ptr<f32>
+
+// COM: Compute the aligned pointer.
+// CHECK:           %[[PTR_TO_INT:.*]] = llvm.ptrtoint %[[F32_PTR_LOCAL]] : !llvm.ptr<f32> to i64
+// CHECK:           %[[INDEX_1:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:           %[[SUB1:.*]] = llvm.sub %[[CONSTANT_1024]], %[[INDEX_1]]  : i64
+// CHECK:           %[[BUMPED:.*]] = llvm.add %[[PTR_TO_INT]], %[[SUB1]]  : i64
+// CHECK:           %[[REM:.*]] = llvm.urem %[[BUMPED]], %[[CONSTANT_1024]]  : i64
+// CHECK:           %[[ALIGNED:.*]] = llvm.sub %[[BUMPED]], %[[REM]]  : i64
+// CHECK:           %[[ALIGNED_PTR_LOCAL:.*]] = llvm.inttoptr %[[ALIGNED]] : i64 to !llvm.ptr<f32>
+
+// COM: Compute constant values to the aligned buffer.
+// CHECK:           %[[I8_ALIGNED_PTR_LOCAL:.*]] = llvm.bitcast %[[ALIGNED_PTR_LOCAL]] : !llvm.ptr<f32> to !llvm.ptr<i8>
+// CHECK:           %[[I8_ALIGNED_PTR_GLOBAL:.*]] = llvm.bitcast %[[GLOBAL_VALUE]] : !llvm.ptr<array<3 x f32>> to !llvm.ptr<i8>
+// CHECK:           %[[VOLATILE:.*]] = llvm.mlir.constant(false) : i1
+// CHECK:           llvm.call @llvm.memcpy.p0i8.p0i8.i64(%[[I8_ALIGNED_PTR_LOCAL]], %[[I8_ALIGNED_PTR_GLOBAL]], %[[CONSTANT_12]], %[[VOLATILE]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
+
+// COM: Create a MemRef to wrap the buffers.
+// CHECK:           %[[MEMREF_0:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[MEMREF_1:.*]] = llvm.insertvalue %[[F32_PTR_LOCAL]], %[[MEMREF_0]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[MEMREF_2:.*]] = llvm.insertvalue %[[F32_PTR_LOCAL]], %[[MEMREF_1]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[CONSTANT_0:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK:           %[[MEMREF_3:.*]] = llvm.insertvalue %[[CONSTANT_0]], %[[MEMREF_2]][2] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[CONSTANT_3:.*]] = llvm.mlir.constant(3 : index) : i64
+// CHECK:           %[[MEMREF_4:.*]] = llvm.insertvalue %[[CONSTANT_3]], %[[MEMREF_3]][3, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[CONSTANT_1:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:           %[[MEMREF_5:.*]] = llvm.insertvalue %[[CONSTANT_1]], %[[MEMREF_4]][4, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+
+// COM: Update the MemRef with a new aligned pointer.
+// CHECK:           %[[RES:.*]] = llvm.insertvalue %[[ALIGNED_PTR_LOCAL]], %[[MEMREF_5]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[DEALLOCATION:.*]] = llvm.call @free(%[[I8_PTR_LOCAL]]) : (!llvm.ptr<i8>) -> !llvm.void
+// CHECK:           llvm.return %[[RES]] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:         }
+
+}


### PR DESCRIPTION
This patch is to put aligned constants on the heap to avoid stack overflow.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>