### PR TITLE
Basic support for c and jni runtimes on z/OS

### DIFF
--- a/include/onnx-mlir/Runtime/OMTensor.h
+++ b/include/onnx-mlir/Runtime/OMTensor.h
@@ -27,7 +27,7 @@
 #include <stdbool.h>
 #endif // #ifdef __cplusplus
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__MVS__)
 #include <stdlib.h>
 #else
 #include <malloc.h>

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -25,7 +25,7 @@
 #include <assert.h>
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__MVS__)
 #include <stdlib.h>
 #else
 #include <malloc.h>

--- a/src/Runtime/OMTensorList.inc
+++ b/src/Runtime/OMTensorList.inc
@@ -13,7 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__MVS__)
 #include <stdlib.h>
 #else
 #include <malloc.h>

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -14,7 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <assert.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__MVS__)
 #include <stdlib.h>
 #else
 #include <malloc.h>


### PR DESCRIPTION
Use __MVS__ standard macro to identify when building on z/OS.  Only the
cruntime and jniruntime need to be built on z/OS, the rest of onnx-mlir
is not needed and would be non-trivial to get working.

Also depends on https://github.com/onnx/onnx-mlir/pull/744

There is no CI support for building this subset on z/OS, and cmake is not supported