### PR TITLE
Replacing the remaining old code in LSTM/RNN/GRU by IndexExpr

### DIFF
--- a/test/mlir/onnx/onnx_lowering_gru_op.mlir
+++ b/test/mlir/onnx/onnx_lowering_gru_op.mlir
@@ -1,22 +1,27 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl='check-rnn-ops-lowering' %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl='check-rnn-ops-lowering' --canonicalize %s -split-input-file | FileCheck %s
 
 func private @test_gru_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12x3xf32>, %arg2: tensor<1x12x4xf32>, %arg3: tensor<1x24xf32>, %arg4: tensor<1x2x4xf32>) -> tensor<*xf32> {
   %cst = constant unit
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64} : (tensor<7x2x3xf32>, tensor<1x12x3xf32>, tensor<1x12x4xf32>, tensor<1x24xf32>, none, tensor<1x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_gru_forward_mode
+// mlir2FileCheck.py
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-LABEL:  builtin.func private @test_gru_forward_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x12x3xf32>, [[PARAM_2_:%.+]]: memref<1x12x4xf32>, [[PARAM_3_:%.+]]: memref<1x24xf32>, [[PARAM_4_:%.+]]: memref<1x2x4xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x12x3xf32>) -> memref<12x3xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x12x4xf32>) -> memref<12x4xf32>
@@ -32,36 +37,22 @@ func private @test_gru_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
 // CHECK-DAG:       [[VAR_11_:%.+]]:6 = "onnx.Split"([[VAR_10_]]) {axis = 0 : si64} : (memref<24xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[VAR_14_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[VAR_15_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_23_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_23_]]#0, [[VAR_23_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[VAR_15_]]{{.}}[[VAR_23_]]#0, [[VAR_23_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_4_]]{{.}}[[VAR_23_]]#0, [[VAR_23_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_17_:%.+]] = "onnx.MatMul"([[VAR_15_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
-// CHECK-DAG:         [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
-// CHECK-DAG:         [[VAR_18_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_7_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[VAR_19_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_8_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_17_:%.+]] = "onnx.MatMul"([[RES_4_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
+// CHECK-DAG:         [[VAR_18_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_7_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_19_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_8_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_23_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_23_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[VAR_25_:%.+]] = affine.apply #map0(){{.}}[[VAR_23_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_17_MEM_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_23_1_]]#0, [[VAR_25_]]{{.}} : memref<2x12xf32>
@@ -72,21 +63,19 @@ func private @test_gru_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_1_:%.+]] = krnl.load [[VAR_11_]]#4{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_31_:%.+]] = addf [[VAR_28_]], [[LOAD_VAR_11_MEM_]] : f32
 // CHECK-DAG:           [[VAR_32_:%.+]] = addf [[VAR_31_]], [[LOAD_VAR_11_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_33_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_32_]], [[VAR_33_]][] : memref<f32>
-// CHECK:               [[VAR_34_:%.+]] = "onnx.Sigmoid"([[VAR_33_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_32_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_34_:%.+]] = "onnx.Sigmoid"([[RES_5_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_34_MEM_:%.+]] = krnl.load [[VAR_34_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_34_MEM_]], [[VAR_14_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_VAR_34_MEM_]], [[RES_3_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
 // CHECK:               [[VAR_36_:%.+]] = mulf [[LOAD_VAR_34_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:               krnl.store [[VAR_36_]], [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_36_]], [[RES_2_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_21_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_1_]], [[VAR_9_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_21_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_9_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_4_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_23_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_2_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_23_2_]]#0, [[VAR_23_2_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_23_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_23_2_]]#0, [[VAR_23_2_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_17_MEM_1_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_23_2_]]#0, [[VAR_23_2_]]#1] : memref<2x12xf32>
 // CHECK-DAG:           [[LOAD_VAR_17_MEM_2_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_23_2_]]#0, [[VAR_23_2_]]#1] : memref<2x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -95,12 +84,10 @@ func private @test_gru_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_3_:%.+]] = krnl.load [[VAR_11_]]#3{{.}}[[VAR_23_2_]]#1] : memref<4xf32>
 // CHECK:               [[LOAD_VAR_11_MEM_1_:%.+]] = addf [[LOAD_VAR_19_MEM_1_]], [[LOAD_VAR_11_MEM_2_]] : f32
 // CHECK-DAG:           [[VAR_31_1_:%.+]] = addf [[LOAD_VAR_11_MEM_1_]], [[LOAD_VAR_11_MEM_3_]] : f32
-// CHECK-DAG:           [[VAR_32_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_31_1_]], [[VAR_32_1_]][] : memref<f32>
-// CHECK:               [[VAR_33_1_:%.+]] = "onnx.Sigmoid"([[VAR_32_1_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[VAR_34_1_:%.+]] = krnl.load [[VAR_33_1_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_31_1_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[RES_5_:%.+]] = "onnx.Sigmoid"([[RES_6_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[VAR_34_1_:%.+]] = krnl.load [[RES_5_]][] : memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_34_MEM_1_:%.+]] = affine.apply #map1(){{.}}[[VAR_23_2_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_17_MEM_3_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_23_2_]]#0, [[LOAD_VAR_34_MEM_1_]]{{.}} : memref<2x12xf32>
@@ -111,25 +98,26 @@ func private @test_gru_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_5_:%.+]] = krnl.load [[VAR_11_]]#5{{.}}[[VAR_23_2_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_41_:%.+]] = addf [[VAR_38_]], [[LOAD_VAR_11_MEM_4_]] : f32
 // CHECK-DAG:           [[VAR_42_:%.+]] = addf [[VAR_41_]], [[LOAD_VAR_11_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_43_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_42_]], [[VAR_43_]][] : memref<f32>
-// CHECK:               [[VAR_44_:%.+]] = "onnx.Tanh"([[VAR_43_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_42_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_44_:%.+]] = "onnx.Tanh"([[RES_7_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_44_MEM_:%.+]] = krnl.load [[VAR_44_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_46_:%.+]] = subf [[CST_1_dot_000000_]], [[VAR_34_1_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_47_:%.+]] = mulf [[VAR_46_]], [[LOAD_VAR_44_MEM_]] : f32
 // CHECK-DAG:           [[VAR_48_:%.+]] = mulf [[VAR_34_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK:               [[VAR_49_:%.+]] = addf [[VAR_47_]], [[VAR_48_]] : f32
-// CHECK:               krnl.store [[VAR_49_]], [[VAR_0_]]{{.}}[[VAR_23_2_]]#0, [[VAR_23_2_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_49_]], [[RES_]]{{.}}[[VAR_23_2_]]#0, [[VAR_23_2_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[VAR_14_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[VAR_15_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_4_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_0_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_1_]], [[RES_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_1_]] : memref<1x2x4xf32>
+// CHECK:         }
+
 }
 
 // -----
@@ -139,18 +127,22 @@ func private @test_gru_forward_mode_linear_before_reset(%arg0: tensor<7x2x3xf32>
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64, linear_before_reset = 1 : si64} : (tensor<7x2x3xf32>, tensor<1x12x3xf32>, tensor<1x12x4xf32>, tensor<1x24xf32>, none, tensor<1x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
   
-// CHECK-LABEL:  func private @test_gru_forward_mode_linear_before_reset
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-LABEL:  builtin.func private @test_gru_forward_mode_linear_before_reset
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x12x3xf32>, [[PARAM_2_:%.+]]: memref<1x12x4xf32>, [[PARAM_3_:%.+]]: memref<1x24xf32>, [[PARAM_4_:%.+]]: memref<1x2x4xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x12x3xf32>) -> memref<12x3xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x12x4xf32>) -> memref<12x4xf32>
@@ -162,33 +154,19 @@ func private @test_gru_forward_mode_linear_before_reset(%arg0: tensor<7x2x3xf32>
 // CHECK-DAG:       [[VAR_8_:%.+]]:6 = "onnx.Split"([[VAR_7_]]) {axis = 0 : si64} : (memref<24xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_15_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_15_]]#0, [[VAR_15_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_15_]]#0, [[VAR_15_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_2_]]{{.}}[[VAR_15_]]#0, [[VAR_15_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_12_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_1_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
-// CHECK-DAG:         [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
-// CHECK-DAG:         [[VAR_13_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_6_]]) : (memref<2x4xf32>, memref<4x12xf32>) -> memref<2x12xf32>
+// CHECK-DAG:         [[VAR_12_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
+// CHECK-DAG:         [[VAR_13_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_6_]]) : (memref<2x4xf32>, memref<4x12xf32>) -> memref<2x12xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_15_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_15_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_12_MEM_:%.+]] = krnl.load [[VAR_12_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x12xf32>
 // CHECK-DAG:           [[LOAD_VAR_13_MEM_:%.+]] = krnl.load [[VAR_13_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x12xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -197,9 +175,9 @@ func private @test_gru_forward_mode_linear_before_reset(%arg0: tensor<7x2x3xf32>
 // CHECK-DAG:           [[LOAD_VAR_8_MEM_1_:%.+]] = krnl.load [[VAR_8_]]#3{{.}}[[VAR_15_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_22_:%.+]] = addf [[VAR_19_]], [[LOAD_VAR_8_MEM_]] : f32
 // CHECK-DAG:           [[VAR_23_:%.+]] = addf [[VAR_22_]], [[LOAD_VAR_8_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_24_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_23_]], [[VAR_24_]][] : memref<f32>
-// CHECK:               [[VAR_25_:%.+]] = "onnx.Sigmoid"([[VAR_24_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_3_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_23_]], [[RES_3_]][] : memref<f32>
+// CHECK:               [[VAR_25_:%.+]] = "onnx.Sigmoid"([[RES_3_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_25_MEM_:%.+]] = krnl.load [[VAR_25_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_27_:%.+]] = affine.apply #map0(){{.}}[[VAR_15_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
@@ -211,17 +189,13 @@ func private @test_gru_forward_mode_linear_before_reset(%arg0: tensor<7x2x3xf32>
 // CHECK-DAG:           [[LOAD_VAR_8_MEM_3_:%.+]] = krnl.load [[VAR_8_]]#4{{.}}[[VAR_15_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_34_:%.+]] = addf [[VAR_31_]], [[LOAD_VAR_8_MEM_2_]] : f32
 // CHECK-DAG:           [[VAR_35_:%.+]] = addf [[VAR_34_]], [[LOAD_VAR_8_MEM_3_]] : f32
-// CHECK-DAG:           [[VAR_36_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_35_]], [[VAR_36_]][] : memref<f32>
-// CHECK:               [[VAR_37_:%.+]] = "onnx.Sigmoid"([[VAR_36_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_4_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_35_]], [[RES_4_]][] : memref<f32>
+// CHECK:               [[VAR_37_:%.+]] = "onnx.Sigmoid"([[RES_4_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_37_MEM_:%.+]] = krnl.load [[VAR_37_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[VAR_39_:%.+]] = affine.apply #map1(){{.}}[[VAR_15_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_12_MEM_2_:%.+]] = krnl.load [[VAR_12_]]{{.}}[[VAR_15_1_]]#0, [[VAR_39_]]{{.}} : memref<2x12xf32>
-// CHECK-DAG:           [[CST_2_3_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_1_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[VAR_41_:%.+]] = affine.apply #map1(){{.}}[[VAR_15_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_13_MEM_2_:%.+]] = krnl.load [[VAR_13_]]{{.}}[[VAR_15_1_]]#0, [[VAR_41_]]{{.}} : memref<2x12xf32>
@@ -232,24 +206,24 @@ func private @test_gru_forward_mode_linear_before_reset(%arg0: tensor<7x2x3xf32>
 // CHECK-DAG:           [[LOAD_VAR_8_MEM_5_:%.+]] = krnl.load [[VAR_8_]]#2{{.}}[[VAR_15_1_]]#1] : memref<4xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_48_:%.+]] = addf [[VAR_46_]], [[LOAD_VAR_8_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_49_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_48_]], [[VAR_49_]][] : memref<f32>
-// CHECK:               [[VAR_50_:%.+]] = "onnx.Tanh"([[VAR_49_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_48_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_50_:%.+]] = "onnx.Tanh"([[RES_5_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_50_MEM_:%.+]] = krnl.load [[VAR_50_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_52_:%.+]] = subf [[CST_1_dot_000000_]], [[LOAD_VAR_25_MEM_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_53_:%.+]] = mulf [[VAR_52_]], [[LOAD_VAR_50_MEM_]] : f32
 // CHECK-DAG:           [[VAR_54_:%.+]] = mulf [[LOAD_VAR_25_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK:               [[VAR_55_:%.+]] = addf [[VAR_53_]], [[VAR_54_]] : f32
-// CHECK:               krnl.store [[VAR_55_]], [[VAR_0_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_55_]], [[RES_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_0_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_1_]], [[RES_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_1_]] : memref<1x2x4xf32>
 // CHECK:         }
+
 }
 
 // -----
@@ -263,139 +237,116 @@ func private @test_gru_forward_mode_constant_weight_and_bias(%arg0: tensor<7x2x3
   %Y, %Y_h = "onnx.GRU"(%arg0, %w, %r, %b, %cst, %arg1) {hidden_size = 4 : si64} : (tensor<7x2x3xf32>, tensor<1x12x3xf32>, tensor<1x12x4xf32>, tensor<1x24xf32>, none, tensor<1x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_gru_forward_mode_constant_weight_and_bias
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-LABEL:  builtin.func private @test_gru_forward_mode_constant_weight_and_bias
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x2x4xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_0", shape = [1, 12, 3], value = dense<1.000000e+00> : tensor<1x12x3xf32>} : () -> memref<1x12x3xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_1", shape = [1, 12, 4], value = dense<2.000000e+00> : tensor<1x12x4xf32>} : () -> memref<1x12x4xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_2", shape = [1, 24], value = dense<{{.}}[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01, 2.000000e+01, 2.100000e+01, 2.200000e+01, 2.300000e+01, 2.400000e+01]{{.}}> : tensor<1x24xf32>} : () -> memref<1x24xf32>
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_1_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_1_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
-// CHECK-DAG:       [[VAR_6_:%.+]] = "krnl.global"() {name = "constant_3", shape = [12, 3], value = dense<1.000000e+00> : tensor<12x3xf32>} : () -> memref<12x3xf32>
-// CHECK-DAG:       [[VAR_7_:%.+]] = "krnl.global"() {name = "constant_4", shape = [12, 4], value = dense<2.000000e+00> : tensor<12x4xf32>} : () -> memref<12x4xf32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = "krnl.global"() {name = "constant_5", shape = [3, 12], value = dense<1.000000e+00> : tensor<3x12xf32>} : () -> memref<3x12xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = "krnl.global"() {name = "constant_6", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_10_:%.+]] = "krnl.global"() {name = "constant_7", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_11_:%.+]] = "krnl.global"() {name = "constant_8", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = "krnl.global"() {name = "constant_9", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_13_:%.+]] = "krnl.global"() {name = "constant_10", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_14_:%.+]] = "krnl.global"() {name = "constant_11", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_15_:%.+]] = "krnl.global"() {name = "constant_12", shape = [24], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01, 2.000000e+01, 2.100000e+01, 2.200000e+01, 2.300000e+01, 2.400000e+01]> : tensor<24xf32>} : () -> memref<24xf32>
-// CHECK-DAG:       [[VAR_16_:%.+]] = "krnl.global"() {name = "constant_13", shape = [4], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_17_:%.+]] = "krnl.global"() {name = "constant_14", shape = [4], value = dense<[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_18_:%.+]] = "krnl.global"() {name = "constant_15", shape = [4], value = dense<[9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_19_:%.+]] = "krnl.global"() {name = "constant_16", shape = [4], value = dense<[1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_20_:%.+]] = "krnl.global"() {name = "constant_17", shape = [4], value = dense<[1.700000e+01, 1.800000e+01, 1.900000e+01, 2.000000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_21_:%.+]] = "krnl.global"() {name = "constant_18", shape = [4], value = dense<[2.100000e+01, 2.200000e+01, 2.300000e+01, 2.400000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_5", shape = [3, 12], value = dense<1.000000e+00> : tensor<3x12xf32>} : () -> memref<3x12xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_9", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "krnl.global"() {name = "constant_10", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "krnl.global"() {name = "constant_11", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "krnl.global"() {name = "constant_13", shape = [4], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "krnl.global"() {name = "constant_14", shape = [4], value = dense<[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "krnl.global"() {name = "constant_15", shape = [4], value = dense<[9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "krnl.global"() {name = "constant_16", shape = [4], value = dense<[1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "krnl.global"() {name = "constant_17", shape = [4], value = dense<[1.700000e+01, 1.800000e+01, 1.900000e+01, 2.000000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = "krnl.global"() {name = "constant_18", shape = [4], value = dense<[2.100000e+01, 2.200000e+01, 2.300000e+01, 2.400000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_1_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[VAR_24_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[VAR_25_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
-// CHECK:               [[VAR_33_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_33_]]#0, [[VAR_33_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[VAR_25_]]{{.}}[[VAR_33_]]#0, [[VAR_33_]]#1] : memref<2x3xf32>
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
+// CHECK:               [[VAR_24_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_24_]]#0, [[VAR_24_]]#1] : memref<7x2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_4_]]{{.}}[[VAR_24_]]#0, [[VAR_24_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_27_:%.+]] = "onnx.MatMul"([[VAR_25_]], [[VAR_8_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
-// CHECK-DAG:         [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
-// CHECK-DAG:         [[VAR_28_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_12_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[VAR_29_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_13_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_18_:%.+]] = "onnx.MatMul"([[RES_4_]], [[VAR_3_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
+// CHECK-DAG:         [[VAR_19_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_4_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_20_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_5_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_33_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_24_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[VAR_26_:%.+]] = affine.apply #map0(){{.}}[[VAR_24_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_33_1_]]#0, [[VAR_33_1_]]#1] : memref<2x4xf32>
-// CHECK-DAG:           [[VAR_35_:%.+]] = affine.apply #map0(){{.}}[[VAR_33_1_]]#1]
+// CHECK-DAG:           [[LOAD_VAR_18_MEM_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_24_1_]]#0, [[VAR_26_]]{{.}} : memref<2x12xf32>
+// CHECK-DAG:           [[LOAD_VAR_20_MEM_:%.+]] = krnl.load [[VAR_20_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_27_MEM_:%.+]] = krnl.load [[VAR_27_]]{{.}}[[VAR_33_1_]]#0, [[VAR_35_]]{{.}} : memref<2x12xf32>
-// CHECK-DAG:           [[LOAD_VAR_29_MEM_:%.+]] = krnl.load [[VAR_29_]]{{.}}[[VAR_33_1_]]#0, [[VAR_33_1_]]#1] : memref<2x4xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_38_:%.+]] = addf [[LOAD_VAR_27_MEM_]], [[LOAD_VAR_29_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_17_MEM_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_33_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_20_MEM_:%.+]] = krnl.load [[VAR_20_]]{{.}}[[VAR_33_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_41_:%.+]] = addf [[VAR_38_]], [[LOAD_VAR_17_MEM_]] : f32
-// CHECK-DAG:           [[VAR_42_:%.+]] = addf [[VAR_41_]], [[LOAD_VAR_20_MEM_]] : f32
-// CHECK-DAG:           [[VAR_43_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_42_]], [[VAR_43_]][] : memref<f32>
-// CHECK:               [[VAR_44_:%.+]] = "onnx.Sigmoid"([[VAR_43_]]) : (memref<f32>) -> memref<f32>
-// CHECK:               [[LOAD_VAR_44_MEM_:%.+]] = krnl.load [[VAR_44_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_44_MEM_]], [[VAR_24_]]{{.}}[[VAR_33_1_]]#0, [[VAR_33_1_]]#1] : memref<2x4xf32>
-// CHECK:               [[VAR_46_:%.+]] = mulf [[LOAD_VAR_44_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:               krnl.store [[VAR_46_]], [[LOAD_PARAM_1_MEM_1_]]{{.}}[[VAR_33_1_]]#0, [[VAR_33_1_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[VAR_29_:%.+]] = addf [[LOAD_VAR_18_MEM_]], [[LOAD_VAR_20_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_8_MEM_:%.+]] = krnl.load [[VAR_8_]]{{.}}[[VAR_24_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_11_MEM_:%.+]] = krnl.load [[VAR_11_]]{{.}}[[VAR_24_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_32_:%.+]] = addf [[VAR_29_]], [[LOAD_VAR_8_MEM_]] : f32
+// CHECK-DAG:           [[VAR_33_:%.+]] = addf [[VAR_32_]], [[LOAD_VAR_11_MEM_]] : f32
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_33_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_35_:%.+]] = "onnx.Sigmoid"([[RES_5_]]) : (memref<f32>) -> memref<f32>
+// CHECK:               [[LOAD_VAR_35_MEM_:%.+]] = krnl.load [[VAR_35_]][] : memref<f32>
+// CHECK:               krnl.store [[LOAD_VAR_35_MEM_]], [[RES_3_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
+// CHECK:               [[VAR_37_:%.+]] = mulf [[LOAD_VAR_35_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK:               krnl.store [[VAR_37_]], [[RES_2_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_31_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_1_MEM_1_]], [[VAR_14_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_22_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_6_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_4_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_33_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_2_:%.+]] = constant 4 : index
+// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_24_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_18_MEM_1_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x12xf32>
+// CHECK-DAG:           [[LOAD_VAR_18_MEM_2_:%.+]] = krnl.load [[VAR_19_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_33_2_]]#0, [[VAR_33_2_]]#1] : memref<2x4xf32>
-// CHECK-DAG:           [[LOAD_VAR_27_MEM_1_:%.+]] = krnl.load [[VAR_27_]]{{.}}[[VAR_33_2_]]#0, [[VAR_33_2_]]#1] : memref<2x12xf32>
-// CHECK-DAG:           [[LOAD_VAR_27_MEM_2_:%.+]] = krnl.load [[VAR_28_]]{{.}}[[VAR_33_2_]]#0, [[VAR_33_2_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_20_MEM_1_:%.+]] = addf [[LOAD_VAR_18_MEM_1_]], [[LOAD_VAR_18_MEM_2_]] : f32
+// CHECK-DAG:           [[VAR_29_1_:%.+]] = krnl.load [[VAR_7_]]{{.}}[[VAR_24_2_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_8_MEM_1_:%.+]] = krnl.load [[VAR_10_]]{{.}}[[VAR_24_2_]]#1] : memref<4xf32>
+// CHECK:               [[LOAD_VAR_11_MEM_1_:%.+]] = addf [[LOAD_VAR_20_MEM_1_]], [[VAR_29_1_]] : f32
+// CHECK-DAG:           [[VAR_32_1_:%.+]] = addf [[LOAD_VAR_11_MEM_1_]], [[LOAD_VAR_8_MEM_1_]] : f32
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_32_1_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[RES_5_:%.+]] = "onnx.Sigmoid"([[RES_6_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[VAR_35_1_:%.+]] = krnl.load [[RES_5_]][] : memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_35_MEM_1_:%.+]] = affine.apply #map1(){{.}}[[VAR_24_2_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_29_MEM_1_:%.+]] = addf [[LOAD_VAR_27_MEM_1_]], [[LOAD_VAR_27_MEM_2_]] : f32
-// CHECK-DAG:           [[VAR_38_1_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_33_2_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_17_MEM_1_:%.+]] = krnl.load [[VAR_19_]]{{.}}[[VAR_33_2_]]#1] : memref<4xf32>
-// CHECK:               [[LOAD_VAR_20_MEM_1_:%.+]] = addf [[LOAD_VAR_29_MEM_1_]], [[VAR_38_1_]] : f32
-// CHECK-DAG:           [[VAR_41_1_:%.+]] = addf [[LOAD_VAR_20_MEM_1_]], [[LOAD_VAR_17_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_42_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_41_1_]], [[VAR_42_1_]][] : memref<f32>
-// CHECK:               [[VAR_43_1_:%.+]] = "onnx.Sigmoid"([[VAR_42_1_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[VAR_44_1_:%.+]] = krnl.load [[VAR_43_1_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
-// CHECK-DAG:           [[LOAD_VAR_44_MEM_1_:%.+]] = affine.apply #map1(){{.}}[[VAR_33_2_]]#1]
+// CHECK-DAG:           [[LOAD_VAR_18_MEM_3_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_24_2_]]#0, [[LOAD_VAR_35_MEM_1_]]{{.}} : memref<2x12xf32>
+// CHECK-DAG:           [[LOAD_VAR_22_MEM_:%.+]] = krnl.load [[VAR_22_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_27_MEM_3_:%.+]] = krnl.load [[VAR_27_]]{{.}}[[VAR_33_2_]]#0, [[LOAD_VAR_44_MEM_1_]]{{.}} : memref<2x12xf32>
-// CHECK-DAG:           [[LOAD_VAR_31_MEM_:%.+]] = krnl.load [[VAR_31_]]{{.}}[[VAR_33_2_]]#0, [[VAR_33_2_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[VAR_39_:%.+]] = addf [[LOAD_VAR_18_MEM_3_]], [[LOAD_VAR_22_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_9_MEM_:%.+]] = krnl.load [[VAR_9_]]{{.}}[[VAR_24_2_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_:%.+]] = krnl.load [[VAR_12_]]{{.}}[[VAR_24_2_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_42_:%.+]] = addf [[VAR_39_]], [[LOAD_VAR_9_MEM_]] : f32
+// CHECK-DAG:           [[VAR_43_:%.+]] = addf [[VAR_42_]], [[LOAD_VAR_12_MEM_]] : f32
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_43_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_45_:%.+]] = "onnx.Tanh"([[RES_7_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_45_MEM_:%.+]] = krnl.load [[VAR_45_]][] : memref<f32>
+// CHECK-DAG:           [[VAR_47_:%.+]] = subf [[CST_1_dot_000000_]], [[VAR_35_1_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_48_:%.+]] = addf [[LOAD_VAR_27_MEM_3_]], [[LOAD_VAR_31_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_18_MEM_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_33_2_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_21_MEM_:%.+]] = krnl.load [[VAR_21_]]{{.}}[[VAR_33_2_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_51_:%.+]] = addf [[VAR_48_]], [[LOAD_VAR_18_MEM_]] : f32
-// CHECK-DAG:           [[VAR_52_:%.+]] = addf [[VAR_51_]], [[LOAD_VAR_21_MEM_]] : f32
-// CHECK-DAG:           [[VAR_53_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_52_]], [[VAR_53_]][] : memref<f32>
-// CHECK:               [[VAR_54_:%.+]] = "onnx.Tanh"([[VAR_53_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_54_MEM_:%.+]] = krnl.load [[VAR_54_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_56_:%.+]] = subf [[CST_1_dot_000000_]], [[VAR_44_1_]] : f32
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_57_:%.+]] = mulf [[VAR_56_]], [[LOAD_VAR_54_MEM_]] : f32
-// CHECK-DAG:           [[VAR_58_:%.+]] = mulf [[VAR_44_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:               [[VAR_59_:%.+]] = addf [[VAR_57_]], [[VAR_58_]] : f32
-// CHECK:               krnl.store [[VAR_59_]], [[VAR_0_]]{{.}}[[VAR_33_2_]]#0, [[VAR_33_2_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[VAR_48_:%.+]] = mulf [[VAR_47_]], [[LOAD_VAR_45_MEM_]] : f32
+// CHECK-DAG:           [[VAR_49_:%.+]] = mulf [[VAR_35_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK:               [[VAR_50_:%.+]] = addf [[VAR_48_]], [[VAR_49_]] : f32
+// CHECK:               krnl.store [[VAR_50_]], [[RES_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[VAR_24_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[LOAD_PARAM_1_MEM_1_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[VAR_25_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_4_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_0_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x2x4xf32>
-// CHECK:         } 
+// CHECK:           "krnl.memcpy"([[RES_1_]], [[RES_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_1_]] : memref<1x2x4xf32>
+// CHECK:         }
+
 }
 
 // -----
@@ -405,18 +356,23 @@ func private @test_gru_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64, direction = "reverse"} : (tensor<7x2x3xf32>, tensor<1x12x3xf32>, tensor<1x12x4xf32>, tensor<1x24xf32>, none, tensor<1x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
   
-// CHECK-LABEL:  func private @test_gru_reverse_mode
+// CHECK-DAG: #map0 = affine_map<(d0) -> (-d0 + 6)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-DAG: #map2 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-LABEL:  builtin.func private @test_gru_reverse_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x12x3xf32>, [[PARAM_2_:%.+]]: memref<1x12x4xf32>, [[PARAM_3_:%.+]]: memref<1x24xf32>, [[PARAM_4_:%.+]]: memref<1x2x4xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x12x3xf32>) -> memref<12x3xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x12x4xf32>) -> memref<12x4xf32>
@@ -432,39 +388,23 @@ func private @test_gru_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
 // CHECK-DAG:       [[VAR_11_:%.+]]:6 = "onnx.Split"([[VAR_10_]]) {axis = 0 : si64} : (memref<24xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[VAR_14_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[VAR_15_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_7_:%.+]] = constant 7 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_16_:%.+]] = affine.apply #map0([[I_2_]]){{.}}[[CST_7_]]{{.}}
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
+// CHECK-DAG:         [[VAR_16_:%.+]] = affine.apply #map0([[I_2_]])
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_24_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_16_]], [[VAR_24_]]#0, [[VAR_24_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[VAR_15_]]{{.}}[[VAR_24_]]#0, [[VAR_24_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_4_]]{{.}}[[VAR_24_]]#0, [[VAR_24_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_18_:%.+]] = "onnx.MatMul"([[VAR_15_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
-// CHECK-DAG:         [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
-// CHECK-DAG:         [[VAR_19_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_7_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[VAR_20_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_8_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_18_:%.+]] = "onnx.MatMul"([[RES_4_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
+// CHECK-DAG:         [[VAR_19_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_7_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_20_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_8_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_24_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_24_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[VAR_26_:%.+]] = affine.apply #map1(){{.}}[[VAR_24_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_18_MEM_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_24_1_]]#0, [[VAR_26_]]{{.}} : memref<2x12xf32>
@@ -475,21 +415,19 @@ func private @test_gru_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_1_:%.+]] = krnl.load [[VAR_11_]]#4{{.}}[[VAR_24_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_32_:%.+]] = addf [[VAR_29_]], [[LOAD_VAR_11_MEM_]] : f32
 // CHECK-DAG:           [[VAR_33_:%.+]] = addf [[VAR_32_]], [[LOAD_VAR_11_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_34_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_33_]], [[VAR_34_]][] : memref<f32>
-// CHECK:               [[VAR_35_:%.+]] = "onnx.Sigmoid"([[VAR_34_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_33_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_35_:%.+]] = "onnx.Sigmoid"([[RES_5_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_35_MEM_:%.+]] = krnl.load [[VAR_35_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_35_MEM_]], [[VAR_14_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_VAR_35_MEM_]], [[RES_3_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
 // CHECK:               [[VAR_37_:%.+]] = mulf [[LOAD_VAR_35_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:               krnl.store [[VAR_37_]], [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_37_]], [[RES_2_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_22_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_1_]], [[VAR_9_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_22_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_9_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_4_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_24_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_2_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_24_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_18_MEM_1_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x12xf32>
 // CHECK-DAG:           [[LOAD_VAR_18_MEM_2_:%.+]] = krnl.load [[VAR_19_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -498,12 +436,10 @@ func private @test_gru_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_3_:%.+]] = krnl.load [[VAR_11_]]#3{{.}}[[VAR_24_2_]]#1] : memref<4xf32>
 // CHECK:               [[LOAD_VAR_11_MEM_1_:%.+]] = addf [[LOAD_VAR_20_MEM_1_]], [[LOAD_VAR_11_MEM_2_]] : f32
 // CHECK-DAG:           [[VAR_32_1_:%.+]] = addf [[LOAD_VAR_11_MEM_1_]], [[LOAD_VAR_11_MEM_3_]] : f32
-// CHECK-DAG:           [[VAR_33_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_32_1_]], [[VAR_33_1_]][] : memref<f32>
-// CHECK:               [[VAR_34_1_:%.+]] = "onnx.Sigmoid"([[VAR_33_1_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[VAR_35_1_:%.+]] = krnl.load [[VAR_34_1_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_32_1_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[RES_5_:%.+]] = "onnx.Sigmoid"([[RES_6_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[VAR_35_1_:%.+]] = krnl.load [[RES_5_]][] : memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_35_MEM_1_:%.+]] = affine.apply #map2(){{.}}[[VAR_24_2_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_18_MEM_3_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_24_2_]]#0, [[LOAD_VAR_35_MEM_1_]]{{.}} : memref<2x12xf32>
@@ -514,26 +450,26 @@ func private @test_gru_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x12
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_5_:%.+]] = krnl.load [[VAR_11_]]#5{{.}}[[VAR_24_2_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_42_:%.+]] = addf [[VAR_39_]], [[LOAD_VAR_11_MEM_4_]] : f32
 // CHECK-DAG:           [[VAR_43_:%.+]] = addf [[VAR_42_]], [[LOAD_VAR_11_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_44_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_43_]], [[VAR_44_]][] : memref<f32>
-// CHECK:               [[VAR_45_:%.+]] = "onnx.Tanh"([[VAR_44_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_43_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_45_:%.+]] = "onnx.Tanh"([[RES_7_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_45_MEM_:%.+]] = krnl.load [[VAR_45_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_47_:%.+]] = subf [[CST_1_dot_000000_]], [[VAR_35_1_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_48_:%.+]] = mulf [[VAR_47_]], [[LOAD_VAR_45_MEM_]] : f32
 // CHECK-DAG:           [[VAR_49_:%.+]] = mulf [[VAR_35_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK:               [[VAR_50_:%.+]] = addf [[VAR_48_]], [[VAR_49_]] : f32
-// CHECK:               krnl.store [[VAR_50_]], [[VAR_0_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_50_]], [[RES_]]{{.}}[[VAR_24_2_]]#0, [[VAR_24_2_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[VAR_14_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[VAR_15_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_4_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_0_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_1_]], [[RES_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_1_]] : memref<1x2x4xf32>
 // CHECK:         }
+
 }
 
 // -----
@@ -543,21 +479,26 @@ func private @test_gru_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64, direction = "bidirectional"} : (tensor<7x2x3xf32>, tensor<2x12x3xf32>, tensor<2x12x4xf32>, tensor<2x24xf32>, none, tensor<2x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
   
-// CHECK-LABEL:  func private @test_gru_bidirectional_mode
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #map2 = affine_map<(d0) -> (-d0 + 6)>
+// CHECK-LABEL:  builtin.func private @test_gru_bidirectional_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<2x12x3xf32>, [[PARAM_2_:%.+]]: memref<2x12x4xf32>, [[PARAM_3_:%.+]]: memref<2x24xf32>, [[PARAM_4_:%.+]]: memref<2x2x4xf32>) -> memref<2x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<2x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
-// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<2x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:             [[LOAD_PARAM_4_MEM_1_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_1_]], [[I_0_]], [[I_1_]]{{.}} : memref<2x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_1_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_1_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK:           [[VAR_4_:%.+]]:2 = "onnx.Split"([[PARAM_1_]]) {axis = 0 : si64} : (memref<2x12x3xf32>) -> (memref<1x12x3xf32>, memref<1x12x3xf32>)
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.SqueezeV11"([[VAR_4_]]#0) {axes = [0]} : (memref<1x12x3xf32>) -> memref<12x3xf32>
@@ -586,36 +527,22 @@ func private @test_gru_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:       [[VAR_24_:%.+]]:6 = "onnx.Split"([[VAR_22_]]) {axis = 0 : si64} : (memref<24xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_2_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[VAR_30_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_5_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_38_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_38_]]#0, [[VAR_38_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[VAR_30_]]{{.}}[[VAR_38_]]#0, [[VAR_38_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_5_]]{{.}}[[VAR_38_]]#0, [[VAR_38_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_32_:%.+]] = "onnx.MatMul"([[VAR_30_]], [[VAR_10_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
-// CHECK-DAG:         [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
-// CHECK-DAG:         [[VAR_33_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_1_]]2) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[VAR_34_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_1_]]3) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_32_:%.+]] = "onnx.MatMul"([[RES_5_]], [[VAR_10_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
+// CHECK-DAG:         [[VAR_33_:%.+]] = "onnx.MatMul"([[RES_1_]], [[RES_1_]]2) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_34_:%.+]] = "onnx.MatMul"([[RES_1_]], [[RES_1_]]3) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_38_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[VAR_38_1_]]#0, [[VAR_38_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_38_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_38_1_]]#0, [[VAR_38_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[VAR_40_:%.+]] = affine.apply #map0(){{.}}[[VAR_38_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_32_MEM_:%.+]] = krnl.load [[VAR_32_]]{{.}}[[VAR_38_1_]]#0, [[VAR_40_]]{{.}} : memref<2x12xf32>
@@ -626,21 +553,19 @@ func private @test_gru_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:           [[LOAD_VAR_23_MEM_1_:%.+]] = krnl.load [[VAR_23_]]#4{{.}}[[VAR_38_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_46_:%.+]] = addf [[VAR_43_]], [[LOAD_VAR_23_MEM_]] : f32
 // CHECK-DAG:           [[VAR_47_:%.+]] = addf [[VAR_46_]], [[LOAD_VAR_23_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_48_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_47_]], [[VAR_48_]][] : memref<f32>
-// CHECK:               [[VAR_49_:%.+]] = "onnx.Sigmoid"([[VAR_48_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_47_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[VAR_49_:%.+]] = "onnx.Sigmoid"([[RES_6_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_49_MEM_:%.+]] = krnl.load [[VAR_49_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_49_MEM_]], [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_38_1_]]#0, [[VAR_38_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_VAR_49_MEM_]], [[RES_4_]]{{.}}[[VAR_38_1_]]#0, [[VAR_38_1_]]#1] : memref<2x4xf32>
 // CHECK:               [[VAR_51_:%.+]] = mulf [[LOAD_VAR_49_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:               krnl.store [[VAR_51_]], [[LOAD_PARAM_4_MEM_2_]]{{.}}[[VAR_38_1_]]#0, [[VAR_38_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_51_]], [[RES_3_]]{{.}}[[VAR_38_1_]]#0, [[VAR_38_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_36_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_2_]], [[VAR_14_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_36_:%.+]] = "onnx.MatMul"([[RES_3_]], [[VAR_14_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_4_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_38_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_2_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[VAR_38_2_]]#0, [[VAR_38_2_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_38_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_38_2_]]#0, [[VAR_38_2_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_32_MEM_1_:%.+]] = krnl.load [[VAR_32_]]{{.}}[[VAR_38_2_]]#0, [[VAR_38_2_]]#1] : memref<2x12xf32>
 // CHECK-DAG:           [[LOAD_VAR_32_MEM_2_:%.+]] = krnl.load [[VAR_33_]]{{.}}[[VAR_38_2_]]#0, [[VAR_38_2_]]#1] : memref<2x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -649,12 +574,10 @@ func private @test_gru_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:           [[LOAD_VAR_23_MEM_3_:%.+]] = krnl.load [[VAR_23_]]#3{{.}}[[VAR_38_2_]]#1] : memref<4xf32>
 // CHECK:               [[LOAD_VAR_23_MEM_1_:%.+]] = addf [[LOAD_VAR_34_MEM_1_]], [[LOAD_VAR_23_MEM_2_]] : f32
 // CHECK-DAG:           [[VAR_46_1_:%.+]] = addf [[LOAD_VAR_23_MEM_1_]], [[LOAD_VAR_23_MEM_3_]] : f32
-// CHECK-DAG:           [[VAR_47_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_46_1_]], [[VAR_47_1_]][] : memref<f32>
-// CHECK:               [[VAR_48_1_:%.+]] = "onnx.Sigmoid"([[VAR_47_1_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[VAR_49_1_:%.+]] = krnl.load [[VAR_48_1_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_46_1_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[RES_6_:%.+]] = "onnx.Sigmoid"([[RES_7_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[VAR_49_1_:%.+]] = krnl.load [[RES_6_]][] : memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_49_MEM_1_:%.+]] = affine.apply #map1(){{.}}[[VAR_38_2_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_32_MEM_3_:%.+]] = krnl.load [[VAR_32_]]{{.}}[[VAR_38_2_]]#0, [[LOAD_VAR_49_MEM_1_]]{{.}} : memref<2x12xf32>
@@ -665,56 +588,40 @@ func private @test_gru_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:           [[LOAD_VAR_23_MEM_5_:%.+]] = krnl.load [[VAR_23_]]#5{{.}}[[VAR_38_2_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_56_:%.+]] = addf [[VAR_53_]], [[LOAD_VAR_23_MEM_4_]] : f32
 // CHECK-DAG:           [[VAR_57_:%.+]] = addf [[VAR_56_]], [[LOAD_VAR_23_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_58_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_57_]], [[VAR_58_]][] : memref<f32>
-// CHECK:               [[VAR_59_:%.+]] = "onnx.Tanh"([[VAR_58_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_8_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_57_]], [[RES_8_]][] : memref<f32>
+// CHECK:               [[VAR_59_:%.+]] = "onnx.Tanh"([[RES_8_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_59_MEM_:%.+]] = krnl.load [[VAR_59_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_61_:%.+]] = subf [[CST_1_dot_000000_]], [[VAR_49_1_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_62_:%.+]] = mulf [[VAR_61_]], [[LOAD_VAR_59_MEM_]] : f32
 // CHECK-DAG:           [[VAR_63_:%.+]] = mulf [[VAR_49_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK:               [[VAR_64_:%.+]] = addf [[VAR_62_]], [[VAR_63_]] : f32
-// CHECK:               krnl.store [[VAR_64_]], [[VAR_1_]]{{.}}[[VAR_38_2_]]#0, [[VAR_38_2_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_64_]], [[RES_1_]]{{.}}[[VAR_38_2_]]#0, [[VAR_38_2_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_2_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[VAR_30_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_4_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_5_]] : memref<2x3xf32>
 // CHECK:           }
 // CHECK:           [[LOOP_5_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_5_]]) with ([[LOOP_5_]] -> [[I_9_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_2_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:         [[VAR_30_1_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_1_3_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_7_:%.+]] = constant 7 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[LOOP_2_:%.+]] = affine.apply #map2([[I_9_]]){{.}}[[CST_7_]]{{.}}
-// CHECK-DAG:         [[CST_0_6_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_7_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_3_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_4_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_1_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_9_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_10_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:         [[RES_11_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
+// CHECK-DAG:         [[LOOP_2_:%.+]] = affine.apply #map2([[I_9_]])
 // CHECK-DAG:         [[LOOP_6_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_6_]]#0, [[LOOP_6_]]#1) with ([[LOOP_6_]]#0 -> [[I_10_:%.+]] = [[CST_0_6_]] to [[CST_2_3_]], [[LOOP_6_]]#1 -> [[I_11_:%.+]] = [[CST_0_6_]] to [[CST_3_1_]]) {
+// CHECK:             krnl.iterate([[LOOP_6_]]#0, [[LOOP_6_]]#1) with ([[LOOP_6_]]#0 -> [[I_10_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_6_]]#1 -> [[I_11_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[LOAD_PARAM_0_MEM_1_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_6_]]#0, [[LOOP_6_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[LOOP_2_]], [[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_2_]], [[VAR_30_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_2_]], [[RES_11_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_33_1_:%.+]] = "onnx.MatMul"([[VAR_30_1_]], [[VAR_15_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
-// CHECK-DAG:         [[CST_1_dot_000000_1_:%.+]] = constant 1.000000e+00 : f32
-// CHECK-DAG:         [[CST_0_8_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_9_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_4_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_5_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_3_:%.+]] = constant 4 : index
-// CHECK-DAG:         [[VAR_34_1_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_17_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[LOOP_3_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_18_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_33_1_:%.+]] = "onnx.MatMul"([[RES_11_]], [[VAR_15_]]) : (memref<2x3xf32>, memref<3x12xf32>) -> memref<2x12xf32>
+// CHECK-DAG:         [[VAR_34_1_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_17_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[LOOP_3_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_18_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_7_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_7_]]#0, [[LOOP_7_]]#1) with ([[LOOP_7_]]#0 -> [[I_12_:%.+]] = [[CST_0_8_]] to [[CST_2_4_]], [[LOOP_7_]]#1 -> [[I_13_:%.+]] = [[CST_0_8_]] to [[CST_4_3_]]) {
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_7_]]#0, [[LOOP_7_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_4_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_7_]]#0, [[LOOP_7_]]#1) with ([[LOOP_7_]]#0 -> [[I_12_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_7_]]#1 -> [[I_13_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[LOAD_PARAM_0_MEM_1_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_7_]]#0, [[LOOP_7_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[RES_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_32_MEM_2_:%.+]] = affine.apply #map0(){{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_34_MEM_1_:%.+]] = krnl.load [[VAR_33_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_VAR_32_MEM_2_]]{{.}} : memref<2x12xf32>
@@ -723,23 +630,21 @@ func private @test_gru_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:           [[LOAD_VAR_23_MEM_3_:%.+]] = addf [[LOAD_VAR_34_MEM_1_]], [[LOAD_VAR_23_MEM_2_]] : f32
 // CHECK-DAG:           [[LOAD_VAR_23_MEM_1_1_:%.+]] = krnl.load [[VAR_24_]]#1{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
 // CHECK-DAG:           [[VAR_46_1_:%.+]] = krnl.load [[VAR_24_]]#4{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_47_2_:%.+]] = addf [[LOAD_VAR_23_MEM_3_]], [[LOAD_VAR_23_MEM_1_1_]] : f32
-// CHECK-DAG:           [[VAR_48_2_:%.+]] = addf [[VAR_47_2_]], [[VAR_46_1_]] : f32
-// CHECK-DAG:           [[VAR_49_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_48_2_]], [[VAR_49_2_]][] : memref<f32>
-// CHECK:               [[LOAD_VAR_49_MEM_1_:%.+]] = "onnx.Sigmoid"([[VAR_49_2_]]) : (memref<f32>) -> memref<f32>
+// CHECK:               [[VAR_47_1_:%.+]] = addf [[LOAD_VAR_23_MEM_3_]], [[LOAD_VAR_23_MEM_1_1_]] : f32
+// CHECK-DAG:           [[RES_6_1_:%.+]] = addf [[VAR_47_1_]], [[VAR_46_1_]] : f32
+// CHECK-DAG:           [[RES_12_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[RES_6_1_]], [[RES_12_]][] : memref<f32>
+// CHECK:               [[LOAD_VAR_49_MEM_1_:%.+]] = "onnx.Sigmoid"([[RES_12_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_32_MEM_3_:%.+]] = krnl.load [[LOAD_VAR_49_MEM_1_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_32_MEM_3_]], [[LOAD_PARAM_4_MEM_1_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_VAR_32_MEM_3_]], [[RES_10_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
 // CHECK:               [[LOAD_VAR_36_MEM_1_:%.+]] = mulf [[LOAD_VAR_32_MEM_3_]], [[LOAD_PARAM_0_MEM_2_]] : f32
-// CHECK:               krnl.store [[LOAD_VAR_36_MEM_1_]], [[LOAD_PARAM_4_MEM_2_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_VAR_36_MEM_1_]], [[RES_9_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK-DAG:         [[LOOP_4_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_2_]], [[VAR_19_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[LOOP_4_:%.+]] = "onnx.MatMul"([[RES_9_]], [[VAR_19_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_8_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_8_]]#0, [[LOOP_8_]]#1) with ([[LOOP_8_]]#0 -> [[I_14_:%.+]] = [[CST_0_8_]] to [[CST_2_4_]], [[LOOP_8_]]#1 -> [[I_15_:%.+]] = [[CST_0_8_]] to [[CST_4_3_]]) {
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_1_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_8_]]#0, [[LOOP_8_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_5_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_8_]]#0, [[LOOP_8_]]#1) with ([[LOOP_8_]]#0 -> [[I_14_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_8_]]#1 -> [[I_15_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[LOAD_PARAM_0_MEM_1_1_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_8_]]#0, [[LOOP_8_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_1_:%.+]] = krnl.load [[RES_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_32_MEM_2_1_:%.+]] = krnl.load [[VAR_33_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<2x12xf32>
 // CHECK-DAG:           [[LOAD_VAR_34_MEM_1_1_:%.+]] = krnl.load [[VAR_34_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<2x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -747,13 +652,11 @@ func private @test_gru_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:           [[LOAD_VAR_23_MEM_3_1_:%.+]] = krnl.load [[VAR_24_]]#0{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<4xf32>
 // CHECK-DAG:           [[LOAD_VAR_23_MEM_1_1_:%.+]] = krnl.load [[VAR_24_]]#3{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_46_2_:%.+]] = addf [[VAR_43_1_]], [[LOAD_VAR_23_MEM_3_1_]] : f32
-// CHECK-DAG:           [[VAR_47_3_:%.+]] = addf [[VAR_46_2_]], [[LOAD_VAR_23_MEM_1_1_]] : f32
-// CHECK-DAG:           [[VAR_48_3_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_47_3_]], [[VAR_48_3_]][] : memref<f32>
-// CHECK:               [[VAR_49_3_:%.+]] = "onnx.Sigmoid"([[VAR_48_3_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_49_MEM_1_1_:%.+]] = krnl.load [[VAR_49_3_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_5_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_1_:%.+]] = constant 8 : index
+// CHECK-DAG:           [[VAR_47_2_:%.+]] = addf [[VAR_46_2_]], [[LOAD_VAR_23_MEM_1_1_]] : f32
+// CHECK-DAG:           [[RES_13_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_47_2_]], [[RES_13_]][] : memref<f32>
+// CHECK:               [[VAR_49_2_:%.+]] = "onnx.Sigmoid"([[RES_13_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_49_MEM_1_1_:%.+]] = krnl.load [[VAR_49_2_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_51_1_:%.+]] = affine.apply #map1(){{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_36_MEM_1_:%.+]] = krnl.load [[VAR_33_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#0, [[VAR_51_1_]]{{.}} : memref<2x12xf32>
@@ -763,38 +666,163 @@ func private @test_gru_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:           [[LOAD_VAR_23_MEM_5_:%.+]] = krnl.load [[VAR_24_]]#2{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<4xf32>
 // CHECK-DAG:           [[VAR_56_1_:%.+]] = krnl.load [[VAR_24_]]#5{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_57_1_:%.+]] = addf [[LOAD_VAR_23_MEM_4_]], [[LOAD_VAR_23_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_58_1_:%.+]] = addf [[VAR_57_1_]], [[VAR_56_1_]] : f32
-// CHECK-DAG:           [[VAR_59_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_58_1_]], [[VAR_59_1_]][] : memref<f32>
-// CHECK:               [[LOAD_VAR_59_MEM_1_:%.+]] = "onnx.Tanh"([[VAR_59_1_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_8_:%.+]] = addf [[VAR_57_1_]], [[VAR_56_1_]] : f32
+// CHECK-DAG:           [[RES_14_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[RES_8_]], [[RES_14_]][] : memref<f32>
+// CHECK:               [[LOAD_VAR_59_MEM_1_:%.+]] = "onnx.Tanh"([[RES_14_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[VAR_61_1_:%.+]] = krnl.load [[LOAD_VAR_59_MEM_1_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_62_1_:%.+]] = subf [[CST_1_dot_000000_1_]], [[LOAD_VAR_49_MEM_1_1_]] : f32
+// CHECK-DAG:           [[VAR_62_1_:%.+]] = subf [[CST_1_dot_000000_]], [[LOAD_VAR_49_MEM_1_1_]] : f32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_63_1_:%.+]] = mulf [[VAR_62_1_]], [[VAR_61_1_]] : f32
 // CHECK-DAG:           [[VAR_64_1_:%.+]] = mulf [[LOAD_VAR_49_MEM_1_1_]], [[LOAD_PARAM_0_MEM_2_1_]] : f32
 // CHECK:               [[VAR_65_:%.+]] = addf [[VAR_63_1_]], [[VAR_64_1_]] : f32
-// CHECK:               krnl.store [[VAR_65_]], [[VAR_0_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_65_]], [[RES_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_1_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_2_]] : memref<2x4xf32>
-// CHECK:             memref.dealloc [[VAR_30_1_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_10_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_9_]] : memref<2x4xf32>
+// CHECK:             memref.dealloc [[RES_11_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK-DAG:       [[CST_0_10_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_6_:%.+]] = constant 1 : index
-// CHECK-DAG:       [[CST_0_11_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_2_6_:%.+]] = constant 2 : index
-// CHECK-DAG:       [[CST_1_7_:%.+]] = constant 1 : index
-// CHECK-DAG:       [[CST_4_6_:%.+]] = constant 4 : index
-// CHECK-DAG:       [[LOOP_9_:%.+]]:2 = krnl.define_loops 2
-// CHECK:           krnl.iterate([[LOOP_9_]]#0, [[LOOP_9_]]#1) with ([[LOOP_9_]]#0 -> [[I_16_:%.+]] = [[CST_0_10_]] to [[CST_2_6_]], [[LOOP_9_]]#1 -> [[I_17_:%.+]] = [[CST_0_10_]] to [[CST_4_6_]]) {
-// CHECK:             [[LOAD_PARAM_4_MEM_2_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_9_]]#0, [[LOOP_9_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOAD_PARAM_4_MEM_1_1_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[LOAD_PARAM_4_MEM_2_1_]]#0, [[LOAD_PARAM_4_MEM_2_1_]]#1] : memref<2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_1_1_]], [[VAR_2_]]{{.}}[[CST_0_10_]], [[VAR_2_]]8#0, [[VAR_2_]]8#1] : memref<2x2x4xf32>
-// CHECK:             [[VAR_30_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[LOAD_PARAM_4_MEM_2_1_]]#0, [[LOAD_PARAM_4_MEM_2_1_]]#1] : memref<2x4xf32>
-// CHECK:             krnl.store [[VAR_30_1_]], [[VAR_2_]]{{.}}[[CST_1_6_]], [[VAR_2_]]8#0, [[VAR_2_]]8#1] : memref<2x2x4xf32>
+// CHECK:           [[LOOP_9_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_9_]]#0, [[LOOP_9_]]#1) with ([[LOOP_9_]]#0 -> [[I_16_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_9_]]#1 -> [[I_17_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:             [[RES_9_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_9_]]#0, [[LOOP_9_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:             [[RES_10_:%.+]] = krnl.load [[RES_1_]]{{.}}[[RES_9_]]#0, [[RES_9_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.store [[RES_10_]], [[RES_2_]]{{.}}[[CST_0_]], [[RES_2_]]8#0, [[RES_2_]]8#1] : memref<2x2x4xf32>
+// CHECK:             [[RES_11_:%.+]] = krnl.load [[RES_]]{{.}}[[RES_9_]]#0, [[RES_9_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.store [[RES_11_]], [[RES_2_]]{{.}}[[CST_1_]], [[RES_2_]]8#0, [[RES_2_]]8#1] : memref<2x2x4xf32>
 // CHECK:           }
-// CHECK:           memref.dealloc [[VAR_1_]] : memref<2x4xf32>
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_2_]] : memref<2x2x4xf32>
+// CHECK:           memref.dealloc [[RES_1_]] : memref<2x4xf32>
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_2_]] : memref<2x2x4xf32>
 // CHECK:         }
+
+}
+
+// -----
+
+func private @test_gru_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: tensor<1x12x?xf32>, %arg2: tensor<1x12x4xf32>, %arg3: tensor<1x24xf32>, %arg4: tensor<1x2x4xf32>) -> tensor<*xf32> {
+  %cst = constant unit
+  %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64} : (tensor<?x?x?xf32>, tensor<1x12x?xf32>, tensor<1x12x4xf32>, tensor<1x24xf32>, none, tensor<1x2x4xf32>) -> (none, tensor<*xf32>)
+  return %Y_h : tensor<*xf32>
+
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-LABEL:  builtin.func private @test_gru_unknown_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x?xf32>, [[PARAM_1_:%.+]]: memref<1x12x?xf32>, [[PARAM_2_:%.+]]: memref<1x12x4xf32>, [[PARAM_3_:%.+]]: memref<1x24xf32>, [[PARAM_4_:%.+]]: memref<1x2x4xf32>) -> memref<1x?x4xf32> {
+// CHECK-DAG:       [[CST_16_:%.+]] = constant 16 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK:           [[VAR_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<1x?x4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc([[VAR_2_]]) {{.*}}: memref<?x4xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_2_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
+// CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x4xf32>
+// CHECK:           }
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x12x?xf32>) -> memref<12x?xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x12x4xf32>) -> memref<12x4xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [1, 0]} : (memref<12x?xf32>) -> memref<?x12xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]]:3 = "onnx.Split"([[VAR_6_]]) {axis = 0 : si64} : (memref<12x4xf32>) -> (memref<4x4xf32>, memref<4x4xf32>, memref<4x4xf32>)
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.Transpose"([[VAR_8_]]#0) {perm = [1, 0]} : (memref<4x4xf32>) -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.Transpose"([[VAR_8_]]#1) {perm = [1, 0]} : (memref<4x4xf32>) -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Transpose"([[VAR_8_]]#2) {perm = [1, 0]} : (memref<4x4xf32>) -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = "onnx.SqueezeV11"([[PARAM_3_]]) {axes = [0]} : (memref<1x24xf32>) -> memref<24xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_13_:%.+]]:6 = "onnx.Split"([[VAR_12_]]) {axis = 0 : si64} : (memref<24xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>)
+// CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
+// CHECK-DAG:       [[VAR_15_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x?x?xf32>
+// CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to [[VAR_15_]]) {
+// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
+// CHECK-DAG:         [[VAR_19_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<?x?x?xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc([[LOAD_PARAM_4_MEM_1_]], [[VAR_19_]]) {{.*}}: memref<?x?xf32>
+// CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[LOAD_PARAM_4_MEM_1_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[VAR_19_]]) {
+// CHECK:               [[VAR_30_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_30_]]#0, [[VAR_30_]]#1] : memref<?x?x?xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_2_]]{{.}}[[VAR_30_]]#0, [[VAR_30_]]#1] : memref<?x?xf32>
+// CHECK:             }
+// CHECK-DAG:         [[VAR_22_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_7_]]) : (memref<?x?xf32>, memref<?x12xf32>) -> memref<?x12xf32>
+// CHECK-DAG:         [[VAR_23_:%.+]] = "onnx.MatMul"([[RES_1_]], [[VAR_9_]]) : (memref<?x4xf32>, memref<4x4xf32>) -> memref<?x4xf32>
+// CHECK-DAG:         [[VAR_24_:%.+]] = "onnx.MatMul"([[RES_1_]], [[VAR_10_]]) : (memref<?x4xf32>, memref<4x4xf32>) -> memref<?x4xf32>
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc([[VAR_2_]]) {{.*}}: memref<?x4xf32>
+// CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc([[VAR_2_]]) {{.*}}: memref<?x4xf32>
+// CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[VAR_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_30_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[RES_1_]]0#0, [[RES_1_]]0#1] : memref<?x4xf32>
+// CHECK-DAG:           [[VAR_32_:%.+]] = affine.apply #map0(){{.}}[[VAR_30_1_]]#1]
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[LOAD_VAR_22_MEM_:%.+]] = krnl.load [[VAR_22_]]{{.}}[[VAR_30_1_]]#0, [[VAR_32_]]{{.}} : memref<?x12xf32>
+// CHECK-DAG:           [[LOAD_VAR_24_MEM_:%.+]] = krnl.load [[VAR_24_]]{{.}}[[VAR_30_1_]]#0, [[VAR_30_1_]]#1] : memref<?x4xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[VAR_35_:%.+]] = addf [[LOAD_VAR_22_MEM_]], [[LOAD_VAR_24_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_13_MEM_:%.+]] = krnl.load [[VAR_13_]]#1{{.}}[[VAR_30_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_13_MEM_1_:%.+]] = krnl.load [[VAR_13_]]#4{{.}}[[VAR_30_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_38_:%.+]] = addf [[VAR_35_]], [[LOAD_VAR_13_MEM_]] : f32
+// CHECK-DAG:           [[VAR_39_:%.+]] = addf [[VAR_38_]], [[LOAD_VAR_13_MEM_1_]] : f32
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_39_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_41_:%.+]] = "onnx.Sigmoid"([[RES_5_]]) : (memref<f32>) -> memref<f32>
+// CHECK:               [[LOAD_VAR_41_MEM_:%.+]] = krnl.load [[VAR_41_]][] : memref<f32>
+// CHECK:               krnl.store [[LOAD_VAR_41_MEM_]], [[RES_3_]]{{.}}[[VAR_30_1_]]#0, [[VAR_30_1_]]#1] : memref<?x4xf32>
+// CHECK:               [[VAR_43_:%.+]] = mulf [[LOAD_VAR_41_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK:               krnl.store [[VAR_43_]], [[RES_4_]]{{.}}[[VAR_30_1_]]#0, [[VAR_30_1_]]#1] : memref<?x4xf32>
+// CHECK:             }
+// CHECK-DAG:         [[VAR_28_:%.+]] = "onnx.MatMul"([[RES_4_]], [[VAR_11_]]) : (memref<?x4xf32>, memref<4x4xf32>) -> memref<?x4xf32>
+// CHECK-DAG:         [[LOOP_4_:%.+]]:2 = krnl.define_loops 2
+// CHECK:             krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_7_:%.+]] = [[CST_0_]] to [[VAR_2_]], [[LOOP_4_]]#1 -> [[I_8_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_30_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[RES_1_]]0#0, [[RES_1_]]0#1] : memref<?x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_22_MEM_1_:%.+]] = krnl.load [[VAR_22_]]{{.}}[[VAR_30_2_]]#0, [[VAR_30_2_]]#1] : memref<?x12xf32>
+// CHECK-DAG:           [[LOAD_VAR_22_MEM_2_:%.+]] = krnl.load [[VAR_23_]]{{.}}[[VAR_30_2_]]#0, [[VAR_30_2_]]#1] : memref<?x4xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[LOAD_VAR_24_MEM_1_:%.+]] = addf [[LOAD_VAR_22_MEM_1_]], [[LOAD_VAR_22_MEM_2_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_13_MEM_2_:%.+]] = krnl.load [[VAR_13_]]#0{{.}}[[VAR_30_2_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_13_MEM_3_:%.+]] = krnl.load [[VAR_13_]]#3{{.}}[[VAR_30_2_]]#1] : memref<4xf32>
+// CHECK:               [[LOAD_VAR_13_MEM_1_:%.+]] = addf [[LOAD_VAR_24_MEM_1_]], [[LOAD_VAR_13_MEM_2_]] : f32
+// CHECK-DAG:           [[VAR_38_1_:%.+]] = addf [[LOAD_VAR_13_MEM_1_]], [[LOAD_VAR_13_MEM_3_]] : f32
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_38_1_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[RES_5_:%.+]] = "onnx.Sigmoid"([[RES_6_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[VAR_41_1_:%.+]] = krnl.load [[RES_5_]][] : memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_41_MEM_1_:%.+]] = affine.apply #map1(){{.}}[[VAR_30_2_]]#1]
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[LOAD_VAR_22_MEM_3_:%.+]] = krnl.load [[VAR_22_]]{{.}}[[VAR_30_2_]]#0, [[LOAD_VAR_41_MEM_1_]]{{.}} : memref<?x12xf32>
+// CHECK-DAG:           [[LOAD_VAR_28_MEM_:%.+]] = krnl.load [[VAR_28_]]{{.}}[[VAR_30_2_]]#0, [[VAR_30_2_]]#1] : memref<?x4xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[VAR_45_:%.+]] = addf [[LOAD_VAR_22_MEM_3_]], [[LOAD_VAR_28_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_13_MEM_4_:%.+]] = krnl.load [[VAR_13_]]#2{{.}}[[VAR_30_2_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_13_MEM_5_:%.+]] = krnl.load [[VAR_13_]]#5{{.}}[[VAR_30_2_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_48_:%.+]] = addf [[VAR_45_]], [[LOAD_VAR_13_MEM_4_]] : f32
+// CHECK-DAG:           [[VAR_49_:%.+]] = addf [[VAR_48_]], [[LOAD_VAR_13_MEM_5_]] : f32
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_49_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_51_:%.+]] = "onnx.Tanh"([[RES_7_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_51_MEM_:%.+]] = krnl.load [[VAR_51_]][] : memref<f32>
+// CHECK-DAG:           [[VAR_53_:%.+]] = subf [[CST_1_dot_000000_]], [[VAR_41_1_]] : f32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:           [[VAR_54_:%.+]] = mulf [[VAR_53_]], [[LOAD_VAR_51_MEM_]] : f32
+// CHECK-DAG:           [[VAR_55_:%.+]] = mulf [[VAR_41_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK:               [[VAR_56_:%.+]] = addf [[VAR_54_]], [[VAR_55_]] : f32
+// CHECK:               krnl.store [[VAR_56_]], [[RES_1_]]{{.}}[[RES_1_]]0#0, [[RES_1_]]0#1] : memref<?x4xf32>
+// CHECK:             }
+// CHECK:             memref.dealloc [[RES_3_]] : memref<?x4xf32>
+// CHECK:             memref.dealloc [[RES_4_]] : memref<?x4xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<?x?xf32>
+// CHECK:           }
+// CHECK:           [[VAR_16_:%.+]] = index_cast [[VAR_2_]] : index to i64
+// CHECK:           [[VAR_17_:%.+]] = muli [[VAR_16_]], [[CST_16_]] : i64
+// CHECK:           "krnl.memcpy"([[RES_]], [[RES_1_]], [[RES_]]7) : (memref<1x?x4xf32>, memref<?x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_1_]] : memref<?x4xf32>
+// CHECK:           return [[RES_]] : memref<1x?x4xf32>
+// CHECK:         }
+
 }

--- a/test/mlir/onnx/onnx_lowering_lstm_op.mlir
+++ b/test/mlir/onnx/onnx_lowering_lstm_op.mlir
@@ -1,25 +1,30 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl='check-rnn-ops-lowering' %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl='check-rnn-ops-lowering' --canonicalize %s -split-input-file | FileCheck %s
 
 func private @test_lstm_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x16x3xf32>, %arg2: tensor<1x16x4xf32>, %arg3: tensor<1x32xf32>, %arg4: tensor<1x2x4xf32>, %arg5: tensor<1x2x4xf32>, %arg6: tensor<1x12xf32>) -> tensor<*xf32> {
   %cst = constant unit
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4, %arg5, %arg6) {hidden_size = 4 : si64} : (tensor<7x2x3xf32>, tensor<1x16x3xf32>, tensor<1x16x4xf32>, tensor<1x32xf32>, none, tensor<1x2x4xf32>, tensor<1x2x4xf32>, tensor<1x12xf32>) -> (none, tensor<*xf32>, none)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_lstm_forward_mode
+// mlir2FileCheck.py
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 12)>
+// CHECK-DAG: #map2 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-LABEL:  builtin.func private @test_lstm_forward_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x16x3xf32>, [[PARAM_2_:%.+]]: memref<1x16x4xf32>, [[PARAM_3_:%.+]]: memref<1x32xf32>, [[PARAM_4_:%.+]]: memref<1x2x4xf32>, [[PARAM_5_:%.+]]: memref<1x2x4xf32>, [[PARAM_6_:%.+]]: memref<1x12xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:             [[LOAD_PARAM_5_MEM_:%.+]] = krnl.load [[PARAM_5_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x16x3xf32>) -> memref<16x3xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x16x4xf32>) -> memref<16x4xf32>
@@ -34,32 +39,19 @@ func private @test_lstm_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:       [[VAR_11_:%.+]]:3 = "onnx.Split"([[VAR_10_]]) {axis = 0 : si64} : (memref<12xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_18_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_18_]]#0, [[VAR_18_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_18_]]#0, [[VAR_18_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_3_]]{{.}}[[VAR_18_]]#0, [[VAR_18_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_15_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_1_]], [[VAR_6_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[VAR_16_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_7_]]) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_15_:%.+]] = "onnx.MatMul"([[RES_3_]], [[VAR_6_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
+// CHECK-DAG:         [[VAR_16_:%.+]] = "onnx.MatMul"([[RES_1_]], [[VAR_7_]]) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_18_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_18_1_]]#0, [[VAR_18_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_18_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_18_1_]]#0, [[VAR_18_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_15_MEM_:%.+]] = krnl.load [[VAR_15_]]{{.}}[[VAR_18_1_]]#0, [[VAR_18_1_]]#1] : memref<2x16xf32>
 // CHECK-DAG:           [[LOAD_VAR_16_MEM_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_18_1_]]#0, [[VAR_18_1_]]#1] : memref<2x16xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -71,17 +63,13 @@ func private @test_lstm_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_:%.+]] = krnl.load [[VAR_11_]]#0{{.}}[[VAR_18_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_28_:%.+]] = mulf [[LOAD_VAR_11_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK-DAG:           [[VAR_29_:%.+]] = addf [[VAR_26_]], [[VAR_28_]] : f32
-// CHECK-DAG:           [[VAR_30_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_29_]], [[VAR_30_]][] : memref<f32>
-// CHECK:               [[VAR_31_:%.+]] = "onnx.Sigmoid"([[VAR_30_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_4_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_29_]], [[RES_4_]][] : memref<f32>
+// CHECK:               [[VAR_31_:%.+]] = "onnx.Sigmoid"([[RES_4_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_31_MEM_:%.+]] = krnl.load [[VAR_31_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[VAR_33_:%.+]] = affine.apply #map0(){{.}}[[VAR_18_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_15_MEM_1_:%.+]] = krnl.load [[VAR_15_]]{{.}}[[VAR_18_1_]]#0, [[VAR_33_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_2_3_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_1_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[VAR_35_:%.+]] = affine.apply #map0(){{.}}[[VAR_18_1_]]#1]
 // CHECK:               [[LOAD_VAR_16_MEM_1_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_18_1_]]#0, [[VAR_35_]]{{.}} : memref<2x16xf32>
 // CHECK-DAG:           [[VAR_37_:%.+]] = addf [[LOAD_VAR_15_MEM_1_]], [[LOAD_VAR_16_MEM_1_]] : f32
@@ -92,17 +80,13 @@ func private @test_lstm_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_1_:%.+]] = krnl.load [[VAR_11_]]#2{{.}}[[VAR_18_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_43_:%.+]] = mulf [[LOAD_VAR_11_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK-DAG:           [[VAR_44_:%.+]] = addf [[VAR_41_]], [[VAR_43_]] : f32
-// CHECK-DAG:           [[VAR_45_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_44_]], [[VAR_45_]][] : memref<f32>
-// CHECK:               [[VAR_46_:%.+]] = "onnx.Sigmoid"([[VAR_45_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_44_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_46_:%.+]] = "onnx.Sigmoid"([[RES_5_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_46_MEM_:%.+]] = krnl.load [[VAR_46_]][] : memref<f32>
-// CHECK-DAG:           [[CST_3_1_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_:%.+]] = constant 12 : index
 // CHECK-DAG:           [[VAR_48_:%.+]] = affine.apply #map1(){{.}}[[VAR_18_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_15_MEM_2_:%.+]] = krnl.load [[VAR_15_]]{{.}}[[VAR_18_1_]]#0, [[VAR_48_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_3_2_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_1_:%.+]] = constant 12 : index
 // CHECK-DAG:           [[VAR_50_:%.+]] = affine.apply #map1(){{.}}[[VAR_18_1_]]#1]
 // CHECK:               [[LOAD_VAR_16_MEM_2_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_18_1_]]#0, [[VAR_50_]]{{.}} : memref<2x16xf32>
 // CHECK-DAG:           [[VAR_52_:%.+]] = addf [[LOAD_VAR_15_MEM_2_]], [[LOAD_VAR_16_MEM_2_]] : f32
@@ -110,9 +94,9 @@ func private @test_lstm_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:           [[LOAD_VAR_9_MEM_5_:%.+]] = krnl.load [[VAR_9_]]#7{{.}}[[VAR_18_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_55_:%.+]] = addf [[VAR_52_]], [[LOAD_VAR_9_MEM_4_]] : f32
 // CHECK-DAG:           [[VAR_56_:%.+]] = addf [[VAR_55_]], [[LOAD_VAR_9_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_57_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_56_]], [[VAR_57_]][] : memref<f32>
-// CHECK:               [[VAR_58_:%.+]] = "onnx.Tanh"([[VAR_57_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_56_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[VAR_58_:%.+]] = "onnx.Tanh"([[RES_6_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_58_MEM_:%.+]] = krnl.load [[VAR_58_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_60_:%.+]] = mulf [[LOAD_VAR_46_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK:               [[VAR_61_:%.+]] = mulf [[LOAD_VAR_31_MEM_]], [[LOAD_VAR_58_MEM_]] : f32
@@ -130,25 +114,24 @@ func private @test_lstm_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_2_:%.+]] = krnl.load [[VAR_11_]]#1{{.}}[[VAR_18_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_73_:%.+]] = mulf [[LOAD_VAR_11_MEM_2_]], [[VAR_62_]] : f32
 // CHECK-DAG:           [[VAR_74_:%.+]] = addf [[VAR_71_]], [[VAR_73_]] : f32
-// CHECK-DAG:           [[VAR_75_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_74_]], [[VAR_75_]][] : memref<f32>
-// CHECK:               [[VAR_76_:%.+]] = "onnx.Sigmoid"([[VAR_75_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_74_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_76_:%.+]] = "onnx.Sigmoid"([[RES_7_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_76_MEM_:%.+]] = krnl.load [[VAR_76_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_78_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_62_]], [[VAR_78_]][] : memref<f32>
-// CHECK:               [[VAR_79_:%.+]] = "onnx.Tanh"([[VAR_78_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_8_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_62_]], [[RES_8_]][] : memref<f32>
+// CHECK:               [[VAR_79_:%.+]] = "onnx.Tanh"([[RES_8_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_79_MEM_:%.+]] = krnl.load [[VAR_79_]][] : memref<f32>
 // CHECK:               [[VAR_81_:%.+]] = mulf [[LOAD_VAR_76_MEM_]], [[LOAD_VAR_79_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_62_]], [[VAR_0_]]{{.}}[[VAR_18_1_]]#0, [[VAR_18_1_]]#1] : memref<2x4xf32>
-// CHECK:               krnl.store [[VAR_81_]], [[VAR_1_]]{{.}}[[VAR_1_]]8#0, [[VAR_1_]]8#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_62_]], [[RES_]]{{.}}[[VAR_18_1_]]#0, [[VAR_18_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_81_]], [[RES_1_]]{{.}}[[RES_1_]]8#0, [[RES_1_]]8#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_2_]], [[VAR_1_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_1_]] : memref<2x4xf32>
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_2_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_2_]], [[RES_1_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_1_]] : memref<2x4xf32>
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_2_]] : memref<1x2x4xf32>
 // CHECK:         }
 }
 
@@ -164,161 +147,136 @@ func private @test_lstm_forward_mode_constant_weight_and_bias(%arg0: tensor<7x2x
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %w, %r, %b, %cst, %arg1, %arg2, %p) {hidden_size = 4 : si64} : (tensor<7x2x3xf32>, tensor<1x16x3xf32>, tensor<1x16x4xf32>, tensor<1x32xf32>, none, tensor<1x2x4xf32>, tensor<1x2x4xf32>, tensor<1x12xf32>) -> (none, tensor<*xf32>, none)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_lstm_forward_mode_constant_weight_and_bias
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 12)>
+// CHECK-DAG: #map2 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-LABEL:  builtin.func private @test_lstm_forward_mode_constant_weight_and_bias
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x2x4xf32>, [[PARAM_2_:%.+]]: memref<1x2x4xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_0", shape = [1, 16, 3], value = dense<1.000000e+00> : tensor<1x16x3xf32>} : () -> memref<1x16x3xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_1", shape = [1, 16, 4], value = dense<2.000000e+00> : tensor<1x16x4xf32>} : () -> memref<1x16x4xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = "krnl.global"() {name = "constant_2", shape = [1, 32], value = dense<{{.}}[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01, 2.000000e+01, 2.100000e+01, 2.200000e+01, 2.300000e+01, 2.400000e+01, 2.500000e+01, 2.600000e+01, 2.700000e+01, 2.800000e+01, 2.900000e+01, 3.000000e+01, 3.100000e+01, 3.200000e+01]{{.}}> : tensor<1x32xf32>} : () -> memref<1x32xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = "krnl.global"() {name = "constant_3", shape = [1, 12], value = dense<{{.}}[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01]{{.}}> : tensor<1x12xf32>} : () -> memref<1x12xf32>
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_1_MEM_]], [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_1_MEM_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:             [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_2_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_2_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
-// CHECK-DAG:       [[VAR_8_:%.+]] = "krnl.global"() {name = "constant_4", shape = [16, 3], value = dense<1.000000e+00> : tensor<16x3xf32>} : () -> memref<16x3xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = "krnl.global"() {name = "constant_5", shape = [16, 4], value = dense<2.000000e+00> : tensor<16x4xf32>} : () -> memref<16x4xf32>
-// CHECK-DAG:       [[VAR_10_:%.+]] = "krnl.global"() {name = "constant_6", shape = [3, 16], value = dense<1.000000e+00> : tensor<3x16xf32>} : () -> memref<3x16xf32>
-// CHECK-DAG:       [[VAR_11_:%.+]] = "krnl.global"() {name = "constant_7", shape = [4, 16], value = dense<2.000000e+00> : tensor<4x16xf32>} : () -> memref<4x16xf32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = "krnl.global"() {name = "constant_8", shape = [32], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01, 2.000000e+01, 2.100000e+01, 2.200000e+01, 2.300000e+01, 2.400000e+01, 2.500000e+01, 2.600000e+01, 2.700000e+01, 2.800000e+01, 2.900000e+01, 3.000000e+01, 3.100000e+01, 3.200000e+01]> : tensor<32xf32>} : () -> memref<32xf32>
-// CHECK-DAG:       [[VAR_13_:%.+]] = "krnl.global"() {name = "constant_9", shape = [4], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_14_:%.+]] = "krnl.global"() {name = "constant_10", shape = [4], value = dense<[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_15_:%.+]] = "krnl.global"() {name = "constant_11", shape = [4], value = dense<[9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_16_:%.+]] = "krnl.global"() {name = "constant_12", shape = [4], value = dense<[1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_17_:%.+]] = "krnl.global"() {name = "constant_13", shape = [4], value = dense<[1.700000e+01, 1.800000e+01, 1.900000e+01, 2.000000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_18_:%.+]] = "krnl.global"() {name = "constant_14", shape = [4], value = dense<[2.100000e+01, 2.200000e+01, 2.300000e+01, 2.400000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_19_:%.+]] = "krnl.global"() {name = "constant_15", shape = [4], value = dense<[2.500000e+01, 2.600000e+01, 2.700000e+01, 2.800000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_20_:%.+]] = "krnl.global"() {name = "constant_16", shape = [4], value = dense<[2.900000e+01, 3.000000e+01, 3.100000e+01, 3.200000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_21_:%.+]] = "krnl.global"() {name = "constant_17", shape = [12], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01]> : tensor<12xf32>} : () -> memref<12xf32>
-// CHECK-DAG:       [[VAR_22_:%.+]] = "krnl.global"() {name = "constant_18", shape = [4], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_23_:%.+]] = "krnl.global"() {name = "constant_19", shape = [4], value = dense<[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_24_:%.+]] = "krnl.global"() {name = "constant_20", shape = [4], value = dense<[9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_6", shape = [3, 16], value = dense<1.000000e+00> : tensor<3x16xf32>} : () -> memref<3x16xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "krnl.global"() {name = "constant_7", shape = [4, 16], value = dense<2.000000e+00> : tensor<4x16xf32>} : () -> memref<4x16xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "krnl.global"() {name = "constant_9", shape = [4], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "krnl.global"() {name = "constant_10", shape = [4], value = dense<[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "krnl.global"() {name = "constant_11", shape = [4], value = dense<[9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "krnl.global"() {name = "constant_12", shape = [4], value = dense<[1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "krnl.global"() {name = "constant_13", shape = [4], value = dense<[1.700000e+01, 1.800000e+01, 1.900000e+01, 2.000000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "krnl.global"() {name = "constant_14", shape = [4], value = dense<[2.100000e+01, 2.200000e+01, 2.300000e+01, 2.400000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = "krnl.global"() {name = "constant_15", shape = [4], value = dense<[2.500000e+01, 2.600000e+01, 2.700000e+01, 2.800000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = "krnl.global"() {name = "constant_16", shape = [4], value = dense<[2.900000e+01, 3.000000e+01, 3.100000e+01, 3.200000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_14_:%.+]] = "krnl.global"() {name = "constant_18", shape = [4], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_15_:%.+]] = "krnl.global"() {name = "constant_19", shape = [4], value = dense<[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_16_:%.+]] = "krnl.global"() {name = "constant_20", shape = [4], value = dense<[9.000000e+00, 1.000000e+01, 1.100000e+01, 1.200000e+01]> : tensor<4xf32>} : () -> memref<4xf32>
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_1_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
-// CHECK:               [[VAR_31_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_31_]]#0, [[VAR_31_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_1_]]{{.}}[[VAR_31_]]#0, [[VAR_31_]]#1] : memref<2x3xf32>
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
+// CHECK:               [[VAR_23_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_23_]]#0, [[VAR_23_]]#1] : memref<7x2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_3_]]{{.}}[[VAR_23_]]#0, [[VAR_23_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_28_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_1_MEM_1_]], [[VAR_10_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[VAR_29_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_1_]]1) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_20_:%.+]] = "onnx.MatMul"([[RES_3_]], [[VAR_4_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
+// CHECK-DAG:         [[VAR_21_:%.+]] = "onnx.MatMul"([[RES_1_]], [[VAR_5_]]) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_31_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_23_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_20_MEM_:%.+]] = krnl.load [[VAR_20_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x16xf32>
+// CHECK-DAG:           [[LOAD_VAR_21_MEM_:%.+]] = krnl.load [[VAR_21_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x16xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_31_1_]]#0, [[VAR_31_1_]]#1] : memref<2x4xf32>
-// CHECK-DAG:           [[LOAD_VAR_28_MEM_:%.+]] = krnl.load [[VAR_28_]]{{.}}[[VAR_31_1_]]#0, [[VAR_31_1_]]#1] : memref<2x16xf32>
-// CHECK-DAG:           [[LOAD_VAR_29_MEM_:%.+]] = krnl.load [[VAR_29_]]{{.}}[[VAR_31_1_]]#0, [[VAR_31_1_]]#1] : memref<2x16xf32>
+// CHECK-DAG:           [[VAR_27_:%.+]] = addf [[LOAD_VAR_20_MEM_]], [[LOAD_VAR_21_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_6_MEM_:%.+]] = krnl.load [[VAR_6_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_10_MEM_:%.+]] = krnl.load [[VAR_10_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_30_:%.+]] = addf [[VAR_27_]], [[LOAD_VAR_6_MEM_]] : f32
+// CHECK-DAG:           [[VAR_31_:%.+]] = addf [[VAR_30_]], [[LOAD_VAR_10_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_14_MEM_:%.+]] = krnl.load [[VAR_14_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_33_:%.+]] = mulf [[LOAD_VAR_14_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK-DAG:           [[VAR_34_:%.+]] = addf [[VAR_31_]], [[VAR_33_]] : f32
+// CHECK-DAG:           [[RES_4_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_34_]], [[RES_4_]][] : memref<f32>
+// CHECK:               [[VAR_36_:%.+]] = "onnx.Sigmoid"([[RES_4_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_36_MEM_:%.+]] = krnl.load [[VAR_36_]][] : memref<f32>
+// CHECK-DAG:           [[VAR_38_:%.+]] = affine.apply #map0(){{.}}[[VAR_23_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_35_:%.+]] = addf [[LOAD_VAR_28_MEM_]], [[LOAD_VAR_29_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_:%.+]] = krnl.load [[VAR_13_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_17_MEM_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_38_:%.+]] = addf [[VAR_35_]], [[LOAD_VAR_13_MEM_]] : f32
-// CHECK-DAG:           [[VAR_39_:%.+]] = addf [[VAR_38_]], [[LOAD_VAR_17_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_22_MEM_:%.+]] = krnl.load [[VAR_22_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_41_:%.+]] = mulf [[LOAD_VAR_22_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_42_:%.+]] = addf [[VAR_39_]], [[VAR_41_]] : f32
-// CHECK-DAG:           [[VAR_43_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_42_]], [[VAR_43_]][] : memref<f32>
-// CHECK:               [[VAR_44_:%.+]] = "onnx.Sigmoid"([[VAR_43_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_44_MEM_:%.+]] = krnl.load [[VAR_44_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
-// CHECK-DAG:           [[VAR_46_:%.+]] = affine.apply #map0(){{.}}[[VAR_31_1_]]#1]
+// CHECK-DAG:           [[LOAD_VAR_20_MEM_1_:%.+]] = krnl.load [[VAR_20_]]{{.}}[[VAR_23_1_]]#0, [[VAR_38_]]{{.}} : memref<2x16xf32>
+// CHECK-DAG:           [[VAR_40_:%.+]] = affine.apply #map0(){{.}}[[VAR_23_1_]]#1]
+// CHECK:               [[LOAD_VAR_21_MEM_1_:%.+]] = krnl.load [[VAR_21_]]{{.}}[[VAR_23_1_]]#0, [[VAR_40_]]{{.}} : memref<2x16xf32>
+// CHECK-DAG:           [[VAR_42_:%.+]] = addf [[LOAD_VAR_20_MEM_1_]], [[LOAD_VAR_21_MEM_1_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_8_MEM_:%.+]] = krnl.load [[VAR_8_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_:%.+]] = krnl.load [[VAR_12_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_45_:%.+]] = addf [[VAR_42_]], [[LOAD_VAR_8_MEM_]] : f32
+// CHECK-DAG:           [[VAR_46_:%.+]] = addf [[VAR_45_]], [[LOAD_VAR_12_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_16_MEM_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_48_:%.+]] = mulf [[LOAD_VAR_16_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK-DAG:           [[VAR_49_:%.+]] = addf [[VAR_46_]], [[VAR_48_]] : f32
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_49_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_51_:%.+]] = "onnx.Sigmoid"([[RES_5_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_51_MEM_:%.+]] = krnl.load [[VAR_51_]][] : memref<f32>
+// CHECK-DAG:           [[VAR_53_:%.+]] = affine.apply #map1(){{.}}[[VAR_23_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_28_MEM_1_:%.+]] = krnl.load [[VAR_28_]]{{.}}[[VAR_31_1_]]#0, [[VAR_46_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_2_3_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_1_:%.+]] = constant 8 : index
-// CHECK-DAG:           [[VAR_48_:%.+]] = affine.apply #map0(){{.}}[[VAR_31_1_]]#1]
-// CHECK:               [[LOAD_VAR_29_MEM_1_:%.+]] = krnl.load [[VAR_29_]]{{.}}[[VAR_31_1_]]#0, [[VAR_48_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[VAR_50_:%.+]] = addf [[LOAD_VAR_28_MEM_1_]], [[LOAD_VAR_29_MEM_1_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_15_MEM_:%.+]] = krnl.load [[VAR_15_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_19_MEM_:%.+]] = krnl.load [[VAR_19_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_53_:%.+]] = addf [[VAR_50_]], [[LOAD_VAR_15_MEM_]] : f32
-// CHECK-DAG:           [[VAR_54_:%.+]] = addf [[VAR_53_]], [[LOAD_VAR_19_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_24_MEM_:%.+]] = krnl.load [[VAR_24_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_56_:%.+]] = mulf [[LOAD_VAR_24_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_57_:%.+]] = addf [[VAR_54_]], [[VAR_56_]] : f32
-// CHECK-DAG:           [[VAR_58_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_57_]], [[VAR_58_]][] : memref<f32>
-// CHECK:               [[VAR_59_:%.+]] = "onnx.Sigmoid"([[VAR_58_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_59_MEM_:%.+]] = krnl.load [[VAR_59_]][] : memref<f32>
-// CHECK-DAG:           [[CST_3_1_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_:%.+]] = constant 12 : index
-// CHECK-DAG:           [[VAR_61_:%.+]] = affine.apply #map1(){{.}}[[VAR_31_1_]]#1]
+// CHECK-DAG:           [[LOAD_VAR_20_MEM_2_:%.+]] = krnl.load [[VAR_20_]]{{.}}[[VAR_23_1_]]#0, [[VAR_53_]]{{.}} : memref<2x16xf32>
+// CHECK-DAG:           [[VAR_55_:%.+]] = affine.apply #map1(){{.}}[[VAR_23_1_]]#1]
+// CHECK:               [[LOAD_VAR_21_MEM_2_:%.+]] = krnl.load [[VAR_21_]]{{.}}[[VAR_23_1_]]#0, [[VAR_55_]]{{.}} : memref<2x16xf32>
+// CHECK-DAG:           [[VAR_57_:%.+]] = addf [[LOAD_VAR_20_MEM_2_]], [[LOAD_VAR_21_MEM_2_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_9_MEM_:%.+]] = krnl.load [[VAR_9_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_13_MEM_:%.+]] = krnl.load [[VAR_13_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_60_:%.+]] = addf [[VAR_57_]], [[LOAD_VAR_9_MEM_]] : f32
+// CHECK-DAG:           [[VAR_61_:%.+]] = addf [[VAR_60_]], [[LOAD_VAR_13_MEM_]] : f32
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_61_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[VAR_63_:%.+]] = "onnx.Tanh"([[RES_6_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_63_MEM_:%.+]] = krnl.load [[VAR_63_]][] : memref<f32>
+// CHECK-DAG:           [[VAR_65_:%.+]] = mulf [[LOAD_VAR_51_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK:               [[VAR_66_:%.+]] = mulf [[LOAD_VAR_36_MEM_]], [[LOAD_VAR_63_MEM_]] : f32
+// CHECK-DAG:           [[VAR_67_:%.+]] = addf [[VAR_65_]], [[VAR_66_]] : f32
+// CHECK-DAG:           [[VAR_68_:%.+]] = affine.apply #map2(){{.}}[[VAR_23_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_28_MEM_2_:%.+]] = krnl.load [[VAR_28_]]{{.}}[[VAR_31_1_]]#0, [[VAR_61_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_3_2_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_1_:%.+]] = constant 12 : index
-// CHECK-DAG:           [[VAR_63_:%.+]] = affine.apply #map1(){{.}}[[VAR_31_1_]]#1]
-// CHECK:               [[LOAD_VAR_29_MEM_2_:%.+]] = krnl.load [[VAR_29_]]{{.}}[[VAR_31_1_]]#0, [[VAR_63_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[VAR_65_:%.+]] = addf [[LOAD_VAR_28_MEM_2_]], [[LOAD_VAR_29_MEM_2_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_16_MEM_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_20_MEM_:%.+]] = krnl.load [[VAR_20_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_68_:%.+]] = addf [[VAR_65_]], [[LOAD_VAR_16_MEM_]] : f32
-// CHECK-DAG:           [[VAR_69_:%.+]] = addf [[VAR_68_]], [[LOAD_VAR_20_MEM_]] : f32
-// CHECK-DAG:           [[VAR_70_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_69_]], [[VAR_70_]][] : memref<f32>
-// CHECK:               [[VAR_71_:%.+]] = "onnx.Tanh"([[VAR_70_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_71_MEM_:%.+]] = krnl.load [[VAR_71_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_73_:%.+]] = mulf [[LOAD_VAR_59_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:               [[VAR_74_:%.+]] = mulf [[LOAD_VAR_44_MEM_]], [[LOAD_VAR_71_MEM_]] : f32
-// CHECK-DAG:           [[VAR_75_:%.+]] = addf [[VAR_73_]], [[VAR_74_]] : f32
-// CHECK-DAG:           [[VAR_76_:%.+]] = affine.apply #map2(){{.}}[[VAR_31_1_]]#1]
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_28_MEM_3_:%.+]] = krnl.load [[VAR_28_]]{{.}}[[VAR_31_1_]]#0, [[VAR_76_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[VAR_78_:%.+]] = affine.apply #map2(){{.}}[[VAR_31_1_]]#1]
-// CHECK:               [[LOAD_VAR_29_MEM_3_:%.+]] = krnl.load [[VAR_29_]]{{.}}[[VAR_31_1_]]#0, [[VAR_78_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[VAR_80_:%.+]] = addf [[LOAD_VAR_28_MEM_3_]], [[LOAD_VAR_29_MEM_3_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_14_MEM_:%.+]] = krnl.load [[VAR_14_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_18_MEM_:%.+]] = krnl.load [[VAR_18_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_83_:%.+]] = addf [[VAR_80_]], [[LOAD_VAR_14_MEM_]] : f32
-// CHECK-DAG:           [[VAR_84_:%.+]] = addf [[VAR_83_]], [[LOAD_VAR_18_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_23_MEM_:%.+]] = krnl.load [[VAR_23_]]{{.}}[[VAR_31_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_86_:%.+]] = mulf [[LOAD_VAR_23_MEM_]], [[VAR_75_]] : f32
-// CHECK-DAG:           [[VAR_87_:%.+]] = addf [[VAR_84_]], [[VAR_86_]] : f32
-// CHECK-DAG:           [[VAR_88_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_87_]], [[VAR_88_]][] : memref<f32>
-// CHECK:               [[VAR_89_:%.+]] = "onnx.Sigmoid"([[VAR_88_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_89_MEM_:%.+]] = krnl.load [[VAR_89_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_91_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_75_]], [[VAR_91_]][] : memref<f32>
-// CHECK:               [[VAR_92_:%.+]] = "onnx.Tanh"([[VAR_91_]]) : (memref<f32>) -> memref<f32>
-// CHECK:               [[LOAD_VAR_92_MEM_:%.+]] = krnl.load [[VAR_92_]][] : memref<f32>
-// CHECK:               [[VAR_94_:%.+]] = mulf [[LOAD_VAR_89_MEM_]], [[LOAD_VAR_92_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_75_]], [[VAR_0_]]{{.}}[[VAR_31_1_]]#0, [[VAR_31_1_]]#1] : memref<2x4xf32>
-// CHECK:               krnl.store [[VAR_94_]], [[VAR_1_]]{{.}}[[VAR_31_1_]]#0, [[VAR_31_1_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_20_MEM_3_:%.+]] = krnl.load [[VAR_20_]]{{.}}[[VAR_23_1_]]#0, [[VAR_68_]]{{.}} : memref<2x16xf32>
+// CHECK-DAG:           [[VAR_70_:%.+]] = affine.apply #map2(){{.}}[[VAR_23_1_]]#1]
+// CHECK:               [[LOAD_VAR_21_MEM_3_:%.+]] = krnl.load [[VAR_21_]]{{.}}[[VAR_23_1_]]#0, [[VAR_70_]]{{.}} : memref<2x16xf32>
+// CHECK-DAG:           [[VAR_72_:%.+]] = addf [[LOAD_VAR_20_MEM_3_]], [[LOAD_VAR_21_MEM_3_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_7_MEM_:%.+]] = krnl.load [[VAR_7_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_11_MEM_:%.+]] = krnl.load [[VAR_11_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_75_:%.+]] = addf [[VAR_72_]], [[LOAD_VAR_7_MEM_]] : f32
+// CHECK-DAG:           [[VAR_76_:%.+]] = addf [[VAR_75_]], [[LOAD_VAR_11_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_15_MEM_:%.+]] = krnl.load [[VAR_15_]]{{.}}[[VAR_23_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_78_:%.+]] = mulf [[LOAD_VAR_15_MEM_]], [[VAR_67_]] : f32
+// CHECK-DAG:           [[VAR_79_:%.+]] = addf [[VAR_76_]], [[VAR_78_]] : f32
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_79_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_81_:%.+]] = "onnx.Sigmoid"([[RES_7_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_81_MEM_:%.+]] = krnl.load [[VAR_81_]][] : memref<f32>
+// CHECK-DAG:           [[RES_8_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_67_]], [[RES_8_]][] : memref<f32>
+// CHECK:               [[VAR_84_:%.+]] = "onnx.Tanh"([[RES_8_]]) : (memref<f32>) -> memref<f32>
+// CHECK:               [[LOAD_VAR_84_MEM_:%.+]] = krnl.load [[VAR_84_]][] : memref<f32>
+// CHECK:               [[VAR_86_:%.+]] = mulf [[LOAD_VAR_81_MEM_]], [[LOAD_VAR_84_MEM_]] : f32
+// CHECK:               krnl.store [[VAR_67_]], [[RES_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_86_]], [[RES_1_]]{{.}}[[VAR_23_1_]]#0, [[VAR_23_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_1_MEM_1_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_2_]], [[VAR_1_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_1_]] : memref<2x4xf32>
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_2_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_2_]], [[RES_1_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_1_]] : memref<2x4xf32>
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_2_]] : memref<1x2x4xf32>
 // CHECK:         }
+
 }
 
 // -----
@@ -328,21 +286,26 @@ func private @test_lstm_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4, %arg5, %arg6) {hidden_size = 4 : si64, direction = "reverse"} : (tensor<7x2x3xf32>, tensor<1x16x3xf32>, tensor<1x16x4xf32>, tensor<1x32xf32>, none, tensor<1x2x4xf32>, tensor<1x2x4xf32>, tensor<1x12xf32>) -> (none, tensor<*xf32>, none)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_lstm_reverse_mode
+// CHECK-DAG: #map0 = affine_map<(d0) -> (-d0 + 6)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #map2 = affine_map<()[s0] -> (s0 + 12)>
+// CHECK-DAG: #map3 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-LABEL:  builtin.func private @test_lstm_reverse_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x16x3xf32>, [[PARAM_2_:%.+]]: memref<1x16x4xf32>, [[PARAM_3_:%.+]]: memref<1x32xf32>, [[PARAM_4_:%.+]]: memref<1x2x4xf32>, [[PARAM_5_:%.+]]: memref<1x2x4xf32>, [[PARAM_6_:%.+]]: memref<1x12xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:             [[LOAD_PARAM_5_MEM_:%.+]] = krnl.load [[PARAM_5_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x16x3xf32>) -> memref<16x3xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x16x4xf32>) -> memref<16x4xf32>
@@ -357,35 +320,20 @@ func private @test_lstm_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:       [[VAR_11_:%.+]]:3 = "onnx.Split"([[VAR_10_]]) {axis = 0 : si64} : (memref<12xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_7_:%.+]] = constant 7 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[LOAD_PARAM_5_MEM_1_:%.+]] = affine.apply #map0([[I_2_]]){{.}}[[CST_7_]]{{.}}
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
+// CHECK-DAG:         [[LOAD_PARAM_5_MEM_1_:%.+]] = affine.apply #map0([[I_2_]])
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_19_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[LOAD_PARAM_5_MEM_1_]], [[VAR_19_]]#0, [[VAR_19_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_19_]]#0, [[VAR_19_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_3_]]{{.}}[[VAR_19_]]#0, [[VAR_19_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_16_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_1_]], [[VAR_6_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[VAR_17_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_7_]]) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_16_:%.+]] = "onnx.MatMul"([[RES_3_]], [[VAR_6_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
+// CHECK-DAG:         [[VAR_17_:%.+]] = "onnx.MatMul"([[RES_1_]], [[VAR_7_]]) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_19_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_19_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_16_MEM_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x16xf32>
 // CHECK-DAG:           [[LOAD_VAR_17_MEM_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x16xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -397,17 +345,13 @@ func private @test_lstm_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_:%.+]] = krnl.load [[VAR_11_]]#0{{.}}[[VAR_19_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_29_:%.+]] = mulf [[LOAD_VAR_11_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK-DAG:           [[VAR_30_:%.+]] = addf [[VAR_27_]], [[VAR_29_]] : f32
-// CHECK-DAG:           [[VAR_31_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_30_]], [[VAR_31_]][] : memref<f32>
-// CHECK:               [[VAR_32_:%.+]] = "onnx.Sigmoid"([[VAR_31_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_4_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_30_]], [[RES_4_]][] : memref<f32>
+// CHECK:               [[VAR_32_:%.+]] = "onnx.Sigmoid"([[RES_4_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_32_MEM_:%.+]] = krnl.load [[VAR_32_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[VAR_34_:%.+]] = affine.apply #map1(){{.}}[[VAR_19_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_16_MEM_1_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_19_1_]]#0, [[VAR_34_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_2_3_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_1_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[VAR_36_:%.+]] = affine.apply #map1(){{.}}[[VAR_19_1_]]#1]
 // CHECK:               [[LOAD_VAR_17_MEM_1_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_19_1_]]#0, [[VAR_36_]]{{.}} : memref<2x16xf32>
 // CHECK-DAG:           [[VAR_38_:%.+]] = addf [[LOAD_VAR_16_MEM_1_]], [[LOAD_VAR_17_MEM_1_]] : f32
@@ -418,17 +362,13 @@ func private @test_lstm_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_1_:%.+]] = krnl.load [[VAR_11_]]#2{{.}}[[VAR_19_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_44_:%.+]] = mulf [[LOAD_VAR_11_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK-DAG:           [[VAR_45_:%.+]] = addf [[VAR_42_]], [[VAR_44_]] : f32
-// CHECK-DAG:           [[VAR_46_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_45_]], [[VAR_46_]][] : memref<f32>
-// CHECK:               [[VAR_47_:%.+]] = "onnx.Sigmoid"([[VAR_46_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_45_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_47_:%.+]] = "onnx.Sigmoid"([[RES_5_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_47_MEM_:%.+]] = krnl.load [[VAR_47_]][] : memref<f32>
-// CHECK-DAG:           [[CST_3_1_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_:%.+]] = constant 12 : index
 // CHECK-DAG:           [[VAR_49_:%.+]] = affine.apply #map2(){{.}}[[VAR_19_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_VAR_16_MEM_2_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_19_1_]]#0, [[VAR_49_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_3_2_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_1_:%.+]] = constant 12 : index
 // CHECK-DAG:           [[VAR_51_:%.+]] = affine.apply #map2(){{.}}[[VAR_19_1_]]#1]
 // CHECK:               [[LOAD_VAR_17_MEM_2_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_19_1_]]#0, [[VAR_51_]]{{.}} : memref<2x16xf32>
 // CHECK-DAG:           [[VAR_53_:%.+]] = addf [[LOAD_VAR_16_MEM_2_]], [[LOAD_VAR_17_MEM_2_]] : f32
@@ -436,9 +376,9 @@ func private @test_lstm_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:           [[LOAD_VAR_9_MEM_5_:%.+]] = krnl.load [[VAR_9_]]#7{{.}}[[VAR_19_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_56_:%.+]] = addf [[VAR_53_]], [[LOAD_VAR_9_MEM_4_]] : f32
 // CHECK-DAG:           [[VAR_57_:%.+]] = addf [[VAR_56_]], [[LOAD_VAR_9_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_58_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_57_]], [[VAR_58_]][] : memref<f32>
-// CHECK:               [[VAR_59_:%.+]] = "onnx.Tanh"([[VAR_58_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_57_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[VAR_59_:%.+]] = "onnx.Tanh"([[RES_6_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_59_MEM_:%.+]] = krnl.load [[VAR_59_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_61_:%.+]] = mulf [[LOAD_VAR_47_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK:               [[VAR_62_:%.+]] = mulf [[LOAD_VAR_32_MEM_]], [[LOAD_VAR_59_MEM_]] : f32
@@ -456,27 +396,28 @@ func private @test_lstm_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x1
 // CHECK-DAG:           [[LOAD_VAR_11_MEM_2_:%.+]] = krnl.load [[VAR_11_]]#1{{.}}[[VAR_19_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_74_:%.+]] = mulf [[LOAD_VAR_11_MEM_2_]], [[VAR_63_]] : f32
 // CHECK-DAG:           [[VAR_75_:%.+]] = addf [[VAR_72_]], [[VAR_74_]] : f32
-// CHECK-DAG:           [[VAR_76_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_75_]], [[VAR_76_]][] : memref<f32>
-// CHECK:               [[VAR_77_:%.+]] = "onnx.Sigmoid"([[VAR_76_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_75_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_77_:%.+]] = "onnx.Sigmoid"([[RES_7_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_77_MEM_:%.+]] = krnl.load [[VAR_77_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_79_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_63_]], [[VAR_79_]][] : memref<f32>
-// CHECK:               [[VAR_80_:%.+]] = "onnx.Tanh"([[VAR_79_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_8_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_63_]], [[RES_8_]][] : memref<f32>
+// CHECK:               [[VAR_80_:%.+]] = "onnx.Tanh"([[RES_8_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_80_MEM_:%.+]] = krnl.load [[VAR_80_]][] : memref<f32>
 // CHECK:               [[VAR_82_:%.+]] = mulf [[LOAD_VAR_77_MEM_]], [[LOAD_VAR_80_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_63_]], [[VAR_0_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x4xf32>
-// CHECK:               krnl.store [[VAR_82_]], [[VAR_1_]]{{.}}[[VAR_1_]]9#0, [[VAR_1_]]9#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_63_]], [[RES_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_82_]], [[RES_1_]]{{.}}[[RES_1_]]9#0, [[RES_1_]]9#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_2_]], [[VAR_1_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_1_]] : memref<2x4xf32>
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_2_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_2_]], [[RES_1_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_1_]] : memref<2x4xf32>
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_2_]] : memref<1x2x4xf32>
 // CHECK:         }
+
 }
+
 
 // -----
 
@@ -485,27 +426,32 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4, %arg5, %arg6) {hidden_size = 4 : si64, direction = "bidirectional"} : (tensor<7x2x3xf32>, tensor<2x16x3xf32>, tensor<2x16x4xf32>, tensor<2x32xf32>, none, tensor<2x2x4xf32>, tensor<2x2x4xf32>, tensor<2x12xf32>) -> (none, tensor<*xf32>, none)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_lstm_bidirectional_mode
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 12)>
+// CHECK-DAG: #map2 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-DAG: #map3 = affine_map<(d0) -> (-d0 + 6)>
+// CHECK-LABEL:  builtin.func private @test_lstm_bidirectional_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<2x16x3xf32>, [[PARAM_2_:%.+]]: memref<2x16x4xf32>, [[PARAM_3_:%.+]]: memref<2x32xf32>, [[PARAM_4_:%.+]]: memref<2x2x4xf32>, [[PARAM_5_:%.+]]: memref<2x2x4xf32>, [[PARAM_6_:%.+]]: memref<2x12xf32>) -> memref<2x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = memref.alloc() {{.*}}: memref<2x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
-// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<2x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<2x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_3_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_3_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:             [[LOAD_PARAM_5_MEM_:%.+]] = krnl.load [[PARAM_5_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<2x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_]], [[VAR_2_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_]], [[RES_2_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:             [[LOAD_PARAM_4_MEM_1_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_1_]], [[I_0_]], [[I_1_]]{{.}} : memref<2x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_1_]], [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_1_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:             [[LOAD_PARAM_5_MEM_1_:%.+]] = krnl.load [[PARAM_5_]]{{.}}[[CST_1_]], [[I_0_]], [[I_1_]]{{.}} : memref<2x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_1_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_1_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK:           [[VAR_6_:%.+]]:2 = "onnx.Split"([[PARAM_1_]]) {axis = 0 : si64} : (memref<2x16x3xf32>) -> (memref<1x16x3xf32>, memref<1x16x3xf32>)
 // CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.SqueezeV11"([[VAR_6_]]#0) {axes = [0]} : (memref<1x16x3xf32>) -> memref<16x3xf32>
@@ -535,32 +481,19 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
 // CHECK-DAG:       [[VAR_25_:%.+]]:3 = "onnx.Split"([[VAR_23_]]) {axis = 0 : si64} : (memref<12xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_2_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_5_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_34_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_34_]]#0, [[VAR_34_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_4_MEM_2_]]{{.}}[[VAR_34_]]#0, [[VAR_34_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_5_]]{{.}}[[VAR_34_]]#0, [[VAR_34_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_2_]], [[VAR_12_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[LOAD_PARAM_5_MEM_1_:%.+]] = "onnx.MatMul"([[VAR_3_]], [[VAR_13_]]) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = "onnx.MatMul"([[RES_5_]], [[VAR_12_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
+// CHECK-DAG:         [[LOAD_PARAM_5_MEM_1_:%.+]] = "onnx.MatMul"([[RES_3_]], [[VAR_13_]]) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_34_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_2_]]{{.}}[[VAR_34_1_]]#0, [[VAR_34_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_34_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_2_]]{{.}}[[VAR_34_1_]]#0, [[VAR_34_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_4_MEM_1_MEM_:%.+]] = krnl.load [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_34_1_]]#0, [[VAR_34_1_]]#1] : memref<2x16xf32>
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_5_MEM_1_MEM_:%.+]] = krnl.load [[LOAD_PARAM_5_MEM_1_]]{{.}}[[VAR_34_1_]]#0, [[VAR_34_1_]]#1] : memref<2x16xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -572,17 +505,13 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
 // CHECK-DAG:           [[LOAD_VAR_24_MEM_:%.+]] = krnl.load [[VAR_24_]]#0{{.}}[[VAR_34_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_44_:%.+]] = mulf [[LOAD_VAR_24_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK-DAG:           [[VAR_45_:%.+]] = addf [[VAR_42_]], [[VAR_44_]] : f32
-// CHECK-DAG:           [[VAR_46_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_45_]], [[VAR_46_]][] : memref<f32>
-// CHECK:               [[VAR_47_:%.+]] = "onnx.Sigmoid"([[VAR_46_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_45_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[VAR_47_:%.+]] = "onnx.Sigmoid"([[RES_6_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_47_MEM_:%.+]] = krnl.load [[VAR_47_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[VAR_49_:%.+]] = affine.apply #map0(){{.}}[[VAR_34_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_4_MEM_1_MEM_1_:%.+]] = krnl.load [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_34_1_]]#0, [[VAR_49_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_2_3_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_1_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[VAR_51_:%.+]] = affine.apply #map0(){{.}}[[VAR_34_1_]]#1]
 // CHECK:               [[LOAD_LOAD_PARAM_5_MEM_1_MEM_1_:%.+]] = krnl.load [[LOAD_PARAM_5_MEM_1_]]{{.}}[[VAR_34_1_]]#0, [[VAR_51_]]{{.}} : memref<2x16xf32>
 // CHECK-DAG:           [[VAR_53_:%.+]] = addf [[LOAD_LOAD_PARAM_4_MEM_1_MEM_1_]], [[LOAD_LOAD_PARAM_5_MEM_1_MEM_1_]] : f32
@@ -593,17 +522,13 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
 // CHECK-DAG:           [[LOAD_VAR_24_MEM_1_:%.+]] = krnl.load [[VAR_24_]]#2{{.}}[[VAR_34_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_59_:%.+]] = mulf [[LOAD_VAR_24_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK-DAG:           [[VAR_60_:%.+]] = addf [[VAR_57_]], [[VAR_59_]] : f32
-// CHECK-DAG:           [[VAR_61_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_60_]], [[VAR_61_]][] : memref<f32>
-// CHECK:               [[VAR_62_:%.+]] = "onnx.Sigmoid"([[VAR_61_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_60_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_62_:%.+]] = "onnx.Sigmoid"([[RES_7_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_62_MEM_:%.+]] = krnl.load [[VAR_62_]][] : memref<f32>
-// CHECK-DAG:           [[CST_3_1_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_:%.+]] = constant 12 : index
 // CHECK-DAG:           [[VAR_64_:%.+]] = affine.apply #map1(){{.}}[[VAR_34_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_4_MEM_1_MEM_2_:%.+]] = krnl.load [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_34_1_]]#0, [[VAR_64_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_3_2_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_1_:%.+]] = constant 12 : index
 // CHECK-DAG:           [[VAR_66_:%.+]] = affine.apply #map1(){{.}}[[VAR_34_1_]]#1]
 // CHECK:               [[LOAD_LOAD_PARAM_5_MEM_1_MEM_2_:%.+]] = krnl.load [[LOAD_PARAM_5_MEM_1_]]{{.}}[[VAR_34_1_]]#0, [[VAR_66_]]{{.}} : memref<2x16xf32>
 // CHECK-DAG:           [[VAR_68_:%.+]] = addf [[LOAD_LOAD_PARAM_4_MEM_1_MEM_2_]], [[LOAD_LOAD_PARAM_5_MEM_1_MEM_2_]] : f32
@@ -611,9 +536,9 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
 // CHECK-DAG:           [[LOAD_VAR_19_MEM_5_:%.+]] = krnl.load [[VAR_19_]]#7{{.}}[[VAR_34_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_71_:%.+]] = addf [[VAR_68_]], [[LOAD_VAR_19_MEM_4_]] : f32
 // CHECK-DAG:           [[VAR_72_:%.+]] = addf [[VAR_71_]], [[LOAD_VAR_19_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_73_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_72_]], [[VAR_73_]][] : memref<f32>
-// CHECK:               [[VAR_74_:%.+]] = "onnx.Tanh"([[VAR_73_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_8_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_72_]], [[RES_8_]][] : memref<f32>
+// CHECK:               [[VAR_74_:%.+]] = "onnx.Tanh"([[RES_8_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_74_MEM_:%.+]] = krnl.load [[VAR_74_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_76_:%.+]] = mulf [[LOAD_VAR_62_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
 // CHECK:               [[VAR_77_:%.+]] = mulf [[LOAD_VAR_47_MEM_]], [[LOAD_VAR_74_MEM_]] : f32
@@ -631,51 +556,36 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
 // CHECK-DAG:           [[LOAD_VAR_24_MEM_2_:%.+]] = krnl.load [[VAR_24_]]#1{{.}}[[VAR_34_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_89_:%.+]] = mulf [[LOAD_VAR_24_MEM_2_]], [[VAR_78_]] : f32
 // CHECK-DAG:           [[VAR_90_:%.+]] = addf [[VAR_87_]], [[VAR_89_]] : f32
-// CHECK-DAG:           [[VAR_91_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_90_]], [[VAR_91_]][] : memref<f32>
-// CHECK:               [[VAR_92_:%.+]] = "onnx.Sigmoid"([[VAR_91_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_9_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_90_]], [[RES_9_]][] : memref<f32>
+// CHECK:               [[VAR_92_:%.+]] = "onnx.Sigmoid"([[RES_9_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[LOAD_VAR_92_MEM_:%.+]] = krnl.load [[VAR_92_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_94_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_78_]], [[VAR_94_]][] : memref<f32>
-// CHECK:               [[VAR_95_:%.+]] = "onnx.Tanh"([[VAR_94_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_10_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_78_]], [[RES_10_]][] : memref<f32>
+// CHECK:               [[VAR_95_:%.+]] = "onnx.Tanh"([[RES_10_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_95_MEM_:%.+]] = krnl.load [[VAR_95_]][] : memref<f32>
 // CHECK:               [[VAR_97_:%.+]] = mulf [[LOAD_VAR_92_MEM_]], [[LOAD_VAR_95_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_78_]], [[VAR_2_]]{{.}}[[VAR_34_1_]]#0, [[VAR_34_1_]]#1] : memref<2x4xf32>
-// CHECK:               krnl.store [[VAR_97_]], [[VAR_3_]]{{.}}[[VAR_3_]]4#0, [[VAR_3_]]4#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_78_]], [[RES_2_]]{{.}}[[VAR_34_1_]]#0, [[VAR_34_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_97_]], [[RES_3_]]{{.}}[[RES_3_]]4#0, [[RES_3_]]4#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_2_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_5_]] : memref<2x3xf32>
 // CHECK:           }
 // CHECK:           [[LOOP_4_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_4_]]) with ([[LOOP_4_]] -> [[I_7_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_2_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_1_3_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_7_:%.+]] = constant 7 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[LOOP_2_:%.+]] = affine.apply #map3([[I_7_]]){{.}}[[CST_7_]]{{.}}
-// CHECK-DAG:         [[CST_0_6_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_7_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_4_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_4_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_11_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
+// CHECK-DAG:         [[LOOP_2_:%.+]] = affine.apply #map3([[I_7_]])
 // CHECK-DAG:         [[LOOP_5_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_5_]]#0, [[LOOP_5_]]#1) with ([[LOOP_5_]]#0 -> [[I_8_:%.+]] = [[CST_0_6_]] to [[CST_2_4_]], [[LOOP_5_]]#1 -> [[I_9_:%.+]] = [[CST_0_6_]] to [[CST_3_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_5_]]#0, [[LOOP_5_]]#1) with ([[LOOP_5_]]#0 -> [[I_8_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_5_]]#1 -> [[I_9_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_5_]]#0, [[LOOP_5_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[LOOP_2_]], [[LOAD_PARAM_0_MEM_1_]]#0, [[LOAD_PARAM_0_MEM_1_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_2_]], [[LOAD_PARAM_4_MEM_2_]]{{.}}[[LOAD_PARAM_0_MEM_1_]]#0, [[LOAD_PARAM_0_MEM_1_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_2_]], [[RES_11_]]{{.}}[[LOAD_PARAM_0_MEM_1_]]#0, [[LOAD_PARAM_0_MEM_1_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[LOAD_PARAM_5_MEM_1_1_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_2_]], [[VAR_14_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[LOOP_3_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_1_]]5) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
-// CHECK-DAG:         [[CST_0_8_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_9_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_5_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_5_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_2_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[LOAD_PARAM_5_MEM_1_1_:%.+]] = "onnx.MatMul"([[RES_11_]], [[VAR_14_]]) : (memref<2x3xf32>, memref<3x16xf32>) -> memref<2x16xf32>
+// CHECK-DAG:         [[LOOP_3_:%.+]] = "onnx.MatMul"([[RES_1_]], [[RES_1_]]5) : (memref<2x4xf32>, memref<4x16xf32>) -> memref<2x16xf32>
 // CHECK-DAG:         [[LOOP_6_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_6_]]#0, [[LOOP_6_]]#1) with ([[LOOP_6_]]#0 -> [[I_10_:%.+]] = [[CST_0_8_]] to [[CST_2_5_]], [[LOOP_6_]]#1 -> [[I_11_:%.+]] = [[CST_0_8_]] to [[CST_4_2_]]) {
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_6_]]#0, [[LOOP_6_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_3_:%.+]] = constant 4 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_6_]]#0, [[LOOP_6_]]#1) with ([[LOOP_6_]]#0 -> [[I_10_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_6_]]#1 -> [[I_11_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[LOAD_PARAM_0_MEM_1_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_6_]]#0, [[LOOP_6_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[RES_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_5_MEM_1_MEM_4_:%.+]] = krnl.load [[LOAD_PARAM_5_MEM_1_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x16xf32>
 // CHECK-DAG:           [[VAR_38_1_:%.+]] = krnl.load [[LOOP_3_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x16xf32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -686,18 +596,14 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
 // CHECK-DAG:           [[LOAD_VAR_24_MEM_3_:%.+]] = addf [[VAR_42_1_]], [[VAR_41_1_]] : f32
 // CHECK-DAG:           [[VAR_44_1_:%.+]] = krnl.load [[VAR_25_]]#0{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_45_1_:%.+]] = mulf [[VAR_44_1_]], [[LOAD_PARAM_0_MEM_2_]] : f32
-// CHECK-DAG:           [[VAR_46_1_:%.+]] = addf [[LOAD_VAR_24_MEM_3_]], [[VAR_45_1_]] : f32
-// CHECK-DAG:           [[VAR_47_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_46_1_]], [[VAR_47_1_]][] : memref<f32>
-// CHECK:               [[LOAD_VAR_47_MEM_1_:%.+]] = "onnx.Sigmoid"([[VAR_47_1_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_6_:%.+]] = addf [[LOAD_VAR_24_MEM_3_]], [[VAR_45_1_]] : f32
+// CHECK-DAG:           [[RES_12_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[RES_6_]], [[RES_12_]][] : memref<f32>
+// CHECK:               [[LOAD_VAR_47_MEM_1_:%.+]] = "onnx.Sigmoid"([[RES_12_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[VAR_49_1_:%.+]] = krnl.load [[LOAD_VAR_47_MEM_1_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_6_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_2_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_4_MEM_1_MEM_1_:%.+]] = affine.apply #map0(){{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_51_1_:%.+]] = krnl.load [[LOAD_PARAM_5_MEM_1_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_LOAD_PARAM_4_MEM_1_MEM_1_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_2_7_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_3_:%.+]] = constant 8 : index
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_5_MEM_1_MEM_1_:%.+]] = affine.apply #map0(){{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1]
 // CHECK:               [[VAR_53_1_:%.+]] = krnl.load [[LOOP_3_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_LOAD_PARAM_5_MEM_1_MEM_1_]]{{.}} : memref<2x16xf32>
 // CHECK-DAG:           [[LOAD_VAR_19_MEM_2_:%.+]] = addf [[VAR_51_1_]], [[VAR_53_1_]] : f32
@@ -707,28 +613,24 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
 // CHECK-DAG:           [[LOAD_VAR_24_MEM_1_:%.+]] = addf [[VAR_57_1_]], [[VAR_56_1_]] : f32
 // CHECK-DAG:           [[VAR_59_1_:%.+]] = krnl.load [[VAR_25_]]#2{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_60_1_:%.+]] = mulf [[VAR_59_1_]], [[LOAD_PARAM_0_MEM_2_]] : f32
-// CHECK-DAG:           [[VAR_61_1_:%.+]] = addf [[LOAD_VAR_24_MEM_1_]], [[VAR_60_1_]] : f32
-// CHECK-DAG:           [[VAR_62_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_61_1_]], [[VAR_62_1_]][] : memref<f32>
-// CHECK:               [[LOAD_VAR_62_MEM_1_:%.+]] = "onnx.Sigmoid"([[VAR_62_1_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_7_:%.+]] = addf [[LOAD_VAR_24_MEM_1_]], [[VAR_60_1_]] : f32
+// CHECK-DAG:           [[RES_13_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[RES_7_]], [[RES_13_]][] : memref<f32>
+// CHECK:               [[LOAD_VAR_62_MEM_1_:%.+]] = "onnx.Sigmoid"([[RES_13_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[VAR_64_1_:%.+]] = krnl.load [[LOAD_VAR_62_MEM_1_]][] : memref<f32>
-// CHECK-DAG:           [[CST_3_4_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_2_:%.+]] = constant 12 : index
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_4_MEM_1_MEM_2_:%.+]] = affine.apply #map1(){{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_66_1_:%.+]] = krnl.load [[LOAD_PARAM_5_MEM_1_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_LOAD_PARAM_4_MEM_1_MEM_2_]]{{.}} : memref<2x16xf32>
-// CHECK-DAG:           [[CST_3_5_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_3_:%.+]] = constant 12 : index
 // CHECK-DAG:           [[LOAD_LOAD_PARAM_5_MEM_1_MEM_2_:%.+]] = affine.apply #map1(){{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1]
 // CHECK:               [[VAR_68_1_:%.+]] = krnl.load [[LOOP_3_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_LOAD_PARAM_5_MEM_1_MEM_2_]]{{.}} : memref<2x16xf32>
 // CHECK-DAG:           [[LOAD_VAR_19_MEM_4_:%.+]] = addf [[VAR_66_1_]], [[VAR_68_1_]] : f32
 // CHECK-DAG:           [[LOAD_VAR_19_MEM_5_:%.+]] = krnl.load [[VAR_20_]]#3{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
 // CHECK-DAG:           [[VAR_71_1_:%.+]] = krnl.load [[VAR_20_]]#7{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_72_1_:%.+]] = addf [[LOAD_VAR_19_MEM_4_]], [[LOAD_VAR_19_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_73_1_:%.+]] = addf [[VAR_72_1_]], [[VAR_71_1_]] : f32
-// CHECK-DAG:           [[VAR_74_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_73_1_]], [[VAR_74_1_]][] : memref<f32>
-// CHECK:               [[LOAD_VAR_74_MEM_1_:%.+]] = "onnx.Tanh"([[VAR_74_1_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_8_:%.+]] = addf [[VAR_72_1_]], [[VAR_71_1_]] : f32
+// CHECK-DAG:           [[RES_14_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[RES_8_]], [[RES_14_]][] : memref<f32>
+// CHECK:               [[LOAD_VAR_74_MEM_1_:%.+]] = "onnx.Tanh"([[RES_14_]]) : (memref<f32>) -> memref<f32>
 // CHECK-DAG:           [[VAR_76_1_:%.+]] = krnl.load [[LOAD_VAR_74_MEM_1_]][] : memref<f32>
 // CHECK-DAG:           [[VAR_77_1_:%.+]] = mulf [[VAR_64_1_]], [[LOAD_PARAM_0_MEM_2_]] : f32
 // CHECK:               [[VAR_78_1_:%.+]] = mulf [[VAR_49_1_]], [[VAR_76_1_]] : f32
@@ -745,41 +647,36 @@ func private @test_lstm_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tens
 // CHECK-DAG:           [[LOAD_VAR_24_MEM_2_:%.+]] = addf [[VAR_87_1_]], [[VAR_86_1_]] : f32
 // CHECK-DAG:           [[VAR_89_1_:%.+]] = krnl.load [[VAR_25_]]#1{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_90_1_:%.+]] = mulf [[VAR_89_1_]], [[VAR_79_1_]] : f32
-// CHECK-DAG:           [[VAR_91_1_:%.+]] = addf [[LOAD_VAR_24_MEM_2_]], [[VAR_90_1_]] : f32
-// CHECK-DAG:           [[VAR_92_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_91_1_]], [[VAR_92_1_]][] : memref<f32>
-// CHECK:               [[LOAD_VAR_92_MEM_1_:%.+]] = "onnx.Sigmoid"([[VAR_92_1_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[VAR_94_1_:%.+]] = krnl.load [[LOAD_VAR_92_MEM_1_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_95_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_79_1_]], [[VAR_95_1_]][] : memref<f32>
-// CHECK:               [[LOAD_VAR_95_MEM_1_:%.+]] = "onnx.Tanh"([[VAR_95_1_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_9_:%.+]] = addf [[LOAD_VAR_24_MEM_2_]], [[VAR_90_1_]] : f32
+// CHECK-DAG:           [[RES_15_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[RES_9_]], [[RES_15_]][] : memref<f32>
+// CHECK:               [[LOAD_VAR_92_MEM_1_:%.+]] = "onnx.Sigmoid"([[RES_15_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_10_:%.+]] = krnl.load [[LOAD_VAR_92_MEM_1_]][] : memref<f32>
+// CHECK-DAG:           [[RES_16_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_79_1_]], [[RES_16_]][] : memref<f32>
+// CHECK:               [[LOAD_VAR_95_MEM_1_:%.+]] = "onnx.Tanh"([[RES_16_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[VAR_97_1_:%.+]] = krnl.load [[LOAD_VAR_95_MEM_1_]][] : memref<f32>
-// CHECK:               [[VAR_98_:%.+]] = mulf [[VAR_94_1_]], [[VAR_97_1_]] : f32
-// CHECK:               krnl.store [[VAR_79_1_]], [[VAR_0_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
-// CHECK:               krnl.store [[VAR_98_]], [[VAR_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
+// CHECK:               [[VAR_98_:%.+]] = mulf [[RES_10_]], [[VAR_97_1_]] : f32
+// CHECK:               krnl.store [[VAR_79_1_]], [[RES_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[VAR_98_]], [[RES_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_2_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_11_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK-DAG:       [[CST_0_10_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_6_:%.+]] = constant 1 : index
-// CHECK-DAG:       [[CST_0_11_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_2_8_:%.+]] = constant 2 : index
-// CHECK-DAG:       [[CST_1_7_:%.+]] = constant 1 : index
-// CHECK-DAG:       [[CST_4_4_:%.+]] = constant 4 : index
-// CHECK-DAG:       [[LOOP_7_:%.+]]:2 = krnl.define_loops 2
-// CHECK:           krnl.iterate([[LOOP_7_]]#0, [[LOOP_7_]]#1) with ([[LOOP_7_]]#0 -> [[I_12_:%.+]] = [[CST_0_10_]] to [[CST_2_8_]], [[LOOP_7_]]#1 -> [[I_13_:%.+]] = [[CST_0_10_]] to [[CST_4_4_]]) {
-// CHECK:             [[LOAD_PARAM_4_MEM_2_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_7_]]#0, [[LOOP_7_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOOP_2_1_:%.+]] = krnl.load [[VAR_3_]]{{.}}[[LOAD_PARAM_4_MEM_2_1_]]#0, [[LOAD_PARAM_4_MEM_2_1_]]#1] : memref<2x4xf32>
-// CHECK:             krnl.store [[LOOP_2_1_]], [[VAR_4_]]{{.}}[[CST_0_10_]], [[LOAD_PARAM_4_MEM_2_1_]]#0, [[LOAD_PARAM_4_MEM_2_1_]]#1] : memref<2x2x4xf32>
-// CHECK:             [[LOOP_5_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[LOAD_PARAM_4_MEM_2_1_]]#0, [[LOAD_PARAM_4_MEM_2_1_]]#1] : memref<2x4xf32>
-// CHECK:             krnl.store [[LOOP_5_]], [[VAR_4_]]{{.}}[[CST_1_6_]], [[LOAD_PARAM_4_MEM_2_1_]]#0, [[LOAD_PARAM_4_MEM_2_1_]]#1] : memref<2x2x4xf32>
+// CHECK:           [[LOOP_7_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_7_]]#0, [[LOOP_7_]]#1) with ([[LOOP_7_]]#0 -> [[I_12_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_7_]]#1 -> [[I_13_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:             [[RES_11_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_7_]]#0, [[LOOP_7_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:             [[LOOP_2_1_:%.+]] = krnl.load [[RES_3_]]{{.}}[[RES_11_]]#0, [[RES_11_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.store [[LOOP_2_1_]], [[RES_4_]]{{.}}[[CST_0_]], [[RES_11_]]#0, [[RES_11_]]#1] : memref<2x2x4xf32>
+// CHECK:             [[LOOP_5_:%.+]] = krnl.load [[RES_1_]]{{.}}[[RES_11_]]#0, [[RES_11_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.store [[LOOP_5_]], [[RES_4_]]{{.}}[[CST_1_]], [[RES_11_]]#0, [[RES_11_]]#1] : memref<2x2x4xf32>
 // CHECK:           }
-// CHECK:           memref.dealloc [[VAR_3_]] : memref<2x4xf32>
-// CHECK:           memref.dealloc [[VAR_2_]] : memref<2x4xf32>
-// CHECK:           memref.dealloc [[VAR_1_]] : memref<2x4xf32>
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_4_]] : memref<2x2x4xf32>
+// CHECK:           memref.dealloc [[RES_3_]] : memref<2x4xf32>
+// CHECK:           memref.dealloc [[RES_2_]] : memref<2x4xf32>
+// CHECK:           memref.dealloc [[RES_1_]] : memref<2x4xf32>
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_4_]] : memref<2x2x4xf32>
 // CHECK:         }
+
 }
 
 // -----
@@ -788,166 +685,144 @@ func private @test_lstm_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: tensor<1x1
   %cst = constant unit
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4, %arg5, %arg6) {hidden_size = 4 : si64} : (tensor<?x?x?xf32>, tensor<1x16x?xf32>, tensor<1x16x4xf32>, tensor<1x32xf32>, none, tensor<1x?x4xf32>, tensor<1x?x4xf32>, tensor<1x12xf32>) -> (none, tensor<*xf32>, none)
   return %Y_h : tensor<*xf32>
-  
-// CHECK-LABEL:  func private @test_lstm_unknown_dims
+
+// CHECK-DAG: #map0 = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #map1 = affine_map<()[s0] -> (s0 + 12)>
+// CHECK-DAG: #map2 = affine_map<()[s0] -> (s0 + 4)>
+// CHECK-LABEL:  builtin.func private @test_lstm_unknown_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x?xf32>, [[PARAM_1_:%.+]]: memref<1x16x?xf32>, [[PARAM_2_:%.+]]: memref<1x16x4xf32>, [[PARAM_3_:%.+]]: memref<1x32xf32>, [[PARAM_4_:%.+]]: memref<1x?x4xf32>, [[PARAM_5_:%.+]]: memref<1x?x4xf32>, [[PARAM_6_:%.+]]: memref<1x12xf32>) -> memref<1x?x4xf32> {
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
+// CHECK-DAG:       [[CST_16_:%.+]] = constant 16 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
 // CHECK:           [[VAR_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<1x?x4xf32>
-// CHECK-DAG:       [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK:           [[VAR_2_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_1_]] : memref<?x?x?xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = memref.alloc([[VAR_2_]]) {{.*}}: memref<?x4xf32>
-// CHECK-DAG:       [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK:           [[VAR_4_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_2_]] : memref<?x?x?xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = memref.alloc([[VAR_4_]]) {{.*}}: memref<?x4xf32>
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
-// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_3_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<1x?x4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc([[VAR_2_]]) {{.*}}: memref<?x4xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc([[VAR_4_]]) {{.*}}: memref<?x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
-// CHECK-DAG:       [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK:           [[VAR_7_:%.+]] = memref.dim [[VAR_3_]], [[CST_0_1_]] : memref<?x4xf32>
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_7_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_2_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x?x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_3_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x4xf32>
 // CHECK:             [[LOAD_PARAM_5_MEM_:%.+]] = krnl.load [[PARAM_5_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x?x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_]], [[VAR_5_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_5_MEM_]], [[RES_2_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x4xf32>
 // CHECK:           }
-// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x16x?xf32>) -> memref<16x?xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x16x4xf32>) -> memref<16x4xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x16x?xf32>) -> memref<16x?xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x16x4xf32>) -> memref<16x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.Transpose"([[VAR_8_]]) {perm = [1, 0]} : (memref<16x?xf32>) -> memref<?x16xf32>
-// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.Transpose"([[VAR_9_]]) {perm = [1, 0]} : (memref<16x4xf32>) -> memref<4x16xf32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = "onnx.SqueezeV11"([[PARAM_3_]]) {axes = [0]} : (memref<1x32xf32>) -> memref<32xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.Transpose"([[VAR_7_]]) {perm = [1, 0]} : (memref<16x?xf32>) -> memref<?x16xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.Transpose"([[VAR_8_]]) {perm = [1, 0]} : (memref<16x4xf32>) -> memref<4x16xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "onnx.SqueezeV11"([[PARAM_3_]]) {axes = [0]} : (memref<1x32xf32>) -> memref<32xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_13_:%.+]]:8 = "onnx.Split"([[VAR_12_]]) {axis = 0 : si64} : (memref<32xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>)
-// CHECK-DAG:       [[VAR_14_:%.+]] = "onnx.SqueezeV11"([[PARAM_6_]]) {axes = [0]} : (memref<1x12xf32>) -> memref<12xf32>
+// CHECK-DAG:       [[VAR_12_:%.+]]:8 = "onnx.Split"([[VAR_11_]]) {axis = 0 : si64} : (memref<32xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>, memref<4xf32>)
+// CHECK-DAG:       [[VAR_13_:%.+]] = "onnx.SqueezeV11"([[PARAM_6_]]) {axes = [0]} : (memref<1x12xf32>) -> memref<12xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_15_:%.+]]:3 = "onnx.Split"([[VAR_14_]]) {axis = 0 : si64} : (memref<12xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>)
+// CHECK-DAG:       [[VAR_14_:%.+]]:3 = "onnx.Split"([[VAR_13_]]) {axis = 0 : si64} : (memref<12xf32>) -> (memref<4xf32>, memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
-// CHECK-DAG:       [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK:           [[VAR_17_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_2_]] : memref<?x?x?xf32>
-// CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to [[VAR_17_]]) {
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_1_4_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[VAR_16_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x?x?xf32>
+// CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to [[VAR_16_]]) {
+// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
+// CHECK-DAG:         [[LOAD_PARAM_5_MEM_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<?x?x?xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_4_]] : memref<?x?x?xf32>
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK:             [[LOAD_PARAM_5_MEM_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<?x?x?xf32>
-// CHECK-DAG:         [[VAR_23_:%.+]] = memref.alloc([[LOAD_PARAM_4_MEM_1_]], [[LOAD_PARAM_5_MEM_1_]]) {{.*}}: memref<?x?xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_1_5_:%.+]] = constant 1 : index
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc([[LOAD_PARAM_4_MEM_1_]], [[LOAD_PARAM_5_MEM_1_]]) {{.*}}: memref<?x?xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_4_]] to [[LOAD_PARAM_4_MEM_1_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_4_]] to [[LOAD_PARAM_5_MEM_1_]]) {
-// CHECK:               [[VAR_28_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_28_]]#0, [[VAR_28_]]#1] : memref<?x?x?xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[VAR_23_]]{{.}}[[VAR_28_]]#0, [[VAR_28_]]#1] : memref<?x?xf32>
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[LOAD_PARAM_4_MEM_1_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[LOAD_PARAM_5_MEM_1_]]) {
+// CHECK:               [[VAR_26_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_26_]]#0, [[VAR_26_]]#1] : memref<?x?x?xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_3_]]{{.}}[[VAR_26_]]#0, [[VAR_26_]]#1] : memref<?x?xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_25_:%.+]] = "onnx.MatMul"([[VAR_23_]], [[VAR_10_]]) : (memref<?x?xf32>, memref<?x16xf32>) -> memref<?x16xf32>
-// CHECK-DAG:         [[VAR_26_:%.+]] = "onnx.MatMul"([[VAR_3_]], [[VAR_11_]]) : (memref<?x4xf32>, memref<4x16xf32>) -> memref<?x16xf32>
-// CHECK-DAG:         [[CST_0_6_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_7_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_1_6_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_23_:%.+]] = "onnx.MatMul"([[RES_3_]], [[VAR_9_]]) : (memref<?x?xf32>, memref<?x16xf32>) -> memref<?x16xf32>
+// CHECK-DAG:         [[VAR_24_:%.+]] = "onnx.MatMul"([[RES_1_]], [[VAR_10_]]) : (memref<?x4xf32>, memref<4x16xf32>) -> memref<?x16xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_6_]] to [[VAR_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_6_]] to [[CST_4_]]) {
-// CHECK-DAG:           [[VAR_28_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[CST_4_1_:%.+]] = constant 4 : index
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[VAR_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_26_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_2_]]{{.}}[[VAR_26_1_]]#0, [[VAR_26_1_]]#1] : memref<?x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_23_MEM_:%.+]] = krnl.load [[VAR_23_]]{{.}}[[VAR_26_1_]]#0, [[VAR_26_1_]]#1] : memref<?x16xf32>
+// CHECK-DAG:           [[LOAD_VAR_24_MEM_:%.+]] = krnl.load [[VAR_24_]]{{.}}[[VAR_26_1_]]#0, [[VAR_26_1_]]#1] : memref<?x16xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_5_]]{{.}}[[VAR_28_1_]]#0, [[VAR_28_1_]]#1] : memref<?x4xf32>
-// CHECK-DAG:           [[LOAD_VAR_25_MEM_:%.+]] = krnl.load [[VAR_25_]]{{.}}[[VAR_28_1_]]#0, [[VAR_28_1_]]#1] : memref<?x16xf32>
-// CHECK-DAG:           [[LOAD_VAR_26_MEM_:%.+]] = krnl.load [[VAR_26_]]{{.}}[[VAR_28_1_]]#0, [[VAR_28_1_]]#1] : memref<?x16xf32>
+// CHECK-DAG:           [[VAR_30_:%.+]] = addf [[LOAD_VAR_23_MEM_]], [[LOAD_VAR_24_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_:%.+]] = krnl.load [[VAR_12_]]#0{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_1_:%.+]] = krnl.load [[VAR_12_]]#4{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_33_:%.+]] = addf [[VAR_30_]], [[LOAD_VAR_12_MEM_]] : f32
+// CHECK-DAG:           [[VAR_34_:%.+]] = addf [[VAR_33_]], [[LOAD_VAR_12_MEM_1_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_14_MEM_:%.+]] = krnl.load [[VAR_14_]]#0{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_36_:%.+]] = mulf [[LOAD_VAR_14_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK-DAG:           [[VAR_37_:%.+]] = addf [[VAR_34_]], [[VAR_36_]] : f32
+// CHECK-DAG:           [[RES_4_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_37_]], [[RES_4_]][] : memref<f32>
+// CHECK:               [[VAR_39_:%.+]] = "onnx.Sigmoid"([[RES_4_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_39_MEM_:%.+]] = krnl.load [[VAR_39_]][] : memref<f32>
+// CHECK-DAG:           [[VAR_41_:%.+]] = affine.apply #map0(){{.}}[[VAR_26_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_32_:%.+]] = addf [[LOAD_VAR_25_MEM_]], [[LOAD_VAR_26_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_:%.+]] = krnl.load [[VAR_13_]]#0{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_1_:%.+]] = krnl.load [[VAR_13_]]#4{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_35_:%.+]] = addf [[VAR_32_]], [[LOAD_VAR_13_MEM_]] : f32
-// CHECK-DAG:           [[VAR_36_:%.+]] = addf [[VAR_35_]], [[LOAD_VAR_13_MEM_1_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_15_MEM_:%.+]] = krnl.load [[VAR_15_]]#0{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_38_:%.+]] = mulf [[LOAD_VAR_15_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_39_:%.+]] = addf [[VAR_36_]], [[VAR_38_]] : f32
-// CHECK-DAG:           [[VAR_40_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_39_]], [[VAR_40_]][] : memref<f32>
-// CHECK:               [[VAR_41_:%.+]] = "onnx.Sigmoid"([[VAR_40_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_41_MEM_:%.+]] = krnl.load [[VAR_41_]][] : memref<f32>
-// CHECK-DAG:           [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_:%.+]] = constant 8 : index
-// CHECK-DAG:           [[VAR_43_:%.+]] = affine.apply #map0(){{.}}[[VAR_28_1_]]#1]
+// CHECK-DAG:           [[LOAD_VAR_23_MEM_1_:%.+]] = krnl.load [[VAR_23_]]{{.}}[[VAR_26_1_]]#0, [[VAR_41_]]{{.}} : memref<?x16xf32>
+// CHECK-DAG:           [[VAR_43_:%.+]] = affine.apply #map0(){{.}}[[VAR_26_1_]]#1]
+// CHECK:               [[LOAD_VAR_24_MEM_1_:%.+]] = krnl.load [[VAR_24_]]{{.}}[[VAR_26_1_]]#0, [[VAR_43_]]{{.}} : memref<?x16xf32>
+// CHECK-DAG:           [[VAR_45_:%.+]] = addf [[LOAD_VAR_23_MEM_1_]], [[LOAD_VAR_24_MEM_1_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_2_:%.+]] = krnl.load [[VAR_12_]]#2{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_3_:%.+]] = krnl.load [[VAR_12_]]#6{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_48_:%.+]] = addf [[VAR_45_]], [[LOAD_VAR_12_MEM_2_]] : f32
+// CHECK-DAG:           [[VAR_49_:%.+]] = addf [[VAR_48_]], [[LOAD_VAR_12_MEM_3_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_14_MEM_1_:%.+]] = krnl.load [[VAR_14_]]#2{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_51_:%.+]] = mulf [[LOAD_VAR_14_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK-DAG:           [[VAR_52_:%.+]] = addf [[VAR_49_]], [[VAR_51_]] : f32
+// CHECK-DAG:           [[RES_5_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_52_]], [[RES_5_]][] : memref<f32>
+// CHECK:               [[VAR_54_:%.+]] = "onnx.Sigmoid"([[RES_5_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_54_MEM_:%.+]] = krnl.load [[VAR_54_]][] : memref<f32>
+// CHECK-DAG:           [[VAR_56_:%.+]] = affine.apply #map1(){{.}}[[VAR_26_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_25_MEM_1_:%.+]] = krnl.load [[VAR_25_]]{{.}}[[VAR_28_1_]]#0, [[VAR_43_]]{{.}} : memref<?x16xf32>
-// CHECK-DAG:           [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:           [[CST_8_1_:%.+]] = constant 8 : index
-// CHECK-DAG:           [[VAR_45_:%.+]] = affine.apply #map0(){{.}}[[VAR_28_1_]]#1]
-// CHECK:               [[LOAD_VAR_26_MEM_1_:%.+]] = krnl.load [[VAR_26_]]{{.}}[[VAR_28_1_]]#0, [[VAR_45_]]{{.}} : memref<?x16xf32>
-// CHECK-DAG:           [[VAR_47_:%.+]] = addf [[LOAD_VAR_25_MEM_1_]], [[LOAD_VAR_26_MEM_1_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_2_:%.+]] = krnl.load [[VAR_13_]]#2{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_3_:%.+]] = krnl.load [[VAR_13_]]#6{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_50_:%.+]] = addf [[VAR_47_]], [[LOAD_VAR_13_MEM_2_]] : f32
-// CHECK-DAG:           [[VAR_51_:%.+]] = addf [[VAR_50_]], [[LOAD_VAR_13_MEM_3_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_15_MEM_1_:%.+]] = krnl.load [[VAR_15_]]#2{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_53_:%.+]] = mulf [[LOAD_VAR_15_MEM_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_54_:%.+]] = addf [[VAR_51_]], [[VAR_53_]] : f32
-// CHECK-DAG:           [[VAR_55_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_54_]], [[VAR_55_]][] : memref<f32>
-// CHECK:               [[VAR_56_:%.+]] = "onnx.Sigmoid"([[VAR_55_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_56_MEM_:%.+]] = krnl.load [[VAR_56_]][] : memref<f32>
-// CHECK-DAG:           [[CST_3_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_:%.+]] = constant 12 : index
-// CHECK-DAG:           [[VAR_58_:%.+]] = affine.apply #map1(){{.}}[[VAR_28_1_]]#1]
+// CHECK-DAG:           [[LOAD_VAR_23_MEM_2_:%.+]] = krnl.load [[VAR_23_]]{{.}}[[VAR_26_1_]]#0, [[VAR_56_]]{{.}} : memref<?x16xf32>
+// CHECK-DAG:           [[VAR_58_:%.+]] = affine.apply #map1(){{.}}[[VAR_26_1_]]#1]
+// CHECK:               [[LOAD_VAR_24_MEM_2_:%.+]] = krnl.load [[VAR_24_]]{{.}}[[VAR_26_1_]]#0, [[VAR_58_]]{{.}} : memref<?x16xf32>
+// CHECK-DAG:           [[VAR_60_:%.+]] = addf [[LOAD_VAR_23_MEM_2_]], [[LOAD_VAR_24_MEM_2_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_4_:%.+]] = krnl.load [[VAR_12_]]#3{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_5_:%.+]] = krnl.load [[VAR_12_]]#7{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_63_:%.+]] = addf [[VAR_60_]], [[LOAD_VAR_12_MEM_4_]] : f32
+// CHECK-DAG:           [[VAR_64_:%.+]] = addf [[VAR_63_]], [[LOAD_VAR_12_MEM_5_]] : f32
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_64_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[VAR_66_:%.+]] = "onnx.Tanh"([[RES_6_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_66_MEM_:%.+]] = krnl.load [[VAR_66_]][] : memref<f32>
+// CHECK-DAG:           [[VAR_68_:%.+]] = mulf [[LOAD_VAR_54_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK:               [[VAR_69_:%.+]] = mulf [[LOAD_VAR_39_MEM_]], [[LOAD_VAR_66_MEM_]] : f32
+// CHECK-DAG:           [[VAR_70_:%.+]] = addf [[VAR_68_]], [[VAR_69_]] : f32
+// CHECK-DAG:           [[VAR_71_:%.+]] = affine.apply #map2(){{.}}[[VAR_26_1_]]#1]
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_25_MEM_2_:%.+]] = krnl.load [[VAR_25_]]{{.}}[[VAR_28_1_]]#0, [[VAR_58_]]{{.}} : memref<?x16xf32>
-// CHECK-DAG:           [[CST_3_1_:%.+]] = constant 3 : index
-// CHECK-DAG:           [[CST_12_1_:%.+]] = constant 12 : index
-// CHECK-DAG:           [[VAR_60_:%.+]] = affine.apply #map1(){{.}}[[VAR_28_1_]]#1]
-// CHECK:               [[LOAD_VAR_26_MEM_2_:%.+]] = krnl.load [[VAR_26_]]{{.}}[[VAR_28_1_]]#0, [[VAR_60_]]{{.}} : memref<?x16xf32>
-// CHECK-DAG:           [[VAR_62_:%.+]] = addf [[LOAD_VAR_25_MEM_2_]], [[LOAD_VAR_26_MEM_2_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_4_:%.+]] = krnl.load [[VAR_13_]]#3{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_5_:%.+]] = krnl.load [[VAR_13_]]#7{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_65_:%.+]] = addf [[VAR_62_]], [[LOAD_VAR_13_MEM_4_]] : f32
-// CHECK-DAG:           [[VAR_66_:%.+]] = addf [[VAR_65_]], [[LOAD_VAR_13_MEM_5_]] : f32
-// CHECK-DAG:           [[VAR_67_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_66_]], [[VAR_67_]][] : memref<f32>
-// CHECK:               [[VAR_68_:%.+]] = "onnx.Tanh"([[VAR_67_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_68_MEM_:%.+]] = krnl.load [[VAR_68_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_70_:%.+]] = mulf [[LOAD_VAR_56_MEM_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:               [[VAR_71_:%.+]] = mulf [[LOAD_VAR_41_MEM_]], [[LOAD_VAR_68_MEM_]] : f32
-// CHECK-DAG:           [[VAR_72_:%.+]] = addf [[VAR_70_]], [[VAR_71_]] : f32
-// CHECK-DAG:           [[VAR_73_:%.+]] = affine.apply #map2(){{.}}[[VAR_28_1_]]#1]
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_VAR_25_MEM_3_:%.+]] = krnl.load [[VAR_25_]]{{.}}[[VAR_28_1_]]#0, [[VAR_73_]]{{.}} : memref<?x16xf32>
-// CHECK-DAG:           [[VAR_75_:%.+]] = affine.apply #map2(){{.}}[[VAR_28_1_]]#1]
-// CHECK:               [[LOAD_VAR_26_MEM_3_:%.+]] = krnl.load [[VAR_26_]]{{.}}[[VAR_28_1_]]#0, [[VAR_75_]]{{.}} : memref<?x16xf32>
-// CHECK-DAG:           [[VAR_77_:%.+]] = addf [[LOAD_VAR_25_MEM_3_]], [[LOAD_VAR_26_MEM_3_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_6_:%.+]] = krnl.load [[VAR_13_]]#1{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_13_MEM_7_:%.+]] = krnl.load [[VAR_13_]]#5{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_80_:%.+]] = addf [[VAR_77_]], [[LOAD_VAR_13_MEM_6_]] : f32
-// CHECK-DAG:           [[VAR_81_:%.+]] = addf [[VAR_80_]], [[LOAD_VAR_13_MEM_7_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_15_MEM_2_:%.+]] = krnl.load [[VAR_15_]]#1{{.}}[[VAR_28_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_83_:%.+]] = mulf [[LOAD_VAR_15_MEM_2_]], [[VAR_72_]] : f32
-// CHECK-DAG:           [[VAR_84_:%.+]] = addf [[VAR_81_]], [[VAR_83_]] : f32
-// CHECK-DAG:           [[VAR_85_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_84_]], [[VAR_85_]][] : memref<f32>
-// CHECK:               [[VAR_86_:%.+]] = "onnx.Sigmoid"([[VAR_85_]]) : (memref<f32>) -> memref<f32>
-// CHECK-DAG:           [[LOAD_VAR_86_MEM_:%.+]] = krnl.load [[VAR_86_]][] : memref<f32>
-// CHECK-DAG:           [[VAR_88_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_72_]], [[VAR_88_]][] : memref<f32>
-// CHECK:               [[VAR_89_:%.+]] = "onnx.Tanh"([[VAR_88_]]) : (memref<f32>) -> memref<f32>
-// CHECK:               [[LOAD_VAR_89_MEM_:%.+]] = krnl.load [[VAR_89_]][] : memref<f32>
-// CHECK:               [[VAR_91_:%.+]] = mulf [[LOAD_VAR_86_MEM_]], [[LOAD_VAR_89_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_72_]], [[VAR_5_]]{{.}}[[VAR_28_1_]]#0, [[VAR_28_1_]]#1] : memref<?x4xf32>
-// CHECK:               krnl.store [[VAR_91_]], [[VAR_3_]]{{.}}[[VAR_28_1_]]#0, [[VAR_28_1_]]#1] : memref<?x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_23_MEM_3_:%.+]] = krnl.load [[VAR_23_]]{{.}}[[VAR_26_1_]]#0, [[VAR_71_]]{{.}} : memref<?x16xf32>
+// CHECK-DAG:           [[VAR_73_:%.+]] = affine.apply #map2(){{.}}[[VAR_26_1_]]#1]
+// CHECK:               [[LOAD_VAR_24_MEM_3_:%.+]] = krnl.load [[VAR_24_]]{{.}}[[VAR_26_1_]]#0, [[VAR_73_]]{{.}} : memref<?x16xf32>
+// CHECK-DAG:           [[VAR_75_:%.+]] = addf [[LOAD_VAR_23_MEM_3_]], [[LOAD_VAR_24_MEM_3_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_6_:%.+]] = krnl.load [[VAR_12_]]#1{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_12_MEM_7_:%.+]] = krnl.load [[VAR_12_]]#5{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_78_:%.+]] = addf [[VAR_75_]], [[LOAD_VAR_12_MEM_6_]] : f32
+// CHECK-DAG:           [[VAR_79_:%.+]] = addf [[VAR_78_]], [[LOAD_VAR_12_MEM_7_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_14_MEM_2_:%.+]] = krnl.load [[VAR_14_]]#1{{.}}[[VAR_26_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_81_:%.+]] = mulf [[LOAD_VAR_14_MEM_2_]], [[VAR_70_]] : f32
+// CHECK-DAG:           [[VAR_82_:%.+]] = addf [[VAR_79_]], [[VAR_81_]] : f32
+// CHECK-DAG:           [[RES_7_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_82_]], [[RES_7_]][] : memref<f32>
+// CHECK:               [[VAR_84_:%.+]] = "onnx.Sigmoid"([[RES_7_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[LOAD_VAR_84_MEM_:%.+]] = krnl.load [[VAR_84_]][] : memref<f32>
+// CHECK-DAG:           [[RES_8_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_70_]], [[RES_8_]][] : memref<f32>
+// CHECK:               [[VAR_87_:%.+]] = "onnx.Tanh"([[RES_8_]]) : (memref<f32>) -> memref<f32>
+// CHECK:               [[LOAD_VAR_87_MEM_:%.+]] = krnl.load [[VAR_87_]][] : memref<f32>
+// CHECK:               [[VAR_89_:%.+]] = mulf [[LOAD_VAR_84_MEM_]], [[LOAD_VAR_87_MEM_]] : f32
+// CHECK:               krnl.store [[VAR_70_]], [[RES_2_]]{{.}}[[VAR_26_1_]]#0, [[VAR_26_1_]]#1] : memref<?x4xf32>
+// CHECK:               krnl.store [[VAR_89_]], [[RES_1_]]{{.}}[[VAR_26_1_]]#0, [[VAR_26_1_]]#1] : memref<?x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[VAR_23_]] : memref<?x?xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<?x?xf32>
 // CHECK:           }
-// CHECK-DAG:       [[CST_16_:%.+]] = constant 16 : i64
-// CHECK-DAG:       [[CST_0_8_:%.+]] = constant 0 : index
-// CHECK:           [[VAR_18_:%.+]] = memref.dim [[VAR_3_]], [[CST_0_8_]] : memref<?x4xf32>
-// CHECK:           [[VAR_19_:%.+]] = index_cast [[VAR_18_]] : index to i64
-// CHECK:           [[VAR_20_:%.+]] = muli [[CST_16_]], [[VAR_19_]] : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_3_]], [[VAR_20_]]) : (memref<1x?x4xf32>, memref<?x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_3_]] : memref<?x4xf32>
-// CHECK:           memref.dealloc [[VAR_5_]] : memref<?x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x?x4xf32>
-// CHECK:         }
+// CHECK:           [[VAR_17_:%.+]] = index_cast [[VAR_2_]] : index to i64
+// CHECK:           [[VAR_18_:%.+]] = muli [[VAR_17_]], [[CST_16_]] : i64
+// CHECK:           "krnl.memcpy"([[RES_]], [[RES_1_]], [[RES_]]8) : (memref<1x?x4xf32>, memref<?x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_1_]] : memref<?x4xf32>
+// CHECK:           memref.dealloc [[RES_2_]] : memref<?x4xf32>
+// CHECK:           return [[RES_]] : memref<1x?x4xf32>
+// CHECK:         } 
+
 }

--- a/test/mlir/onnx/onnx_lowering_rnn_op.mlir
+++ b/test/mlir/onnx/onnx_lowering_rnn_op.mlir
@@ -1,22 +1,24 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl='check-rnn-ops-lowering' %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl='check-rnn-ops-lowering' --canonicalize %s -split-input-file | FileCheck %s
 
 func private @test_rnn_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x4x3xf32>, %arg2: tensor<1x4x4xf32>, %arg3: tensor<1x8xf32>, %arg4: tensor<1x2x4xf32>) -> tensor<*xf32> {
   %cst = constant unit
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64} : (tensor<7x2x3xf32>, tensor<1x4x3xf32>, tensor<1x4x4xf32>, tensor<1x8xf32>, none, tensor<1x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_rnn_forward_mode
+// mlir2FileCheck.py
+// CHECK-LABEL:  builtin.func private @test_rnn_forward_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x4x3xf32>, [[PARAM_2_:%.+]]: memref<1x4x4xf32>, [[PARAM_3_:%.+]]: memref<1x8xf32>, [[PARAM_4_:%.+]]: memref<1x2x4xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x4x3xf32>) -> memref<4x3xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x4x4xf32>) -> memref<4x4xf32>
@@ -28,28 +30,17 @@ func private @test_rnn_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x4x
 // CHECK-DAG:       [[VAR_8_:%.+]]:2 = "onnx.Split"([[VAR_7_]]) {axis = 0 : si64} : (memref<8xf32>) -> (memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_15_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_15_]]#0, [[VAR_15_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_15_]]#0, [[VAR_15_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_2_]]{{.}}[[VAR_15_]]#0, [[VAR_15_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_12_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_1_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[VAR_13_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_6_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_12_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_13_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_6_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
 // CHECK:               [[VAR_15_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_12_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_13_MEM_:%.+]] = krnl.load [[VAR_13_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x4xf32>
@@ -59,18 +50,17 @@ func private @test_rnn_forward_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x4x
 // CHECK-DAG:           [[LOAD_VAR_8_MEM_1_:%.+]] = krnl.load [[VAR_8_]]#1{{.}}[[VAR_15_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_21_:%.+]] = addf [[VAR_18_]], [[LOAD_VAR_8_MEM_]] : f32
 // CHECK-DAG:           [[VAR_22_:%.+]] = addf [[VAR_21_]], [[LOAD_VAR_8_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_23_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_22_]], [[VAR_23_]][] : memref<f32>
-// CHECK:               [[VAR_24_:%.+]] = "onnx.Tanh"([[VAR_23_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_3_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_22_]], [[RES_3_]][] : memref<f32>
+// CHECK:               [[VAR_24_:%.+]] = "onnx.Tanh"([[RES_3_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_24_MEM_:%.+]] = krnl.load [[VAR_24_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_24_MEM_]], [[VAR_0_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_VAR_24_MEM_]], [[RES_]]{{.}}[[VAR_15_1_]]#0, [[VAR_15_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_0_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_1_]], [[RES_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_1_]] : memref<1x2x4xf32>
 // CHECK:         }
 
 }
@@ -86,74 +76,57 @@ func private @test_rnn_forward_mode_constant_weight_and_bias(%arg0: tensor<7x2x3
   %Y, %Y_h = "onnx.RNN"(%arg0, %w, %r, %b, %cst, %arg1) {hidden_size = 4 : si64} : (tensor<7x2x3xf32>, tensor<1x4x3xf32>, tensor<1x4x4xf32>, tensor<1x8xf32>, none, tensor<1x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_rnn_forward_mode_constant_weight_and_bias
+// CHECK-LABEL:  builtin.func private @test_rnn_forward_mode_constant_weight_and_bias
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x2x4xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() {name = "constant_0", shape = [1, 4, 3], value = dense<1.000000e+00> : tensor<1x4x3xf32>} : () -> memref<1x4x3xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_1", shape = [1, 4, 4], value = dense<2.000000e+00> : tensor<1x4x4xf32>} : () -> memref<1x4x4xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_2", shape = [1, 8], value = dense<{{.}}[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]{{.}}> : tensor<1x8xf32>} : () -> memref<1x8xf32>
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_1_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_1_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
-// CHECK-DAG:       [[VAR_6_:%.+]] = "krnl.global"() {name = "constant_3", shape = [4, 3], value = dense<1.000000e+00> : tensor<4x3xf32>} : () -> memref<4x3xf32>
-// CHECK-DAG:       [[VAR_7_:%.+]] = "krnl.global"() {name = "constant_4", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = "krnl.global"() {name = "constant_5", shape = [3, 4], value = dense<1.000000e+00> : tensor<3x4xf32>} : () -> memref<3x4xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = "krnl.global"() {name = "constant_6", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_10_:%.+]] = "krnl.global"() {name = "constant_7", shape = [8], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<8xf32>} : () -> memref<8xf32>
-// CHECK-DAG:       [[VAR_11_:%.+]] = "krnl.global"() {name = "constant_8", shape = [4], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = "krnl.global"() {name = "constant_9", shape = [4], value = dense<[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() {name = "constant_5", shape = [3, 4], value = dense<1.000000e+00> : tensor<3x4xf32>} : () -> memref<3x4xf32>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "krnl.global"() {name = "constant_6", shape = [4, 4], value = dense<2.000000e+00> : tensor<4x4xf32>} : () -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "krnl.global"() {name = "constant_8", shape = [4], value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "krnl.global"() {name = "constant_9", shape = [4], value = dense<[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_1_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
-// CHECK:               [[VAR_19_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_19_]]#0, [[VAR_19_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_1_]]{{.}}[[VAR_19_]]#0, [[VAR_19_]]#1] : memref<2x3xf32>
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
+// CHECK:               [[VAR_13_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_13_]]#0, [[VAR_13_]]#1] : memref<7x2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_2_]]{{.}}[[VAR_13_]]#0, [[VAR_13_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_16_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_1_MEM_1_]], [[VAR_8_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[VAR_17_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_9_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_10_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_3_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_11_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_4_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
-// CHECK:               [[VAR_19_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_16_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x4xf32>
-// CHECK-DAG:           [[LOAD_VAR_17_MEM_:%.+]] = krnl.load [[VAR_17_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_13_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_10_]]{{.}}[[VAR_13_1_]]#0, [[VAR_13_1_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_11_MEM_:%.+]] = krnl.load [[VAR_11_]]{{.}}[[VAR_13_1_]]#0, [[VAR_13_1_]]#1] : memref<2x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_22_:%.+]] = addf [[LOAD_PARAM_0_MEM_1_]], [[LOAD_VAR_17_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_11_MEM_:%.+]] = krnl.load [[VAR_11_]]{{.}}[[VAR_19_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_12_MEM_:%.+]] = krnl.load [[VAR_12_]]{{.}}[[VAR_19_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_25_:%.+]] = addf [[VAR_22_]], [[LOAD_VAR_11_MEM_]] : f32
-// CHECK-DAG:           [[VAR_26_:%.+]] = addf [[VAR_25_]], [[LOAD_VAR_12_MEM_]] : f32
-// CHECK-DAG:           [[VAR_27_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_26_]], [[VAR_27_]][] : memref<f32>
-// CHECK:               [[VAR_28_:%.+]] = "onnx.Tanh"([[VAR_27_]]) : (memref<f32>) -> memref<f32>
-// CHECK:               [[LOAD_VAR_28_MEM_:%.+]] = krnl.load [[VAR_28_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_28_MEM_]], [[VAR_0_]]{{.}}[[VAR_19_1_]]#0, [[VAR_19_1_]]#1] : memref<2x4xf32>
+// CHECK-DAG:           [[VAR_16_:%.+]] = addf [[LOAD_PARAM_0_MEM_1_]], [[LOAD_VAR_11_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_5_MEM_:%.+]] = krnl.load [[VAR_5_]]{{.}}[[VAR_13_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_6_MEM_:%.+]] = krnl.load [[VAR_6_]]{{.}}[[VAR_13_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_19_:%.+]] = addf [[VAR_16_]], [[LOAD_VAR_5_MEM_]] : f32
+// CHECK-DAG:           [[VAR_20_:%.+]] = addf [[VAR_19_]], [[LOAD_VAR_6_MEM_]] : f32
+// CHECK-DAG:           [[RES_3_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_20_]], [[RES_3_]][] : memref<f32>
+// CHECK:               [[VAR_22_:%.+]] = "onnx.Tanh"([[RES_3_]]) : (memref<f32>) -> memref<f32>
+// CHECK:               [[LOAD_VAR_22_MEM_:%.+]] = krnl.load [[VAR_22_]][] : memref<f32>
+// CHECK:               krnl.store [[LOAD_VAR_22_MEM_]], [[RES_]]{{.}}[[VAR_13_1_]]#0, [[VAR_13_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_1_MEM_1_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_0_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_1_]], [[RES_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_1_]] : memref<1x2x4xf32>
 // CHECK:         }
 
 }
@@ -165,18 +138,20 @@ func private @test_rnn_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x4x
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64, direction = "reverse"} : (tensor<7x2x3xf32>, tensor<1x4x3xf32>, tensor<1x4x4xf32>, tensor<1x8xf32>, none, tensor<1x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_rnn_reverse_mode
+// CHECK-DAG: #map = affine_map<(d0) -> (-d0 + 6)>
+// CHECK-LABEL:  builtin.func private @test_rnn_reverse_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<1x4x3xf32>, [[PARAM_2_:%.+]]: memref<1x4x4xf32>, [[PARAM_3_:%.+]]: memref<1x8xf32>, [[PARAM_4_:%.+]]: memref<1x2x4xf32>) -> memref<1x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = constant 32 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x4x3xf32>) -> memref<4x3xf32>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x4x4xf32>) -> memref<4x4xf32>
@@ -188,31 +163,18 @@ func private @test_rnn_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x4x
 // CHECK-DAG:       [[VAR_8_:%.+]]:2 = "onnx.Split"([[VAR_7_]]) {axis = 0 : si64} : (memref<8xf32>) -> (memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_7_:%.+]] = constant 7 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_11_:%.+]] = affine.apply #map([[I_2_]]){{.}}[[CST_7_]]{{.}}
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
+// CHECK-DAG:         [[VAR_11_:%.+]] = affine.apply #map([[I_2_]])
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_16_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_11_]], [[VAR_16_]]#0, [[VAR_16_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_4_MEM_1_]]{{.}}[[VAR_16_]]#0, [[VAR_16_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_2_]]{{.}}[[VAR_16_]]#0, [[VAR_16_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_13_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_1_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[VAR_14_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_6_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_13_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_5_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_14_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_6_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
 // CHECK:               [[VAR_16_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_13_]]{{.}}[[VAR_16_1_]]#0, [[VAR_16_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_14_MEM_:%.+]] = krnl.load [[VAR_14_]]{{.}}[[VAR_16_1_]]#0, [[VAR_16_1_]]#1] : memref<2x4xf32>
@@ -222,18 +184,17 @@ func private @test_rnn_reverse_mode(%arg0: tensor<7x2x3xf32>, %arg1: tensor<1x4x
 // CHECK-DAG:           [[LOAD_VAR_8_MEM_1_:%.+]] = krnl.load [[VAR_8_]]#1{{.}}[[VAR_16_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_22_:%.+]] = addf [[VAR_19_]], [[LOAD_VAR_8_MEM_]] : f32
 // CHECK-DAG:           [[VAR_23_:%.+]] = addf [[VAR_22_]], [[LOAD_VAR_8_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_24_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_23_]], [[VAR_24_]][] : memref<f32>
-// CHECK:               [[VAR_25_:%.+]] = "onnx.Tanh"([[VAR_24_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_3_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_23_]], [[RES_3_]][] : memref<f32>
+// CHECK:               [[VAR_25_:%.+]] = "onnx.Tanh"([[RES_3_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_25_MEM_:%.+]] = krnl.load [[VAR_25_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_25_MEM_]], [[VAR_0_]]{{.}}[[VAR_16_1_]]#0, [[VAR_16_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_VAR_25_MEM_]], [[RES_]]{{.}}[[VAR_16_1_]]#0, [[VAR_16_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_1_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK:           [[CST_32_:%.+]] = constant 32 : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_0_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x2x4xf32>
+// CHECK:           "krnl.memcpy"([[RES_1_]], [[RES_]], [[CST_32_]]) : (memref<1x2x4xf32>, memref<2x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_1_]] : memref<1x2x4xf32>
 // CHECK:         }
 
 }
@@ -245,21 +206,23 @@ func private @test_rnn_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64, direction = "bidirectional"} : (tensor<7x2x3xf32>, tensor<2x4x3xf32>, tensor<2x4x4xf32>, tensor<2x8xf32>, none, tensor<2x2x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_rnn_bidirectional_mode
+// CHECK-DAG: #map = affine_map<(d0) -> (-d0 + 6)>
+// CHECK-LABEL:  builtin.func private @test_rnn_bidirectional_mode
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<7x2x3xf32>, [[PARAM_1_:%.+]]: memref<2x4x3xf32>, [[PARAM_2_:%.+]]: memref<2x4x4xf32>, [[PARAM_3_:%.+]]: memref<2x8xf32>, [[PARAM_4_:%.+]]: memref<2x2x4xf32>) -> memref<2x2x4xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<2x2x4xf32>
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
-// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<2x4xf32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<2x2x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<2x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:             [[LOAD_PARAM_4_MEM_1_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_1_]], [[I_0_]], [[I_1_]]{{.}} : memref<2x2x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_1_]], [[VAR_0_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_1_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x4xf32>
 // CHECK:           }
 // CHECK:           [[VAR_4_:%.+]]:2 = "onnx.Split"([[PARAM_1_]]) {axis = 0 : si64} : (memref<2x4x3xf32>) -> (memref<1x4x3xf32>, memref<1x4x3xf32>)
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.SqueezeV11"([[VAR_4_]]#0) {axes = [0]} : (memref<1x4x3xf32>) -> memref<4x3xf32>
@@ -282,28 +245,17 @@ func private @test_rnn_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:       [[VAR_18_:%.+]]:2 = "onnx.Split"([[VAR_16_]]) {axis = 0 : si64} : (memref<8xf32>) -> (memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_2_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_2_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_2_]] to [[CST_3_]]) {
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[VAR_27_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_27_]]#0, [[VAR_27_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_4_MEM_2_]]{{.}}[[VAR_27_]]#0, [[VAR_27_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_3_]]{{.}}[[VAR_27_]]#0, [[VAR_27_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_24_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_2_]], [[VAR_10_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[VAR_25_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_1_]]1) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_1_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_2_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_24_:%.+]] = "onnx.MatMul"([[RES_3_]], [[VAR_10_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[VAR_25_:%.+]] = "onnx.MatMul"([[RES_1_]], [[RES_1_]]1) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_4_]] to [[CST_2_1_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_4_]] to [[CST_4_]]) {
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
 // CHECK:               [[VAR_27_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_24_]]{{.}}[[VAR_27_1_]]#0, [[VAR_27_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[LOAD_VAR_25_MEM_:%.+]] = krnl.load [[VAR_25_]]{{.}}[[VAR_27_1_]]#0, [[VAR_27_1_]]#1] : memref<2x4xf32>
@@ -313,41 +265,28 @@ func private @test_rnn_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:           [[LOAD_VAR_17_MEM_1_:%.+]] = krnl.load [[VAR_17_]]#1{{.}}[[VAR_27_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_33_:%.+]] = addf [[VAR_30_]], [[LOAD_VAR_17_MEM_]] : f32
 // CHECK-DAG:           [[VAR_34_:%.+]] = addf [[VAR_33_]], [[LOAD_VAR_17_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_35_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_34_]], [[VAR_35_]][] : memref<f32>
-// CHECK:               [[VAR_36_:%.+]] = "onnx.Tanh"([[VAR_35_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_4_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_34_]], [[RES_4_]][] : memref<f32>
+// CHECK:               [[VAR_36_:%.+]] = "onnx.Tanh"([[RES_4_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_VAR_36_MEM_:%.+]] = krnl.load [[VAR_36_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_36_MEM_]], [[VAR_1_]]{{.}}[[VAR_27_1_]]#0, [[VAR_27_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_VAR_36_MEM_]], [[RES_1_]]{{.}}[[VAR_27_1_]]#0, [[VAR_27_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_2_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_3_]] : memref<2x3xf32>
 // CHECK:           }
 // CHECK:           [[LOOP_4_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_4_]]) with ([[LOOP_4_]] -> [[I_7_:%.+]] = 0 to 7) {
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_2_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
-// CHECK-DAG:         [[CST_1_3_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_7_:%.+]] = constant 7 : index
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[LOOP_2_:%.+]] = affine.apply #map([[I_7_]]){{.}}[[CST_7_]]{{.}}
-// CHECK-DAG:         [[CST_0_6_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_7_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_2_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_4_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_3_1_:%.+]] = constant 3 : index
+// CHECK-DAG:         [[RES_5_:%.+]] = memref.alloc() {{.*}}: memref<2x3xf32>
+// CHECK-DAG:         [[LOOP_2_:%.+]] = affine.apply #map([[I_7_]])
 // CHECK-DAG:         [[LOOP_5_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_5_]]#0, [[LOOP_5_]]#1) with ([[LOOP_5_]]#0 -> [[I_8_:%.+]] = [[CST_0_6_]] to [[CST_2_2_]], [[LOOP_5_]]#1 -> [[I_9_:%.+]] = [[CST_0_6_]] to [[CST_3_1_]]) {
+// CHECK:             krnl.iterate([[LOOP_5_]]#0, [[LOOP_5_]]#1) with ([[LOOP_5_]]#0 -> [[I_8_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_5_]]#1 -> [[I_9_:%.+]] = [[CST_0_]] to [[CST_3_]]) {
 // CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_5_]]#0, [[LOOP_5_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[LOOP_2_]], [[LOAD_PARAM_0_MEM_1_]]#0, [[LOAD_PARAM_0_MEM_1_]]#1] : memref<7x2x3xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_2_]], [[LOAD_PARAM_4_MEM_2_]]{{.}}[[LOAD_PARAM_0_MEM_1_]]#0, [[LOAD_PARAM_0_MEM_1_]]#1] : memref<2x3xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_2_]], [[RES_5_]]{{.}}[[LOAD_PARAM_0_MEM_1_]]#0, [[LOAD_PARAM_0_MEM_1_]]#1] : memref<2x3xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_25_1_:%.+]] = "onnx.MatMul"([[LOAD_PARAM_4_MEM_2_]], [[VAR_12_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[LOOP_3_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[VAR_13_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
-// CHECK-DAG:         [[CST_0_8_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_9_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_2_3_:%.+]] = constant 2 : index
-// CHECK-DAG:         [[CST_1_5_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_1_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_25_1_:%.+]] = "onnx.MatMul"([[RES_5_]], [[VAR_12_]]) : (memref<2x3xf32>, memref<3x4xf32>) -> memref<2x4xf32>
+// CHECK-DAG:         [[LOOP_3_:%.+]] = "onnx.MatMul"([[RES_]], [[VAR_13_]]) : (memref<2x4xf32>, memref<4x4xf32>) -> memref<2x4xf32>
 // CHECK-DAG:         [[LOOP_6_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_6_]]#0, [[LOOP_6_]]#1) with ([[LOOP_6_]]#0 -> [[I_10_:%.+]] = [[CST_0_8_]] to [[CST_2_3_]], [[LOOP_6_]]#1 -> [[I_11_:%.+]] = [[CST_0_8_]] to [[CST_4_1_]]) {
+// CHECK:             krnl.iterate([[LOOP_6_]]#0, [[LOOP_6_]]#1) with ([[LOOP_6_]]#0 -> [[I_10_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_6_]]#1 -> [[I_11_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
 // CHECK:               [[LOAD_PARAM_0_MEM_1_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_6_]]#0, [[LOOP_6_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK-DAG:           [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[VAR_25_1_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
 // CHECK-DAG:           [[VAR_30_1_:%.+]] = krnl.load [[LOOP_3_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
@@ -356,32 +295,26 @@ func private @test_rnn_bidirectional_mode(%arg0: tensor<7x2x3xf32>, %arg1: tenso
 // CHECK-DAG:           [[LOAD_VAR_17_MEM_1_:%.+]] = krnl.load [[VAR_18_]]#0{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
 // CHECK-DAG:           [[VAR_33_1_:%.+]] = krnl.load [[VAR_18_]]#1{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<4xf32>
 // CHECK:               [[VAR_34_1_:%.+]] = addf [[LOAD_VAR_17_MEM_2_]], [[LOAD_VAR_17_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_35_1_:%.+]] = addf [[VAR_34_1_]], [[VAR_33_1_]] : f32
-// CHECK-DAG:           [[VAR_36_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_35_1_]], [[VAR_36_1_]][] : memref<f32>
-// CHECK:               [[LOAD_VAR_36_MEM_1_:%.+]] = "onnx.Tanh"([[VAR_36_1_]]) : (memref<f32>) -> memref<f32>
+// CHECK-DAG:           [[RES_4_:%.+]] = addf [[VAR_34_1_]], [[VAR_33_1_]] : f32
+// CHECK-DAG:           [[RES_6_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[RES_4_]], [[RES_6_]][] : memref<f32>
+// CHECK:               [[LOAD_VAR_36_MEM_1_:%.+]] = "onnx.Tanh"([[RES_6_]]) : (memref<f32>) -> memref<f32>
 // CHECK:               [[LOAD_LOAD_VAR_36_MEM_1_MEM_:%.+]] = krnl.load [[LOAD_VAR_36_MEM_1_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_LOAD_VAR_36_MEM_1_MEM_]], [[VAR_0_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
+// CHECK:               krnl.store [[LOAD_LOAD_VAR_36_MEM_1_MEM_]], [[RES_]]{{.}}[[LOAD_PARAM_0_MEM_1_1_]]#0, [[LOAD_PARAM_0_MEM_1_1_]]#1] : memref<2x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[LOAD_PARAM_4_MEM_2_]] : memref<2x3xf32>
+// CHECK:             memref.dealloc [[RES_5_]] : memref<2x3xf32>
 // CHECK:           }
-// CHECK-DAG:       [[CST_0_10_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_6_:%.+]] = constant 1 : index
-// CHECK-DAG:       [[CST_0_11_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_2_4_:%.+]] = constant 2 : index
-// CHECK-DAG:       [[CST_1_7_:%.+]] = constant 1 : index
-// CHECK-DAG:       [[CST_4_2_:%.+]] = constant 4 : index
-// CHECK-DAG:       [[LOOP_7_:%.+]]:2 = krnl.define_loops 2
-// CHECK:           krnl.iterate([[LOOP_7_]]#0, [[LOOP_7_]]#1) with ([[LOOP_7_]]#0 -> [[I_12_:%.+]] = [[CST_0_10_]] to [[CST_2_4_]], [[LOOP_7_]]#1 -> [[I_13_:%.+]] = [[CST_0_10_]] to [[CST_4_2_]]) {
-// CHECK:             [[LOAD_PARAM_4_MEM_2_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_7_]]#0, [[LOOP_7_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOOP_2_1_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[LOAD_PARAM_4_MEM_2_1_]]#0, [[LOAD_PARAM_4_MEM_2_1_]]#1] : memref<2x4xf32>
-// CHECK:             krnl.store [[LOOP_2_1_]], [[VAR_2_]]{{.}}[[CST_0_10_]], [[VAR_2_]]2#0, [[VAR_2_]]2#1] : memref<2x2x4xf32>
-// CHECK:             [[LOOP_5_:%.+]] = krnl.load [[VAR_0_]]{{.}}[[LOAD_PARAM_4_MEM_2_1_]]#0, [[LOAD_PARAM_4_MEM_2_1_]]#1] : memref<2x4xf32>
-// CHECK:             krnl.store [[LOOP_5_]], [[VAR_2_]]{{.}}[[CST_1_6_]], [[VAR_2_]]2#0, [[VAR_2_]]2#1] : memref<2x2x4xf32>
+// CHECK:           [[LOOP_7_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_7_]]#0, [[LOOP_7_]]#1) with ([[LOOP_7_]]#0 -> [[I_12_:%.+]] = [[CST_0_]] to [[CST_2_]], [[LOOP_7_]]#1 -> [[I_13_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:             [[RES_5_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_7_]]#0, [[LOOP_7_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:             [[LOOP_2_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[RES_5_]]#0, [[RES_5_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.store [[LOOP_2_1_]], [[RES_2_]]{{.}}[[CST_0_]], [[RES_2_]]2#0, [[RES_2_]]2#1] : memref<2x2x4xf32>
+// CHECK:             [[LOOP_5_:%.+]] = krnl.load [[RES_]]{{.}}[[RES_5_]]#0, [[RES_5_]]#1] : memref<2x4xf32>
+// CHECK:             krnl.store [[LOOP_5_]], [[RES_2_]]{{.}}[[CST_1_]], [[RES_2_]]2#0, [[RES_2_]]2#1] : memref<2x2x4xf32>
 // CHECK:           }
-// CHECK:           memref.dealloc [[VAR_1_]] : memref<2x4xf32>
-// CHECK:           memref.dealloc [[VAR_0_]] : memref<2x4xf32>
-// CHECK:           return [[VAR_2_]] : memref<2x2x4xf32>
+// CHECK:           memref.dealloc [[RES_1_]] : memref<2x4xf32>
+// CHECK:           memref.dealloc [[RES_]] : memref<2x4xf32>
+// CHECK:           return [[RES_2_]] : memref<2x2x4xf32>
 // CHECK:         }
 
 }
@@ -393,85 +326,70 @@ func private @test_rnn_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: tensor<1x4x
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %arg3, %cst, %arg4) {hidden_size = 4 : si64} : (tensor<?x?x?xf32>, tensor<1x4x?xf32>, tensor<1x4x4xf32>, tensor<1x8xf32>, none, tensor<1x?x4xf32>) -> (none, tensor<*xf32>)
   return %Y_h : tensor<*xf32>
 
-// CHECK-LABEL:  func private @test_rnn_unknown_dims
+// CHECK-LABEL:  builtin.func private @test_rnn_unknown_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x?xf32>, [[PARAM_1_:%.+]]: memref<1x4x?xf32>, [[PARAM_2_:%.+]]: memref<1x4x4xf32>, [[PARAM_3_:%.+]]: memref<1x8xf32>, [[PARAM_4_:%.+]]: memref<1x?x4xf32>) -> memref<1x?x4xf32> {
-// CHECK-DAG:       [[VAR_cst_:%.+]] = constant unit
+// CHECK-DAG:       [[CST_16_:%.+]] = constant 16 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[CST_2_:%.+]] = constant 2 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = constant 1 : index
 // CHECK:           [[VAR_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<1x?x4xf32>
-// CHECK-DAG:       [[CST_1_1_:%.+]] = constant 1 : index
-// CHECK:           [[VAR_2_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_1_]] : memref<?x?x?xf32>
-// CHECK-DAG:       [[VAR_3_:%.+]] = memref.alloc([[VAR_2_]]) {{.*}}: memref<?x4xf32>
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
-// CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
-// CHECK-DAG:       [[CST_1_2_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<1x?x4xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc([[VAR_2_]]) {{.*}}: memref<?x4xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
-// CHECK-DAG:       [[CST_0_1_:%.+]] = constant 0 : index
-// CHECK:           [[VAR_5_:%.+]] = memref.dim [[VAR_3_]], [[CST_0_1_]] : memref<?x4xf32>
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_5_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[VAR_2_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4) {
 // CHECK:             [[LOAD_PARAM_4_MEM_:%.+]] = krnl.load [[PARAM_4_]]{{.}}[[CST_0_]], [[I_0_]], [[I_1_]]{{.}} : memref<1x?x4xf32>
-// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[VAR_3_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x4xf32>
+// CHECK:             krnl.store [[LOAD_PARAM_4_MEM_]], [[RES_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<?x4xf32>
 // CHECK:           }
-// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x4x?xf32>) -> memref<4x?xf32>
-// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x4x4xf32>) -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.SqueezeV11"([[PARAM_1_]]) {axes = [0]} : (memref<1x4x?xf32>) -> memref<4x?xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.SqueezeV11"([[PARAM_2_]]) {axes = [0]} : (memref<1x4x4xf32>) -> memref<4x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [1, 0]} : (memref<4x?xf32>) -> memref<?x4xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.Transpose"([[VAR_7_]]) {perm = [1, 0]} : (memref<4x4xf32>) -> memref<4x4xf32>
-// CHECK-DAG:       [[VAR_10_:%.+]] = "onnx.SqueezeV11"([[PARAM_3_]]) {axes = [0]} : (memref<1x8xf32>) -> memref<8xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_5_]]) {perm = [1, 0]} : (memref<4x?xf32>) -> memref<?x4xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [1, 0]} : (memref<4x4xf32>) -> memref<4x4xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.SqueezeV11"([[PARAM_3_]]) {axes = [0]} : (memref<1x8xf32>) -> memref<8xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_11_:%.+]]:2 = "onnx.Split"([[VAR_10_]]) {axis = 0 : si64} : (memref<8xf32>) -> (memref<4xf32>, memref<4xf32>)
+// CHECK-DAG:       [[VAR_10_:%.+]]:2 = "onnx.Split"([[VAR_9_]]) {axis = 0 : si64} : (memref<8xf32>) -> (memref<4xf32>, memref<4xf32>)
 // CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
-// CHECK-DAG:       [[CST_0_2_:%.+]] = constant 0 : index
-// CHECK:           [[VAR_13_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_2_]] : memref<?x?x?xf32>
-// CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to [[VAR_13_]]) {
-// CHECK-DAG:         [[CST_0_3_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_1_3_:%.+]] = constant 1 : index
+// CHECK-DAG:       [[VAR_12_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x?x?xf32>
+// CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to [[VAR_12_]]) {
+// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf32>
+// CHECK-DAG:         [[VAR_16_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<?x?x?xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[LOAD_PARAM_4_MEM_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_3_]] : memref<?x?x?xf32>
-// CHECK-DAG:         [[CST_2_:%.+]] = constant 2 : index
-// CHECK:             [[VAR_18_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<?x?x?xf32>
-// CHECK-DAG:         [[VAR_19_:%.+]] = memref.alloc([[LOAD_PARAM_4_MEM_1_]], [[VAR_18_]]) {{.*}}: memref<?x?xf32>
-// CHECK-DAG:         [[CST_0_4_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_5_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_1_4_:%.+]] = constant 1 : index
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc([[LOAD_PARAM_4_MEM_1_]], [[VAR_16_]]) {{.*}}: memref<?x?xf32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_4_]] to [[LOAD_PARAM_4_MEM_1_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_4_]] to [[VAR_18_]]) {
-// CHECK:               [[VAR_24_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_24_]]#0, [[VAR_24_]]#1] : memref<?x?x?xf32>
-// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[VAR_19_]]{{.}}[[VAR_24_]]#0, [[VAR_24_]]#1] : memref<?x?xf32>
+// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = [[CST_0_]] to [[LOAD_PARAM_4_MEM_1_]], [[LOOP_2_]]#1 -> [[I_4_:%.+]] = [[CST_0_]] to [[VAR_16_]]) {
+// CHECK:               [[VAR_22_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[I_2_]], [[VAR_22_]]#0, [[VAR_22_]]#1] : memref<?x?x?xf32>
+// CHECK:               krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_2_]]{{.}}[[VAR_22_]]#0, [[VAR_22_]]#1] : memref<?x?xf32>
 // CHECK:             }
-// CHECK-DAG:         [[VAR_21_:%.+]] = "onnx.MatMul"([[VAR_19_]], [[VAR_8_]]) : (memref<?x?xf32>, memref<?x4xf32>) -> memref<?x4xf32>
-// CHECK-DAG:         [[VAR_22_:%.+]] = "onnx.MatMul"([[VAR_3_]], [[VAR_9_]]) : (memref<?x4xf32>, memref<4x4xf32>) -> memref<?x4xf32>
-// CHECK-DAG:         [[CST_0_6_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_0_7_:%.+]] = constant 0 : index
-// CHECK-DAG:         [[CST_1_5_:%.+]] = constant 1 : index
-// CHECK-DAG:         [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[VAR_19_:%.+]] = "onnx.MatMul"([[RES_2_]], [[VAR_7_]]) : (memref<?x?xf32>, memref<?x4xf32>) -> memref<?x4xf32>
+// CHECK-DAG:         [[VAR_20_:%.+]] = "onnx.MatMul"([[RES_1_]], [[VAR_8_]]) : (memref<?x4xf32>, memref<4x4xf32>) -> memref<?x4xf32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_6_]] to [[VAR_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_6_]] to [[CST_4_]]) {
-// CHECK:               [[VAR_24_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_21_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<?x4xf32>
-// CHECK-DAG:           [[LOAD_VAR_22_MEM_:%.+]] = krnl.load [[VAR_22_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<?x4xf32>
+// CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = [[CST_0_]] to [[VAR_2_]], [[LOOP_3_]]#1 -> [[I_6_:%.+]] = [[CST_0_]] to [[CST_4_]]) {
+// CHECK:               [[VAR_22_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[VAR_19_]]{{.}}[[VAR_22_1_]]#0, [[VAR_22_1_]]#1] : memref<?x4xf32>
+// CHECK-DAG:           [[LOAD_VAR_20_MEM_:%.+]] = krnl.load [[VAR_20_]]{{.}}[[VAR_22_1_]]#0, [[VAR_22_1_]]#1] : memref<?x4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[VAR_27_:%.+]] = addf [[LOAD_PARAM_0_MEM_1_]], [[LOAD_VAR_22_MEM_]] : f32
-// CHECK-DAG:           [[LOAD_VAR_11_MEM_:%.+]] = krnl.load [[VAR_11_]]#0{{.}}[[VAR_24_1_]]#1] : memref<4xf32>
-// CHECK-DAG:           [[LOAD_VAR_11_MEM_1_:%.+]] = krnl.load [[VAR_11_]]#1{{.}}[[VAR_24_1_]]#1] : memref<4xf32>
-// CHECK:               [[VAR_30_:%.+]] = addf [[VAR_27_]], [[LOAD_VAR_11_MEM_]] : f32
-// CHECK-DAG:           [[VAR_31_:%.+]] = addf [[VAR_30_]], [[LOAD_VAR_11_MEM_1_]] : f32
-// CHECK-DAG:           [[VAR_32_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:               krnl.store [[VAR_31_]], [[VAR_32_]][] : memref<f32>
-// CHECK:               [[VAR_33_:%.+]] = "onnx.Tanh"([[VAR_32_]]) : (memref<f32>) -> memref<f32>
-// CHECK:               [[LOAD_VAR_33_MEM_:%.+]] = krnl.load [[VAR_33_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_VAR_33_MEM_]], [[VAR_3_]]{{.}}[[VAR_24_1_]]#0, [[VAR_24_1_]]#1] : memref<?x4xf32>
+// CHECK-DAG:           [[VAR_25_:%.+]] = addf [[LOAD_PARAM_0_MEM_1_]], [[LOAD_VAR_20_MEM_]] : f32
+// CHECK-DAG:           [[LOAD_VAR_10_MEM_:%.+]] = krnl.load [[VAR_10_]]#0{{.}}[[VAR_22_1_]]#1] : memref<4xf32>
+// CHECK-DAG:           [[LOAD_VAR_10_MEM_1_:%.+]] = krnl.load [[VAR_10_]]#1{{.}}[[VAR_22_1_]]#1] : memref<4xf32>
+// CHECK:               [[VAR_28_:%.+]] = addf [[VAR_25_]], [[LOAD_VAR_10_MEM_]] : f32
+// CHECK-DAG:           [[VAR_29_:%.+]] = addf [[VAR_28_]], [[LOAD_VAR_10_MEM_1_]] : f32
+// CHECK-DAG:           [[RES_3_:%.+]] = memref.alloca() : memref<f32>
+// CHECK:               krnl.store [[VAR_29_]], [[RES_3_]][] : memref<f32>
+// CHECK:               [[VAR_31_:%.+]] = "onnx.Tanh"([[RES_3_]]) : (memref<f32>) -> memref<f32>
+// CHECK:               [[LOAD_VAR_31_MEM_:%.+]] = krnl.load [[VAR_31_]][] : memref<f32>
+// CHECK:               krnl.store [[LOAD_VAR_31_MEM_]], [[RES_1_]]{{.}}[[VAR_22_1_]]#0, [[VAR_22_1_]]#1] : memref<?x4xf32>
 // CHECK:             }
-// CHECK:             memref.dealloc [[VAR_19_]] : memref<?x?xf32>
+// CHECK:             memref.dealloc [[RES_2_]] : memref<?x?xf32>
 // CHECK:           }
-// CHECK-DAG:       [[CST_16_:%.+]] = constant 16 : i64
-// CHECK-DAG:       [[CST_0_8_:%.+]] = constant 0 : index
-// CHECK:           [[VAR_14_:%.+]] = memref.dim [[VAR_3_]], [[CST_0_8_]] : memref<?x4xf32>
-// CHECK:           [[VAR_15_:%.+]] = index_cast [[VAR_14_]] : index to i64
-// CHECK:           [[VAR_16_:%.+]] = muli [[CST_16_]], [[VAR_15_]] : i64
-// CHECK:           "krnl.memcpy"([[VAR_1_]], [[VAR_3_]], [[VAR_1_]]6) : (memref<1x?x4xf32>, memref<?x4xf32>, i64) -> ()
-// CHECK:           memref.dealloc [[VAR_3_]] : memref<?x4xf32>
-// CHECK:           return [[VAR_1_]] : memref<1x?x4xf32>
+// CHECK:           [[VAR_13_:%.+]] = index_cast [[VAR_2_]] : index to i64
+// CHECK:           [[VAR_14_:%.+]] = muli [[VAR_13_]], [[CST_16_]] : i64
+// CHECK:           "krnl.memcpy"([[RES_]], [[RES_1_]], [[RES_]]4) : (memref<1x?x4xf32>, memref<?x4xf32>, i64) -> ()
+// CHECK:           memref.dealloc [[RES_1_]] : memref<?x4xf32>
+// CHECK:           return [[RES_]] : memref<1x?x4xf32>
 // CHECK:         }
+
 }


### PR DESCRIPTION
There are some remaining code in LSTM/RNN/GRU still using the old coding style. Replace them with IndexExpr.

Since we use IndexExpr, lit tests are modified to use canonicalization.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>