### PR TITLE
Add the data_layout attribute to ModuleOp to denote endianness

### DIFF
--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -221,16 +221,16 @@ test_to_enable_dict = {
     # Compress
 
     # Concat
-    "test_concat_1d_axis_0_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{0}}}, # CONSTANT_INPUT:{-1}}, failed
+    "test_concat_1d_axis_0_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{0}}, CONSTANT_INPUT:{-1}},
     "test_concat_2d_axis_0_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{0}}, CONSTANT_INPUT:{-1}},
-    "test_concat_2d_axis_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{1}}}, # CONSTANT_INPUT:{-1}}, failed
+    "test_concat_2d_axis_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{1}}, CONSTANT_INPUT:{-1}},
     "test_concat_3d_axis_0_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{0}}, CONSTANT_INPUT:{-1}},
     "test_concat_3d_axis_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{1}}, CONSTANT_INPUT:{-1}},
-    "test_concat_3d_axis_2_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{2}}}, # CONSTANT_INPUT:{-1}}, failed
-    "test_concat_1d_axis_negative_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{0}}}, # CONSTANT_INPUT:{-1}}, failed
-    "test_concat_2d_axis_negative_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{1}}}, # CONSTANT_INPUT:{-1}}, failed
+    "test_concat_3d_axis_2_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{2}}, CONSTANT_INPUT:{-1}},
+    "test_concat_1d_axis_negative_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{0}}, CONSTANT_INPUT:{-1}},
+    "test_concat_2d_axis_negative_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{1}}, CONSTANT_INPUT:{-1}},
     "test_concat_2d_axis_negative_2_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{0}}, CONSTANT_INPUT:{-1}},
-    "test_concat_3d_axis_negative_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{2}}}, # CONSTANT_INPUT:{-1}}, failed
+    "test_concat_3d_axis_negative_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{2}}, CONSTANT_INPUT:{-1}},
     "test_concat_3d_axis_negative_2_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{1}}, CONSTANT_INPUT:{-1}},
     "test_concat_3d_axis_negative_3_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{0}}, CONSTANT_INPUT:{-1}},
 
@@ -271,7 +271,7 @@ test_to_enable_dict = {
     # Div
     "test_div_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
     "test_div_bcast_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
-    "test_div_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}}, # CONSTANT_INPUT:{-1}}, failed
+    "test_div_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
 
     # Dropout
     "test_dropout_default_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
@@ -464,7 +464,7 @@ test_to_enable_dict = {
     # Multinomial (NMV)
 
     # Neg
-    "test_neg_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}}, # CONSTANT_INPUT:{-1}}, failed
+    "test_neg_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
     "test_neg_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
 
     # Negative Log Likelihood Loss

--- a/test/mlir/module_op_be/lit.local.cfg
+++ b/test/mlir/module_op_be/lit.local.cfg
@@ -1,0 +1,5 @@
+root = config.root
+if sys.byteorder == "little":
+  config.unsupported = True
+else:
+  config.unsupported = False

--- a/test/mlir/module_op_be/module_op.mlir
+++ b/test/mlir/module_op_be/module_op.mlir
@@ -1,0 +1,6 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
+
+// CHECK: module attributes {llvm.data_layout = "E"}
+module {
+}
+

--- a/test/mlir/module_op_le/lit.local.cfg
+++ b/test/mlir/module_op_le/lit.local.cfg
@@ -1,0 +1,5 @@
+root = config.root
+if sys.byteorder == "little":
+  config.unsupported = False
+else:
+  config.unsupported = True

--- a/test/mlir/module_op_le/module_op.mlir
+++ b/test/mlir/module_op_le/module_op.mlir
@@ -1,0 +1,5 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
+
+// CHECK: module attributes {llvm.data_layout = "e"}
+module {
+}


### PR DESCRIPTION
Resolves #816

Since LLVM optimizations use module's DataLayout to know whether constant data is in little or big endian. We should annotate ModuleOp with correct endianness so that LLVM optimizations correctly read constant data.

This patch adds `llvm.data_layout` to ModuleOp whose value is `e` or `E` for little or big endian, respectively.

By this patch, all constant-related end-to-end tests, except ones our builder does not support, are passed.