### PR TITLE
Fix the compiler lib builds for multiconfig generators

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -2,6 +2,17 @@
 
 include_directories(${PROJECT_BINARY_DIR}/src)
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/ExternalUtil.hpp.in
+  ${CMAKE_CURRENT_BINARY_DIR}/ExternalUtil.hpp.cfg
+  @ONLY
+  )
+
+file(GENERATE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ExternalUtil.hpp
+  INPUT ${CMAKE_CURRENT_BINARY_DIR}/ExternalUtil.hpp.cfg
+  )
+
 # CMAKE_CFG_INTDIR is . for single-config generators such as make, and
 # it has a value (e.g. $(Configuration)) otherwise, so we can use it to
 # determine whether we are dealing with a multi-config generator.
@@ -10,17 +21,6 @@ if (NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")
 else()
   set(FILE_GENERATE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
 endif()
-
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/ExternalUtil.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/ExternalUtil.hpp.cfg
-  @ONLY
-  )
-
-file(GENERATE
-  OUTPUT ${FILE_GENERATE_DIR}/ExternalUtil.hpp
-  INPUT ${CMAKE_CURRENT_BINARY_DIR}/ExternalUtil.hpp.cfg
-  )
 
 add_custom_target(ExternalUtil DEPENDS ${FILE_GENERATE_DIR}/ExternalUtil.hpp)
 


### PR DESCRIPTION
When the code was separated into its own library, the generator expression for the file configuration was dropped. This is needed because file generation happens at cmake config time and for multiconfig generators such as VS or Xcode the build configuration is not known.

This change brings back the generator expression for file generation.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>