### PR TITLE
Generate datalayout in module.

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -110,6 +110,7 @@ endfunction()
 #     Same semantics as target_link_libraries().
 #   LINK_COMPONENTS llvm_components...
 #     Link the specified LLVM components.
+#     Note: only one linkage mode can be specified.
 #   )
 function(add_onnx_mlir_library name)
   cmake_parse_arguments(ARG

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -92,7 +92,7 @@ endfunction()
 
 # add_onnx_mlir_library(name sources...
 #   This function (generally) has the same semantic as add_library. In
-#   addition is supports the arguments below and it does the following
+#   addition it supports the arguments below and it does the following
 #   by default (unless an argument overrides this):
 #   1. Add the library
 #   2. Add the default target_include_directories
@@ -108,12 +108,14 @@ endfunction()
 #     Same semantics as target_include_directories().
 #   LINK_LIBS lib_targets...
 #     Same semantics as target_link_libraries().
+#   LINK_COMPONENTS llvm_components...
+#     Link the specified LLVM components.
 #   )
 function(add_onnx_mlir_library name)
   cmake_parse_arguments(ARG
     "EXCLUDE_FROM_OM_LIBS;NO_INSTALL"
     ""
-    "DEPENDS;INCLUDE_DIRS;LINK_LIBS"
+    "DEPENDS;INCLUDE_DIRS;LINK_LIBS;LINK_COMPONENTS"
     ${ARGN}
     )
 
@@ -140,6 +142,21 @@ function(add_onnx_mlir_library name)
 
   if (ARG_LINK_LIBS)
     target_link_libraries(${name} ${ARG_LINK_LIBS})
+  endif()
+
+  if (ARG_LINK_COMPONENTS)
+    set(LinkageMode)
+    if (ARG_LINK_COMPONENTS MATCHES "^(PUBLIC|PRIVATE|INTERFACE)")
+      list(POP_FRONT ARG_LINK_COMPONENTS LinkageMode)
+    endif()
+
+    llvm_map_components_to_libnames(COMPONENT_LIBS ${ARG_LINK_COMPONENTS})
+
+    if (LinkageMode)
+      target_link_libraries(${name} ${LinkageMode} ${COMPONENT_LIBS})
+    else()
+      target_link_libraries(${name} PRIVATE ${COMPONENT_LIBS})
+    endif()
   endif()
 
   if (NOT ARG_NO_INSTALL)

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -43,6 +43,14 @@ add_onnx_mlir_library(CompilerUtils
   MLIRAffineTransforms
   MLIRLinalgTransforms
   MLIRLLVMToLLVMIRTranslation
+
+  # Link LLVM libraries necessary to query which target architectures are configured.
+  LINK_COMPONENTS PRIVATE
+  AllTargetsDescs 
+  AllTargetsInfos 
+  AllTargetsCodeGens 
+  AllTargetsAsmParsers 
+  MC
   )
 
 # CompilerUtils does not require cruntime or jniruntime to build, however, they are

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -46,10 +46,10 @@ add_onnx_mlir_library(CompilerUtils
 
   # Link LLVM libraries necessary to query which target architectures are configured.
   LINK_COMPONENTS PRIVATE
-  AllTargetsDescs 
-  AllTargetsInfos 
-  AllTargetsCodeGens 
-  AllTargetsAsmParsers 
+  AllTargetsAsmParsers
+  AllTargetsCodeGens
+  AllTargetsDescs
+  AllTargetsInfos
   MC
   )
 

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===--------------------------- MainUtils.cpp ---------------------------===//
+//===-------------------------- CompilerUtils.cpp -------------------------===//
 //
 // Copyright 2019-2020 The IBM Research Authors.
 //
@@ -17,12 +17,16 @@
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Target/TargetMachine.h"
 
-#include "CompilerUtils.hpp"
 #include "ExternalUtil.hpp"
+#include "src/Compiler/CompilerUtils.hpp"
 #include "src/Support/OMOptions.hpp"
 
 using namespace std;
@@ -88,13 +92,14 @@ llvm::cl::opt<string> shapeInformation("shapeInformation",
         "unknown dimensions)"),
     llvm::cl::value_desc("value"), llvm::cl::cat(OnnxMlirOptions));
 
-llvm::cl::opt<string> mtriple("mtriple", llvm::cl::desc("Target architecture"),
-    llvm::cl::value_desc("<llvm target triple>"),
-    llvm::cl::cat(OnnxMlirOptions), llvm::cl::ValueRequired);
-
-llvm::cl::opt<string> mcpu("mcpu", llvm::cl::desc("Target cpu"),
-    llvm::cl::value_desc("<llvm cpu value>"), llvm::cl::cat(OnnxMlirOptions),
+llvm::cl::opt<std::string> mtriple("mtriple",
+    llvm::cl::desc("Target architecture"),
+    llvm::cl::value_desc("LLVM target triple>"), llvm::cl::cat(OnnxMlirOptions),
     llvm::cl::ValueRequired);
+
+llvm::cl::opt<std::string> mcpu("mcpu", llvm::cl::desc("Target cpu"),
+    llvm::cl::value_desc("Target a specific CPU type"),
+    llvm::cl::cat(OnnxMlirOptions), llvm::cl::ValueRequired);
 
 // Make a function that forces preserving all files using the runtime arguments
 // and/or the overridePreserveFiles enum.
@@ -291,7 +296,7 @@ void LoadMLIR(string inputFilename, mlir::MLIRContext &context,
   }
 }
 
-string getTargetCpuOption() {
+static std::string getTargetCpuOption() {
   string targetOptions = "";
   if (mcpu != "")
     targetOptions += "--mcpu=" + mcpu;
@@ -648,9 +653,6 @@ void outputCode(
 
   module->print(output->os(), flags);
   output->keep();
-
-  if (printIR)
-    module->print(llvm::outs(), flags);
 }
 
 void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
@@ -713,8 +715,50 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
   }
 }
 
+/// Return the module datalayout string. The datalayout string is determined by
+/// creating a target machine using the target triple and target cpu.
+static std::string getDataLayout(const Location &loc) {
+  const std::string targetTriple =
+      (mtriple != "") ? mtriple.getValue() : kDefaultTriple;
+  const std::string targetCpu = (mcpu != "") ? mcpu.getValue() : "";
+
+  std::string error;
+  const llvm::Target *LLVMTarget =
+      llvm::TargetRegistry::lookupTarget(targetTriple, error);
+  if (!LLVMTarget) {
+    emitError(loc, Twine("Target architecture is unknown: ") + error);
+    return nullptr;
+  }
+
+  llvm::TargetOptions ops;
+  llvm::TargetMachine *targetMachine = LLVMTarget->createTargetMachine(
+      targetTriple, targetCpu, "" /*features*/, ops, None);
+  if (!targetMachine) {
+    emitError(loc, "failed to create target machine");
+    return nullptr;
+  }
+
+  const llvm::DataLayout &dl = targetMachine->createDataLayout();
+  std::string dataLayoutString = dl.getStringRepresentation();
+  assert(dataLayoutString != "" && "Expecting a valid target datalayout");
+
+  return dataLayoutString;
+}
+
 int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
     std::string outputBaseName, EmissionTargetType emissionTarget) {
+  // Initialize the targets support for all targets LLVM was configured for.
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllAsmPrinters();
+  llvm::InitializeAllAsmParsers();
+
+  // Set the module datalayout.
+  Operation &moduleOp = *(module->getOperation());
+  Location loc = moduleOp.getLoc();
+  moduleOp.setAttr(LLVM::LLVMDialect::getDataLayoutAttrName(),
+      StringAttr::get(&context, getDataLayout(loc)));
+
   mlir::PassManager pm(&context, mlir::OpPassManager::Nesting::Implicit);
 
   if (keepFiles(KeepFilesOfType::MLIR)) {
@@ -725,9 +769,8 @@ int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
 
   InputIRLevelType inputIRLevel = determineInputIRLevel(module);
 
-  if (inputIRLevel <= ONNXLevel && emissionTarget >= EmitONNXIR) {
+  if (inputIRLevel <= ONNXLevel && emissionTarget >= EmitONNXIR)
     addONNXToMLIRPasses(pm);
-  }
 
   if (emissionTarget >= EmitMLIR) {
     if (inputIRLevel <= ONNXLevel)
@@ -743,6 +786,13 @@ int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
   if (mlir::failed(pm.run(*module)))
     return 4;
 
-  emitOutputFiles(outputBaseName, emissionTarget, context, module);
+  if (printIR) {
+    mlir::OpPrintingFlags flags;
+    if (preserveLocations)
+      flags.enableDebugInfo();
+    module->print(llvm::outs(), flags);
+  } else
+    emitOutputFiles(outputBaseName, emissionTarget, context, module);
+
   return 0;
 }

--- a/test/mlir/module_op_be/module_op.mlir
+++ b/test/mlir/module_op_be/module_op.mlir
@@ -1,6 +1,6 @@
-// RUN: onnx-mlir-opt --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir --printIR %s | FileCheck %s
 
-// CHECK: module attributes {llvm.data_layout = "E"}
+// CHECK: module attributes {llvm.data_layout = "E-{{.*}}"}
 module {
 }
 

--- a/test/mlir/module_op_le/module_op.mlir
+++ b/test/mlir/module_op_le/module_op.mlir
@@ -1,5 +1,5 @@
-// RUN: onnx-mlir-opt --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir --printIR %s | FileCheck %s
 
-// CHECK: module attributes {llvm.data_layout = "e"}
+// CHECK: module attributes {llvm.data_layout = "e-{{.*}}"}
 module {
 }

--- a/test/mlir/onnx/onnx_location.mlir
+++ b/test/mlir/onnx/onnx_location.mlir
@@ -1,11 +1,11 @@
 
-// RUN: onnx-mlir --EmitMLIR  --preserveLocations --printIR %s |  FileCheck %s --check-prefix=PRESENT; rm %p/*.onnx.mlir ; rm %p/*.tmp
-// RUN: onnx-mlir --EmitMLIR  --printIR %s | FileCheck %s --check-prefix=ABSENT; rm %p/*.onnx.mlir ; rm %p/*.tmp
+// RUN: onnx-mlir --preserveLocations --printIR %s |  FileCheck %s --check-prefix=PRESENT
+// RUN: onnx-mlir --printIR %s | FileCheck %s --check-prefix=ABSENT
 
   func @main_graph(%arg0: tensor<1x16xf32>, %arg1: tensor<1x16xf32>) -> tensor<1x16xf32>  {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<1x16xf32>, tensor<1x16xf32>) -> tensor<1x16xf32> loc("/build/workspace/addop.onnx":1:0)
      return %0 : tensor<1x16xf32>
   }
 
-// PRESENT: loc("onnx.Add"("{{(/[[:alnum:]]+)+}}.onnx":1:0))
-// ABSENT-NOT: loc("{{("onnx.Add"(/[[:alnum:]]+)+}}.onnx":1:0))
+// PRESENT:    loc("onnx.Add"("{{(/[[:alnum:]]+)+}}.onnx":1:0))
+// ABSENT-NOT: loc("onnx.Add"("{{(/[[:alnum:]]+)+}}.onnx":1:0))


### PR DESCRIPTION
This PR sets the datalayout for the generate LLVM IR module. The datalayout is set according to the effective value of the `triple`. used to compile the input MLIR file. With this PR:

```
 % ./Debug/bin/onnx-mlir ~/tmp/test.mlir  --preserveBitcode
Shared library /Users/etiotto@ca.ibm.com/tmp/test.so has been compiled.
% ~/Source/onnx/llvm-project/build/bin/llvm-dis  ~/tmp/test.bc
% head  ~/tmp/test.ll 
; ModuleID = '/Users/etiotto@ca.ibm.com/tmp/test.bc'
source_filename = "LLVMDialectModule"
target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-apple-darwin20.6.0"

@c = internal constant [6 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6]

declare i8* @malloc(i64)

declare void @free(i8*)
```