### PR TITLE
Fix instrument error on windows

### DIFF
--- a/src/Runtime/OMInstrument.inc
+++ b/src/Runtime/OMInstrument.inc
@@ -33,18 +33,22 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "onnx-mlir/Runtime/OMInstrument.h"
 
+#ifdef _WIN32
+  // TO BE FIXED 
+#else
 #include <sys/time.h>
-#include <string.h>
-#include <unistd.h>
 #include <sys/types.h>
 
 static struct timeval globalTimeVal, initTimeVal;
+static pid_t mypid;
+#endif
+
 static bool timeEnabled = true;
 static bool virtualMemEnabled = true;
-static pid_t mypid;
 static char memCommand[200];
 
 void OMInstrumentInit() {
@@ -55,6 +59,9 @@ void OMInstrumentInit() {
 	  virtualMemEnabled = !virtualMemEnabled;
   }
 
+#ifdef _WIN32
+  // TO BE FIXED
+#else
   if (timeEnabled) {
     gettimeofday(&globalTimeVal, NULL);
     initTimeVal = globalTimeVal;
@@ -64,9 +71,13 @@ void OMInstrumentInit() {
      mypid = getpid();
      sprintf(memCommand, "ps -o vsz --noheader -p %d", mypid);
   }
+#endif
 }
 
 void OMInstrumentPoint(int64_t id, int64_t tag) {
+#ifdef _WIN32
+  // TO BE FIXED
+#else
   if (timeEnabled) {
     struct timeval newTimeValue, result;
     gettimeofday(&newTimeValue, NULL);
@@ -81,6 +92,6 @@ void OMInstrumentPoint(int64_t id, int64_t tag) {
   if (virtualMemEnabled) {
     system(memCommand);
   }
-
+#endif
 }
 

--- a/src/Runtime/OMInstrument.inc
+++ b/src/Runtime/OMInstrument.inc
@@ -38,7 +38,7 @@
 #include "onnx-mlir/Runtime/OMInstrument.h"
 
 #ifdef _WIN32
-  // TO BE FIXED 
+// TO BE FIXED
 #else
 #include <sys/time.h>
 #include <sys/types.h>
@@ -49,49 +49,66 @@ static pid_t mypid;
 
 static bool timeEnabled = true;
 static bool virtualMemEnabled = true;
-static char memCommand[200];
+
+#ifdef _WIN32
+void TimeInit() {}
+#else
+void TimeInit() {
+  gettimeofday(&globalTimeVal, NULL);
+  initTimeVal = globalTimeVal;
+}
+#endif
+
+#ifdef __WIN32
+void ReportTime() {}
+#else
+void ReportTime() {
+  struct timeval newTimeValue, result;
+  gettimeofday(&newTimeValue, NULL);
+  timersub(&newTimeValue, &globalTimeVal, &result);
+  printf("Time elapsed: %ld.%06ld ", (long int)result.tv_sec,
+      (long int)result.tv_usec);
+  timersub(&newTimeValue, &initTimeVal, &result);
+  printf("accumulated: %ld.%06ld\n", (long int)result.tv_sec,
+      (long int)result.tv_usec);
+  globalTimeVal = newTimeValue;
+}
+#endif
+
+#ifdef __WIN32
+void ReportMemory() {}
+#else
+void ReportMemory() {
+  char memCommand[200];
+  mypid = getpid();
+  sprintf(memCommand, "ps -o vsz --noheader -p %d", mypid);
+  system(memCommand);
+}
+#endif
 
 void OMInstrumentInit() {
   if (getenv("OMINSTRUMENTTIME")) {
-	  timeEnabled = !timeEnabled;
+    timeEnabled = !timeEnabled;
   }
   if (getenv("OMINSTRUMENTMEMORY")) {
-	  virtualMemEnabled = !virtualMemEnabled;
+    virtualMemEnabled = !virtualMemEnabled;
   }
 
-#ifdef _WIN32
-  // TO BE FIXED
-#else
   if (timeEnabled) {
-    gettimeofday(&globalTimeVal, NULL);
-    initTimeVal = globalTimeVal;
+    TimeInit();
   }
-
-  if (virtualMemEnabled) {
-     mypid = getpid();
-     sprintf(memCommand, "ps -o vsz --noheader -p %d", mypid);
-  }
-#endif
 }
 
 void OMInstrumentPoint(int64_t id, int64_t tag) {
-#ifdef _WIN32
-  // TO BE FIXED
-#else
+  // Print header
+  if (timeEnabled || virtualMemEnabled)
+    printf("ID=%s TAG=%ld ", (char *)&id, tag);
+
   if (timeEnabled) {
-    struct timeval newTimeValue, result;
-    gettimeofday(&newTimeValue, NULL);
-    printf("ID=%s TAG=%ld ",(char *)&id, tag);
-    timersub(&newTimeValue, &globalTimeVal, &result);
-    printf("Time elapsed: %ld.%06ld ", (long int)result.tv_sec, (long int)result.tv_usec);
-    timersub(&newTimeValue, &initTimeVal, &result);
-    printf("accumulated: %ld.%06ld\n", (long int)result.tv_sec, (long int)result.tv_usec);
-    globalTimeVal = newTimeValue;
+    ReportTime();
   }
 
   if (virtualMemEnabled) {
-    system(memCommand);
+    ReportMemory();
   }
-#endif
 }
-

--- a/src/Runtime/OMInstrument.inc
+++ b/src/Runtime/OMInstrument.inc
@@ -33,13 +33,14 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+#include <stdint.h>
 
 #include "onnx-mlir/Runtime/OMInstrument.h"
 
 #ifdef _WIN32
 // TO BE FIXED
 #else
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/types.h>
 

--- a/src/Runtime/OMInstrument.inc
+++ b/src/Runtime/OMInstrument.inc
@@ -60,7 +60,7 @@ void TimeInit() {
 }
 #endif
 
-#ifdef __WIN32
+#ifdef _WIN32
 void ReportTime() {}
 #else
 void ReportTime() {
@@ -76,7 +76,7 @@ void ReportTime() {
 }
 #endif
 
-#ifdef __WIN32
+#ifdef _WIN32
 void ReportMemory() {}
 #else
 void ReportMemory() {


### PR DESCRIPTION
Signed-off-by: Tong Chen <chentong@us.ibm.com>
The OM runtime library used libraries not available on windows. This temporary fix added `#ifdef _WIN32' with `TO BE FIXED` comment.
When instrumentation part becomes mature, we will add the corresponding part for windows.