### PR TITLE
Update onnx.EntryPoint op definition to allow operation generation by tablegen.

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td
+++ b/src/Dialect/ONNX/ONNXOps.td
@@ -73,6 +73,10 @@ def ONNXEntryPointOp: ONNX_Op<"EntryPoint"> {
   let description = [{
     The "onnx.EntryPoint" function indicates the main entry point of ONNX model.
   }];
+  let arguments = (ins SymbolRefAttr:$func,
+           I32Attr:$numInputs,
+           I32Attr:$numOutputs,
+           StrAttr:$signature);
 
   let builders = [OpBuilder<(ins "FuncOp":$function, "int":$numInputs,
                                  "int":$numOutputs, "std::string":$signature)>];


### PR DESCRIPTION
Add the following argument part in the onnx.EntryPoint op definition to enable operation generation by tablegen.
let arguments = (ins SymbolRefAttr:$func,
           I32Attr:$numInputs,
           I32Attr:$numOutputs,
           StrAttr:$signature);

Otherwise, tablegen causes an error with the "error: op 'onnx.EntryPoint' argument number mismatch: 4 in pattern vs. 0 in definition ..." message.