### PR TITLE
Set splat for DenseElementAttr when all dimensions are 1

### DIFF
--- a/src/Transform/ONNX/ConstPropHelper.cpp
+++ b/src/Transform/ONNX/ConstPropHelper.cpp
@@ -143,7 +143,8 @@ DenseElementsAttr createDenseElementsAttrFromArray(char *arr, Type outputType) {
   bool isSplat;
   if (resType.getShape().size() == 0)
     isSplat = true;
-  else if (resType.getShape().size() == 1 && resType.getShape()[0] == 1)
+  else if (llvm::all_of(
+               resType.getShape(), [](int64_t dim) { return dim == 1; }))
     isSplat = true;
   else
     isSplat = false;


### PR DESCRIPTION
This patch fixes a bug in constant propagation when creating DenseElementAttr for tensors whose all dimension sizes are 1.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>