### PR TITLE
Small dependency optimization for ModelLib

### DIFF
--- a/test/modellib/CMakeLists.txt
+++ b/test/modellib/CMakeLists.txt
@@ -11,7 +11,7 @@ add_onnx_mlir_library(ModelLib
 
   EXCLUDE_FROM_OM_LIBS
 
-  LINK_LIBS PRIVATE
+  LINK_LIBS PUBLIC
   CompilerUtils
   ExecutionSession
   )

--- a/test/numerical/CMakeLists.txt
+++ b/test/numerical/CMakeLists.txt
@@ -55,7 +55,7 @@ llvm_update_compile_flags(rapidcheck)
 
 # The CompilerUtils ExecutionSession are also included in ModelLib,
 # but it did not compile when I removed these two. TODO, figure out why.
-set(TEST_LINK_LIBS rapidcheck CompilerUtils ExecutionSession ModelLib)
+set(TEST_LINK_LIBS rapidcheck ModelLib)
 
 add_numerical_unittest(TestConv
   TestConv.cpp


### PR DESCRIPTION
`ModelLib` already has a dependency on `ExecutionSession` and `CompilerUtils`. By making the dependency public, it can propagate to other targets simplifying the dependency chain.