### PR TITLE
Removed default building of onnx-mlir docs

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -68,7 +68,7 @@ function(add_onnx_mlir_dialect_doc dialect dialect_tablegen_file)
   add_custom_target(${dialect}DocGen DEPENDS ${GEN_DOC_FILE})
   add_dependencies(onnx-mlir-docs ${dialect}DocGen)
 endfunction()
-add_custom_target(onnx-mlir-docs ALL)
+add_custom_target(onnx-mlir-docs)
 
 function(add_onnx_mlir_dialect dialect)
   set(LLVM_TARGET_DEFINITIONS ${dialect}.td)


### PR DESCRIPTION
Right now, the onnx-mlir docs (generating the dialect md files for onnx and krnl) is generated by default. But this may fail for users that did not install onnx third party tools. In any case, this target `onnx-mlir-docs` should only be called when changes were made to either Krnl or ONNX dialect. This is generally a rare event. So definitely does not belong to the default build process.

This will address issue #1001

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>