### PR TITLE
Rewrite ONNX Upsample into ONNX Resize

### DIFF
--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -184,7 +184,7 @@ op_dialect_version_map_["TreeEnsembleClassifier"] = {1};
 op_dialect_version_map_["TreeEnsembleRegressor"] = {1};
 op_dialect_version_map_["Unique"] = {11};
 op_dialect_version_map_["Unsqueeze"] = {13, 11};
-op_dialect_version_map_["Upsample"] = {10};
+op_dialect_version_map_["Upsample"] = {10, 9, 7};
 op_dialect_version_map_["Where"] = {9};
 op_dialect_version_map_["Xor"] = {7};
 op_dialect_version_map_["ZipMap"] = {1};
@@ -516,6 +516,10 @@ import_handler_map_["UnsqueezeV11"] =
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXUnsqueezeV11Op>;
 import_handler_map_["Upsample"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXUpsampleOp>;
+import_handler_map_["UpsampleV9"] = 
+   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXUpsampleV9Op>;
+import_handler_map_["UpsampleV7"] = 
+   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXUpsampleV7Op>;
 import_handler_map_["Where"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXWhereOp>;
 import_handler_map_["Xor"] = 

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -4034,6 +4034,16 @@ LogicalResult ONNXUpsampleOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
+LogicalResult ONNXUpsampleV9Op::inferShapes(
+    std::function<void(mlir::Region &)> doShapeInference) {
+  return emitError(NOT_IMPLEMENTED_MESSAGE);
+}
+
+LogicalResult ONNXUpsampleV7Op::inferShapes(
+    std::function<void(mlir::Region &)> doShapeInference) {
+  return emitError(NOT_IMPLEMENTED_MESSAGE);
+}
+
 LogicalResult ONNXWhereOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
   return emitError(NOT_IMPLEMENTED_MESSAGE);

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -6208,6 +6208,56 @@ def ONNXUpsampleOp:ONNX_Op<"Upsample",
   }];
 }
 
+def ONNXUpsampleV9Op:ONNX_Op<"UpsampleV9",
+  [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
+  let summary = "ONNX Upsample operation";
+  let description = [{
+  "Upsample the input tensor."
+  "Each dimension value of the output tensor is:"
+  "  output_dimension = floor(input_dimension * scale)."
+  }];
+  let arguments = (ins AnyTypeOf<[TensorOf<[UI8]>, TensorOf<[UI16]>, TensorOf<[UI32]>, TensorOf<[UI64]>, TensorOf<[I8]>, TensorOf<[I16]>, TensorOf<[I32]>, TensorOf<[I64]>, TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[StringType]>, TensorOf<[I1]>, TensorOf<[Complex<F32>]>, TensorOf<[Complex<F64>]>, AnyMemRef]>:$X,
+    AnyTypeOf<[TensorOf<[F32]>, AnyMemRef]>:$scales,
+    DefaultValuedAttr<StrAttr, "nearest">:$mode);
+  let results = (outs AnyTypeOf<[TensorOf<[UI8]>, TensorOf<[UI16]>, TensorOf<[UI32]>, TensorOf<[UI64]>, TensorOf<[I8]>, TensorOf<[I16]>, TensorOf<[I32]>, TensorOf<[I64]>, TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[StringType]>, TensorOf<[I1]>, TensorOf<[Complex<F32>]>, TensorOf<[Complex<F64>]>, AnyMemRef]>:$Y);
+  let extraClassDeclaration = [{
+    static int getNumberOfOperands() {
+      return 2;
+    }
+    static int getNumberOfResults() {
+      return 1;
+    }
+    static std::vector<int> getTypeMap() {
+      return {20};
+    }
+  }];
+}
+
+def ONNXUpsampleV7Op:ONNX_Op<"UpsampleV7",
+  [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
+  let summary = "ONNX Upsample operation";
+  let description = [{
+  "Upsample the input tensor."
+  "Each dimension value of the output tensor is:"
+  "  output_dimension = floor(input_dimension * scale)."
+  }];
+  let arguments = (ins AnyTypeOf<[TensorOf<[UI8]>, TensorOf<[UI16]>, TensorOf<[UI32]>, TensorOf<[UI64]>, TensorOf<[I8]>, TensorOf<[I16]>, TensorOf<[I32]>, TensorOf<[I64]>, TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[StringType]>, TensorOf<[I1]>, TensorOf<[Complex<F32>]>, TensorOf<[Complex<F64>]>, AnyMemRef]>:$X,
+    DefaultValuedAttr<StrAttr, "nearest">:$mode,
+    F32ArrayAttr:$scales);
+  let results = (outs AnyTypeOf<[TensorOf<[UI8]>, TensorOf<[UI16]>, TensorOf<[UI32]>, TensorOf<[UI64]>, TensorOf<[I8]>, TensorOf<[I16]>, TensorOf<[I32]>, TensorOf<[I64]>, TensorOf<[F16]>, TensorOf<[F32]>, TensorOf<[F64]>, TensorOf<[StringType]>, TensorOf<[I1]>, TensorOf<[Complex<F32>]>, TensorOf<[Complex<F64>]>, AnyMemRef]>:$Y);
+  let extraClassDeclaration = [{
+    static int getNumberOfOperands() {
+      return 1;
+    }
+    static int getNumberOfResults() {
+      return 1;
+    }
+    static std::vector<int> getTypeMap() {
+      return {20};
+    }
+  }];
+}
+
 def ONNXWhereOp:ONNX_Op<"Where",
   [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
   let summary = "ONNX Where operation";

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -111,6 +111,9 @@ void DecomposeONNXToONNXPass::runOnFunction() {
   target.addIllegalOp<ONNXReduceSumSquareOp>();
   target.addIllegalOp<ONNXScalerOp>();
   target.addIllegalOp<ONNXLogSoftmaxOp>();
+  target.addIllegalOp<ONNXUpsampleOp>();
+  target.addIllegalOp<ONNXUpsampleV9Op>();
+  target.addIllegalOp<ONNXUpsampleV7Op>();
 
   RewritePatternSet patterns(context);
   populateWithGenerated(patterns);

--- a/src/Transform/ONNX/Decompose.td
+++ b/src/Transform/ONNX/Decompose.td
@@ -41,6 +41,15 @@ def IsNoneType : Constraint<CPred<"(($_self).getType().isa<NoneType>())">>;
 
 def GetNullAttr : NativeCodeCall<"Attribute()">;
 
+def GetNullFloatAttr :
+        NativeCodeCall<"FloatAttr()">;
+
+def GetNullIntegerAttr :
+        NativeCodeCall<"IntegerAttr()">;
+
+def GetNullStringAttr :
+        NativeCodeCall<"StringAttr()">;
+
 // Create a unit constant that will be used as none input.
 def CreateUnitConstant
     : NativeCodeCall<"createUnitConstant($_builder, $_loc)">;
@@ -231,5 +240,21 @@ def ScalerPattern2
 // Express LogSoftmax using Log and Softmax.
 def LogSoftmaxPattern
     : Pat<(ONNXLogSoftmaxOp $x, $axis), (ONNXLogOp(ONNXSoftmaxOp $x, $axis))>;
+
+// Express Upsample using Resize.
+def UpsamplePattern : Pat<
+  (ONNXUpsampleOp $x, $scales, $mode),
+  (ONNXResizeOp $x, (CreateUnitConstant), $scales, (CreateUnitConstant), (GetNullStringAttr), (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), $mode, (GetNullFloatAttr))
+>;
+
+def UpsampleV9Pattern : Pat<
+  (ONNXUpsampleV9Op $x, $scales, $mode),
+  (ONNXResizeOp $x, (CreateUnitConstant), $scales, (CreateUnitConstant), (GetNullStringAttr), (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), $mode, (GetNullFloatAttr))
+>;
+
+def UpsampleV7Pattern : Pat<
+  (ONNXUpsampleV7Op $x, $mode, $scales),
+  (ONNXResizeOp $x, (CreateUnitConstant), (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scales)), (CreateUnitConstant), (GetNullStringAttr), (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), $mode, (GetNullFloatAttr))
+>;
 
 #endif // ONNX_DECOMPOSE

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -812,6 +812,7 @@ test_to_enable_dict = {
     "test_unsqueeze_unsorted_axes_cpu": {CONSTANT_INPUT:{1}},
 
     # Upsample
+    "test_upsample_nearest_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE: {0:{-1}}, CONSTANT_INPUT:{-1}},
 
     # Where
 

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -221,3 +221,40 @@ func @test_logsoftmax(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
   // CHECK: [[RES:%.+]] = "onnx.Log"([[SOFTMAX]]) : (tensor<*xf32>) -> tensor<*xf32>
   // CHECK: return [[RES]] : tensor<*xf32>
 }
+
+// -----
+
+func @test_upsample(%arg0: tensor<1x1x2x2xf32>, %arg1: tensor<4xf32>) -> tensor<1x1x4x6xf32> {
+  %0 = "onnx.Upsample"(%arg0, %arg1) {mode = "nearest"} : (tensor<1x1x2x2xf32>, tensor<4xf32>) -> tensor<1x1x4x6xf32>
+  return %0 : tensor<1x1x4x6xf32>
+  // CHECK-LABEL: test_upsample
+  // CHECK: [[NONE_0:%.+]] = constant unit
+  // CHECK: [[NONE_1:%.+]] = constant unit
+  // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], %arg1, [[NONE_1]]) {mode = "nearest"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
+  // CHECK: return [[RES]] : tensor<1x1x4x6xf32>
+}
+
+// -----
+
+func @test_upsamplev9(%arg0: tensor<1x1x2x2xf32>, %arg1: tensor<4xf32>) -> tensor<1x1x4x6xf32> {
+  %0 = "onnx.UpsampleV9"(%arg0, %arg1) {mode = "nearest"} : (tensor<1x1x2x2xf32>, tensor<4xf32>) -> tensor<1x1x4x6xf32>
+  return %0 : tensor<1x1x4x6xf32>
+  // CHECK-LABEL: test_upsamplev9
+  // CHECK: [[NONE_0:%.+]] = constant unit
+  // CHECK: [[NONE_1:%.+]] = constant unit
+  // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], %arg1, [[NONE_1]]) {mode = "nearest"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
+  // CHECK: return [[RES]] : tensor<1x1x4x6xf32>
+}
+
+// -----
+
+func @test_upsamplev7(%arg0: tensor<1x1x2x2xf32>) -> tensor<1x1x4x6xf32> {
+  %0 = "onnx.UpsampleV7"(%arg0) {mode = "nearest", scales = [0.1 : f32, 0.2 : f32, 0.3 : f32, 0.4 : f32]} : (tensor<1x1x2x2xf32>) -> tensor<1x1x4x6xf32>
+  return %0 : tensor<1x1x4x6xf32>
+  // CHECK-LABEL: test_upsamplev7
+  // CHECK: [[NONE_0:%.+]] = constant unit
+  // CHECK: [[SCALES:%.+]] = "onnx.Constant"() {value = dense<[1.000000e-01, 2.000000e-01, 3.000000e-01, 4.000000e-01]> : tensor<4xf32>} : () -> tensor<4xf32>
+  // CHECK: [[NONE_1:%.+]] = constant unit
+  // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], [[SCALES]], [[NONE_1]]) {mode = "nearest"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
+  // CHECK: return [[RES]] : tensor<1x1x4x6xf32>
+}

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -231,7 +231,7 @@ version_dict = {'Abs': [13],
  'Unique': [11],
  #'Unsqueeze': [13],
  'Unsqueeze': [13, 11],
- 'Upsample': [10],
+ 'Upsample': [10, 9, 7],
  'Where': [9],
  'Xor': [7],
  'ZipMap': [1]}


### PR DESCRIPTION
ONNX Upsample is deprecated and can be replaced by ONNX Resize, so we rewrite Upsample into Resize. 

This patch supports all Upsample versions 10, 9, 7.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>