### PR TITLE
Pass type converter to all ONNX operations

### DIFF
--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -17,8 +17,9 @@
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 
 struct ONNXLoopOpLowering : public ConversionPattern {
-  explicit ONNXLoopOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXLoopOp::getOperationName(), 1, ctx) {}
+  explicit ONNXLoopOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXLoopOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -295,7 +296,7 @@ struct ONNXLoopOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXLoopOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXLoopOpLowering>(ctx);
+void populateLoweringONNXLoopOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXLoopOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Scan.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Scan.cpp
@@ -4,7 +4,7 @@
 
 //===-------------------- Scan.cpp - Lowering Scan Op ---------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 
 struct ONNXScanOpLowering : public ConversionPattern {
-  explicit ONNXScanOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXScanOp::getOperationName(), 1, ctx) {}
+  explicit ONNXScanOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXScanOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -329,7 +330,7 @@ struct ONNXScanOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXScanOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXScanOpLowering>(ctx);
+void populateLoweringONNXScanOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXScanOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -44,7 +44,7 @@ public:
 };
 
 void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
-    MLIRContext *ctx, TypeConverter &typeConverter) {
+    TypeConverter &typeConverter, MLIRContext *ctx) {
   // Type conversion for function signatures.
   // Call MLIR FuncOp signature conversion when result type is
   // a ranked tensor.
@@ -54,62 +54,62 @@ void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
 
   // Frontend operation lowering.
   // ControlFlow
-  populateLoweringONNXLoopOpPattern(patterns, ctx);
-  populateLoweringONNXScanOpPattern(patterns, ctx);
+  populateLoweringONNXLoopOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXScanOpPattern(patterns, typeConverter, ctx);
   // Math
-  populateLoweringONNXClipOpPattern(patterns, ctx);
-  populateLoweringONNXCumSumOpPattern(patterns, ctx);
+  populateLoweringONNXClipOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXCumSumOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXElementwiseOpPattern(patterns, typeConverter, ctx);
-  populateLoweringONNXGemmOpPattern(patterns, ctx);
-  populateLoweringONNXHardmaxOpPattern(patterns, ctx);
-  populateLoweringONNXReductionOpPattern(patterns, ctx);
-  populateLoweringONNXSoftmaxOpPattern(patterns, ctx);
-  populateLoweringONNXTopKOpPattern(patterns, ctx);
-  populateLoweringONNXMatMulOpPattern(patterns, ctx);
-  populateLoweringONNXRandomNormalOpPattern(patterns, ctx);
-  populateLoweringONNXLRNOpPattern(patterns, ctx);
+  populateLoweringONNXGemmOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXHardmaxOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXReductionOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXSoftmaxOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXTopKOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXMatMulOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXRandomNormalOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXLRNOpPattern(patterns, typeConverter, ctx);
   // ML
-  populateLoweringONNXCategoryMapperOpPattern(patterns, ctx);
+  populateLoweringONNXCategoryMapperOpPattern(patterns, typeConverter, ctx);
   // ObjectDetection
-  populateLoweringONNXNonMaxSuppressionOpPattern(patterns, ctx);
+  populateLoweringONNXNonMaxSuppressionOpPattern(patterns, typeConverter, ctx);
   // Tensor
-  populateLoweringONNXArgMaxOpPattern(patterns, ctx);
-  populateLoweringONNXReshapeOpPattern(patterns, ctx);
-  populateLoweringONNXPadOpPattern(patterns, ctx);
-  populateLoweringONNXUnsqueezeOpPattern(patterns, ctx);
-  populateLoweringONNXUnsqueezeV11OpPattern(patterns, ctx);
-  populateLoweringONNXTransposeOpPattern(patterns, ctx);
-  populateLoweringONNXGatherOpPattern(patterns, ctx);
+  populateLoweringONNXArgMaxOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXReshapeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXPadOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXUnsqueezeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXUnsqueezeV11OpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXTransposeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXGatherOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXIdentityOpPattern(patterns, typeConverter, ctx);
-  populateLoweringONNXConstantOfShapeOpPattern(patterns, ctx);
-  populateLoweringONNXConstantOpPattern(patterns, ctx);
-  populateLoweringONNXConcatOpPattern(patterns, ctx);
-  populateLoweringONNXDepthToSpaceOpPattern(patterns, ctx);
-  populateLoweringONNXSpaceToDepthOpPattern(patterns, ctx);
-  populateLoweringONNXShapeOpPattern(patterns, ctx);
-  populateLoweringONNXSliceOpPattern(patterns, ctx);
-  populateLoweringONNXSqueezeOpPattern(patterns, ctx);
-  populateLoweringONNXSqueezeV11OpPattern(patterns, ctx);
-  populateLoweringONNXSplitOpPattern(patterns, ctx);
-  populateLoweringONNXSplitV11OpPattern(patterns, ctx);
-  populateLoweringONNXSizeOpPattern(patterns, ctx);
-  populateLoweringONNXTileOpPattern(patterns, ctx);
-  populateLoweringONNXFlattenOpPattern(patterns, ctx);
-  populateLoweringONNXRangeOpPattern(patterns, ctx);
-  populateLoweringONNXResizeOpPattern(patterns, ctx);
-  populateLoweringONNXNonZeroOpPattern(patterns, ctx);
-  populateLoweringONNXReverseSequenceOpPattern(patterns, ctx);
-  populateLoweringONNXExpandOpPattern(patterns, ctx);
-  populateLoweringONNXOneHotOpPattern(patterns, ctx);
-  populateLoweringONNXCompressOpPattern(patterns, ctx);
+  populateLoweringONNXConstantOfShapeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXConstantOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXConcatOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXDepthToSpaceOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXSpaceToDepthOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXShapeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXSliceOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXSqueezeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXSqueezeV11OpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXSplitOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXSplitV11OpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXSizeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXTileOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXFlattenOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXRangeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXResizeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXNonZeroOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXReverseSequenceOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXExpandOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXOneHotOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXCompressOpPattern(patterns, typeConverter, ctx);
   // Neural network
-  populateLoweringONNXConvOpPattern(patterns, ctx);
-  populateLoweringONNXNormalizationOpPattern(patterns, ctx);
-  populateLoweringONNXPoolingOpPattern(patterns, ctx);
+  populateLoweringONNXConvOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXNormalizationOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXPoolingOpPattern(patterns, typeConverter, ctx);
   // Recurrent neural network
-  populateLoweringONNXGRUOpPattern(patterns, ctx);
-  populateLoweringONNXLSTMOpPattern(patterns, ctx);
-  populateLoweringONNXRNNOpPattern(patterns, ctx);
+  populateLoweringONNXGRUOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXLSTMOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXRNNOpPattern(patterns, typeConverter, ctx);
   // Entry point
   patterns.insert<ONNXEntryPointLowering>(ctx);
 }
@@ -240,7 +240,7 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
 
   // Define patterns.
   populateONNXToKrnlConversionPattern(
-      patterns, &getContext(), krnlTypeConverter);
+      patterns, krnlTypeConverter, &getContext());
 
   // With the target and rewrite patterns defined, we can now attempt the
   // conversion. The conversion will signal failure if any of our `illegal`

--- a/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
+++ b/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
@@ -4,7 +4,7 @@
 
 //===------------ CategoryMapper.cpp - Lowering CategoryMapper Op ---------===//
 //
-// Copyright 2021 The IBM Research Authors.
+// Copyright 2021-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -34,8 +34,9 @@ struct ONNXCategoryMapperOpLowering : public ConversionPattern {
     Value len;
   };
 
-  ONNXCategoryMapperOpLowering(MLIRContext *ctx)
-      : ConversionPattern(ONNXCategoryMapperOp::getOperationName(), 1, ctx) {}
+  ONNXCategoryMapperOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, ONNXCategoryMapperOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -291,7 +292,7 @@ private:
   }
 };
 
-void populateLoweringONNXCategoryMapperOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXCategoryMapperOpLowering>(ctx);
+void populateLoweringONNXCategoryMapperOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXCategoryMapperOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/Clip.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Clip.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- Clip.cpp - Lowering Clip Op ------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -22,8 +22,9 @@ using namespace mlir;
 //===----------------------------------------------------------------------===//
 
 struct ONNXClipOpLowering : public ConversionPattern {
-  ONNXClipOpLowering(MLIRContext *ctx)
-      : ConversionPattern(ONNXClipOp::getOperationName(), 1, ctx) {}
+  ONNXClipOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, ONNXClipOp::getOperationName(), 1, ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
@@ -101,7 +102,7 @@ struct ONNXClipOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXClipOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXClipOpLowering>(ctx);
+void populateLoweringONNXClipOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXClipOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/CumSum.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/CumSum.cpp
@@ -4,7 +4,7 @@
 
 //===-------------- CumSum.cpp - Lowering CumSum Ops ----------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -54,8 +54,9 @@ static Value getLoopIndexByAxisAndOffset(MathBuilder &createMath,
 }
 
 struct ONNXCumSumOpLowering : public ConversionPattern {
-  ONNXCumSumOpLowering(MLIRContext *ctx)
-      : ConversionPattern(ONNXCumSumOp::getOperationName(), 1, ctx) {}
+  ONNXCumSumOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, ONNXCumSumOp::getOperationName(), 1, ctx) {}
 
   /// We use a paralel algorithm for cumsum [1] as follows:
   /// Assume that input is x whose shape in [n,m], and axis for cumsum is 0.
@@ -244,7 +245,7 @@ struct ONNXCumSumOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXCumSumOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXCumSumOpLowering>(ctx);
+void populateLoweringONNXCumSumOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXCumSumOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- Gemm.cpp - Lowering Gemm Op ------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -29,8 +29,8 @@ using namespace mlir;
 
 template <typename GemmOp>
 struct ONNXGemmOpLowering : public ConversionPattern {
-  ONNXGemmOpLowering(MLIRContext *ctx)
-      : ConversionPattern(GemmOp::getOperationName(), 1, ctx) {}
+  ONNXGemmOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter, GemmOp::getOperationName(), 1, ctx) {}
 
   void genericGemm(ONNXGemmOp &gemmOp, ONNXGemmOpAdaptor &operandAdaptor,
       Type elementType, ONNXGemmOpShapeHelper &shapeHelper, Value alloc,
@@ -372,7 +372,7 @@ struct ONNXGemmOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXGemmOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXGemmOpLowering<ONNXGemmOp>>(ctx);
+void populateLoweringONNXGemmOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXGemmOpLowering<ONNXGemmOp>>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/Hardmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Hardmax.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- Hardmax.cpp - Hardmax Op ---------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -74,8 +74,9 @@ static Value emitArgmax(ConversionPatternRewriter &rewriter, Location loc,
 }
 
 struct ONNXHardmaxOpLowering : public ConversionPattern {
-  ONNXHardmaxOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXHardmaxOp::getOperationName(), 1, ctx) {}
+  ONNXHardmaxOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXHardmaxOp::getOperationName(), 1, ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
@@ -141,7 +142,7 @@ struct ONNXHardmaxOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXHardmaxOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXHardmaxOpLowering>(ctx);
+void populateLoweringONNXHardmaxOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXHardmaxOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/LRN.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LRN.cpp
@@ -4,7 +4,7 @@
 
 //===----------------LRN.cpp - Lowering LRN Op----------------------=== //
 //
-// Copyright 2020 The IBM Research Authors.
+// Copyright 2020-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXLRNOpLowering : public ConversionPattern {
-  ONNXLRNOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXLRNOp::getOperationName(), 1, ctx) {}
+  ONNXLRNOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXLRNOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -143,7 +144,7 @@ struct ONNXLRNOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXLRNOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXLRNOpLowering>(ctx);
+void populateLoweringONNXLRNOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXLRNOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- Matmul.cpp - Lowering Matmul Op --------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -23,8 +23,9 @@ using namespace mlir;
 #define DEBUG_TRACE 0
 
 struct ONNXMatMulOpLowering : public ConversionPattern {
-  ONNXMatMulOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXMatMulOp::getOperationName(), 1, ctx) {}
+  ONNXMatMulOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXMatMulOp::getOperationName(), 1, ctx) {}
 
   // Handle the generic cases, including when there are broadcasts.
   void replaceGenericMatmul(ONNXMatMulOp &matMulOp,
@@ -223,7 +224,7 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXMatMulOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXMatMulOpLowering>(ctx);
+void populateLoweringONNXMatMulOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXMatMulOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/RandomNormal.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/RandomNormal.cpp
@@ -4,7 +4,7 @@
 
 //===----------- RandomNormal.cpp - Lowering RandomNormal Op --------------===//
 //
-// Copyright 2019-2021 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -23,8 +23,8 @@
 using namespace mlir;
 
 struct ONNXRandomNormalOpLowering : public ConversionPattern {
-  ONNXRandomNormalOpLowering(MLIRContext *ctx)
-      : ConversionPattern(
+  ONNXRandomNormalOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
             mlir::ONNXRandomNormalOp::getOperationName(), 1, ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -66,7 +66,7 @@ struct ONNXRandomNormalOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXRandomNormalOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXRandomNormalOpLowering>(ctx);
+void populateLoweringONNXRandomNormalOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXRandomNormalOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -4,7 +4,7 @@
 
 //===-------------- Reduction.cpp - Lowering Reduction Ops ----------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -132,8 +132,10 @@ template <typename ONNXReductionOp>
 struct ONNXReductionOpLowering : public ConversionPattern {
   bool computeMean = false;
 
-  ONNXReductionOpLowering(MLIRContext *ctx, bool computeMean = false)
-      : ConversionPattern(ONNXReductionOp::getOperationName(), 1, ctx) {
+  ONNXReductionOpLowering(
+      TypeConverter &typeConverter, MLIRContext *ctx, bool computeMean = false)
+      : ConversionPattern(
+            typeConverter, ONNXReductionOp::getOperationName(), 1, ctx) {
     this->computeMean = computeMean;
   }
 
@@ -358,8 +360,10 @@ struct ONNXReductionOpLowering : public ConversionPattern {
 struct ONNXReduceSumOpLowering : public ConversionPattern {
   bool computeMean = false;
 
-  ONNXReduceSumOpLowering(MLIRContext *ctx, bool computeMean = false)
-      : ConversionPattern(ONNXReduceSumOp::getOperationName(), 1, ctx),
+  ONNXReduceSumOpLowering(
+      TypeConverter &typeConverter, MLIRContext *ctx, bool computeMean = false)
+      : ConversionPattern(
+            typeConverter, ONNXReduceSumOp::getOperationName(), 1, ctx),
         computeMean(computeMean) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
@@ -690,13 +694,13 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXReductionOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
+void populateLoweringONNXReductionOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
   patterns.insert<ONNXReductionOpLowering<mlir::ONNXReduceMaxOp>,
       ONNXReductionOpLowering<mlir::ONNXReduceMinOp>,
       ONNXReductionOpLowering<mlir::ONNXReduceProdOp>,
       ONNXReductionOpLowering<mlir::ONNXReduceSumV11Op>,
-      ONNXReduceSumOpLowering>(ctx);
+      ONNXReduceSumOpLowering>(typeConverter, ctx);
   patterns.insert<ONNXReductionOpLowering<mlir::ONNXReduceMeanOp>>(
-      ctx, /*computeMean=*/true);
+      typeConverter, ctx, /*computeMean=*/true);
 }

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- Softmax.cpp - Softmax Op ---------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -218,8 +218,9 @@ static void emitInstForSoftmaxV13(ConversionPatternRewriter &rewriter,
 }
 
 struct ONNXSoftmaxOpLowering : public ConversionPattern {
-  ONNXSoftmaxOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXSoftmaxOp::getOperationName(), 1, ctx) {}
+  ONNXSoftmaxOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXSoftmaxOp::getOperationName(), 1, ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     // softmax(x) = let max_x = max(x) in
@@ -278,7 +279,7 @@ struct ONNXSoftmaxOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXSoftmaxOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXSoftmaxOpLowering>(ctx);
+void populateLoweringONNXSoftmaxOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXSoftmaxOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Math/TopK.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/TopK.cpp
@@ -4,7 +4,7 @@
 
 //===----------------------- TopK.cpp - TopK Op ---------------------------===//
 //
-// Copyright 2021 The IBM Research Authors.
+// Copyright 2021-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXTopKOpLowering : public ConversionPattern {
-  ONNXTopKOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXTopKOp::getOperationName(), 1, ctx) {}
+  ONNXTopKOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXTopKOp::getOperationName(), 1, ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
@@ -89,7 +90,7 @@ struct ONNXTopKOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXTopKOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXTopKOpLowering>(ctx);
+void populateLoweringONNXTopKOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXTopKOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -4,7 +4,7 @@
 
 //===--------------- Conv.cpp - Lowering Convolution Op -------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXConvOpLowering : public ConversionPattern {
-  ONNXConvOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXConvOp::getOperationName(), 1, ctx) {}
+  ONNXConvOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXConvOp::getOperationName(), 1, ctx) {}
 
   void convUnoptimized(ConversionPatternRewriter &rewriter,
       IndexExprScope *topScope, ONNXConvOp &convOp,
@@ -227,7 +228,7 @@ struct ONNXConvOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXConvOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXConvOpLowering>(ctx);
+void populateLoweringONNXConvOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXConvOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -4,7 +4,7 @@
 
 //===----------- Normalization.cpp - Lowering Normalization Ops -----------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@ using namespace mlir;
 
 struct ONNXBatchNormalizationInferenceModeOpLowering
     : public ConversionPattern {
-  ONNXBatchNormalizationInferenceModeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(
+  ONNXBatchNormalizationInferenceModeOpLowering(
+      TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
             mlir::ONNXBatchNormalizationInferenceModeOp::getOperationName(), 1,
             ctx) {}
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
@@ -138,9 +139,9 @@ struct ONNXBatchNormalizationInferenceModeOpLowering
 };
 
 struct ONNXInstanceNormalizationOpLowering : public ConversionPattern {
-
-  ONNXInstanceNormalizationOpLowering(MLIRContext *ctx)
-      : ConversionPattern(
+  ONNXInstanceNormalizationOpLowering(
+      TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
             mlir::ONNXInstanceNormalizationOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
@@ -284,8 +285,9 @@ struct ONNXInstanceNormalizationOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXNormalizationOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXBatchNormalizationInferenceModeOpLowering>(ctx);
-  patterns.insert<ONNXInstanceNormalizationOpLowering>(ctx);
+void populateLoweringONNXNormalizationOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXBatchNormalizationInferenceModeOpLowering>(
+      typeConverter, ctx);
+  patterns.insert<ONNXInstanceNormalizationOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Pooling.cpp - Lowering Pooling Ops ------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -195,8 +195,8 @@ void postProcessPoolingWindow<ONNXAveragePoolOp>(
 //
 template <typename PoolOp, typename PoolOpAdaptor, typename PoolOpShapeHelper>
 struct ONNXPoolOpLowering : public ConversionPattern {
-  ONNXPoolOpLowering(MLIRContext *ctx)
-      : ConversionPattern(PoolOp::getOperationName(), 1, ctx) {}
+  ONNXPoolOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter, PoolOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -491,10 +491,12 @@ struct ONNXPoolOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXPoolingOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
+void populateLoweringONNXPoolingOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
   patterns.insert<ONNXPoolOpLowering<ONNXMaxPoolSingleOutOp,
-      ONNXMaxPoolSingleOutOpAdaptor, ONNXMaxPoolSingleOutOpShapeHelper>>(ctx);
+      ONNXMaxPoolSingleOutOpAdaptor, ONNXMaxPoolSingleOutOpShapeHelper>>(
+      typeConverter, ctx);
   patterns.insert<ONNXPoolOpLowering<ONNXAveragePoolOp,
-      ONNXAveragePoolOpAdaptor, ONNXAveragePoolOpShapeHelper>>(ctx);
+      ONNXAveragePoolOpAdaptor, ONNXAveragePoolOpShapeHelper>>(
+      typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -4,7 +4,7 @@
 
 //====----- ONNXToKrnlCommon.cpp - ONNX dialects to Krnl lowering ---------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -250,167 +250,124 @@ public:
 //===----------------------------------------------------------------------===//
 
 // For all ONNX operations.
-void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
-    MLIRContext *ctx, TypeConverter &typeConverter);
+void populateONNXToKrnlConversionPattern(
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 
 // `ControlFlow` directory methods:
 void populateLoweringONNXLoopOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXScanOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 
 // `Math` directory methods:
 void populateLoweringONNXClipOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXCumSumOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXElementwiseOpPattern(
     RewritePatternSet &, TypeConverter &, MLIRContext *);
-
 void populateLoweringONNXGemmOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXHardmaxOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXLRNOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXMatMulOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXRandomNormalOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXReductionOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXSoftmaxOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXTopKOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 
 // `ML` directory methods:
 void populateLoweringONNXCategoryMapperOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 
 // `NN` directory methods:
 void populateLoweringONNXConvOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXNormalizationOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXPoolingOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 
 // `ObjectDetection` directory methods:
 void populateLoweringONNXNonMaxSuppressionOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 
 // `RNN` directory methods:
 void populateLoweringONNXGRUOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXLSTMOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXRNNOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 
 // `Tensor` directory methods:
 void populateLoweringONNXArgMaxOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXUnsqueezeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXUnsqueezeV11OpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXTransposeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXGatherOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXPadConstantValuePadOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXPadOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXRangeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXReshapeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXIdentityOpPattern(
     RewritePatternSet &, TypeConverter &, MLIRContext *);
-
 void populateLoweringONNXConstantOfShapeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXConstantOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXConcatOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXDepthToSpaceOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXSpaceToDepthOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXShapeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXSliceOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXSqueezeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXSqueezeV11OpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXSplitOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXSplitV11OpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXSizeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXTileOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXFlattenOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXResizeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXNonZeroOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXReverseSequenceOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXExpandOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXOneHotOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
-
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 void populateLoweringONNXCompressOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx);
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
 
 bool checkOpResultIsUsedByGetRef(memref::AllocOp *allocOp);
 

--- a/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
+++ b/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
@@ -4,7 +4,7 @@
 
 //===----- NonMaxSuppression.cpp - Lowering NonMaxSuppression Op ----------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2020 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -203,9 +203,10 @@ static Value tryToUnflip(
 }
 
 struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
-  ONNXNonMaxSuppressionOpLowering(MLIRContext *ctx)
-      : ConversionPattern(ONNXNonMaxSuppressionOp::getOperationName(), 1, ctx) {
-  }
+  ONNXNonMaxSuppressionOpLowering(
+      TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
+            ONNXNonMaxSuppressionOp::getOperationName(), 1, ctx) {}
 
   /// To understand how code is generated for NonMaxSuppression, look at the
   /// python implementation at the end of this file.
@@ -466,9 +467,9 @@ struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXNonMaxSuppressionOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXNonMaxSuppressionOpLowering>(ctx);
+void populateLoweringONNXNonMaxSuppressionOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXNonMaxSuppressionOpLowering>(typeConverter, ctx);
 }
 
 // clang-format off

--- a/src/Conversion/ONNXToKrnl/RNN/GRU.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/GRU.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- GRU.cpp - Lowering GRU Op --------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -615,8 +615,8 @@ void stateToOutput<ONNXGRUOp, GruState>(ConversionPatternRewriter &rewriter,
   }
 }
 
-void populateLoweringONNXGRUOpPattern(
-    OwningRewritePatternList &patterns, MLIRContext *ctx) {
+void populateLoweringONNXGRUOpPattern(OwningRewritePatternList &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
   patterns.insert<ONNXRNNOpLowering<ONNXGRUOp, GruState, GruActivationPack,
-      GruWeightPack, GruBiasPack>>(ctx);
+      GruWeightPack, GruBiasPack>>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/RNN/LSTM.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/LSTM.cpp
@@ -4,7 +4,7 @@
 
 //===--------------- LSTM.cpp - Lowering LSTM Op --------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -609,8 +609,8 @@ void stateToOutput<ONNXLSTMOp, LstmState>(ConversionPatternRewriter &rewriter,
   }
 }
 
-void populateLoweringONNXLSTMOpPattern(
-    OwningRewritePatternList &patterns, MLIRContext *ctx) {
+void populateLoweringONNXLSTMOpPattern(OwningRewritePatternList &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
   patterns.insert<ONNXRNNOpLowering<ONNXLSTMOp, LstmState, LstmActivationPack,
-      LstmWeightPack, LstmBiasPack>>(ctx);
+      LstmWeightPack, LstmBiasPack>>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- RNN.cpp - Lowering RNN Op --------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -372,8 +372,8 @@ void stateToOutput<ONNXRNNOp, RnnState>(ConversionPatternRewriter &rewriter,
   }
 }
 
-void populateLoweringONNXRNNOpPattern(
-    OwningRewritePatternList &patterns, MLIRContext *ctx) {
+void populateLoweringONNXRNNOpPattern(OwningRewritePatternList &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
   patterns.insert<ONNXRNNOpLowering<ONNXRNNOp, RnnState, RnnActivationPack,
-      RnnWeightPack, RnnBiasPack>>(ctx);
+      RnnWeightPack, RnnBiasPack>>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp
@@ -4,7 +4,7 @@
 
 //===--------------- RNNBase.hpp - Lowering RNN Ops -----------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -123,8 +123,8 @@ void stateToOutput(ConversionPatternRewriter &rewriter, Location loc, RNNOp *op,
 // A common template for lowering an RNN operation.
 template <typename RNNOp, typename S, typename A, typename W, typename B>
 struct ONNXRNNOpLowering : public ConversionPattern {
-  ONNXRNNOpLowering(MLIRContext *ctx)
-      : ConversionPattern(RNNOp::getOperationName(), 1, ctx) {}
+  ONNXRNNOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter, RNNOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {

--- a/src/Conversion/ONNXToKrnl/Tensor/ArgMax.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ArgMax.cpp
@@ -4,6 +4,10 @@
 
 //===---------------- ArgMax.cpp - Lowering ArgMax Op -------------------===//
 //
+// Copyright 2021-2022 The IBM Research Authors.
+//
+// =============================================================================
+//
 // This file lowers the ONNX ArgMax Operator to Krnl dialect.
 //
 //===----------------------------------------------------------------------===//
@@ -15,8 +19,9 @@
 using namespace mlir;
 
 struct ONNXArgMaxOpLowering : public ConversionPattern {
-  ONNXArgMaxOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXArgMaxOp::getOperationName(), 1, ctx) {}
+  ONNXArgMaxOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXArgMaxOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -139,7 +144,7 @@ struct ONNXArgMaxOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXArgMaxOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXArgMaxOpLowering>(ctx);
+void populateLoweringONNXArgMaxOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXArgMaxOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Compress.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Compress.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Compress.cpp - Lowering Compress Op -----------------===//
 //
-// Copyright 2021 The IBM Research Authors.
+// Copyright 2021-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -19,8 +19,9 @@ using namespace mlir;
 
 struct ONNXCompressOpLowering : public ConversionPattern {
 
-  ONNXCompressOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXCompressOp::getOperationName(), 1, ctx) {}
+  ONNXCompressOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXCompressOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -257,7 +258,7 @@ struct ONNXCompressOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXCompressOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXCompressOpLowering>(ctx);
+void populateLoweringONNXCompressOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXCompressOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Concat.cpp - Lowering Concat Op -------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXConcatOpLowering : public ConversionPattern {
-  ONNXConcatOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXConcatOp::getOperationName(), 1, ctx) {}
+  ONNXConcatOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXConcatOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -85,7 +86,7 @@ struct ONNXConcatOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXConcatOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXConcatOpLowering>(ctx);
+void populateLoweringONNXConcatOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXConcatOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Constant.cpp - Lowering Constant Op -----------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -19,8 +19,9 @@ using namespace mlir;
 struct ONNXConstantOpLowering : public ConversionPattern {
   static int constantID;
 
-  ONNXConstantOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXConstantOp::getOperationName(), 1, ctx) {}
+  ONNXConstantOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXConstantOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -60,7 +61,7 @@ struct ONNXConstantOpLowering : public ConversionPattern {
 
 int ONNXConstantOpLowering::constantID = 0;
 
-void populateLoweringONNXConstantOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXConstantOpLowering>(ctx);
+void populateLoweringONNXConstantOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXConstantOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/ConstantOfShape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConstantOfShape.cpp
@@ -4,7 +4,7 @@
 
 //===------------ ConstantOfShape.cpp - Lowering ConstantOfShape Op -------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -17,8 +17,8 @@
 using namespace mlir;
 
 struct ONNXConstantOfShapeOpLowering : public ConversionPattern {
-  ONNXConstantOfShapeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(
+  ONNXConstantOfShapeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
             mlir::ONNXConstantOfShapeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
@@ -99,7 +99,7 @@ struct ONNXConstantOfShapeOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXConstantOfShapeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXConstantOfShapeOpLowering>(ctx);
+void populateLoweringONNXConstantOfShapeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXConstantOfShapeOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/DepthToSpace.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/DepthToSpace.cpp
@@ -4,7 +4,7 @@
 
 //===------------ DepthToSpace.cpp - Lowering DepthToSpace Op -------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2021-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -23,8 +23,8 @@ using llvm::dbgs;
 #define DEBUG_TYPE "depth_to_space_onnx_to_krnl"
 
 struct ONNXDepthToSpaceOpLowering : public ConversionPattern {
-  ONNXDepthToSpaceOpLowering(MLIRContext *ctx)
-      : ConversionPattern(
+  ONNXDepthToSpaceOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
             mlir::ONNXDepthToSpaceOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
@@ -96,7 +96,7 @@ struct ONNXDepthToSpaceOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXDepthToSpaceOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXDepthToSpaceOpLowering>(ctx);
+void populateLoweringONNXDepthToSpaceOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXDepthToSpaceOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Expand.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Expand.cpp
@@ -4,7 +4,7 @@
 
 //===----------------Expand.cpp - Lowering Expand Op----------------------=== //
 //
-// Copyright 2020 The IBM Research Authors.
+// Copyright 2020-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -19,8 +19,9 @@
 using namespace mlir;
 
 struct ONNXExpandOpLowering : public ConversionPattern {
-  ONNXExpandOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXExpandOp::getOperationName(), 1, ctx) {}
+  ONNXExpandOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXExpandOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -64,7 +65,7 @@ struct ONNXExpandOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXExpandOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXExpandOpLowering>(ctx);
+void populateLoweringONNXExpandOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXExpandOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Flatten.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Flatten.cpp
@@ -2,10 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===---------------- Flatten.cpp - Lowering Flatten Op
-//-------------------===//
+//===---------------- Flatten.cpp - Lowering Flatten Op -------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -58,8 +57,9 @@ Value insertAllocAndDeallocForFlatten(MemRefType memRefType, Location loc,
 }
 
 struct ONNXFlattenOpLowering : public ConversionPattern {
-  ONNXFlattenOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXFlattenOp::getOperationName(), 1, ctx) {}
+  ONNXFlattenOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXFlattenOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -170,7 +170,7 @@ struct ONNXFlattenOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXFlattenOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXFlattenOpLowering>(ctx);
+void populateLoweringONNXFlattenOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXFlattenOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Gather.cpp
@@ -4,7 +4,7 @@
 
 //===----------------Gather.cpp - Lowering Gather Op----------------------=== //
 //
-// Copyright 2020 The IBM Research Authors.
+// Copyright 2020-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXGatherOpLowering : public ConversionPattern {
-  ONNXGatherOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXGatherOp::getOperationName(), 1, ctx) {}
+  ONNXGatherOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXGatherOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -110,7 +111,7 @@ struct ONNXGatherOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXGatherOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXGatherOpLowering>(ctx);
+void populateLoweringONNXGatherOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXGatherOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
@@ -4,7 +4,7 @@
 
 //===------------------- NonZero.cpp - Lowering NonZero Op ----------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXNonZeroOpLowering : public ConversionPattern {
-  ONNXNonZeroOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXNonZeroOp::getOperationName(), 1, ctx) {}
+  ONNXNonZeroOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXNonZeroOp::getOperationName(), 1, ctx) {}
 
   /// Given an input of shape (3, 2):
   /// [[2, 1],
@@ -213,7 +214,7 @@ struct ONNXNonZeroOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXNonZeroOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXNonZeroOpLowering>(ctx);
+void populateLoweringONNXNonZeroOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXNonZeroOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/OneHot.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/OneHot.cpp
@@ -4,6 +4,10 @@
 
 //===---------------- OneHot.cpp - Lowering OneHot Op -------------------===//
 //
+// Copyright 2021-2022 The IBM Research Authors.
+//
+// =============================================================================
+//
 // This file lowers the ONNX OneHot Operator to Krnl dialect.
 //
 //===----------------------------------------------------------------------===//
@@ -14,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXOneHotOpLowering : public ConversionPattern {
-  ONNXOneHotOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXOneHotOp::getOperationName(), 1, ctx) {}
+  ONNXOneHotOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXOneHotOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -107,7 +112,7 @@ struct ONNXOneHotOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXOneHotOpPattern(
-    OwningRewritePatternList &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXOneHotOpLowering>(ctx);
+void populateLoweringONNXOneHotOpPattern(OwningRewritePatternList &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXOneHotOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
@@ -4,7 +4,7 @@
 
 //===-----------------------Pad.cpp - Lowering Pad Op -------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXPadOpLowering : public ConversionPattern {
-  ONNXPadOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXPadOp::getOperationName(), 1, ctx) {}
+  ONNXPadOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXPadOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -132,7 +133,7 @@ struct ONNXPadOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXPadOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXPadOpLowering>(ctx);
+void populateLoweringONNXPadOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXPadOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
@@ -4,7 +4,7 @@
 
 //===------------------- Range.cpp - Lowering Range Op --------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXRangeOpLowering : public ConversionPattern {
-  ONNXRangeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXRangeOp::getOperationName(), 1, ctx) {}
+  ONNXRangeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXRangeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -199,7 +200,7 @@ struct ONNXRangeOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXRangeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXRangeOpLowering>(ctx);
+void populateLoweringONNXRangeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXRangeOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Reshape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Reshape.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Reshape.cpp - Lowering Reshape Op -------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -22,8 +22,9 @@ using llvm::dbgs;
 #define DEBUG_TYPE "reshape_onnx_to_krnl"
 
 struct ONNXReshapeOpLowering : public ConversionPattern {
-  ONNXReshapeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXReshapeOp::getOperationName(), 1, ctx) {}
+  ONNXReshapeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXReshapeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -52,7 +53,7 @@ struct ONNXReshapeOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXReshapeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXReshapeOpLowering>(ctx);
+void populateLoweringONNXReshapeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXReshapeOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -2,10 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===---------------- Resize.cpp - Lowering Resize Op
-//-------------------===//
+//===---------------- Resize.cpp - Lowering Resize Op ---------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -19,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXResizeOpLowering : public ConversionPattern {
-  ONNXResizeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXResizeOp::getOperationName(), 1, ctx) {}
+  ONNXResizeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXResizeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -215,7 +215,7 @@ struct ONNXResizeOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXResizeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXResizeOpLowering>(ctx);
+void populateLoweringONNXResizeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXResizeOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/ReverseSequence.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ReverseSequence.cpp
@@ -4,7 +4,7 @@
 
 //===----------------Gather.cpp - Lowering Gather Op----------------------=== //
 //
-// Copyright 2020 The IBM Research Authors.
+// Copyright 2020-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,8 @@
 using namespace mlir;
 
 struct ONNXReverseSequenceOpLowering : public ConversionPattern {
-  ONNXReverseSequenceOpLowering(MLIRContext *ctx)
-      : ConversionPattern(
+  ONNXReverseSequenceOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
             mlir::ONNXReverseSequenceOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
@@ -127,7 +127,7 @@ struct ONNXReverseSequenceOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXReverseSequenceOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXReverseSequenceOpLowering>(ctx);
+void populateLoweringONNXReverseSequenceOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXReverseSequenceOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
@@ -4,7 +4,7 @@
 
 //===----------------Shape.cpp - Lowering Shape Op----------------------=== //
 //
-// Copyright 2020 The IBM Research Authors.
+// Copyright 2020-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -19,8 +19,9 @@
 using namespace mlir;
 
 struct ONNXShapeOpLowering : public ConversionPattern {
-  ONNXShapeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXShapeOp::getOperationName(), 1, ctx) {}
+  ONNXShapeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXShapeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -55,7 +56,7 @@ struct ONNXShapeOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXShapeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXShapeOpLowering>(ctx);
+void populateLoweringONNXShapeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXShapeOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXSizeOpLowering : public ConversionPattern {
-  ONNXSizeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXSizeOp::getOperationName(), 1, ctx) {}
+  ONNXSizeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXSizeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -72,7 +73,7 @@ struct ONNXSizeOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXSizeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXSizeOpLowering>(ctx);
+void populateLoweringONNXSizeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXSizeOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -4,7 +4,7 @@
 
 //===----------------Slice.cpp - Lowering Slice Op----------------------=== //
 //
-// Copyright 2020 The IBM Research Authors.
+// Copyright 2020-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXSliceOpLowering : public ConversionPattern {
-  ONNXSliceOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXSliceOp::getOperationName(), 1, ctx) {}
+  ONNXSliceOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXSliceOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -71,7 +72,7 @@ struct ONNXSliceOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXSliceOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXSliceOpLowering>(ctx);
+void populateLoweringONNXSliceOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXSliceOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/SpaceToDepth.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/SpaceToDepth.cpp
@@ -4,7 +4,7 @@
 
 //===---------- SpaceToDepth.cpp - Lowering SpaceToDepthOp ----------------===//
 //
-// Copyright 2021 The IBM Research Authors.
+// Copyright 2021-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -23,8 +23,9 @@ using llvm::dbgs;
 #define DEBUG_TYPE "space_to_depth_onnx_to_krnl"
 
 struct ONNXSpaceToDepthOpLowering : public ConversionPattern {
-  ONNXSpaceToDepthOpLowering(MLIRContext *ctx)
-      : ConversionPattern(ONNXSpaceToDepthOp::getOperationName(), 1, ctx) {}
+  ONNXSpaceToDepthOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, ONNXSpaceToDepthOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -81,7 +82,7 @@ struct ONNXSpaceToDepthOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXSpaceToDepthOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXSpaceToDepthOpLowering>(ctx);
+void populateLoweringONNXSpaceToDepthOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXSpaceToDepthOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Split.cpp - Lowering Split Op -----------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -83,8 +83,9 @@ LogicalResult ONNXSplitOpLoweringCommon(Operation *op, ArrayRef<Value> operands,
 }
 
 struct ONNXSplitOpLowering : public ConversionPattern {
-  ONNXSplitOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXSplitOp::getOperationName(), 1, ctx) {}
+  ONNXSplitOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXSplitOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -94,8 +95,9 @@ struct ONNXSplitOpLowering : public ConversionPattern {
 };
 
 struct ONNXSplitV11OpLowering : public ConversionPattern {
-  ONNXSplitV11OpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXSplitV11Op::getOperationName(), 1, ctx) {}
+  ONNXSplitV11OpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXSplitV11Op::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -104,12 +106,12 @@ struct ONNXSplitV11OpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXSplitOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXSplitOpLowering>(ctx);
+void populateLoweringONNXSplitOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXSplitOpLowering>(typeConverter, ctx);
 }
 
-void populateLoweringONNXSplitV11OpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXSplitV11OpLowering>(ctx);
+void populateLoweringONNXSplitV11OpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXSplitV11OpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Squeeze.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Squeeze.cpp
@@ -4,7 +4,7 @@
 
 //===--------------- Squeeze.cpp - Lowering Squeeze Op --------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -40,8 +40,9 @@ LogicalResult ONNXSqueezeOpLoweringCommon(Operation *op,
 }
 
 struct ONNXSqueezeOpLowering : public ConversionPattern {
-  ONNXSqueezeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXSqueezeOp::getOperationName(), 1, ctx) {}
+  ONNXSqueezeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXSqueezeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -51,8 +52,9 @@ struct ONNXSqueezeOpLowering : public ConversionPattern {
 };
 
 struct ONNXSqueezeV11OpLowering : public ConversionPattern {
-  ONNXSqueezeV11OpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXSqueezeV11Op::getOperationName(), 1, ctx) {}
+  ONNXSqueezeV11OpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
+            mlir::ONNXSqueezeV11Op::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -61,12 +63,12 @@ struct ONNXSqueezeV11OpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXSqueezeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXSqueezeOpLowering>(ctx);
+void populateLoweringONNXSqueezeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXSqueezeOpLowering>(typeConverter, ctx);
 }
 
-void populateLoweringONNXSqueezeV11OpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXSqueezeV11OpLowering>(ctx);
+void populateLoweringONNXSqueezeV11OpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXSqueezeV11OpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -4,7 +4,7 @@
 
 //===----------------Tile.cpp - Lowering Tile Op----------------------=== //
 //
-// Copyright 2020 The IBM Research Authors.
+// Copyright 2020-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -54,8 +54,9 @@ Value insertAllocAndDeallocForTile(MemRefType memRefType, Location loc,
 }
 
 struct ONNXTileOpLowering : public ConversionPattern {
-  ONNXTileOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXTileOp::getOperationName(), 1, ctx) {}
+  ONNXTileOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXTileOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -122,8 +123,9 @@ struct ONNXTileOpLowering : public ConversionPattern {
 // This is the alternative way of lowering.
 // It is kept here for record in case this implementation is needed
 struct ONNXTileOpLoweringAlternative : public ConversionPattern {
-  ONNXTileOpLoweringAlternative(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXTileOp::getOperationName(), 1, ctx) {}
+  ONNXTileOpLoweringAlternative(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXTileOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -214,7 +216,7 @@ struct ONNXTileOpLoweringAlternative : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXTileOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXTileOpLowering>(ctx);
+void populateLoweringONNXTileOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXTileOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Transpose.cpp - Lowering Transpose Op ---------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -18,8 +18,9 @@
 using namespace mlir;
 
 struct ONNXTransposeOpLowering : public ConversionPattern {
-  ONNXTransposeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXTransposeOp::getOperationName(), 1, ctx) {}
+  ONNXTransposeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXTransposeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -78,7 +79,7 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXTransposeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXTransposeOpLowering>(ctx);
+void populateLoweringONNXTransposeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXTransposeOpLowering>(typeConverter, ctx);
 }

--- a/src/Conversion/ONNXToKrnl/Tensor/Unsqueeze.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Unsqueeze.cpp
@@ -4,7 +4,7 @@
 
 //===--------------- Unsqueeze.cpp - Lowering Unsqueeze Op ----------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -40,8 +40,9 @@ LogicalResult ONNXUnsqueezeOpLoweringCommon(Operation *op,
 }
 
 struct ONNXUnsqueezeOpLowering : public ConversionPattern {
-  ONNXUnsqueezeOpLowering(MLIRContext *ctx)
-      : ConversionPattern(mlir::ONNXUnsqueezeOp::getOperationName(), 1, ctx) {}
+  ONNXUnsqueezeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXUnsqueezeOp::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -51,8 +52,8 @@ struct ONNXUnsqueezeOpLowering : public ConversionPattern {
 };
 
 struct ONNXUnsqueezeV11OpLowering : public ConversionPattern {
-  ONNXUnsqueezeV11OpLowering(MLIRContext *ctx)
-      : ConversionPattern(
+  ONNXUnsqueezeV11OpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter,
             mlir::ONNXUnsqueezeV11Op::getOperationName(), 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
@@ -63,12 +64,12 @@ struct ONNXUnsqueezeV11OpLowering : public ConversionPattern {
   }
 };
 
-void populateLoweringONNXUnsqueezeOpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXUnsqueezeOpLowering>(ctx);
+void populateLoweringONNXUnsqueezeOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXUnsqueezeOpLowering>(typeConverter, ctx);
 }
 
-void populateLoweringONNXUnsqueezeV11OpPattern(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<ONNXUnsqueezeV11OpLowering>(ctx);
+void populateLoweringONNXUnsqueezeV11OpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXUnsqueezeV11OpLowering>(typeConverter, ctx);
 }

--- a/src/Dialect/ONNX/MLIRDialectBuilder.cpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.cpp
@@ -397,7 +397,6 @@ Value MemRefBuilder::dim(Value val, int64_t index) const {
          "memref::DimOp expects input operand to have MemRefType or "
          "UnrankedMemRefType");
   assert(index >= 0 && "Expecting a valid index");
-
   Value i = b.create<arith::ConstantIndexOp>(loc, index);
   return b.createOrFold<memref::DimOp>(loc, val, i);
 }


### PR DESCRIPTION
This PR finishes the type conversion related changes started in #1095. Specifically this pull request modifies all ONNX operators to pass a type converter to their base class.