### PR TITLE
Change RankedTensorType to ShapedType in verifyKernelShape().

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -1610,6 +1610,10 @@ LogicalResult ONNXReduceSumV11Op::inferShapes(
 template <class T>
 static LogicalResult verifyKernelShape(T *op, Value filterOperand,
     Optional<ArrayAttr> kernelShapeOpt, int64_t spatialRank) {
+  if (filterOperand && !hasShapeAndRank(filterOperand)) {
+    // Won't be able to do any checking at this stage.
+    return success();
+  }
   // 1) Get shape of filter. Shape is not guaranteed to be compile time
   // constant.
   ArrayRef<int64_t> filterShape =


### PR DESCRIPTION
This updates PR #908 a bit. Just change a line from RankedTensorType to ShapedType in verifyKernelShape().
This verification failed when `filterOperand` was memref type.

Signed-off-by: Haruki Imai <imaihal@jp.ibm.com>