### PR TITLE
Output clearer messsaging on output file permission issues

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1431,16 +1431,13 @@ void ImportFrontendModelArray(const void *onnxBuffer, int size,
 
 void ImportFrontendModelFile(std::string model_fname, MLIRContext &context,
     OwningModuleRef &module, std::string *errorMessage, ImportOptions options) {
-  // try to open the input file to check if it can be opened in advance.
-  std::fstream test;
-  test.open(model_fname);
-  if (!test) {
+  onnx::ModelProto model;
+  std::fstream input(model_fname, std::ios::in | std::ios::binary);
+  // check if the input file is opened
+  if (!input.is_open()) {
     *errorMessage = "Unable to open or access " + model_fname;
     return;
   }
-  test.close();
-  onnx::ModelProto model;
-  std::fstream input(model_fname, std::ios::in | std::ios::binary);
 
   auto parse_success = model.ParseFromIstream(&input);
   if (!parse_success) {

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1396,6 +1396,14 @@ void ImportFrontendModelArray(const void *onnxBuffer, int size,
 
 void ImportFrontendModelFile(std::string model_fname, MLIRContext &context,
     OwningModuleRef &module, std::string *errorMessage, ImportOptions options) {
+  // try to open the input file to check if it can be opened in advance.
+  std::fstream test;
+  test.open(model_fname);
+  if (!test) {
+    *errorMessage = "Unable to open or access " + model_fname;
+    return;
+  }
+  test.close();
   onnx::ModelProto model;
   std::fstream input(model_fname, std::ios::in | std::ios::binary);
 


### PR DESCRIPTION



```
==== invalid input file name case
/home/negishi/src/dlc.git/onnx-mlir/build/Debug/bin/onnx-mlir afoafo.afo
Invaid input file 'afoafo.afo': Either ONNX model or MLIR file needs to be provided.
==== output file error case (write permission error/-o not specified)
/home/negishi/src/dlc.git/onnx-mlir/build/Debug/bin/onnx-mlir relufixed-onnx.mlir
no write permission for onnxtempdumpH5cLjd at /home/negishi/src/dlc.git/MLIR
==== output file error case (write permission error/-o specified)
/home/negishi/src/dlc.git/onnx-mlir/build/Debug/bin/onnx-mlir -o OUTDIR/relufixed-onnx.so relufixed-onnx.mlir
Permission denied to write OUTDIR/relufixed-onnx.so.unoptimized.bc
==== output file error case (directory not exist error/-o specified)
/home/negishi/src/dlc.git/onnx-mlir/build/Debug/bin/onnx-mlir -o OUTDIR_NOTEXIST/relufixed-onnx.so relufixed-onnx.mlir
Path not found for OUTDIR_NOTEXIST/relufixed-onnx.so.unoptimized.bc
```