### PR TITLE
Script to run onnx-mlir from docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,23 @@ The Open Neural Network Exchange implementation in MLIR (http://onnx.ai/onnx-mli
 | amd64-Windows | [![Build Status](https://dev.azure.com/onnx-pipelines/onnx/_apis/build/status/MLIR-Windows-CI?branchName=master)](https://dev.azure.com/onnx-pipelines/onnx/_build/latest?definitionId=9&branchName=master)             |
 | amd64-macOS   | [![Build Status](https://github.com/onnx/onnx-mlir/workflows/Build%20x86%20onnx-mlir%20on%20macOS/badge.svg)](https://github.com/onnx/onnx-mlir/actions?query=workflow%3A%22Build+x86+onnx-mlir+on+macOS%22)             |
 
-## Prebuilt Container
+## Prebuilt Containers
 An easy way to get started with ONNX-MLIR is to use a prebuilt docker image.
 These images are created as a result of a successful merge build on the trunk.
 This means that the latest image represents the tip of the trunk.
 Currently there are both Release and Debug mode images for `amd64`, `ppc64le` and `s390x` saved in Docker Hub as, respectively, [onnxmlirczar/onnx-mlir](https://hub.docker.com/r/onnxmlirczar/onnx-mlir) and [onnxmlirczar/onnx-mlir-dev](https://hub.docker.com/r/onnxmlirczar/onnx-mlir-dev).
 To use one of these images either pull it directly from Docker Hub, launch a container and run an interactive bash shell in it, or use it as the base image in a dockerfile.
-The onnx-mlir image just contains the built compiler and can be used to compile models.
+The onnx-mlir image just contains the built compiler and you can use it immediately to compile your model without any installation. A python convenience script is provided to allow you to run ONNX-MLIR inside a docker container as if running the ONNX-MLIR compiler directly on the host. For example,
+```
+# docker/onnx-mlir.py --EmitLib mnist/model.onnx
+505a5a6fb7d0: Pulling fs layer
+505a5a6fb7d0: Verifying Checksum
+505a5a6fb7d0: Download complete
+505a5a6fb7d0: Pull complete
+Shared library model.so has been compiled.
+```
+The script will pull the onnx-mlir image if it's not available locally, mount the directory containing the `model.onnx` into the container, and compile and generate the `model.so` in the same directory.
+
 The onnx-mlir-dev image contains the full build tree including the prerequisites and a clone of the source code.
 The source can be modified and onnx-mlir rebuilt from within the container, so it is possible to use it
 as a development environment.

--- a/docker/onnx-mlir.py
+++ b/docker/onnx-mlir.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+
+DOCKER_SOCKET   = '/var/run/docker.sock'
+ONNX_MLIR_IMAGE = 'onnxmlirczar/onnx-mlir'
+WORK_DIR        = '/workdir'
+OUTPUT_DIR      = '/output'
+EMIT_OPTS       = [ '--EmitONNXBasic',
+                    '--EmitONNXIR',
+                    '--EmitMLIR',
+                    '--EmitLLVMIR',
+                    '--EmitLib',
+                    '--EmitJNI' ]
+
+# When running onnx-mlir inside a docker container, the directory
+# containing the input ONNX model file must be mounted into the
+# container for onnx-mlir to read the input and generate the output.
+#
+# This convenient script will do that automatically to make it
+# as if you are running onnx-mlir directly on the host.
+def main():
+    # Make sure docker client is installed
+    if not shutil.which('docker'):
+        print('docker client not found')
+        return
+
+    # Make sure docker daemon is running
+    if not stat.S_ISSOCK(os.stat(DOCKER_SOCKET).st_mode):
+        print('docker daemon not running')
+        return
+
+    # Pull the latest onnxmlirczar/onnx-mlir image, if image
+    # is already up-to-date, pull will do nothing.
+    args = [ 'docker', 'pull', ONNX_MLIR_IMAGE ]
+    proc = subprocess.Popen(args,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
+    # Only print messages related to pulling a layer or error.
+    for l in proc.stdout:
+        line = l.decode('utf-8')
+        print(line if re.match('^([0-9a-f]{12})|Error', line) else '',
+              end='', flush=True)
+    proc.wait()
+    if (proc.returncode != 0):
+        return
+
+    # Go through the command line options and locate the
+    # input ONNX model file.
+    argi  = 0
+    ionnx = None
+    argo  = 0
+    obase = None
+    argv  = sys.argv
+    argc  = len(sys.argv)
+
+    for i, arg in enumerate(argv):
+        # File specified on the first argument, defaults to --EmitLib
+        if i == 1 and not argv[i].startswith('-'):
+            argi = i
+            ionnx = argv[i]
+        # If a file is not specified on the first argument, it must be
+        # specified after a valid --EmitXXX option.
+        elif (arg in EMIT_OPTS and i < argc-1 and
+              not argv[i+1].startswith('-')):
+            # File specified more than once, treat as not specified
+            if ionnx:
+                sys.exit("Too many --EmitXXX options")
+            argi = i + 1
+            ionnx = argv[argi]
+        elif (arg == "-o" and i < argc-1 and
+              not argv[i+1].startswith('-')):
+            if obase:
+                sys.exit("Too many -o options")
+            argo = i + 1
+            obase = argv[argo]
+
+    # Prepare the arguments for docker run
+    args = [ 'docker', 'run', '--rm', '-ti' ]
+
+    # Construct the mount option if an input ONNX model file is found
+    if ionnx:
+        p = os.path.abspath(ionnx)
+        d = os.path.dirname(p)
+        f = os.path.basename(p)
+
+        # Add the mount option, directory containing the input
+        # ONNX model file will be mounted under /workdir inside
+        # the container. If /workdir doesn't exist, it will be
+        # created.
+        args.append('-v')
+        args.append(d + ':' + WORK_DIR + d)
+
+        # Change directory into /workdir
+        #args.append('-w')
+        #args.append(WORK_DIR)
+
+        # Rewrite the original input ONNX model file, which will
+        # reside under /workdir inside the container.
+        argv[argi] = WORK_DIR + p
+
+    # Construct the mount option if -o is specified
+    if obase:
+        # Check invalid -o values such as ".", "..", "/.", "./", etc.
+        if re.match('(.*/)*\.*$', obase):
+            sys.exit("Invalid value for -o option")
+
+        p = os.path.abspath(obase)
+        d = os.path.dirname(p)
+        f = os.path.basename(p)
+
+        # Add the mount option, directory containing the output
+        # files will be mounted under /output inside the container.
+        # If /output/... doesn't exist, it will be
+        # created.
+        args.append('-v')
+        args.append(d + ':' + OUTPUT_DIR + d)
+
+        # Rewrite the original output basename, which will
+        # reside under /output inside the container.
+        argv[argo] = OUTPUT_DIR + p
+
+    # Add effective uid and gid
+    args.append('-u')
+    args.append(str(os.geteuid()) + ':' + str(os.getegid()))
+
+    # Add image name
+    args.append(ONNX_MLIR_IMAGE)
+
+    # Pass in all the original arguments
+    argv.remove(argv[0])
+    args.extend(argv)
+    # print(args) #debug only
+
+    # Run onnx-mlir in the container
+    proc = subprocess.Popen(args,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
+    for line in proc.stdout:
+        # Remove first occurrence of /workdir or /output before printing
+        print(re.sub(WORK_DIR + '|' + OUTPUT_DIR, '',
+                     line.decode('utf-8'), 1),
+              end='', flush=True)
+    proc.wait()
+    if (proc.returncode != 0):
+        print(os.strerror(proc.returncode))
+
+if __name__ == "__main__":
+    main()

--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -244,7 +244,8 @@ struct Command {
       fprintf(stderr, "%s\n", llvm::join(argsRef, " ").c_str());
       fprintf(stderr, "Error message: %s\n", errMsg.c_str());
       fprintf(stderr, "Program path: %s\n", _path.c_str());
-      llvm_unreachable("Command execution failed.");
+      fprintf(stderr, "Command execution failed.");
+      exit(rc);
     }
   }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,8 +56,15 @@ int main(int argc, char *argv[]) {
   processInputFile(inputFilename, context, module);
 
   // Input file base name, replace path if required.
-  if (outputBaseName == "")
+  // outputBaseName must specify a file, so ignore invalid values
+  // such as ".", "..", "./", "/.", etc.
+  bool b = false;
+  if (outputBaseName == "" ||
+      (b = std::regex_match(outputBaseName, std::regex("(.*/)*\\.*$")))) {
+    if (b)
+      printf("Invalid -o option value %s ignored.\n", outputBaseName.c_str());
     outputBaseName = inputFilename.substr(0, inputFilename.find_last_of("."));
+  }
 
   return compileModule(module, context, outputBaseName, emissionTarget);
 }


### PR DESCRIPTION
- Convenient python script to run onnx-mlir from docker container
- Check freopen failure in MainUtils.cpp:outputCode
- Ignore invalid -o option values in main.cpp
- Update README.md about the convenient python script

Signed-off-by: Gong Su <gong_su@hotmail.com>