### PR TITLE
removed reference to master where possible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,21 @@
 
 # Contributing to the ONNX-MLIR project
 
+## Temporary warning: we now use a `main` branch
+
+In case you forked your own repo some times ago, you will need to update your forked onnx-mlir to also use the `main` branch as a basis for all your pull requests.
+
+Assuming that you have a remote upstream which points to the original onnx-mlir repo, and a remote origin which points to your fork of the onnx-mlir repo, you can get a local clone of the main branch with the following commands:
+
+```
+# git fetch upstream                  (fetch upstream/main and other branches)
+# git checkout main                   (checkout local copy of upstream/main)
+# git branch --unset-upstream         (stop tracking upstream/main)
+# git push --set-upstream origin main (push to and track origin/main instead)
+```
+
+Now you have a local `main`, which tracks `origin/main`.
+
 ## Building ONNX-MLIR
 
 Up to date info on how to build the project is located in the top directory [here](README.md). 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ RUN apt-get install -y vim
 # WORKDIR /workdir/workspace
 # ADD workspace /workdir/workspace
 
-# 5) Fix git by reattaching head and making git see other branches than master.
+# 5) Fix git by reattaching head and making git see other branches than main.
 WORKDIR /workdir/onnx-mlir
-RUN git checkout master
+RUN git checkout main
 RUN git fetch --unshallow
 
 # 6) Set the PATH environment vars for make/debug mode. Replace Debug

--- a/docs/ConstPropagationPass.md
+++ b/docs/ConstPropagationPass.md
@@ -4,7 +4,7 @@ This document describes `--constprop-onnx` pass which is used to do
 constant propagation for operations in the ONNX dialect.
 
 [source
-code](https://github.com/onnx/onnx-mlir/blob/master/src/Transform/ONNX/ConstProp.td).
+code](https://github.com/onnx/onnx-mlir/blob/main/src/Transform/ONNX/ConstProp.td).
 
 ## Example
 Given the following code:
@@ -100,7 +100,7 @@ Now, we go through a simple example that adds constant propagation for ONNXAddOp
 ### Step 1: Write DRR patterns <a id="step1"></a>
 
 We first add a pattern to
-[ConstProp.td](https://github.com/onnx/onnx-mlir/blob/master/src/Transform/ONNX/ConstProp.td).
+[ConstProp.td](https://github.com/onnx/onnx-mlir/blob/main/src/Transform/ONNX/ConstProp.td).
 
 ```mlir
 // Constant Propagation for Add
@@ -138,7 +138,7 @@ def CreateAddOfTwoConst :
 ### Step 2: Prepare array buffers for inputs and result <a id="step2"></a>
 
 Function `CreateAddOfTwoConst` in the pattern calls
-`ConstPropElementwiseBinary` in [ConstProp.cpp](https://github.com/onnx/onnx-mlir/blob/master/src/Transform/ONNX/ConstProp.cpp) whose content is as follows.
+`ConstPropElementwiseBinary` in [ConstProp.cpp](https://github.com/onnx/onnx-mlir/blob/main/src/Transform/ONNX/ConstProp.cpp) whose content is as follows.
 
 ```c++
 template <typename ElementwiseBinaryOp>
@@ -267,6 +267,6 @@ indices for the lhs and rhs according to the broadcasting rule. After that, it
 computes linear indices for the lhs and rhs, then get lhs and rhs values for
 addition. The result is finally stored to the result array buffer.
 
-For more information about constant propagation, please see [ConstProp.td](https://github.com/onnx/onnx-mlir/blob/master/src/Transform/ONNX/ConstProp.td)
+For more information about constant propagation, please see [ConstProp.td](https://github.com/onnx/onnx-mlir/blob/main/src/Transform/ONNX/ConstProp.td)
 and
-[ConstProp.cpp](https://github.com/onnx/onnx-mlir/blob/master/src/Transform/ONNX/ConstProp.cpp).
+[ConstProp.cpp](https://github.com/onnx/onnx-mlir/blob/main/src/Transform/ONNX/ConstProp.cpp).

--- a/docs/Workflow.md
+++ b/docs/Workflow.md
@@ -39,7 +39,7 @@ cd $working_dir/onnx-mlir
 git remote add upstream https://github.com/onnx-mlir/onnx-mlir.git
 # or: git remote add upstream git@github.com:onnx-mlir/onnx-mlir.git
 
-# Never push to upstream master since you do not have write access.
+# Never push to upstream main since you do not have write access.
 git remote set-url --push upstream no_push
 
 # Confirm that your remotes make sense:
@@ -53,16 +53,16 @@ git remote -v
 
 ### Step 3: Branch
 
-Get your local master up to date:
+Get your local main up to date:
 
 ```sh
 cd $working_dir/onnx-mlir
 git fetch upstream
-git checkout master
-git rebase upstream/master
+git checkout main
+git rebase upstream/main
 ```
 
-Branch from master:
+Branch from main:
 
 ```sh
 git checkout -b myfeature
@@ -107,10 +107,10 @@ in a few cycles.
 ```sh
 # While on your myfeature branch.
 git fetch upstream
-git rebase upstream/master
+git rebase upstream/main
 ```
 
-If the administrator merges other's PR on master branch while you're working on the `myfeature` branch,
+If the administrator merges other's PR on main branch while you're working on the `myfeature` branch,
 conflict may occurs. You're responsible for solving the conflict. Then continue:
 
 ```sh

--- a/docs/docker-example/Dockerfile
+++ b/docs/docker-example/Dockerfile
@@ -34,9 +34,9 @@ RUN apt-get install -y vim
 # WORKDIR /workdir/workspace
 # ADD workspace /workdir/workspace
 
-# 5) Fix git by reattaching head and making git see other branches than master.
+# 5) Fix git by reattaching head and making git see other branches than main.
 WORKDIR /workdir/onnx-mlir
-RUN git checkout master
+RUN git checkout main
 RUN git fetch --unshallow
 
 # 6) Set the PATH environment vars for make/debug mode. Replace Debug

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -115,7 +115,7 @@ static int64_t getRankFromMemRefType(LLVM::LLVMStructType memRefTy) {
   // that the corresponding tensor of this MemRef is a scalar, the 4th and 5th
   // elements will have 0-length, which in turn causes the MemRef struct to
   // degenerate into a 3-element struct. For more information, refer to
-  // https://github.com/llvm/llvm-project/blob/master/mlir/docs/ConversionToLLVMDialect.md#memref-types.
+  // https://github.com/llvm/llvm-project/blob/main/mlir/docs/ConversionToLLVMDialect.md#memref-types.
   auto numElems = memRefTy.getBody().size();
   assert((numElems == 3 || numElems == 5) &&
          "Expect MemRef type to contain either 3 or 5 elements.");


### PR DESCRIPTION
Added a temporary warning on how to transition to using `main` branch (thanks Gong) and removed spurious reference to `master` branch, mostly in http addresses.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>