### PR TITLE
[NFC]: Modernize code to follow C++11 clang-tidy recommendations

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -41,16 +41,16 @@ using namespace mlir;
 namespace onnx_mlir {
 namespace detail {
 
-typedef SymbolMapping<Value> ValueSymbolMapping;
-typedef SymbolMapping<onnx::TypeProto> SymbolToOnnxTypeMapping;
+using ValueSymbolMapping = SymbolMapping<Value>;
+using SymbolToOnnxTypeMapping = SymbolMapping<onnx::TypeProto>;
 
 class FrontendGenImpl {
 public:
   explicit FrontendGenImpl(MLIRContext &context)
-      : context_(context), builder_(&context) {
+      : context_(context), builder_(&context),
+        force_dim_dynamic_enabled_(false) {
     module_ = ModuleOp::create(UnknownLoc::get(&context));
     InitHandlerMap();
-    force_dim_dynamic_enabled_ = false;
     if (const char *envInputString = std::getenv("IMPORTER_FORCE_DYNAMIC")) {
       force_dim_dynamic_enabled_ = true;
       std::stringstream envString;
@@ -175,12 +175,12 @@ private:
     }
   }
 
-  typedef void (onnx_mlir::detail::FrontendGenImpl::*ImportHandlerType)(
+  using ImportHandlerType = void (onnx_mlir::detail::FrontendGenImpl::*)(
       const onnx::NodeProto &);
 
   std::map<std::string, ImportHandlerType> import_handler_map_;
 
-  Location UnknownLoc() { return UnknownLoc::get(&context_); }
+  Location UnknownLoc() const { return UnknownLoc::get(&context_); }
 
   Value none() {
     // Get the enclosing Func Op.
@@ -504,7 +504,8 @@ private:
     }
   }
 
-#define MAX_TYPE 20
+  static constexpr int MAX_TYPE = 20;
+
   // itblgen_types = ('I1', 'I8', 'I16', 'I32', 'I64', 'BF16', 'F16', 'F32',
   // 'F64', 'Complex<F32>', 'Complex<F64>' )
   Type buildTypeFromIndex(int index) {
@@ -812,7 +813,6 @@ private:
    * Special handle for Pad operations.
    */
   void ImportNodePad(const onnx::NodeProto &node) {
-
     int nOps = node.input().size();
     if (nOps == 2) {
       llvm::SmallVector<int64_t, 2> dims;
@@ -1010,7 +1010,6 @@ private:
 
   void InferTypes(const onnx::FunctionProto *func,
       std::vector<onnx::TypeProto> &inputTypes) {
-
     // types: Used for temporary copies of Types, freed at end of function.
     std::vector<std::unique_ptr<onnx::TypeProto>> types;
     std::unordered_map<std::string, onnx::TypeProto *> typeMap;

--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -31,11 +31,14 @@
 #include "src/Support/Common.hpp"
 #include "src/Support/KrnlSupport.hpp"
 
+#include "llvm/Support/Debug.h"
+
 #include <functional>
 #include <mutex>
 
-#define BUFFER_ALIGN 64
-#define DEBUG_TRACE 0
+static constexpr int BUFFER_ALIGN = 64;
+
+#define DEBUG_TYPE "krnl_to_affine"
 
 using namespace mlir;
 
@@ -379,9 +382,9 @@ private:
 }; // namespace
 
 // To assist unroll and jam
-typedef std::pair<AffineForOp, int64_t> UnrollAndJamRecord;
-typedef SmallVector<UnrollAndJamRecord, 4> UnrollAndJamList;
-typedef std::map<Operation *, UnrollAndJamList *> UnrollAndJamMap;
+using UnrollAndJamRecord = std::pair<AffineForOp, int64_t>;
+using UnrollAndJamList = SmallVector<UnrollAndJamRecord, 4>;
+using UnrollAndJamMap = std::map<Operation *, UnrollAndJamList *>;
 UnrollAndJamMap unrollAndJamMap;
 std::mutex unrollAndJamMutex;
 
@@ -825,14 +828,13 @@ public:
     if (!vectorLen.isLiteral()) {
       // Cannot simdize if the vector length is not a compile time constant.
       simdize = false;
-      if (DEBUG_TRACE)
-        printf("Matmul: No simd due to vl not a literal\n");
+      LLVM_DEBUG(llvm::dbgs() << "Matmul: No simd due to vl not a literal\n");
     }
     if (!bBounds.isLiteral(bRank - 1) || !cBounds.isLiteral(cRank - 1)) {
       // Cannot simdize if the last dim of B or C are not constant.
       simdize = false;
-      if (DEBUG_TRACE)
-        printf("Matmul: No simd due to B & C last dim not a literal\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Matmul: No simd due to B & C last dim not a literal\n");
     }
     if (simdize) {
       int64_t VL = vectorLen.getLiteral();
@@ -841,9 +843,9 @@ public:
         // If the memref of B and C are not multiple of the vector length in
         // their last dim, then we cannot simdize either.
         simdize = false;
-        if (DEBUG_TRACE)
-          printf(
-              "Matmul: No simd due to B & C last dim not a multiple of VL\n");
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "Matmul: No simd due to B & C last dim not a multiple of VL\n");
       }
     }
     if (!simdize)
@@ -1112,14 +1114,11 @@ private:
       auto list = getUnrollAndJamList(op.getOperation());
       if (K.isLiteral()) {
         int64_t kUnroll = K.getLiteral();
-        int64_t cutoff = 4;
-        if (!I.isLiteral() || I.getLiteral() < 2) {
-          // We know there is no unrolling along I, make a bigger cutoff.
-          cutoff = 8;
-        }
+        // We know there is no unrolling along I, make a bigger cutoff.
+        int64_t cutoff = (!I.isLiteral() || I.getLiteral() < 2) ? 8 : 4;
         if (kUnroll >= cutoff) {
           // When kUnroll is too big, reduce it by a divisor.
-          for (int m = cutoff; m >= 1; --m) {
+          for (int64_t m = cutoff; m >= 1; --m) {
             if (kUnroll % m == 0) {
               kUnroll = m;
               break;
@@ -1127,15 +1126,15 @@ private:
           }
         }
         if (kUnroll > 1) {
-          if (DEBUG_TRACE)
-            printf("Matmul: unroll k by %d\n", (int)kUnroll);
+          LLVM_DEBUG(
+              llvm::dbgs() << "Matmul: unroll k by " << kUnroll << "\n";);
           UnrollAndJamRecord record(getForInductionVarOwner(kSaved), kUnroll);
           list->emplace_back(record);
         }
       }
       if (I.isLiteral() && I.getLiteral() > 1) {
-        if (DEBUG_TRACE)
-          printf("Matmul: unroll i by %d\n", (int)I.getLiteral());
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Matmul: unroll i by " << (int)I.getLiteral() << "\n");
         UnrollAndJamRecord record(
             getForInductionVarOwner(iSaved), I.getLiteral());
         list->emplace_back(record);

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -124,7 +124,7 @@ static size_t getRankFromMemRefType(LLVM::LLVMStructType memRefTy) {
 static FlatSymbolRefAttr getOrInsertInstrument(
     PatternRewriter &rewriter, ModuleOp module) {
   auto *context = module.getContext();
-  const char funcName[] = "OMInstrumentPoint";
+  std::string funcName("OMInstrumentPoint");
   if (module.lookupSymbol<LLVM::LLVMFuncOp>(funcName))
     return SymbolRefAttr::get(context, funcName);
   auto llvmVoidTy = LLVM::LLVMVoidType::get(context);

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -55,7 +55,7 @@ struct FrontendToKrnlLoweringPass
   // Make sure that we have a valid default constructor and copy
   // constructor to make sure that the options are initialized properly.
   FrontendToKrnlLoweringPass() = default;
-  FrontendToKrnlLoweringPass(const FrontendToKrnlLoweringPass &pass) {}
+  FrontendToKrnlLoweringPass(const FrontendToKrnlLoweringPass &pass){};
   FrontendToKrnlLoweringPass(bool emitDealloc) {
     this->emitDealloc = emitDealloc;
   }

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1098,7 +1098,6 @@ struct ONNXWhereOpLowering : public ConversionPattern {
         Identifier::get(ONNXWhereOp::getOperationName(), op->getContext()),
         op->getLoc());
     auto outputMemRefType = convertToMemRefType(*op->result_type_begin());
-    auto outputElementType = outputMemRefType.getElementType();
     auto outputRank = outputMemRefType.getRank();
 
     // Shape helper.

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -354,9 +354,8 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
   bool computeMean = false;
 
   ONNXReduceSumOpLowering(MLIRContext *ctx, bool computeMean = false)
-      : ConversionPattern(ONNXReduceSumOp::getOperationName(), 1, ctx) {
-    this->computeMean = computeMean;
-  }
+      : ConversionPattern(ONNXReduceSumOp::getOperationName(), 1, ctx),
+        computeMean(computeMean) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {

--- a/src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp
@@ -16,7 +16,7 @@
 
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 
-#define BUFFER_ALIGN 128
+static constexpr int BUFFER_ALIGN = 128;
 using namespace mlir;
 
 static constexpr StringRef FORWARD = "forward";

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -213,7 +213,7 @@ void KrnlIterateOperandPack::pushIndexExprsBound(
 
 BuildKrnlLoop::BuildKrnlLoop(
     ConversionPatternRewriter &rewriter, Location loc, int loopNum)
-    : rewriter(rewriter), loc(loc), originalLoopNum(loopNum), pack(NULL),
+    : rewriter(rewriter), loc(loc), originalLoopNum(loopNum), pack(nullptr),
       pushCount(0), createdDefineOp(false), createdIterateOp(false) {
   if (originalLoopNum < 0)
     emitError(loc, "Expected non-negative number of original loops.");
@@ -223,11 +223,6 @@ BuildKrnlLoop::BuildKrnlLoop(
     ConversionPatternRewriter &rewriter, Location loc, Value memRefOperand)
     : BuildKrnlLoop(rewriter, loc,
           memRefOperand.getType().cast<MemRefType>().getShape().size()) {}
-
-BuildKrnlLoop::~BuildKrnlLoop() {
-  if (pack)
-    delete pack;
-}
 
 void BuildKrnlLoop::createDefineOp() {
   // Insert define loop operation.

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -154,12 +154,19 @@ class BuildKrnlLoop {
 public:
   // Create kernel loop builder for a loop nest of depth loopNum.
   BuildKrnlLoop(ConversionPatternRewriter &rewriter, Location loc, int loopNum);
+  BuildKrnlLoop(const BuildKrnlLoop &) = delete;
+  BuildKrnlLoop(BuildKrnlLoop &&) = delete;
+  BuildKrnlLoop &operator=(const BuildKrnlLoop &) = delete;
+  BuildKrnlLoop &operator=(BuildKrnlLoop &&) = delete;
 
   // Create kernel loop builder for a loop nest of depth equal to the
   // dimensionality of the operand. An operand of MemRef type is requied.
   BuildKrnlLoop(
       ConversionPatternRewriter &rewriter, Location loc, Value memRefOperand);
-  ~BuildKrnlLoop();
+  virtual ~BuildKrnlLoop() {
+    if (pack)
+      delete pack;
+  }
 
   // Create define and optimize loop with loopNum original loops. If
   // withEmptyOptimization is true, the optimization is simply the identity

--- a/src/Dialect/ONNX/IndexExpr.hpp
+++ b/src/Dialect/ONNX/IndexExpr.hpp
@@ -267,8 +267,8 @@ inference part as no code may be generated during such phases.
 
 #include "src/Dialect/ONNX/MLIRDialectBuilder.hpp"
 
+#include <cstdint>
 #include <functional>
-#include <stdint.h>
 #include <string>
 
 namespace mlir {
@@ -330,7 +330,13 @@ public:
   IndexExprScope(OpBuilder &rewriter, IndexExprScope &enclosingScope);
   IndexExprScope(DialectBuilder &db, IndexExprScope &enclosingScope);
   // Destructor which release all IndexExpr associated with this scope.
-  ~IndexExprScope();
+  virtual ~IndexExprScope();
+
+  IndexExprScope() = delete;
+  IndexExprScope(const IndexExprScope &) = delete;
+  IndexExprScope(IndexExprScope &&) = delete;
+  IndexExprScope &operator=(const IndexExprScope &) = delete;
+  IndexExprScope &operator=(IndexExprScope &&) = delete;
 
   // Public getters.
   static IndexExprScope &getCurrentScope();
@@ -339,8 +345,8 @@ public:
   bool isShapeInferencePass() const { return !rewriter; }
 
   // Queries and getters.
-  bool isCurrentScope();
-  bool isEnclosingScope();
+  bool isCurrentScope() const;
+  bool isEnclosingScope() const;
   void getDimAndSymbolList(SmallVectorImpl<Value> &list) const;
   int getNumDims() const { return dims.size(); }
   int getNumSymbols() const { return symbols.size(); }
@@ -349,8 +355,6 @@ public:
   void debugPrint(const std::string &msg) const;
 
 private:
-  IndexExprScope();
-
   static IndexExprScope *&getCurrentScopePtr() {
     thread_local IndexExprScope *scope = nullptr; // Thread local, null init.
     return scope;
@@ -385,7 +389,6 @@ private:
 // Data structure that is the public interface for IndexExpr. It is a shallow
 // data structure that is simply a pointer to the actual data (IndexExprImpl).
 class IndexExpr {
-
   friend class IndexExprScope;
   friend class NonAffineIndexExpr;
   friend class LiteralIndexExpr;
@@ -399,10 +402,15 @@ class IndexExpr {
 public:
   // Default and shallow copy constructors. Index expressions are usually built
   // using the subclasses listed as friend above.
-  IndexExpr() : indexExprObj(nullptr) {} // Undefined index expression.
+  IndexExpr() = default;
   IndexExpr(IndexExprImpl *implObj) : indexExprObj(implObj) {}     // Shallow.
   IndexExpr(IndexExpr const &obj) : IndexExpr(obj.indexExprObj) {} // Shallow.
+  IndexExpr(IndexExpr &&obj) noexcept : indexExprObj(obj.indexExprObj) {
+    obj.indexExprObj = nullptr;
+  }
+  virtual ~IndexExpr() {}
   IndexExpr &operator=(const IndexExpr &) = default;
+  IndexExpr &operator=(IndexExpr &&) = default;
 
   // To construct meaningful IndexExpr, use subclasses constructors.
   IndexExpr deepCopy() const;
@@ -533,13 +541,12 @@ protected:
   IndexExprKind getKind() const;
 
   // Support for operations: lambda function types.
-  typedef std::function<IndexExpr(IndexExpr const, IndexExpr const)> F2;
-  typedef std::function<IndexExpr(IndexExpr, IndexExpr const)> F2Self;
-  typedef std::function<IndexExpr(IndexExpr, SmallVectorImpl<IndexExpr> &)>
-      Flist;
-  typedef std::function<IndexExpr(
-      IndexExpr const, IndexExpr const, IndexExpr const)>
-      F3;
+  using F2 = std::function<IndexExpr(IndexExpr const, IndexExpr const)>;
+  using F2Self = std::function<IndexExpr(IndexExpr, IndexExpr const)>;
+  using Flist =
+      std::function<IndexExpr(IndexExpr, SmallVectorImpl<IndexExpr> &)>;
+  using F3 = std::function<IndexExpr(
+      IndexExpr const, IndexExpr const, IndexExpr const)>;
   // Support for operations: common handling for multiple operations.
   IndexExpr binaryOp(IndexExpr const b, bool affineWithLitB,
       bool affineExprCompatible, F2 fInteger, F2 fAffine, F2 fValue) const;
@@ -547,7 +554,7 @@ protected:
   static IndexExpr reductionOp(SmallVectorImpl<IndexExpr> &vals, F2Self litRed,
       Flist affineRed, F2Self valueRed);
   // Data: pointer to implemented object.
-  IndexExprImpl *indexExprObj;
+  IndexExprImpl *indexExprObj = nullptr;
 };
 
 //===----------------------------------------------------------------------===//
@@ -565,7 +572,7 @@ public:
 // values, use PredicateIndexExpr(true) or PredicateIndexExpr(false).
 class LiteralIndexExpr : public IndexExpr {
 public:
-  LiteralIndexExpr() : IndexExpr() {}    // Make undefined.
+  LiteralIndexExpr() = default;
   LiteralIndexExpr(int64_t const value); // Make an index constant value.
   LiteralIndexExpr(IndexExpr const &o);
   LiteralIndexExpr(UndefinedIndexExpr const &o);
@@ -577,6 +584,11 @@ public:
   LiteralIndexExpr(DimIndexExpr const &o);
   LiteralIndexExpr(SymbolIndexExpr const &o);
 
+  LiteralIndexExpr(LiteralIndexExpr &&) = delete;
+  ~LiteralIndexExpr() = default;
+  LiteralIndexExpr &operator=(const LiteralIndexExpr &) = delete;
+  LiteralIndexExpr &operator=(LiteralIndexExpr &&) = delete;
+
 private:
   void init(int64_t const value);
 };
@@ -584,7 +596,7 @@ private:
 // Subclass to explicitly create non affine IndexExpr.
 class NonAffineIndexExpr : public IndexExpr {
 public:
-  NonAffineIndexExpr() : IndexExpr() {} // Make undefined expression.
+  NonAffineIndexExpr() = default;
   NonAffineIndexExpr(Value const value);
   NonAffineIndexExpr(IndexExpr const &o);
   NonAffineIndexExpr(UndefinedIndexExpr const &o);
@@ -595,6 +607,11 @@ public:
   NonAffineIndexExpr(AffineIndexExpr const &o);
   NonAffineIndexExpr(DimIndexExpr const &o);
   NonAffineIndexExpr(SymbolIndexExpr const &o);
+
+  NonAffineIndexExpr(NonAffineIndexExpr &&) = delete;
+  ~NonAffineIndexExpr() = default;
+  NonAffineIndexExpr &operator=(const NonAffineIndexExpr &) = delete;
+  NonAffineIndexExpr &operator=(NonAffineIndexExpr &&) = delete;
 
 private:
   NonAffineIndexExpr(IndexExprImpl *otherObjPtr);
@@ -613,12 +630,17 @@ public:
   QuestionmarkIndexExpr(AffineIndexExpr const &o);
   QuestionmarkIndexExpr(DimIndexExpr const &o);
   QuestionmarkIndexExpr(SymbolIndexExpr const &o);
+
+  QuestionmarkIndexExpr(QuestionmarkIndexExpr &&) = delete;
+  ~QuestionmarkIndexExpr() = default;
+  QuestionmarkIndexExpr &operator=(const QuestionmarkIndexExpr &) = delete;
+  QuestionmarkIndexExpr &operator=(QuestionmarkIndexExpr &&) = delete;
 };
 
 // Subclass to explicitly create Predicate IndexExpr.
 class PredicateIndexExpr : public IndexExpr {
 public:
-  PredicateIndexExpr() : IndexExpr() {} // Make undefined predicate expression.
+  PredicateIndexExpr() = default;
   PredicateIndexExpr(bool const value); // Make a predicate constant value.
   PredicateIndexExpr(Value const value);
   PredicateIndexExpr(IndexExpr const &o);
@@ -631,6 +653,11 @@ public:
   PredicateIndexExpr(DimIndexExpr const &o);
   PredicateIndexExpr(SymbolIndexExpr const &o);
 
+  PredicateIndexExpr(PredicateIndexExpr &&) = delete;
+  ~PredicateIndexExpr() = default;
+  PredicateIndexExpr &operator=(const PredicateIndexExpr &) = delete;
+  PredicateIndexExpr &operator=(PredicateIndexExpr &&) = delete;
+
 private:
   PredicateIndexExpr(IndexExprImpl *otherObjPtr);
 };
@@ -638,7 +665,7 @@ private:
 // Subclass to explicitly create Affine IndexExpr.
 class AffineIndexExpr : public IndexExpr {
 public:
-  AffineIndexExpr() : IndexExpr() {} // Make undefined expression.
+  AffineIndexExpr() = default;
   AffineIndexExpr(AffineExpr const value);
   AffineIndexExpr(IndexExpr const &o);
   AffineIndexExpr(UndefinedIndexExpr const &o);
@@ -650,6 +677,11 @@ public:
   AffineIndexExpr(DimIndexExpr const &o);
   AffineIndexExpr(SymbolIndexExpr const &o);
 
+  AffineIndexExpr(AffineIndexExpr &&) = delete;
+  ~AffineIndexExpr() = default;
+  AffineIndexExpr &operator=(const AffineIndexExpr &) = delete;
+  AffineIndexExpr &operator=(AffineIndexExpr &&) = delete;
+
 private:
   AffineIndexExpr(IndexExprImpl *otherObjPtr);
 };
@@ -657,7 +689,7 @@ private:
 // Subclass to explicitly create Dim IndexExpr.
 class DimIndexExpr : public IndexExpr {
 public:
-  DimIndexExpr() : IndexExpr() {} // Make undefined expression.
+  DimIndexExpr() = default;
   DimIndexExpr(Value const value);
   DimIndexExpr(IndexExpr const &o);
   DimIndexExpr(UndefinedIndexExpr const &o);
@@ -668,7 +700,11 @@ public:
   DimIndexExpr(AffineIndexExpr const &o);
   DimIndexExpr(DimIndexExpr const &o);
   DimIndexExpr(SymbolIndexExpr const &o);
+
+  DimIndexExpr(DimIndexExpr &&) = delete;
+  ~DimIndexExpr() = default;
   DimIndexExpr &operator=(const DimIndexExpr &) = default;
+  DimIndexExpr &operator=(DimIndexExpr &&) = default;
 
 private:
   DimIndexExpr(IndexExprImpl *otherObjPtr);
@@ -677,7 +713,7 @@ private:
 // Subclass to explicitly create IndexExpr.
 class SymbolIndexExpr : public IndexExpr {
 public:
-  SymbolIndexExpr() : IndexExpr() {} // Make undefined expression.
+  SymbolIndexExpr() = default;
   SymbolIndexExpr(Value const value);
   SymbolIndexExpr(IndexExpr const &o);
   SymbolIndexExpr(UndefinedIndexExpr const &o);
@@ -689,6 +725,11 @@ public:
   SymbolIndexExpr(DimIndexExpr const &o);
   SymbolIndexExpr(SymbolIndexExpr const &o);
 
+  SymbolIndexExpr(SymbolIndexExpr &&) = default;
+  ~SymbolIndexExpr() = default;
+  SymbolIndexExpr &operator=(const SymbolIndexExpr &) = delete;
+  SymbolIndexExpr &operator=(SymbolIndexExpr &&) = delete;
+
 private:
   SymbolIndexExpr(IndexExprImpl *otherObjPtr);
 };
@@ -697,9 +738,13 @@ private:
 // Additional operators with integer values in first position
 //===----------------------------------------------------------------------===//
 
-inline IndexExpr operator+(int64_t const a, const IndexExpr b) { return b + a; }
-inline IndexExpr operator*(int64_t const a, const IndexExpr b) { return b * a; }
-inline IndexExpr operator-(int64_t const a, const IndexExpr b) {
+inline IndexExpr operator+(int64_t const a, const IndexExpr &b) {
+  return b + a;
+}
+inline IndexExpr operator*(int64_t const a, const IndexExpr &b) {
+  return b * a;
+}
+inline IndexExpr operator-(int64_t const a, const IndexExpr &b) {
   return LiteralIndexExpr(a) - b;
 }
 
@@ -718,24 +763,22 @@ public:
   // GetDenseVal locate a DenseElementAttr by looking at the definition of the
   // array value. Return null if this definition is not generating a dense
   // array.
-  typedef std::function<DenseElementsAttr(Value array)> GetDenseVal;
+  using GetDenseVal = std::function<DenseElementsAttr(Value array)>;
   // LoadVal will load the value at array[i] where array is a single dimensional
   // array.
-  typedef std::function<Value(
-      OpBuilder &rewriter, Location loc, Value array, int64_t index)>
-      LoadVal;
+  using LoadVal = std::function<Value(
+      OpBuilder &rewriter, Location loc, Value array, int64_t index)>;
 
   ArrayValueIndexCapture(
       Operation *op, Value array, GetDenseVal fGetDenseVal, LoadVal fLoadVal);
   ArrayValueIndexCapture(Operation *op, Value array, int64_t defaultLiteral,
       GetDenseVal fGetDenseVal, LoadVal fLoadVal);
+  ArrayValueIndexCapture() = delete;
 
   IndexExpr getSymbol(uint64_t i);
   void getSymbolList(int num, SmallVectorImpl<IndexExpr> &symbolList);
 
 private:
-  ArrayValueIndexCapture() { llvm_unreachable("forbidden constructor"); };
-
   Operation *op;
   Value array;
   int64_t defaultLiteral;
@@ -749,13 +792,12 @@ class ArrayAttributeIndexCapture {
 public:
   ArrayAttributeIndexCapture(ArrayAttr array);
   ArrayAttributeIndexCapture(ArrayAttr array, int64_t defaultLiteral);
+  ArrayAttributeIndexCapture() = delete;
 
   IndexExpr getLiteral(uint64_t i);
   uint64_t size() { return arraySize; }
 
 private:
-  ArrayAttributeIndexCapture() { llvm_unreachable("forbidden constructor"); };
-
   ArrayAttr array;
   uint64_t arraySize;
   int64_t defaultLiteral;

--- a/src/Dialect/ONNX/MLIRDialectBuilder.cpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.cpp
@@ -11,11 +11,6 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
-// Default value should be changed for target with SIMD width of more than 16
-// bytes.
-// TODO: make it a global variable
-// int64_t gDefaultAllocAlign = 16;
-
 using namespace mlir;
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/MLIRDialectBuilder.hpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.hpp
@@ -22,9 +22,13 @@ struct DialectBuilder {
   DialectBuilder(OpBuilder &b, Location loc) : b(b), loc(loc) {}
   DialectBuilder(ImplicitLocOpBuilder &lb) : b(lb), loc(lb.getLoc()) {}
   DialectBuilder(DialectBuilder &db) : b(db.b), loc(db.loc) {}
+  virtual ~DialectBuilder() {}
+  DialectBuilder(DialectBuilder &&) = delete;
+  DialectBuilder &operator=(const DialectBuilder &) = delete;
+  DialectBuilder &&operator=(const DialectBuilder &&) = delete;
 
-  OpBuilder &getBuilder() { return b; }
-  Location getLoc() { return loc; }
+  OpBuilder &getBuilder() const { return b; }
+  Location getLoc() const { return loc; }
 
 protected:
   OpBuilder &b;
@@ -79,9 +83,7 @@ struct MemRefBuilder : DialectBuilder {
 
 // Default alignment attribute for all allocation of memory. On most system, it
 // is 16 bytes.
-// TODO: make it a global variable
-// extern int64_t gDefaultAllocAlign;
-#define gDefaultAllocAlign 16
+static constexpr int64_t gDefaultAllocAlign = 16;
 
 } // namespace mlir
 #endif

--- a/src/Dialect/ONNX/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXShapeHelper.cpp
@@ -20,12 +20,7 @@
 
 using namespace mlir;
 
-#define DEBUG 0
-
-#if DEBUG
-#include <iostream>
-using namespace std;
-#endif
+#define DEBUG_TYPE "shape-helper"
 
 //===----------------------------------------------------------------------===//
 // ONNX Op Shape Helper


### PR DESCRIPTION
I have installed and run `clang-tidy` with the following configuration:

```
    "clang-tidy.checks": [
        "cppcoreguidelines-*",
        "modernize-*",
        "performance-*",
        "-modernize-use-trailing-return-type",
        "-cppcoreguidelines-init-variables",
        "-cppcoreguidelines-avoid-non-const-global-variables",
        "-cppcoreguidelines-non-private-member-variables-in-classes",
        "-cppcoreguidelines-pro-type-member-init"
    ],
```

The tool highlights several problems with the code base which this patch is fixing. Namely:
- uninitialized variables
- use of typedefs instead of alias declaration (via `using` keyword)
- classes that have declared a custom constructor but have not declared move constructor and move `operator=` ...
- use of `define` to declare names associated with a constant (should use `static constexpr` instead)
- etc...

This patch also introduces the use of the standard LLVM facility for code tracing (i.e. the `LLVM_DEBUG` macro)

 