### PR TITLE
removing compiler warnings

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1069,11 +1069,7 @@ private:
       int nIn = 0;
       int nOut = 0;
       getNodeInputs(node, inputs);
-
-      // TODO: isn't nOut just node.output().size()?
-      for (const auto &item : node.output())
-        ++nOut;
-
+      nOut = node.output().size();
       buildOutputAndOperation<ONNXCustomOp>(
           node, inputs, nIn, nOut, attributes);
     }

--- a/src/Runtime/jni/jnilog.c
+++ b/src/Runtime/jni/jnilog.c
@@ -40,7 +40,7 @@ static THREAD_LOCAL_SPEC int log_level;
 static THREAD_LOCAL_SPEC FILE *log_fp;
 
 /* Must match enum in log.h */
-static char *log_level_name[] = {
+static const char *log_level_name[] = {
     "trace", "debug", "info", "warning", "error", "fatal"};
 
 unsigned long get_threadid() {
@@ -103,7 +103,7 @@ void log_printf(
 /* Return numerical log level of give level name */
 static int get_log_level_by_name(char *name) {
   int level = -1;
-  for (int i = 0; i < sizeof(log_level_name) / sizeof(char *); i++) {
+  for (int i = 0; i < (int) (sizeof(log_level_name) / sizeof(char *)); i++) {
     if (!strcmp(name, log_level_name[i])) {
       level = i;
       break;

--- a/src/Runtime/jni/jnilog.c
+++ b/src/Runtime/jni/jnilog.c
@@ -103,7 +103,7 @@ void log_printf(
 /* Return numerical log level of give level name */
 static int get_log_level_by_name(char *name) {
   int level = -1;
-  for (int i = 0; i < (int) (sizeof(log_level_name) / sizeof(char *)); i++) {
+  for (int i = 0; i < (int)(sizeof(log_level_name) / sizeof(char *)); i++) {
     if (!strcmp(name, log_level_name[i])) {
       level = i;
       break;

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -482,7 +482,6 @@ ONNXConstantOp ConstPropTranspose(
 
 ONNXConstantOp ConstPropUnsqueeze(
     PatternRewriter &rewriter, Value replacingValue, Value input) {
-  Type replacingType = replacingValue.getType();
   Operation *inputOp = input.getDefiningOp();
 
   char *resArray = getArrayFromAttributeOrBuffer(rewriter, inputOp);


### PR DESCRIPTION
Removing spurious compiler warnings that have accumulated during recent PRs.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>