### PR TITLE
Fix an issue that knrl_unroll does not work with krnl.get_induction_var_value

### DIFF
--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -557,7 +557,6 @@ LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
       llvm_unreachable("Loop to unroll must not contain movable op.");
     });
     LogicalResult res = loopUnrollFull(loopToUnroll);
-
     assert(succeeded(res) && "failed to unroll");
     opsToErase.insert(op);
     return success();

--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -163,8 +163,16 @@ public:
     explicit Movable(KrnlMovableOp op) : movableOp(op) {}
     explicit Movable(KrnlIterateOp op) {
       auto operandRange = op->getOperands();
-      loopsToSkip = llvm::SmallVector<Value, 4>(operandRange.begin(),
-          operandRange.begin() + op.getNumOptimizedLoops());
+      SmallVector<Value, 4> values;
+      for (int64_t i = 0; i < op.getNumOptimizedLoops(); ++i) {
+        Value val = operandRange[i];
+        // Only skip non-unroll loops.
+        if (llvm::all_of(val.getUsers(), [&](Operation *user) {
+              return dyn_cast_or_null<KrnlUnrollOp>(user);
+            }))
+          values.emplace_back(val);
+      }
+      loopsToSkip = values;
     }
   };
 
@@ -237,7 +245,7 @@ public:
 
         // Move iterator to point to the next AffineFor Op.
         while (insertPt != loopBody.end() &&
-               !dyn_cast_or_null<AffineForOp>(&*insertPt)) {
+               !dyn_cast_or_null<AffineForOp>(&*insertPt) && loopToSkip) {
           assert(dyn_cast_or_null<KrnlMovableOp>(&*insertPt));
           insertPt++;
         }
@@ -405,6 +413,17 @@ void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
     refToOps.try_emplace(pair.first, pair.second);
 }
 
+void lowerGetInductionVariableValueOp(KrnlGetInductionVariableValueOp &getIVOp,
+    llvm::SmallDenseMap<Value, AffineForOp, 4> &loopRefToOp) {
+  auto zippedOperandsResults =
+      llvm::zip(getIVOp->getOperands(), getIVOp->getResults());
+  for (const auto &operandAndResult : zippedOperandsResults) {
+    auto operand = std::get<0>(operandAndResult);
+    auto result = std::get<1>(operandAndResult);
+    result.replaceAllUsesWith(loopRefToOp[operand].getInductionVar());
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // ConvertKrnlToAffinePass
 //===----------------------------------------------------------------------===//
@@ -429,16 +448,20 @@ LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
   for (auto &region : op->getRegions())
     for (auto &block : region.getBlocks()) {
       auto &blockOps = block.getOperations();
-      for (auto itr = blockOps.begin(); itr != blockOps.end();)
+      for (auto itr = blockOps.begin(); itr != blockOps.end();) {
+        LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << " Call interpretOperation \n");
         if (failed(interpretOperation(
                 &(*itr), builder, loopRefToOp, opsToErase, mover))) {
           return failure();
         } else {
           ++itr;
         }
+      }
     }
 
   if (auto defineOp = dyn_cast_or_null<KrnlDefineLoopsOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << DEBUG_TYPE << " interpret define op " << defineOp << "\n");
     // Collect users of defineLoops operations that are iterate operations.
     std::vector<KrnlIterateOp> iterateOps;
     for (auto result : op->getResults())
@@ -461,6 +484,8 @@ LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     opsToErase.insert(op);
     return success();
   } else if (auto iterateOp = dyn_cast_or_null<KrnlIterateOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << DEBUG_TYPE << " interpret iterate op " << iterateOp << "\n");
     // If an iterateOp has no unoptimized loop references, then we need to lower
     // them manually.
     if (opsToErase.count(op) == 0) {
@@ -469,6 +494,8 @@ LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     }
     return success();
   } else if (auto blockOp = dyn_cast_or_null<KrnlBlockOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << DEBUG_TYPE << " interpret block op " << blockOp << "\n");
     SmallVector<AffineForOp, 2> tiledLoops;
     SmallVector<AffineForOp, 1> loopsToTile = {loopRefToOp[blockOp.loop()]};
 
@@ -489,6 +516,8 @@ LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     opsToErase.insert(op);
     return success();
   } else if (auto permuteOp = dyn_cast_or_null<KrnlPermuteOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << DEBUG_TYPE << " interpret permute op " << permuteOp << "\n");
     // TODO(tjingrant): call it whenever an operation lowering completes.
     removeOps(opsToErase);
     // Collect loops to permute.
@@ -508,17 +537,35 @@ LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     opsToErase.insert(op);
     return success();
   } else if (auto unrollOp = dyn_cast_or_null<KrnlUnrollOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << DEBUG_TYPE << " interpret unroll op " << unrollOp << "\n");
     // Unroll the affine for loop fully.
     auto loopRef = unrollOp.loop();
     auto loopToUnroll = loopRefToOp[loopRef];
+
     mover.moveOne(loopRef, loopRefToOp);
+
+    // Interpret and remove 'krnl.get_induction_var' inside the unrolling loop
+    // if any. Otherwise, we lost the trace of the loop induction variables.
+    if (failed(interpretOperation(loopToUnroll.getOperation(), builder,
+            loopRefToOp, opsToErase, mover)))
+      return failure();
+    removeOps(opsToErase);
 
     // Assert that there's no floating code within the loop to be unrolled.
     loopToUnroll.walk([](KrnlMovableOp op) {
       llvm_unreachable("Loop to unroll must not contain movable op.");
     });
     LogicalResult res = loopUnrollFull(loopToUnroll);
+
     assert(succeeded(res) && "failed to unroll");
+    opsToErase.insert(op);
+    return success();
+  } else if (auto getIVOp =
+                 dyn_cast_or_null<KrnlGetInductionVariableValueOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << " interpret get_induction_var op "
+                            << getIVOp << "\n");
+    lowerGetInductionVariableValueOp(getIVOp, loopRefToOp);
     opsToErase.insert(op);
     return success();
   }
@@ -1433,18 +1480,6 @@ void ConvertKrnlToAffinePass::runOnFunction() {
       for (auto loopRef : loopRefs)
         opsToErase.insert(loopRefToOp[loopRef]);
       kernelOp.getLoopRefs().clear();
-    }
-
-    if (auto convertOp =
-            dyn_cast_or_null<KrnlGetInductionVariableValueOp>(op)) {
-      auto zippedOperandsResults =
-          llvm::zip(op->getOperands(), op->getResults());
-      for (const auto &operandAndResult : zippedOperandsResults) {
-        auto operand = std::get<0>(operandAndResult);
-        auto result = std::get<1>(operandAndResult);
-        result.replaceAllUsesWith(loopRefToOp[operand].getInductionVar());
-      }
-      opsToErase.insert(op);
     }
   });
   removeOps(opsToErase);

--- a/test/mlir/krnl/unroll.mlir
+++ b/test/mlir/krnl/unroll.mlir
@@ -38,7 +38,7 @@ func @unroll_with_block() {
   }
   return
 
-  // CHECK: #map = affine_map<(d0) -> (d0 + 1)>
+  // CHECK-DAG: #map = affine_map<(d0) -> (d0 + 1)>
   // CHECK-LABEL: unroll_with_block
   // CHECK:       affine.for [[IV:%.+]] = 0 to 8 step 2 {
   // CHECK-NEXT:    [[FOO_UNROLL_0:%.+]] = arith.addi [[IV]], [[IV]] : index
@@ -62,11 +62,54 @@ func @unroll_with_block_get_iv(%arg0 : memref<8xf32>) {
   }
   return
 
-  // CHECK: #map = affine_map<(d0) -> (d0 + 1)>
+  // CHECK-DAG: #map = affine_map<(d0) -> (d0 + 1)>
   // CHECK-LABEL: unroll_with_block_get_iv
   // CHECK:       affine.for [[IV:%.+]] = 0 to 8 step 2 {
   // CHECK-NEXT:    [[FOO_UNROLL_0:%.+]] = arith.addi [[IV]], [[IV]] : index
   // CHECK-NEXT:    [[IV_PLUS_1:%.+]] = affine.apply #map([[IV]])
   // CHECK-NEXT:    [[FOO_UNROLL_1:%.+]] = arith.addi [[IV]], [[IV_PLUS_1]] : index
   // CHECK-NEXT:  }
+}
+
+// -----
+
+func @unroll_with_block_and_permute() {
+  %ii, %ij = krnl.define_loops 2
+  %ib, %il = krnl.block %ii 5 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  %jb, %jl = krnl.block %ij 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  krnl.permute(%ib, %il, %jb, %jl) [0, 2, 1, 3] : !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop
+  krnl.unroll %jl : !krnl.loop
+  krnl.iterate(%ib, %jb) with (%ii -> %i = 0 to 10, %ij -> %j = 0 to 20) {
+    %b1, %b2 = krnl.get_induction_var_value(%ib, %jb) : (!krnl.loop, !krnl.loop) -> (index, index)
+    krnl.iterate(%il, %jl) with () {
+      %l1, %l2 = krnl.get_induction_var_value(%il, %jl) : (!krnl.loop, !krnl.loop) -> (index, index)
+      %foo = arith.addi %l1, %l2 : index
+      %bar = arith.addi %b1, %l2 : index
+    }
+  }
+  return
+
+  // CHECK-DAG: #map0 = affine_map<(d0) -> (d0)>
+  // CHECK-DAG: #map1 = affine_map<(d0) -> (d0 + 5)>
+  // CHECK-DAG: #map2 = affine_map<(d0) -> (d0 + 1)>
+  // CHECK-DAG: #map3 = affine_map<(d0) -> (d0 + 2)>
+  // CHECK-DAG: #map4 = affine_map<(d0) -> (d0 + 3)>
+  // CHECK-LABEL:  unroll_with_block_and_permute
+  // CHECK:        affine.for [[I_0_:%.+]] = 0 to 10 step 5 {
+  // CHECK:          affine.for [[I_1_:%.+]] = 0 to 20 step 4 {
+  // CHECK:            affine.for [[I_2_:%.+]] = #map0([[I_0_]]) to #map1([[I_0_]]) {
+  // CHECK-NEXT:         [[VAR_0_:%.+]] = arith.addi [[I_2_]], [[I_1_]] : index
+  // CHECK-NEXT:         [[VAR_1_:%.+]] = arith.addi [[I_0_]], [[I_1_]] : index
+  // CHECK-NEXT:         [[VAR_2_:%.+]] = affine.apply #map2([[I_1_]])
+  // CHECK-NEXT:         [[VAR_3_:%.+]] = arith.addi [[I_2_]], [[VAR_2_]] : index
+  // CHECK-NEXT:         [[VAR_4_:%.+]] = arith.addi [[I_0_]], [[VAR_2_]] : index
+  // CHECK-NEXT:         [[VAR_5_:%.+]] = affine.apply #map3([[I_1_]])
+  // CHECK-NEXT:         [[VAR_6_:%.+]] = arith.addi [[I_2_]], [[VAR_5_]] : index
+  // CHECK-NEXT:         [[VAR_7_:%.+]] = arith.addi [[I_0_]], [[VAR_5_]] : index
+  // CHECK-NEXT:         [[VAR_8_:%.+]] = affine.apply #map4([[I_1_]])
+  // CHECK-NEXT:         [[VAR_9_:%.+]] = arith.addi [[I_2_]], [[VAR_8_]] : index
+  // CHECK-NEXT:         [[VAR_10_:%.+]] = arith.addi [[I_0_]], [[VAR_8_]] : index
+  // CHECK:            }
+  // CHECK:          }
+  // CHECK:        }
 }

--- a/test/mlir/krnl/unroll.mlir
+++ b/test/mlir/krnl/unroll.mlir
@@ -23,3 +23,50 @@ func @simple_unroll() {
   //CHECK-NEST:  %6 = arith.addi %5, [[CONST_ONE_3]] : index
   return
 }
+
+// -----
+
+func @unroll_with_block() {
+  %ii = krnl.define_loops 1
+  %ii1, %ii2 = krnl.block %ii 2 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  krnl.unroll %ii2 : !krnl.loop
+  krnl.iterate(%ii1) with (%ii -> %i = 0 to 8) {
+    krnl.iterate(%ii2) with () {
+      %i2 = krnl.get_induction_var_value(%ii2) : (!krnl.loop) -> index
+      %foo = arith.addi %i2, %i2 : index
+    }
+  }
+  return
+
+  // CHECK: #map = affine_map<(d0) -> (d0 + 1)>
+  // CHECK-LABEL: unroll_with_block
+  // CHECK:       affine.for [[IV:%.+]] = 0 to 8 step 2 {
+  // CHECK-NEXT:    [[FOO_UNROLL_0:%.+]] = arith.addi [[IV]], [[IV]] : index
+  // CHECK-NEXT:    [[IV_PLUS_1:%.+]] = affine.apply #map([[IV]])
+  // CHECK-NEXT:    [[FOO_UNROLL_1:%.+]] = arith.addi [[IV_PLUS_1]], [[IV_PLUS_1]]  : index
+  // CHECK-NEXT:  }
+}
+
+// -----
+
+func @unroll_with_block_get_iv(%arg0 : memref<8xf32>) {
+  %ii = krnl.define_loops 1
+  %ii1, %ii2 = krnl.block %ii 2 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  krnl.unroll %ii2 : !krnl.loop
+  krnl.iterate(%ii1) with (%ii -> %i = 0 to 8) {
+    %i1 = krnl.get_induction_var_value(%ii1) : (!krnl.loop) -> index
+    krnl.iterate(%ii2) with () {
+      %i2 = krnl.get_induction_var_value(%ii2) : (!krnl.loop) -> index
+      %foo = arith.addi %i1, %i2 : index
+    }
+  }
+  return
+
+  // CHECK: #map = affine_map<(d0) -> (d0 + 1)>
+  // CHECK-LABEL: unroll_with_block_get_iv
+  // CHECK:       affine.for [[IV:%.+]] = 0 to 8 step 2 {
+  // CHECK-NEXT:    [[FOO_UNROLL_0:%.+]] = arith.addi [[IV]], [[IV]] : index
+  // CHECK-NEXT:    [[IV_PLUS_1:%.+]] = affine.apply #map([[IV]])
+  // CHECK-NEXT:    [[FOO_UNROLL_1:%.+]] = arith.addi [[IV]], [[IV_PLUS_1]] : index
+  // CHECK-NEXT:  }
+}


### PR DESCRIPTION
`krnl-to-affine` pass failed when lowering a krnl code in which `krnl.unroll` was used together with `krnl.get_induction_var_value`. This issue was reported in #984.

The issue happened because `krnl.get_induction_var_value` was lowered after `krnl.unroll`. When it's the turn of `krnl.get_induction_var_value`, loop induction variables were disappeared because they were already unrolled.

This patch fixes the issue by interpreting `krnl.get_induction_var_value` together with `krnl_unroll`, so the lowering can correctly interpret induction variable values.

Resolves #984

Signed-off-by: Tung D. Le <tung@jp.ibm.com>