### PR TITLE
Use ninja to build on Windows

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -20,6 +20,18 @@ jobs:
     submodules: recursive
     path: onnx-mlir
 
+  - task: PowerShell@2
+    displayName: Setup ninja
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo "Check and set up ninja"
+        if (-Not (Get-Command ninja -errorAction SilentlyContinue))
+        {
+          echo "choco install ninja"
+          choco install ninja
+        }
+
   - script: |
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
       call onnx-mlir\utils\install-protobuf.cmd

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The following CMake variables from LLVM and ONNX MLIR can be used when compiling
 ## Installation on Windows
 Building onnx-mlir on Windows requires building some additional prerequisites that are not available by default.
 
-Note that the instructions in this file assume you are using [Visual Studio  2019 Community Edition](https://visualstudio.microsoft.com/downloads/). It is recommended that you have the **Desktop development with C++** and **Linux development with C++** workloads installed. This ensures you have all toolchains and libraries needed to compile this project and its dependencies on Windows.
+Note that the instructions in this file assume you are using [Visual Studio  2019 Community Edition](https://visualstudio.microsoft.com/downloads/) with ninja. It is recommended that you have the **Desktop development with C++** and **Linux development with C++** workloads installed. This ensures you have all toolchains and libraries needed to compile this project and its dependencies on Windows.
 
 Run all the commands from a shell started from **"Developer Command Prompt for VS 2019"**.
 
@@ -211,7 +211,7 @@ cd protobuf && git checkout d0bfd5221182da1a7cc280f3337b5e41a89539cf && cd ..
 set root_dir=%cd%
 md protobuf_build
 cd protobuf_build
-call cmake %root_dir%\protobuf\cmake -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\protobuf\cmake -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX="%root_dir%\protobuf_install" ^
    -DCMAKE_BUILD_TYPE=Release ^
    -Dprotobuf_BUILD_EXAMPLES=OFF ^
@@ -220,8 +220,8 @@ call cmake %root_dir%\protobuf\cmake -G "Visual Studio 16 2019" -A x64 -T host=x
    -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ^
    -Dprotobuf_WITH_ZLIB=OFF
 
-call cmake --build . --config Release -- /m
-call cmake --build . --config Release --target install -- /m
+call cmake --build . --config Release
+call cmake --build . --config Release --target install
 ```
 
 Before running CMake for onnx-mlir, ensure that the bin directory to this protobuf is before any others in your PATH:
@@ -244,7 +244,7 @@ cd llvm-project && git checkout 23dd750279c9e32ea631cc9e92c4413c7a3df60a && cd .
 set root_dir=%cd%
 md llvm-project\build
 cd llvm-project\build
-call cmake %root_dir%\llvm-project\llvm -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\llvm-project\llvm -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX="%root_dir%\llvm-project\build\install" ^
    -DLLVM_ENABLE_PROJECTS=mlir ^
    -DLLVM_TARGETS_TO_BUILD="host" ^
@@ -253,9 +253,9 @@ call cmake %root_dir%\llvm-project\llvm -G "Visual Studio 16 2019" -A x64 -T hos
    -DLLVM_ENABLE_RTTI=ON ^
    -DLLVM_ENABLE_ZLIB=OFF
 
-call cmake --build . --config Release -- /m
-call cmake --build . --config Release --target install -- /m
-call cmake --build . --config Release --target check-mlir -- /m
+call cmake --build . --config Release
+call cmake --build . --config Release --target install
+call cmake --build . --config Release --target check-mlir
 ```
 
 #### ONNX-MLIR (this project)
@@ -274,27 +274,27 @@ set root_dir=%cd%
 
 md onnx-mlir\build
 cd onnx-mlir\build
-call cmake %root_dir%\onnx-mlir -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DCMAKE_BUILD_TYPE=Release ^
    -DCMAKE_PREFIX_PATH=%root_dir%\protobuf_install ^
    -DLLVM_LIT_ARGS=-v ^
    -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir
 
-call cmake --build . --config Release --target onnx-mlir -- /m
+call cmake --build . --config Release --target onnx-mlir
 ```
 
 To run the lit ONNX MLIR tests, use the following command:
 
 [same-as-file]: <> ({"ref": "utils/check-onnx-mlir.cmd", "skip-ref": 1})
 ```shell
-call cmake --build . --config Release --target check-onnx-lit -- /m
+call cmake --build . --config Release --target check-onnx-lit
 ```
 
 To run the numerical ONNX MLIR tests, use the following command:
 
 [same-as-file]: <> ({"ref": "utils/check-numerical.cmd", "skip-ref": 1})
 ```shell
-call cmake --build . --config Release --target check-numerical -- /m
+call cmake --build . --config Release --target check-numerical
 ```
 
 After the above commands succeed, an `onnx-mlir` executable should appear in the `bin` directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -194,7 +194,7 @@ The following CMake variables from LLVM and ONNX MLIR can be used when compiling
 ## Installation on Windows
 Building onnx-mlir on Windows requires building some additional prerequisites that are not available by default.
 
-Note that the instructions in this file assume you are using [Visual Studio  2019 Community Edition](https://visualstudio.microsoft.com/downloads/). It is recommended that you have the **Desktop development with C++** and **Linux development with C++** workloads installed. This ensures you have all toolchains and libraries needed to compile this project and its dependencies on Windows.
+Note that the instructions in this file assume you are using [Visual Studio  2019 Community Edition](https://visualstudio.microsoft.com/downloads/) with ninja. It is recommended that you have the **Desktop development with C++** and **Linux development with C++** workloads installed. This ensures you have all toolchains and libraries needed to compile this project and its dependencies on Windows.
 
 Run all the commands from a shell started from **"Developer Command Prompt for VS 2019"**.
 
@@ -211,7 +211,7 @@ cd protobuf && git checkout d0bfd5221182da1a7cc280f3337b5e41a89539cf && cd ..
 set root_dir=%cd%
 md protobuf_build
 cd protobuf_build
-call cmake %root_dir%\protobuf\cmake -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\protobuf\cmake -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX="%root_dir%\protobuf_install" ^
    -DCMAKE_BUILD_TYPE=Release ^
    -Dprotobuf_BUILD_EXAMPLES=OFF ^
@@ -220,8 +220,8 @@ call cmake %root_dir%\protobuf\cmake -G "Visual Studio 16 2019" -A x64 -T host=x
    -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ^
    -Dprotobuf_WITH_ZLIB=OFF
 
-call cmake --build . --config Release -- /m
-call cmake --build . --config Release --target install -- /m
+call cmake --build . --config Release
+call cmake --build . --config Release --target install
 ```
 
 Before running CMake for onnx-mlir, ensure that the bin directory to this protobuf is before any others in your PATH:
@@ -244,7 +244,7 @@ cd llvm-project && git checkout 23dd750279c9e32ea631cc9e92c4413c7a3df60a && cd .
 set root_dir=%cd%
 md llvm-project\build
 cd llvm-project\build
-call cmake %root_dir%\llvm-project\llvm -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\llvm-project\llvm -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX="%root_dir%\llvm-project\build\install" ^
    -DLLVM_ENABLE_PROJECTS=mlir ^
    -DLLVM_TARGETS_TO_BUILD="host" ^
@@ -253,9 +253,9 @@ call cmake %root_dir%\llvm-project\llvm -G "Visual Studio 16 2019" -A x64 -T hos
    -DLLVM_ENABLE_RTTI=ON ^
    -DLLVM_ENABLE_ZLIB=OFF
 
-call cmake --build . --config Release -- /m
-call cmake --build . --config Release --target install -- /m
-call cmake --build . --config Release --target check-mlir -- /m
+call cmake --build . --config Release
+call cmake --build . --config Release --target install
+call cmake --build . --config Release --target check-mlir
 ```
 
 #### ONNX-MLIR (this project)
@@ -274,27 +274,27 @@ set root_dir=%cd%
 
 md onnx-mlir\build
 cd onnx-mlir\build
-call cmake %root_dir%\onnx-mlir -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DCMAKE_BUILD_TYPE=Release ^
    -DCMAKE_PREFIX_PATH=%root_dir%\protobuf_install ^
    -DLLVM_LIT_ARGS=-v ^
    -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir
 
-call cmake --build . --config Release --target onnx-mlir -- /m
+call cmake --build . --config Release --target onnx-mlir
 ```
 
 To run the lit ONNX MLIR tests, use the following command:
 
 [same-as-file]: <> ({"ref": "utils/check-onnx-mlir.cmd", "skip-ref": 1})
 ```shell
-call cmake --build . --config Release --target check-onnx-lit -- /m
+call cmake --build . --config Release --target check-onnx-lit
 ```
 
 To run the numerical ONNX MLIR tests, use the following command:
 
 [same-as-file]: <> ({"ref": "utils/check-numerical.cmd", "skip-ref": 1})
 ```shell
-call cmake --build . --config Release --target check-numerical -- /m
+call cmake --build . --config Release --target check-numerical
 ```
 
 After the above commands succeed, an `onnx-mlir` executable should appear in the `bin` directory.

--- a/utils/build-mlir.cmd
+++ b/utils/build-mlir.cmd
@@ -1,7 +1,7 @@
 set root_dir=%cd%
 md llvm-project\build
 cd llvm-project\build
-call cmake %root_dir%\llvm-project\llvm -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\llvm-project\llvm -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX="%root_dir%\llvm-project\build\install" ^
    -DLLVM_ENABLE_PROJECTS=mlir ^
    -DLLVM_TARGETS_TO_BUILD="host" ^
@@ -10,6 +10,6 @@ call cmake %root_dir%\llvm-project\llvm -G "Visual Studio 16 2019" -A x64 -T hos
    -DLLVM_ENABLE_RTTI=ON ^
    -DLLVM_ENABLE_ZLIB=OFF
 
-call cmake --build . --config Release -- /m
-call cmake --build . --config Release --target install -- /m
-call cmake --build . --config Release --target check-mlir -- /m
+call cmake --build . --config Release
+call cmake --build . --config Release --target install
+call cmake --build . --config Release --target check-mlir

--- a/utils/build-onnx-mlir.cmd
+++ b/utils/build-onnx-mlir.cmd
@@ -2,10 +2,10 @@ set root_dir=%cd%
 
 md onnx-mlir\build
 cd onnx-mlir\build
-call cmake %root_dir%\onnx-mlir -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DCMAKE_BUILD_TYPE=Release ^
    -DCMAKE_PREFIX_PATH=%root_dir%\protobuf_install ^
    -DLLVM_LIT_ARGS=-v ^
    -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir
 
-call cmake --build . --config Release --target onnx-mlir -- /m
+call cmake --build . --config Release --target onnx-mlir

--- a/utils/check-numerical.cmd
+++ b/utils/check-numerical.cmd
@@ -1,2 +1,2 @@
 cd onnx-mlir\build
-call cmake --build . --config Release --target check-numerical -- /m
+call cmake --build . --config Release --target check-numerical

--- a/utils/check-onnx-mlir.cmd
+++ b/utils/check-onnx-mlir.cmd
@@ -1,2 +1,2 @@
 cd onnx-mlir\build
-call cmake --build . --config Release --target check-onnx-lit -- /m
+call cmake --build . --config Release --target check-onnx-lit

--- a/utils/install-protobuf.cmd
+++ b/utils/install-protobuf.cmd
@@ -6,7 +6,7 @@ cd protobuf && git checkout d0bfd5221182da1a7cc280f3337b5e41a89539cf && cd ..
 set root_dir=%cd%
 md protobuf_build
 cd protobuf_build
-call cmake %root_dir%\protobuf\cmake -G "Visual Studio 16 2019" -A x64 -T host=x64 ^
+call cmake %root_dir%\protobuf\cmake -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX="%root_dir%\protobuf_install" ^
    -DCMAKE_BUILD_TYPE=Release ^
    -Dprotobuf_BUILD_EXAMPLES=OFF ^
@@ -15,5 +15,5 @@ call cmake %root_dir%\protobuf\cmake -G "Visual Studio 16 2019" -A x64 -T host=x
    -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ^
    -Dprotobuf_WITH_ZLIB=OFF
 
-call cmake --build . --config Release -- /m
-call cmake --build . --config Release --target install -- /m
+call cmake --build . --config Release
+call cmake --build . --config Release --target install


### PR DESCRIPTION
This updates the Windows CI to use ninja as the cmake generator (though the build tools are still Visual Studio). The scripts and readme are updated accordingly as well
