### PR TITLE
Add an option to stop compilation after objects are created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,12 @@ These are frontend options.
 
   Choose target to emit:
       --EmitONNXBasic - Ingest ONNX and emit the basic ONNX operations without inferred shapes.
-      --EmitONNXIR   - Ingest ONNX and emit corresponding ONNX dialect.
-      --EmitMLIR     - Lower input to MLIR built-in transformation dialect.
-      --EmitLLVMIR   - Lower input to LLVM IR (LLVM MLIR dialect).
-      --EmitLib      - Lower input to LLVM IR, emit LLVM bitcode,
-                       compile and link it to a shared library (default).
-      --EmitJNI      - Lower input to LLVM IR -> LLVM bitcode -> JNI shared library ->
-                       jar.
+      --EmitONNXIR    - Ingest ONNX and emit corresponding ONNX dialect.
+      --EmitMLIR      - Lower the input to MLIR built-in transformation dialect.
+      --EmitLLVMIR    - Lower the input to LLVM IR (LLVM MLIR dialect).
+      --EmitObj       - Compile the input to an object file.      
+      --EmitLib       - Compile and link the input into a shared library (default).
+      --EmitJNI       - Compile the input to a jar file.
 
   Optimization levels:
       --O0           - Optimization level 0 (default).

--- a/docker/onnx-mlir.py
+++ b/docker/onnx-mlir.py
@@ -16,6 +16,7 @@ EMIT_IR_OPTS    = [ '--EmitONNXBasic',
                     '--EmitMLIR',
                     '--EmitLLVMIR' ]
 EMIT_BIN_OPTS   = [ '--EmitLib',
+                    '--EmitObj',
                     '--EmitJNI' ]
 
 # When running onnx-mlir inside a docker container, the directory

--- a/include/onnx-mlir/Compiler/OMCompilerTypes.h
+++ b/include/onnx-mlir/Compiler/OMCompilerTypes.h
@@ -12,6 +12,7 @@ enum EmissionTargetType {
   EmitONNXIR,
   EmitMLIR,
   EmitLLVMIR,
+  EmitObj,
   EmitLib,
   EmitJNI,
 };

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -4,7 +4,7 @@
 
 //===-------------------------- CompilerUtils.cpp -------------------------===//
 //
-// Copyright 2019-2021 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -302,7 +302,7 @@ struct Command {
 void setTargetCPU(const std::string &cpu) { mcpu = cpu; }
 void setTargetTriple(const std::string &triple) { mtriple = triple; }
 
-void LoadMLIR(string inputFilename, mlir::MLIRContext &context,
+static void LoadMLIR(string inputFilename, mlir::MLIRContext &context,
     mlir::OwningModuleRef &module) {
   // Handle '.mlir' input to the ONNX-MLIR frontend.
   // The mlir format indicates that one or more of the supported
@@ -487,15 +487,19 @@ static void genJniJar(const mlir::OwningModuleRef &module,
       .exec();
 }
 
-std::string compileModuleToSharedLibrary(
+std::string compileModuleToObject(
     const mlir::OwningModuleRef &module, std::string outputBaseName) {
-
   string bitcodePath = outputBaseName + ".bc";
   genLLVMBitcode(module, bitcodePath, outputBaseName);
   llvm::FileRemover bitcodeRemover(
       bitcodePath, !keepFiles(KeepFilesOfType::Bitcode));
 
-  string modelObjPath = genModelObject(bitcodePath, outputBaseName);
+  return genModelObject(bitcodePath, outputBaseName);
+}
+
+std::string compileModuleToSharedLibrary(
+    const mlir::OwningModuleRef &module, std::string outputBaseName) {
+  string modelObjPath = compileModuleToObject(module, outputBaseName);
   llvm::FileRemover modelObjRemover(
       modelObjPath, !keepFiles(KeepFilesOfType::Object));
 
@@ -505,13 +509,7 @@ std::string compileModuleToSharedLibrary(
 
 void compileModuleToJniJar(
     const mlir::OwningModuleRef &module, std::string outputBaseName) {
-
-  string bitcodePath = outputBaseName + ".bc";
-  genLLVMBitcode(module, bitcodePath, outputBaseName);
-  llvm::FileRemover bitcodeRemover(
-      bitcodePath, !keepFiles(KeepFilesOfType::Bitcode));
-
-  string modelObjPath = genModelObject(bitcodePath, outputBaseName);
+  string modelObjPath = compileModuleToObject(module, outputBaseName);
   llvm::FileRemover modelObjRemover(
       modelObjPath, !keepFiles(KeepFilesOfType::Object));
 
@@ -641,9 +639,11 @@ void processInputFile(string inputFilename, mlir::MLIRContext &context,
   string extension = inputFilename.substr(inputFilename.find_last_of(".") + 1);
   bool inputIsONNX = (extension == "onnx");
   bool inputIsMLIR = (extension == "mlir");
-  if (inputIsONNX == inputIsMLIR) {
+
+  if (!inputIsONNX && !inputIsMLIR) {
     *errorMessage = "Invaid input file '" + inputFilename +
-                    "': Either ONNX model or MLIR file needs to be provided.";
+                    "': Either an ONNX model (.onnx), or an MLIR file (.mlir) "
+                    "needs to be provided.";
     return;
   }
 
@@ -654,9 +654,8 @@ void processInputFile(string inputFilename, mlir::MLIRContext &context,
     options.shapeInformation = shapeInformation;
     ImportFrontendModelFile(
         inputFilename, context, module, errorMessage, options);
-  } else {
+  } else if (inputIsMLIR)
     LoadMLIR(inputFilename, context, module);
-  }
 }
 
 void processInputArray(const void *onnxBuffer, int bufferSize,
@@ -668,7 +667,7 @@ void processInputArray(const void *onnxBuffer, int bufferSize,
   ImportFrontendModelArray(onnxBuffer, bufferSize, context, module, options);
 }
 
-InputIRLevelType determineInputIRLevel(mlir::OwningModuleRef &module) {
+static InputIRLevelType determineInputIRLevel(mlir::OwningModuleRef &module) {
   Operation *moduleOp = module->getOperation();
 
   // Collect dialect namespaces.
@@ -688,15 +687,14 @@ InputIRLevelType determineInputIRLevel(mlir::OwningModuleRef &module) {
   bool hasKrnlOps = llvm::any_of(dialectNamespace, [&](StringRef ns) {
     return (ns == KrnlOpsDialect::getDialectNamespace());
   });
-  if (hasKrnlOps) {
+  if (hasKrnlOps)
     return MLIRLevel;
-  }
 
   // Otherwise, set to the lowest level, LLVMLevel.
   return LLVMLevel;
 }
 
-void outputCode(
+static void outputCode(
     mlir::OwningModuleRef &module, string filename, string extension) {
   mlir::OpPrintingFlags flags;
   if (preserveLocations)
@@ -713,8 +711,9 @@ void outputCode(
   output->keep();
 }
 
-void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
-    mlir::MLIRContext &context, mlir::OwningModuleRef &module) {
+static void emitOutputFiles(string outputBaseName,
+    EmissionTargetType emissionTarget, mlir::MLIRContext &context,
+    mlir::OwningModuleRef &module) {
   // For EmitONNXIR and EmitMLIR the constant value are embedded in the code
   // thus making the code hard to read. These values can be elided by emitting
   // two versions of the same source code:
@@ -732,21 +731,30 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
   // outside the function code at the beginning of the file in which case the
   // elision of these constants is not strictly required. Elision is also not
   // necessary when emitting the .bc file.
-  if (emissionTarget == EmitLib) {
-    // Write LLVM bitcode to disk, compile & link.
-    string sharedLib = compileModuleToSharedLibrary(module, outputBaseName);
-    if (keepFiles(KeepFilesOfType::MLIR)) {
+  switch (emissionTarget) {
+  case EmitObj: {
+    string modelObjPath = compileModuleToObject(module, outputBaseName);
+    if (keepFiles(KeepFilesOfType::MLIR))
       outputCode(module, outputBaseName, ".llvm.mlir");
-    }
+
+    if (VerboseOutput)
+      printf("Object file %s.o has been compiled.\n", outputBaseName.c_str());
+  } break;
+  case EmitLib: {
+    string sharedLib = compileModuleToSharedLibrary(module, outputBaseName);
+    if (keepFiles(KeepFilesOfType::MLIR))
+      outputCode(module, outputBaseName, ".llvm.mlir");
     if (VerboseOutput)
       printf("Shared library %s has been compiled.\n", sharedLib.c_str());
-  } else if (emissionTarget == EmitJNI) {
+  } break;
+  case EmitJNI: {
     compileModuleToJniJar(module, outputBaseName);
     if (keepFiles(KeepFilesOfType::MLIR))
       outputCode(module, outputBaseName, ".llvm.mlir");
     if (VerboseOutput)
       printf("JNI archive %s.jar has been compiled.\n", outputBaseName.c_str());
-  } else {
+  } break;
+  default: {
     // Emit the version with all constants included.
     outputCode(module, outputBaseName, ".onnx.mlir");
     if (VerboseOutput)
@@ -775,10 +783,11 @@ void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
       }
     }
   }
-}
+  }
+} // end anonymous namespace
 
-/// Return the module datalayout string. The datalayout string is determined by
-/// creating a target machine using the target triple and target cpu.
+/// Return the module datalayout string. The datalayout string is determined
+/// by creating a target machine using the target triple and target cpu.
 static std::string getDataLayout(const Location &loc) {
   const std::string targetTriple =
       (mtriple != "") ? mtriple.getValue() : kDefaultTriple;
@@ -807,8 +816,8 @@ static std::string getDataLayout(const Location &loc) {
   return dataLayoutString;
 }
 
-void setupModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
-    std::string outputBaseName) {
+static void setupModule(mlir::OwningModuleRef &module,
+    mlir::MLIRContext &context, std::string outputBaseName) {
   // Initialize the targets support for all targets LLVM was configured for.
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
@@ -828,7 +837,7 @@ void setupModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
   }
 }
 
-void addPasses(mlir::OwningModuleRef &module, mlir::PassManager &pm,
+static void addPasses(mlir::OwningModuleRef &module, mlir::PassManager &pm,
     EmissionTargetType emissionTarget) {
   InputIRLevelType inputIRLevel = determineInputIRLevel(module);
 
@@ -846,9 +855,9 @@ void addPasses(mlir::OwningModuleRef &module, mlir::PassManager &pm,
     addKrnlToLLVMPasses(pm);
 }
 
-void emitOutput(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
-    std::string outputBaseName, mlir::PassManager &pm,
-    EmissionTargetType emissionTarget) {
+static void emitOutput(mlir::OwningModuleRef &module,
+    mlir::MLIRContext &context, std::string outputBaseName,
+    mlir::PassManager &pm, EmissionTargetType emissionTarget) {
   if (printIR) {
     mlir::OpPrintingFlags flags;
     if (preserveLocations)

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -4,7 +4,7 @@
 
 //===-------------------------- CompilerUtils.hpp -------------------------===//
 //
-// Copyright 2019-2021 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -37,47 +37,24 @@ extern llvm::cl::opt<std::string> instrumentONNXOps;
 void setTargetCPU(const std::string &cpu);
 void setTargetTriple(const std::string &triple);
 
-void LoadMLIR(std::string inputFilename, mlir::MLIRContext &context,
-    mlir::OwningModuleRef &module);
-
+std::string compileModuleToObject(
+    const mlir::OwningModuleRef &module, std::string outputBaseName);
 std::string compileModuleToSharedLibrary(
     const mlir::OwningModuleRef &module, std::string outputBaseName);
-
 void compileModuleToJniJar(
     const mlir::OwningModuleRef &module, std::string outputBaseName);
 
 void registerDialects(mlir::MLIRContext &context);
 
 void addONNXToMLIRPasses(mlir::PassManager &pm);
-
 void addONNXToKrnlPasses(mlir::PassManager &pm);
-
 void addKrnlToAffinePasses(mlir::PassManager &pm);
-
 void addKrnlToLLVMPasses(mlir::OpPassManager &pm);
 
 void processInputFile(std::string inputFilename, mlir::MLIRContext &context,
     mlir::OwningModuleRef &module, std::string *errorMessage);
-
 void processInputArray(const void *onnxBuffer, int bufferSize,
     mlir::MLIRContext &context, mlir::OwningModuleRef &module);
 
-onnx_mlir::InputIRLevelType determineInputIRLevel(
-    mlir::OwningModuleRef &module);
-
-void outputCode(
-    mlir::OwningModuleRef &module, std::string filename, std::string extension);
-
-void emitOutputFiles(std::string outputBaseName,
-    onnx_mlir::EmissionTargetType emissionTarget, mlir::MLIRContext &context,
-    mlir::OwningModuleRef &module);
-
 int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
     std::string outputBaseName, onnx_mlir::EmissionTargetType emissionTarget);
-
-void setupModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
-    std::string outputBaseName);
-
-void emitOutput(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
-    std::string outputBaseName, mlir::PassManager &pm,
-    onnx_mlir::EmissionTargetType emissionTarget);

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -7,12 +7,10 @@
 
 void setCompileContext(
     mlir::MLIRContext &context, const char *mcpu, const char *mtriple) {
-  if (mcpu) {
+  if (mcpu)
     setTargetCPU(std::string(mcpu));
-  }
-  if (mtriple) {
+  if (mtriple)
     setTargetTriple(std::string(mtriple));
-  }
 
   registerDialects(context);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 
 //===--------------------------- main.cpp ---------------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -36,17 +36,16 @@ int main(int argc, char *argv[]) {
               "inferred shapes."),
           clEnumVal(
               EmitONNXIR, "Ingest ONNX and emit corresponding ONNX dialect."),
+          clEnumVal(EmitMLIR,
+              "Lower the input to MLIR built-in transformation dialect."),
           clEnumVal(
-              EmitMLIR, "Lower input to MLIR built-in transformation dialect."),
-          clEnumVal(EmitLLVMIR, "Lower input to LLVM IR (LLVM MLIR dialect)."),
-          clEnumVal(EmitLib, "Lower input to LLVM IR, emit "
-                             "LLVM bitcode, compile and link it to a "
-                             "shared library (default)."),
-          clEnumVal(EmitJNI, "Lower input to LLVM IR -> LLVM bitcode "
-                             "-> JNI shared library -> jar")),
+              EmitLLVMIR, "Lower the input to LLVM IR (LLVM MLIR dialect)."),
+          clEnumVal(EmitObj, "Compile the input into a object file."),
+          clEnumVal(
+              EmitLib, "Compile the input into a shared library (default)."),
+          clEnumVal(EmitJNI, "Compile the input into a jar file.")),
       llvm::cl::init(EmitLib), llvm::cl::cat(OnnxMlirOptions));
 
-  // llvm::cl::HideUnrelatedOptions(OnnxMlirOptions);
   mlir::registerPassManagerCLOptions();
   llvm::cl::ParseCommandLineOptions(
       argc, argv, "ONNX-MLIR modular optimizer driver\n");

--- a/test/backend/common.py
+++ b/test/backend/common.py
@@ -2,7 +2,7 @@
 
 ##################### common.py ################################################
 #
-# Copyright 2021 The IBM Research Authors.
+# Copyright 2021-2022 The IBM Research Authors.
 #
 ################################################################################
 # commom function `compile_model` called by both
@@ -65,8 +65,8 @@ def execute_commands(cmds, dynamic_inputs_dims):
 
 
 def compile_model(model, emit):
-    suffix = {"lib": ".so", "jni": ".jar"}
-    target = {"lib": "--EmitLib", "jni": "--EmitJNI"}
+    suffix = {"lib": ".so", "obj" : ".o", "jni": ".jar"}
+    target = {"lib": "--EmitLib", "obj": "--EmitObj", "jni": "--EmitJNI"}
     name = model.graph.name
 
     # Each model will have its own model_dir. This is necessary for JNI tests


### PR DESCRIPTION
Add the `--emitObj` option to `onnx-mlir`. This option stops the compiler after an object is created (skips the link step).  