### PR TITLE
Fix a wrong file name for LRN shape inference

### DIFF
--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -34,7 +34,7 @@ add_onnx_mlir_library(OMONNXOps
   ShapeInference/ONNXShapeHelper.cpp  
   ShapeInference/OneHot.cpp
   ShapeInference/Pad.cpp
-  ShapeInference/RNN.cpp
+  ShapeInference/LRN.cpp
   ShapeInference/Reshape.cpp
   ShapeInference/ReverseSequence.cpp
   ShapeInference/Shape.cpp

--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -29,12 +29,12 @@ add_onnx_mlir_library(OMONNXOps
   ShapeInference/Expand.cpp
   ShapeInference/Gather.cpp
   ShapeInference/Gemm.cpp
+  ShapeInference/LRN.cpp
   ShapeInference/MatMul.cpp
   ShapeInference/MaxPool.cpp
   ShapeInference/ONNXShapeHelper.cpp  
   ShapeInference/OneHot.cpp
   ShapeInference/Pad.cpp
-  ShapeInference/LRN.cpp
   ShapeInference/Reshape.cpp
   ShapeInference/ReverseSequence.cpp
   ShapeInference/Shape.cpp

--- a/src/Dialect/ONNX/ShapeInference/LRN.cpp
+++ b/src/Dialect/ONNX/ShapeInference/LRN.cpp
@@ -2,9 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===--------------- RNN.cpp - Shape Inference for RNN Op -----------------===//
+//===--------------- LRN.cpp - Shape Inference for LRN Op -----------------===//
 //
-// This file implements shape inference for the ONNX RNN Operator.
+// This file implements shape inference for the ONNX LRN Operator.
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
The file for shape inference for LRN was wrongly named `RNN.cpp`. This patch changed it to `LRN.cpp`.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>