### PR TITLE
Switch URLs to use main instead of master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Now you have a local `main`, which tracks `origin/main`.
 
 ## Building ONNX-MLIR
 
-Up to date info on how to build the project is located in the top directory [here](README.md). 
+Up to date info on how to build the project is located in the top directory [here](README.md).
 
 Since you are interested in contributing code, you may look [here](docs/Workflow.md) for detailed step by step directives on how to create a fork, compile it, and then push your changes for review.
 
@@ -35,7 +35,7 @@ Since you are interested in contributing code, you may look [here](docs/Workflow
 
 ## ONNX-MLIR specific dialects
 
-* The onnx-mlir project is based on the opset version defined [here](docs/Dialects/onnx.md). This is a reference to a possibly older version of the current version of the ONNX operators defined in the onnx/onnx repo [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md).
+* The onnx-mlir project is based on the opset version defined [here](docs/Dialects/onnx.md). This is a reference to a possibly older version of the current version of the ONNX operators defined in the onnx/onnx repo [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md).
 * The Krnl Dialect is used to lower ONNX operators to MLIR affine. The Krnl Dialect is defined [here](docs/Dialects/krnl.md).
 * To update the internal documentation on our dialects when there are changes, please look for guidance [here](docs/HowToAddAnOperation.md#update-your-operations-status).
 
@@ -59,4 +59,3 @@ Since you are interested in contributing code, you may look [here](docs/Workflow
 
 * Check this issue for status on operations required for ONNX Model Zoo [Issue 128](https://github.com/onnx/onnx-mlir/issues/128).
 * Claim an op that you are working on by adding a comment on this [Issue #922](https://github.com/onnx/onnx-mlir/issues/922).
-

--- a/docs/DebuggingNumericalError.md
+++ b/docs/DebuggingNumericalError.md
@@ -23,8 +23,8 @@ reference inputs and outputs in protobuf.
 - To verify using reference outputs, use `--verify=ref --ref_folder=ref_folder`
   where `ref_folder` is the path to a folder containing protobuf files for
   inputs and outputs. [This
-  guideline](https://github.com/onnx/onnx/blob/master/docs/PythonAPIOverview.md#manipulating-tensorproto-and-numpy-array)
-  is a how-to for creating protobuf files from numpy arrays. 
+  guideline](https://github.com/onnx/onnx/blob/main/docs/PythonAPIOverview.md#manipulating-tensorproto-and-numpy-array)
+  is a how-to for creating protobuf files from numpy arrays.
 
 ## Usage
 

--- a/docs/ImportONNXDefs.md
+++ b/docs/ImportONNXDefs.md
@@ -2,9 +2,9 @@
 
 # Import ONNX specifications into ONNX-MLIR
 
-ONNX specifications are defined under `onnx/defs` directory in the ONNX project repository. 
-There is a python script [utils/gen_onnx_mlir.py](../utils/gen_onnx_mlir.py) that automatically generates documents about operations in ONNX (docs/Operations.md). 
-ONNX-MLIR modified this script to import ONNX specifications into ONNX-MLIR. 
+ONNX specifications are defined under `onnx/defs` directory in the ONNX project repository.
+There is a python script [utils/gen_onnx_mlir.py](../utils/gen_onnx_mlir.py) that automatically generates documents about operations in ONNX (docs/Operations.md).
+ONNX-MLIR modified this script to import ONNX specifications into ONNX-MLIR.
 There are two files generated for ONNX-MLIR with the modified gen_onnx_mlir.py:
 
 1. `src/Dialect/ONNX/ONNXOps.td.inc`: Operation definition for MLIR TableGen. `src/Dialect/ONNX/ONNXOps.td` includes this file.
@@ -19,8 +19,8 @@ make OMONNXOpsIncTranslation
 Target `OMONNXOpsIncTranslation` invokes the script and places the generated files into the correct directories correspondingly.
 
 ## Consistency
-For reference to the schema and semantics of an operation, please refer to [ONNX Dialect](Dialects/onnx.md). 
-Even though we strive to support the latest version of ONNX specification as quickly as we can, there will inevitably be a delay between the introduction of new changes in the ONNX specification and the adoption in our codebase. 
+For reference to the schema and semantics of an operation, please refer to [ONNX Dialect](Dialects/onnx.md).
+Even though we strive to support the latest version of ONNX specification as quickly as we can, there will inevitably be a delay between the introduction of new changes in the ONNX specification and the adoption in our codebase.
 Due to the possibility of such a delay, operator definition within the ONNX project repository may describe features and schemas that we do not yet support.
 
 ## Customization
@@ -40,11 +40,11 @@ To support multiple versions of an op, the selected version should be added in t
 
 In onnx dialect, the op for the top version has no version in the op name, while other version with name followed by 'V' and version number. For example, ReduceSum of opset 13 will be `ONNXReduceSumOp`, while ReduceSum of opset 11 is 'ONNXReduceSumV11Op`. Since most of onnx op are compatible when upgraded to higher version, we can keep the name of the operation in the dialect and just update version_dict in gen_onnx_mlir.py without touching the code in onnx-mlir.
 
-When a model is imported, the highest version which is not higher than the next available version is used. For the example of ReduceSum, if the opset is 12, ONNXReduceSumV11Op is chosen.  
+When a model is imported, the highest version which is not higher than the next available version is used. For the example of ReduceSum, if the opset is 12, ONNXReduceSumV11Op is chosen.
 
 ## Update the documentation
 
-When adding a new op version or making changes to the ONNX version, we would like to also reflect these changes in the ONNX documentation of our supported operations. While the latest [ONNX specs](https://github.com/onnx/onnx/blob/master/docs/Operators.md) are always available, the specs that we support are often a bit back, plus we support older versions under the versioned name as mentioned in the previous section.
+When adding a new op version or making changes to the ONNX version, we would like to also reflect these changes in the ONNX documentation of our supported operations. While the latest [ONNX specs](https://github.com/onnx/onnx/blob/main/docs/Operators.md) are always available, the specs that we support are often a bit back, plus we support older versions under the versioned name as mentioned in the previous section.
 
 There is a convenient command to update both the ONNX and Krnl dialect, as shown below.
 ```

--- a/include/onnx-mlir/Runtime/OnnxDataTypeMetaData.inc
+++ b/include/onnx-mlir/Runtime/OnnxDataTypeMetaData.inc
@@ -6,7 +6,7 @@
 // Data type metadata declared in the following format:
 // OM_TYPE_METADATA_DEF( dtype enum name, dtype enum value, dtype size)
 // dtype enum values are standard ONNX data types defined in
-// https://github.com/onnx/onnx/blob/master/onnx/onnx.proto#L484
+// https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L484
 // clang-format off
 OM_TYPE_METADATA_DEF(ONNX_TYPE_UNDEFINED,   0,  0)
 OM_TYPE_METADATA_DEF(ONNX_TYPE_FLOAT,       1,  sizeof(float))

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -129,7 +129,7 @@ static void emitInstForSoftmaxBeforeV13(ConversionPatternRewriter &rewriter,
 
   // Coerce the input into a 2-D tensor. `axis` will be the coercing
   // point. This coercing follows the softmax definition in ONNX:
-  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax
+  // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softmax
   // Here, we create an outer loop and inner loop for handling the two
   // dimensions. The outer loop is only created once `axis` is not
   // zero.

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -1860,7 +1860,7 @@ static LogicalResult verify(ONNXConvOp op) {
     // https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
     // ONNX clearly states that C (channel in or CI here) is a multiple of group
     // number (G).
-    // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Conv
+    // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Conv
     // Quote: X.shape[1] == (W.shape[1] * group) == C
     // Keras also specifies it: Input channels and filters must both be
     // divisible by groups.

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -65,7 +65,7 @@ def ONNXConstantOpNormalize: NativeCodeCall<
 def AttributeIsNotNull :
     Constraint<CPred<" ($_self) ">, "Attribute is null">;
 
-// Intended to check whether there is at least one not-Null the attributes 
+// Intended to check whether there is at least one not-Null the attributes
 // However, the current table gen can only support max 4 parameters
 // Multiple rules are used instead of one rule
 def AttributesNotAllNull :
@@ -170,7 +170,7 @@ def GemmTransA : NativeCodeCall<"IntegerAttr::get($_builder.getIntegerType(64, /
 def GemmTransB : NativeCodeCall<"IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), APInt(64, 0, /*isSigned=*/true))">;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXAddOp 
+// Canonicalization for ONNXAddOp
 //===----------------------------------------------------------------------===//
 
 // onnx.add(onnx.matmul(%X, %Y), %Z) = onnx.Gemm(%X, %Y, %Z)
@@ -184,12 +184,12 @@ def FuseGemmFollowedByAddition : Pat<(ONNXAddOp (ONNXGemmOp:$res $m1, $m2, $none
                                      [(HasOneUse $res), (HasNoneType $none)]>;
 
 //===----------------------------------------------------------------------===//
-// This is to fuse the composition: 'Add o Conv' into 'Conv' if the other input 
+// This is to fuse the composition: 'Add o Conv' into 'Conv' if the other input
 // of Add is a constant, by adding the constant to 'b' of 'Conv':
 //
 // We have:
-//   (Conv)      z = w * x + b 
-//   (Add)       y = z + constant 
+//   (Conv)      z = w * x + b
+//   (Add)       y = z + constant
 //
 // which corresponds to the following computation:
 //   y = w * x + new_b
@@ -246,7 +246,7 @@ def FuseAddConvPattern: Pat<
 >;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXIdentityOp 
+// Canonicalization for ONNXIdentityOp
 //===----------------------------------------------------------------------===//
 
 // ONNX_Op (onnx.Identity (%X)) = ONNX_Op (%X)
@@ -259,7 +259,7 @@ def DropoutEliminationPattern : Pattern<(ONNXDropoutOp $arg, $arg1, $arg2, $rati
                                          (ONNXConstantOp (GetNullAttr), (GetUnitAttr), (GetNullAttr), (GetNullAttr), (GetNullAttr), (GetNullAttr), (GetNullAttr), (GetNullAttr))]>;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXCastOp 
+// Canonicalization for ONNXCastOp
 //===----------------------------------------------------------------------===//
 
 // ONNX_Op (onnx.Cast (%X, $type)) = ONNX_Op (%X)
@@ -269,7 +269,7 @@ def CastEliminationPattern : Pat<
   [(HasSameElementType $arg, $type)]>;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXTransposeOp 
+// Canonicalization for ONNXTransposeOp
 //===----------------------------------------------------------------------===//
 
 // Combine transposes.
@@ -295,7 +295,7 @@ def RemoveIdentityTransposePattern:  Pat<
   [(IsIdentityPermuteAttribute:$p)]>;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXReshapeOp 
+// Canonicalization for ONNXReshapeOp
 //===----------------------------------------------------------------------===//
 
 def FuseReshapePattern:  Pat<
@@ -314,7 +314,7 @@ def RemoveIdentityReshapePattern:  Pat<
 
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXSqueezeOp 
+// Canonicalization for ONNXSqueezeOp
 //===----------------------------------------------------------------------===//
 
 /// Combine squeeze and unsqueeze.
@@ -339,7 +339,7 @@ def RemoveSqueezeV11UnsqueezeV11Pattern:  Pat<
   [(AreTheSameAxisArray $val, $u_axes, $s_axes)]>;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXUnsqueezeOp 
+// Canonicalization for ONNXUnsqueezeOp
 //===----------------------------------------------------------------------===//
 
 /// Combine unsqueeze and squeeze.
@@ -364,7 +364,7 @@ def RemoveUnsqueezeV11SqueezeV11Pattern:  Pat<
   [(AreTheSameAxisArray $res, $u_axes, $s_axes)]>;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXBatchNormOp 
+// Canonicalization for ONNXBatchNormOp
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
@@ -372,7 +372,7 @@ def RemoveUnsqueezeV11SqueezeV11Pattern:  Pat<
 // by deriving new 'w' and 'b' for 'Conv':
 //
 // We have:
-//   (Conv)      z = w * x + b 
+//   (Conv)      z = w * x + b
 //   (BatchNorm) y = scale * (z - mean) / sqrt(var + eps) + bias
 //
 // which corresponds to the following computation:
@@ -381,7 +381,7 @@ def RemoveUnsqueezeV11SqueezeV11Pattern:  Pat<
 //   w_ = scale * w / sqrt(var + eps)
 //   b_ = B + scale * (b - mean) / sqrt(var + eps)
 //
-// Hence, we rewrite: 
+// Hence, we rewrite:
 //   onnx.BatchNormalizationInferenceMode(
 //       onnx.Conv(x, w, b),
 //       scale, B, mean, var
@@ -389,7 +389,7 @@ def RemoveUnsqueezeV11SqueezeV11Pattern:  Pat<
 //
 // as:
 //    onnx.Conv(x, w_, b_)
-//    
+//
 //    where
 //      w_ = scale * w / sqrt(var + eps)
 //      b_ = B + scale * (b - mean) / sqrt(var + eps)
@@ -467,7 +467,7 @@ def RewriteBatchNormInferenceModeConvPattern1: Pat<
 
 // Special case of BatchNorm whose input shape is [N]. In this case, 'scale',
 // 'bias', 'mean', and 'var' will have shape of [1], according to ONNXBatchNorm
-// decription: https://github.com/onnx/onnx/blob/master/docs/Operators.md#inputs-12.
+// decription: https://github.com/onnx/onnx/blob/main/docs/Operators.md#inputs-12.
 // Thus, we need not unsqueeze intermediate results.
 def RewriteBatchNormInferenceModeConvPattern2: Pat<
   (ONNXBatchNormalizationInferenceModeOp:$res
@@ -489,7 +489,7 @@ def RewriteBatchNormInferenceModeConvPattern2: Pat<
 >;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXShapeOp 
+// Canonicalization for ONNXShapeOp
 //===----------------------------------------------------------------------===//
 
 def IsStaticShapeTensor:
@@ -510,7 +510,7 @@ def ShapeToConstantPattern: Pat<
 >;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXSizeOp 
+// Canonicalization for ONNXSizeOp
 //===----------------------------------------------------------------------===//
 
 def SizeToConstantPattern: Pat<
@@ -524,7 +524,7 @@ def SizeToConstantPattern: Pat<
 >;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXGlobalAveragePoolOp 
+// Canonicalization for ONNXGlobalAveragePoolOp
 //===----------------------------------------------------------------------===//
 
 // Rewrite GlobalAveragePool using ReduceMean.
@@ -540,46 +540,46 @@ def GlobalMaxPoolPattern: Pat<
 >;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXConstantOp 
+// Canonicalization for ONNXConstantOp
 //===----------------------------------------------------------------------===//
 
 def ConstantOpNormalizationPattern1: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr, 
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
        $intsAttr, $stringAttr, $stringsAttr),
    (ONNXConstantOpNormalize $res, $floatAttr),
    [(AttributeIsNotNull:$floatAttr)]
 >;
 
 def ConstantOpNormalizationPattern2: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr, 
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
        $intsAttr, $stringAttr, $stringsAttr),
    (ONNXConstantOpNormalize $res, $intAttr),
    [(AttributeIsNotNull:$intAttr)]
 >;
 
 def ConstantOpNormalizationPattern3: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr, 
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
        $intsAttr, $stringAttr, $stringsAttr),
    (ONNXConstantOpNormalize $res, $stringAttr),
    [(AttributeIsNotNull:$stringAttr)]
 >;
 
 def ConstantOpNormalizationPattern4: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr, 
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
        $intsAttr, $stringAttr, $stringsAttr),
    (ONNXConstantOpNormalize $res, $floatsAttr),
    [(AttributeIsNotNull:$floatsAttr)]
 >;
 
 def ConstantOpNormalizationPattern5: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr, 
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
        $intsAttr, $stringAttr, $stringsAttr),
    (ONNXConstantOpNormalize $res, $intsAttr),
    [(AttributeIsNotNull:$intsAttr)]
 >;
 
 def ConstantOpNormalizationPattern6: Pat<
-   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr, 
+   (ONNXConstantOp:$res $sparseAttr, $denseAttr, $floatAttr, $floatsAttr, $intAttr,
        $intsAttr, $stringAttr, $stringsAttr),
    (ONNXConstantOpNormalize $res, $stringsAttr),
    [(AttributeIsNotNull:$stringsAttr)]

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
@@ -304,7 +304,7 @@ LogicalResult ONNXGenericPoolShapeHelper<OP_TYPE, OP_ADAPTOR>::computeShape(
     outputDims.emplace_back(XBounds.getDim(1)); // CO is CI.
 
   // Insert dimensions for the spatial axes. From MaxPool:
-  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#maxpool
+  // https://github.com/onnx/onnx/blob/main/docs/Operators.md#maxpool
   //
   // NOSET:
   //  * O[i] = floor((I[i] + P[i] - ((K[i] - 1) * d[i] + 1)) / s[i] + 1)

--- a/src/Runtime/jni/src/com/ibm/onnxmlir/OMTensor.java
+++ b/src/Runtime/jni/src/com/ibm/onnxmlir/OMTensor.java
@@ -13,12 +13,12 @@ import java.nio.ShortBuffer;
 public class OMTensor {
 
     private final ByteOrder nativeEndian = ByteOrder.nativeOrder();
-    
+
     /* We can use enum but that creates another class
      * which complicates things for JNI.
      *
      * Values are standard ONNX data types defined in
-     * https://github.com/onnx/onnx/blob/master/onnx/onnx.proto#L484
+     * https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L484
      */
     final static int ONNX_TYPE_UNDEFINED  = 0;
     final static int ONNX_TYPE_FLOAT      = 1;
@@ -244,7 +244,7 @@ public class OMTensor {
 
     /**
      * Byte data setter
-     * 
+     *
      * @param data byte array to be set
      */
     public void setByteData(byte[] data) {
@@ -260,7 +260,7 @@ public class OMTensor {
 
     /**
      * Short data getter
-     * 
+     *
      * @return short data array
      */
     public short[] getShortData() {
@@ -281,7 +281,7 @@ public class OMTensor {
 
     /**
      * Short data setter
-     * 
+     *
      * @param data short array to be set
      */
     public void setShortData(short[] data) {
@@ -318,7 +318,7 @@ public class OMTensor {
 
     /**
      * Int data setter
-     * 
+     *
      * @param data int array to be set
      */
     public void setIntData(int[] data) {
@@ -334,7 +334,7 @@ public class OMTensor {
 
     /**
      * Long data getter
-     * 
+     *
      * @return long data array
      */
     public long[] getLongData() {
@@ -355,7 +355,7 @@ public class OMTensor {
 
     /**
      * Long data setter
-     * 
+     *
      * @param data long array to be set
      */
     public void setLongData(long[] data) {
@@ -371,7 +371,7 @@ public class OMTensor {
 
     /**
      * Float data getter
-     * 
+     *
      * @return float data array
      */
     public float[] getFloatData() {
@@ -392,7 +392,7 @@ public class OMTensor {
 
     /**
      * Float data setter
-     * 
+     *
      * @param data float array to be set
      */
     public void setFloatData(float[] data) {
@@ -408,7 +408,7 @@ public class OMTensor {
 
     /**
      * Double data getter
-     * 
+     *
      * @return double data array
      */
     public double[] getDoubleData() {
@@ -429,7 +429,7 @@ public class OMTensor {
 
     /**
      * Double data setter
-     * 
+     *
      * @param data double array to be set
      */
     public void setDoubleData(double[] data) {
@@ -468,7 +468,7 @@ public class OMTensor {
 
     /**
      * Data strides getter
-     * 
+     *
      * @return data strides array
      */
     public long[] getStrides() {
@@ -477,7 +477,7 @@ public class OMTensor {
 
     /**
      * Data strides setter
-     * 
+     *
      * @param strides data strides array to be set
      */
     public void setStrides(long[] strides) {
@@ -500,7 +500,7 @@ public class OMTensor {
 
     /**
      * Data type setter
-     * 
+     *
      * @param type data type to be set
      */
     public void setDataType(int dataType) {
@@ -511,10 +511,10 @@ public class OMTensor {
     }
 
     /* ---------- Data buffer size getter ---------- */
-    
+
     /**
      * Data buffer size getter
-     * 
+     *
      * @return total size of the data buffer in bytes
      */
     public long getBufferSize() {
@@ -536,7 +536,7 @@ public class OMTensor {
 
     /**
      * Number of elements getter
-     * 
+     *
      * @return number of data elements in the data buffer
      */
     public long getNumElems() {
@@ -554,7 +554,7 @@ public class OMTensor {
         _rank = shape.length;
         _shape = new long[_rank];
         _strides = new long[_rank];
-                
+
         /* Using signed indices helps detect when index falls below 0. */
         for (int i = _rank - 1; i >= 0; i--) {
           _shape[i] = shape[i];
@@ -587,7 +587,7 @@ public class OMTensor {
 
     /**
      * Constructor (For JNI wrapper only. Not intended for end user)
-     * 
+     *
      * @param data data buffer
      * @param shape data shape
      * @param strides data stride
@@ -609,7 +609,7 @@ public class OMTensor {
 
     /**
      * Raw data getter (For JNI wrapper only. Not intended for end user)
-     * 
+     *
      * @return raw data
      */
     protected ByteBuffer getData() {
@@ -618,7 +618,7 @@ public class OMTensor {
 
     /**
      * Raw data setter (For JNI wrapper only. Not intended for end user)
-     * 
+     *
      * @param data raw data to be set
      */
     protected void setData(ByteBuffer data) {

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -616,7 +616,7 @@ public:
   }
 };
 
-// https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ScatterND-13
+// https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ScatterND-13
 /*
  * output = np.copy(data)
  * update_indices = indices.shape[:-1]

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -26,7 +26,7 @@ from common import compile_model
 
 def get_test_models():
     # Test directories:
-    # https://github.com/onnx/onnx/tree/master/onnx/backend/test/data/node
+    # https://github.com/onnx/onnx/tree/main/onnx/backend/test/data/node
     # In our directories, the python files that generate the tests are found here
     # onnx-mlir/third_party/onnx/onnx/backend/test/case/node
 
@@ -454,7 +454,7 @@ def get_test_models():
         # "test_min_uint16_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # "test_min_uint32_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # "test_min_uint64_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
-        
+
         # Mod
         "test_mod_mixed_sign_float32_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         "test_mod_mixed_sign_float64_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},

--- a/test/numerical/TestConv.cpp
+++ b/test/numerical/TestConv.cpp
@@ -78,7 +78,7 @@ LogicalResult checkShapes(const int NIn, const int CIn, const int HIn,
   int O[] = {HOut, WOut};
 
   // Check dimensions for the spatial axes. From MaxPool:
-  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#maxpool
+  // https://github.com/onnx/onnx/blob/main/docs/Operators.md#maxpool
   int myO[2], myPBegin[2], myPEnd[2];
   for (int i = 0; i < 2; ++i) {
     if (autoPad == AUTO_PAD_NOTSET) {


### PR DESCRIPTION
Now that [onnx switched from master to main](https://github.com/onnx/onnx/issues/3901), update URLs in onnx-mlir to also reflect the change.

Also remove some extraneous whitespace that my editor caught in the updated files.