### PR TITLE
Change the option memory-bundling-enabled to disable-memory-bundling

### DIFF
--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -481,21 +481,19 @@ void addONNXToKrnlPasses(mlir::PassManager &pm) {
   // Only emit memref.dealloc if memory bundling is enabled.
   // Otherwise, memref.dealloc will be emitted by buffer-deallocation pass.
   pm.addPass(
-      mlir::createLowerToKrnlPass(/*emitDealloc=*/memoryBundlingEnabled));
+      mlir::createLowerToKrnlPass(/*emitDealloc=*/!disableMemoryBundling));
   // An additional pass of canonicalization is helpful because lowering
   // from ONNX dialect to Standard dialect exposes additional canonicalization
-  // oppertunities.
+  // opportunities.
   pm.addPass(mlir::createCanonicalizerPass());
-  if (memoryBundlingEnabled) {
-    pm.addNestedPass<FuncOp>(createDisconnectKrnlDimFromAllocPass());
-
-    // TODO: make this pass optional:
+  pm.addNestedPass<FuncOp>(createDisconnectKrnlDimFromAllocPass());
+  if (disableMemoryBundling) {
+    pm.addNestedPass<FuncOp>(mlir::createBufferDeallocationPass());
+  } else {
     pm.addNestedPass<FuncOp>(mlir::createKrnlEnableMemoryPoolPass());
     pm.addNestedPass<FuncOp>(mlir::createKrnlBundleMemoryPoolsPass());
     pm.addPass(mlir::createCanonicalizerPass());
     pm.addNestedPass<FuncOp>(mlir::createKrnlOptimizeMemoryPoolsPass());
-  } else {
-    pm.addNestedPass<FuncOp>(mlir::createBufferDeallocationPass());
   }
   pm.addPass(mlir::createCanonicalizerPass());
 }

--- a/src/Support/OMOptions.cpp
+++ b/src/Support/OMOptions.cpp
@@ -39,8 +39,9 @@ llvm::cl::opt<string> instrumentONNXOps("instrument-onnx-ops",
                    "\"op1 op2 ...\" for the specified ops."),
     llvm::cl::init(""), llvm::cl::cat(OMPassOptions));
 
-llvm::cl::opt<bool> memoryBundlingEnabled("memory-bundling-enabled",
-    llvm::cl::desc("enable memory bundling related optimization"
-                   "several passes work together to bundle buffers"
-                   "if disabled, buffer management by mlir is used"),
-    llvm::cl::init(true), llvm::cl::cat(OMPassOptions));
+llvm::cl::opt<bool> disableMemoryBundling("disable-memory-bundling",
+    llvm::cl::desc("disable memory bundling related optimizations\n"
+                   "where several passes work together to bundle buffers.\n"
+                   "Buffer management by MLIR is used instead.\n"
+                   "Try this if you experience a significant compile time."),
+    llvm::cl::init(false), llvm::cl::cat(OMPassOptions));

--- a/src/Support/OMOptions.hpp
+++ b/src/Support/OMOptions.hpp
@@ -23,4 +23,4 @@ extern llvm::cl::OptionCategory OMPassOptions;
 // Declare options
 extern llvm::cl::opt<std::string> instrumentONNXOps;
 
-extern llvm::cl::opt<bool> memoryBundlingEnabled;
+extern llvm::cl::opt<bool> disableMemoryBundling;


### PR DESCRIPTION
Change the option `memory-bundling-enabled` to `disable-memory-bundling` to make it easier to understand.

By default, memory bundling is enabled, passing `--disable-memory-bundling` to `onnx-mlir` to disable.

Help is now better to understand:
```
--disable-memory-bundling                 - disable memory bundling related optimizations
                                            where several passes work together to bundle buffers.
                                            Buffer management by MLIR is used instead.
                                            Try this if you experience a significant compile time.

```

Signed-off-by: Tung D. Le <tung@jp.ibm.com>