### PR TITLE
Split compileModule() to improve reusability

### DIFF
--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -74,3 +74,10 @@ void emitOutputFiles(std::string outputBaseName,
 
 int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
     std::string outputBaseName, onnx_mlir::EmissionTargetType targetType);
+
+void setupModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
+    std::string outputBaseName);
+
+void emitOutput(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
+    std::string outputBaseName, mlir::PassManager &pm,
+    onnx_mlir::EmissionTargetType emissionTarget);

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -2,9 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===--------------------------- main_utils.hpp ---------------------------===//
+//===-------------------------- CompilerUtils.hpp -------------------------===//
 //
-// Copyright 2019-2020 The IBM Research Authors.
+// Copyright 2019-2021 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -73,7 +73,7 @@ void emitOutputFiles(std::string outputBaseName,
     mlir::OwningModuleRef &module);
 
 int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
-    std::string outputBaseName, onnx_mlir::EmissionTargetType targetType);
+    std::string outputBaseName, onnx_mlir::EmissionTargetType emissionTarget);
 
 void setupModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
     std::string outputBaseName);


### PR DESCRIPTION
This PR splits `compileModule()` into three routines (`setupModule()`, `addPasses()`, and `emitOutput()`) to improve reusability.

My use case will reuse `setupModule()` and `emitOutput()` and replace `addPasses()` to add my own passes.
 
Signed-off-by: Haruki Imai <imaihal@jp.ibm.com>