### PR TITLE
onnx-mlir.py warning about binary output

### DIFF
--- a/docker/onnx-mlir.py
+++ b/docker/onnx-mlir.py
@@ -11,11 +11,11 @@ DOCKER_SOCKET   = '/var/run/docker.sock'
 ONNX_MLIR_IMAGE = 'onnxmlirczar/onnx-mlir'
 WORK_DIR        = '/workdir'
 OUTPUT_DIR      = '/output'
-EMIT_OPTS       = [ '--EmitONNXBasic',
+EMIT_IR_OPTS    = [ '--EmitONNXBasic',
                     '--EmitONNXIR',
                     '--EmitMLIR',
-                    '--EmitLLVMIR',
-                    '--EmitLib',
+                    '--EmitLLVMIR' ]
+EMIT_BIN_OPTS   = [ '--EmitLib',
                     '--EmitJNI' ]
 
 # When running onnx-mlir inside a docker container, the directory
@@ -67,11 +67,14 @@ def main():
             ionnx = argv[i]
         # If a file is not specified on the first argument, it must be
         # specified after a valid --EmitXXX option.
-        elif (arg in EMIT_OPTS and i < argc-1 and
+        elif (arg in EMIT_IR_OPTS+EMIT_BIN_OPTS and i < argc-1 and
               not argv[i+1].startswith('-')):
             # File specified more than once, treat as not specified
             if ionnx:
                 sys.exit("Too many --EmitXXX options")
+            if (arg in EMIT_BIN_OPTS and sys.platform != 'linux'):
+                print(('Warning: host {} is not linux, ' +
+                       'output not directly usable').format(sys.platform))
             argi = i + 1
             ionnx = argv[argi]
         elif (arg == "-o" and i < argc-1 and


### PR DESCRIPTION
onnx-mlir.py warning about binary output (.so and .jar) not directly usable if host is not Linux

Signed-off-by: Gong Su <gong_su@hotmail.com>