### PR TITLE
Allow onnx-mlir, onnx-mlir-opt to use MLIR's timing infrastructure.

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -940,9 +940,12 @@ void emitOutput(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
 int compileModule(mlir::OwningModuleRef &module, mlir::MLIRContext &context,
     std::string outputBaseName, EmissionTargetType emissionTarget) {
   setupModule(module, context, outputBaseName);
+
   mlir::PassManager pm(&context, mlir::OpPassManager::Nesting::Implicit);
   addPasses(module, pm, emissionTarget);
   mlir::applyPassManagerCLOptions(pm);
+  mlir::applyDefaultTimingPassManagerCLOptions(pm);
+
   if (mlir::failed(pm.run(*module)))
     return 4;
   emitOutput(module, context, outputBaseName, pm, emissionTarget);

--- a/src/Tool/ONNXMLIROpt/ONNXMLIROpt.cpp
+++ b/src/Tool/ONNXMLIROpt/ONNXMLIROpt.cpp
@@ -116,10 +116,11 @@ int main(int argc, char **argv) {
   initOMPasses(OptimizationLevel);
   initMLIRPasses();
 
+  // Register any command line options.
   mlir::registerAsmPrinterCLOptions();
   mlir::registerMLIRContextCLOptions();
-  // Register any pass manager command line options.
   mlir::registerPassManagerCLOptions();
+  mlir::registerDefaultTimingManagerCLOptions();
 
   mlir::PassPipelineCLParser passPipeline("", "Compiler passes to run");
   llvm::cl::ParseCommandLineOptions(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,10 @@ int main(int argc, char *argv[]) {
           clEnumVal(EmitJNI, "Compile the input into a jar file.")),
       llvm::cl::init(EmitLib), llvm::cl::cat(OnnxMlirOptions));
 
+  // Register MLIR command line options.
   mlir::registerPassManagerCLOptions();
+  mlir::registerDefaultTimingManagerCLOptions();
+
   llvm::cl::ParseCommandLineOptions(
       argc, argv, "ONNX-MLIR modular optimizer driver\n");
 


### PR DESCRIPTION
MLIR has an infrastructure that is useful to time compiler passes (see section `Pass Timing` in https://mlir.llvm.org/docs/PassManagement). This PR allows `onnx-mlir` and `onnx-mlir-opt` to report timing information by leveraging the MLIR pass timing infrastructure. Here is an example:

```
% onnx-mlir ~/Downloads/gpt2-lm-head-10/GPT-2-LM-HEAD/model.onnx -mlir-timing  -mlir-timing-display=list
===-------------------------------------------------------------------------===
                         ... Execution time report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 125.6608 seconds

  ----Wall Time----  ----Name----
  125.6608 (100.0%)  root
   57.6053 ( 45.8%)  (anonymous namespace)::ONNXOpTransformPass
    0.9355 (  0.7%)  (anonymous namespace)::ConvertKrnlToLLVMPass
    0.8031 (  0.6%)  Pipeline Collection : ['builtin.func']
    0.8028 (  0.6%)  'builtin.func' Pipeline
    0.7585 (  0.6%)  Canonicalizer
    0.5811 (  0.5%)  (anonymous namespace)::FrontendToKrnlLoweringPass
    0.2758 (  0.2%)  (anonymous namespace)::ConvertKrnlToAffinePass
    0.2516 (  0.2%)  SCFToStandard
    0.2444 (  0.2%)  ReconcileUnrealizedCasts
    0.2097 (  0.2%)  'builtin.module' Pipeline
    0.1481 (  0.1%)  (anonymous namespace)::ShapeInferencePass
    0.1343 (  0.1%)  BufferDeallocation
    0.1183 (  0.1%)  ConvertVectorToSCF
    0.1025 (  0.1%)  (anonymous namespace)::DisconnectKrnlDimFromAllocPass
    0.0811 (  0.1%)  ConvertAffineToStandard
    0.0690 (  0.1%)  (anonymous namespace)::ConstPropONNXToONNXPass
    0.0535 (  0.0%)  (anonymous namespace)::DecomposeONNXToONNXPass
    0.0252 (  0.0%)  (anonymous namespace)::ONNXPreKrnlVerifyPass
    0.0240 (  0.0%)  (anonymous namespace)::InstrumentONNXPass
    0.0237 (  0.0%)  SymbolDCE
    0.0040 (  0.0%)  (A) DataLayoutAnalysis
   64.4381 ( 51.3%)  Rest
  125.6608 (100.0%)  Total
```
Signed-off-by: Ettore Tiotto <etiotto@ca.ibm.com>