### PR TITLE
Remove Usage of Deprecated FunctionPass

### DIFF
--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -1525,7 +1525,7 @@ void ConvertKrnlToAffinePass::runOnOperation() {
   patterns.insert<KrnlCopyFromBufferLowering>(&getContext());
   patterns.insert<KrnlMemsetLowering>(&getContext());
 
-  // runOrecording the <loop, unroll factor> pairs associated with
+  // Create list for recording the <loop, unroll factor> pairs associated with
   // this function.
   UnrollAndJamList *currUnrollAndJamList = new UnrollAndJamList();
   Operation *currFuncOp = funcOp.getOperation();

--- a/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlToAffine.cpp
@@ -432,13 +432,13 @@ void lowerGetInductionVariableValueOp(KrnlGetInductionVariableValueOp &getIVOp,
 /// At this stage the dialect will contain standard operations as well like
 /// add and multiply, this pass will leave these operations intact.
 struct ConvertKrnlToAffinePass
-    : public PassWrapper<ConvertKrnlToAffinePass, FunctionPass> {
+    : public PassWrapper<ConvertKrnlToAffinePass, OperationPass<FuncOp>> {
 
   StringRef getArgument() const override { return "convert-krnl-to-affine"; }
 
   StringRef getDescription() const override { return "Lower Krnl dialect."; }
 
-  void runOnFunction() final;
+  void runOnOperation() final;
 };
 
 LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
@@ -1443,9 +1443,15 @@ void markLoopBodyAsMovable(
   }
 }
 
-void ConvertKrnlToAffinePass::runOnFunction() {
+void ConvertKrnlToAffinePass::runOnOperation() {
   OpBuilder builder(&getContext());
-  FuncOp funcOp = getFunction();
+  FuncOp funcOp = getOperation();
+
+  // external function: nothing to do
+  if (funcOp.body().empty()) {
+    return;
+  }
+
   // Move invariant instructions outside of the loops as many as possible. This
   // helps make loops perfectly nested, which facilitates transformations.
   funcOp.walk([&](KrnlIterateOp loopOp) {
@@ -1519,7 +1525,7 @@ void ConvertKrnlToAffinePass::runOnFunction() {
   patterns.insert<KrnlCopyFromBufferLowering>(&getContext());
   patterns.insert<KrnlMemsetLowering>(&getContext());
 
-  // Create list for recording the <loop, unroll factor> pairs associated with
+  // runOrecording the <loop, unroll factor> pairs associated with
   // this function.
   UnrollAndJamList *currUnrollAndJamList = new UnrollAndJamList();
   Operation *currFuncOp = funcOp.getOperation();
@@ -1530,7 +1536,7 @@ void ConvertKrnlToAffinePass::runOnFunction() {
 
   DenseSet<Operation *> unconverted;
   if (failed(applyPartialConversion(
-          getFunction(), target, std::move(patterns), &unconverted))) {
+          getOperation(), target, std::move(patterns), &unconverted))) {
     {
       const std::lock_guard<std::mutex> lock(unrollAndJamMutex);
       unrollAndJamMap.erase(currFuncOp);

--- a/src/Transform/BundleMemoryPools.cpp
+++ b/src/Transform/BundleMemoryPools.cpp
@@ -506,7 +506,7 @@ public:
  */
 
 class KrnlBundleMemoryPoolsPass
-    : public PassWrapper<KrnlBundleMemoryPoolsPass, FunctionPass> {
+    : public PassWrapper<KrnlBundleMemoryPoolsPass, OperationPass<FuncOp>> {
 
   BlockToMemPool blockToStaticPool;
   BlockToMemPool blockToDynamicPool;
@@ -518,8 +518,8 @@ public:
     return "Bundle memory pools of internal MemRefs into a single memory pool.";
   }
 
-  void runOnFunction() override {
-    auto function = getFunction();
+  void runOnOperation() override {
+    auto function = getOperation();
 
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());

--- a/src/Transform/DisconnectKrnlDimFromAlloc.cpp
+++ b/src/Transform/DisconnectKrnlDimFromAlloc.cpp
@@ -129,7 +129,7 @@ public:
  *  Function pass that disconnects krnl.dim emission from its MemRef alloc.
  */
 class DisconnectKrnlDimFromAllocPass
-    : public PassWrapper<DisconnectKrnlDimFromAllocPass, FunctionPass> {
+    : public PassWrapper<DisconnectKrnlDimFromAllocPass, OperationPass<FuncOp>> {
 public:
   StringRef getArgument() const override { return "lower-krnl-shape-to-std"; }
 
@@ -137,8 +137,8 @@ public:
     return "Lowers krnl shape-related operations.";
   }
 
-  void runOnFunction() override {
-    auto function = getFunction();
+  void runOnOperation() override {
+    auto function = getOperation();
 
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());

--- a/src/Transform/DisconnectKrnlDimFromAlloc.cpp
+++ b/src/Transform/DisconnectKrnlDimFromAlloc.cpp
@@ -129,7 +129,8 @@ public:
  *  Function pass that disconnects krnl.dim emission from its MemRef alloc.
  */
 class DisconnectKrnlDimFromAllocPass
-    : public PassWrapper<DisconnectKrnlDimFromAllocPass, OperationPass<FuncOp>> {
+    : public PassWrapper<DisconnectKrnlDimFromAllocPass,
+          OperationPass<FuncOp>> {
 public:
   StringRef getArgument() const override { return "lower-krnl-shape-to-std"; }
 

--- a/src/Transform/ElideKrnlGlobalConstants.cpp
+++ b/src/Transform/ElideKrnlGlobalConstants.cpp
@@ -80,7 +80,7 @@ namespace {
  *  Function pass that performs constant value elision of Krnl globals.
  */
 class ElideConstGlobalValuePass
-    : public PassWrapper<ElideConstGlobalValuePass, FunctionPass> {
+    : public PassWrapper<ElideConstGlobalValuePass, OperationPass<FuncOp>> {
 public:
   StringRef getArgument() const override { return "elide-krnl-constants"; }
 
@@ -88,8 +88,8 @@ public:
     return "Elide the constant values of the Global Krnl operations.";
   }
 
-  void runOnFunction() override {
-    auto function = getFunction();
+  void runOnOperation() override {
+    auto function = getOperation();
 
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());

--- a/src/Transform/EnableMemoryPool.cpp
+++ b/src/Transform/EnableMemoryPool.cpp
@@ -185,7 +185,7 @@ public:
  *  Function pass that enables memory pooling for MemRefs.
  */
 class KrnlEnableMemoryPoolPass
-    : public PassWrapper<KrnlEnableMemoryPoolPass, FunctionPass> {
+    : public PassWrapper<KrnlEnableMemoryPoolPass, OperationPass<FuncOp>> {
 public:
   StringRef getArgument() const override { return "enable-memory-pool"; }
 
@@ -193,8 +193,8 @@ public:
     return "Enable a memory pool for allocating internal MemRefs.";
   }
 
-  void runOnFunction() override {
-    auto function = getFunction();
+  void runOnOperation() override {
+    auto function = getOperation();
 
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());

--- a/src/Transform/LowerKrnlShape.cpp
+++ b/src/Transform/LowerKrnlShape.cpp
@@ -78,7 +78,7 @@ public:
  *  Function pass that emits the shape of a MemRef.
  */
 class LowerKrnlShapePass
-    : public PassWrapper<LowerKrnlShapePass, FunctionPass> {
+    : public PassWrapper<LowerKrnlShapePass, OperationPass<FuncOp>> {
 public:
   StringRef getArgument() const override { return "lower-krnl-shape"; }
 
@@ -86,8 +86,8 @@ public:
     return "Lower krnl.shape operation to use Shape dialect operations.";
   }
 
-  void runOnFunction() override {
-    auto function = getFunction();
+  void runOnOperation() override {
+    auto function = getOperation();
 
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -745,7 +745,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 struct ConstPropONNXToONNXPass
-    : public PassWrapper<ConstPropONNXToONNXPass, FunctionPass> {
+    : public PassWrapper<ConstPropONNXToONNXPass, OperationPass<FuncOp>> {
 
   StringRef getArgument() const override { return "constprop-onnx"; }
 
@@ -754,12 +754,12 @@ struct ConstPropONNXToONNXPass
            "other ONNX operations.";
   }
 
-  void runOnFunction() final;
+  void runOnOperation() final;
 };
 } // end anonymous namespace.
 
-void ConstPropONNXToONNXPass::runOnFunction() {
-  auto function = getFunction();
+void ConstPropONNXToONNXPass::runOnOperation() {
+  auto function = getOperation();
   MLIRContext *context = &getContext();
 
   ConversionTarget target(getContext());

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -123,7 +123,7 @@ Value createSequenceConstructOp(
 namespace {
 
 struct DecomposeONNXToONNXPass
-    : public PassWrapper<DecomposeONNXToONNXPass, FunctionPass> {
+    : public PassWrapper<DecomposeONNXToONNXPass, OperationPass<FuncOp>> {
 
   StringRef getArgument() const override { return "decompose-onnx"; }
 
@@ -132,12 +132,12 @@ struct DecomposeONNXToONNXPass
            "operations.";
   }
 
-  void runOnFunction() final;
+  void runOnOperation() final;
 };
 } // end anonymous namespace.
 
-void DecomposeONNXToONNXPass::runOnFunction() {
-  auto function = getFunction();
+void DecomposeONNXToONNXPass::runOnOperation() {
+  auto function = getOperation();
   MLIRContext *context = &getContext();
 
   ConversionTarget target(getContext());

--- a/src/Transform/ONNX/ElideConstants.cpp
+++ b/src/Transform/ONNX/ElideConstants.cpp
@@ -64,7 +64,7 @@ public:
  *  Function pass that performs constant value elision.
  */
 class ElideConstantValuePass
-    : public PassWrapper<ElideConstantValuePass, FunctionPass> {
+    : public PassWrapper<ElideConstantValuePass, OperationPass<FuncOp>> {
 public:
   StringRef getArgument() const override { return "elide-constants"; }
 
@@ -72,8 +72,8 @@ public:
     return "Elide values of constant operations.";
   }
 
-  void runOnFunction() override {
-    auto function = getFunction();
+  void runOnOperation() override {
+    auto function = getOperation();
 
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());

--- a/src/Transform/ONNX/InstrumentONNXPass.cpp
+++ b/src/Transform/ONNX/InstrumentONNXPass.cpp
@@ -57,7 +57,7 @@ llvm::cl::bits<InstrumentActions> InstrumentControlBits(
     llvm::cl::cat(OMPassOptions));
 
 class InstrumentONNXPass
-    : public mlir::PassWrapper<InstrumentONNXPass, FunctionPass> {
+    : public mlir::PassWrapper<InstrumentONNXPass, OperationPass<FuncOp>> {
 
 private:
   bool allOpsAllowed;
@@ -84,13 +84,13 @@ public:
     runtimeActions = InstrumentControlBits.getBits();
   };
 
-  void runOnFunction() override {
+  void runOnOperation() override {
     if (instrumentONNXOps == "" || instrumentONNXOps == "NONE")
       return;
     init(instrumentONNXOps);
 
     // Iterate on the operations nested in this function
-    getFunction().walk([&](mlir::Operation *op) {
+    getOperation().walk([&](mlir::Operation *op) {
       if (isa<mlir::ONNXOpsDialect>(op->getDialect())) {
         // Skip the prefix "onnx." of onnx op name
         const char *opName = op->getName().getStringRef().data() + 5;

--- a/src/Transform/ONNX/ONNXPreKrnlVerifyPass.cpp
+++ b/src/Transform/ONNX/ONNXPreKrnlVerifyPass.cpp
@@ -38,15 +38,15 @@ namespace {
  */
 
 class ONNXPreKrnlVerifyPass
-    : public mlir::PassWrapper<ONNXPreKrnlVerifyPass, FunctionPass> {
+    : public mlir::PassWrapper<ONNXPreKrnlVerifyPass, OperationPass<FuncOp>> {
 
 public:
   StringRef getArgument() const override { return "onnx-pre-krnl-verify"; }
 
   StringRef getDescription() const override { return "Verify onnx ops."; }
 
-  void runOnFunction() override {
-    auto function = getFunction();
+  void runOnOperation() override {
+    auto function = getOperation();
     auto &funcBody = function.getBody();
 
     // Iterate on the operations

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -41,7 +41,7 @@ static SmallVector<mlir::FuncOp, 4> lookUpFuncsMatching(
 }
 
 /*!
- *  OperationPass<FuncOp> that performs shape inference by iterating over a list of
+ *  Function pass that performs shape inference by iterating over a list of
  *  candidate operations and propagating the shape information until the list
  *  of operations is empty [credit MLIR authors].
  *

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -41,7 +41,7 @@ static SmallVector<mlir::FuncOp, 4> lookUpFuncsMatching(
 }
 
 /*!
- *  FunctionPass that performs shape inference by iterating over a list of
+ *  OperationPass<FuncOp> that performs shape inference by iterating over a list of
  *  candidate operations and propagating the shape information until the list
  *  of operations is empty [credit MLIR authors].
  *

--- a/src/Transform/OptimizeMemoryPools.cpp
+++ b/src/Transform/OptimizeMemoryPools.cpp
@@ -868,7 +868,7 @@ public:
  *  Function pass that optimizes memory pools.
  */
 class KrnlOptimizeMemoryPoolsPass
-    : public PassWrapper<KrnlOptimizeMemoryPoolsPass, FunctionPass> {
+    : public PassWrapper<KrnlOptimizeMemoryPoolsPass, OperationPass<FuncOp>> {
   BlockToCompactedAlignments blockToStaticPoolAlignments;
   BlockToDiscardedGetRefs blockToDiscardedGetRefs;
 
@@ -879,8 +879,8 @@ public:
     return "Optimize the static and dynamic memory pools.";
   }
 
-  void runOnFunction() override {
-    auto function = getFunction();
+  void runOnOperation() override {
+    auto function = getOperation();
 
     ConversionTarget target(getContext());
     RewritePatternSet patterns(&getContext());


### PR DESCRIPTION
Replace usage of FunctionPass with OperationPass<FuncOp> within ONNX-MLIR.

This change is motivated by the deprecation of FunctionPass as described here: https://llvm.discourse.group/t/functionpass-deprecated-in-favor-of-operationpass-funcop/5808