### PR TITLE
Set krnl.global alignment using module datalayout if present

### DIFF
--- a/test/mlir/krnl/krnl_category_mapper.mlir
+++ b/test/mlir/krnl/krnl_category_mapper.mlir
@@ -12,8 +12,8 @@ func private @test_find_index_str(%str: !krnl.string) -> index {
 }
 
 // CHECK-DAG:   llvm.func @find_index_str(!llvm.ptr<i8>, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
-// CHECK-DAG:   llvm.mlir.global internal constant @V(dense<[1, 2, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
-// CHECK-DAG:   llvm.mlir.global internal constant @G(dense<[1, 0, -3]> : vector<3xi32>) : !llvm.array<3 x i32>
+// CHECK-DAG:   llvm.mlir.global internal constant @V(dense<[1, 2, 0]> : vector<3xi32>) {alignment = 16 : i64} : !llvm.array<3 x i32>
+// CHECK-DAG:   llvm.mlir.global internal constant @G(dense<[1, 0, -3]> : vector<3xi32>) {alignment = 16 : i64} : !llvm.array<3 x i32>
 
 // CHECK-LABEL: @test_find_index_str(%arg0: !llvm.struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>) -> i64
 // CHECK-DAG:   [[LEN:%.+]] = llvm.mlir.constant(3 : i32) : i32
@@ -35,8 +35,8 @@ func private @test_find_index_int(%val: i64) -> index {
   return %index : index
 
 // CHECK-DAG:   llvm.func @find_index_i64(i64, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
-// CHECK-DAG:   llvm.mlir.global internal constant @V(dense<[1, 2, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
-// CHECK-DAG:   llvm.mlir.global internal constant @G(dense<[1, 0, -3]> : vector<3xi32>) : !llvm.array<3 x i32>
+// CHECK-DAG:   llvm.mlir.global internal constant @V(dense<[1, 2, 0]> : vector<3xi32>) {alignment = 16 : i64} : !llvm.array<3 x i32>
+// CHECK-DAG:   llvm.mlir.global internal constant @G(dense<[1, 0, -3]> : vector<3xi32>) {alignment = 16 : i64} : !llvm.array<3 x i32>
 
 // CHECK-LABEL: llvm.func @test_find_index_int(%arg0: i64) -> i64
 // CHECK-DAG:   [[LEN:%.+]] = llvm.mlir.constant(3 : i32) : i32
@@ -80,10 +80,10 @@ func private @test_category_mapper_string_to_int64(%arg0: memref<2x2x!krnl.strin
   // CHECK-DAG: llvm.func @strncmp(!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
   // CHECK-DAG: llvm.func @strlen(!llvm.ptr<i8>) -> i64
   // CHECK-DAG: llvm.func @find_index_str(!llvm.ptr<i8>, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
-  // CHECK-DAG: llvm.mlir.global internal constant {{.*}}(dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>) : !llvm.array<3 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
-  // CHECK-DAG: llvm.mlir.global internal constant {{.*}}(dense<[1, 2, 3]> : tensor<3xi64>) : !llvm.array<3 x i64>
-  // CHECK-DAG: llvm.mlir.global internal constant @V{{.*}}(dense<[1, 2, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
-  // CHECK-DAG: llvm.mlir.global internal constant @G{{.*}}(dense<[1, 0, -3]> : vector<3xi32>) : !llvm.array<3 x i32>
+  // CHECK-DAG: llvm.mlir.global internal constant {{.*}}(dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>) {alignment = 16 : i64} : !llvm.array<3 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK-DAG: llvm.mlir.global internal constant {{.*}}(dense<[1, 2, 3]> : tensor<3xi64>) {alignment = 16 : i64} : !llvm.array<3 x i64>
+  // CHECK-DAG: llvm.mlir.global internal constant @V{{.*}}(dense<[1, 2, 0]> : vector<3xi32>) {alignment = 16 : i64} : !llvm.array<3 x i32>
+  // CHECK-DAG: llvm.mlir.global internal constant @G{{.*}}(dense<[1, 0, -3]> : vector<3xi32>) {alignment = 16 : i64} : !llvm.array<3 x i32>
 
   // CHECK-LABEL: @test_category_mapper_string_to_int64(%arg0: !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, %arg1: !llvm.ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, %arg2: i64, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64) -> !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<2 x i64>, array<2 x i64>)>
   // CHECK-DAG:   [[C0:%.+]] = llvm.mlir.constant(0 : i32) : i32  
@@ -147,11 +147,11 @@ func private @test_category_mapper_int64_to_string(%arg0: memref<2x2xi64>) -> me
   return %0 : memref<2x2x!krnl.string>
 
   // CHECK-DAG:  llvm.func @find_index_i64(i64, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i32
-  // CHECK-DAG:  llvm.mlir.global internal constant @default_string{{.*}}(dense<"none"> : tensor<!krnl.string>) : !llvm.array<1 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
-  // CHECK-DAG:  llvm.mlir.global internal constant @cats_strings{{.*}}(dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>) : !llvm.array<3 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
-  // CHECK-DAG:  llvm.mlir.global internal constant @cats_int64s{{.*}}(dense<[1, 2, 3]> : tensor<3xi64>) : !llvm.array<3 x i64>
-  // CHECK-DAG:  llvm.mlir.global internal constant @V{{.*}}(dense<[2, 1, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
-  // CHECK-DAG:  llvm.mlir.global internal constant @G{{.*}}(dense<[-1, 1, 0]> : vector<3xi32>) : !llvm.array<3 x i32>
+  // CHECK-DAG:  llvm.mlir.global internal constant @default_string{{.*}}(dense<"none"> : tensor<!krnl.string>) {alignment = 16 : i64} : !llvm.array<1 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK-DAG:  llvm.mlir.global internal constant @cats_strings{{.*}}(dense<["cat", "dog", "cow"]> : tensor<3x!krnl.string>) {alignment = 16 : i64} : !llvm.array<3 x struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>
+  // CHECK-DAG:  llvm.mlir.global internal constant @cats_int64s{{.*}}(dense<[1, 2, 3]> : tensor<3xi64>) {alignment = 16 : i64} : !llvm.array<3 x i64>
+  // CHECK-DAG:  llvm.mlir.global internal constant @V{{.*}}(dense<[2, 1, 0]> : vector<3xi32>) {alignment = 16 : i64} : !llvm.array<3 x i32>
+  // CHECK-DAG:  llvm.mlir.global internal constant @G{{.*}}(dense<[-1, 1, 0]> : vector<3xi32>) {alignment = 16 : i64} : !llvm.array<3 x i32>
 
   // CHECK-LABEL: @test_category_mapper_int64_to_string(%arg0: !llvm.ptr<i64>, %arg1: !llvm.ptr<i64>, %arg2: i64, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64) -> !llvm.struct<(ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, ptr<struct<(ptr<i8>, ptr<i8>, i64, array<1 x i64>, array<1 x i64>)>>, i64, array<2 x i64>, array<2 x i64>)> 
   // CHECK-DAG:   [[LEN:%.+]] = llvm.mlir.constant(3 : i32) : i32

--- a/test/mlir/krnl/krnl_global_with_alignment_lowering.mlir
+++ b/test/mlir/krnl/krnl_global_with_alignment_lowering.mlir
@@ -1,11 +1,12 @@
 // RUN: onnx-mlir-opt --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
 
+// Test that the global constant is aligned as specified by the explicit alignment.
 func @test_krnl_global_constant_alignment() -> memref<3xf32> {
   %0 = "krnl.global"() {name = "constant", alignment = 1024 : i64, shape = [3], value = dense<[0.0, 0.1, 0.2]> : tensor<3xf32>} : () -> memref<3xf32>
   return %0 : memref<3xf32>
 
 // CHECK:         llvm.mlir.global internal constant @constant(dense<[0.000000e+00, 1.000000e-01, 2.000000e-01]> : tensor<3xf32>) {alignment = 1024 : i64} : !llvm.array<3 x f32>
-// CHECK:         llvm.func @test_krnl_global_constant_alignment() -> !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)> {
+// CHECK-LABEL:   llvm.func @test_krnl_global_constant_alignment() -> !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)> {
 // CHECK:           [[VAR_0_:%.+]] = llvm.mlir.addressof @constant : !llvm.ptr<array<3 x f32>>
 // CHECK-DAG:       [[VAR_1_:%.+]] = llvm.bitcast [[VAR_0_]] : !llvm.ptr<array<3 x f32>> to !llvm.ptr<f32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
@@ -20,5 +21,31 @@ func @test_krnl_global_constant_alignment() -> memref<3xf32> {
 // CHECK-DAG:       [[VAR_9_:%.+]] = llvm.mlir.constant(1 : index) : i64
 // CHECK:           [[VAR_10_:%.+]] = llvm.insertvalue [[VAR_9_]], [[VAR_8_]][4, 0] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
 // CHECK:           llvm.return [[VAR_10_]] : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:         }
+}
+
+// -----
+
+// Test that the global constant is aligned on a 16 bytes boundary when an explicit alignment is not specified. 
+func @test_krnl_global_constant_no_alignment() -> memref<2xi64> {
+  %0 = "krnl.global"() {name = "constant", shape = [2], value = dense<[0, 1]> : tensor<2xi64>} : () -> memref<2xi64>
+  return %0 : memref<2xi64>
+
+// CHECK:         llvm.mlir.global internal constant @constant(dense<[0, 1]> : tensor<2xi64>) {alignment = 16 : i64} : !llvm.array<2 x i64>
+// CHECK-LABEL:   llvm.func @test_krnl_global_constant_no_alignment() -> !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)> {
+// CHECK:           [[VAR_0_:%.+]] = llvm.mlir.addressof @constant : !llvm.ptr<array<2 x i64>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = llvm.bitcast [[VAR_0_]] : !llvm.ptr<array<2 x i64>> to !llvm.ptr<i64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = llvm.mlir.undef : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           [[VAR_3_:%.+]] = llvm.insertvalue [[VAR_1_]], [[VAR_2_]][0] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:       [[VAR_4_:%.+]] = llvm.insertvalue [[VAR_1_]], [[VAR_3_]][1] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:       [[VAR_5_:%.+]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_6_:%.+]] = llvm.insertvalue [[VAR_5_]], [[VAR_4_]][2] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:       [[VAR_7_:%.+]] = llvm.mlir.constant(2 : index) : i64
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_8_:%.+]] = llvm.insertvalue [[VAR_7_]], [[VAR_6_]][3, 0] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-DAG:       [[VAR_9_:%.+]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:           [[VAR_10_:%.+]] = llvm.insertvalue [[VAR_9_]], [[VAR_8_]][4, 0] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           llvm.return [[VAR_10_]] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
 // CHECK:         }
 }


### PR DESCRIPTION
If `krnl.global` does not have an explicit alignment attribute sets the alignment based on the module's datalayout attribute (if present).