### PR TITLE
CategoryMapper Onnx to Krnl lowering.

### DIFF
--- a/docs/Dialects/krnl.md
+++ b/docs/Dialects/krnl.md
@@ -334,6 +334,30 @@ Krnl erf scalar operation.
 | :----: | ----------- |
 `out` | floating-point
 
+### `krnl.find_index` (::mlir::KrnlFindIndexOp)
+
+Retrieve an index into a perfect hash table described by G and V.
+
+This operation can be used to generate a call to a runtime function which, 
+given two arrays of int32_t values (G and V), whih are used to represent a perfect 
+hash table for a dictionary, returns the index corresponding to the input value.
+The index returned is valid only if 'input' is in the dictionary described by G and V.
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`input` | string type or 64-bit signless integer
+`G` | memref of 32-bit signless integer values
+`V` | memref of 32-bit signless integer values
+`len` | 32-bit signless integer
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`index` | index
+
 ### `krnl.get_induction_var_value` (::mlir::KrnlGetInductionVariableValueOp)
 
 Krnl 
@@ -857,6 +881,44 @@ the memref.
 `value` | any type
 `memref` | memref of any type values
 `indices` | index
+
+### `krnl.strlen` (::mlir::KrnlStrlenOp)
+
+Compute the length of a string.
+
+Krnl operation that computes the length of a string.
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`str` | string type
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`res` | 64-bit signless integer
+
+### `krnl.strncmp` (::mlir::KrnlStrncmpOp)
+
+Perform string comparison up to N bytes.
+
+Krnl operation that performs a string comparison up to N bytes.
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`str1` | string type
+`str2` | string type
+`len` | 64-bit signless integer
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`res` | 32-bit signless integer
 
 ### `krnl.tan` (::mlir::KrnlTanOp)
 

--- a/docs/Dialects/onnx.md
+++ b/docs/Dialects/onnx.md
@@ -618,6 +618,46 @@ ONNX BitShift operation
 | :----: | ----------- |
 `Z` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or memref of any type values
 
+### `onnx.ONNX_Call` (::mlir::ONNXCallOp)
+
+call operation
+
+
+Syntax:
+
+```
+operation ::= `onnx.ONNX_Call` $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
+```
+
+The `call` operation represents a direct call to a function that is within
+the same symbol scope as the call. The operands and result types of the
+call must match the specified function type. The callee is encoded as a
+symbol reference attribute named "callee".
+
+Example:
+
+```mlir
+%2 = call @my_add(%0, %1) : (f32, f32) -> f32
+```
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`callee` | ::mlir::FlatSymbolRefAttr | flat symbol reference attribute
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`operands` | any type
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+&laquo;unnamed&raquo; | tensor of any type values
+
 ### `onnx.CastMap` (::mlir::ONNXCastMapOp)
 
 ONNX CastMap operation

--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_onnx_mlir_library(OMONNXToKrnl
   ConvertONNXToKrnl.cpp
   ONNXToKrnlCommon.cpp
+  PerfectHash.cpp
   ControlFlow/Loop.cpp
   ControlFlow/Scan.cpp
   Math/CumSum.cpp
@@ -17,6 +18,7 @@ add_onnx_mlir_library(OMONNXToKrnl
   Math/Reduction.cpp
   Math/Softmax.cpp
   Math/TopK.cpp
+  ML/CategoryMapper.cpp
   NN/Conv.cpp
   NN/Normalization.cpp
   NN/Pooling.cpp

--- a/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
+++ b/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
@@ -1,0 +1,297 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------------ CategoryMapper.cpp - Lowering CategoryMapper Op ---------===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file lowers the ONNX CategoryMapper Operator to Krnl dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+#include "src/Conversion/ONNXToKrnl/PerfectHash.hpp"
+#include "src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp"
+
+#include "mlir/Dialect/SCF/SCF.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using llvm::dbgs;
+
+#define DEBUG_TYPE "category_mapper_onnx_to_krnl"
+
+struct ONNXCategoryMapperOpLowering : public ConversionPattern {
+  using PerfectHashTable = struct {
+    Value G;
+    Value V;
+    Value len;
+  };
+
+  ONNXCategoryMapperOpLowering(MLIRContext *ctx)
+      : ConversionPattern(ONNXCategoryMapperOp::getOperationName(), 1, ctx) {}
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const final {
+    auto categoryMapperOp = cast<ONNXCategoryMapperOp>(op);
+    ONNXCategoryMapperOpAdaptor operandAdaptor(operands);
+
+    ONNXCategoryMapperOpShapeHelper shapeHelper(&categoryMapperOp, &rewriter,
+        getDenseElementAttributeFromKrnlValue,
+        loadDenseElementArrayValueAtIndex);
+    LogicalResult shapeComputed = shapeHelper.computeShape(operandAdaptor);
+    (void)shapeComputed;
+    assert(succeeded(shapeComputed) && "Could not compute output shape");
+
+    // Operands and attributes.
+    Location loc = categoryMapperOp.getLoc();
+    Value X = operandAdaptor.X();
+    ArrayAttr cats_int64sAttr = categoryMapperOp.cats_int64sAttr();
+    ArrayAttr cats_stringsAttr = categoryMapperOp.cats_stringsAttr();
+
+    DenseElementsAttr cats_int64s = mlir::DenseElementsAttr::get(
+        RankedTensorType::get(
+            cats_int64sAttr.size(), rewriter.getIntegerType(64)),
+        cats_int64sAttr.getValue());
+    DenseElementsAttr cats_strings = mlir::DenseElementsAttr::get(
+        RankedTensorType::get(
+            cats_stringsAttr.size(), StringType::get(rewriter.getContext())),
+        cats_stringsAttr.getValue());
+
+    IntegerAttr default_int64 = categoryMapperOp.default_int64Attr();
+    DenseElementsAttr default_string =
+        (categoryMapperOp.default_stringAttr())
+            ? mlir::DenseElementsAttr::get(
+                  RankedTensorType::get(
+                      {}, StringType::get(rewriter.getContext())),
+                  categoryMapperOp.default_stringAttr().getValue())
+            : nullptr;
+
+    // Basic information.
+    auto memRefType = convertToMemRefType(*op->result_type_begin());
+    int64_t rank = memRefType.getShape().size();
+    ShapedType inputType = X.getType().cast<ShapedType>();
+    Type elementType = inputType.getElementType();
+
+    // Insert an allocation and deallocation for the result of this operation.
+    Value alloc = insertAllocAndDeallocSimple(
+        rewriter, op, memRefType, loc, shapeHelper.dimsForOutput(0));
+
+    MultiDialectBuilder<KrnlBuilder, MathBuilder> create(
+        rewriter, op->getLoc());
+
+    // Generate a perfect hash table. The hash table will be used to lookup the
+    // index of the input values.
+    PerfectHashTable perfectHashTable = createPerfectHashTable(cats_int64s,
+        cats_strings, cats_int64sAttr, cats_stringsAttr, elementType, create);
+
+    // Create loop invariant values.
+    Value constantForCatsInt64s = create.krnl.constant(
+        convertToMemRefType(cats_int64s.getType()), "cats_int64s", cats_int64s);
+
+    Value constantForCatsStrings =
+        create.krnl.constant(convertToMemRefType(cats_strings.getType()),
+            "cats_strings", cats_strings);
+
+    Value defaultInt64 = (default_int64)
+                             ? create.math.constant(rewriter.getIntegerType(64),
+                                   default_int64.getSInt())
+                             : nullptr;
+    Value defaultString =
+        (default_string)
+            ? create.krnl.constant(
+                  MemRefType::get({}, StringType::get(rewriter.getContext())),
+                  "default_string", default_string)
+            : nullptr;
+
+    // Lookup the index in the perfect hash table corresponding to
+    // each input value.
+    MemRefBoundsIndexCapture inputBounds(X);
+    LiteralIndexExpr zeroIE(0);
+    SmallVector<IndexExpr, 4> lbs(rank, zeroIE);
+    SmallVector<IndexExpr, 4> ubs;
+    inputBounds.getDimList(ubs);
+
+    ValueRange loopDef = create.krnl.defineLoops(rank);
+    create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
+        [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
+          // Determine the index of 'inputElem' in the perfect hash table
+          // 'pHash'. Note: the index might not be valid (this happens
+          // when the 'inputElem' is not present in the perfect hash
+          // table).
+          Value inputElem = createKrnl.load(X, loopInd);
+          Value index, isIndexValid;
+          std::tie(index, isIndexValid) =
+              emitFindIndex(inputElem, elementType, perfectHashTable,
+                  constantForCatsInt64s, constantForCatsStrings, create);
+
+          // Store the final result.
+          scf::IfOp ifOp = rewriter.create<scf::IfOp>(
+              loc, isIndexValid, /*withElseRegion=*/true);
+          storeResult(index, elementType, ifOp, constantForCatsInt64s,
+              constantForCatsStrings, defaultInt64, defaultString, alloc,
+              loopInd, createKrnl, rewriter);
+        });
+
+    rewriter.replaceOp(op, alloc);
+
+    LLVM_DEBUG({
+      FuncOp function = getContainingFunction(op);
+      assert(function && "Could not find parent function");
+      dbgs() << "function: " << function << "\n";
+    });
+
+    return success();
+  }
+
+private:
+  Attribute getElemAttr(ArrayAttr arr, int32_t idx) const {
+    return arr.getValue()[idx];
+  }
+
+  // Generate a perfect hash table for the input dictionary.
+  // Depending on the runtime type 'elementType' (the type of the element of
+  // the input tensor) this function created a perfect hash table for:
+  //  - cats_int64s if elementType is a int64_t
+  //  - cats_strings if elementType is a string
+  PerfectHashTable createPerfectHashTable(DenseElementsAttr cats_int64s,
+      DenseElementsAttr cats_strings, ArrayAttr cats_int64s_ArrayAttr,
+      ArrayAttr cats_strings_ArrayAttr, Type elementType,
+      const MultiDialectBuilder<KrnlBuilder, MathBuilder> &create) const {
+    OpBuilder builder = create.krnl.getBuilder();
+    PerfectHashTable res;
+
+    // Create constants to hold the arrays 'G' and 'V'.
+    auto createConstants = [&](const SmallVector<int32_t> &G,
+                               const SmallVector<int32_t> &V) {
+      assert(V.size() == G.size() && "V and G should have the same size");
+
+      MemRefType type = MemRefType::get(
+          {static_cast<int64_t>(V.size())}, builder.getIntegerType(32));
+      res.G = create.krnl.constant(type, "G", builder.getI32VectorAttr(G));
+      res.V = create.krnl.constant(type, "V", builder.getI32VectorAttr(V));
+      res.len = create.math.constant(builder.getIntegerType(32), G.size());
+      return res;
+    };
+
+    TypeSwitch<Type>(elementType)
+        .Case<IntegerType>([&](IntegerType type) {
+          // Populate the dictionary.
+          assert(type.getWidth() == 64 && "Unexpected integer type");
+          std::map<int64_t, int32_t> dict;
+          int32_t size = cats_int64s.size();
+          for (int32_t idx = 0; idx < size; ++idx) {
+            Attribute elemAttr = getElemAttr(cats_int64s_ArrayAttr, idx);
+            int64_t key = elemAttr.cast<IntegerAttr>().getInt();
+            dict[key] = idx;
+          }
+
+          // Create the perfect hash (i.e. G and V), store them into
+          // constants.
+          PerfectHash<int64_t, int32_t> pHash(dict);
+          res = createConstants(pHash.getG(), pHash.getV());
+        })
+        .Case<StringType>([&](StringType type) {
+          // Populate the dictionary.
+          std::map<StringRef, int32_t> dict;
+          int32_t size = cats_strings.size();
+          for (int32_t idx = 0; idx < size; ++idx) {
+            Attribute elemAttr = getElemAttr(cats_strings_ArrayAttr, idx);
+            StringRef key = elemAttr.cast<StringAttr>().getValue();
+            dict[key] = idx;
+          }
+
+          // Create the perfect hash (i.e. G and V), store them into
+          // constants.
+          PerfectHash<StringRef, int32_t> pHash(dict);
+          res = createConstants(pHash.getG(), pHash.getV());
+        })
+        .Default([&](Type type) { llvm_unreachable("Illegal KeyTy"); });
+
+    return res;
+  }
+
+  // Determine the index of 'inputElem' in the perfect hash table 'pHash'.
+  // Return the index and a true/false value depending on whether the index is
+  // valid or not.
+  std::tuple<Value, Value> emitFindIndex(Value inputElem, Type elementType,
+      const PerfectHashTable &pHash, Value constantForCatsInt64s,
+      Value constantForCatsStrings,
+      const MultiDialectBuilder<KrnlBuilder, MathBuilder> &create) const {
+    OpBuilder builder = create.krnl.getBuilder();
+    Value index = create.krnl.findIndex(inputElem, pHash.G, pHash.V, pHash.len);
+
+    std::tuple<Value, Value> res;
+    TypeSwitch<Type>(elementType)
+        .Case<IntegerType>([&](IntegerType type) {
+          // Determine whether the index returned is valid.
+          // The index is valid if 'inputElem' compares equal to the string in
+          // 'constantForCatsInt64s'.
+          Value compareVal = create.krnl.load(constantForCatsInt64s, {index});
+          Value isIndexValid = create.math.eq(inputElem, compareVal);
+          res = std::make_tuple(index, isIndexValid);
+        })
+        .Case<StringType>([&](StringType type) {
+          // Determine whether the index returned is valid.
+          // The index is valid if 'inputElem' compares equal to the string in
+          // 'constantForCatsStrings'.
+          Value compareVal = create.krnl.load(constantForCatsStrings, {index});
+          Value strlenRes = create.krnl.strlen(compareVal);
+          Value strncmpRes =
+              create.krnl.strncmp(inputElem, compareVal, strlenRes);
+          Value zeroVal = create.math.constant(builder.getIntegerType(32), 0);
+          Value isIndexValid = create.math.eq(strncmpRes, zeroVal);
+          res = std::make_tuple(index, isIndexValid);
+        })
+        .Default([&](Type type) { llvm_unreachable("Illegal KeyTy"); });
+
+    return res;
+  }
+
+  // Store the result in the 'alloc' buffer.
+  // Given the 'index' of the input element and an 'ifOp' operation, this
+  // function generates code in the 'then' and 'else' basic blocks to determines
+  // whether the index is valid. If the index is valid it is used to retrieve
+  // the mapped value corresponding to the input element, otherwise the default
+  // value is used.
+  void storeResult(Value index, Type elementType, scf::IfOp ifOp,
+      Value constantForCatsInt64s, Value constantForCatsStrings,
+      Value defaultInt64, Value defaultString, Value alloc, ValueRange loopInd,
+      const KrnlBuilder &createKrnl,
+      ConversionPatternRewriter &rewriter) const {
+    TypeSwitch<Type>(elementType)
+        .Case<IntegerType>([&](IntegerType type) {
+          // index is valid: retrieve the value from 'cat_strings'.
+          rewriter.setInsertionPointToStart(&ifOp.thenRegion().front());
+          Value loadData = createKrnl.load(constantForCatsStrings, {index});
+          createKrnl.store(loadData, alloc, loopInd);
+
+          // index is not valid: store the default value.
+          rewriter.setInsertionPointToStart(&ifOp.elseRegion().front());
+          Value loadDefault = createKrnl.load(defaultString);
+          createKrnl.store(loadDefault, alloc, loopInd);
+        })
+        .Case<StringType>([&](StringType type) {
+          // index is valid: retrieve the value from 'cat_int64s'.
+          rewriter.setInsertionPointToStart(&ifOp.thenRegion().front());
+          Value loadData = createKrnl.load(constantForCatsInt64s, {index});
+          createKrnl.store(loadData, alloc, loopInd);
+
+          // index is not valid: store the default value.
+          rewriter.setInsertionPointToStart(&ifOp.elseRegion().front());
+          createKrnl.store(defaultInt64, alloc, loopInd);
+        })
+        .Default([&](Type type) { llvm_unreachable("Illegal KeyTy"); });
+  }
+};
+
+void populateLoweringONNXCategoryMapperOpPattern(
+    RewritePatternSet &patterns, MLIRContext *ctx) {
+  patterns.insert<ONNXCategoryMapperOpLowering>(ctx);
+}

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -4,7 +4,7 @@
 
 //====------ ONNXToKrnlCommon.hpp - ONNX dialects to Krnl lowering --------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2021 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -217,23 +217,16 @@ Value emitScalarOpFor(ConversionPatternRewriter &rewriter, Location loc,
 }
 
 //===----------------------------------------------------------------------===//
-// Conversion from Tensor type to the Standard dialect MemRef type.
+// Type conversion from Onnx types to Krnl types:
+//   - from Tensor type to the Standard dialect MemRef type
+//   - from onnx.StringType to krnl.StringType
 //===----------------------------------------------------------------------===//
 
-struct TensorTypeConverter : public TypeConverter {
+class KrnlTypeConverter : public TypeConverter {
+public:
   using TypeConverter::TypeConverter;
 
-  TensorTypeConverter() { addConversion(convertType); }
-
-  static LogicalResult convertType(Type t, SmallVectorImpl<Type> &results) {
-    if (auto type = convertToMemRefType(t)) {
-      results.push_back(type);
-      return success();
-    }
-
-    results.push_back(t);
-    return success();
-  }
+  KrnlTypeConverter();
 
   /// Return true if the inputs and outputs of the given function type are
   /// legal. [Taken from MLIR and adapted to only check the legality of the
@@ -258,7 +251,6 @@ struct TensorTypeConverter : public TypeConverter {
 //===----------------------------------------------------------------------===//
 
 // `ControlFlow` directory methods:
-
 void populateLoweringONNXLoopOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx);
 
@@ -266,7 +258,6 @@ void populateLoweringONNXScanOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx);
 
 // `Math` directory methods:
-
 void populateLoweringONNXClipOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx);
 
@@ -300,8 +291,11 @@ void populateLoweringONNXSoftmaxOpPattern(
 void populateLoweringONNXTopKOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx);
 
-// `NN` directory methods:
+// `ML` directory methods:
+void populateLoweringONNXCategoryMapperOpPattern(
+    RewritePatternSet &patterns, MLIRContext *ctx);
 
+// `NN` directory methods:
 void populateLoweringONNXConvOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx);
 
@@ -441,7 +435,7 @@ Location ONNXLoc(Operation *op) {
 }
 
 /// This function returns a scalar of type 'dtype' from an optional value.
-/// Optional value must be: NoneType, memref<1xdtype> or memref<dtype>. Default
-/// value is used in case of NoneType.
+/// Optional value must be: NoneType, memref<1xdtype> or memref<dtype>.
+/// Default value is used in case of NoneType.
 Value getOptionalScalarValue(ConversionPatternRewriter &rewriter, Location loc,
     Value optionalScalar, Type elementType, double defaultValue);

--- a/src/Conversion/ONNXToKrnl/PerfectHash.cpp
+++ b/src/Conversion/ONNXToKrnl/PerfectHash.cpp
@@ -1,0 +1,211 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====--------------- PerfectHash.cpp - Perfect Hash Table ----------------===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains the inplementation of a perfect hash table.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/ONNXToKrnl/PerfectHash.hpp"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <map>
+#include <numeric>
+#include <string>
+#include <vector>
+
+using namespace mlir;
+using llvm::dbgs;
+using llvm::SmallVector;
+
+#define DEBUG_TYPE "perfect_hash"
+
+class Utilities {
+public:
+  // Perform a 32-bit FNV (Fowler-Noll-Vo) hash on the given string.
+  static inline uint32_t hash(uint32_t hval, llvm::StringRef str) {
+    constexpr uint32_t prime = 0x01000193;
+    hval = (hval == 0) ? prime : hval;
+
+    for (const char c : str) {
+      hval *= prime;
+      hval ^= c;
+    }
+    return hval;
+  }
+
+  // Adaptation of 32-bit FNV for int64_t values.
+  static inline uint32_t hash(uint32_t hval, int64_t val) {
+    char str[20];
+    sprintf(str, "%lld", (long long)val);
+
+    return hash(hval, std::string(str));
+  }
+
+  // Extracts the keys of the given map.
+  template <typename KeyType, typename ValueType>
+  static SmallVector<KeyType> extractKeys(
+      const std::map<KeyType, ValueType> &map) {
+    SmallVector<KeyType> keys;
+    for (const auto &entry : map)
+      keys.push_back(entry.first);
+    return keys;
+  }
+
+  // Generate the integers in the range [0 .. max-1].
+  static SmallVector<uint32_t> range(uint32_t max) {
+    SmallVector<uint32_t> range(max);
+    std::iota(range.begin(), range.end(), 0);
+    return range;
+  }
+
+  // Generate the integers in the range [min .. max-1].
+  static SmallVector<uint32_t> range(uint32_t min, uint32_t max) {
+    SmallVector<uint32_t> range(max - min);
+    std::iota(range.begin(), range.end(), min);
+    return range;
+  }
+
+  // Generate the integers [min, min+step, ...].
+  static SmallVector<uint32_t> range(int32_t min, int32_t max, int32_t step) {
+    SmallVector<uint32_t> range;
+    int32_t nElems = (max - min) / step;
+    if (nElems < 1)
+      return range;
+
+    range.resize(nElems);
+    int32_t num = min;
+    std::generate_n(range.begin(), nElems, [&num, step]() {
+      int32_t res = num;
+      num += step;
+      return res;
+    });
+    return range;
+  }
+
+  template <typename T>
+  static void print(const llvm::SmallVectorImpl<T> &V,
+      const llvm::StringRef name, llvm::raw_ostream &os) {
+    os << name << ": [ ";
+    for (const T &elem : V)
+      os << elem << ", ";
+    os << "]\n";
+  }
+
+  template <typename KeyType, typename ValueType>
+  static void print(const std::map<KeyType, ValueType> &M,
+      const llvm::StringRef name, llvm::raw_ostream &os) {
+    os << name << " : {";
+    for (const auto &entry : M)
+      os << "'" << entry.first << "': " << entry.second << ", ";
+    os << "}\n";
+  }
+};
+
+template <typename KeyTy, typename ValueTy>
+PerfectHash<KeyTy, ValueTy>::PerfectHash(const std::map<KeyTy, ValueTy> &dict)
+    : dict(dict) {
+  assert(!dict.empty() && "Dictionary should not be empty");
+  size_t size = dict.size();
+  G.resize(size, 0);
+  V.resize(size, -1);
+  createPerfectHash();
+}
+
+// Note: KeyTy is expected to be either a char* or a int64_t.
+// TODO: add a trait to ensure template cannot be instantiated with an
+// unexpected type.
+template <typename KeyTy, typename ValueTy>
+void PerfectHash<KeyTy, ValueTy>::createPerfectHash() {
+  LLVM_DEBUG({ Utilities::print(dict, "dict", dbgs()); });
+
+  // Step 1: place all of the keys into buckets.
+  size_t size = dict.size();
+  SmallVector<KeyTy> keys = Utilities::extractKeys<KeyTy, ValueTy>(dict);
+  LLVM_DEBUG({ Utilities::print(keys, "keys", dbgs()); });
+
+  SmallVector<SmallVector<KeyTy>> buckets(size);
+  for (const KeyTy &key : keys) {
+    buckets[Utilities::hash(0, key) % size].push_back(key);
+  }
+
+  // Step 2: Sort the buckets and process the ones with the most items first.
+  llvm::sort(buckets, [](const llvm::SmallVectorImpl<KeyTy> &v1,
+                          const llvm::SmallVectorImpl<KeyTy> &v2) {
+    return v1.size() > v2.size();
+  });
+
+  uint32_t biMax = 0;
+  for (uint32_t bi : Utilities::range(size)) {
+    LLVM_DEBUG(dbgs() << "bi=" << bi << "\n");
+    biMax = bi;
+    SmallVector<KeyTy> &bucket = buckets[bi];
+    if (bucket.size() <= 1)
+      break;
+
+    int32_t hval = 1;
+    size_t item = 0;
+    SmallVector<uint32_t> slots;
+
+    // Repeatedly try different hash values until we find a hash function that
+    // places all items in the bucket into free slots.
+    while (item < bucket.size()) {
+      uint32_t slot = Utilities::hash(hval, bucket[item]) % size;
+      if (V[slot] != -1 ||
+          std::find(slots.begin(), slots.end(), slot) != slots.end()) {
+        hval++;
+        item = 0;
+        slots.clear();
+      } else {
+        slots.push_back(slot);
+        item++;
+      }
+    }
+
+    G[Utilities::hash(0, bucket[0]) % size] = hval;
+    for (uint32_t i : Utilities::range(bucket.size()))
+      V[slots[i]] = dict.at(bucket[i]);
+
+    LLVM_DEBUG({ Utilities::print(G, "G", dbgs()); });
+    LLVM_DEBUG({ Utilities::print(V, "V", dbgs()); });
+  }
+
+  // Place remaining buckets (containing a single entry) into a free slot. Use
+  // a negative value of hval to indicate this.
+  SmallVector<uint32_t> freeList;
+  for (uint32_t i : Utilities::range(size))
+    if (V[i] == -1)
+      freeList.push_back(i);
+
+  LLVM_DEBUG(Utilities::print(freeList, "freeList", dbgs()));
+  LLVM_DEBUG(dbgs() << "biMax: " << biMax << "\n");
+
+  for (uint32_t i : Utilities::range(biMax, size)) {
+    SmallVector<KeyTy> &bucket = buckets[i];
+    if (bucket.size() == 0)
+      break;
+
+    uint32_t slot = freeList.back();
+    freeList.pop_back();
+
+    // Subtract one to ensure it's negative even if the zeroeth slot was used.
+    G[Utilities::hash(0, bucket[0]) % size] = -(int32_t)slot - 1;
+    V[slot] = dict.at(bucket[0]);
+
+    LLVM_DEBUG({ Utilities::print(G, "G", dbgs()); });
+    LLVM_DEBUG({ Utilities::print(V, "V", dbgs()); });
+  }
+}
+
+namespace mlir {
+template class PerfectHash<int64_t, int32_t>;
+template class PerfectHash<llvm::StringRef, int32_t>;
+} // namespace mlir

--- a/src/Conversion/ONNXToKrnl/PerfectHash.hpp
+++ b/src/Conversion/ONNXToKrnl/PerfectHash.hpp
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====--------------- PerfectHash.hpp - Perfect Hash Table ----------------===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains the declaration of a perfect hash table.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <map>
+
+namespace mlir {
+
+template <typename T>
+struct is_supported {
+  enum { value = false };
+};
+
+template <>
+struct is_supported<int64_t> {
+  enum { value = true };
+};
+
+template <>
+struct is_supported<llvm::StringRef> {
+  enum { value = true };
+};
+
+template <typename KeyTy, typename ValueTy>
+class PerfectHash {
+  static_assert(is_supported<KeyTy>::value, "KeyTy not supported");
+
+  // The hash table is defined by G and V.
+  llvm::SmallVector<int32_t> G;
+  llvm::SmallVector<int32_t> V;
+  const std::map<KeyTy, ValueTy> &dict;
+
+public:
+  PerfectHash(const std::map<KeyTy, ValueTy> &dict);
+
+  const llvm::SmallVector<int32_t> &getG() const { return G; }
+  const llvm::SmallVector<int32_t> &getV() const { return V; }
+
+private:
+  // Creates a minimal perfect hash for the dictionary.
+  void createPerfectHash();
+};
+
+} // namespace mlir

--- a/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
@@ -20,14 +20,13 @@ struct ONNXConstantOpLowering : public ConversionPattern {
   static int constantID;
 
   ONNXConstantOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXConstantOp::getOperationName(), 1, ctx) {
-    constantID = 0;
-  }
+      : ConversionPattern(mlir::ONNXConstantOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     auto loc = ONNXLoc<ONNXConstantOp>(op);
     auto constantOp = llvm::dyn_cast<ONNXConstantOp>(op);
+    assert(constantOp && "Op does not have type ONNXConstantOp");
 
     if (constantOp.sparse_value().hasValue())
       return emitError(loc, "Only support dense values at this time");
@@ -59,7 +58,7 @@ struct ONNXConstantOpLowering : public ConversionPattern {
   }
 };
 
-int ONNXConstantOpLowering::constantID;
+int ONNXConstantOpLowering::constantID = 0;
 
 void populateLoweringONNXConstantOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx) {

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -396,22 +396,22 @@ void generateIndexMap(
 
 //====---------------- Support for Krnl Builder ----------------------===//
 
-Value KrnlBuilder::load(Value memref, ValueRange indices) {
+Value KrnlBuilder::load(Value memref, ValueRange indices) const {
   return b.create<KrnlLoadOp>(loc, memref, indices);
 }
 
-Value KrnlBuilder::loadIE(Value memref, ArrayRef<IndexExpr> indices) {
+Value KrnlBuilder::loadIE(Value memref, ArrayRef<IndexExpr> indices) const {
   SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
   return b.create<KrnlLoadOp>(loc, memref, indexValues);
 }
 
-void KrnlBuilder::store(Value val, Value memref, ValueRange indices) {
+void KrnlBuilder::store(Value val, Value memref, ValueRange indices) const {
   b.create<KrnlStoreOp>(loc, val, memref, indices);
 }
 
 void KrnlBuilder::storeIE(
-    Value val, Value memref, ArrayRef<IndexExpr> indices) {
+    Value val, Value memref, ArrayRef<IndexExpr> indices) const {
   SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
   b.create<KrnlStoreOp>(loc, val, memref, indexValues);
@@ -469,14 +469,6 @@ void KrnlBuilder::iterateIE(ValueRange originalLoops, ValueRange optimizedLoops,
       });
 }
 
-void KrnlBuilder::memcpy(Value dest, Value src, Value size) {
-  b.create<KrnlMemcpyOp>(loc, dest, src, size);
-}
-
-void KrnlBuilder::memset(Value dest, Value val) {
-  b.create<KrnlMemsetOp>(loc, dest, val);
-}
-
 void KrnlBuilder::copyToBuffer(Value bufferMemref, Value sourceMemref,
     ValueRange starts, Value padValue, ArrayRef<int64_t> tileSize,
     ArrayRef<int64_t> padToNext, bool transpose) {
@@ -517,6 +509,35 @@ void KrnlBuilder::matmul(Value A, ValueRange aStart, Value B, ValueRange bStart,
   b.create<KrnlMatMulOp>(loc, A, aStart, B, bStart, C, cStart, loops,
       computeStarts[0], computeStarts[1], computeStarts[2], globalUBs[0],
       globalUBs[1], globalUBs[2], simdize, unroll, overcompute);
+}
+
+Value KrnlBuilder::constant(
+    MemRefType type, StringRef name, DenseElementsAttr value) const {
+  static int32_t constantID = 0;
+  return b.create<KrnlGlobalOp>(loc, type, b.getI64ArrayAttr(type.getShape()),
+      b.getStringAttr(name + std::to_string(constantID++)), value,
+      /*offset=*/nullptr,
+      /*alignment=*/nullptr);
+}
+
+void KrnlBuilder::memcpy(Value dest, Value src, Value size) const {
+  b.create<KrnlMemcpyOp>(loc, dest, src, size);
+}
+
+void KrnlBuilder::memset(Value dest, Value val) const {
+  b.create<KrnlMemsetOp>(loc, dest, val);
+}
+
+Value KrnlBuilder::strncmp(Value str1, Value str2, Value len) const {
+  return b.create<KrnlStrncmpOp>(loc, b.getI32Type(), str1, str2, len);
+}
+
+Value KrnlBuilder::strlen(Value str) const {
+  return b.create<KrnlStrlenOp>(loc, b.getI64Type(), str);
+}
+
+Value KrnlBuilder::findIndex(Value input, Value G, Value V, Value len) const {
+  return b.create<KrnlFindIndexOp>(loc, b.getIndexType(), input, G, V, len);
 }
 
 bool isKrnlGlobalConstant(Value result) {

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -278,10 +278,10 @@ struct KrnlBuilder : public DialectBuilder {
   KrnlBuilder(OpBuilder &b, Location loc) : DialectBuilder(b, loc) {}
   KrnlBuilder(DialectBuilder &db) : DialectBuilder(db) {}
 
-  Value load(Value memref, ValueRange indices = {});
-  Value loadIE(Value memref, ArrayRef<IndexExpr> indices);
-  void store(Value val, Value memref, ValueRange indices = {});
-  void storeIE(Value val, Value memref, ArrayRef<IndexExpr> indices);
+  Value load(Value memref, ValueRange indices = {}) const;
+  Value loadIE(Value memref, ArrayRef<IndexExpr> indices) const;
+  void store(Value val, Value memref, ValueRange indices = {}) const;
+  void storeIE(Value val, Value memref, ArrayRef<IndexExpr> indices) const;
 
   Value vectorTypeCast(Value sourceMemref, int64_t vectorLen);
 
@@ -301,9 +301,6 @@ struct KrnlBuilder : public DialectBuilder {
       ArrayRef<IndexExpr> lbs, ArrayRef<IndexExpr> ubs,
       function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
           bodyBuilderFn);
-
-  void memcpy(Value dest, Value src, Value size);
-  void memset(Value dest, Value val);
 
   void copyToBuffer(
       // Buffer and source memory. Source memref may have a higher rank than
@@ -357,6 +354,18 @@ struct KrnlBuilder : public DialectBuilder {
   void matmul(Value A, ValueRange aStart, Value B, ValueRange bStart, Value C,
       ValueRange cStart, ValueRange loops, ValueRange computeStarts,
       ValueRange globalUBs, bool simdize, bool unroll, bool overcompute);
+
+  Value constant(
+      MemRefType type, StringRef name, DenseElementsAttr value) const;
+
+  // C library functions.
+  void memcpy(Value dest, Value src, Value size) const;
+  void memset(Value dest, Value val) const;
+  Value strncmp(Value str1, Value str2, Value len) const;
+  Value strlen(Value str) const;
+
+  // Onnx-mlir runtime functions.
+  Value findIndex(Value input, Value G, Value V, Value len) const;
 };
 
 // Recursive class specialized for KrnlBuilder refereed to as krnl.

--- a/src/Dialect/Krnl/KrnlOps.hpp
+++ b/src/Dialect/Krnl/KrnlOps.hpp
@@ -31,28 +31,21 @@
 #include "src/Dialect/ONNX/MLIRDialectBuilder.hpp"
 
 namespace mlir {
+
 class KrnlOpsDialect : public Dialect {
 public:
   KrnlOpsDialect(MLIRContext *context);
+  KrnlOpsDialect() = delete;
+
   static StringRef getDialectNamespace() { return "krnl"; }
 
   /// Parse a type registered to this dialect.
-  Type parseType(DialectAsmParser &parser) const override {
-    if (succeeded(parser.parseOptionalKeyword("loop")))
-      return LoopType::get(parser.getBuilder().getContext());
-
-    parser.emitError(parser.getCurrentLocation(), "Unknown type");
-    return {};
-  }
+  Type parseType(DialectAsmParser &parser) const override;
 
   /// Print a type registered to this dialect.
-  void printType(Type type, DialectAsmPrinter &os) const override {
-    TypeSwitch<Type>(type).Case<LoopType>([&](Type) {
-      os << "loop";
-      return;
-    });
-  }
+  void printType(Type type, DialectAsmPrinter &os) const override;
 };
+
 } // namespace mlir
 
 #define GET_OP_CLASSES

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -26,6 +26,8 @@ def Krnl_Dialect : Dialect {
   let cppNamespace = "::mlir";
 }
 
+def StringType : Type<CPred<"$_self.isa<::mlir::StringType>()">, "string type">;
+
 // Require regions to have krnl.terminate terminator operation.
 def ImplicitKrnlTerminator : SingleBlockImplicitTerminator<"KrnlTerminatorOp">;
 
@@ -997,6 +999,26 @@ def KrnlMemsetOp : Op<Krnl_Dialect, "memset", [MemRefsNormalizable,
   let assemblyFormat = [{ $dest `,` $value attr-dict `:` type($dest) }];
 }
 
+def KrnlStrlenOp : Op<Krnl_Dialect, "strlen", [NoSideEffect, MemRefsNormalizable]> {
+  let summary = "Compute the length of a string.";
+  let description = [{
+    Krnl operation that computes the length of a string.
+  }];
+
+  let arguments = (ins StringType:$str);
+  let results = (outs I64:$res);
+}
+
+def KrnlStrncmpOp : Op<Krnl_Dialect, "strncmp", [NoSideEffect, MemRefsNormalizable]> {
+  let summary = "Perform string comparison up to N bytes.";
+  let description = [{
+    Krnl operation that performs a string comparison up to N bytes.
+  }];
+
+  let arguments = (ins StringType:$str1, StringType:$str2, I64:$len);
+  let results = (outs I32:$res);
+}
+
 def KrnlRandomNormalOp : Op<Krnl_Dialect, "random_normal",
     []> {
   let summary = "Generate a random normal tensor.";
@@ -1011,4 +1033,18 @@ def KrnlRandomNormalOp : Op<Krnl_Dialect, "random_normal",
     AnyFloat:$seed);
 
   let results = (outs );
+}
+
+def KrnlFindIndexOp : Op<Krnl_Dialect, "find_index",
+    [NoSideEffect, MemRefsNormalizable]> {
+  let summary = "Retrieve an index into a perfect hash table described by G and V.";
+  let description = [{
+    This operation can be used to generate a call to a runtime function which, 
+    given two arrays of int32_t values (G and V), whih are used to represent a perfect 
+    hash table for a dictionary, returns the index corresponding to the input value.
+    The index returned is valid only if 'input' is in the dictionary described by G and V.
+  }];
+
+  let arguments = (ins AnyTypeOf<[StringType, I64]>:$input, I32MemRef:$G, I32MemRef:$V, I32:$len);
+  let results = (outs Index:$index);
 }

--- a/src/Dialect/Krnl/KrnlTypes.hpp
+++ b/src/Dialect/Krnl/KrnlTypes.hpp
@@ -14,9 +14,11 @@
 
 #pragma once
 
-#include <mlir/IR/Types.h>
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
 
 namespace mlir {
+
 class LoopType
     : public mlir::Type::TypeBase<LoopType, mlir::Type, mlir::TypeStorage> {
 
@@ -28,4 +30,18 @@ public:
   // Get a unique instance of Loop type.
   static LoopType get(mlir::MLIRContext *context) { return Base::get(context); }
 };
+
+class StringType
+    : public mlir::Type::TypeBase<StringType, mlir::Type, mlir::TypeStorage,
+          mlir::MemRefElementTypeInterface::Trait> {
+
+public:
+  using Base::Base;
+
+  // Get a unique instance of StringType.
+  static StringType get(mlir::MLIRContext *context) {
+    return Base::get(context);
+  }
+};
+
 } // namespace mlir

--- a/src/Dialect/ONNX/ONNXOps.hpp
+++ b/src/Dialect/ONNX/ONNXOps.hpp
@@ -63,9 +63,12 @@ namespace mlir {
 // Will put all the ONNXOps into this namespace
 namespace onnxmlir {
 class StringType
-    : public mlir::Type::TypeBase<StringType, mlir::Type, mlir::TypeStorage> {
+    : public mlir::Type::TypeBase<StringType, mlir::Type, mlir::TypeStorage,
+          mlir::MemRefElementTypeInterface::Trait> {
+
 public:
   using Base::Base;
+  using Base::getChecked;
 
   static StringType get(MLIRContext *ctx) { return Base::get(ctx); }
 };

--- a/src/Dialect/ONNX/ONNXOpsHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.cpp
@@ -53,7 +53,7 @@ Value OnnxBuilder::transpose(
   return b.create<ONNXTransposeOp>(loc, outputType, input, perm);
 }
 
-Value OnnxBuilder::constant(Attribute denseAttr) {
+Value OnnxBuilder::constant(Attribute denseAttr) const {
   return b.create<ONNXConstantOp>(loc, Attribute(), denseAttr);
 }
 

--- a/src/Dialect/ONNX/ONNXOpsHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.hpp
@@ -40,7 +40,7 @@ struct OnnxBuilder : DialectBuilder {
   Value reshape(Type outputType, Value input, Value shape) const;
   Value transpose(Type outputType, Value input, ArrayAttr perm) const;
 
-  Value constant(Attribute denseAttr);
+  Value constant(Attribute denseAttr) const;
 };
 
 // Recursive class specialized for OnnxBuilder refereed to as onnx.

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -729,7 +729,7 @@ func private @test_reducesum(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   "std.return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reducesum
-  // CHECK: [[GLOBAL:%.+]] = "krnl.global"() {name = "constant_0", shape = [1], value = dense<1> : tensor<1xi64>} : () -> memref<1xi64>
+  // CHECK: [[GLOBAL:%.+]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1> : tensor<1xi64>} : () -> memref<1xi64>
   // CHECK: [[RES:%.+]] = memref.alloc() {{.*}}: memref<3x2xf32>
   // CHECK: [[DEF_LOOPS1:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_LOOPS1]]#0, [[DEF_LOOPS1]]#1) with ([[DEF_LOOPS1]]#0 -> %arg1 = 0 to 3, [[DEF_LOOPS1]]#1 -> %arg2 = 0 to 2) {
@@ -1249,7 +1249,7 @@ func private @test_constant_dense_2d_value(%arg0: tensor<1xf32>) -> tensor<*xf32
   %0 = "onnx.Constant"() {value = dense<[[0.0, 0.0], [1.0, 1.1], [2.0, 2.1]]> : tensor<3x2xf32>} : () -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_constant_dense_2d_value
-  // CHECK: [[GLOBAL:%.+]] = "krnl.global"() {name = "constant_0", shape = [3, 2], value = dense<{{.*}}[0.000000e+00, 0.000000e+00], [1.000000e+00, 1.100000e+00], [2.000000e+00, 2.100000e+00]{{.*}}> : tensor<3x2xf32>} : () -> memref<3x2xf32>
+  // CHECK: [[GLOBAL:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3, 2], value = dense<{{.*}}[0.000000e+00, 0.000000e+00], [1.000000e+00, 1.100000e+00], [2.000000e+00, 2.100000e+00]{{.*}}> : tensor<3x2xf32>} : () -> memref<3x2xf32>
   // CHECK: return [[GLOBAL]] : memref<3x2xf32>
 }
 
@@ -1861,7 +1861,7 @@ func private @test_constant_of_shape_static_dims() -> tensor<*xf32> {
   "std.return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_constant_of_shape_static_dims
-  // CHECK: [[GLOBAL_CST:%.+]] = "krnl.global"() {name = "constant_0", shape = [3], value = dense<[3, 4, 5]> : tensor<3xi64>} : () -> memref<3xi64>
+  // CHECK: [[GLOBAL_CST:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<[3, 4, 5]> : tensor<3xi64>} : () -> memref<3xi64>
   // CHECK: [[RES:%.+]] = memref.alloc() {{.*}}: memref<3x4x5xf32>
   // CHECK: [[CST_VALUE:%.+]] = arith.constant 1.000000e+00 : f32
   // CHECK: [[LOOP_DEF:%.+]]:3 = krnl.define_loops 3
@@ -2229,8 +2229,8 @@ func @test_resize1(%arg0 : tensor<3x4xf32>) -> tensor<*xf32> {
 // CHECK-LABEL:       func @test_resize1       
 // CHECK-SAME:     ([[VAR_arg0:%.+]]: memref<3x4xf32>) -> memref<3x12xf32> {
 // CHECK:           [[VAR_cst:%.+]] = constant unit
-// CHECK:           [[VAR_1:%.+]] = "krnl.global"() {name = "constant_0", shape = [4], value = dense<[0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
-// CHECK:           [[VAR_2:%.+]] = "krnl.global"() {name = "constant_1", shape = [2], value = dense<[1.000000e+00, 3.000000e+00]> : tensor<2xf32>} : () -> memref<2xf32>
+// CHECK:           [[VAR_1:%.+]] = "krnl.global"() {name = {{.*}}, shape = [4], value = dense<[0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<4xf32>} : () -> memref<4xf32>
+// CHECK:           [[VAR_2:%.+]] = "krnl.global"() {name = {{.*}}, shape = [2], value = dense<[1.000000e+00, 3.000000e+00]> : tensor<2xf32>} : () -> memref<2xf32>
 // CHECK:           [[VAR_cst_0:%.+]] = arith.constant 1.000000e+00 : f32
 // CHECK:           [[VAR_cst_1:%.+]] = arith.constant 3.000000e+00 : f32
 // CHECK:           [[VAR_0:%.+]] = memref.alloc() {{.*}}: memref<3x12xf32>

--- a/test/mlir/onnx/onnx_lowering_category_mapper.mlir
+++ b/test/mlir/onnx/onnx_lowering_category_mapper.mlir
@@ -1,0 +1,68 @@
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
+
+// -----
+
+// Test whether lowering is correct for a string tensor input.
+func private @test_category_mapper_string_to_int64(%arg0 : tensor<2x2x!onnx.String>) -> tensor<2x2xi64> {
+  %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "cow"], default_int64 = -1: si64} : (tensor<2x2x!onnx.String>) -> tensor<2x2xi64>
+  "std.return"(%0) : (tensor<2x2xi64>) -> ()
+
+  // CHECK-LABEL: test_category_mapper_string_to_int64
+  // CHECK-DAG: [[LEN:%.+]] = arith.constant 3 : i32
+  // CHECK-DAG: [[ALLOCA:%.+]] = memref.alloc() {alignment = 16 : i64} : memref<2x2xi64>
+  // CHECK-DAG: [[G:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<[1, 0, -3]> : vector<3xi32>} : () -> memref<3xi32>
+  // CHECK-DAG: [[V:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<[1, 2, 0]> : vector<3xi32>} : () -> memref<3xi32>
+  // CHECK-DAG: [[CAT_INT64s:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<[1, 2, 3]> : tensor<3xi64>} : () -> memref<3xi64>
+  // CHECK-DAG: [[CAT_STRINGS:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>} : () -> memref<3x!krnl.string>
+  // CHECK-DAG: [[DEFAULT_INT64:%.+]] = arith.constant -1 : i64
+  // CHECK-DAG: [[ZERO:%.+]] = arith.constant 0 : i32
+  // CHECK-DAG: [[LOOP_0:%.+]]:2 = krnl.define_loops 2
+  // CHECK:     krnl.iterate([[LOOP_0]]#0, [[LOOP_0]]#1) with ([[LOOP_0]]#0 -> [[I_0:%.+]] = 0 to 2, [[LOOP_0]]#1 -> [[I_1:%.+]] = 0 to 2) {  
+  // CHECK:     [[IVS:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0]]#0, [[LOOP_0]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+  // CHECK:     [[LOAD1:%.+]] = krnl.load %arg0{{.}}[[IVS]]#0, [[IVS]]#1{{.}} : memref<2x2x!krnl.string>
+  // CHECK:     [[INDEX:%.+]] = "krnl.find_index"([[LOAD1]], [[G]], [[V]], [[LEN]]) : (!krnl.string, memref<3xi32>, memref<3xi32>, i32) -> index
+  // CHECK:     [[LOAD2:%.+]] = krnl.load [[CAT_STRINGS]]{{.}}[[INDEX]]{{.}} : memref<3x!krnl.string>
+  // CHECK:     [[STRLEN:%.+]] = "krnl.strlen"([[LOAD2]]) : (!krnl.string) -> i64
+  // CHECK:     [[STRNCMP:%.+]] = "krnl.strncmp"([[LOAD1]], [[LOAD2]], [[STRLEN]]) : (!krnl.string, !krnl.string, i64) -> i32
+  // CHECK:     [[VALID:%.+]] = arith.cmpi eq, [[STRNCMP]], [[ZERO]] : i32
+  // CHECK:     scf.if [[VALID]] {
+  // CHECK:     [[LOAD3:%.+]] = krnl.load [[CAT_INT64s]]{{.}}[[INDEX]]{{.}} : memref<3xi64>
+  // CHECK:     krnl.store [[LOAD3]], [[ALLOCA]]{{.}}[[IVS]]#0, [[IVS]]#1{{.}} : memref<2x2xi64>
+  // CHECK:     } else {
+  // CHECK:     krnl.store [[DEFAULT_INT64]], [[ALLOCA]]{{.}}[[IVS]]#0, [[IVS]]#1{{.}} : memref<2x2xi64>
+  // CHECK:     }
+  // CHECK:     return [[ALLOCA]] : memref<2x2xi64>
+}
+
+// -----
+
+// Test whether lowering is correct for a int64_t tensor input.
+func private @test_category_mapper_int64_to_string(%arg0 : tensor<2x2xi64>) -> tensor<2x2x!onnx.String> {
+  %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "cow"], default_string = "none"} : (tensor<2x2xi64>) -> tensor<2x2x!onnx.String>
+  "std.return"(%0) : (tensor<2x2x!onnx.String>) -> ()
+
+  // CHECK-LABEL: test_category_mapper_int64_to_string
+  // CHECK-DAG: [[LEN:%.+]] = arith.constant 3 : i32  
+  // CHECK-DAG: [[ALLOCA:%.+]] = memref.alloc() {alignment = 16 : i64} : memref<2x2x!krnl.string>
+  // CHECK-DAG: [[G:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<[-1, 1, 0]> : vector<3xi32>} : () -> memref<3xi32>
+  // CHECK-DAG: [[V:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<[2, 1, 0]> : vector<3xi32>} : () -> memref<3xi32>
+  // CHECK-DAG: [[CAT_INT64s:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<[1, 2, 3]> : tensor<3xi64>} : () -> memref<3xi64>
+  // CHECK-DAG: [[CAT_STRINGS:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3], value = dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>} : () -> memref<3x!krnl.string>
+  // CHECK-DAG: [[DEFAULT_STRING:%.+]] = "krnl.global"() {name = {{.*}}, shape = [], value = dense<"none"> : tensor<!krnl.string>} : () -> memref<!krnl.string>
+  // CHECK-DAG: [[LOOP_0:%.+]]:2 = krnl.define_loops 2
+  // CHECK:     krnl.iterate([[LOOP_0]]#0, [[LOOP_0]]#1) with ([[LOOP_0]]#0 -> [[I_0:%.+]] = 0 to 2, [[LOOP_0]]#1 -> [[I_1:%.+]] = 0 to 2) {  
+  // CHECK:     [[IVS:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0]]#0, [[LOOP_0]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+  // CHECK:     [[LOAD1:%.+]] = krnl.load %arg0{{.}}[[IVS]]#0, [[IVS]]#1{{.}} : memref<2x2xi64>
+  // CHECK:     [[INDEX:%.+]] = "krnl.find_index"([[LOAD1]], [[G]], [[V]], [[LEN]]) : (i64, memref<3xi32>, memref<3xi32>, i32) -> index
+  // CHECK:     [[LOAD2:%.+]] = krnl.load [[CAT_INT64s]]{{.}}[[INDEX]]{{.}} : memref<3xi64>
+  // CHECK:     [[VALID:%.+]] = arith.cmpi eq, [[LOAD1]], [[LOAD2]] : i64
+  // CHECK:     scf.if [[VALID]] {
+  // CHECK:     [[LOAD3:%.+]] = krnl.load [[CAT_STRINGS]]{{.}}[[INDEX]]{{.}} : memref<3x!krnl.string>
+  // CHECK:     krnl.store [[LOAD3]], [[ALLOCA]]{{.}}[[IVS]]#0, [[IVS]]#1{{.}} : memref<2x2x!krnl.string>
+  // CHECK:     } else {
+  // CHECK:     [[LOAD4:%.+]] = krnl.load [[DEFAULT_STRING]][] : memref<!krnl.string>    
+  // CHECK:     krnl.store [[LOAD4]], [[ALLOCA]]{{.}}[[IVS]]#0, [[IVS]]#1{{.}} : memref<2x2x!krnl.string>
+  // CHECK:     }
+  // CHECK:     return [[ALLOCA]] : memref<2x2x!krnl.string>
+}
+

--- a/test/mlir/onnx/onnx_lowering_range_op.mlir
+++ b/test/mlir/onnx/onnx_lowering_range_op.mlir
@@ -179,9 +179,9 @@ func @test_range_static_f32() -> tensor<*xf32> {
   return %0 : tensor<*xf32>
 
   // CHECK-LABEL: test_range_static_f32
-  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = "constant_0", shape = [1], value = dense<1.000000e+00> : tensor<1xf32>} : () -> memref<1xf32>
-  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = "constant_1", shape = [1], value = dense<1.000000e+01> : tensor<1xf32>} : () -> memref<1xf32>
-  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = "constant_2", shape = [1], value = dense<1.000000e+00> : tensor<1xf32>} : () -> memref<1xf32>
+  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1.000000e+00> : tensor<1xf32>} : () -> memref<1xf32>
+  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1.000000e+01> : tensor<1xf32>} : () -> memref<1xf32>
+  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1.000000e+00> : tensor<1xf32>} : () -> memref<1xf32>
     
   // CHECK: %[[C0:.*]] = arith.constant 0 : index
   // CHECK: [[START:%.*]] = krnl.load [[START_GLOBAL]][%[[C0]]] : memref<1xf32>
@@ -213,9 +213,9 @@ func @test_range_static_f64() -> tensor<*xf64> {
   return %0 : tensor<*xf64>
 
   // CHECK-LABEL: test_range_static_f64
-  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = "constant_0", shape = [1], value = dense<1.000000e+00> : tensor<1xf64>} : () -> memref<1xf64>
-  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = "constant_1", shape = [1], value = dense<1.000000e+01> : tensor<1xf64>} : () -> memref<1xf64>
-  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = "constant_2", shape = [1], value = dense<1.000000e+00> : tensor<1xf64>} : () -> memref<1xf64>
+  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1.000000e+00> : tensor<1xf64>} : () -> memref<1xf64>
+  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1.000000e+01> : tensor<1xf64>} : () -> memref<1xf64>
+  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1.000000e+00> : tensor<1xf64>} : () -> memref<1xf64>
     
   // CHECK: %[[C0:.*]] = arith.constant 0 : index
   // CHECK: [[START:%.*]] = krnl.load [[START_GLOBAL]][%[[C0]]] : memref<1xf64>
@@ -247,9 +247,9 @@ func @test_range_static_i16() -> tensor<*xi16> {
   return %0 : tensor<*xi16>
 
   // CHECK-LABEL: test_range_static_i16
-  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = "constant_0", shape = [1], value = dense<1> : tensor<1xi16>} : () -> memref<1xi16>
-  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = "constant_1", shape = [1], value = dense<10> : tensor<1xi16>} : () -> memref<1xi16>
-  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = "constant_2", shape = [1], value = dense<1> : tensor<1xi16>} : () -> memref<1xi16>
+  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1> : tensor<1xi16>} : () -> memref<1xi16>
+  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<10> : tensor<1xi16>} : () -> memref<1xi16>
+  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1> : tensor<1xi16>} : () -> memref<1xi16>
     
   // CHECK: %[[C0:.*]] = arith.constant 0 : index
   // CHECK: [[START:%.*]] = krnl.load [[START_GLOBAL]][%[[C0]]] : memref<1xi16>
@@ -281,9 +281,9 @@ func @test_range_static_i32() -> tensor<*xi32> {
   return %0 : tensor<*xi32>
 
   // CHECK-LABEL: test_range_static_i32
-  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = "constant_0", shape = [1], value = dense<1> : tensor<1xi32>} : () -> memref<1xi32>
-  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = "constant_1", shape = [1], value = dense<10> : tensor<1xi32>} : () -> memref<1xi32>
-  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = "constant_2", shape = [1], value = dense<1> : tensor<1xi32>} : () -> memref<1xi32>
+  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1> : tensor<1xi32>} : () -> memref<1xi32>
+  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<10> : tensor<1xi32>} : () -> memref<1xi32>
+  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1> : tensor<1xi32>} : () -> memref<1xi32>
     
   // CHECK: %[[C0:.*]] = arith.constant 0 : index
   // CHECK: [[START:%.*]] = krnl.load [[START_GLOBAL]][%[[C0]]] : memref<1xi32>
@@ -315,9 +315,9 @@ func @test_range_static_i64() -> tensor<*xi64> {
   return %0 : tensor<*xi64>
 
   // CHECK-LABEL: test_range_static_i64
-  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = "constant_0", shape = [1], value = dense<1> : tensor<1xi64>} : () -> memref<1xi64>
-  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = "constant_1", shape = [1], value = dense<10> : tensor<1xi64>} : () -> memref<1xi64>
-  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = "constant_2", shape = [1], value = dense<1> : tensor<1xi64>} : () -> memref<1xi64>
+  // CHECK: [[START_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1> : tensor<1xi64>} : () -> memref<1xi64>
+  // CHECK: [[LIMIT_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<10> : tensor<1xi64>} : () -> memref<1xi64>
+  // CHECK: [[DELTA_GLOBAL:%.*]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<1> : tensor<1xi64>} : () -> memref<1xi64>
     
   // CHECK: %[[C0:.*]] = arith.constant 0 : index
   // CHECK: [[START:%.*]] = krnl.load [[START_GLOBAL]][%[[C0]]] : memref<1xi64>

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -200,7 +200,7 @@ func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %arg2 
 // CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : index
 // CHECK-DAG:       [[CST_minus_2147483648_:%.+]] = arith.constant -2147483648 : index
 // CHECK-DAG:       [[CST_2147483647_:%.+]] = arith.constant 2147483647 : index
-// CHECK-DAG:       [[VAR_0_:%.+]] = "krnl.global"() {name = "constant_0", shape = [3, 4, 5], value = dense<{{.}}{{.}}[0, 1, 2, 3, 4], [10, 11, 12, 13, 14], [20, 21, 22, 23, 24], [30, 31, 32, 33, 34]{{.}}, {{.}}[100, 101, 102, 103, 104], [110, 111, 112, 113, 114], [120, 121, 122, 123, 124], [130, 131, 132, 133, 134]{{.}}, {{.}}[200, 201, 202, 203, 204], [210, 211, 212, 213, 214], [220, 221, 222, 223, 224], [230, 231, 232, 233, 234]{{.}}{{.}}> : tensor<3x4x5xi64>} : () -> memref<3x4x5xi64>
+// CHECK-DAG:       [[VAR_0_:%.+]] = "krnl.global"() {name = {{.*}}, shape = [3, 4, 5], value = dense<{{.}}{{.}}[0, 1, 2, 3, 4], [10, 11, 12, 13, 14], [20, 21, 22, 23, 24], [30, 31, 32, 33, 34]{{.}}, {{.}}[100, 101, 102, 103, 104], [110, 111, 112, 113, 114], [120, 121, 122, 123, 124], [130, 131, 132, 133, 134]{{.}}, {{.}}[200, 201, 202, 203, 204], [210, 211, 212, 213, 214], [220, 221, 222, 223, 224], [230, 231, 232, 233, 234]{{.}}{{.}}> : tensor<3x4x5xi64>} : () -> memref<3x4x5xi64>
 // CHECK-DAG:       [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{\[}}[[CST_0_]]{{\]}} : memref<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = arith.index_cast [[LOAD_PARAM_0_MEM_]] : i64 to index
@@ -405,7 +405,7 @@ func @test_gather_axis0(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 // CHECK-LABEL:  func @test_gather_axis0
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3x2xf32>) -> memref<2x2x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x2x2xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2, 2], value = dense<{{.}}[0, 1], [1, 2]{{.}}> : tensor<2x2xi64>} : () -> memref<2x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = {{.*}}, shape = [2, 2], value = dense<{{.}}[0, 1], [1, 2]{{.}}> : tensor<2x2xi64>} : () -> memref<2x2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 2) {
 // CHECK:             [[LOAD_VAR_1_MEM_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x2xi64>
@@ -430,7 +430,7 @@ func @test_gather_axis0neg(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x2x2xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [2, 2], value = dense<{{.}}[0, -1], [1, 2]{{.}}> : tensor<2x2xi64>} : () -> memref<2x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = {{.*}}, shape = [2, 2], value = dense<{{.}}[0, -1], [1, 2]{{.}}> : tensor<2x2xi64>} : () -> memref<2x2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 2) {
 // CHECK:             [[LOAD_VAR_1_MEM_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<2x2xi64>
@@ -456,7 +456,7 @@ func @test_gather_axis1(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
 // CHECK-LABEL:  func @test_gather_axis1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3x3xf32>) -> memref<3x1x2xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<3x1x2xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = "constant_0", shape = [1, 2], value = dense<{{.}}[0, 2]{{.}}> : tensor<1x2xi64>} : () -> memref<1x2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() {name = {{.*}}, shape = [1, 2], value = dense<{{.}}[0, 2]{{.}}> : tensor<1x2xi64>} : () -> memref<1x2xi64>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 1, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 2) {
 // CHECK:             [[LOAD_VAR_1_MEM_:%.+]] = krnl.load [[VAR_1_]]{{.}}[[I_1_]], [[I_2_]]{{.}} : memref<1x2xi64>
@@ -2133,7 +2133,7 @@ func @pad_constant_mode_constant_pads(%arg0: tensor<16x16xf32>) -> tensor<18x20x
 // CHECK-DAG: #map = affine_map<(d0) -> (d0 + 3)>
 // CHECK-LABEL:  func @pad_constant_mode_constant_pads
 // CHECK-SAME:   ([[DATA_:%.+]]: memref<16x16xf32>) -> memref<18x20xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = "krnl.global"() {name = "constant_1", shape = [1], value = dense<0.000000e+00> : tensor<1xf32>} : () -> memref<1xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = "krnl.global"() {name = {{.*}}, shape = [1], value = dense<0.000000e+00> : tensor<1xf32>} : () -> memref<1xf32>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<18x20xf32>
 // CHECK:           [[LOAD_VAR_0_MEM_:%.+]] = krnl.load [[VAR_0_]][] : memref<1xf32>
 // CHECK:           krnl.memset [[RES_]], [[LOAD_VAR_0_MEM_]] : memref<18x20xf32>


### PR DESCRIPTION
In this PR I have implemented the lowering code from the Onnx dialect to the Krnl dialect for the `CategoryMapper` operation.  The codegen supports `CategoryMapper` operators that have either a tensor of strings or a tensor of int64_t as their input. I have introduced a `krnl.string` custom type which is used to lower the existing `onnx.String` type. 

Signed-off-by: Ettore Tiotto <etiotto@ca.ibm.com>