### PR TITLE
Make OptLevel option sharable

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -307,6 +307,7 @@ void setTargetCPU(const std::string &cpu) { mcpu = cpu; }
 void setTargetArch(const std::string &arch) { march = arch; }
 void setTargetTriple(const std::string &triple) { mtriple = triple; }
 void setOptLevel(const OptLevel level) { OptimizationLevel = level; }
+OptLevel getOptLevel() { return OptimizationLevel; }
 
 static void setCompilerKeyValue(const OptionKind key, const string val) {
   switch (key) {

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -396,7 +396,7 @@ static std::string getTargetTripleOption() {
 }
 
 static std::string getOptimizationLevelOption() {
-  switch (OptimizationLevel) {
+  switch (getOptLevel()) {
   case OptLevel::O0:
     return "-O0";
   case OptLevel::O1:
@@ -917,7 +917,7 @@ static void addPasses(mlir::OwningModuleRef &module, mlir::PassManager &pm,
 
   if (emissionTarget >= EmitMLIR) {
     if (inputIRLevel <= ONNXLevel)
-      addONNXToKrnlPasses(pm, OptimizationLevel);
+      addONNXToKrnlPasses(pm, getOptLevel());
     if (inputIRLevel <= MLIRLevel)
       addKrnlToAffinePasses(pm);
   }

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -39,10 +39,14 @@ extern llvm::cl::opt<std::string> instrumentONNXOps;
 using CompilerOptionList =
     llvm::SmallVector<std::pair<onnx_mlir::OptionKind, std::string>, 4>;
 
+// Setters for command-line options.
 void setTargetCPU(const std::string &cpu);
 void setTargetArch(const std::string &arch);
 void setTargetTriple(const std::string &triple);
 void setOptLevel(const onnx_mlir::OptLevel level);
+// Getters for command-line options.
+onnx_mlir::OptLevel getOptLevel();
+
 // Set compile context according to the (key, value) fields passed.
 void setCompileContext(
     mlir::MLIRContext &context, const CompilerOptionList &options);


### PR DESCRIPTION
This patch allows other drivers to use the OptLevel option.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>