### PR TITLE
Infrastructure for lowering to LLVM CategoryMapper.

### DIFF
--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -511,13 +511,14 @@ void KrnlBuilder::matmul(Value A, ValueRange aStart, Value B, ValueRange bStart,
       globalUBs[1], globalUBs[2], simdize, unroll, overcompute);
 }
 
-Value KrnlBuilder::constant(
-    MemRefType type, StringRef name, DenseElementsAttr value) const {
+Value KrnlBuilder::constant(MemRefType type, StringRef name,
+    DenseElementsAttr value, Optional<IntegerAttr> offset,
+    Optional<IntegerAttr> alignment) const {
   static int32_t constantID = 0;
   return b.create<KrnlGlobalOp>(loc, type, b.getI64ArrayAttr(type.getShape()),
       b.getStringAttr(name + std::to_string(constantID++)), value,
-      /*offset=*/nullptr,
-      /*alignment=*/nullptr);
+      offset.hasValue() ? offset.getValue() : nullptr,
+      alignment.hasValue() ? alignment.getValue() : nullptr);
 }
 
 void KrnlBuilder::memcpy(Value dest, Value src, Value size) const {

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -355,8 +355,9 @@ struct KrnlBuilder : public DialectBuilder {
       ValueRange cStart, ValueRange loops, ValueRange computeStarts,
       ValueRange globalUBs, bool simdize, bool unroll, bool overcompute);
 
-  Value constant(
-      MemRefType type, StringRef name, DenseElementsAttr value) const;
+  Value constant(MemRefType type, StringRef name, DenseElementsAttr value,
+      Optional<IntegerAttr> offset = None,
+      Optional<IntegerAttr> alignment = None) const;
 
   // C library functions.
   void memcpy(Value dest, Value src, Value size) const;

--- a/src/Dialect/Krnl/KrnlTypes.hpp
+++ b/src/Dialect/Krnl/KrnlTypes.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 
@@ -42,6 +43,25 @@ public:
   static StringType get(mlir::MLIRContext *context) {
     return Base::get(context);
   }
+
+  // Return the LLVM dialect type for a string with unknown value.
+  Type getLLVMType(mlir::MLIRContext *context) const {
+    // This should really be an i8* so a
+    // LLVM::PointerType::get(IntegerType::get(context, 8)); but a ptr type is
+    // not a valid element type for a memref, so we represents the string as a
+    // memref<?xi8>.
+    SmallVector<int64_t> shape(1, -1);
+    return MemRefType::get(shape, IntegerType::get(context, 8));
+  }
+
+  // Return the LLVM dialect type for a string with a know value (a string
+  // literal). In LLVM a string literal is represented by an array of i8.
+  Type getLLVMType(mlir::MLIRContext *context, StringRef value) const {
+    return LLVM::LLVMArrayType::get(IntegerType::get(context, 8), value.size());
+  }
+
+  // Return the size in bits for the underlying element type (i8).
+  int32_t getElementSize() const { return 8; }
 };
 
 } // namespace mlir

--- a/src/Runtime/CMakeLists.txt
+++ b/src/Runtime/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(jni)
 # such static library in a shared library can cause runtime failure on some architectures,
 # such as z. So we override the default and explicitly compile with -fPIC.
 add_onnx_mlir_library(cruntime STATIC
+  OMIndexLookup.c
   OMInstrument.c
   OMRandomNormal.c
   OMTensor.c
@@ -25,6 +26,7 @@ set_target_properties(cruntime
   )
 
 add_onnx_mlir_library(OMTensorUtils
+  OMIndexLookup.cpp
   OMInstrument.cpp
   OMRandomNormal.cpp
   OMTensor.cpp

--- a/src/Runtime/OMIndexLookup.c
+++ b/src/Runtime/OMIndexLookup.c
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------- OMIndexLookup.c - OMIndexLookup C Implementation ----------===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains implementation of the OMIndexLookup functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OMIndexLookup.inc"

--- a/src/Runtime/OMIndexLookup.cpp
+++ b/src/Runtime/OMIndexLookup.cpp
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------- OMIndexLookup.cpp - OMIndexLookup C++ Implementation --------===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains implementation of the OMIndexLookup functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OMIndexLookup.inc"

--- a/src/Runtime/OMIndexLookup.inc
+++ b/src/Runtime/OMIndexLookup.inc
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------- OMIndexLookup.inc - OMIndexLookup C/C++ Implementation -------===//
+//
+// Copyright 2021 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains C/C++ implementation of the OMIndexLookup functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+// Perform a 32-bit FNV (Fowler-Noll-Vo) hash on the given string.
+static inline uint32_t hash_string(uint32_t hval, const char *str) {
+  uint32_t prime = 0x01000193;
+  hval = (hval == 0) ? prime : hval;
+
+  int32_t len = strlen(str);
+  for (int32_t i = 0; i < len; ++i) {
+    char c = str[i];
+    hval *= prime;
+    hval ^= c;
+  }
+  return hval;
+}
+
+// Adaptation of 32-bit FNV for int64_t values.
+static inline uint32_t hash_int64(uint32_t hval, int64_t val) {
+  char str[20];
+  sprintf(str, "%lld", (long long)val);
+  return hash_string(hval, str);
+}
+
+/// Return the index (i.e. value) of the given string \p str in a perfect hash
+/// table described by the arrays \p G and \p V. The arrays length is given by
+/// \p dictSize. The index returned is valid if the string \p str provided is
+/// garanteed to be in the dictionary described by \p G and \p V.
+#ifdef __cplusplus
+extern "C"
+#endif
+    uint32_t
+    find_index_str(
+        const char *str, int32_t G[], int32_t V[], int32_t dictSize) {
+  assert(str && G && V && dictSize > 0);
+  int32_t d = G[hash_string(0, str) % dictSize];
+  int32_t index = (d < 0) ? V[-d - 1] : V[hash_string(d, str) % dictSize];
+  assert(index >= 0 && index < dictSize);
+  return index;
+}
+
+/// Return the index (i.e. value) of the given integer \p val in a perfect hash
+/// table described by the arrays \p G and \p V. The arrays length is given by
+/// \p dictSize. The index returned is valid if the value provided \p val is
+/// garanteed to be in the 'dictionary' described by \p G and \p V.
+#ifdef __cplusplus
+extern "C"
+#endif
+    uint32_t
+    find_index_i64(int64_t val, int32_t G[], int32_t V[], int32_t dictSize) {
+  assert(G && V && dictSize > 0);
+  int32_t d = G[hash_int64(0, val) % dictSize];
+  int32_t index = (d < 0) ? V[-d - 1] : V[hash_int64(d, val) % dictSize];
+  assert(index >= 0 && index < dictSize);
+  return index;
+}

--- a/src/Support/KrnlSupport.cpp
+++ b/src/Support/KrnlSupport.cpp
@@ -249,7 +249,11 @@ unsigned getMemRefEltSizeInBytes(MemRefType memRefType) {
   unsigned sizeInBits;
   if (elementType.isIntOrFloat()) {
     sizeInBits = elementType.getIntOrFloatBitWidth();
+  } else if (elementType.isa<StringType>()) {
+    auto stringType = elementType.cast<StringType>();
+    sizeInBits = stringType.getElementSize();
   } else {
+    assert(elementType.isa<VectorType>() && "elementType is not a VectorType");
     auto vectorType = elementType.cast<VectorType>();
     sizeInBits =
         vectorType.getElementTypeBitWidth() * vectorType.getNumElements();
@@ -273,6 +277,8 @@ int64_t getMemRefSizeInBytes(Value value) {
 /// Otherwise, emit runtime computations.
 Value getDynamicMemRefSizeInBytes(
     PatternRewriter &rewriter, Location loc, Value val) {
+  assert(
+      val.getType().isa<MemRefType>() && "Value type should be a MemRefType");
   MemRefType memRefType = val.getType().cast<MemRefType>();
   auto shape = memRefType.getShape();
   // Accumulate static dimensions first.


### PR DESCRIPTION
Lowering CategoryMapper from Krnl to LLVM. This PR contains part 1 of the necessary code.

Signed-off-by: Ettore Tiotto <etiotto@ca.ibm.com>