### PR TITLE
Make onnx-to-krnl patterns re-usable

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -42,7 +42,7 @@ toc:
       - page: Instrumentation
         url:  Instrumentation.html
       - page: Constant Propagation
-        url:  ConstantPropagationPass.html
+        url:  ConstPropagationPass.html
   - title: Tools
   - title: Tools
     subfolderitems:

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -43,6 +43,77 @@ public:
   }
 };
 
+void populateONNXToKrnlConversion(RewritePatternSet &patterns, MLIRContext *ctx,
+    TypeConverter &typeConverter) {
+  // Type conversion for function signatures.
+  // Call MLIR FuncOp signature conversion when result type is
+  // a ranked tensor.
+  populateFuncOpTypeConversionPattern(patterns, typeConverter);
+  populateCallOpTypeConversionPattern(patterns, typeConverter);
+  populateReturnOpTypeConversionPattern(patterns, typeConverter);
+
+  // Frontend operation lowering.
+  // ControlFlow
+  populateLoweringONNXLoopOpPattern(patterns, ctx);
+  populateLoweringONNXScanOpPattern(patterns, ctx);
+  // Math
+  populateLoweringONNXClipOpPattern(patterns, ctx);
+  populateLoweringONNXCumSumOpPattern(patterns, ctx);
+  populateLoweringONNXElementwiseOpPattern(patterns, ctx);
+  populateLoweringONNXGemmOpPattern(patterns, ctx);
+  populateLoweringONNXHardmaxOpPattern(patterns, ctx);
+  populateLoweringONNXReductionOpPattern(patterns, ctx);
+  populateLoweringONNXSoftmaxOpPattern(patterns, ctx);
+  populateLoweringONNXTopKOpPattern(patterns, ctx);
+  populateLoweringONNXMatMulOpPattern(patterns, ctx);
+  populateLoweringONNXRandomNormalOpPattern(patterns, ctx);
+  populateLoweringONNXLRNOpPattern(patterns, ctx);
+  // ML
+  populateLoweringONNXCategoryMapperOpPattern(patterns, ctx);
+  // ObjectDetection
+  populateLoweringONNXNonMaxSuppressionOpPattern(patterns, ctx);
+  // Tensor
+  populateLoweringONNXArgMaxOpPattern(patterns, ctx);
+  populateLoweringONNXReshapeOpPattern(patterns, ctx);
+  populateLoweringONNXPadOpPattern(patterns, ctx);
+  populateLoweringONNXUnsqueezeOpPattern(patterns, ctx);
+  populateLoweringONNXUnsqueezeV11OpPattern(patterns, ctx);
+  populateLoweringONNXTransposeOpPattern(patterns, ctx);
+  populateLoweringONNXGatherOpPattern(patterns, ctx);
+  populateLoweringONNXIdentityOpPattern(patterns, ctx);
+  populateLoweringONNXConstantOfShapeOpPattern(patterns, ctx);
+  populateLoweringONNXConstantOpPattern(patterns, ctx);
+  populateLoweringONNXConcatOpPattern(patterns, ctx);
+  populateLoweringONNXDepthToSpaceOpPattern(patterns, ctx);
+  populateLoweringONNXSpaceToDepthOpPattern(patterns, ctx);
+  populateLoweringONNXShapeOpPattern(patterns, ctx);
+  populateLoweringONNXSliceOpPattern(patterns, ctx);
+  populateLoweringONNXSqueezeOpPattern(patterns, ctx);
+  populateLoweringONNXSqueezeV11OpPattern(patterns, ctx);
+  populateLoweringONNXSplitOpPattern(patterns, ctx);
+  populateLoweringONNXSplitV11OpPattern(patterns, ctx);
+  populateLoweringONNXSizeOpPattern(patterns, ctx);
+  populateLoweringONNXTileOpPattern(patterns, ctx);
+  populateLoweringONNXFlattenOpPattern(patterns, ctx);
+  populateLoweringONNXRangeOpPattern(patterns, ctx);
+  populateLoweringONNXResizeOpPattern(patterns, ctx);
+  populateLoweringONNXNonZeroOpPattern(patterns, ctx);
+  populateLoweringONNXReverseSequenceOpPattern(patterns, ctx);
+  populateLoweringONNXExpandOpPattern(patterns, ctx);
+  populateLoweringONNXOneHotOpPattern(patterns, ctx);
+  populateLoweringONNXCompressOpPattern(patterns, ctx);
+  // Neural network
+  populateLoweringONNXConvOpPattern(patterns, ctx);
+  populateLoweringONNXNormalizationOpPattern(patterns, ctx);
+  populateLoweringONNXPoolingOpPattern(patterns, ctx);
+  // Recurrent neural network
+  populateLoweringONNXGRUOpPattern(patterns, ctx);
+  populateLoweringONNXLSTMOpPattern(patterns, ctx);
+  populateLoweringONNXRNNOpPattern(patterns, ctx);
+  // Entry point
+  patterns.insert<ONNXEntryPointLowering>(ctx);
+}
+
 //===----------------------------------------------------------------------===//
 // Frontend to Krnl Dialect lowering pass
 //===----------------------------------------------------------------------===//
@@ -162,73 +233,8 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
     return krnlTypeConverter.isLegal(op);
   });
 
-  // Type conversion for function signatures.
-  // Call MLIR FuncOp signature conversion when result type is
-  // a ranked tensor.
-  populateFuncOpTypeConversionPattern(patterns, krnlTypeConverter);
-  populateCallOpTypeConversionPattern(patterns, krnlTypeConverter);
-  populateReturnOpTypeConversionPattern(patterns, krnlTypeConverter);
-
-  // Frontend operation lowering.
-  // ControlFlow
-  populateLoweringONNXLoopOpPattern(patterns, &getContext());
-  populateLoweringONNXScanOpPattern(patterns, &getContext());
-  // Math
-  populateLoweringONNXClipOpPattern(patterns, &getContext());
-  populateLoweringONNXCumSumOpPattern(patterns, &getContext());
-  populateLoweringONNXElementwiseOpPattern(patterns, &getContext());
-  populateLoweringONNXGemmOpPattern(patterns, &getContext());
-  populateLoweringONNXHardmaxOpPattern(patterns, &getContext());
-  populateLoweringONNXReductionOpPattern(patterns, &getContext());
-  populateLoweringONNXSoftmaxOpPattern(patterns, &getContext());
-  populateLoweringONNXTopKOpPattern(patterns, &getContext());
-  populateLoweringONNXMatMulOpPattern(patterns, &getContext());
-  populateLoweringONNXRandomNormalOpPattern(patterns, &getContext());
-  populateLoweringONNXLRNOpPattern(patterns, &getContext());
-  // ML
-  populateLoweringONNXCategoryMapperOpPattern(patterns, &getContext());
-  // ObjectDetection
-  populateLoweringONNXNonMaxSuppressionOpPattern(patterns, &getContext());
-  // Tensor
-  populateLoweringONNXArgMaxOpPattern(patterns, &getContext());
-  populateLoweringONNXReshapeOpPattern(patterns, &getContext());
-  populateLoweringONNXPadOpPattern(patterns, &getContext());
-  populateLoweringONNXUnsqueezeOpPattern(patterns, &getContext());
-  populateLoweringONNXUnsqueezeV11OpPattern(patterns, &getContext());
-  populateLoweringONNXTransposeOpPattern(patterns, &getContext());
-  populateLoweringONNXGatherOpPattern(patterns, &getContext());
-  populateLoweringONNXIdentityOpPattern(patterns, &getContext());
-  populateLoweringONNXConstantOfShapeOpPattern(patterns, &getContext());
-  populateLoweringONNXConstantOpPattern(patterns, &getContext());
-  populateLoweringONNXConcatOpPattern(patterns, &getContext());
-  populateLoweringONNXDepthToSpaceOpPattern(patterns, &getContext());
-  populateLoweringONNXSpaceToDepthOpPattern(patterns, &getContext());
-  populateLoweringONNXShapeOpPattern(patterns, &getContext());
-  populateLoweringONNXSliceOpPattern(patterns, &getContext());
-  populateLoweringONNXSqueezeOpPattern(patterns, &getContext());
-  populateLoweringONNXSqueezeV11OpPattern(patterns, &getContext());
-  populateLoweringONNXSplitOpPattern(patterns, &getContext());
-  populateLoweringONNXSplitV11OpPattern(patterns, &getContext());
-  populateLoweringONNXSizeOpPattern(patterns, &getContext());
-  populateLoweringONNXTileOpPattern(patterns, &getContext());
-  populateLoweringONNXFlattenOpPattern(patterns, &getContext());
-  populateLoweringONNXRangeOpPattern(patterns, &getContext());
-  populateLoweringONNXResizeOpPattern(patterns, &getContext());
-  populateLoweringONNXNonZeroOpPattern(patterns, &getContext());
-  populateLoweringONNXReverseSequenceOpPattern(patterns, &getContext());
-  populateLoweringONNXExpandOpPattern(patterns, &getContext());
-  populateLoweringONNXOneHotOpPattern(patterns, &getContext());
-  populateLoweringONNXCompressOpPattern(patterns, &getContext());
-  // Neural network
-  populateLoweringONNXConvOpPattern(patterns, &getContext());
-  populateLoweringONNXNormalizationOpPattern(patterns, &getContext());
-  populateLoweringONNXPoolingOpPattern(patterns, &getContext());
-  // Recurrent neural network
-  populateLoweringONNXGRUOpPattern(patterns, &getContext());
-  populateLoweringONNXLSTMOpPattern(patterns, &getContext());
-  populateLoweringONNXRNNOpPattern(patterns, &getContext());
-  // Entry point
-  patterns.insert<ONNXEntryPointLowering>(&getContext());
+  // Define patterns.
+  populateONNXToKrnlConversion(patterns, &getContext(), krnlTypeConverter);
 
   // With the target and rewrite patterns defined, we can now attempt the
   // conversion. The conversion will signal failure if any of our `illegal`

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -43,8 +43,8 @@ public:
   }
 };
 
-void populateONNXToKrnlConversion(RewritePatternSet &patterns, MLIRContext *ctx,
-    TypeConverter &typeConverter) {
+void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
+    MLIRContext *ctx, TypeConverter &typeConverter) {
   // Type conversion for function signatures.
   // Call MLIR FuncOp signature conversion when result type is
   // a ranked tensor.
@@ -234,7 +234,8 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   });
 
   // Define patterns.
-  populateONNXToKrnlConversion(patterns, &getContext(), krnlTypeConverter);
+  populateONNXToKrnlConversionPattern(
+      patterns, &getContext(), krnlTypeConverter);
 
   // With the target and rewrite patterns defined, we can now attempt the
   // conversion. The conversion will signal failure if any of our `illegal`

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -251,8 +251,8 @@ public:
 //===----------------------------------------------------------------------===//
 
 // For all ONNX operations.
-void populateONNXToKrnlConversion(RewritePatternSet &patterns, MLIRContext *ctx,
-    TypeConverter &typeConverter);
+void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
+    MLIRContext *ctx, TypeConverter &typeConverter);
 
 // `ControlFlow` directory methods:
 void populateLoweringONNXLoopOpPattern(

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -250,6 +250,10 @@ public:
 // Functions to add lowering patterns for frontend operations.
 //===----------------------------------------------------------------------===//
 
+// For all ONNX operations.
+void populateONNXToKrnlConversion(RewritePatternSet &patterns, MLIRContext *ctx,
+    TypeConverter &typeConverter);
+
 // `ControlFlow` directory methods:
 void populateLoweringONNXLoopOpPattern(
     RewritePatternSet &patterns, MLIRContext *ctx);


### PR DESCRIPTION
This patch makes onnx-to-krnl patterns re-usable by grouping all patterns into a single function. Hence, the patterns can be called from a lowering pass in another project.

This patch also fixes a typo in a link in the onnxai webpage.