### PR TITLE
Enable SIMD in backend and numerical tests for user docker image

### DIFF
--- a/docker/Dockerfile.onnx-mlir
+++ b/docker/Dockerfile.onnx-mlir
@@ -37,12 +37,17 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
        cmake -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_MESSAGE=NEVER .. \
     && make -j${NPROC} \
-    && LIT_OPTS=-v make -j${NPROC} check-onnx-lit \
-    && NPROC=${NPROC} make check-onnx-backend \
-    && NPROC=${NPROC} make check-onnx-backend-dynamic \
-    && NPROC=${NPROC} make check-onnx-backend-constant \
+    && make -j${NPROC} LIT_OPTS=-v check-onnx-lit \
+# User image is built with SIMD (currently on s390x only)
+    && TEST_MCPU=$([ "$(uname -m)" = "s390x" ] && echo z14 || \
+                   [ "$(uname -m)" = "x86_64" ] &&  echo || \
+                   [ "$(uname -m)" = "ppc64le" ] && echo || echo) \
+    && TEST_ARGS="-mcpu=${TEST_MCPU}" \
+    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend \
+    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend-dynamic \
+    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend-constant \
+    && make ARGS=-j${NPROC} TEST_ARGS="${TEST_ARGS}" test \
     && make check-docs \
-    && make ARGS=-j${NPROC} test \
     && make onnx-mlir-doc \
     && make -j${NPROC} install \
 # Clean up

--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -32,12 +32,17 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
     && MLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
        cmake .. \
     && make -j${NPROC} \
-    && LIT_OPTS=-v make -j${NPROC} check-onnx-lit \
-    && NPROC=${NPROC} make check-onnx-backend \
-    && NPROC=${NPROC} make check-onnx-backend-dynamic \
-    && NPROC=${NPROC} make check-onnx-backend-constant \
+    && make -j${NPROC} LIT_OPTS=-v check-onnx-lit \
+# Dev image is built without SIMD, placeholder for easy SIMD enablement
+    && TEST_MCPU=$([ "$(uname -m)" = "s390x" ] && echo || \
+                   [ "$(uname -m)" = "x86_64" ] &&  echo || \
+                   [ "$(uname -m)" = "ppc64le" ] && echo || echo) \
+    && TEST_ARGS="-mcpu=${TEST_MCPU}" \
+    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend \
+    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend-dynamic \
+    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend-constant \
+    && make ARGS=-j${NPROC} TEST_ARGS="${TEST_ARGS}" test \
     && make check-docs \
-    && make ARGS=-j${NPROC} test \
     && make onnx-mlir-doc \
     && rm -rf /tmp/*
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -95,6 +95,13 @@ The environment variable `IMPORTER_FORCE_CONSTANT` is a list of indices
 separated by `,` (starting from 0, or -1 for all input indices), e.g. `0, 2, 3`
 or `-1`.
 
+### Enable SIMD instructions
+
+On supported platforms, currently s390x only, backend tests can generate SIMD instructions for the compiled models. To enable SIMD, set the TEST_MCPU environment variable, e.g.,
+```
+TEST_MCPU=z14 cmake --build . --config Release --target check-onnx-backend
+```
+
 ### Execution of backend tests
 
 A tool defined in `utils/RunONNXLib.cpp` can be used to easily execute files from their `.so`
@@ -201,3 +208,10 @@ variable in `src/MainUtils.cpp` to the types of files that you want to
 preserve (e.g. `KeepFilesOfType::All`). Then, no matter how you compile
 your model, input and output mlir files will be preserved, as well as
 unoptimized and optimized bytecode files as well as a few additional binaries.
+
+### Enable SIMD instructions
+
+On supported platforms, currently s390x only, numerical tests can generate SIMD instructions for the compiled models. To enable SIMD, set the TEST_ARGS environment variable, e.g.,
+```
+TEST_ARGS="-mcpu=z14" ARGS=-j$(nproc) cmake --build . --config Release --target test
+```

--- a/test/backend/CMakeLists.txt
+++ b/test/backend/CMakeLists.txt
@@ -33,11 +33,11 @@ execute_process(
   ERROR_QUIET
 )
 if (${PYTEST_XDIST_FOUND} EQUAL 0)
-  message(STATUS "Parallel backend tests  : ON")
+  message(STATUS "Parallel backend tests      : ON")
   set(BACKEND_TEST_COMMAND "${Python3_EXECUTABLE}" "-m" "pytest")
   set(BACKEND_TEST_ARGS "--forked" "-n" "$$\{NPROC:-auto\}")
 else()
-  message(STATUS "Parallel backend tests  : OFF (install pytest-xdist to enable)")
+  message(STATUS "Parallel backend tests      : OFF (install pytest-xdist to enable)")
   set(BACKEND_TEST_COMMAND ${Python3_EXECUTABLE})
   set(BACKEND_TEST_ARGS "")
 endif()

--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -291,6 +291,8 @@ int main(int argc, char *argv[]) {
   setExecPath(argv[0], (void *)main);
   llvm::FileRemover remover(getSharedLibName(SHARED_LIB_BASE));
 
+  llvm::cl::ParseCommandLineOptions(argc, argv, "TestConv\n", nullptr, "TEST_ARGS");
+
   // Had to explicitly iterate over dynamic as otherwise the random algorithm
   // never got to testing the dynamic cases.
   for (isDynamic = 0; isDynamic < 2; ++isDynamic) {

--- a/test/numerical/TestGRU.cpp
+++ b/test/numerical/TestGRU.cpp
@@ -303,6 +303,8 @@ int main(int argc, char *argv[]) {
   setExecPath(argv[0], (void *)main);
   llvm::FileRemover remover(getSharedLibName(SHARED_LIB_BASE));
 
+  llvm::cl::ParseCommandLineOptions(argc, argv, "TestGRU\n", nullptr, "TEST_ARGS");
+
   // RapidCheck test case generation.
   bool success = rc::check("GRU implementation correctness", []() {
     // The number of directions.

--- a/test/numerical/TestGemm.cpp
+++ b/test/numerical/TestGemm.cpp
@@ -218,6 +218,8 @@ int main(int argc, char *argv[]) {
   setExecPath(argv[0], (void *)main);
   llvm::FileRemover remover(getSharedLibName(SHARED_LIB_BASE));
 
+  llvm::cl::ParseCommandLineOptions(argc, argv, "TestGemm\n", nullptr, "TEST_ARGS");
+
   if (true) {
     printf("RapidCheck test case generation.\n");
     bool success = rc::check("Gemm implementation correctness", []() {

--- a/test/numerical/TestLSTM.cpp
+++ b/test/numerical/TestLSTM.cpp
@@ -312,6 +312,8 @@ int main(int argc, char *argv[]) {
   setExecPath(argv[0], (void *)main);
   llvm::FileRemover remover(getSharedLibName(SHARED_LIB_BASE));
 
+  llvm::cl::ParseCommandLineOptions(argc, argv, "TestLSTM\n", nullptr, "TEST_ARGS");
+
   // RapidCheck test case generation.
   bool success = rc::check("LSTM implementation correctness", []() {
     // The number of directions.

--- a/test/numerical/TestLoop.cpp
+++ b/test/numerical/TestLoop.cpp
@@ -129,6 +129,8 @@ int main(int argc, char *argv[]) {
   setExecPath(argv[0], (void *)main);
   llvm::FileRemover remover(getSharedLibName(SHARED_LIB_BASE));
 
+  llvm::cl::ParseCommandLineOptions(argc, argv, "TestLoop\n", nullptr, "TEST_ARGS");
+
   // Loop tests, simple.
   assert(isOMLoopTheSameAsNaiveImplFor(testLoopSimpleIR, 0, 42));
   assert(isOMLoopTheSameAsNaiveImplFor(testLoopSimpleIR, 1, 42));

--- a/test/numerical/TestMatMul2D.cpp
+++ b/test/numerical/TestMatMul2D.cpp
@@ -116,6 +116,8 @@ int main(int argc, char *argv[]) {
   setExecPath(argv[0], (void *)main);
   llvm::FileRemover remover(getSharedLibName(SHARED_LIB_BASE));
 
+  llvm::cl::ParseCommandLineOptions(argc, argv, "TestMatMul2D\n", nullptr, "TEST_ARGS");
+
   printf("RapidCheck test case generation.\n");
   bool success = rc::check("Matmul implementation correctness", []() {
     const auto I = *rc::gen::inRange(1, 50);

--- a/test/numerical/TestRNN.cpp
+++ b/test/numerical/TestRNN.cpp
@@ -219,6 +219,8 @@ int main(int argc, char *argv[]) {
   setExecPath(argv[0], (void *)main);
   llvm::FileRemover remover(getSharedLibName(SHARED_LIB_BASE));
 
+  llvm::cl::ParseCommandLineOptions(argc, argv, "TestRNN\n", nullptr, "TEST_ARGS");
+
   // RapidCheck test case generation.
   bool success = rc::check("RNN implementation correctness", []() {
     // The number of directions.


### PR DESCRIPTION
Enable SIMD in backend and numerical tests for user docker image,
dev docker image is built without SIMD so we cover both cases.

Signed-off-by: Gong Su <gong_su@hotmail.com>