### PR TITLE
Update LLVM to 700997aef8c1

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -893,7 +893,7 @@ private:
     const auto elementType = builder_.getIntegerType(64);
     const auto attributes = ImportNodeAttributes(node);
     for (auto attr : attributes) {
-      if (auto arrayAttr = attr.second.dyn_cast<ArrayAttr>()) {
+      if (auto arrayAttr = attr.getValue().dyn_cast<ArrayAttr>()) {
         const auto tensorType =
             RankedTensorType::get({(int64_t)arrayAttr.size()}, elementType);
         auto constantDenseAttribute =
@@ -904,7 +904,7 @@ private:
 
         // Map from ONNX attributes to indices, which are
         // matched with ONNXSliceOp::build ordering.
-        auto inputIdx = llvm::StringSwitch<int>(attr.first)
+        auto inputIdx = llvm::StringSwitch<int>(attr.getName())
                             .Case("starts", 1)
                             .Case("ends", 2)
                             .Case("axes", 3)
@@ -956,7 +956,7 @@ private:
     auto attributes = ImportNodeAttributes(node);
     bool hasAxisAttribute = false;
     for (auto &attr : attributes)
-      if (attr.first.strref().equals_insensitive("axis")) {
+      if (attr.getName().strref().equals_insensitive("axis")) {
         hasAxisAttribute = true;
         break;
       }

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -14,6 +14,7 @@
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
+#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
@@ -628,7 +629,7 @@ void addKrnlToLLVMPasses(mlir::OpPassManager &pm) {
   // Currently this has to be done *after* lowering the affine dialect because
   // operations in that dialect do not conform to the requirements explained in
   // https://mlir.llvm.org/docs/BufferDeallocationInternals.
-  pm.addNestedPass<FuncOp>(mlir::createBufferDeallocationPass());
+  pm.addNestedPass<FuncOp>(mlir::bufferization::createBufferDeallocationPass());
   if (enableMemoryBundling) {
     pm.addNestedPass<FuncOp>(mlir::createKrnlEnableMemoryPoolPass());
     pm.addNestedPass<FuncOp>(mlir::createKrnlBundleMemoryPoolsPass());

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -30,7 +30,7 @@
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/StandardOps/Transforms/Passes.h"
-#include "mlir/Dialect/Vector/VectorOps.h"
+#include "mlir/Dialect/Vector/VectorRewritePatterns.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
@@ -505,7 +505,7 @@ public:
     // attempt to set the alignment based on the module datalayout (if it
     // exists).
     if (alignmentAttr && alignmentAttr.getValue().getSExtValue() != 0)
-      global.alignmentAttr(alignmentAttr);
+      global.setAlignmentAttr(alignmentAttr);
     else if (module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName())) {
       // TODO: use MLIR data layout when it becomes available.
       llvm::LLVMContext llvmContext;
@@ -513,9 +513,9 @@ public:
                           .getPreferredAlignment(global.getType(),
                               getTypeConverter()->getDataLayout());
       align = std::max(align, MinGlobalAlign);
-      global.alignmentAttr(rewriter.getI64IntegerAttr(align));
+      global.setAlignmentAttr(rewriter.getI64IntegerAttr(align));
     } else
-      global.alignmentAttr(rewriter.getI64IntegerAttr(MinGlobalAlign));
+      global.setAlignmentAttr(rewriter.getI64IntegerAttr(MinGlobalAlign));
 
     // Prepare data to be inserted into a MemRefDescriptor (a struct).
     Value globalOpAddr = rewriter.create<LLVM::AddressOfOp>(loc, global);

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -69,7 +69,7 @@ struct ONNXLoopOpLowering : public ConversionPattern {
 
       auto condReg = rewriter.create<KrnlLoadOp>(loc, cond).getResult();
       auto ifOp = rewriter.create<scf::IfOp>(loc, condReg, false);
-      rewriter.setInsertionPointToStart(&ifOp.thenRegion().front());
+      rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
 
       // Create a scalar tensor out of loop iteration variable, as the first
       // argument passed to the body graph function.
@@ -98,7 +98,7 @@ struct ONNXLoopOpLowering : public ConversionPattern {
         mapper.map(regionArg, params[i]);
       }
 
-      auto &thenRegion = ifOp.thenRegion();
+      auto &thenRegion = ifOp.getThenRegion();
       auto &thenBlock = thenRegion.front();
 
       // Split the insertion block into two, where the second block

--- a/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
+++ b/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
@@ -268,23 +268,23 @@ private:
     TypeSwitch<Type>(elementType)
         .Case<IntegerType>([&](IntegerType type) {
           // index is valid: retrieve the value from 'cat_strings'.
-          rewriter.setInsertionPointToStart(&ifOp.thenRegion().front());
+          rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
           Value loadData = createKrnl.load(constantForCatsStrings, {index});
           createKrnl.store(loadData, alloc, loopInd);
 
           // index is not valid: store the default value.
-          rewriter.setInsertionPointToStart(&ifOp.elseRegion().front());
+          rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
           Value loadDefault = createKrnl.load(defaultString);
           createKrnl.store(loadDefault, alloc, loopInd);
         })
         .Case<StringType>([&](StringType type) {
           // index is valid: retrieve the value from 'cat_int64s'.
-          rewriter.setInsertionPointToStart(&ifOp.thenRegion().front());
+          rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
           Value loadData = createKrnl.load(constantForCatsInt64s, {index});
           createKrnl.store(loadData, alloc, loopInd);
 
           // index is not valid: store the default value.
-          rewriter.setInsertionPointToStart(&ifOp.elseRegion().front());
+          rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
           createKrnl.store(defaultInt64, alloc, loopInd);
         })
         .Default([&](Type type) { llvm_unreachable("Illegal KeyTy"); });

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -15,6 +15,7 @@
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 #include "src/Dialect/Krnl/KrnlHelper.hpp"
 #include "src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp"
+#include "llvm/Support/Debug.h"
 
 // Used to trace which op are used, good for profiling apps.
 #define DEBUG_TYPE "gemm"

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -18,8 +18,7 @@
 #include <map>
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/Linalg/IR/LinalgTypes.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"

--- a/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
+++ b/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
@@ -361,7 +361,7 @@ struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
                     createMath._and(checkScore, checkMOPC), isNotRemoved);
                 auto ifOp = rewriter.create<scf::IfOp>(
                     loc, canSelectBox, /*withElseRegion=*/false);
-                rewriter.setInsertionPointToStart(&ifOp.thenRegion().front());
+                rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
 
                 // Select the bounding box with the largest score.
                 SmallVector<Value, 4> selectedBox;
@@ -406,7 +406,7 @@ struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
                       auto if1Op = rewriter.create<scf::IfOp>(
                           loc, isNotRemoved, /*withElseRegion=*/false);
                       rewriter.setInsertionPointToStart(
-                          &if1Op.thenRegion().front());
+                          &if1Op.getThenRegion().front());
 
                       // Pick the current box.
                       SmallVector<Value, 4> otherBox;
@@ -425,7 +425,7 @@ struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
                       auto if2Op = rewriter.create<scf::IfOp>(
                           loc, checkIOU, /*withElseRegion=*/false);
                       rewriter.setInsertionPointToStart(
-                          &if2Op.thenRegion().front());
+                          &if2Op.getThenRegion().front());
 
                       // If IOU is satified, mark the current box as removed.
                       createKrnl.store(trueVal, removedIndices, {o});

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -644,16 +644,16 @@ static LogicalResult verify(KrnlMatMulOp op) {
     return op.emitOpError("cMemStart should have same rank as memref A");
   if (operandAdaptor.loops().size() != 3)
     return op.emitOpError("loops rank should be 3 (i,j,k)");
-  ArrayAttr computeAttr = operandAdaptor.computeTileSize();
+  ArrayAttr computeAttr = operandAdaptor.computeTileSize().getValue();
   if (computeAttr && !(computeAttr.size() == 0 || computeAttr.size() == 3))
     return op.emitOpError("computeTileSize rank should be 0 or 3");
-  ArrayAttr aTileAttr = operandAdaptor.aTileSize();
+  ArrayAttr aTileAttr = operandAdaptor.aTileSize().getValue();;
   if (aTileAttr && !(aTileAttr.size() == 0 || aTileAttr.size() == 2))
     return op.emitOpError("aTileSize rank should be 0 or 2");
-  ArrayAttr bTileAttr = operandAdaptor.bTileSize();
+  ArrayAttr bTileAttr = operandAdaptor.bTileSize().getValue();;
   if (bTileAttr && !(bTileAttr.size() == 0 || bTileAttr.size() == 2))
     return op.emitOpError("bTileSize rank should be 0 or 2");
-  ArrayAttr cTileAttr = operandAdaptor.cTileSize();
+  ArrayAttr cTileAttr = operandAdaptor.cTileSize().getValue();;
   if (cTileAttr && !(cTileAttr.size() == 0 || cTileAttr.size() == 2))
     return op.emitOpError("cTileSize rank should be 0 or 2");
   return success();
@@ -701,12 +701,12 @@ static LogicalResult verify(KrnlCopyToBufferOp op) {
   if (startRank != srcRank)
     return op.emitOpError("Rank of starts and memrefs must be identical");
   if (opAdaptor.tileSize()) {
-    int64_t tRank = opAdaptor.tileSize().size();
+    int64_t tRank = opAdaptor.tileSize().getValue().size();
     if (!(tRank == 0 || tRank == bufferRank))
       return op.emitOpError("Rank of tileSize must be identical to buffer");
   }
   if (opAdaptor.padToNext()) {
-    int64_t padRank = opAdaptor.padToNext().size();
+    int64_t padRank = opAdaptor.padToNext().getValue().size();
     if (!(padRank == 0 || padRank == bufferRank))
       return op.emitOpError("Rank of padToNext must be identical to buffer");
   }
@@ -756,7 +756,7 @@ static LogicalResult verify(KrnlCopyFromBufferOp op) {
   if (startRank != destRank)
     return op.emitOpError("Rank of starts and memrefs must be identical");
   if (opAdaptor.tileSize()) {
-    int64_t tRank = opAdaptor.tileSize().size();
+    int64_t tRank = opAdaptor.tileSize().getValue().size();
     if (!(tRank == 0 || tRank == bufferRank))
       return op.emitOpError("Rank of tileSize must be identical to buffer");
   }

--- a/src/Dialect/ONNX/IndexExpr.cpp
+++ b/src/Dialect/ONNX/IndexExpr.cpp
@@ -1475,7 +1475,7 @@ IndexExpr ArrayValueIndexCapture::getSymbol(uint64_t i) {
       // Has no default: error
       return UndefinedIndexExpr();
     }
-    auto attrVal = attrArray.getValue(ArrayRef<uint64_t>({i}));
+    auto attrVal = attrArray.getValues<Attribute>()[ArrayRef<uint64_t>({i})];
     int64_t attrInt = attrVal.cast<IntegerAttr>().getInt();
     return LiteralIndexExpr(attrInt);
   }

--- a/src/Dialect/ONNX/IndexExprDetail.cpp
+++ b/src/Dialect/ONNX/IndexExprDetail.cpp
@@ -61,7 +61,7 @@ static bool getIntegerLiteralFromValue(Value value, int64_t &intLit) {
   // From lib/Dialect/LinAlg/Transform/Promotion.cpp
   if (auto constantOp = value.getDefiningOp<arith::ConstantOp>()) {
     if (constantOp.getType().isa<IndexType>())
-      intLit = constantOp.value().cast<IntegerAttr>().getInt();
+      intLit = constantOp.getValue().cast<IntegerAttr>().getInt();
     return true;
   }
   // Since ConsantIndexOp is a subclass of ConstantOp, not sure if this one is

--- a/src/Dialect/ONNX/MLIRDialectBuilder.cpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.cpp
@@ -97,11 +97,11 @@ Value MathBuilder::min(Value lhs, Value rhs) const {
   if (lhs.getType().isa<IntegerType>() || lhs.getType().isa<IndexType>())
     // Test for unsigned as signless are treated as signed.
     if (lhs.getType().isUnsignedInteger())
-      return b.create<MinUIOp>(loc, lhs, rhs);
+      return b.create<arith::MinUIOp>(loc, lhs, rhs);
     else
-      return b.create<MinSIOp>(loc, lhs, rhs);
+      return b.create<arith::MinSIOp>(loc, lhs, rhs);
   else
-    return b.create<MinFOp>(loc, lhs, rhs);
+    return b.create<arith::MinFOp>(loc, lhs, rhs);
 }
 
 Value MathBuilder::max(Value lhs, Value rhs) const {
@@ -109,11 +109,11 @@ Value MathBuilder::max(Value lhs, Value rhs) const {
   if (lhs.getType().isa<IntegerType>() || lhs.getType().isa<IndexType>())
     // Test for unsigned as signless are treated as signed.
     if (lhs.getType().isUnsignedInteger())
-      return b.create<MaxUIOp>(loc, lhs, rhs);
+      return b.create<arith::MaxUIOp>(loc, lhs, rhs);
     else
-      return b.create<MaxSIOp>(loc, lhs, rhs);
+      return b.create<arith::MaxSIOp>(loc, lhs, rhs);
   else
-    return b.create<MaxFOp>(loc, lhs, rhs);
+    return b.create<arith::MaxFOp>(loc, lhs, rhs);
 }
 
 Value MathBuilder::sgt(Value lhs, Value rhs) const {

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -3637,18 +3637,17 @@ static LogicalResult verify(ONNXDepthToSpaceOp op) {
     return op.emitError("Input should have a rank of four");
 
   // Check blocksize.
-  APInt blocksize = operandAdaptor.blocksize().getValue();
-  if (blocksize.isNegative())
+  int64_t blocksize = operandAdaptor.blocksize();
+  if (blocksize < 0)
     return op.emitError("Blocksize should be non negative");
 
   int64_t C = inputShape[1];
-  uint64_t bs = blocksize.getZExtValue();
-  if (C != -1 && C % (bs * bs) != 0)
+  if (C != -1 && C % (blocksize * blocksize) != 0)
     return op.emitError("The input tensor depth must be divisible by the "
                         "(blocksize * blocksize)");
 
   // Check mode.
-  StringRef mode = operandAdaptor.mode().getValue();
+  StringRef mode = operandAdaptor.mode();
   if (mode != "DCR" && mode != "CRD")
     return op.emitError("Mode must be DCR or CRD");
 
@@ -4383,18 +4382,17 @@ static LogicalResult verify(ONNXSpaceToDepthOp op) {
     return op.emitError("Input should have a rank of four");
 
   // Check blocksize.
-  APInt blocksize = operandAdaptor.blocksize().getValue();
-  if (blocksize.isNegative())
+  int64_t blocksize = operandAdaptor.blocksize();
+  if (blocksize < 0)
     return op.emitError("Blocksize should be non negative");
 
   int64_t H = inputShape[2];
   int64_t W = inputShape[3];
-  uint64_t bs = blocksize.getZExtValue();
 
-  if (H != -1 && H % bs != 0)
+  if (H != -1 && H % blocksize != 0)
     return op.emitError(
         "The input tensor height must be divisible by the block size");
-  if (W != -1 && W % bs != 0)
+  if (W != -1 && W % blocksize != 0)
     return op.emitError(
         "The input tensor width must be divisible by the block size");
 


### PR DESCRIPTION
Updating LLVM to SHA `700997aef8c1` causes a number of build issues due to the following MLIR interface changes:
- https://reviews.llvm.org/D115728
- https://reviews.llvm.org/D113229
- https://reviews.llvm.org/D113881
- https://reviews.llvm.org/D116648
- https://reviews.llvm.org/D113956
- https://reviews.llvm.org/D114698

This patch modifies `onnx-mlir` to use LLVM  `700997aef8c1`.


Signed-off-by: Ettore Tiotto <etiotto@ca.ibm.com>