### PR TITLE
Set alignment for LLVM GlobalOp

### DIFF
--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -456,87 +456,22 @@ public:
         llvm_unreachable("Unsupported attribute type");
     }
 
-    // Prepare data to be inserted into MemRef.
-    // If global needs alignment, we need to allocate a new buffer that is
-    // aligned.
-    // - Otherwise, no preparation is needed, directly use the global.
+    // Set alignment if alignment != 0.
+    if (alignmentAttr && alignmentAttr.getValue().getSExtValue() != 0) {
+      global.alignmentAttr(alignmentAttr);
+    }
 
-    // Get the address of the global.
+    // Prepare data to be inserted into MemRef.
     Value globalValue = rewriter.create<LLVM::AddressOfOp>(loc, global);
     auto globalPtrType =
         LLVM::LLVMPointerType::get(constantElementType.cast<Type>());
-
-    Value localValue, alignedLocalValue;
-    if (alignmentAttr && alignmentAttr.getValue().getSExtValue() != 0) {
-      // Some frequently used types.
-      auto llvmVoidTy = LLVM::LLVMVoidType::get(context);
-      auto llvmI8PtrTy =
-          LLVM::LLVMPointerType::get(IntegerType::get(context, 8));
-
-      // Compute allocation size.
-      Value alignment = createIndexConstant(
-          rewriter, loc, alignmentAttr.getValue().getSExtValue());
-      Value sizeBytes = createIndexConstant(rewriter, loc, sizeInBytes);
-      // Adjust the allocation size to consider alignment.
-      Value sizeBytesWithAligment =
-          rewriter.create<LLVM::AddOp>(loc, sizeBytes, alignment);
-
-      // Allocate a local buffer for the constant.
-      FlatSymbolRefAttr mallocSym = getOrInsertMalloc(rewriter, module);
-      Value i8PtrLocal = rewriter
-                             .create<LLVM::CallOp>(loc, llvmI8PtrTy, mallocSym,
-                                 ArrayRef<Value>(sizeBytesWithAligment))
-                             .getResult(0);
-
-      // Bitcast the local buffer to the MemRefType's element type.
-      localValue =
-          rewriter.create<LLVM::BitcastOp>(loc, globalPtrType, i8PtrLocal);
-
-      // Compute the aligned pointer.
-      Type intPtrType = getIntPtrType(memRefTy.getMemorySpaceAsInt());
-      Value intPtrLocal =
-          rewriter.create<LLVM::PtrToIntOp>(loc, intPtrType, localValue);
-      Value intAlignment = createAligned(rewriter, loc, intPtrLocal, alignment);
-      alignedLocalValue =
-          rewriter.create<LLVM::IntToPtrOp>(loc, globalPtrType, intAlignment);
-
-      // Copy constant values into the local aligned buffer:
-      //  - Bitcast alignedPtr to i8*
-      Value i8AlignedPtrLocal =
-          rewriter.create<LLVM::BitcastOp>(loc, llvmI8PtrTy, alignedLocalValue);
-      //  - Bitcast global to i8*
-      Value i8PtrGlobal =
-          rewriter.create<LLVM::BitcastOp>(loc, llvmI8PtrTy, globalValue);
-      //  - Set volatile.
-      Value isVolatile =
-          rewriter.create<LLVM::ConstantOp>(loc, IntegerType::get(context, 1),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(1), 0));
-      //  - Call memcpy.
-      FlatSymbolRefAttr memcpyRef = getOrInsertMemcpy(rewriter, module);
-      rewriter.create<CallOp>(loc, memcpyRef, ArrayRef<Type>({}),
-          ArrayRef<Value>(
-              {i8AlignedPtrLocal, i8PtrGlobal, sizeBytes, isVolatile}));
-
-      // Insert deallocation for the local buffer.
-      Block *parentBlock = i8PtrLocal.getDefiningOp()->getBlock();
-      FlatSymbolRefAttr deallocSym = getOrInsertDealloc(rewriter, module);
-      LLVM::CallOp dealloc = rewriter.create<LLVM::CallOp>(
-          loc, llvmVoidTy, deallocSym, ArrayRef<Value>(i8PtrLocal));
-      dealloc.getOperation()->moveBefore(&parentBlock->back());
-    } else {
-      // Bitcast the global to the MemRefType's element type.
-      localValue =
-          rewriter.create<LLVM::BitcastOp>(loc, globalPtrType, globalValue);
-    }
+    // Bitcast the global to the MemRefType's element type.
+    Value localValue =
+        rewriter.create<LLVM::BitcastOp>(loc, globalPtrType, globalValue);
 
     // Create llvm MemRef from original MemRef and fill the data pointers.
     auto llvmMemRef = MemRefDescriptor::fromStaticShape(
         rewriter, loc, *getTypeConverter(), memRefTy, localValue);
-
-    // If alignment, update alignedPtr.
-    if (alignedLocalValue) {
-      llvmMemRef.setAlignedPtr(rewriter, loc, alignedLocalValue);
-    }
 
     rewriter.replaceOp(op, {llvmMemRef});
     return success();

--- a/test/mlir/krnl/krnl_global_with_alignment_lowering.mlir
+++ b/test/mlir/krnl/krnl_global_with_alignment_lowering.mlir
@@ -4,51 +4,21 @@ func @test_krnl_global_constant_alignment() -> memref<3xf32> {
   %0 = "krnl.global"() {name = "constant", alignment = 1024 : i64, shape = [3], value = dense<[0.0, 0.1, 0.2]> : tensor<3xf32>} : () -> memref<3xf32>
   return %0 : memref<3xf32>
 
-// CHECK-LABEL:   llvm.func @free(!llvm.ptr<i8>)
-// CHECK:         llvm.func @llvm.memcpy.p0i8.p0i8.i64(!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1)
-// CHECK:         llvm.func @malloc(i64) -> !llvm.ptr<i8>
-// CHECK:         llvm.mlir.global internal constant @constant(dense<[0.000000e+00, 1.000000e-01, 2.000000e-01]> : tensor<3xf32>) : !llvm.array<3 x f32>
-
-// CHECK-LABEL:   llvm.func @test_krnl_global_constant_alignment() -> !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)> {
-// CHECK:           %[[GLOBAL_VALUE:.*]] = llvm.mlir.addressof @constant : !llvm.ptr<array<3 x f32>>
-// CHECK-DAG:       %[[CONSTANT_1024:.*]] = llvm.mlir.constant(1024 : index) : i64
-// CHECK-DAG:       %[[CONSTANT_12:.*]] = llvm.mlir.constant(12 : index) : i64
-// CHECK:           %[[ALLOCATION_SIZE:.*]] = llvm.add %[[CONSTANT_12]], %[[CONSTANT_1024]]  : i64
-
-// COM: Allocate a local buffer considering alignment.
-// CHECK:           %[[I8_PTR_LOCAL:.*]] = llvm.call @malloc(%[[ALLOCATION_SIZE]]) : (i64) -> !llvm.ptr<i8>
-// CHECK:           %[[F32_PTR_LOCAL:.*]] = llvm.bitcast %[[I8_PTR_LOCAL]] : !llvm.ptr<i8> to !llvm.ptr<f32>
-
-// COM: Compute the aligned pointer.
-// CHECK:           %[[PTR_TO_INT:.*]] = llvm.ptrtoint %[[F32_PTR_LOCAL]] : !llvm.ptr<f32> to i64
-// CHECK:           %[[INDEX_1:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:           %[[SUB1:.*]] = llvm.sub %[[CONSTANT_1024]], %[[INDEX_1]]  : i64
-// CHECK:           %[[BUMPED:.*]] = llvm.add %[[PTR_TO_INT]], %[[SUB1]]  : i64
-// CHECK:           %[[REM:.*]] = llvm.urem %[[BUMPED]], %[[CONSTANT_1024]]  : i64
-// CHECK:           %[[ALIGNED:.*]] = llvm.sub %[[BUMPED]], %[[REM]]  : i64
-// CHECK:           %[[ALIGNED_PTR_LOCAL:.*]] = llvm.inttoptr %[[ALIGNED]] : i64 to !llvm.ptr<f32>
-
-// COM: Copy constant values to the aligned buffer.
-// CHECK:           %[[I8_ALIGNED_PTR_LOCAL:.*]] = llvm.bitcast %[[ALIGNED_PTR_LOCAL]] : !llvm.ptr<f32> to !llvm.ptr<i8>
-// CHECK:           %[[I8_ALIGNED_PTR_GLOBAL:.*]] = llvm.bitcast %[[GLOBAL_VALUE]] : !llvm.ptr<array<3 x f32>> to !llvm.ptr<i8>
-// CHECK:           %[[VOLATILE:.*]] = llvm.mlir.constant(false) : i1
-// CHECK:           llvm.call @llvm.memcpy.p0i8.p0i8.i64(%[[I8_ALIGNED_PTR_LOCAL]], %[[I8_ALIGNED_PTR_GLOBAL]], %[[CONSTANT_12]], %[[VOLATILE]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
-
-// COM: Create a MemRef to wrap the buffers.
-// CHECK:           %[[MEMREF_0:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
-// CHECK:           %[[MEMREF_1:.*]] = llvm.insertvalue %[[F32_PTR_LOCAL]], %[[MEMREF_0]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
-// CHECK:           %[[MEMREF_2:.*]] = llvm.insertvalue %[[F32_PTR_LOCAL]], %[[MEMREF_1]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
-// CHECK:           %[[CONSTANT_0:.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK:           %[[MEMREF_3:.*]] = llvm.insertvalue %[[CONSTANT_0]], %[[MEMREF_2]][2] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
-// CHECK:           %[[CONSTANT_3:.*]] = llvm.mlir.constant(3 : index) : i64
-// CHECK:           %[[MEMREF_4:.*]] = llvm.insertvalue %[[CONSTANT_3]], %[[MEMREF_3]][3, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
-// CHECK:           %[[CONSTANT_1:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:           %[[MEMREF_5:.*]] = llvm.insertvalue %[[CONSTANT_1]], %[[MEMREF_4]][4, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
-
-// COM: Update the MemRef with the new aligned pointer.
-// CHECK:           %[[RES:.*]] = llvm.insertvalue %[[ALIGNED_PTR_LOCAL]], %[[MEMREF_5]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
-// CHECK:           %[[DEALLOCATION:.*]] = llvm.call @free(%[[I8_PTR_LOCAL]]) : (!llvm.ptr<i8>) -> !llvm.void
-// CHECK:           llvm.return %[[RES]] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:         llvm.mlir.global internal constant @constant(dense<[0.000000e+00, 1.000000e-01, 2.000000e-01]> : tensor<3xf32>) {alignment = 1024 : i64} : !llvm.array<3 x f32>
+// CHECK:         llvm.func @test_krnl_global_constant_alignment() -> !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)> {
+// CHECK:           [[VAR_0_:%.+]] = llvm.mlir.addressof @constant : !llvm.ptr<array<3 x f32>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = llvm.bitcast [[VAR_0_]] : !llvm.ptr<array<3 x f32>> to !llvm.ptr<f32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           [[VAR_3_:%.+]] = llvm.insertvalue [[VAR_1_]], [[VAR_2_]][0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:       [[VAR_4_:%.+]] = llvm.insertvalue [[VAR_1_]], [[VAR_3_]][1] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:       [[VAR_5_:%.+]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_6_:%.+]] = llvm.insertvalue [[VAR_5_]], [[VAR_4_]][2] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:       [[VAR_7_:%.+]] = llvm.mlir.constant(3 : index) : i64
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_8_:%.+]] = llvm.insertvalue [[VAR_7_]], [[VAR_6_]][3, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:       [[VAR_9_:%.+]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:           [[VAR_10_:%.+]] = llvm.insertvalue [[VAR_9_]], [[VAR_8_]][4, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           llvm.return [[VAR_10_]] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
 // CHECK:         }
-
 }


### PR DESCRIPTION
MLIR now supports LLVM GlobalOp with alignment.  We can use it for our aligned constants so that there is no need of creating a separate buffer for aligned data.

This patch updates our lowering code to use the LLVM GlobalOp with alignment. 

Signed-off-by: Tung D. Le <tung@jp.ibm.com>