### PR TITLE
Add -v option to onnx-mlir

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -111,6 +111,10 @@ static llvm::cl::opt<OptLevel> OptimizationLevel(
         clEnumVal(O3, "Optimization level 3.")),
     llvm::cl::init(O0), llvm::cl::cat(OnnxMlirOptions));
 
+static llvm::cl::opt<bool> VerboseOutput("v",
+    llvm::cl::desc("Use verbose output"), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirOptions));
+
 // Make a function that forces preserving all files using the runtime arguments
 // and/or the overridePreserveFiles enum.
 enum class KeepFilesOfType { All, MLIR, Bitcode, Object, None };
@@ -279,8 +283,8 @@ struct Command {
     }
 
     // If in verbose mode, print out command before execution.
-    if (verbose)
-      llvm::outs() << "[" << StringRef(new_wdir).str() << "]" << _path << ": "
+    if (VerboseOutput || verbose)
+      llvm::errs() << "[" << StringRef(new_wdir).str() << "]" << _path << ": "
                    << llvm::join(argsRef, " ") << "\n";
 
     std::string errMsg;
@@ -445,7 +449,7 @@ static std::string genSharedLib(string outputBaseName, std::vector<string> opts,
   // link has to be before def and libpath since they need to be passed through
   // to the linker
   std::vector<string> sharedLibOpts = {
-      "/LD", "/link", "/def:" + outputBaseName + ".def"};
+      "/LD", "/link", "/NOLOGO", "/def:" + outputBaseName + ".def"};
 
   llvm::for_each(libs, [](string &lib) { lib = lib + ".lib"; });
   llvm::for_each(

--- a/test/mlir/driver/unix/check_verbosity.mlir
+++ b/test/mlir/driver/unix/check_verbosity.mlir
@@ -1,0 +1,13 @@
+// RUN: onnx-mlir -v %s 2>&1 |  FileCheck %s
+
+// REQUIRES: system-linux
+// CHECK:      opt {{.*}} -o {{.*}}check_verbosity.bc
+// CHECK-NEXT: llc {{.*}} -filetype=obj {{.*}} -o {{.*}}check_verbosity.o {{.*}}check_verbosity.bc
+// CHECK-NEXT: {{clang|c|g}}++ {{.*}}check_verbosity.o -o {{.*}}check_verbosity.so -shared -fPIC -L{{.*}}/lib -lcruntime
+module {
+    func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
+    %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+    return %0 : tensor<1x1xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 1 : i32, signature = ""} : () -> ()
+}

--- a/test/mlir/driver/windows/check_verbosity.def
+++ b/test/mlir/driver/windows/check_verbosity.def
@@ -1,0 +1,1 @@
+EXPORTS

--- a/test/mlir/driver/windows/check_verbosity.mlir
+++ b/test/mlir/driver/windows/check_verbosity.mlir
@@ -1,0 +1,13 @@
+// RUN: onnx-mlir -v %s 2>&1 |  FileCheck %s
+
+// REQUIRES: system-windows
+// CHECK:      opt.exe {{.*}} -o {{.*}}check_verbosity.bc 
+// CHECK-NEXT: llc.exe {{.*}} -filetype=obj {{.*}} -o {{.*}}check_verbosity.obj {{.*}}check_verbosity.bc 
+// CHECK-NEXT: cl.exe {{.*}}check_verbosity.obj /Fe:{{.*}}check_verbosity.dll {{.*}}
+module  {
+  func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
+    %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+    return %0 : tensor<1x1xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 1 : i32, signature = ""} : () -> ()
+}

--- a/test/mlir/onnx/onnx_location.mlir
+++ b/test/mlir/onnx/onnx_location.mlir
@@ -7,5 +7,5 @@
      return %0 : tensor<1x16xf32>
   }
 
-// PRESENT:    loc("onnx.Add"("{{(/[[:alnum:]]+)+}}.onnx":1:0))
+// PRESENT: loc("onnx.Add"("{{(/[[:alnum:]]+)+}}.onnx":1:0))
 // ABSENT-NOT: loc("onnx.Add"("{{(/[[:alnum:]]+)+}}.onnx":1:0))


### PR DESCRIPTION
Add an option (-v) to print out the commands the `onnx-mlir` driver invokes.

Signed-off-by: Ettore Tiotto <etiotto@ca.ibm.com>