### PR TITLE
PyRuntime shared lib protobuf error fix

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -60,7 +60,7 @@ if (ONNX_MLIR_ENABLE_JNI)
   add_dependencies(CompilerUtils jniruntime)
 endif()
 
-add_onnx_mlir_library(OnnxMlirCompiler SHARED
+add_onnx_mlir_library(OnnxMlirCompiler
   OnnxMlirCompiler.cpp
 
   EXCLUDE_FROM_OM_LIBS

--- a/src/Runtime/CMakeLists.txt
+++ b/src/Runtime/CMakeLists.txt
@@ -58,8 +58,16 @@ set_target_properties(ExecutionSession
   )
 
 pybind11_add_module(PyRuntime PyExecutionSession.cpp)
+target_compile_definitions(PyRuntime
+  PRIVATE
+  -DONNX_ML=1 -DONNX_NAMESPACE=onnx
+  )
+target_include_directories(PyRuntime
+  PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third_party/onnx>
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/third_party/onnx>
+  )
 target_link_libraries(PyRuntime
   PRIVATE
   ExecutionSession
-  onnx
   )

--- a/src/Runtime/PyExecutionSession.cpp
+++ b/src/Runtime/PyExecutionSession.cpp
@@ -14,7 +14,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "onnx/onnx_pb.h"
-#include <third_party/onnx/onnx/onnx_pb.h>
 
 #include "PyExecutionSession.hpp"
 


### PR DESCRIPTION
When running on ubi8 image, shared lib backend tests fail with the following error:

[libprotobuf ERROR google/protobuf/descriptor_database.cc:641] File already exists in database: onnx/onnx-ml.proto
[libprotobuf FATAL google/protobuf/descriptor.cc:1371] CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
terminate called after throwing an instance of 'google::protobuf::FatalException'
  what():  CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
Aborted (core dumped)

This is because test.py loads (among others) the following two .so shared libs:

- onnx_cpp2py_export.cpython-39-s390x-linux-gnu.so (import onnx)
- PyRuntime.cpython-39-s390x-linux-gnu.so (from PyRuntime import ExecutionSession)

Both libs share the same libprotobuf.so when loaded by test.py. However, they were
both built with the same onnx-ml.pb.cc generated from onnx-ml.proto and the protobuf
runtime requires all compiled-in .proto files have unique names. Hence the error.

PyRuntime doesn't really need onnx beyond the onnx::TensorProto::* types so
we remove onnx from its target_link_libraries. But that also removes some of the
compile definitions and include directories which we add back through
target_compile_definitions and target_include_directories.

I don't know yet why this didn't fail on Ubuntu Focal.

Signed-off-by: Gong Su <gong_su@hotmail.com>