### PR TITLE
Fix help statement for enable-memory-bundling

### DIFF
--- a/src/Support/OMOptions.cpp
+++ b/src/Support/OMOptions.cpp
@@ -27,7 +27,7 @@ llvm::cl::opt<std::string> instrumentONNXOps("instrument-onnx-ops",
 llvm::cl::opt<bool> enableMemoryBundling("enable-memory-bundling",
     llvm::cl::desc(
         "Enable memory bundling related optimizations (default=false)\n"
-        "Set to 'true' if you experience significant compile time."),
+        "Set to 'false' if you experience significant compile time."),
     llvm::cl::init(false), llvm::cl::cat(OMPassOptions));
 
 llvm::cl::opt<int> onnxOpTransformThreshold("onnx-op-transform-threshold",


### PR DESCRIPTION

Just fix help statement for `--enable-memory-bundling` option. This is update of  https://github.com/onnx/onnx-mlir/pull/1062

Signed-off-by: Haruki Imai <imaihal@jp.ibm.com>