### PR TITLE
Allow empty Krnl Loop for scalar type

### DIFF
--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -215,8 +215,8 @@ BuildKrnlLoop::BuildKrnlLoop(
     ConversionPatternRewriter &rewriter, Location loc, int loopNum)
     : rewriter(rewriter), loc(loc), originalLoopNum(loopNum), pack(NULL),
       pushCount(0), createdDefineOp(false), createdIterateOp(false) {
-  if (originalLoopNum <= 0)
-    emitError(loc, "Expected positive number of original loops.");
+  if (originalLoopNum < 0)
+    emitError(loc, "Expected non-negative number of original loops.");
 }
 
 BuildKrnlLoop::BuildKrnlLoop(

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -2216,3 +2216,27 @@ func @test_resize1(%arg0 : tensor<3x4xf32>) -> tensor<*xf32> {
 // CHECK:           }
 // CHECK:           return [[VAR_0]] : memref<3x12xf32>
 }
+
+//-----
+  func @test_gather_scalar(%arg0: tensor<4xi64>, %arg1: tensor<i64>) -> tensor<i64> {
+    %0 = "onnx.Gather"(%arg0, %arg1) {axis = 0 : si64} : (tensor<4xi64>, tensor<i64>) -> tensor<i64>
+    return %0 : tensor<i64>
+// CHECK-LABEL:  @test_gather_scalar
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<4xi64>, [[PARAM_1_:%.+]]: memref<i64>) -> memref<i64> {
+// CHECK-DAG:       [[CST_4_:%.+]] = constant 4 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<i64>
+// CHECK:           krnl.define_loops 0
+// CHECK:           krnl.iterate() with () {
+// CHECK-DAG:         [[CST_0_:%.+]] = constant 0 : index
+// CHECK-DAG:         [[CST_0_1_:%.+]] = constant 0 : index
+// CHECK-DAG:         [[CST_4_1_:%.+]] = constant 4 : index
+// CHECK-DAG:         [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]][] : memref<i64>
+// CHECK:             [[VAR_2_:%.+]] = index_cast [[LOAD_PARAM_1_MEM_]] : i64 to index
+// CHECK-DAG:         [[VAR_3_:%.+]] = cmpi slt, [[VAR_2_]], [[CST_0_]] : index
+// CHECK-DAG:         [[VAR_4_:%.+]] = addi [[VAR_2_]], [[CST_4_1_]] : index
+// CHECK:             [[VAR_5_:%.+]] = select [[VAR_3_]], [[VAR_4_]], [[VAR_2_]] : index
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_5_]]{{.}} : memref<4xi64>
+// CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]][] : memref<i64>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<i64>
+}


### PR DESCRIPTION
Signed-off-by: Tong Chen <chentong@us.ibm.com>

A simple fix: allow the loop nest be empty.
Compiled yolov5m.onnx.
A text case is added.