### PR TITLE
CategoryMapper: shape inference and verification support.

### DIFF
--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -21,6 +21,7 @@ add_onnx_mlir_library(OMONNXOps
 
   ShapeInference/ArgMax.cpp
   ShapeInference/AveragePool.cpp
+  ShapeInference/CategoryMapper.cpp  
   ShapeInference/Compress.cpp
   ShapeInference/Concat.cpp
   ShapeInference/Conv.cpp

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -4414,9 +4414,68 @@ LogicalResult ONNXCastMapOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
+static LogicalResult verify(ONNXCategoryMapperOp op) {
+  ONNXCategoryMapperOpAdaptor operandAdaptor(op);
+
+  // Check input.
+  const Value X = operandAdaptor.X();
+  if (!hasShapeAndRank(X)) {
+    // Won't be able to do any checking at this stage.
+    return success();
+  }
+
+  ShapedType inputType = X.getType().dyn_cast<RankedTensorType>();
+  Type elementType = inputType.getElementType();
+  if (!elementType.isInteger(64) && !elementType.isa<StringType>())
+    return op.emitError("input must be a tensor of int64 or string");
+
+  // Check attributes.
+  if (!op.cats_int64s())
+    return op.emitError("cats_int64 attribute must be present");
+  if (!op.cats_strings())
+    return op.emitError("cats_strings attribute must be present");
+  if (ArrayAttrSize(op.cats_int64s()) != ArrayAttrSize(op.cats_strings()))
+    return op.emitError(
+        "cats_int64 and cats_strings should have the same size");
+
+  if (elementType.isInteger(64) && !op.default_stringAttr())
+    return op.emitError("'default_string' attribute is missing.");
+  if (elementType.isa<StringType>() && !op.default_int64Attr())
+    return op.emitError("'default_int64' attribute is missing.");
+  if (op.default_stringAttr() && op.default_int64Attr())
+    return op.emitError("Only one of 'default_int64' or 'default_string' "
+                        "attributes must be specified");
+
+  return success();
+}
+
 LogicalResult ONNXCategoryMapperOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  return emitError(NOT_IMPLEMENTED_MESSAGE);
+  // Cannot infer shape if no shape exists.
+  if (!X().getType().isa<RankedTensorType>())
+    return success();
+
+  Type inputElementType = X().getType().cast<ShapedType>().getElementType();
+  assert(
+      (inputElementType.isInteger(64) || inputElementType.isa<StringType>()) &&
+      "Input tensor must have int64 or string element type.");
+
+  ONNXCategoryMapperOpAdaptor operandAdaptor(*this);
+  ONNXCategoryMapperOpShapeHelper shapeHelper(this);
+  if (failed(shapeHelper.computeShape(operandAdaptor)))
+    return emitError("Failed to scan CategoryMapper parameters successfully");
+
+  Type outputElementType;
+  if (inputElementType.isInteger(64))
+    outputElementType = StringType::get(getContext());
+  else
+    outputElementType = IntegerType::get(getContext(), /*width=*/64);
+
+  SmallVector<int64_t, 4> outputDims;
+  IndexExpr::getShape(shapeHelper.dimsForOutput(0), outputDims);
+  getResult().setType(RankedTensorType::get(outputDims, outputElementType));
+
+  return success();
 }
 
 LogicalResult ONNXDictVectorizerOp::inferShapes(

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -6583,6 +6583,7 @@ def ONNXCategoryMapperOp:ONNX_Op<"CategoryMapper",
       return {-1};
     }
   }];
+  let verifier = [{ return ::verify(*this); }];
 }
 
 def ONNXDictVectorizerOp:ONNX_Op<"DictVectorizer",

--- a/src/Dialect/ONNX/ShapeInference/CategoryMapper.cpp
+++ b/src/Dialect/ONNX/ShapeInference/CategoryMapper.cpp
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----- CategoryMapper.cpp - Shape Inference for CategoryMapper Op -----===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file implements shape inference for the ONNX CategoryMapper operator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
+#include "src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp"
+
+ONNXCategoryMapperOpShapeHelper::ONNXCategoryMapperOpShapeHelper(
+    ONNXCategoryMapperOp *newOp)
+    : ONNXOpShapeHelper<ONNXCategoryMapperOp>(
+          newOp, newOp->getOperation()->getNumResults()) {}
+
+ONNXCategoryMapperOpShapeHelper::ONNXCategoryMapperOpShapeHelper(
+    ONNXCategoryMapperOp *newOp, OpBuilder *rewriter,
+    ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+    ArrayValueIndexCapture::LoadVal fLoadVal)
+    : ONNXOpShapeHelper<ONNXCategoryMapperOp>(newOp,
+          newOp->getOperation()->getNumResults(), rewriter, fGetDenseVal,
+          fLoadVal) {}
+
+LogicalResult ONNXCategoryMapperOpShapeHelper::computeShape(
+    ONNXCategoryMapperOpAdaptor operandAdaptor) {
+  Value X = operandAdaptor.X();
+  MemRefBoundsIndexCapture bounds(X);
+  int64_t rank = bounds.getRank();
+
+  DimsExpr outputDims(rank);
+  for (int64_t i = 0; i < rank; ++i)
+    outputDims[i] = bounds.getDim(i);
+  dimsForOutput() = outputDims;
+
+  return success();
+}

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
@@ -404,6 +404,7 @@ LogicalResult ONNXGenericPoolShapeHelper<OP_TYPE, OP_ADAPTOR>::computeShape(
 
 template struct ONNXOpShapeHelper<ONNXArgMaxOp>;
 template struct ONNXOpShapeHelper<ONNXAveragePoolOp>;
+template struct ONNXOpShapeHelper<ONNXCategoryMapperOp>;
 template struct ONNXOpShapeHelper<ONNXCompressOp>;
 template struct ONNXOpShapeHelper<ONNXConcatOp>;
 template struct ONNXOpShapeHelper<ONNXConvOp>;

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp
@@ -515,3 +515,13 @@ struct ONNXTopKOpShapeHelper : public ONNXOpShapeHelper<ONNXTopKOp> {
       ArrayValueIndexCapture::LoadVal fLoadVal);
   LogicalResult computeShape(ONNXTopKOpAdaptor operandAdaptor);
 };
+
+// Shape for ONNXCategoryMapperOp.
+struct ONNXCategoryMapperOpShapeHelper
+    : public ONNXOpShapeHelper<ONNXCategoryMapperOp> {
+  ONNXCategoryMapperOpShapeHelper(ONNXCategoryMapperOp *newOp);
+  ONNXCategoryMapperOpShapeHelper(ONNXCategoryMapperOp *newOp,
+      OpBuilder *rewriter, ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
+  LogicalResult computeShape(ONNXCategoryMapperOpAdaptor operandAdaptor);
+};

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2263,3 +2263,29 @@ func @topk_constant_k(%X: tensor<3x4x5xf32>) -> tensor<*xf32> {
   // CHECK-LABEL: topk_constant_k
   // CHECK: {{.*}} = "onnx.TopK"({{.*}}, {{.*}}) {axis = 1 : si64} : (tensor<3x4x5xf32>, tensor<i64>) -> (tensor<3x2x5xf32>, tensor<3x2x5xi64>)
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Test shape inference for CategoryMapper.
+//===----------------------------------------------------------------------===//
+
+func @test_category_mapper_string (%arg0: tensor<20x1x!onnx.String>) -> tensor<*xi64> {
+  %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "human"], default_int64 = 0 : si64} : (tensor<20x1x!onnx.String>) -> tensor<*xi64>
+  "std.return"(%0) : (tensor<*xi64>) -> ()
+
+  // CHECK-LABEL: test_category_mapper_string
+  // CHECK: [[RES:%.+]] = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "human"], default_int64 = 0 : si64} : (tensor<20x1x!onnx.String>) -> tensor<20x1xi64>
+  // CHECK: return [[RES]] : tensor<20x1xi64>
+}
+
+// -----
+
+func @test_category_mapper_int64 (%arg0: tensor<20x1xi64>) -> tensor<*x!onnx.String> {
+  %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "human"], default_string = "unclassified" : !onnx.String} : (tensor<20x1xi64>) -> tensor<*x!onnx.String>
+  "std.return"(%0) : (tensor<*x!onnx.String>) -> ()
+
+  // CHECK-LABEL: test_category_mapper_int64
+  // CHECK: [[RES:%.+]] = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "human"], default_string = "unclassified" : !onnx.String} : (tensor<20x1xi64>) -> tensor<20x1x!onnx.String>
+  // CHECK: return [[RES]] : tensor<20x1x!onnx.String>
+}

--- a/test/mlir/onnx/onnx_shape_inference_error.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_error.mlir
@@ -148,3 +148,39 @@ func @unsupport_resize_cubic_mode(%arg0 : tensor<3x4x5x6xf32>) -> tensor<*xf32> 
   "std.return"(%2) : (tensor<*xf32>) -> ()
 }
 
+// -----
+
+//===----------------------------------------------------------------------===//
+/// Unsupported configurations for ONNXCategoryMapperOp.
+//===----------------------------------------------------------------------===//
+
+func @unsupport_category_mapper_default_int64_missing(%arg0: tensor<20x1x!onnx.String>) -> tensor<*xi64> {
+  // expected-error @+1 {{'default_int64' attribute is missing.}}    
+  %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2], cats_strings = ["cat", "dog"], default_string = "abc" : si64} : (tensor<20x1x!onnx.String>) -> tensor<*xi64>
+  "std.return"(%0) : (tensor<*xi64>) -> ()
+}
+
+// -----
+
+func @unsupport_category_mapper_default_string_missing (%arg0: tensor<20x1xi64>) -> tensor<*x!onnx.String> {
+  // expected-error @+1 {{'default_string' attribute is missing.}}      
+  %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2], cats_strings = ["cat", "dog"], default_int64 = 1 : si64} : (tensor<20x1xi64>) -> tensor<*x!onnx.String>
+  "std.return"(%0) : (tensor<*x!onnx.String>) -> ()
+}
+
+// -----
+
+func @test_category_mapper_diff_size_attrs (%arg0: tensor<20x1xi64>) -> tensor<*x!onnx.String> {
+  // expected-error @+1 {{cats_int64 and cats_strings should have the same size}}      
+  %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2], cats_strings = ["dog"]} : (tensor<20x1xi64>) -> tensor<*x!onnx.String>
+  "std.return"(%0) : (tensor<*x!onnx.String>) -> ()
+}
+
+// -----
+
+func @test_category_mapper_diff_size_attrs (%arg0: tensor<20x1xi32>) -> tensor<*x!onnx.String> {
+  // expected-error @+1 {{'onnx.CategoryMapper' op operand #0 must be tensor of string type values or tensor of 64-bit signless integer values or memref of any type values, but got 'tensor<20x1xi32>'}}      
+  %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1], cats_strings = ["cat"]} : (tensor<20x1xi32>) -> tensor<*x!onnx.String>
+  "std.return"(%0) : (tensor<*x!onnx.String>) -> ()
+}
+

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -371,6 +371,7 @@ OpsWithCanonicalizer = [
 # Operations with custom verifiers (alphabetical order).
 OpsWithVerifier = [
     'AveragePool',
+    'CategoryMapper',    
     'Compress',
     'Conv',
     'DepthToSpace',


### PR DESCRIPTION
This PR adds support for shape inference for the `CategoryMapper` operator. It also adds a custom verification method for that operator. 

