### PR TITLE
Support WhereOp

### DIFF
--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1027,7 +1027,8 @@ struct ONNXWhereOpLowering : public ConversionPattern {
     // Shape helper.
     ONNXOpBroadcastedShapeHelper shapeHelper(
         &rewriter, loc, /*isUniBroadcasting=*/false);
-    auto shapecomputed = shapeHelper.Compute(operands);
+    DimsExpr empty;
+    auto shapecomputed = shapeHelper.Compute(operands, empty);
     assert(succeeded(shapecomputed));
     // Scope for krnl ops
     IndexExprScope outerScope(rewriter, shapeHelper.scope);

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -4075,7 +4075,19 @@ LogicalResult ONNXUpsampleV7Op::inferShapes(
 
 LogicalResult ONNXWhereOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  return emitError(NOT_IMPLEMENTED_MESSAGE);
+  for (unsigned int i = 0; i < getNumOperands(); ++i) {
+    if (!getOperand(i).getType().cast<RankedTensorType>())
+      return success();
+  }
+  Type resultElementType =
+      getOperand(1).getType().cast<RankedTensorType>().getElementType();
+  Type resultTy = getOperand(0).getType().cast<RankedTensorType>();
+  for (unsigned int i = 1; i < getNumOperands(); ++i) {
+    Type nextTy = getOperand(i).getType().cast<RankedTensorType>();
+    resultTy = getBroadcastedType(resultTy, nextTy, resultElementType);
+  }
+  getResult().setType(resultTy);
+  return success();
 }
 
 LogicalResult ONNXArrayFeatureExtractorOp::inferShapes(

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -1849,3 +1849,26 @@ func @test_mean(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>
 // CHECK:           return [[RES_]] : memref<3xf32>
 // CHECK:         }
 }
+
+// -----
+
+func @where(%arg0: tensor<2x2xi1>, %arg1: tensor<2x2xf32>, %arg2: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %0 = "onnx.Where"(%arg0, %arg1, %arg2) : (tensor<2x2xi1>, tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %0 : tensor<2x2xf32>
+
+// mlir2FileCheck.py -a'["condition", "x", "y"]'
+// CHECK-LABEL:  builtin.func @where
+// CHECK-SAME:   ([[CONDITION_:%.+]]: memref<2x2xi1>, [[X_:%.+]]: memref<2x2xf32>, [[Y_:%.+]]: memref<2x2xf32>) -> memref<2x2xf32> {
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x2xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2) {
+// CHECK-DAG:         [[LOAD_CONDITION_MEM_:%.+]] = krnl.load [[CONDITION_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x2xi1>
+// CHECK-DAG:         [[LOAD_X_MEM_:%.+]] = krnl.load [[X_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x2xf32>
+// CHECK-DAG:         [[LOAD_Y_MEM_:%.+]] = krnl.load [[Y_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x2xf32>
+// CHECK:             [[VAR_5_:%.+]] = select [[LOAD_CONDITION_MEM_]], [[LOAD_X_MEM_]], [[LOAD_Y_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_5_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x2xf32>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<2x2xf32>
+// CHECK:         }
+}
+


### PR DESCRIPTION
This patch implements ONNX WhereOp.

It also fixed an endianness issue in `test.py` happened with WhereOp where there was a mix of boolean and non-boolean types in inputs.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>