### PR TITLE
Add ViewLikeOpInterface to krnl.vector_type_cast

### DIFF
--- a/src/Dialect/Krnl/KrnlOps.td
+++ b/src/Dialect/Krnl/KrnlOps.td
@@ -21,6 +21,7 @@ include "mlir/IR/OpBase.td"
 include "mlir/Dialect/Shape/IR/ShapeBase.td"
 include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 include "src/Interface/SpecializedKernelOpInterface.td"
 
 def Krnl_Dialect : Dialect {
@@ -629,7 +630,8 @@ def KrnlGetInductionVariableValueOp : Op<Krnl_Dialect, "get_induction_var_value"
 
 // =============================================================================
 
-def KrnlVectorTypeCastOp : Op<Krnl_Dialect, "vector_type_cast", [NoSideEffect, MemRefsNormalizable]> {
+def KrnlVectorTypeCastOp : Op<Krnl_Dialect, "vector_type_cast", [NoSideEffect,
+    MemRefsNormalizable, ViewLikeOpInterface]> {
   let summary = "vector type cast operation";
   let description = [{
     The "vector_type_cast" operation converts a memref from an non-vector
@@ -657,6 +659,9 @@ def KrnlVectorTypeCastOp : Op<Krnl_Dialect, "vector_type_cast", [NoSideEffect, M
 
     /// The result of a vector_type_cast is always a memref.
     MemRefType getType() { return getResult().getType().cast<MemRefType>(); }
+
+    /// Return the view source.
+    Value getViewSource() { return source(); }
   }];
 
   let hasFolder = 1;


### PR DESCRIPTION
`krnl.vector_type_cast` op is a view of the source memref, so this patch adds ViewLikeOpInterface to it. 

Though the current onnx-mlir has no problem since `krnl.vector_type_cast` is only used inside MatMul, this change helps buffer-related passes correctly analyze buffer's lifetime when `krnl.vector_type_cast` is used more often.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>