### PR TITLE
Memset

### DIFF
--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -114,11 +114,7 @@ struct ONNXGemmOpLowering : public ConversionPattern {
 
     // Initialize alloc/R to zero.
     KrnlBuilder createKrnl(rewriter, loc);
-    ValueRange zeroLoop = createKrnl.defineLoops(2);
-    createKrnl.iterateIE(zeroLoop, zeroLoop, {zero, zero}, {I, J},
-        [&](KrnlBuilder &createKrnl, ValueRange indices) {
-          createKrnl.store(zeroVal, R, indices);
-        });
+    createKrnl.memset(R, zeroVal);
 
     // Prepare for the computations.
     // 1) Define blocking, with simdization along the j axis.

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -115,11 +115,7 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     Value K = createMemRef.dim(A, 1);
 
     // Initialize alloc/C to zero.
-    ValueRange zLoop = createKrnl.defineLoops(2);
-    createKrnl.iterate(zLoop, zLoop, {zero, zero}, {I, J},
-        [&](KrnlBuilder &createKrnl, ValueRange indices) {
-          createKrnl.store(zeroVal, alloc, indices);
-        });
+    createKrnl.memset(alloc, zeroVal);
 
     // Compute.
     // Define blocking, with simdization along the j axis.

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -472,6 +472,10 @@ void KrnlBuilder::memcpy(Value dest, Value src, Value size) {
   b.create<KrnlMemcpyOp>(loc, dest, src, size);
 }
 
+void KrnlBuilder::memset(Value dest, Value val) {
+  b.create<KrnlMemsetOp>(loc, dest, val);
+}
+
 void KrnlBuilder::copyToBuffer(Value bufferMemref, Value sourceMemref,
     ValueRange starts, Value padValue, ArrayRef<int64_t> tileSize,
     ArrayRef<int64_t> padToNext, bool transpose) {

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -295,6 +295,8 @@ struct KrnlBuilder : public DialectBuilder {
           bodyBuilderFn);
 
   void memcpy(Value dest, Value src, Value size);
+  void memset(Value dest, Value val);
+
   void copyToBuffer(
       // Buffer and source memory. Source memref may have a higher rank than
       // buffer.

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -976,3 +976,16 @@ def KrnlInstrumentOp : Op<Krnl_Dialect, "runtime_instrument",
 
   let builders = [ OpBuilder<(ins "Operation *": $op, "int ": $tag)> ];
 }
+
+def KrnlMemsetOp : Op<Krnl_Dialect, "memset", [MemRefsNormalizable,
+    TypesMatchWith<"type of 'value' matches element type of 'dest'",
+                   "dest", "value",
+                   "$_self.cast<MemRefType>().getElementType()">]> {
+  let summary = "Set buffer to a given value.";
+  let description = [{
+    Krnl operation that set buffer to a given value.
+  }];
+
+  let arguments = (ins AnyMemRef:$dest, AnyType: $value); 
+  let assemblyFormat = [{ $dest `,` $value attr-dict `:` type($dest) }];
+}

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -3432,8 +3432,6 @@ LogicalResult ONNXClipOp::inferShapes(
   return success();
 }
 
-// hi alex
-
 static LogicalResult verify(ONNXInstanceNormalizationOp op) {
   ONNXInstanceNormalizationOpAdaptor operandAdaptor =
       ONNXInstanceNormalizationOpAdaptor(op);

--- a/test/mlir/conversion/krnl_to_affine/krnl_to_affine_with_canonicalize.mlir
+++ b/test/mlir/conversion/krnl_to_affine/krnl_to_affine_with_canonicalize.mlir
@@ -1,0 +1,52 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-affine --canonicalize %s -split-input-file | FileCheck %s
+
+func private @memset(%p0 : index, %p1 : index) -> () {
+  //A source, B buffer
+  %A = memref.alloca() : memref<8x4x20x30xf32>
+  %f0 = constant 0.0 : f32
+
+  krnl.memset %A, %f0 : memref<8x4x20x30xf32>
+  return
+// CHECK-LABEL:  builtin.func private @memset
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: index, [[PARAM_1_:%.+]]: index) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloca() : memref<8x4x20x30xf32>
+// CHECK:           affine.for [[I_0_:%.+]] = 0 to 8 {
+// CHECK:             affine.for [[I_1_:%.+]] = 0 to 4 {
+// CHECK:               affine.for [[I_2_:%.+]] = 0 to 20 {
+// CHECK:                 affine.for [[I_3_:%.+]] = 0 to 30 {
+// CHECK:                   affine.store [[CST_0_dot_000000_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<8x4x20x30xf32>
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+}
+
+// -----
+
+func private @memset_dyn(%p0 : index, %p1 : index) -> () {
+  //A source, B buffer
+  %A = memref.alloca(%p0) : memref<?x4x20x30xf32>
+  %f0 = constant 0.0 : f32
+
+  krnl.memset %A, %f0 : memref<?x4x20x30xf32>
+  return
+// CHECK-LABEL:  builtin.func private @memset_dyn
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: index, [[PARAM_1_:%.+]]: index) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloca([[PARAM_0_]]) : memref<?x4x20x30xf32>
+// CHECK:           affine.for [[I_0_:%.+]] = 0 to [[PARAM_0_]] {
+// CHECK:             affine.for [[I_1_:%.+]] = 0 to 4 {
+// CHECK:               affine.for [[I_2_:%.+]] = 0 to 20 {
+// CHECK:                 affine.for [[I_3_:%.+]] = 0 to 30 {
+// CHECK:                   affine.store [[CST_0_dot_000000_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]], [[I_2_]], [[I_3_]]{{.}} : memref<?x4x20x30xf32>
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+}
+

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -902,27 +902,24 @@ func private @test_matmul1(%arg0 : tensor<16x16xf32>, %arg1 : tensor<16x16xf32>)
   %0 ="onnx.MatMul"(%arg0, %arg1) : (tensor<16x16xf32>, tensor<16x16xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
-// CHECK-LABEL:  func private @test_matmul1
+// mlir2FileCheck.py -a'["A", "B"]'
+// CHECK-LABEL:  builtin.func private @test_matmul1
 // CHECK-SAME:   ([[A_:%.+]]: memref<16x16xf32>, [[B_:%.+]]: memref<16x16xf32>) -> memref<16x16xf32> {
 // CHECK-DAG:       [[CST_16_:%.+]] = constant 16 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = constant 0 : index
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<16x16xf32>
-// CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = [[CST_0_]] to [[CST_16_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = [[CST_0_]] to [[CST_16_]]) {
-// CHECK:             [[VAR_3_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[VAR_0_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1] : memref<16x16xf32>
-// CHECK:           }
-// CHECK:           [[LOOP_1_:%.+]]:3 = krnl.define_loops 3
-// CHECK:           [[loop_block_:%.+]], [[VAR_loop_local_:%.+]] = krnl.block [[LOOP_1_]]#0 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
-// CHECK:           [[loop_block_0_:%.+]], [[VAR_loop_local_1_:%.+]] = krnl.block [[LOOP_1_]]#1 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
-// CHECK:           [[loop_block_2_:%.+]], [[VAR_loop_local_3_:%.+]] = krnl.block [[LOOP_1_]]#2 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<16x16xf32>
+// CHECK:           krnl.memset [[RES_]], [[CST_0_dot_000000_]] : memref<16x16xf32>
+// CHECK:           [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
+// CHECK:           [[loop_block_:%.+]], [[VAR_loop_local_:%.+]] = krnl.block [[LOOP_0_]]#0 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+// CHECK:           [[loop_block_0_:%.+]], [[VAR_loop_local_1_:%.+]] = krnl.block [[LOOP_0_]]#1 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+// CHECK:           [[loop_block_2_:%.+]], [[VAR_loop_local_3_:%.+]] = krnl.block [[LOOP_0_]]#2 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
 // CHECK:           krnl.permute([[loop_block_]], [[VAR_loop_local_]], [[loop_block_]]_0, [[VAR_loop_local_]]_1, [[loop_block_]]_2, [[VAR_loop_local_]]_3) [0, 3, 1, 4, 2, 5] : !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop
-// CHECK:           krnl.iterate([[loop_block_]], [[loop_block_]]_0, [[loop_block_]]_2) with ([[LOOP_1_]]#0 -> [[I_2_:%.+]] = [[CST_0_]] to [[CST_16_]], [[LOOP_1_]]#1 -> [[I_3_:%.+]] = [[CST_0_]] to [[CST_16_]], [[LOOP_1_]]#2 -> [[I_4_:%.+]] = [[CST_0_]] to [[CST_16_]]) {
-// CHECK:             [[VAR_3_1_:%.+]]:3 = krnl.get_induction_var_value([[loop_block_]], [[loop_block_]]_0, [[loop_block_]]_2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
-// CHECK:             krnl.matmul [[A_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, [[B_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, [[VAR_0_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, ([[VAR_loop_local_]], [[VAR_loop_local_]]_1, [[VAR_loop_local_]]_3), ([[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2), ([[CST_16_]], [[CST_16_]], [[CST_16_]]) {aTileSize = [], bTileSize = [], cTileSize = [], computeTileSize = [4, 8, 8], overcompute = false, simdize = true, unroll = true} : memref<16x16xf32>, memref<16x16xf32>, memref<16x16xf32>, (!krnl.loop, !krnl.loop, !krnl.loop)
+// CHECK:           krnl.iterate([[loop_block_]], [[loop_block_]]_0, [[loop_block_]]_2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = [[CST_0_]] to [[CST_16_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = [[CST_0_]] to [[CST_16_]], [[LOOP_0_]]#2 -> [[I_2_:%.+]] = [[CST_0_]] to [[CST_16_]]) {
+// CHECK:             [[VAR_2_:%.+]]:3 = krnl.get_induction_var_value([[loop_block_]], [[loop_block_]]_0, [[loop_block_]]_2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
+// CHECK:             krnl.matmul [[A_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, [[B_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, [[RES_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, ([[VAR_loop_local_]], [[VAR_loop_local_]]_1, [[VAR_loop_local_]]_3), ([[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_2_]]#2), ([[CST_16_]], [[CST_16_]], [[CST_16_]]) {aTileSize = [], bTileSize = [], cTileSize = [], computeTileSize = [4, 8, 8], overcompute = false, simdize = true, unroll = true} : memref<16x16xf32>, memref<16x16xf32>, memref<16x16xf32>, (!krnl.loop, !krnl.loop, !krnl.loop)
 // CHECK:           }
-// CHECK:           return [[VAR_0_]] : memref<16x16xf32>
+// CHECK:           return [[RES_]] : memref<16x16xf32>
 // CHECK:         }
 }
 


### PR DESCRIPTION
Added memset krnl operation, used it in GEMM and Matmul, will let us eventually optimize this op, possibly with library call to optimized versions.

This PR also add a convenient `createAffine.forIE()` method where we can pass lists of loops. It makes them perfectly nested.