### PR TITLE
Fix EnableMemoryPool to account for 'memref.cast' operation.

### DIFF
--- a/src/Transform/EnableMemoryPool.cpp
+++ b/src/Transform/EnableMemoryPool.cpp
@@ -39,11 +39,14 @@ bool checkOpResultIsReturned(memref::AllocOp *allocOp) {
   // `ReinterpretCastOp`.
   SmallVector<Value, 32> castOpResults;
   function.walk([allocOp, &castOpResults](Operation *op) {
-    if (isa<memref::ReinterpretCastOp>(op) || isa<ONNXReshapeOp>(op) ||
-        isa<ONNXSqueezeV11Op>(op) || isa<ONNXUnsqueezeV11Op>(op)) {
+    if (isa<memref::ReinterpretCastOp>(op) || isa<memref::CastOp>(op) ||
+        isa<ONNXReshapeOp>(op) || isa<ONNXSqueezeV11Op>(op) ||
+        isa<ONNXUnsqueezeV11Op>(op)) {
       auto result = allocOp->getResult();
       for (const auto &operand : op->getOperands())
-        if (operand == result)
+        if (operand == result ||
+            std::find(castOpResults.begin(), castOpResults.end(), operand) !=
+                castOpResults.end())
           castOpResults.emplace_back(op->getResults()[0]);
     }
   });


### PR DESCRIPTION
In this PR we are fixing the problem described in work item #953.