### PR TITLE
new way for optional input (yolo model) 

### DIFF
--- a/src/Dialect/ONNX/ONNXOpsHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.cpp
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
 #include "src/Dialect/ONNX/IndexExpr.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
 
 // Identity affine
 using namespace mlir;
@@ -216,6 +216,18 @@ bool isFromNone(Value v) {
     if (c.getValue().isa<UnitAttr>())
       return true;
   }
+  if (v.getDefiningOp() &&
+      llvm::dyn_cast_or_null<mlir::ONNXConstantOp>(v.getDefiningOp())) {
+    mlir::ONNXConstantOp c =
+        llvm::dyn_cast<mlir::ONNXConstantOp>(v.getDefiningOp());
+    if (c.value().hasValue() && c.valueAttr().isa<DenseElementsAttr>()) {
+      DenseElementsAttr d = c.valueAttr().cast<DenseElementsAttr>();
+      auto shape = d.getType().dyn_cast<RankedTensorType>().getShape();
+      if (shape.size() == 1 && shape[0] == 0)
+        return true;
+    }
+  }
+
   return false;
 }
 


### PR DESCRIPTION
Signed-off-by: Tong Chen <chentong@us.ibm.com>
In the previous model, the missed optional input is an empty item and onnx-mlir will put a constant with UnitAttr in std dialect for the missing input.
In the new model, the missed optional input is represented with an ONNXConstantOp with empty value.  %655 in the following code is an example.
```
    %655 = "onnx.Constant"() {value = dense<> : tensor<0xf32>} : () -> tensor<0xf32>
    %656 = "onnx.Resize"(%647, %654, %655, %653) {coordinate_transformation_mode = "h
alf_pixel", mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize__697"}
 : (tensor<*xf32>, tensor<0xf32>, tensor<0xf32>, tensor<*xi64>) -> tensor<*xf32>
```
This PR is to add this case in the function isFromNone().