### PR TITLE
Category mapper lower to llvm part2

### DIFF
--- a/test/mlir/krnl/krnl_C_library_function_lowering.mlir
+++ b/test/mlir/krnl/krnl_C_library_function_lowering.mlir
@@ -1,0 +1,52 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-affine --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
+
+// -----
+
+// Test that krnl.strlen can be called when the argument is passed into the function.
+func private @test_krnl_strlen1(%arg0: !krnl.string) -> i64  {
+  %len = "krnl.strlen"(%arg0) : (!krnl.string) -> i64
+  return %len : i64
+
+// CHECK:       llvm.func @strlen(!llvm.ptr<i8>) -> i64
+// CHECK-LABEL: @test_krnl_strlen1(%arg0: !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>)
+// CHECK:       [[STR:%.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:       [[LEN:%.+]] = llvm.call @strlen([[STR]]) : (!llvm.ptr<i8>) -> i64
+// CHECK:       llvm.return [[LEN]] : i64
+}
+
+// -----
+
+// Test that krnl.strlen can be called when the argument is created via a load.
+func private @test_krnl_strlen2() -> i64  {
+  %c0 = arith.constant 0 : index  
+  %ptr_str = memref.alloc() {alignment = 16 : i64} : memref<1x!krnl.string>
+  %str = krnl.load %ptr_str[%c0] : memref<1x!krnl.string>
+  %len = "krnl.strlen"(%str) : (!krnl.string) -> i64
+  return %len : i64
+
+// CHECK:       llvm.func @strlen(!llvm.ptr<i8>) -> i64
+// CHECK-LABEL: @test_krnl_strlen2() -> i64
+// CHECK:       [[LOAD:%.+]] = llvm.load {{.*}} : !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+// CHECK:       [[STR:%.+]] = llvm.extractvalue [[LOAD]][1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:       [[LEN:%.+]] = llvm.call @strlen([[STR]]) : (!llvm.ptr<i8>) -> i64
+// CHECK:       llvm.return [[LEN]] : i64
+}
+
+// -----
+
+// Test that krnl.strncmp is lowered to a call to the strncmp standard C function.
+func private @test_strncmp(%str: !krnl.string, %len: i64) -> i32  {
+  %c0 = arith.constant 0 : index
+  %ptr = memref.alloc() {alignment = 16 : i64} : memref<1x!krnl.string>
+  %str1 = krnl.load %ptr[%c0] : memref<1x!krnl.string>
+  %cmp = "krnl.strncmp"(%str, %str1, %len) : (!krnl.string, !krnl.string, i64) -> i32
+  return %cmp : i32
+
+// CHECK:       llvm.func @strncmp(!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
+// CHECK-LABEL: @test_strncmp(%arg0: !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>, %arg1: i64) -> i32
+// CHECK:       [[LOAD:%.+]] = llvm.load {{.*}} : !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+// CHECK:       [[STR1:%.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:       [[STR2:%.+]] = llvm.extractvalue [[LOAD]][1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:       [[CMP:%.+]] = llvm.call @strncmp([[STR1]], [[STR2]], %arg1) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
+// CHECK:       llvm.return [[CMP]] : i32
+}

--- a/test/mlir/krnl/krnl_category_mapper.mlir
+++ b/test/mlir/krnl/krnl_category_mapper.mlir
@@ -1,0 +1,193 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-affine --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
+
+// -----
+
+// Test that 'krnl.find_index' can be called when the first argument is a string.
+func private @test_find_index_str(%str: !krnl.string) -> index {
+  %G = "krnl.global"() {name = "G", shape = [3], value = dense<[1,0,-3]> : vector<3xi32>} : () -> memref<3xi32>
+  %V = "krnl.global"() {name = "V", shape = [3], value = dense<[1,2,0]> : vector<3xi32>} : () -> memref<3xi32>
+  %c3 = arith.constant 3 : i32  
+  %index = "krnl.find_index"(%str, %G, %V, %c3) : (!krnl.string, memref<3xi32>, memref<3xi32>, i32) -> index
+  return %index : index
+}
+
+// CHECK-DAG:   llvm.func @find_index_str(!llvm.ptr<i8>, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
+// CHECK-DAG:   llvm.mlir.global internal constant @V(dense<[1, 2, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
+// CHECK-DAG:   llvm.mlir.global internal constant @G(dense<[1, 0, -3]> : vector<3xi32>) : !llvm.array<3 x i32>
+
+// CHECK-LABEL: @test_find_index_str(%arg0: !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>) -> i64
+// CHECK-DAG:   [[LEN:%.+]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK-DAG:   [[STR:%.+]] = llvm.extractvalue %arg0[1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:   [[G:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:   [[V:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:       [[INDEX:%.+]] = llvm.call @find_index_str([[STR]], [[G]], [[V]], [[LEN]]) : (!llvm.ptr<i8>, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
+// CHECK:       [[UNR_CONV:%.+]] = builtin.unrealized_conversion_cast [[INDEX]] : i32 to i64
+// CHECK:       llvm.return [[UNR_CONV]] : i64
+
+// -----
+
+// Test that 'krnl.find_index' can be called when the first argument is a int64_t.
+func private @test_find_index_int(%val: i64) -> index {
+  %G = "krnl.global"() {name = "G", shape = [3], value = dense<[1,0,-3]> : vector<3xi32>} : () -> memref<3xi32>
+  %V = "krnl.global"() {name = "V", shape = [3], value = dense<[1,2,0]> : vector<3xi32>} : () -> memref<3xi32>
+  %c3 = arith.constant 3 : i32  
+  %index = "krnl.find_index"(%val, %G, %V, %c3) : (i64, memref<3xi32>, memref<3xi32>, i32) -> index
+  return %index : index
+
+// CHECK-DAG:   llvm.func @find_index_i64(i64, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
+// CHECK-DAG:   llvm.mlir.global internal constant @V(dense<[1, 2, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
+// CHECK-DAG:   llvm.mlir.global internal constant @G(dense<[1, 0, -3]> : vector<3xi32>) : !llvm.array<3 x i32>
+
+// CHECK-LABEL: llvm.func @test_find_index_int(%arg0: i64) -> i64
+// CHECK-DAG:   [[LEN:%.+]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK-DAG:   [[G:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:   [[V:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:       [[INDEX:%.+]] = llvm.call @find_index_i64(%arg0, [[G]], [[V]], [[LEN]]) : (i64, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
+// CHECK:       [[UNR_CONV:%.+]] = builtin.unrealized_conversion_cast [[INDEX]] : i32 to i64
+// CHECK:       llvm.return [[UNR_CONV]] : i64
+}
+
+// -----
+
+// Test CategorMapper lowering when the input is a list of strings.
+func private @test_category_mapper_string_to_int64(%arg0: memref<2x2x!krnl.string>) -> memref<2x2xi64> {
+  %c0_i32 = arith.constant 0 : i32
+  %c-1_i64 = arith.constant -1 : i64
+  %c3_i32 = arith.constant 3 : i32
+  %0 = memref.alloc() {alignment = 16 : i64} : memref<2x2xi64>
+  %1 = "krnl.global"() {name = "G0", shape = [3], value = dense<[1, 0, -3]> : vector<3xi32>} : () -> memref<3xi32>
+  %2 = "krnl.global"() {name = "V1", shape = [3], value = dense<[1, 2, 0]> : vector<3xi32>} : () -> memref<3xi32>
+  %3 = "krnl.global"() {name = "cats_int64s2", shape = [3], value = dense<[1, 2, 3]> : tensor<3xi64>} : () -> memref<3xi64>
+  %4 = "krnl.global"() {name = "cats_strings3", shape = [3], value = dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>} : () -> memref<3x!krnl.string>
+  %5:2 = krnl.define_loops 2
+  krnl.iterate(%5#0, %5#1) with (%5#0 -> %arg1 = 0 to 2, %5#1 -> %arg2 = 0 to 2) {
+    %6:2 = krnl.get_induction_var_value(%5#0, %5#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+    %7 = krnl.load %arg0[%6#0, %6#1] : memref<2x2x!krnl.string>
+    %8 = "krnl.find_index"(%7, %1, %2, %c3_i32) : (!krnl.string, memref<3xi32>, memref<3xi32>, i32) -> index
+    %9 = krnl.load %4[%8] : memref<3x!krnl.string>
+    %10 = "krnl.strlen"(%9) : (!krnl.string) -> i64
+    %11 = "krnl.strncmp"(%7, %9, %10) : (!krnl.string, !krnl.string, i64) -> i32
+    %12 = arith.cmpi eq, %11, %c0_i32 : i32
+    scf.if %12 {
+      %13 = krnl.load %3[%8] : memref<3xi64>
+      krnl.store %13, %0[%6#0, %6#1] : memref<2x2xi64>
+    } else {
+      krnl.store %c-1_i64, %0[%6#0, %6#1] : memref<2x2xi64>
+    }
+  }
+  return %0 : memref<2x2xi64>
+
+  // CHECK-DAG: llvm.func @strncmp(!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
+  // CHECK-DAG: llvm.func @strlen(!llvm.ptr<i8>) -> i64
+  // CHECK-DAG: llvm.func @find_index_str(!llvm.ptr<i8>, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
+  // CHECK-DAG: llvm.mlir.global internal constant {{.*}}(dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>) : !llvm.array<3 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK-DAG: llvm.mlir.global internal constant {{.*}}(dense<[1, 2, 3]> : tensor<3xi64>) : !llvm.array<3 x i64>
+  // CHECK-DAG: llvm.mlir.global internal constant @V{{.*}}(dense<[1, 2, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
+  // CHECK-DAG: llvm.mlir.global internal constant @G{{.*}}(dense<[1, 0, -3]> : vector<3xi32>) : !llvm.array<3 x i32>
+
+  // CHECK-LABEL: @test_category_mapper_string_to_int64(%arg0: !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, %arg1: !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, %arg2: i64, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64) -> !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<2 x i64>, array<2 x i64>)>
+  // CHECK-DAG:   [[C0:%.+]] = llvm.mlir.constant(0 : i32) : i32  
+  // CHECK-DAG:   [[DEF_VAL:%.+]] = llvm.mlir.constant(-1 : i64) : i64  
+  // CHECK-DAG:   [[LEN:%.+]] = llvm.mlir.constant(3 : i32) : i32
+
+  /// Find the index of the input string:
+  // CHECK-DAG:   [[STR:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK-DAG:   [[G:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK-DAG:   [[V:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK:       [[INDEX:%.+]] = llvm.call @find_index_str([[STR]], [[G]], [[V]], [[LEN]]) : (!llvm.ptr<i8>, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
+
+  /// Determine whether the index is valid:
+  // CHECK:       [[STR1:%.+]]  = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK-DAG:   [[STRLEN:%.+]] = llvm.call @strlen([[STR1]]) : (!llvm.ptr<i8>) -> i64
+  // CHECK-DAG:   [[STR2:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK-DAG:   [[STR3:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK:       [[STREQ:%.+]] = llvm.call @strncmp([[STR2]], [[STR3]], [[STRLEN]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
+
+  /// Store the index if valid, otherwise store the default value:
+  // CHECK-NEXT:  [[IS_EQUAL:%.+]] = llvm.icmp "eq" [[STREQ]], [[C0]] : i32  
+  // CHECK-NEXT:  llvm.cond_br [[IS_EQUAL]], [[LAB_TRUE:\^.+]], [[LAB_FALSE:\^.+]]
+  // CHECK:       [[LAB_TRUE]]:
+  // CHECK:       [[UNR_CONV1:%.+]] = builtin.unrealized_conversion_cast [[INDEX]] : i32 to i64  
+  // CHECK:       [[GEP1:%.+]] = llvm.getelementptr {{.*}}[[UNR_CONV1]]{{.*}} : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>  
+  // CHECK:       [[LOAD1:%.+]] = llvm.load [[GEP1]] : !llvm.ptr<i64>  
+  // CHECK:       llvm.store [[LOAD1]], {{.*}} : !llvm.ptr<i64>
+  // CHECK-NEXT:  llvm.br [[IF_END:\^.+]]
+  // CHECK:       [[LAB_FALSE]]:  
+  // CHECK:       llvm.store [[DEF_VAL]], {{.*}} : !llvm.ptr<i64>
+  // CHECK-NEXT:  llvm.br [[IF_END]]
+  // CHECK:       [[IF_END]]:
+}
+
+// -----
+
+// Test CategorMapper lowering when the input is a list of int64_t.
+func private @test_category_mapper_int64_to_string(%arg0: memref<2x2xi64>) -> memref<2x2x!krnl.string> {
+  %c3_i32 = arith.constant 3 : i32
+  %0 = memref.alloc() {alignment = 16 : i64} : memref<2x2x!krnl.string>
+  %1 = "krnl.global"() {name = "G4", shape = [3], value = dense<[-1, 1, 0]> : vector<3xi32>} : () -> memref<3xi32>
+  %2 = "krnl.global"() {name = "V5", shape = [3], value = dense<[2, 1, 0]> : vector<3xi32>} : () -> memref<3xi32>
+  %3 = "krnl.global"() {name = "cats_int64s6", shape = [3], value = dense<[1, 2, 3]> : tensor<3xi64>} : () -> memref<3xi64>
+  %4 = "krnl.global"() {name = "cats_strings7", shape = [3], value = dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>} : () -> memref<3x!krnl.string>
+  %5 = "krnl.global"() {name = "default_string8", shape = [], value = dense<"none"> : tensor<!krnl.string>} : () -> memref<!krnl.string>
+  %6:2 = krnl.define_loops 2
+  krnl.iterate(%6#0, %6#1) with (%6#0 -> %arg1 = 0 to 2, %6#1 -> %arg2 = 0 to 2) {
+    %7:2 = krnl.get_induction_var_value(%6#0, %6#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+    %8 = krnl.load %arg0[%7#0, %7#1] : memref<2x2xi64>
+    %9 = "krnl.find_index"(%8, %1, %2, %c3_i32) : (i64, memref<3xi32>, memref<3xi32>, i32) -> index
+    %10 = krnl.load %3[%9] : memref<3xi64>
+    %11 = arith.cmpi eq, %8, %10 : i64
+    scf.if %11 {
+      %12 = krnl.load %4[%9] : memref<3x!krnl.string>
+      krnl.store %12, %0[%7#0, %7#1] : memref<2x2x!krnl.string>
+    } else {
+      %12 = krnl.load %5[] : memref<!krnl.string>
+      krnl.store %12, %0[%7#0, %7#1] : memref<2x2x!krnl.string>
+    }
+  }
+  return %0 : memref<2x2x!krnl.string>
+
+  // CHECK-DAG:  llvm.func @find_index_i64(i64, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
+  // CHECK-DAG:  llvm.mlir.global internal constant @default_string{{.*}}(dense<"none"> : tensor<!krnl.string>) : !llvm.array<1 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK-DAG:  llvm.mlir.global internal constant @cats_strings{{.*}}(dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>) : !llvm.array<3 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK-DAG:  llvm.mlir.global internal constant @cats_int64s{{.*}}(dense<[1, 2, 3]> : tensor<3xi64>) : !llvm.array<3 x i64>
+  // CHECK-DAG:  llvm.mlir.global internal constant @V{{.*}}(dense<[2, 1, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
+  // CHECK-DAG:  llvm.mlir.global internal constant @G{{.*}}(dense<[-1, 1, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
+
+  // CHECK-LABEL: @test_category_mapper_int64_to_string(%arg0: !llvm.ptr<i64>, %arg1: !llvm.ptr<i64>, %arg2: i64, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64) -> !llvm.struct<(ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, i64, array<2 x i64>, array<2 x i64>)> 
+  // CHECK-DAG:   [[LEN:%.+]] = llvm.mlir.constant(3 : i32) : i32
+  // CHECK:       [[MALLOC:%.+]] = llvm.call @malloc({{.*}}) : (i64) -> !llvm.ptr<i8>
+  // CHECK:       [[UNDEF:%.+]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, i64)>  
+  // CHECK:       [[EV_1:%.+]] = llvm.insertvalue {{.*}}, [[UNDEF]][0]
+  // CHECK:       [[EV_2:%.+]] = llvm.insertvalue {{.*}}, [[EV_1]][1]
+  // CHECK:       [[C0:%.+]] = llvm.mlir.constant(0 : index) : i64
+  // CHECK:       [[DEF_VAL:%.+]] = llvm.insertvalue [[C0]], [[EV_2]][2] : !llvm.struct<(ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, i64)>
+
+  /// Find the index of the input string:
+  // CHECK-DAG:   [[INPUT:%.+]] = llvm.load {{.*}} : !llvm.ptr<i64>  
+  // CHECK-DAG:   [[G:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK-DAG:   [[V:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK:       [[INDEX:%.+]] = llvm.call @find_index_i64([[INPUT]], [[G]], [[V]], [[LEN]]) : (i64, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
+  // CHECK-NEXT:  [[UNR_CONV:%.+]] = builtin.unrealized_conversion_cast [[INDEX]] : i32 to i64
+
+  /// Determine whether the index is valid:
+  // CHECK:       [[EV1:%.+]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+  // CHECK-DAG:   [[GEP1:%.+]] = llvm.getelementptr [[EV1]]{{.*}}[[UNR_CONV]]{{.*}} : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+  // CHECK-DAG:   [[INDEX1:%.+]] = llvm.load [[GEP1]] : !llvm.ptr<i64>
+
+  /// Store the index if valid, otherwise store the default value:
+  // CHECK-NEXT:  [[IS_EQUAL:%.+]] = llvm.icmp "eq" {{.*}}, [[INDEX1]] : i64  
+  // CHECK-NEXT:  llvm.cond_br [[IS_EQUAL]], [[LAB_TRUE:\^.+]], [[LAB_FALSE:\^.+]]
+  // CHECK:       [[LAB_TRUE]]:
+  // CHECK:       [[UNR_CONV1:%.+]] = builtin.unrealized_conversion_cast [[INDEX]] : i32 to i64  
+  // CHECK:       [[GEP1:%.+]] = llvm.getelementptr {{.*}}[[UNR_CONV1]]{{.*}} : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, i64) -> !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK:       [[LOAD1:%.+]] = llvm.load [[GEP1]] : !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK:       llvm.store [[LOAD1]], {{.*}} : !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK-NEXT:  llvm.br [[IF_END:\^.+]]
+  // CHECK:       [[LAB_FALSE]]:  
+  // CHECK:       [[EV2:%.+]] = llvm.extractvalue [[DEF_VAL]][1] : !llvm.struct<(ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, i64)>
+  // CHECK:       [[LOAD_EXT_VAL:%.+]] = llvm.load [[EV2]] : !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK:       llvm.store [[LOAD_EXT_VAL]], {{.*}} : !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK-NEXT:  llvm.br [[IF_END]]
+  // CHECK:       [[IF_END]]:
+}
+

--- a/test/mlir/onnx/onnx_lowering_category_mapper.mlir
+++ b/test/mlir/onnx/onnx_lowering_category_mapper.mlir
@@ -65,4 +65,3 @@ func private @test_category_mapper_int64_to_string(%arg0 : tensor<2x2xi64>) -> t
   // CHECK:     }
   // CHECK:     return [[ALLOCA]] : memref<2x2x!krnl.string>
 }
-


### PR DESCRIPTION
This PR implements the support to lower the `CategoryMapper` operator from the Krnl dialect to the LLVM dialect. 
It also add LIT tests to verify that the operator is lowered to LLVM as expected.