### PR TITLE
Implement ONNX NonZeroOp

### DIFF
--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -37,6 +37,7 @@ add_onnx_mlir_library(OMONNXToKrnl
   Tensor/Tile.cpp
   Tensor/Range.cpp
   Tensor/Resize.cpp
+  Tensor/NonZero.cpp
   ConvertONNXToKrnl.cpp
 
   LINK_LIBS PUBLIC

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -192,6 +192,7 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   populateLoweringONNXFlattenOpPattern(patterns, &getContext());
   populateLoweringONNXRangeOpPattern(patterns, &getContext());
   populateLoweringONNXResizeOpPattern(patterns, &getContext());
+  populateLoweringONNXNonZeroOpPattern(patterns, &getContext());
   // Neural network
   populateLoweringONNXConvOpPattern(patterns, &getContext());
   populateLoweringONNXNormalizationOpPattern(patterns, &getContext());

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -348,6 +348,9 @@ void populateLoweringONNXFlattenOpPattern(
 void populateLoweringONNXResizeOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx);
 
+void populateLoweringONNXNonZeroOpPattern(
+    RewritePatternSet &patterns, MLIRContext *ctx);
+
 bool checkOpResultIsUsedByGetRef(memref::AllocOp *allocOp);
 
 /// This function returns the index in the list of alloc arguments of the

--- a/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
@@ -48,7 +48,7 @@ struct ONNXNonZeroOpLowering : public ConversionPattern {
     // Bounds for iterating the input X.
     MemRefBoundsIndexCapture xBounds(X);
     SmallVector<IndexExpr, 4> lbs, ubs;
-    for (decltype(xRank) i = 0; i < xRank; ++i) {
+    for (int64_t i = 0; i < xRank; ++i) {
       lbs.emplace_back(litZero);
       ubs.emplace_back(xBounds.getDim(i));
     }
@@ -104,7 +104,7 @@ struct ONNXNonZeroOpLowering : public ConversionPattern {
           Value val = createKrnl.load(X, loopInd);
           Value eqCond = createMath.eq(val, zero);
           Value zeroOrOne = createMath.select(eqCond, iZero, iOne);
-          for (decltype(xRank) i = 0; i < xRank; ++i) {
+          for (int64_t i = 0; i < xRank; ++i) {
             SmallVector<IndexExpr, 1> posInd;
             posInd.emplace_back(LiteralIndexExpr(i));
             // Load the current position along dimension i.

--- a/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------------------- NonZero.cpp - Lowering NonZero Op ----------------===//
+//
+// Copyright 2019 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file lowers the ONNX NonZero Operator to Krnl dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+#include "src/Dialect/ONNX/ONNXShapeHelper.hpp"
+
+using namespace mlir;
+
+struct ONNXNonZeroOpLowering : public ConversionPattern {
+  ONNXNonZeroOpLowering(MLIRContext *ctx)
+      : ConversionPattern(mlir::ONNXNonZeroOp::getOperationName(), 1, ctx) {}
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const final {
+    ONNXNonZeroOpAdaptor operandAdaptor(operands);
+    auto loc = op->getLoc();
+
+    // Builder helper.
+    KrnlBuilder createKrnl(rewriter, loc);
+    IndexExprScope outerScope(rewriter, loc);
+
+    // Common information.
+    Value X = operandAdaptor.X();
+    MemRefType xMemRefType = X.getType().cast<MemRefType>();
+    MemRefType resMemRefType = convertToMemRefType(*op->result_type_begin());
+    Type xElementType = xMemRefType.getElementType();
+    Type resElementType = resMemRefType.getElementType();
+    int64_t xRank = xMemRefType.getRank();
+
+    // Constant values.
+    Value iZero = emitConstantOp(rewriter, loc, rewriter.getIndexType(), 0);
+    Value iOne = emitConstantOp(rewriter, loc, rewriter.getIndexType(), 1);
+    Value zero = emitConstantOp(rewriter, loc, xElementType, 0);
+    LiteralIndexExpr litZero = LiteralIndexExpr(0);
+    LiteralIndexExpr litRank = LiteralIndexExpr(xRank);
+
+    // Bounds for iterating the input X.
+    MemRefBoundsIndexCapture xBounds(X);
+    SmallVector<IndexExpr, 4> lbs, ubs;
+    for (decltype(xRank) i = 0; i < xRank; ++i) {
+      lbs.emplace_back(litZero);
+      ubs.emplace_back(xBounds.getDim(i));
+    }
+
+    // Compute the number of nonzero values.
+    MemRefType i64MemRefType = MemRefType::get({}, rewriter.getIndexType());
+    Value nonzeroCount = insertAllocAndDealloc(
+        i64MemRefType, loc, rewriter, /*insertDealloc=*/true);
+    createKrnl.store(iZero, nonzeroCount, {});
+
+    // The result's first dimension size is the input's rank, so it is known.
+    // The result's second dimension size is the number of nonzero values in the
+    // input, and it is unknown at compile time. Thus, we will emit a
+    // krnl.iterate to count the number of nonzero values.
+    ValueRange countLoopDef = createKrnl.defineLoops(xMemRefType.getRank());
+    createKrnl.iterateIE(countLoopDef, countLoopDef, lbs, ubs,
+        [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
+          MathBuilder createMath(createKrnl);
+          Value val = createKrnl.load(X, loopInd);
+          Value eqCond = createMath.eq(val, zero);
+          Value zeroOrOne = createMath.select(eqCond, iZero, iOne);
+          Value counter = createKrnl.load(nonzeroCount, {});
+          Value newCount = createMath.add(counter, zeroOrOne);
+          createKrnl.store(newCount, nonzeroCount);
+        });
+
+    // Insert an allocation and deallocation for the result of this operation.
+    Value numberOfZeros = createKrnl.load(nonzeroCount, {});
+    SmallVector<IndexExpr, 2> dimExprs;
+    dimExprs.emplace_back(litRank);
+    dimExprs.emplace_back(DimIndexExpr(numberOfZeros));
+    bool insertDealloc = checkInsertDealloc(op);
+    Value resMemRef = insertAllocAndDeallocSimple(
+        rewriter, op, resMemRefType, loc, dimExprs, insertDealloc);
+
+    // When computing indices of nonzero value, keep trace of current indices
+    // for each dimension so that we know exactly where to store in the result.
+    Value pos =
+        insertAllocAndDealloc(MemRefType::get({xRank}, rewriter.getIndexType()),
+            loc, rewriter, /*insertDealloc=*/true);
+    ValueRange posLoopDef = createKrnl.defineLoops(1);
+    createKrnl.iterateIE(posLoopDef, posLoopDef, {litZero}, {litRank},
+        [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
+          createKrnl.store(iZero, pos, loopInd);
+        });
+
+    // Iterate over the input in row-major order to get indices of nonzero
+    // values.
+    ValueRange mainLoopDef = createKrnl.defineLoops(xMemRefType.getRank());
+    createKrnl.iterateIE(mainLoopDef, mainLoopDef, lbs, ubs,
+        [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
+          MathBuilder createMath(createKrnl);
+          Value val = createKrnl.load(X, loopInd);
+          Value eqCond = createMath.eq(val, zero);
+          Value zeroOrOne = createMath.select(eqCond, iZero, iOne);
+          for (decltype(xRank) i = 0; i < xRank; ++i) {
+            SmallVector<IndexExpr, 1> posInd;
+            posInd.emplace_back(LiteralIndexExpr(i));
+            // Load the current position along dimension i.
+            Value currentPos = createKrnl.loadIE(pos, posInd);
+            // Load the output at the current position along dimension i.
+            SmallVector<IndexExpr, 2> resInd;
+            resInd.emplace_back(LiteralIndexExpr(i));
+            resInd.emplace_back(DimIndexExpr(currentPos));
+            // If value is nonzero, update the output with the value's index.
+            // Otherwise, keep the output unchanged.
+            Value oldIndex = createKrnl.loadIE(resMemRef, resInd);
+            Value newIndex =
+                rewriter.create<IndexCastOp>(loc, loopInd[i], resElementType);
+            newIndex = createMath.select(eqCond, oldIndex, newIndex);
+            createKrnl.storeIE(newIndex, resMemRef, resInd);
+            // Move forward along the current dimension.
+            currentPos = createMath.add(currentPos, zeroOrOne);
+            createKrnl.storeIE(currentPos, pos, posInd);
+          }
+        });
+
+    rewriter.replaceOp(op, resMemRef);
+
+    return success();
+  }
+};
+
+void populateLoweringONNXNonZeroOpPattern(
+    RewritePatternSet &patterns, MLIRContext *ctx) {
+  patterns.insert<ONNXNonZeroOpLowering>(ctx);
+}

--- a/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
@@ -21,110 +21,189 @@ struct ONNXNonZeroOpLowering : public ConversionPattern {
   ONNXNonZeroOpLowering(MLIRContext *ctx)
       : ConversionPattern(mlir::ONNXNonZeroOp::getOperationName(), 1, ctx) {}
 
+  /// Given an input of shape (3, 2):
+  /// [[2, 1],
+  /// [0, 2],
+  /// [0, 1]]
+  ///
+  /// Output will be: [[0, 0, 1, 1], [0, 1, 1, 1]]
+  /// The output's shape is (2, 4) where 2 is the input's rank, 4 is the number
+  /// of nonzero values in the input.
+  ///
+  /// Step 1: Compute a 0-1 matrix:
+  /// 1, 1
+  /// 0, 1
+  /// 0, 1
+  ///
+  /// Step 2: Compute reduction sum for each dimension:
+  /// dim0 = ReduceSum(axis = 1) = [2, 1, 1]
+  /// dim1 = ReduceSum(axis = 0) = [1, 3]
+  ///
+  /// Step 3: Compute the number of nonzero for allocating the output buffer.
+  ///
+  /// Step 4: Compute output for each dimension:
+  /// for each axis:
+  ///   k = 0
+  ///   for i range(len(dim0)):
+  ///     d = dim0[i]
+  ///     for j in range(d):
+  ///       out[0][k+j] = i
+  ///     k += d
+  ///
+  /// Note: in the following implementation:
+  /// - Step1 and Step2 are done with a single nested loop for each dimension,
+  ///   so the 0-1 matrix is not generated explicitly.
+  /// - Step 3 will be done in one of the reduction sums in Step 2. Try to
+  ///   select the reduction sum with the smallest dim size if possible.
+
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     ONNXNonZeroOpAdaptor operandAdaptor(operands);
     auto loc = op->getLoc();
 
     // Builder helper.
-    KrnlBuilder createKrnl(rewriter, loc);
     IndexExprScope outerScope(rewriter, loc);
+    KrnlBuilder createKrnl(rewriter, loc);
+    MemRefBuilder createMemRef(createKrnl);
 
-    // Common information.
+    // Frequently used MemRefType.
     Value X = operandAdaptor.X();
     MemRefType xMemRefType = X.getType().cast<MemRefType>();
     MemRefType resMemRefType = convertToMemRefType(*op->result_type_begin());
-    Type xElementType = xMemRefType.getElementType();
-    Type resElementType = resMemRefType.getElementType();
     int64_t xRank = xMemRefType.getRank();
 
+    // Frequently used element types.
+    Type indexTy = rewriter.getIndexType();
+    Type xElementType = xMemRefType.getElementType();
+    Type resElementType = resMemRefType.getElementType();
+
     // Constant values.
-    Value iZero = emitConstantOp(rewriter, loc, rewriter.getIndexType(), 0);
-    Value iOne = emitConstantOp(rewriter, loc, rewriter.getIndexType(), 1);
+    Value iZero = emitConstantOp(rewriter, loc, indexTy, 0);
+    Value iOne = emitConstantOp(rewriter, loc, indexTy, 1);
     Value zero = emitConstantOp(rewriter, loc, xElementType, 0);
-    LiteralIndexExpr litZero = LiteralIndexExpr(0);
-    LiteralIndexExpr litRank = LiteralIndexExpr(xRank);
+    LiteralIndexExpr litZero(0);
 
     // Bounds for iterating the input X.
     MemRefBoundsIndexCapture xBounds(X);
-    SmallVector<IndexExpr, 4> lbs, ubs;
+    SmallVector<IndexExpr, 4> xLbs, xUbs;
     for (int64_t i = 0; i < xRank; ++i) {
-      lbs.emplace_back(litZero);
-      ubs.emplace_back(xBounds.getDim(i));
+      xLbs.emplace_back(litZero);
+      xUbs.emplace_back(xBounds.getDim(i));
     }
 
-    // Compute the number of nonzero values.
-    MemRefType i64MemRefType = MemRefType::get({}, rewriter.getIndexType());
-    Value nonzeroCount = insertAllocAndDealloc(
-        i64MemRefType, loc, rewriter, /*insertDealloc=*/true);
-    createKrnl.store(iZero, nonzeroCount, {});
+    // Find the axis with the smallest dimension size in the input.
+    // Reduction sum for this axis will be used to compute the number of nonzero
+    int64_t smallestDimAxis = 0;
+    if (xMemRefType.hasStaticShape() && xMemRefType.getRank() != 0) {
+      ArrayRef<int64_t> shape = xMemRefType.getShape();
+      int64_t v = shape[0];
+      for (uint64_t i = 1; i < shape.size(); i++) {
+        if (shape[i] < v) {
+          v = shape[i];
+          smallestDimAxis = i;
+        }
+      }
+    }
 
-    // The result's first dimension size is the input's rank, so it is known.
-    // The result's second dimension size is the number of nonzero values in the
-    // input, and it is unknown at compile time. Thus, we will emit a
-    // krnl.iterate to count the number of nonzero values.
-    ValueRange countLoopDef = createKrnl.defineLoops(xMemRefType.getRank());
-    createKrnl.iterateIE(countLoopDef, countLoopDef, lbs, ubs,
-        [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
-          MathBuilder createMath(createKrnl);
-          Value val = createKrnl.load(X, loopInd);
-          Value eqCond = createMath.eq(val, zero);
-          Value zeroOrOne = createMath.select(eqCond, iZero, iOne);
-          Value counter = createKrnl.load(nonzeroCount, {});
-          Value newCount = createMath.add(counter, zeroOrOne);
-          createKrnl.store(newCount, nonzeroCount);
-        });
+    // Emit alloc and dealloc for reduction sum along each axis
+    // MemRefType: [Dxi64] where D is dimension size of an axis.
+    SmallVector<Value, 4> redMemRefs;
+    for (int i = 0; i < xRank; ++i) {
+      // Alloc and dealloc.
+      SmallVector<IndexExpr, 1> dimIE(1, xBounds.getDim(i));
+      int64_t dim = dimIE[0].isLiteral() ? dimIE[0].getLiteral() : -1;
+      Value alloc = insertAllocAndDeallocSimple(rewriter, op,
+          MemRefType::get({dim}, indexTy), loc, dimIE,
+          /*insertDealloc=*/true);
+      // Initialize to zero.
+      ValueRange initLoopDef = createKrnl.defineLoops(1);
+      createKrnl.iterateIE(initLoopDef, initLoopDef, {litZero}, dimIE,
+          [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
+            createKrnl.store(iZero, alloc, loopInd);
+          });
+      redMemRefs.emplace_back(alloc);
+    }
 
-    // Insert an allocation and deallocation for the result of this operation.
-    Value numberOfZeros = createKrnl.load(nonzeroCount, {});
-    SmallVector<IndexExpr, 2> dimExprs;
-    dimExprs.emplace_back(litRank);
-    dimExprs.emplace_back(DimIndexExpr(numberOfZeros));
-    bool insertDealloc = checkInsertDealloc(op);
-    Value resMemRef = insertAllocAndDeallocSimple(
-        rewriter, op, resMemRefType, loc, dimExprs, insertDealloc);
-
-    // When computing indices of nonzero value, keep trace of current indices
-    // for each dimension so that we know exactly where to store in the result.
-    Value pos =
-        insertAllocAndDealloc(MemRefType::get({xRank}, rewriter.getIndexType()),
-            loc, rewriter, /*insertDealloc=*/true);
-    ValueRange posLoopDef = createKrnl.defineLoops(1);
-    createKrnl.iterateIE(posLoopDef, posLoopDef, {litZero}, {litRank},
-        [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
-          createKrnl.store(iZero, pos, loopInd);
-        });
-
-    // Iterate over the input in row-major order to get indices of nonzero
-    // values.
-    ValueRange mainLoopDef = createKrnl.defineLoops(xMemRefType.getRank());
-    createKrnl.iterateIE(mainLoopDef, mainLoopDef, lbs, ubs,
+    // Emit a loop for reduction sums along each axis.
+    ValueRange redLoopDef = createKrnl.defineLoops(xMemRefType.getRank());
+    createKrnl.iterateIE(redLoopDef, redLoopDef, xLbs, xUbs,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           MathBuilder createMath(createKrnl);
           Value val = createKrnl.load(X, loopInd);
           Value eqCond = createMath.eq(val, zero);
           Value zeroOrOne = createMath.select(eqCond, iZero, iOne);
           for (int64_t i = 0; i < xRank; ++i) {
-            SmallVector<IndexExpr, 1> posInd;
-            posInd.emplace_back(LiteralIndexExpr(i));
-            // Load the current position along dimension i.
-            Value currentPos = createKrnl.loadIE(pos, posInd);
-            // Load the output at the current position along dimension i.
-            SmallVector<IndexExpr, 2> resInd;
-            resInd.emplace_back(LiteralIndexExpr(i));
-            resInd.emplace_back(DimIndexExpr(currentPos));
-            // If value is nonzero, update the output with the value's index.
-            // Otherwise, keep the output unchanged.
-            Value oldIndex = createKrnl.loadIE(resMemRef, resInd);
-            Value newIndex =
-                rewriter.create<IndexCastOp>(loc, loopInd[i], resElementType);
-            newIndex = createMath.select(eqCond, oldIndex, newIndex);
-            createKrnl.storeIE(newIndex, resMemRef, resInd);
-            // Move forward along the current dimension.
-            currentPos = createMath.add(currentPos, zeroOrOne);
-            createKrnl.storeIE(currentPos, pos, posInd);
+            Value sum = createKrnl.load(redMemRefs[i], loopInd[i]);
+            sum = createMath.add(sum, zeroOrOne);
+            createKrnl.store(sum, redMemRefs[i], loopInd[i]);
           }
         });
+
+    // Emit a variable for the number of nonzero values.
+    Value nonzeroCount = createMemRef.alloca(MemRefType::get({}, indexTy));
+    createKrnl.store(iZero, nonzeroCount, {});
+
+    // Emit code to compute the number of nonzero values, using the reduction
+    // sum of the smalles size.
+    ValueRange countLoopDef = createKrnl.defineLoops(1);
+    createKrnl.iterateIE(countLoopDef, countLoopDef, {litZero},
+        xUbs[smallestDimAxis],
+        [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
+          MathBuilder createMath(createKrnl);
+          Value sum = createKrnl.load(
+              redMemRefs[smallestDimAxis], loopInd[smallestDimAxis]);
+          Value count = createKrnl.load(nonzeroCount, {});
+          sum = createMath.add(sum, count);
+          createKrnl.store(sum, nonzeroCount, {});
+        });
+
+    // Emit alloc and dealloc for the result of this operation.
+    // MemRefType : [RxNxi64] where R is the input's rank, N is the number of
+    // non zero values.
+    Value numberOfZeros = createKrnl.load(nonzeroCount, {});
+    SmallVector<IndexExpr, 2> dimExprs;
+    dimExprs.emplace_back(LiteralIndexExpr(xRank));
+    dimExprs.emplace_back(DimIndexExpr(numberOfZeros));
+    bool insertDealloc = checkInsertDealloc(op);
+    Value resMemRef = insertAllocAndDeallocSimple(
+        rewriter, op, resMemRefType, loc, dimExprs, insertDealloc);
+
+    // Emit code to compute the output for each axis.
+    // for each axis:
+    //   k = 0
+    //   for i range(len(dim0)):
+    //     d = dim0[i]
+    //     for j in range(d):
+    //       out[0][k+j] = i
+    //     k += d
+    Value kMemRef = createMemRef.alloca(MemRefType::get({}, indexTy));
+    for (int64_t axis = 0; axis < xRank; ++axis) {
+      Value outInd0 = emitConstantOp(rewriter, loc, indexTy, axis);
+      createKrnl.store(iZero, kMemRef, {});
+      // for i range(len(dim0)):
+      ValueRange iLoopDef = createKrnl.defineLoops(1);
+      createKrnl.iterateIE(iLoopDef, iLoopDef, {litZero}, {xUbs[axis]},
+          [&](KrnlBuilder &createKrnl, ValueRange iLoopInd) {
+            MathBuilder createMath(createKrnl);
+            Value i(iLoopInd[0]);
+            Value iVal = rewriter.create<IndexCastOp>(loc, i, resElementType);
+            Value d = createKrnl.load(redMemRefs[axis], {i});
+            Value k = createKrnl.load(kMemRef, {});
+            // for j in range(d):
+            ValueRange jLoopDef = createKrnl.defineLoops(1);
+            createKrnl.iterate(jLoopDef, jLoopDef, {iZero}, {d},
+                [&](KrnlBuilder &createKrnl, ValueRange jLoopInd) {
+                  MathBuilder createMath(createKrnl);
+                  Value j(jLoopInd[0]);
+                  Value outInd1 = createMath.add(k, j);
+                  // out[0][k+j] = i
+                  createKrnl.store(iVal, resMemRef, {outInd0, outInd1});
+                });
+            // k += d
+            k = createMath.add(k, d);
+            createKrnl.store(k, kMemRef, {});
+          });
+    }
 
     rewriter.replaceOp(op, resMemRef);
 

--- a/src/Dialect/ONNX/MLIRDialectBuilder.cpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.cpp
@@ -65,6 +65,16 @@ Value MathBuilder::slt(Value lhs, Value rhs) {
     return b.create<CmpIOp>(loc, CmpIPredicate::slt, lhs, rhs);
   return b.create<CmpFOp>(loc, CmpFPredicate::OLT, lhs, rhs);
 }
+Value MathBuilder::eq(Value lhs, Value rhs) {
+  Type lhsType = lhs.getType();
+  if (lhsType.isa<FloatType>()) {
+    return b.create<CmpFOp>(loc, CmpFPredicate::OEQ, lhs, rhs);
+  } else if (lhsType.isa<IntegerType>()) {
+    return b.create<CmpIOp>(loc, CmpIPredicate::eq, lhs, rhs);
+  } else {
+    llvm_unreachable("unsupported element type");
+  }
+}
 Value MathBuilder::select(Value cmp, Value lhs, Value rhs) {
   return b.create<SelectOp>(loc, cmp, lhs, rhs);
 }

--- a/src/Dialect/ONNX/MLIRDialectBuilder.cpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.cpp
@@ -66,14 +66,10 @@ Value MathBuilder::slt(Value lhs, Value rhs) {
   return b.create<CmpFOp>(loc, CmpFPredicate::OLT, lhs, rhs);
 }
 Value MathBuilder::eq(Value lhs, Value rhs) {
-  Type lhsType = lhs.getType();
-  if (lhsType.isa<FloatType>()) {
-    return b.create<CmpFOp>(loc, CmpFPredicate::OEQ, lhs, rhs);
-  } else if (lhsType.isa<IntegerType>()) {
+  if (lhs.getType().isa<IndexType, IntegerType>() ||
+      lhs.getType().isa<IndexType>())
     return b.create<CmpIOp>(loc, CmpIPredicate::eq, lhs, rhs);
-  } else {
-    llvm_unreachable("unsupported element type");
-  }
+  return b.create<CmpFOp>(loc, CmpFPredicate::OEQ, lhs, rhs);
 }
 Value MathBuilder::select(Value cmp, Value lhs, Value rhs) {
   return b.create<SelectOp>(loc, cmp, lhs, rhs);

--- a/src/Dialect/ONNX/MLIRDialectBuilder.hpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.hpp
@@ -54,6 +54,7 @@ struct MathBuilder : DialectBuilder {
   Value select(Value cmp, Value lhs, Value rhs);
   Value sgt(Value lhs, Value rhs);
   Value slt(Value lhs, Value rhs);
+  Value eq(Value lhs, Value rhs);
 };
 
 struct MemRefBuilder : DialectBuilder {

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -3615,7 +3615,18 @@ LogicalResult ONNXNonMaxSuppressionOp::inferShapes(
 
 LogicalResult ONNXNonZeroOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  return emitError(NOT_IMPLEMENTED_MESSAGE);
+  auto builder = mlir::Builder(getContext());
+  Type inputType = getOperand().getType();
+  if (!inputType.isa<RankedTensorType>())
+    return success();
+  SmallVector<int64_t, 2> dims;
+  // The first dimension size is the rank of the input.
+  dims.emplace_back(inputType.cast<RankedTensorType>().getRank());
+  // The second dimension size is the number of nonzero values in the input.
+  // So this dimension size is always unknown at compile time.
+  dims.emplace_back(-1);
+  getResult().setType(RankedTensorType::get(dims, builder.getI64Type()));
+  return success();
 }
 
 LogicalResult ONNXNotOp::inferShapes(

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -938,6 +938,18 @@ class EndiannessAwareExecutionSession:
         implicitly_le = (inputs_endianness[0] == "=" and sys_is_le)
         return explicitly_le or implicitly_le
 
+    def is_not_relevant_endian(self, inputs):
+        inputs_endianness = list(map(lambda x: x.dtype.byteorder, inputs))
+        endianness_is_consistent = len(set(inputs_endianness)) <= 1
+        assert endianness_is_consistent, \
+            "Input arrays contain a mixture of endianness configuration."
+
+        sys_is_le = sys.byteorder == 'little'
+        # To interpret character symbols indicating endianness:
+        # https://numpy.org/doc/stable/reference/generated/numpy.dtype.byteorder.html
+        i1_not_relevant_endian = inputs_endianness[0] == "|"
+        return i1_not_relevant_endian
+
     def compile_model(self):
         name = self.model.graph.name
         model_name = result_dir+name+".onnx"
@@ -1001,7 +1013,8 @@ class EndiannessAwareExecutionSession:
             # Deduce desired endianness of output from inputs.
             sys_is_le = sys.byteorder == 'little'
             inp_is_le = self.is_input_le(inputs)
-            if (sys_is_le != inp_is_le):
+            inp_is_not_relevant_endian = self.is_not_relevant_endian(inputs)
+            if (not inp_is_not_relevant_endian and sys_is_le != inp_is_le):
                 inputs = list(
                     map(lambda x: x.byteswap().newbyteorder(), inputs))
             # If constant test, change the model inputs to constants.
@@ -1010,7 +1023,7 @@ class EndiannessAwareExecutionSession:
                 self.exec_name = self.compile_model()
             session = ExecutionSession(self.exec_name, self.entry_point)
             outputs = session.run(inputs)
-            if (sys_is_le != inp_is_le):
+            if (not inp_is_not_relevant_endian and sys_is_le != inp_is_le):
                 outputs = list(
                     map(lambda x: x.byteswap().newbyteorder(), outputs))
             return outputs

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -485,6 +485,7 @@ test_to_enable_dict = {
     # Non Max Supression
 
     # Non Zero
+    "test_nonzero_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
 
     # Not
     "test_not_2d_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},


### PR DESCRIPTION
This patch implements NonZeroOp. 

This op's output shape is quite interesting, it depends on the values of the input, not the input shape. In particular, the second dim of the output shape is the number of nonzero values in the input.
So, the output shape would be dynamic and we should emit code traversing the input before allocating the output memref.

Fix a bug related to endian in `test.py`. When input is of boolean (`i1`), endianness is not relevant but `test.py` wrongly checks that it is in big endian and set output type to big endian, so tests failed on little endian machines x86, ppcle but not Z.