### PR TITLE
Fix missleading error message when bad path to onnx model is given

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1431,16 +1431,13 @@ void ImportFrontendModelArray(const void *onnxBuffer, int size,
 
 void ImportFrontendModelFile(std::string model_fname, MLIRContext &context,
     OwningModuleRef &module, std::string *errorMessage, ImportOptions options) {
-  // try to open the input file to check if it can be opened in advance.
-  std::fstream test;
-  test.open(model_fname);
-  if (!test) {
+  onnx::ModelProto model;
+  std::fstream input(model_fname, std::ios::in | std::ios::binary);
+  // check if the input file is opened
+  if (!input.is_open()) {
     *errorMessage = "Unable to open or access " + model_fname;
     return;
   }
-  test.close();
-  onnx::ModelProto model;
-  std::fstream input(model_fname, std::ios::in | std::ios::binary);
 
   auto parse_success = model.ParseFromIstream(&input);
   if (!parse_success) {

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1396,6 +1396,14 @@ void ImportFrontendModelArray(const void *onnxBuffer, int size,
 
 void ImportFrontendModelFile(std::string model_fname, MLIRContext &context,
     OwningModuleRef &module, std::string *errorMessage, ImportOptions options) {
+  // try to open the input file to check if it can be opened in advance.
+  std::fstream test;
+  test.open(model_fname);
+  if (!test) {
+    *errorMessage = "Unable to open or access " + model_fname;
+    return;
+  }
+  test.close();
   onnx::ModelProto model;
   std::fstream input(model_fname, std::ios::in | std::ios::binary);
 


### PR DESCRIPTION
Fix missleading error message when bad path to onnx model is given.

Currently, if the given .onnx file can't be found the emitted error could be improved. For example: (note model should be resnet50-v1-7.onnx but I'm intentionally making a typo)
"onnx-mlir resnet50-v1.onnx"
Gives
"Onnx Model Parsing Failed on resnet50-v1.onnx"
This current error message is misleading, because it implies the model file was found but is bad or incompatible.

This PR changes the error message to "unable to open or access resnet50-v1.onnx".

Signed-off-by: Yasushi Negishi <negishi@jp.ibm.com>