### PR TITLE
Import softmax with respect to the opset version

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -906,6 +906,47 @@ private:
     buildOutputAndOperation<ONNXSliceOp>(node, in, nIn, nOut, attributes);
   }
 
+  /*!
+   * Special handle for Softmax operation where the default axis value depends
+   * on the opset version.
+   */
+  void ImportNodeSoftmax(const onnx::NodeProto &node) {
+    // Copy the provided inputs first.
+    std::vector<Value> inputs;
+    for (const auto &item : node.input()) {
+      if (initializedTensors.ContainKey(item)) {
+        inputs.push_back(initializedTensors.EmitInitializerForInputTensor(
+            UnknownLoc(), builder_, item));
+      } else if (frontend_symbols_.ContainKey(item)) {
+        inputs.push_back(frontend_symbols_.GetTensorByOnnxName(item));
+      }
+    }
+
+    int nIn = ONNXSoftmaxOp::getNumberOfOperands();
+    int nOut = ONNXSoftmaxOp::getNumberOfResults();
+
+    // If no attribute is provided, axis would depend on the opset version.
+    // - With opset version < 13, default axis value is 1.
+    // - With opset version 13, default axis value is -1.
+    auto attributes = ImportNodeAttributes(node);
+    bool hasAxisAttribute = false;
+    for (auto &attr : attributes)
+      if (attr.first.strref().equals_insensitive("axis")) {
+        hasAxisAttribute = true;
+        break;
+      }
+
+    if (!hasAxisAttribute) {
+      auto currentOpset = opset_map_.find(node.domain())->second;
+      if (currentOpset < 13)
+        attributes.push_back(builder_.getNamedAttr("axis",
+            IntegerAttr::get(builder_.getIntegerType(64, /*isSigned=*/true),
+                APInt(64, /*value=*/1, /*isSigned=*/true))));
+    }
+
+    buildOutputAndOperation<ONNXSoftmaxOp>(node, inputs, nIn, nOut, attributes);
+  }
+
   const onnx::OpSchema *GetOpSchema(const onnx::NodeProto &node) {
     auto &domain = node.domain();
     auto version_it = opset_map_.find(domain);

--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -467,7 +467,7 @@ import_handler_map_["Size"] =
 import_handler_map_["Slice"] = 
    &onnx_mlir::detail::FrontendGenImpl::ImportNodeSlice;
 import_handler_map_["Softmax"] = 
-   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXSoftmaxOp>;
+   &onnx_mlir::detail::FrontendGenImpl::ImportNodeSoftmax;
 import_handler_map_["SoftmaxCrossEntropyLoss"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXSoftmaxCrossEntropyLossOp>;
 import_handler_map_["Softplus"] = 

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -793,6 +793,7 @@ test_to_enable_dict = {
     "test_inception_v1_cpu": {STATIC_SHAPE:{}},
     "test_resnet50_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{0:{-1}}},
     "test_shufflenet_cpu": {STATIC_SHAPE:{}},
+    "test_squeezenet_cpu": {STATIC_SHAPE:{}},
     "test_vgg19_cpu": {STATIC_SHAPE:{}},
 }
 

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -257,6 +257,7 @@ special_op_handler = dict([
     ("MaxPool", "ImportNodeMaxPool"),
     ("Pad", "ImportNodePad"),
     ("Slice", "ImportNodeSlice"),
+    ("Softmax", "ImportNodeSoftmax"),
     #("Transpose", "ImportNodeTranspose")
 ])
 


### PR DESCRIPTION
resolves #832

Since ONNX Opset 13, the default axis value in softmax has changed from 1 to -1, though the number of inputs and outputs are unchanged. 

This patch creates a custom import function for softmax that takes into account the default axis value. 

This patch also enables the squeezenet model that was failed without this patch.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>