### PR TITLE
Fix for CONV with VALID auto_pad

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -1755,11 +1755,11 @@ static LogicalResult verify(ONNXConvOp op) {
 // For this operation, we define the attributes once in the original Conv
 // operation class. There is no need to redefine the attribute names for the
 // other classes based on Conv.
-// Conv attributes output:
-//   -  auto_pad set to NOTSET;
+// Conv attributes output: no changes to the op but the output.
+// ShapeHelper get
 //   -  dilations, strides: set to 1 if not defined by user;
 //   -  kernelShape: inferred from weight matrix if not defined by user;
-//   -  pads: set to proper value, 0 if not defined by user.
+//   -  pads: set to proper value
 
 LogicalResult ONNXConvOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -1025,7 +1025,7 @@ LogicalResult ONNXConvOpShapeHelper::Compute(ONNXConvOpAdaptor operandAdaptor) {
     } else if (autoPad == "VALID") {
       IndexExpr t1 = I - kdTerm; // Compute ceil((I - kdTerm +1)/s).
       IndexExpr t2 = t1 + one;
-      IndexExpr O = t2.floorDiv(s);
+      IndexExpr O = t2.ceilDiv(s);
       // Set output dim, and pads already set to zero, nothing more to do.
       outputDims.emplace_back(O);
     } else if (autoPad == "SAME_UPPER" || autoPad == "SAME_LOWER") {

--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -89,9 +89,9 @@ LogicalResult checkShapes(const int NIn, const int CIn, const int HIn,
       myPEnd[i] = pEnd[i];
     } else if (autoPad == AUTO_PAD_VALID) {
       // VALID:
-      // * O[i] = floor((I[i] - ((K[i] - 1) * d[i] + 1) + 1) / s[i])
+      // * O[i] = ceil((I[i] - ((K[i] - 1) * d[i] + 1) + 1) / s[i])
       // * P = 0
-      myO[i] = myFloor((I[i] - ((K[i] - 1) * d[i] + 1) + 1), s[i]);
+      myO[i] = myCeil((I[i] - ((K[i] - 1) * d[i] + 1) + 1), s[i]);
       myPBegin[i] = myPEnd[i] = 0;
     } else {
       // SAME_LOWER or SAME_UPPER:


### PR DESCRIPTION
change the erroneous floor into a ceil according to ONNX standard fo… r CONV, as seen in MaxPool

From MaxPool doc for VALID:

VALID: output_spatial_shape[i] = ceil((input_spatial_shape[i] - ((kernel_spatial_shape[i] - 1) * dilations[i] + 1) + 1) / strides_spatial_shape[i])

floor was used before, switched to ceil.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>