### PR TITLE
[NFC]: Change -Wno-everything to -w to account for old GNU toolchains.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.13.4)
 project(onnx-mlir)
 
 option(ONNX_MLIR_BUILD_TESTS "Build ONNX MLIR test executables. If OFF, just generate build targets." ON)
+option(ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS "Suppress warning in third_party code." ON)
 
 set(CMAKE_CXX_STANDARD 14)
 
@@ -96,7 +97,33 @@ elseif ((ONNX_USE_PROTOBUF_SHARED_LIBS AND Protobuf_USE_STATIC_LIBS)
     "ONNX_USE_PROTOBUF_SHARED_LIBS and Protobuf_USE_STATIC_LIBS must be opposites of each other.")
 endif()
 
-add_subdirectory(third_party)
+# Suppress warnings in third party code.
+if (ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS)
+  set(CMAKE_C_FLAGS_COPY ${CMAKE_C_FLAGS})
+  set(CMAKE_CXX_FLAGS_COPY ${CMAKE_CXX_FLAGS})
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+  elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC") 
+    # MSVC complains when overriding existing warning levels flags, remove
+    # them and add "/W".
+    STRING(REGEX REPLACE "/W[0-9]" "/W0" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})  
+    STRING(REGEX REPLACE "/W[0-9]" "/W0" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  endif()
+endif()
+
+add_subdirectory(third_party/onnx)
+add_subdirectory(third_party/pybind11)
+add_subdirectory(third_party/rapidcheck)
+
+# Ensure warnings are reported for onnx-mlir code.
+if (ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS)
+  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS_COPY})
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_COPY})
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSUPPRESS_THIRD_PARTY_WARNINGS")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSUPPRESS_THIRD_PARTY_WARNINGS")
+endif()
+
 add_subdirectory(utils)
 add_subdirectory(include)
 add_subdirectory(src)

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -18,23 +18,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <type_traits>
-
-#include "mlir/IR/BuiltinOps.h"
-#include "onnx/defs/schema.h"
-#include "llvm/ADT/TypeSwitch.h"
-
-#include "onnx/checker.h"
-#include "onnx/shape_inference/implementation.h"
-#include "onnx/version_converter/convert.h"
-
+#include "FrontendDialectTransformer.hpp"
 #include "src/Interface/HasOnnxSubgraphOpInterface.hpp"
 #include "src/Interface/ResultTypeInferenceOpInterface.hpp"
+#include "src/Support/SuppressWarnings.h"
 
-#include "FrontendDialectTransformer.hpp"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+SUPPRESS_WARNINGS_PUSH
+#include "onnx/checker.h"
+#include "onnx/defs/schema.h"
+#include "onnx/shape_inference/implementation.h"
+#include "onnx/version_converter/convert.h"
+SUPPRESS_WARNINGS_POP
+
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <type_traits>
 
 using namespace mlir;
 

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -278,7 +278,6 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    KrnlGetRefOp getRefOp = llvm::dyn_cast<KrnlGetRefOp>(op);
     auto loc = op->getLoc();
 
     KrnlGetRefOpAdaptor operandAdaptor(operands);

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -260,8 +260,8 @@ OMTensorList *omtl_java_to_native(
      * in the OMTensor.
      */
     LIB_VAR_CALL(jni_omts[i],
-        omTensorCreate(jni_data, jni_shape, jni_rank, jni_dataType), NULL, env,
-        japi->jecpt_cls, "jni_omts[%d]=null", i);
+        omTensorCreate(jni_data, (int64_t *)jni_shape, jni_rank, jni_dataType),
+        NULL, env, japi->jecpt_cls, "jni_omts[%d]=null", i);
 
     /* Release reference to the java objects */
     JNI_CALL(
@@ -339,14 +339,14 @@ jobject omtl_native_to_java(
     /* Create data shape array Java object, fill in from native array */
     JNI_TYPE_VAR_CALL(
         env, jlongArray, jomt_shape, (*env)->NewLongArray(env, jni_rank));
-    JNI_CALL(env,
-        (*env)->SetLongArrayRegion(env, jomt_shape, 0, jni_rank, jni_shape));
+    JNI_CALL(env, (*env)->SetLongArrayRegion(
+                      env, jomt_shape, 0, jni_rank, (jlong *)jni_shape));
 
     /* Create data strides array Java object, fill in from native array */
     JNI_TYPE_VAR_CALL(
         env, jlongArray, jomt_strides, (*env)->NewLongArray(env, jni_rank));
     JNI_CALL(env, (*env)->SetLongArrayRegion(
-                      env, jomt_strides, 0, jni_rank, jni_strides));
+                      env, jomt_strides, 0, jni_rank, (jlong *)jni_strides));
 
     /* Primitive type int can be directly used. Call setDataType method */
     int jomt_dataType = jni_dataType;

--- a/src/Support/Common.hpp
+++ b/src/Support/Common.hpp
@@ -1,3 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====--------------- Common.hpp - Common Utilities -----------------------===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains common utilities and support code.
+//
+//===----------------------------------------------------------------------===//
+
 #pragma once
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/src/Support/SuppressWarnings.h
+++ b/src/Support/SuppressWarnings.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====--------------- SuppressWarnings.h - Suppress Warnings --------------===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains support code used to suppress warnings.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+// clang-format off
+#if defined(SUPPRESS_THIRD_PARTY_WARNINGS)
+  #if defined(__clang__)
+    #define SUPPRESS_WARNINGS_PUSH                                          \
+      _Pragma("clang diagnostic push")                                      \
+      _Pragma("clang diagnostic ignored \"-Wcast-qual\"")                   \
+      _Pragma("clang diagnostic ignored \"-Wstring-conversion\"")           \
+      _Pragma("clang diagnostic ignored \"-Wmissing-field-initializers\"")  \
+      _Pragma("clang diagnostic ignored \"-Wsuggest-override\"")
+
+    #define SUPPRESS_WARNINGS_POP _Pragma("clang diagnostic pop")
+  #elif defined(__GNUC__)
+    #define SUPPRESS_WARNINGS_PUSH                                          \
+      _Pragma("GCC diagnostic push")                                        \
+      _Pragma("GCC diagnostic ignored \"-Wcast-qual\"")                     \
+      _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")    \
+      _Pragma("GCC diagnostic ignored \"-Wsuggest-override\"")
+
+    #define SUPPRESS_WARNINGS_POP _Pragma("GCC diagnostic pop")
+  #else
+    #define SUPPRESS_WARNINGS_PUSH
+    #define SUPPRESS_WARNINGS_POP
+  #endif
+#else
+  #define SUPPRESS_WARNINGS_PUSH
+  #define SUPPRESS_WARNINGS_POP
+#endif
+// clang-format on

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -12,16 +12,15 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
-#pragma clang diagnostic ignored "-Weverything"
-#pragma gcc diagnostic ignored "-Weverything"
-#include "onnx/defs/function.h"
-#include "onnx/defs/schema.h"
-#pragma clang diagnostic pop
-#pragma gcc diagnostic pop
-
 #include "src/Builder/FrontendDialectTransformer.hpp"
 #include "src/Interface/ShapeInferenceOpInterface.hpp"
 #include "src/Pass/Passes.hpp"
+#include "src/Support/SuppressWarnings.h"
+
+SUPPRESS_WARNINGS_PUSH
+#include "onnx/defs/function.h"
+#include "onnx/defs/schema.h"
+SUPPRESS_WARNINGS_POP
 
 using namespace std;
 using namespace ONNX_NAMESPACE;

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,8 +1,0 @@
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  # Suppress warnings in third party subprojects.
-  add_compile_options(-Wno-everything)
-endif()
-
-add_subdirectory(onnx)
-add_subdirectory(pybind11)
-add_subdirectory(rapidcheck)


### PR DESCRIPTION
Old version of gcc/g++ do not accept the `-Wno-everything` command line options. On Mac the options is accepted:

t.c
```
int f0(int, unsigned);
int f0(int x, unsigned y) {
  if (x=3);
  return x < y; // expected-warning {{comparison of integers}}
}
```

Produces warnings:
```
%Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.5 (clang-1205.0.22.11)
...

% gcc t.c -c                
t.c:3:8: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
  if (x=3);
      ~^~
t.c:3:8: note: place parentheses around the assignment to silence this warning
  if (x=3);
       ^
      (  )
t.c:3:8: note: use '==' to turn this assignment into an equality comparison
  if (x=3);
       ^
       ==
t.c:3:11: warning: if statement has empty body [-Wempty-body]
  if (x=3);
          ^
t.c:3:11: note: put the semicolon on a separate line to silence this warning
2 warnings generated.
```

Suppressed warnings:
```
% gcc t.c -c -Wno-everything
% echo $?
0
```

The solution is to use the `-w` command line options which works as well for both clang and gcc.  
When using MSVC I found from the compiler docs that `-w` can also be used (https://docs.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level?view=msvc-160):


![Screen Shot 2021-10-20 at 11 10 17 AM](https://user-images.githubusercontent.com/56368199/138120535-1f00b823-f86f-41d9-a860-606fb56a3d5d.png)


