### PR TITLE
Index value capture for arrays of 0D

### DIFF
--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -1514,9 +1514,9 @@ bool ArrayValueIndexCapture::getSymbolList(
   auto shapeType = array.getType().dyn_cast_or_null<ShapedType>();
   if (!shapeType)
     return false; // Assume error if its not a shape type.
-  assert(shapeType.getRank() == 1 &&
-         "Array value index capture supports 1D arrays");
-  int num = shapeType.getShape()[0];
+  int rank = shapeType.getRank();
+  assert(rank <= 1 && "Array value index capture supports const or 1D arrays");
+  int num = (rank == 0) ? 1 : shapeType.getShape()[0];
   if (num == -1)
     return false; // Cannot read an unranked array.
   return getSymbolList(num, symbolList);

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1180,6 +1180,22 @@ func @test_unsqueeze(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
 
 // -----
 
+func private @unsqueeze_of_const(%arg0: tensor<32x64xi64>) -> tensor<*xi64> {
+   %1 = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+   %2 = "onnx.Unsqueeze"(%arg0, %1) : (tensor<32x64xi64>, tensor<i64>) -> tensor<*xi64>
+  "std.return"(%2) : (tensor<*xi64>) -> ()
+
+// mlir2FileCheck.py -a'["data"]'
+// CHECK-LABEL:  func private @unsqueeze_of_const
+// CHECK-SAME:   ([[DATA_:%.+]]: tensor<32x64xi64>) -> tensor<1x32x64xi64> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[DATA_]], [[VAR_0_]]) : (tensor<32x64xi64>, tensor<i64>) -> tensor<1x32x64xi64>
+// CHECK:           return [[VAR_1_]] : tensor<1x32x64xi64>
+// CHECK:         }
+}
+
+// -----
+
 func @test_unsqueezev11(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.UnsqueezeV11"(%arg0) { axes = [1]} : (tensor<16x32x64xf32>) -> (tensor<*xf32>)
   "std.return"(%0) : (tensor<*xf32>) -> ()


### PR DESCRIPTION
Case is needed as sometimes instead of a 1D array, we just get a single value. Now the index capture of such 0D array is enabled.