### PR TITLE
Add an option shapeInformation to set static shapes for the inputs

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -157,13 +157,18 @@ private:
       std::string inputString = shapeString.substr(0, pos);
       std::string dimString = shapeString.substr(pos + 1);
 
-      std::stringstream dimIndices(dimString);
-      std::string dimIndex;
+      int64_t inputID = std::stoi(inputString);
+      assert(inputID >= 0 && "input_id must be >= 0");
+
+      std::stringstream dimSizes(dimString);
+      std::string dimStr;
       std::vector<int64_t> dims;
-      while (getline(dimIndices, dimIndex, ',')) {
-        dims.emplace_back(stoi(dimIndex));
+      while (getline(dimSizes, dimStr, ',')) {
+        int64_t dimSize = std::stoi(dimStr);
+        assert((dimSize == -1 || dimSize > 0) && "dim must be -1 or > 0");
+        dims.emplace_back(dimSize);
       }
-      inputs_shape_information.insert(std::make_pair(stoi(inputString), dims));
+      inputs_shape_information.insert(std::make_pair(inputID, dims));
     }
   }
 
@@ -406,7 +411,10 @@ private:
             }
           }
           argTy = RankedTensorType::get(newDims, shapedTy.getElementType());
-        } else if (shapedTy && !inputs_shape_information.empty()) {
+        } else if (shapedTy && !inputs_shape_information.empty() &&
+                   (inputs_shape_information.find(numInputs) !=
+                       inputs_shape_information.end())) {
+          // Change to the custom shape if users provide.
           std::vector<int64_t> shape = inputs_shape_information.at(numInputs);
           argTy = RankedTensorType::get(shape, shapedTy.getElementType());
         }

--- a/src/Builder/FrontendDialectTransformer.hpp
+++ b/src/Builder/FrontendDialectTransformer.hpp
@@ -43,6 +43,16 @@ struct ImportOptions {
   // variables)
   bool useOnnxModelTypes = false;
   bool invokeOnnxVersionConverter = false;
+  // Custom shape information for the graph inputs.
+  // Its format is 'input_id:dim,dim,dim|input_id:dim,dim,dim'
+  // E.g. An ONNX model has two dynamic inputs
+  //   - (arg0: tensor<?x?x?xf32>, arg1: tensor<?x5xf32>)
+  // If we want to compile the model for static dimensions, we can use:
+  //   - shapeInformation = '0:3,4,5|1:10,5'
+  // to obtain a model with two staic inputs:
+  //   - (arg0: tensor<3x4x5xf32>, arg1: tensor<10x5xf32>)
+  //
+  std::string shapeInformation = "";
 };
 
 /*!

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -84,9 +84,15 @@ llvm::cl::opt<bool> useOnnxModelTypes("useOnnxModelTypes",
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
 
 llvm::cl::opt<string> shapeInformation("shapeInformation",
-    llvm::cl::desc("Custom shapes for the inputs of the ONNX model"),
-    llvm::cl::value_desc("<input_id:dim,dim,dim|input_id:dim,dim,dim>"),
-    llvm::cl::cat(OnnxMlirOptions));
+    llvm::cl::desc(
+        "Custom shapes for the inputs of the ONNX model, e.g. setting static "
+        "shapes for dynamic inputs. \"value\" is in the format of "
+        "\"input_id:dim_size,dim_size,dim_size|input_id:dim_size,dim_size,dim_"
+        "size|...\", where \"input_id\" is 0, 1, ... to denote the first, "
+        "second, ... input, and \"dim_size\" is the dimension size for each "
+        "dimension of an input. \"dim_size\" must be a positive integer or -1 "
+        "(for an unknown dimension)."),
+    llvm::cl::value_desc("value"), llvm::cl::cat(OnnxMlirOptions));
 
 llvm::cl::opt<string> mtriple("mtriple", llvm::cl::desc("Target architecture"),
     llvm::cl::value_desc("<llvm target triple>"),

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -83,6 +83,11 @@ llvm::cl::opt<bool> useOnnxModelTypes("useOnnxModelTypes",
     llvm::cl::desc("use types and shapes from ONNX model"),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
 
+llvm::cl::opt<string> shapeInformation("shapeInformation",
+    llvm::cl::desc("Custom shapes for the inputs of the ONNX model"),
+    llvm::cl::value_desc("<input_id:dim,dim,dim|input_id:dim,dim,dim>"),
+    llvm::cl::cat(OnnxMlirOptions));
+
 llvm::cl::opt<string> mtriple("mtriple", llvm::cl::desc("Target architecture"),
     llvm::cl::value_desc("<llvm target triple>"),
     llvm::cl::cat(OnnxMlirOptions), llvm::cl::ValueRequired);
@@ -491,6 +496,7 @@ void processInputFile(string inputFilename, mlir::MLIRContext &context,
     ImportOptions options;
     options.useOnnxModelTypes = useOnnxModelTypes;
     options.invokeOnnxVersionConverter = invokeOnnxVersionConverter;
+    options.shapeInformation = shapeInformation;
     ImportFrontendModelFile(inputFilename, context, module, options);
   } else {
     LoadMLIR(inputFilename, context, module);


### PR DESCRIPTION
This patch introduces an option, `shapeInformation`, to command `onnx-mlir`, which is to set static dimensions for the inputs of a model.

The motivation is that compiling a model with dynamic dimensions may introduce performance overhead. If we know the exact shapes of the inputs to run the model inference, we should give the compiler such static shapes so that more optimizations can be done.

 
Signed-off-by: Tung D. Le <tung@jp.ibm.com>