### PR TITLE
Update the equation used for printing out wrong results.

### DIFF
--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -479,7 +479,7 @@ inline bool omTensorAreTwoOmtsClose(
   // rtol * abs(b) + atol
   std::transform(eqAllclose.begin(), eqAllclose.end(), (T *)atolT->_alignedPtr,
       eqAllclose.begin(), std::plus<>());
-  // (rtol * b + atol) - abs(a - b)
+  // (rtol * abs(b) + atol) - abs(a - b)
   std::transform(eqAllclose.begin(), eqAllclose.end(), absoluteDiff.begin(),
       eqAllclose.begin(), std::minus<>());
   bool satisfied = std::all_of(
@@ -491,10 +491,8 @@ inline bool omTensorAreTwoOmtsClose(
     for (const auto &idx : omTensorComputeIndexSet(a)) {
       T aElem = omTensorGetElem<T>(a, idx);
       T bElem = omTensorGetElem<T>(b, idx);
-      auto elmAbsDiff = abs(aElem - bElem);
-      auto withinRtol = (elmAbsDiff / aElem < rtol);
-      auto withinAtol = (elmAbsDiff < atol);
-      if (!withinRtol || !withinAtol) {
+      auto eq = rtol * std::abs(bElem) + atol - std::abs(aElem - bElem);
+      if (eq < 0) {
         std::cerr << "a[";
         printVector(idx, ",", std::cerr);
         std::cerr << "] = " << aElem << " != ";


### PR DESCRIPTION
PR #549 updated the equation for validating calculation results, but, the equation used for printing out wrong results was not updated. This PR updates it.

Signed-off-by: Haruki Imai <imaihal@jp.ibm.com>