### PR TITLE
Print out debug info about opset of importing onnx ops

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -981,12 +981,13 @@ private:
       return std::string("");
     }
     auto current_opset = opset_map_.find(node.domain())->second;
-    LLVM_DEBUG(llvm::dbgs()
-               << DEBUG_TYPE << ": Importing ONNX " << node.op_type()
-               << ", opset: " << current_opset << "\n");
+
     if (current_opset < OPSET_THRESHOLD)
       llvm::outs() << "Warning: ONNX " << node.op_type() << " opset "
                    << current_opset << " is quite old\n";
+    LLVM_DEBUG(llvm::dbgs()
+               << DEBUG_TYPE << ": Importing ONNX " << node.op_type()
+               << ", opset: " << current_opset << "\n");
 
     // Custom ops may not be present in op_dialect_version_map_. If no version
     // info is found, treat as unversioned (no renaming).

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -25,6 +25,7 @@
 
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
 
 SUPPRESS_WARNINGS_PUSH
 #include "onnx/checker.h"
@@ -37,6 +38,8 @@ SUPPRESS_WARNINGS_POP
 #include <iostream>
 #include <map>
 #include <type_traits>
+
+#define DEBUG_TYPE "frontend_dialect_transformer"
 
 using namespace mlir;
 
@@ -974,6 +977,9 @@ private:
       return std::string("");
     }
     auto current_opset = opset_map_.find(node.domain())->second;
+    LLVM_DEBUG(llvm::dbgs()
+               << DEBUG_TYPE << ": Importing ONNX " << node.op_type()
+               << ", opset: " << current_opset << "\n");
     // Custom ops may not be present in op_dialect_version_map_. If no version
     // info is found, treat as unversioned (no renaming).
     auto opset_list_it = op_dialect_version_map_.find(node.op_type());
@@ -987,6 +993,8 @@ private:
         return std::string("");
       for (int i = opset_list.size() - 1; i > 0; i--) {
         if (current_opset < opset_list[i - 1]) {
+          LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ":   - use opset "
+                                  << opset_list[i] << "\n");
           return "V" + std::to_string(opset_list[i]);
         }
       }

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -43,7 +43,7 @@ SUPPRESS_WARNINGS_POP
 
 /// We consider opset < 6 is old. Users will see a warning if their model
 /// contains ops of old opset.
-#define OPSET_THRESHOLD 6
+static constexpr int32_t MINIMUM_SUPPORTED_OPSET = 6;
 
 using namespace mlir;
 
@@ -982,12 +982,14 @@ private:
     }
     auto current_opset = opset_map_.find(node.domain())->second;
 
-    if (current_opset < OPSET_THRESHOLD)
-      llvm::outs() << "Warning: ONNX " << node.op_type() << " opset "
-                   << current_opset << " is quite old\n";
+    if (current_opset < MINIMUM_SUPPORTED_OPSET)
+      llvm::outs() << "Warning: ONNX " << node.op_type()
+                   << " in your model is using Opset " << current_opset
+                   << ", which is quite old. Please consider regenerating your "
+                      "model with a newer Opset.\n";
     LLVM_DEBUG(llvm::dbgs()
                << DEBUG_TYPE << ": Importing ONNX " << node.op_type()
-               << ", opset: " << current_opset << "\n");
+               << ", Opset: " << current_opset << "\n");
 
     // Custom ops may not be present in op_dialect_version_map_. If no version
     // info is found, treat as unversioned (no renaming).
@@ -1002,7 +1004,7 @@ private:
         return std::string("");
       for (int i = opset_list.size() - 1; i > 0; i--) {
         if (current_opset < opset_list[i - 1]) {
-          LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ":   - use opset "
+          LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ":   - use Opset "
                                   << opset_list[i] << "\n");
           return "V" + std::to_string(opset_list[i]);
         }

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -41,6 +41,10 @@ SUPPRESS_WARNINGS_POP
 
 #define DEBUG_TYPE "frontend_dialect_transformer"
 
+/// We consider opset < 6 is old. Users will see a warning if their model
+/// contains ops of old opset.
+#define OPSET_THRESHOLD 6
+
 using namespace mlir;
 
 namespace onnx_mlir {
@@ -980,6 +984,10 @@ private:
     LLVM_DEBUG(llvm::dbgs()
                << DEBUG_TYPE << ": Importing ONNX " << node.op_type()
                << ", opset: " << current_opset << "\n");
+    if (current_opset < OPSET_THRESHOLD)
+      llvm::outs() << "Warning: ONNX " << node.op_type() << " opset "
+                   << current_opset << " is quite old\n";
+
     // Custom ops may not be present in op_dialect_version_map_. If no version
     // info is found, treat as unversioned (no renaming).
     auto opset_list_it = op_dialect_version_map_.find(node.op_type());


### PR DESCRIPTION
This patch prints out opset of ONNX operations in a given ONNX model. It also prints out the opset version onnx-mlir will use to import an ONNX op.

E.g.
```
$ ./Debug/bin/onnx-mlir --EmitONNXBasic ssd_mobilenet_v1_10.onnx --debug 2>&1 | grep frontend
...
frontend_dialect_transformer: Importing ONNX Cast, opset: 10
frontend_dialect_transformer: Importing ONNX Greater, opset: 10
frontend_dialect_transformer: Importing ONNX If, opset: 10
frontend_dialect_transformer: Importing ONNX Gather, opset: 10
frontend_dialect_transformer: Importing ONNX Shape, opset: 10
frontend_dialect_transformer: Importing ONNX Cast, opset: 10
frontend_dialect_transformer: Importing ONNX Slice, opset: 10
frontend_dialect_transformer: Importing ONNX Squeeze, opset: 10
frontend_dialect_transformer:   - use opset 11
...
```

We can see that all ONNX ops here have opset 10, but ONNX Squeeze will be imported as opset 11 in onnx-mlir.
 
A warning will be printed out if a compiling model contains old ops ( opset < 6).

Signed-off-by: Tung D. Le <tung@jp.ibm.com>