### PR TITLE
Add custom verification for DepthToSpace and SpaceToDepth operators.

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -3465,6 +3465,39 @@ LogicalResult ONNXCumSumOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
+static LogicalResult verify(ONNXDepthToSpaceOp op) {
+  ONNXDepthToSpaceOpAdaptor operandAdaptor(op);
+
+  // Check input.
+  auto input = operandAdaptor.input();
+  if (!hasShapeAndRank(input)) {
+    // Won't be able to do any checking at this stage.
+    return success();
+  }
+  auto inputType = input.getType().cast<ShapedType>();
+  auto inputShape = inputType.getShape();
+  if (inputShape.size() != 4)
+    return op.emitError("Input should have a rank of four");
+
+  // Check blocksize.
+  auto blocksize = operandAdaptor.blocksize().getValue();
+  if (blocksize.isNegative())
+    return op.emitError("Blocksize should be non negative");
+
+  auto C = inputShape[1];
+  uint64_t bs = blocksize.getZExtValue();
+  if (C % (bs * bs) != 0)
+    return op.emitError("The input tensor depth must be divisible by the "
+                        "(blocksize * blocksize)");
+
+  // Check mode.
+  StringRef mode = operandAdaptor.mode().getValue();
+  if (mode != "DCR" && mode != "CRD")
+    return op.emitError("Mode must be DCR or CRD");
+
+  return success();
+}
+
 LogicalResult ONNXDepthToSpaceOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
   // Cannot infer shape if no input shape exists.
@@ -3989,6 +4022,39 @@ LogicalResult ONNXSequenceLengthOp::inferShapes(
 LogicalResult ONNXShrinkOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
   return emitError(NOT_IMPLEMENTED_MESSAGE);
+}
+
+static LogicalResult verify(ONNXSpaceToDepthOp op) {
+  ONNXSpaceToDepthOpAdaptor operandAdaptor(op);
+
+  // Check input.
+  auto input = operandAdaptor.input();
+  if (!hasShapeAndRank(input)) {
+    // Won't be able to do any checking at this stage.
+    return success();
+  }
+  auto inputType = input.getType().cast<ShapedType>();
+  auto inputShape = inputType.getShape();
+  if (inputShape.size() != 4)
+    return op.emitError("Input should have a rank of four");
+
+  // Check blocksize.
+  auto blocksize = operandAdaptor.blocksize().getValue();
+  if (blocksize.isNegative())
+    return op.emitError("Blocksize should be non negative");
+
+  auto H = inputShape[2];
+  auto W = inputShape[3];
+  uint64_t bs = blocksize.getZExtValue();
+
+  if (H % bs != 0)
+    return op.emitError(
+        "The input tensor height must be divisible by the block size");
+  if (W % bs != 0)
+    return op.emitError(
+        "The input tensor width must be divisible by the block size");
+
+  return success();
 }
 
 LogicalResult ONNXSpaceToDepthOp::inferShapes(

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -983,6 +983,7 @@ def ONNXDepthToSpaceOp:ONNX_Op<"DepthToSpace",
       return {20};
     }
   }];
+  let verifier = [{ return ::verify(*this); }];
 }
 
 def ONNXDequantizeLinearOp:ONNX_Op<"DequantizeLinear",
@@ -5630,6 +5631,7 @@ def ONNXSpaceToDepthOp:ONNX_Op<"SpaceToDepth",
       return {20};
     }
   }];
+  let verifier = [{ return ::verify(*this); }];
 }
 
 def ONNXSplitOp:ONNX_Op<"Split",

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -1,8 +1,18 @@
 // RUN: onnx-mlir-opt %s -split-input-file -verify-diagnostics
 
+// -----
+
 func @mod(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{fmod must be 1 when the input type is floating point}}
   %0 = "onnx.Mod"(%arg0, %arg1) {fmod = 0 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }
- 
+
+// -----
+
+func @test_depth_to_space_default(%arg0 : tensor<1x256x8x16xf32>) -> tensor<1x16x32x64xf32> {
+  %cst = constant unit
+  // expected-error @+1 {{The input tensor depth must be divisible by the (blocksize * blocksize)}}  
+  %0 = "onnx.DepthToSpace"(%arg0) {blocksize = 7 : si64} : (tensor<1x256x8x16xf32>) -> tensor<1x16x32x64xf32>
+  "std.return"(%0) : (tensor<1x16x32x64xf32>) -> ()
+}

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -354,8 +354,8 @@ OpsWithCanonicalizer = ['Add', 'Constant', 'Identity', 'Cast', 'Transpose',
                         'Squeeze', 'Unsqueeze', 'Reshape']
 
 # Operations with custom verifiers.
-OpsWithVerifier = ['AveragePool', 'Conv', 'Expand', 'InstanceNormalization',
-                   'Mod']
+OpsWithVerifier = ['AveragePool', 'Conv', 'DepthToSpace', 'Expand',
+                   'InstanceNormalization', 'Mod', 'SpaceToDepth']
 
 OpsWithHelpers = {
   "Loop": """


### PR DESCRIPTION
This PR adds custom `verify` methods for the DepthToSpace and SpaceToDepth operators to check that:
- input tensor has 4 dims
- blocksize is strictly positive and divides the appropriate input tensor dimension(s) without remainder