### PR TITLE
Parallelize test sets

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -63,7 +63,7 @@ jobs:
 
   - script: |
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-      call onnx-mlir\utils\check-numerical.cmd
+      call onnx-mlir\utils\check-onnx-numerical.cmd
     displayName: Run onnx-mlir numerical tests
     workingDirectory: $(Agent.BuildDirectory)
     env:

--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ call cmake --build . --config Release --target check-onnx-lit
 
 To run the numerical ONNX MLIR tests, use the following command:
 
-[same-as-file]: <> ({"ref": "utils/check-numerical.cmd", "skip-ref": 1})
+[same-as-file]: <> ({"ref": "utils/check-onnx-numerical.cmd", "skip-ref": 1})
 ```shell
-call cmake --build . --config Release --target check-numerical
+call cmake --build . --config Release --target check-onnx-numerical
 ```
 
 To run the doc ONNX MLIR tests, use the following command after installing third_party ONNX:

--- a/docker/Dockerfile.onnx-mlir
+++ b/docker/Dockerfile.onnx-mlir
@@ -43,11 +43,15 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
                    [ "$(uname -m)" = "x86_64" ] &&  echo || \
                    [ "$(uname -m)" = "ppc64le" ] && echo || echo) \
     && TEST_ARGS="-mcpu=${TEST_MCPU}" \
-    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend \
-    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend-dynamic \
-    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend-constant \
-    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-compilerlib-backend \
-    && make ARGS=-j${NPROC} TEST_ARGS="${TEST_ARGS}" test \
+    && make NPROC=${NPROC} \
+            CTEST_PARALLEL_LEVEL=${NPROC} \
+            TEST_MCPU=${TEST_MCPU} \
+            TEST_ARGS="${TEST_ARGS}" \
+	    -f CMakeFiles/Makefile2 \
+            check-onnx-backend \
+            check-onnx-backend-dynamic \
+            check-onnx-backend-constant \
+            check-onnx-numerical \
     && make check-docs \
     && make -j${NPROC} install \
 # Clean up

--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -38,11 +38,15 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
                    [ "$(uname -m)" = "x86_64" ] &&  echo || \
                    [ "$(uname -m)" = "ppc64le" ] && echo || echo) \
     && TEST_ARGS="-mcpu=${TEST_MCPU}" \
-    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend \
-    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend-dynamic \
-    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-onnx-backend-constant \
-    && make NPROC=${NPROC} TEST_MCPU=${TEST_MCPU} check-compilerlib-backend \
-    && make ARGS=-j${NPROC} TEST_ARGS="${TEST_ARGS}" test \
+    && make NPROC=${NPROC} \
+            CTEST_PARALLEL_LEVEL=${NPROC} \
+            TEST_MCPU=${TEST_MCPU} \
+            TEST_ARGS="${TEST_ARGS}" \
+	    -f CMakeFiles/Makefile2 \
+            check-onnx-backend \
+            check-onnx-backend-dynamic \
+            check-onnx-backend-constant \
+            check-onnx-numerical \
     && make check-docs \
     && rm -rf /tmp/*
 

--- a/test/backend/CMakeLists.txt
+++ b/test/backend/CMakeLists.txt
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 file(GENERATE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/conftest.py
+  INPUT ${CMAKE_CURRENT_SOURCE_DIR}/conftest.py
+  )
+
+file(GENERATE
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/test.py
   INPUT ${CMAKE_CURRENT_SOURCE_DIR}/test.py
   )
@@ -46,7 +51,7 @@ execute_process(
 if (${PYTEST_XDIST_FOUND} EQUAL 0)
   message(STATUS "Parallel backend tests      : ON")
   set(BACKEND_TEST_COMMAND "${Python3_EXECUTABLE}" "-m" "pytest")
-  set(BACKEND_TEST_ARGS "--forked" "-n" "$$\{NPROC:-auto\}")
+  set(BACKEND_TEST_ARGS "--forked" "-n" "$$\{NPROC:-auto\}" "-q" "--silent")
 else()
   message(STATUS "Parallel backend tests      : OFF (install pytest-xdist to enable)")
   set(BACKEND_TEST_COMMAND ${Python3_EXECUTABLE})
@@ -95,9 +100,9 @@ add_custom_target(clean-onnx-backend
     ${CMAKE_CURRENT_BINARY_DIR}/*.so
   )
   
-add_custom_target(check-compilerlib-backend
+add_custom_target(check-onnx-backend-compilerlib
   COMMAND
-    ONNX_HOME=${CMAKE_CURRENT_BINARY_DIR} ${BACKEND_TEST_COMMAND}
+    TEST_COMPILERLIB=true ONNX_HOME=${CMAKE_CURRENT_BINARY_DIR} ${BACKEND_TEST_COMMAND}
     ${BACKEND_TEST_ARGS} ${FILE_GENERATE_DIR}/test.py
   DEPENDS
     ${FILE_GENERATE_DIR}/test.py
@@ -111,5 +116,5 @@ add_dependencies(check-onnx-backend-dynamic PyRuntime)
 add_dependencies(check-onnx-backend-constant onnx-mlir)
 add_dependencies(check-onnx-backend-constant PyRuntime)
 
-add_dependencies(check-compilerlib-backend CompilerLibTest)
-add_dependencies(check-compilerlib-backend PyRuntime)
+add_dependencies(check-onnx-backend-compilerlib CompilerLibTest)
+add_dependencies(check-onnx-backend-compilerlib PyRuntime)

--- a/test/backend/conftest.py
+++ b/test/backend/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+# Add option --silent to pytest
+def pytest_addoption(parser):
+    parser.addoption('--silent', action='store_true', default=False)
+
+# Function to disable pytest progressive indicators to avoid
+# cluttering the output when running in a parallel CI environment.
+def pytest_report_teststatus(report, config):
+    category, short, verbose = '', '', ''
+    if not config.getoption('--silent'):
+        return None
+
+    if hasattr(report, 'wasxfail'):
+        if report.skipped:
+            category = 'xfailed'
+        elif report.passed:
+            category = 'xpassed'
+        return (category, short, verbose)
+    elif report.when in ('setup', 'teardown'):
+        if report.failed:
+            category = 'error'
+        elif report.skipped:
+            category = 'skipped'
+        return (category, short, verbose)
+    category = report.outcome
+    return (category, short, verbose)

--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -15,7 +15,6 @@ from onnx import numpy_helper
 
 from onnx.backend.base import Device, DeviceType
 import subprocess
-import test_config
 import tempfile
 import argparse
 
@@ -35,6 +34,7 @@ IMPORTER_FORCE_DYNAMIC = os.getenv("IMPORTER_FORCE_DYNAMIC")
 IMPORTER_FORCE_CONSTANT = os.getenv("IMPORTER_FORCE_CONSTANT")
 TEST_DYNAMIC = os.getenv("TEST_DYNAMIC")
 TEST_CONSTANT = os.getenv("TEST_CONSTANT")
+TEST_COMPILERLIB = os.getenv("TEST_COMPILERLIB")
 
 parser = argparse.ArgumentParser(description='with dynamic shape or not.')
 parser.add_argument('--dynamic', action='store_true',
@@ -43,6 +43,9 @@ parser.add_argument('--dynamic', action='store_true',
 parser.add_argument('--constant', action='store_true',
     default=(strtobool(TEST_CONSTANT) if TEST_CONSTANT else False),
     help='enable constant input tests (default: false if TEST_CONSTANT env var not set)')
+parser.add_argument('--compilerlib', action='store_true',
+    default=(strtobool(TEST_COMPILERLIB) if TEST_COMPILERLIB else False),
+    help='enable compiler lib tests (default: false if TEST_COMPILERLIB env var not set)')
 parser.add_argument('-i', '--input', type=int,
     default=os.getenv("TEST_INPUT", -1),
     help='inputs whose dimensions to be changed to unknown (default: all inputs if TEST_INPUT env var not set)')
@@ -76,10 +79,19 @@ if args.mcpu:
 if args.mtriple:
     print("  targeting triple:", args.mtriple)
 
-CXX = test_config.CXX_PATH
-LLC = test_config.LLC_PATH
-RUNTIME_DIR = test_config.TEST_DRIVER_RUNTIME_PATH
-TEST_DRIVER = test_config.TEST_DRIVER_PATH
+if args.compilerlib:
+    import test_config_compilerlib
+    CXX = test_config_compilerlib.CXX_PATH
+    LLC = test_config_compilerlib.LLC_PATH
+    RUNTIME_DIR = test_config_compilerlib.TEST_DRIVER_RUNTIME_PATH
+    TEST_DRIVER = test_config_compilerlib.TEST_DRIVER_PATH
+else:
+    import test_config
+    CXX = test_config.CXX_PATH
+    LLC = test_config.LLC_PATH
+    RUNTIME_DIR = test_config.TEST_DRIVER_RUNTIME_PATH
+    TEST_DRIVER = test_config.TEST_DRIVER_PATH
+
 
 # Make lib folder under build directory visible in PYTHONPATH
 doc_check_base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -1063,7 +1075,7 @@ class EndiannessAwareExecutionSession:
         dynamic_inputs_dims = determine_dynamic_parameters(name)
         execute_commands(command_list, dynamic_inputs_dims)
         if not os.path.exists(exec_name) :
-            print("Failed " + test_config.TEST_DRIVER_PATH + ": " + name)
+            print("Failed " + TEST_DRIVER + ": " + name)
         return exec_name
 
     def turn_model_input_to_constant(self, inputs):

--- a/test/numerical/CMakeLists.txt
+++ b/test/numerical/CMakeLists.txt
@@ -3,15 +3,15 @@
 add_custom_target(numerical)
 set_target_properties(numerical PROPERTIES FOLDER "Tests")
 
-add_custom_target(check-numerical
+add_custom_target(check-onnx-numerical
   COMMENT "Running the ONNX MLIR numerical regression tests"
   COMMAND "${CMAKE_CTEST_COMMAND}" -L numerical --output-on-failure -C $<CONFIG> --force-new-ctest-process
   USES_TERMINAL
   DEPENDS numerical
   )
-set_target_properties(check-numerical PROPERTIES FOLDER "Tests")
+set_target_properties(check-onnx-numerical PROPERTIES FOLDER "Tests")
 # Exclude the target from the default VS build
-set_target_properties(check-numerical PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD ON)
+set_target_properties(check-onnx-numerical PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD ON)
 
 # add_numerical_unittest(test_name sources... options...
 #   This function (generally) has the same semantic as add_onnx_mlir_executable.

--- a/utils/check-numerical.cmd
+++ b/utils/check-numerical.cmd
@@ -1,2 +1,0 @@
-cd onnx-mlir\build
-call cmake --build . --config Release --target check-numerical

--- a/utils/check-onnx-numerical.cmd
+++ b/utils/check-onnx-numerical.cmd
@@ -1,0 +1,2 @@
+cd onnx-mlir\build
+call cmake --build . --config Release --target check-onnx-numerical


### PR DESCRIPTION
    We currenly run a few test sets, e.g., check-onnx-backend, check-onnx-backend-dynamic,
    etc., in serial. While we do parallelize within each test set, we don't get much
    benefit from it. Because within each test set, most of the time was spent on one
    or two long running tests. While waiting for these long running tests, we could have
    started the next test sets.

    This patch parallelizes across tests sets by starting them all at once so the long
    running tests from different test sets can run in parallel.

    CompilerLib tests are disabled because a bug has been uncovered that it was actually
    still using onnx-mlir instead of CompilerLibTest to compile the models. Fix the bug
    to use CompilerLibTest and it fails to compile the models.