### PR TITLE
Reverse some static functions to make them sharable

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -308,7 +308,7 @@ void setTargetCPU(const std::string &cpu) { mcpu = cpu; }
 void setTargetArch(const std::string &arch) { march = arch; }
 void setTargetTriple(const std::string &triple) { mtriple = triple; }
 
-static void LoadMLIR(string inputFilename, mlir::MLIRContext &context,
+void LoadMLIR(string inputFilename, mlir::MLIRContext &context,
     mlir::OwningModuleRef &module) {
   // Handle '.mlir' input to the ONNX-MLIR frontend.
   // The mlir format indicates that one or more of the supported
@@ -684,7 +684,7 @@ void processInputArray(const void *onnxBuffer, int bufferSize,
   ImportFrontendModelArray(onnxBuffer, bufferSize, context, module, options);
 }
 
-static InputIRLevelType determineInputIRLevel(mlir::OwningModuleRef &module) {
+InputIRLevelType determineInputIRLevel(mlir::OwningModuleRef &module) {
   Operation *moduleOp = module->getOperation();
 
   // Collect dialect namespaces.
@@ -711,7 +711,7 @@ static InputIRLevelType determineInputIRLevel(mlir::OwningModuleRef &module) {
   return LLVMLevel;
 }
 
-static void outputCode(
+void outputCode(
     mlir::OwningModuleRef &module, string filename, string extension) {
   mlir::OpPrintingFlags flags;
   if (preserveLocations)
@@ -728,9 +728,8 @@ static void outputCode(
   output->keep();
 }
 
-static void emitOutputFiles(string outputBaseName,
-    EmissionTargetType emissionTarget, mlir::MLIRContext &context,
-    mlir::OwningModuleRef &module) {
+void emitOutputFiles(string outputBaseName, EmissionTargetType emissionTarget,
+    mlir::MLIRContext &context, mlir::OwningModuleRef &module) {
   // For EmitONNXIR and EmitMLIR the constant value are embedded in the code
   // thus making the code hard to read. These values can be elided by emitting
   // two versions of the same source code:
@@ -833,8 +832,8 @@ static std::string getDataLayout(const Location &loc) {
   return dataLayoutString;
 }
 
-static void setupModule(mlir::OwningModuleRef &module,
-    mlir::MLIRContext &context, std::string outputBaseName) {
+void setupModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
+    std::string outputBaseName) {
   // Initialize the targets support for all targets LLVM was configured for.
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
@@ -872,9 +871,9 @@ static void addPasses(mlir::OwningModuleRef &module, mlir::PassManager &pm,
     addKrnlToLLVMPasses(pm);
 }
 
-static void emitOutput(mlir::OwningModuleRef &module,
-    mlir::MLIRContext &context, std::string outputBaseName,
-    mlir::PassManager &pm, EmissionTargetType emissionTarget) {
+void emitOutput(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
+    std::string outputBaseName, mlir::PassManager &pm,
+    EmissionTargetType emissionTarget) {
   if (printIR) {
     mlir::OpPrintingFlags flags;
     if (preserveLocations)

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -34,9 +34,14 @@
 extern llvm::cl::OptionCategory OnnxMlirOptions;
 extern llvm::cl::opt<std::string> instrumentONNXOps;
 
+// The following functions are useful for drivers building upon onnx-mlir.
+
 void setTargetCPU(const std::string &cpu);
 void setTargetArch(const std::string &arch);
 void setTargetTriple(const std::string &triple);
+
+void LoadMLIR(std::string inputFilename, mlir::MLIRContext &context,
+    mlir::OwningModuleRef &module);
 
 std::string compileModuleToObject(
     const mlir::OwningModuleRef &module, std::string outputBaseName);
@@ -56,6 +61,19 @@ void processInputFile(std::string inputFilename, mlir::MLIRContext &context,
     mlir::OwningModuleRef &module, std::string *errorMessage);
 void processInputArray(const void *onnxBuffer, int bufferSize,
     mlir::MLIRContext &context, mlir::OwningModuleRef &module);
+onnx_mlir::InputIRLevelType determineInputIRLevel(
+    mlir::OwningModuleRef &module);
 
+void outputCode(
+    mlir::OwningModuleRef &module, std::string filename, std::string extension);
+void emitOutputFiles(std::string outputBaseName,
+    onnx_mlir::EmissionTargetType emissionTarget, mlir::MLIRContext &context,
+    mlir::OwningModuleRef &module);
+void emitOutput(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
+    std::string outputBaseName, mlir::PassManager &pm,
+    onnx_mlir::EmissionTargetType emissionTarget);
+
+void setupModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
+    std::string outputBaseName);
 int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
     std::string outputBaseName, onnx_mlir::EmissionTargetType emissionTarget);


### PR DESCRIPTION
Some functions to be shared among drivers based on onnx-mlir was made static by this PR  https://github.com/onnx/onnx-mlir/pull/1104.
This patch reverses them back so that other drivers can call them.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>