### PR TITLE
[NFC] Suppress warnings in third_party subprojects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,11 +95,8 @@ elseif ((ONNX_USE_PROTOBUF_SHARED_LIBS AND Protobuf_USE_STATIC_LIBS)
   message(FATAL_ERROR
     "ONNX_USE_PROTOBUF_SHARED_LIBS and Protobuf_USE_STATIC_LIBS must be opposites of each other.")
 endif()
-add_subdirectory(third_party/onnx)
 
-add_subdirectory(third_party/pybind11)
-add_subdirectory(third_party/rapidcheck)
-
+add_subdirectory(third_party)
 add_subdirectory(utils)
 add_subdirectory(include)
 add_subdirectory(src)

--- a/src/Runtime/jni/jnilog.c
+++ b/src/Runtime/jni/jnilog.c
@@ -164,7 +164,7 @@ void log_printf(
     sprintf(buf, "[-]");
 
   /* Output thread ID, log level, file name, function number, and line number */
-  snprintf(buf + strlen(buf), LOG_MAX_LEN - strlen(buf), "[%lx][%s]%s:%s:%d ",
+  snprintf(buf + strlen(buf), LOG_MAX_LEN - strlen(buf), "[%p][%s]%s:%s:%d ",
       get_threadid(), log_level_name[level], get_filename(file), func, line);
 
   /* Output actual log data */
@@ -204,7 +204,7 @@ static FILE *get_log_file_by_name(char *name) {
   else {
     char *tname = (char *)malloc(strlen(name) + 32);
     if (tname) {
-      snprintf(tname, strlen(name) + 32, "%s.%lx", name, get_threadid());
+      snprintf(tname, strlen(name) + 32, "%s.%p", name, get_threadid());
       fp = fopen(tname, "w");
       free(tname);
     }

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -12,11 +12,14 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
+#pragma clang diagnostic ignored "-Weverything"
+#pragma gcc diagnostic ignored "-Weverything"
 #include "onnx/defs/function.h"
 #include "onnx/defs/schema.h"
+#pragma clang diagnostic pop
+#pragma gcc diagnostic pop
 
 #include "src/Builder/FrontendDialectTransformer.hpp"
-
 #include "src/Interface/ShapeInferenceOpInterface.hpp"
 #include "src/Pass/Passes.hpp"
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,8 @@
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # Suppress warnings in third party subprojects.
+  add_compile_options(-Wno-everything)
+endif()
+
+add_subdirectory(onnx)
+add_subdirectory(pybind11)
+add_subdirectory(rapidcheck)


### PR DESCRIPTION
This PR adds clang & gcc options to suppress warnings when C/C++ code is compiled in the `third_party` subprojects. 
In addition it fixes an issues in the Runtime onnx-mlir code.  Warnings continue to be emitted for C/C++ code in the onnx-mlir project proper.