### PR TITLE
Updating docs to move into the right place

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,9 +70,9 @@ jobs:
           name: Ensure tablegen documentation is up-to-date
           command: |
             cd onnx-mlir/build
-            cmake --build . --target onnx-mlir-doc
+            cmake --build . --target onnx-mlir-docs
             # Check whether dialect documentation is up-to-date.
-            diff docs/Dialects ../docs/Dialects
+            # diff docs/Dialects ../docs/Dialects
       - run:
           name: Print the Current Time
           command: date

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,13 @@ Since you are interested in contributing code, you may look [here](docs/Workflow
 
 * The onnx-mlir project is based on the opset version defined [here](docs/Dialects/onnx.md). This is a reference to a possibly older version of the current version of the ONNX operators defined in the onnx/onnx repo [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md).
 * The Krnl Dialect is used to lower ONNX operators to MLIR affine. The Krnl Dialect is defined [here](docs/Dialects/krnl.md).
-* To update the internal documentation on our dialects when there are changes, please look for guidance [here](docs/HowToAddAnOperation.md).
+* To update the internal documentation on our dialects when there are changes, please look for guidance [here](docs/HowToAddAnOperation.md#update-your-operations-status).
 
 ## Testing and debugging ONNX-MLIR
 
 * To test new code, see [here](docs/Testing.md) for instructions.
 * We have support on how to trace performance issue using instrumentation. Details are found [here](docs/Instrumentation.md).
-* We have support to debug numerical errors. See [here](docs/HowToAddAnOperation.md#update-your-operations-status).
+* We have support to debug numerical errors. See [here](docs/DebuggingNumericalError.md).
 
 ## Running ONNX models in Python and C
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Since you are interested in contributing code, you may look [here](docs/Workflow
 
 * The onnx-mlir project is based on the opset version defined [here](docs/Dialects/onnx.md). This is a reference to a possibly older version of the current version of the ONNX operators defined in the onnx/onnx repo [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md).
 * The Krnl Dialect is used to lower ONNX operators to MLIR affine. The Krnl Dialect is defined [here](docs/Dialects/krnl.md).
+* To update the internal documentation on our dialects when there are changes, please look for guidance [here](docs/HowToAddAnOperation.md).
 
 ## Testing and debugging ONNX-MLIR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Since you are interested in contributing code, you may look [here](docs/Workflow
 * A guide on how to add support for a new operation is found [here](docs/HowToAddAnOperation.md).
 * A guide to use Dialect builder details how to generate Krnl, Affine, MemRef, and Standard Dialect operations [here](docs/LoweringCode.md).
 * A guide on how to best report errors is detailed [here](docs/ErrorHandling.md).
-* Our ONNX dialect is derived from the machine readable ONNX specs. When upgrading the supported opset, or simply adding features to the ONNX dialects such as new verifiers, constant folding, canonicalization, or other such features, we need to regenerate the ONNX tablegen files. See [here](docs/ImportONNXDefs.md) on how to proceed in such cases.
+* Our ONNX dialect is derived from the machine readable ONNX specs. When upgrading the supported opset, or simply adding features to the ONNX dialects such as new verifiers, constant folding, canonicalization, or other such features, we need to regenerate the ONNX tablegen files. See [here](docs/ImportONNXDefs.md#how-to-use-the-script)) on how to proceed in such cases.
 * To add an option to the onnx-mlir command, see instructions [here](docs/Options.md).
 * To test new code, see [here](docs/Testing.md) for instructions.
 
@@ -26,7 +26,7 @@ Since you are interested in contributing code, you may look [here](docs/Workflow
 
 * To test new code, see [here](docs/Testing.md) for instructions.
 * We have support on how to trace performance issue using instrumentation. Details are found [here](docs/Instrumentation.md).
-* We have support to debug numerical errors. See [here](docs/DebuggingNumericalError.md).
+* We have support to debug numerical errors. See [here](docs/HowToAddAnOperation.md#update-your-operations-status).
 
 ## Running ONNX models in Python and C
 

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -58,12 +58,12 @@ function(add_onnx_mlir_dialect_doc dialect dialect_tablegen_file)
   # Generate Dialect Documentation
   set(LLVM_TARGET_DEFINITIONS ${dialect_tablegen_file})
   tablegen(MLIR ${dialect}.md -gen-op-doc "-I${ONNX_MLIR_SRC_ROOT}")
-  set(GEN_DOC_FILE ${ONNX_MLIR_BIN_ROOT}/docs/Dialects/${dialect}.md)
+  set(GEN_DOC_FILE ${ONNX_MLIR_SRC_ROOT}/docs/Dialects/${dialect}.md)
   add_custom_command(
           OUTPUT ${GEN_DOC_FILE}
           COMMAND ${CMAKE_COMMAND} -E copy
                   ${CMAKE_CURRENT_BINARY_DIR}/${dialect}.md
-                  ${ONNX_MLIR_SRC_ROOT}/docs/Dialects
+                  ${GEN_DOC_FILE}
           DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${dialect}.md)
   add_custom_target(${dialect}DocGen DEPENDS ${GEN_DOC_FILE})
   add_dependencies(onnx-mlir-docs ${dialect}DocGen)

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -63,12 +63,12 @@ function(add_onnx_mlir_dialect_doc dialect dialect_tablegen_file)
           OUTPUT ${GEN_DOC_FILE}
           COMMAND ${CMAKE_COMMAND} -E copy
                   ${CMAKE_CURRENT_BINARY_DIR}/${dialect}.md
-                  ${GEN_DOC_FILE}
+                  ${ONNX_MLIR_SRC_ROOT}/docs/Dialects
           DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${dialect}.md)
   add_custom_target(${dialect}DocGen DEPENDS ${GEN_DOC_FILE})
-  add_dependencies(onnx-mlir-doc ${dialect}DocGen)
+  add_dependencies(onnx-mlir-docs ${dialect}DocGen)
 endfunction()
-add_custom_target(onnx-mlir-doc ALL)
+add_custom_target(onnx-mlir-docs ALL)
 
 function(add_onnx_mlir_dialect dialect)
   set(LLVM_TARGET_DEFINITIONS ${dialect}.td)

--- a/docs/Dialects/krnl.md
+++ b/docs/Dialects/krnl.md
@@ -777,6 +777,22 @@ affine.for %arg0 = 0 to 1024 step 4 {
 | :-----: | ----------- |
 `loops` | any type
 
+### `krnl.random_normal` (::mlir::KrnlRandomNormalOp)
+
+Generate a random normal tensor.
+
+Operation that generates a random normally distributed tensor.
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`output` | memref of any type values
+`numberOfValues` | index
+`mean` | floating-point
+`scale` | floating-point
+`seed` | floating-point
+
 ### `krnl.shape` (::mlir::KrnlShapeOp)
 
 Krnl operation to retreieve the shape of a MemRef.

--- a/docs/Dialects/onnx.md
+++ b/docs/Dialects/onnx.md
@@ -1461,6 +1461,15 @@ Indicate ONNX entry point
 
 The "onnx.EntryPoint" function indicates the main entry point of ONNX model.
 
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`func` | ::mlir::SymbolRefAttr | symbol reference attribute
+`numInputs` | ::mlir::IntegerAttr | 32-bit signless integer attribute
+`numOutputs` | ::mlir::IntegerAttr | 32-bit signless integer attribute
+`signature` | ::mlir::StringAttr | string attribute
+
 ### `onnx.Equal` (::mlir::ONNXEqualOp)
 
 ONNX Equal operation
@@ -4047,6 +4056,147 @@ ONNX Pad operation
 | :----: | ----------- |
 `output` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of bfloat16 type values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values or none type
 
+### `onnx.PadV11` (::mlir::ONNXPadV11Op)
+
+ONNX Pad operation
+
+"Given a tensor containing the data to be padded (`data`), a tensor containing the number of start and end pad values for axis (`pads`), (optionally) a `mode`, and (optionally) `constant_value`,"
+"a padded tensor (`output`) is generated."
+""
+"The three supported `modes` are (similar to corresponding modes supported by `numpy.pad`):"
+""
+"1) `constant`(default) - pads with a given constant value as specified by `constant_value` (which defaults to 0)"
+""
+"2) `reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis"
+""
+"3) `edge` - pads with the edge values of array"
+""
+""
+"Example 1 (`constant` mode):"
+"  Insert 0 pads to the beginning of the second dimension."
+""
+"  data ="
+"  ["
+"      [1.0, 1.2],"
+"      [2.3, 3.4],"
+"      [4.5, 5.7],"
+"  ]"
+""
+"  pads = [0, 2, 0, 0]"
+""
+"  mode = 'constant'"
+""
+"  constant_value = 0.0"
+""
+"  output ="
+"  ["
+"      [0.0, 0.0, 1.0, 1.2],"
+"      [0.0, 0.0, 2.3, 3.4],"
+"      [0.0, 0.0, 4.5, 5.7],"
+"  ]"
+""
+""
+"Example 2 (`reflect` mode):"
+"  data ="
+"  ["
+"      [1.0, 1.2],"
+"      [2.3, 3.4],"
+"      [4.5, 5.7],"
+"  ]"
+""
+"  pads = [0, 2, 0, 0]"
+""
+"  mode = 'reflect'"
+""
+"  output ="
+"  ["
+"      [1.0, 1.2, 1.0, 1.2],"
+"      [2.3, 3.4, 2.3, 3.4],"
+"      [4.5, 5.7, 4.5, 5.7],"
+"  ]"
+""
+""
+"Example 3 (`edge` mode):"
+"  data ="
+"  ["
+"      [1.0, 1.2],"
+"      [2.3, 3.4],"
+"      [4.5, 5.7],"
+"  ]"
+""
+"  pads = [0, 2, 0, 0]"
+""
+"  mode = 'edge'"
+""
+"  output ="
+"  ["
+"      [1.0, 1.0, 1.0, 1.2],"
+"      [2.3, 2.3, 2.3, 3.4],"
+"      [4.5, 4.5, 4.5, 5.7],"
+"  ]"
+""
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`mode` | ::mlir::StringAttr | string attribute
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`data` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or memref of any type values
+`pads` | tensor of 64-bit signless integer values or memref of any type values
+`constant_value` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or memref of any type values or none type
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`output` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or memref of any type values or none type
+
+### `onnx.PadV2` (::mlir::ONNXPadV2Op)
+
+ONNX Pad operation
+
+"Given `data` tensor, pads, mode, and value."
+"Example:"
+"  Insert 0 pads to the beginning of the second dimension."
+"  data = ["
+"      [1.0, 1.2],"
+"      [2.3, 3.4],"
+"      [4.5, 5.7],"
+"  ]"
+"  pads = [0, 2, 0, 0]"
+"  output = ["
+"      ["
+"          [0.0, 0.0, 1.0, 1.2],"
+"          [0.0, 0.0, 2.3, 3.4],"
+"          [0.0, 0.0, 4.5, 5.7],"
+"      ],"
+"  ]"
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`mode` | ::mlir::StringAttr | string attribute
+`pads` | ::mlir::ArrayAttr | 64-bit integer array attribute
+`value` | ::mlir::FloatAttr | 32-bit float attribute
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`data` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or memref of any type values
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`output` | tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or memref of any type values
+
 ### `onnx.Pow` (::mlir::ONNXPowOp)
 
 ONNX Pow operation
@@ -5983,7 +6133,7 @@ ONNX SpaceToDepth operation
 ONNX Split operation
 
 "Split a tensor into a list of tensors, along the specified"
-"'axis'. Lengths of the parts can be specified using argument 'split'."
+"'axis'. Lengths of the parts can be specified using input 'split'."
 "Otherwise, the tensor is split to equal sized parts."
 
 #### Attributes:
@@ -5991,19 +6141,19 @@ ONNX Split operation
 | Attribute | MLIR Type | Description |
 | :-------: | :-------: | ----------- |
 `axis` | ::mlir::IntegerAttr | 64-bit signed integer attribute
-`split` | ::mlir::ArrayAttr | 64-bit integer array attribute
 
 #### Operands:
 
 | Operand | Description |
 | :-----: | ----------- |
-`input` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
+`input` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of bfloat16 type values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
+`split` | tensor of 64-bit signless integer values or memref of any type values or none type
 
 #### Results:
 
 | Result | Description |
 | :----: | ----------- |
-`outputs` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
+`outputs` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of bfloat16 type values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
 
 ### `onnx.SplitToSequence` (::mlir::ONNXSplitToSequenceOp)
 
@@ -6039,6 +6189,33 @@ ONNX SplitToSequence operation
 | Result | Description |
 | :----: | ----------- |
 `output_sequence` | SeqType of tensor of 8-bit unsigned integer values values or SeqType of tensor of 16-bit unsigned integer values values or SeqType of tensor of 32-bit unsigned integer values values or SeqType of tensor of 64-bit unsigned integer values values or SeqType of tensor of 8-bit signless integer values values or SeqType of tensor of 16-bit signless integer values values or SeqType of tensor of 32-bit signless integer values values or SeqType of tensor of 64-bit signless integer values values or SeqType of tensor of 16-bit float values values or SeqType of tensor of 32-bit float values values or SeqType of tensor of 64-bit float values values or SeqType of tensor of string type values values or SeqType of tensor of 1-bit signless integer values values or SeqType of tensor of complex type with 32-bit float elements values values or SeqType of tensor of complex type with 64-bit float elements values values or memref of any type values
+
+### `onnx.SplitV11` (::mlir::ONNXSplitV11Op)
+
+ONNX Split operation
+
+"Split a tensor into a list of tensors, along the specified"
+"'axis'. Lengths of the parts can be specified using argument 'split'."
+"Otherwise, the tensor is split to equal sized parts."
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`axis` | ::mlir::IntegerAttr | 64-bit signed integer attribute
+`split` | ::mlir::ArrayAttr | 64-bit integer array attribute
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`input` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`outputs` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
 
 ### `onnx.Sqrt` (::mlir::ONNXSqrtOp)
 
@@ -6659,6 +6836,60 @@ ONNX Unsqueeze operation
 `expanded` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
 
 ### `onnx.Upsample` (::mlir::ONNXUpsampleOp)
+
+ONNX Upsample operation
+
+"Upsample the input tensor."
+"Each dimension value of the output tensor is:"
+"  output_dimension = floor(input_dimension * scale)."
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`mode` | ::mlir::StringAttr | string attribute
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`X` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
+`scales` | tensor of 32-bit float values or memref of any type values
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`Y` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
+
+### `onnx.UpsampleV7` (::mlir::ONNXUpsampleV7Op)
+
+ONNX Upsample operation
+
+"Upsample the input tensor."
+"Each dimension value of the output tensor is:"
+"  output_dimension = floor(input_dimension * scale)."
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`mode` | ::mlir::StringAttr | string attribute
+`scales` | ::mlir::ArrayAttr | 32-bit float array attribute
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`X` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`Y` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values or memref of any type values
+
+### `onnx.UpsampleV9` (::mlir::ONNXUpsampleV9Op)
 
 ONNX Upsample operation
 

--- a/docs/ImportONNXDefs.md
+++ b/docs/ImportONNXDefs.md
@@ -36,10 +36,21 @@ Several tables are defined at the beginning of the script:
 ## Version of Operations
 As stated previous, we try to support the latest version of ONNX operations. The version of each operation currently supported is recorded in gen_onnx_mlir.py. This mechanism provides some stability in version. To check the changes in version, run gen_onnx_mlir.py with flag "--check-version" and the changes will be reported. To move to a newer version, manually update the version dictionary in the script.
 
-### Support Mulitple versions
+### Support Multiple versions
 To support multiple versions of an op, the selected version should be added in the version dictionary in gen_onnx_mlir.py. For example, there are two versions (opset), 11 and 13, forReduceSum is supported. The corresponding entry in version_dic is `'ReduceSum': [13, 11]`.
 
 In onnx dialect, the op for the top version has no version in the op name, while other version with name followed by 'V' and version number. For example, ReduceSum of opset 13 will be `ONNXReduceSumOp`, while ReduceSum of opset 11 is 'ONNXReduceSumV11Op`. Since most of onnx op are compatible when upgraded to higher version, we can keep the name of the operation in the dialect and just update version_dict in gen_onnx_mlir.py without touching the code in onnx-mlir.
 
 When a model is imported, the highest version which is not higher than the next available version is used. For the example of ReduceSum, if the opset is 12, ONNXReduceSumV11Op is chosen.  
 
+## Update the documentation
+
+When adding a new op version or making changes to the ONNX version, we would like to also reflect these changes in the ONNX documentation of our supported operations. While the latest [ONNX specs](https://github.com/onnx/onnx/blob/master/docs/Operators.md) are always available, the specs that we support are often a bit back, plus we support older versions under the versioned name as mentioned in the previous section.
+
+There is a convenient command to update both the ONNX and Krnl dialect, as shown below.
+```
+make onnx-mlir-docs
+```
+The above command is run in the usual `build` directory and it will install the new dialect md files directly into the `docs/Dialects` directory.
+
+The same command should be used when adding operations/making changes to the Krnl dialect.

--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -11,10 +11,8 @@
 // to update the Krnl dialect documentation.
 //
 // 1) cd onnx-mlir/build 
-// 2) make onnx-mlir-doc
-// 3) if successful, move the build's docs/Dialects/krnl.md to the git's doc 
-//    directory, namely
-//    cp docs/Dialects/krnl.md ../docs/Dialects
+// 2) make onnx-mlir-docs
+// 3) the newly build krnl.md file resides in the docs/Dialects directory.
 //===----------------------------------------------------------------------===//
 
 include "mlir/IR/OpBase.td"


### PR DESCRIPTION
Just like `make OMONNXOpsIncTranslation` moves the updated ONNX spec files into the source files, now the  `make onnx-mlir-docs` also move the updated description of the ONNX and Krnl dialect into the `docs/Dialects` subdirectory.

Added reference to this command in the documentation files.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>