### PR TITLE
create source code for binary

### DIFF
--- a/src/MainUtils.cpp
+++ b/src/MainUtils.cpp
@@ -611,8 +611,9 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
   if (emissionTarget == EmitLib) {
     // Write LLVM bitcode to disk, compile & link.
     string sharedLib = compileModuleToSharedLibrary(module, outputBaseName);
-    if (keepFiles(KeepFilesOfType::MLIR))
+    if (keepFiles(KeepFilesOfType::MLIR)) {
       outputCode(module, outputBaseName, ".llvm.mlir");
+    }
     printf("Shared library %s has been compiled.\n", sharedLib.c_str());
   } else if (emissionTarget == EmitJNI) {
     compileModuleToJniJar(module, outputBaseName);
@@ -654,6 +655,8 @@ int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
 
   if (keepFiles(KeepFilesOfType::MLIR)) {
     outputCode(module, outputBaseName, ".input.mlir");
+    module.release();
+    LoadMLIR(outputBaseName + ".input.mlir", context, module);
   }
 
   InputIRLevelType inputIRLevel = determineInputIRLevel(module);


### PR DESCRIPTION
The onnx model comes without user friendly source file and our importer assign `UnknownLoc` to all the operations. As a result, we do not have Location info in our transformation and binary. 
This PR will use the output of preserveMLIR as source file and get Location info by rebuilding operations from this file.
I just reused the option `--preserveMLIR`.
Document is added in `docs/Testing.md`.