### PR TITLE
support for multiple dialect builder object

### DIFF
--- a/docs/LoweringCode.md
+++ b/docs/LoweringCode.md
@@ -263,3 +263,42 @@ Note also that we use the loop indices `loopInd` directly in the memory operatio
 ## Generating affine loops
 
 There is one more builder to assist the lowering of the Krnl dialect into the affine dialect. This builder is named `AffineBuilder` and is found in [KrnlToAffine.cpp](../src/Conversion/KrnlToAffine/KrnlToAffine.cpp)  file. It provides helper methods to generate multiple nested `affine.for` loops as well as `affine.if then else` constructs.
+
+## Generating SCF operations
+
+There is an additional builder for generating MLIR's SCF dialect.
+
+## Combining multiple builders
+
+Instead of creating multiple builders, e.g.
+
+```C++
+  KrnlBuilder createKrnl(rewriter, loc);
+  MathBuilder createMath(createKrnl);
+  MemRefBuilder createMemRef(createKrnl);
+```
+and then using them like this
+
+```C++
+  createKrnl.defineLoop(1);
+  createMath.add(i1, i2);
+  createMemRef.alloca(type);
+```
+
+we can create a single builder composed of multiple types and then as follows.
+
+```C++
+  MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder>
+    create(rewriter, loc);
+
+  create.krnl.defineLoop(1);
+  create.math.add(i1, i2);
+  create.mem.alloca(type);
+```
+
+Types that can be used here are listed here.
+  *  `KrnlBuilder`, accessed with `krnl` field.
+  *  `MathBuilder`, accessed with `math` field.
+  *  `MemRefBuilder`, accessed with `mem` field.
+  *  `ONNXBuilder`, accessed with `onnx` field.
+  *  `SCFBuilder`, accessed with the `scf` field.

--- a/src/Conversion/ONNXToKrnl/Math/CumSum.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/CumSum.cpp
@@ -147,7 +147,7 @@ struct ONNXCumSumOpLowering : public ConversionPattern {
       // Use this when math::CeilOp is available in MLIR.
       // nos = createMath.ceil(createMath.log2(nos));
       nos = createMath.log2(nos);
-      nos = rewriter.create<arith::FPToSIOp>(loc, i64Ty, nos);
+      nos = createMath.cast(i64Ty, nos);
       // Use this when math::CeilOp is available in MLIR.
       // numberOfStep = SymbolIndexExpr(nos);
       numberOfStep = SymbolIndexExpr(nos) + LiteralIndexExpr(1);

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -40,19 +40,21 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     createKrnl.iterateIE(outerLoops, outerLoops, outerLbs,
         shapeHelper.dimsForOutput(0),
         [&](KrnlBuilder &createKrnl, ValueRange outerIndices) {
-          MemRefBuilder createMemRef(createKrnl);
-          MathBuilder createMath(createKrnl);
+          MultiDialectBuilder<KrnlBuilder, MemRefBuilder, MathBuilder> create(
+              createKrnl);
           // Single scalar, no need for default alignment.
           Value reductionVal =
-              createMemRef.alignedAlloca(MemRefType::get({}, elementType));
-          createKrnl.store(fzero, reductionVal);
+              create.mem.alignedAlloca(MemRefType::get({}, elementType));
+          create.krnl.store(fzero, reductionVal);
           int aRank = shapeHelper.aDims.size();
           int bRank = aRank; // Add for better readability.
-          ValueRange innerLoop = createKrnl.defineLoops(1);
+          ValueRange innerLoop = create.krnl.defineLoops(1);
           Value innerUb = shapeHelper.aDims[aRank - 1].getValue();
-          Value izero = createMath.constantIndex(0);
-          createKrnl.iterate(innerLoop, innerLoop, {izero}, {innerUb},
+          Value izero = create.math.constantIndex(0);
+          create.krnl.iterate(innerLoop, innerLoop, {izero}, {innerUb},
               [&](KrnlBuilder &createKrnl, ValueRange innerIndex) {
+                MultiDialectBuilder<KrnlBuilder, MathBuilder> create(
+                    createKrnl);
                 Value k = innerIndex[0];
                 SmallVector<Value, 4> aAccessFct, bAccessFct;
                 for (int i = 0; i < aRank; ++i) {
@@ -84,16 +86,17 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
                   }
                 }
                 // Add mat mul operation.
-                Value loadedA = createKrnl.load(operandAdaptor.A(), aAccessFct);
-                Value loadedB = createKrnl.load(operandAdaptor.B(), bAccessFct);
-                Value loadedY = createKrnl.load(reductionVal);
-                MathBuilder createMath(createKrnl);
-                Value AB = createMath.mul(loadedA, loadedB);
-                Value accumulated = createMath.add(loadedY, AB);
-                createKrnl.store(accumulated, reductionVal);
+                Value loadedA =
+                    create.krnl.load(operandAdaptor.A(), aAccessFct);
+                Value loadedB =
+                    create.krnl.load(operandAdaptor.B(), bAccessFct);
+                Value loadedY = create.krnl.load(reductionVal);
+                Value AB = create.math.mul(loadedA, loadedB);
+                Value accumulated = create.math.add(loadedY, AB);
+                create.krnl.store(accumulated, reductionVal);
               });
-          Value accumulated = createKrnl.load(reductionVal);
-          createKrnl.store(accumulated, alloc, outerIndices);
+          Value accumulated = create.krnl.load(reductionVal);
+          create.krnl.store(accumulated, alloc, outerIndices);
         });
   }
 
@@ -106,16 +109,15 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
 
     // Prepare: loop bounds and zero
     Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(alloc);
-    KrnlBuilder createKrnl(rewriter, loc);
-    MemRefBuilder createMemRef(createKrnl);
-    MathBuilder createMath(createKrnl);
-    Value zero = createMath.constantIndex(0);
-    Value I = createMemRef.dim(C, 0);
-    Value J = createMemRef.dim(C, 1);
-    Value K = createMemRef.dim(A, 1);
+    MultiDialectBuilder<KrnlBuilder, MemRefBuilder, MathBuilder> create(
+        rewriter, loc);
+    Value zero = create.math.constantIndex(0);
+    Value I = create.mem.dim(C, 0);
+    Value J = create.mem.dim(C, 1);
+    Value K = create.mem.dim(A, 1);
 
     // Initialize alloc/C to zero.
-    createKrnl.memset(alloc, zeroVal);
+    create.krnl.memset(alloc, zeroVal);
 
     // Compute.
     // Define blocking, with simdization along the j axis.
@@ -151,17 +153,17 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     }
 
     // I, J, K loop.
-    ValueRange origLoop = createKrnl.defineLoops(3);
+    ValueRange origLoop = create.krnl.defineLoops(3);
     Value ii(origLoop[0]), jj(origLoop[1]), kk(origLoop[2]);
     // Define blocked loop and permute.
-    ValueRange iRegBlock = createKrnl.block(ii, iRegTile);
+    ValueRange iRegBlock = create.krnl.block(ii, iRegTile);
     Value ii1(iRegBlock[0]), ii2(iRegBlock[1]);
-    ValueRange jRegBlock = createKrnl.block(jj, jRegTile);
+    ValueRange jRegBlock = create.krnl.block(jj, jRegTile);
     Value jj1(jRegBlock[0]), jj2(jRegBlock[1]);
-    ValueRange kRegBlock = createKrnl.block(kk, kRegTile);
+    ValueRange kRegBlock = create.krnl.block(kk, kRegTile);
     Value kk1(kRegBlock[0]), kk2(kRegBlock[1]);
-    createKrnl.permute({ii1, ii2, jj1, jj2, kk1, kk2}, {0, 3, 1, 4, 2, 5});
-    createKrnl.iterate({ii, jj, kk}, {ii1, jj1, kk1}, {zero, zero, zero},
+    create.krnl.permute({ii1, ii2, jj1, jj2, kk1, kk2}, {0, 3, 1, 4, 2, 5});
+    create.krnl.iterate({ii, jj, kk}, {ii1, jj1, kk1}, {zero, zero, zero},
         {I, J, K}, [&](KrnlBuilder &createKrnl, ValueRange indices) {
           Value i1(indices[0]), j1(indices[1]), k1(indices[2]);
           createKrnl.matmul(A, {zero, zero}, B, {zero, zero}, C, {zero, zero},

--- a/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
@@ -308,9 +308,8 @@ void calculateState<RnnState, RnnActivationPack, RnnWeightPack, RnnBiasPack>(
   // Wbi: [hidden_size]
   // Rbi: [hidden_size]
 
-  KrnlBuilder createKrnl(rewriter, loc);
-  OnnxBuilder createONNX(rewriter, loc);
-  MemRefBuilder createMemRef(rewriter, loc);
+  MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder, OnnxBuilder> create(
+      rewriter, loc);
 
   // Get Ht.
   Value Ht = (isForward) ? state.forwardHt : state.reverseHt;
@@ -318,19 +317,19 @@ void calculateState<RnnState, RnnActivationPack, RnnWeightPack, RnnBiasPack>(
   unsigned htRank = matrixType.getRank();
 
   // Do matrix multiplications.
-  Value XtWi = createONNX.matmul(matrixType, Xt, weightPack.Wi);
-  Value HtRi = createONNX.matmul(matrixType, Ht, weightPack.Ri);
+  Value XtWi = create.onnx.matmul(matrixType, Xt, weightPack.Wi);
+  Value HtRi = create.onnx.matmul(matrixType, Ht, weightPack.Ri);
 
   // Do element-wise computations. Fuse them into a single nested loop.
   // Lower and upper bounds derived from Ht tensor.
-  Value iZero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value iZero = create.math.constantIndex(0);
   SmallVector<Value, 4> htLbs(htRank, iZero);
   SmallVector<Value, 4> htUbs;
   for (unsigned r = 0; r < htRank; ++r) {
-    htUbs.emplace_back(createMemRef.dim(Ht, r));
+    htUbs.emplace_back(create.mem.dim(Ht, r));
   }
-  ValueRange loops = createKrnl.defineLoops(htRank);
-  createKrnl.iterate(loops, loops, htLbs, htUbs,
+  ValueRange loops = create.krnl.defineLoops(htRank);
+  create.krnl.iterate(loops, loops, htLbs, htUbs,
       [&](KrnlBuilder &createKrnl, ValueRange indices) {
         MathBuilder createMath(createKrnl);
         Value bs(indices[0]), hs(indices[1]);

--- a/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
@@ -308,8 +308,8 @@ void calculateState<RnnState, RnnActivationPack, RnnWeightPack, RnnBiasPack>(
   // Wbi: [hidden_size]
   // Rbi: [hidden_size]
 
-  MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder, OnnxBuilder> create(
-      rewriter, loc);
+  MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder, OnnxBuilder>
+      create(rewriter, loc);
 
   // Get Ht.
   Value Ht = (isForward) ? state.forwardHt : state.reverseHt;

--- a/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
@@ -43,13 +43,12 @@ struct ONNXShapeOpLowering : public ConversionPattern {
         rewriter, op, outputMemRefType, loc, shapeHelper.dimsForOutput(0));
 
     // Iterate along the data shape storing dim value to result.
-    KrnlBuilder createKrnl(rewriter, loc);
-    MathBuilder createMath(createKrnl);
+    MultiDialectBuilder<KrnlBuilder, MathBuilder> create(rewriter, loc);
     uint64_t dataRank = shapeHelper.selectedData.size();
     for (uint64_t i = 0; i < dataRank; ++i) {
       Value val = shapeHelper.selectedData[i].getValue();
-      Value intVal = createMath.cast(elementType, val);
-      createKrnl.storeIE(intVal, alloc, {LiteralIndexExpr(i)});
+      Value intVal = create.math.cast(elementType, val);
+      create.krnl.storeIE(intVal, alloc, {LiteralIndexExpr(i)});
     }
     rewriter.replaceOp(op, alloc);
     return success();

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -359,6 +359,16 @@ struct KrnlBuilder : public DialectBuilder {
       ValueRange globalUBs, bool simdize, bool unroll, bool overcompute);
 };
 
+// Recursive class specialized for KrnlBuilder refereed to as krnl.
+template <class... Ts>
+struct MultiDialectBuilder<KrnlBuilder, Ts...> : MultiDialectBuilder<Ts...> {
+  MultiDialectBuilder(OpBuilder &b, Location loc)
+      : MultiDialectBuilder<Ts...>(b, loc), krnl(b, loc) {}
+  MultiDialectBuilder(DialectBuilder &db)
+      : MultiDialectBuilder<Ts...>(db), krnl(db) {}
+  KrnlBuilder krnl;
+};
+
 //====---------------- Common helper functions --------------------------===//
 
 /// Check whether a value is produced by a dense KrnlGlobalOp.

--- a/src/Dialect/ONNX/MLIRDialectBuilder.cpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.cpp
@@ -87,6 +87,11 @@ Value MathBuilder::log2(Value val) const {
   return b.create<math::Log2Op>(loc, val);
 }
 
+Value MathBuilder::sqrt(Value val) const {
+  assert(val.getType().isa<FloatType>() && "Data type must be float.");
+  return b.create<math::SqrtOp>(loc, val);
+}
+
 Value MathBuilder::min(Value lhs, Value rhs) const {
   assert(lhs.getType() == rhs.getType() && "expected same type");
   if (lhs.getType().isa<IntegerType>() || lhs.getType().isa<IndexType>())

--- a/src/Dialect/ONNX/MLIRDialectBuilder.hpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.hpp
@@ -72,6 +72,7 @@ struct MathBuilder final : DialectBuilder {
   Value exp(Value val) const;
   Value exp2(Value val) const;
   Value log2(Value val) const;
+  Value sqrt(Value val) const;
 
   Value select(Value cmp, Value lhs, Value rhs) const;
   Value sgt(Value lhs, Value rhs) const;
@@ -176,6 +177,76 @@ private:
   // Support for adding blocks.
   void appendToBlock(
       Block *block, function_ref<void(ValueRange)> builderFn) const;
+};
+
+//===----------------------------------------------------------------------===//
+// Multi Dialect Builder
+//===----------------------------------------------------------------------===//
+
+/*
+  Instead of creating multiple builders, e.g.
+
+  KrnlBuilder createKrnl(rewriter, loc);
+  MathBuilder createMath(createKrnl);
+  MemRefBuilder createMemRef(createKrnl);
+
+  createKrnl.defineLoop(1);
+  createMath.add(i1, i2);
+  createMemRef.alloca(type);
+
+  We can create a single builder composed of multiple types
+
+  MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder>
+    create(rewriter, loc);
+
+  create.krnl.defineLoop(1);
+  create.math.add(i1, i2);
+  create.mem.alloca(type);
+
+  Types that can be used here are
+  *  KrnlBuilder, access field with krnl
+  *  MathBuilder, access field with math
+  *  MemRefBuilder, access field with mem
+  *  ONNXBuilder, access field with onnx
+
+  PS: at this time, affine cannot be combined as it is itself a template.
+
+*/
+// Anchor class.
+template <class... Ts>
+struct MultiDialectBuilder {
+  MultiDialectBuilder(OpBuilder &b, Location loc) {}
+  MultiDialectBuilder(DialectBuilder &db) {}
+};
+
+// Recursive class specialized for MathBuilder refereed to as math.
+template <class... Ts>
+struct MultiDialectBuilder<MathBuilder, Ts...> : MultiDialectBuilder<Ts...> {
+  MultiDialectBuilder(OpBuilder &b, Location loc)
+      : MultiDialectBuilder<Ts...>(b, loc), math(b, loc) {}
+  MultiDialectBuilder(DialectBuilder &db)
+      : MultiDialectBuilder<Ts...>(db), math(db) {}
+  MathBuilder math;
+};
+
+// Recursive class specialized for MemRefBuilder refereed to as mem.
+template <class... Ts>
+struct MultiDialectBuilder<MemRefBuilder, Ts...> : MultiDialectBuilder<Ts...> {
+  MultiDialectBuilder(OpBuilder &b, Location loc)
+      : MultiDialectBuilder<Ts...>(b, loc), mem(b, loc) {}
+  MultiDialectBuilder(DialectBuilder &db)
+      : MultiDialectBuilder<Ts...>(db), mem(db) {}
+  MemRefBuilder mem;
+};
+
+// Recursive class specialized for SCFBuilder refereed to as scf.
+template <class... Ts>
+struct MultiDialectBuilder<SCFBuilder, Ts...> : MultiDialectBuilder<Ts...> {
+  MultiDialectBuilder(OpBuilder &b, Location loc)
+      : MultiDialectBuilder<Ts...>(b, loc), scf(b, loc) {}
+  MultiDialectBuilder(DialectBuilder &db)
+      : MultiDialectBuilder<Ts...>(db), scf(db) {}
+  SCFBuilder scf;
 };
 
 // Include template implementations.

--- a/src/Dialect/ONNX/MLIRDialectBuilder.hpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.hpp
@@ -208,6 +208,7 @@ private:
   *  MathBuilder, access field with math
   *  MemRefBuilder, access field with mem
   *  ONNXBuilder, access field with onnx
+  *  SCFBuilder, access field with scf
 
   PS: at this time, affine cannot be combined as it is itself a template.
 

--- a/src/Dialect/ONNX/ONNXOpsHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.hpp
@@ -43,6 +43,16 @@ struct OnnxBuilder : DialectBuilder {
   Value constant(Attribute denseAttr);
 };
 
+// Recursive class specialized for OnnxBuilder refereed to as onnx.
+template <class... Ts>
+struct MultiDialectBuilder<OnnxBuilder, Ts...> : MultiDialectBuilder<Ts...> {
+  MultiDialectBuilder(OpBuilder &b, Location loc)
+      : MultiDialectBuilder<Ts...>(b, loc), onnx(b, loc) {}
+  MultiDialectBuilder(DialectBuilder &db)
+      : MultiDialectBuilder<Ts...>(db), onnx(db) {}
+  OnnxBuilder onnx;
+};
+
 } // namespace mlir
 
 // Identity affine map:


### PR DESCRIPTION
Instead of creating multiple builders, e.g.

```C++
  KrnlBuilder createKrnl(rewriter, loc);
  MathBuilder createMath(createKrnl);
  MemRefBuilder createMemRef(createKrnl);
```
and then using them like this

```C++
  createKrnl.defineLoop(1);
  createMath.add(i1, i2);
  createMemRef.alloca(type);
```

we can create a single builder composed of multiple types and then as follows.

```C++
  MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder>
    create(rewriter, loc);

  create.krnl.defineLoop(1);
  create.math.add(i1, i2);
  create.mem.alloca(type);
```

Changed usage where it made sense in the code, and added doc to describe new feature.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>