### PR TITLE
Introduce onn-mlir options -Xopt, -Xllc, and -mllvm

### DIFF
--- a/include/onnx-mlir/Compiler/OMCompilerTypes.h
+++ b/include/onnx-mlir/Compiler/OMCompilerTypes.h
@@ -5,10 +5,12 @@
 #ifndef ONNX_MLIR_OMCOMPILERTYPES_H
 #define ONNX_MLIR_OMCOMPILERTYPES_H
 
+#ifdef __cplusplus
 namespace onnx_mlir {
+#endif
 
 /* Type of compiler emission targets */
-enum EmissionTargetType {
+typedef enum {
   EmitONNXBasic,
   EmitONNXIR,
   EmitMLIR,
@@ -16,31 +18,31 @@ enum EmissionTargetType {
   EmitObj,
   EmitLib,
   EmitJNI,
-};
+} EmissionTargetType;
 
 /* Input IR can be at one of these levels */
-enum InputIRLevelType {
+typedef enum {
   ONNXLevel,
   MLIRLevel,
   LLVMLevel,
-};
+} InputIRLevelType;
 
 /* Compiler optimization level (traditional -O0 ... -O3 flags) */
-enum OptLevel {
-  O0 = 0,
-  O1,
-  O2,
-  O3
-};
+typedef enum { O0 = 0, O1, O2, O3 } OptLevel;
 
 /* Compiler options to describe the architecture, optimization level,... */
-enum OptionKind {
+typedef enum {
   TargetTriple,     /* Kind for mtriple string. */
   TargetArch,       /* Kind for march string. */
   TargetCPU,        /* Kind for mcpu string. */
   CompilerOptLevel, /* Kind for '0'...'3' string describing OptLevel. */
-};
+  OPTFlag,          /* Kind for -Xopt string. */
+  LLCFlag,          /* Kind for -Xllc string. */
+  LLVMFlag          /* Kind for -mllvm string. */
+} OptionKind;
 
+#ifdef __cplusplus
 } // namespace onnx_mlir
-
 #endif
+
+#endif /* ONNX_MLIR_OMCOMPILERTYPES_H */

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -121,6 +121,22 @@ static llvm::cl::opt<bool> VerboseOutput("v",
     llvm::cl::desc("Use verbose output"), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
+static llvm::cl::opt<std::string> Xopt("Xopt",
+    llvm::cl::desc("Arguments to forward to LLVM's 'opt' option processing"),
+    llvm::cl::value_desc("A valid LLVM's 'opt' option"),
+    llvm::cl::cat(OnnxMlirOptions), llvm::cl::Hidden, llvm::cl::ValueRequired);
+
+static llvm::cl::opt<std::string> Xllc("Xllc",
+    llvm::cl::desc("Arguments to forward to LLVM's 'llc' option processing"),
+    llvm::cl::value_desc("A valid LLVM's 'llc' option"),
+    llvm::cl::cat(OnnxMlirOptions), llvm::cl::Hidden, llvm::cl::ValueRequired);
+
+static llvm::cl::opt<std::string> mllvm("mllvm",
+    llvm::cl::desc(
+        "Arguments to forward to LLVM's 'opt' and 'llc' option processing"),
+    llvm::cl::value_desc("A valid LLVM's 'opt' and 'llc' option"),
+    llvm::cl::cat(OnnxMlirOptions), llvm::cl::Hidden, llvm::cl::ValueRequired);
+
 // Make a function that forces preserving all files using the runtime arguments
 // and/or the overridePreserveFiles enum.
 enum class KeepFilesOfType { All, MLIR, Bitcode, Object, None };
@@ -309,26 +325,37 @@ void setTargetArch(const std::string &arch) { march = arch; }
 void setTargetTriple(const std::string &triple) { mtriple = triple; }
 void setOptLevel(const OptLevel level) { OptimizationLevel = level; }
 OptLevel getOptLevel() { return OptimizationLevel; }
+void setXoptOption(const std::string &flag) { Xopt = flag; }
+void setXllcOption(const std::string &flag) { Xllc = flag; }
+void setLLVMOption(const std::string &flag) { mllvm = flag; }
 
 static void setCompilerKeyValue(const OptionKind key, const string val) {
   switch (key) {
   case OptionKind::TargetTriple:
     setTargetTriple(val);
-    return;
+    break;
   case OptionKind::TargetArch:
     setTargetArch(val);
-    return;
-  case OptionKind::TargetCPU:
+    break;
+  case TargetCPU:
     setTargetCPU(val);
-    return;
-  case OptionKind::CompilerOptLevel:
+    break;
+  case OptionKind::CompilerOptLevel: {
     int level = atoi(val.c_str());
     assert(level >= 0 && level <= 3 && "expected an OptLevel in [0..3] range");
     setOptLevel((OptLevel)level);
-    return;
+  } break;
+  case OptionKind::OPTFlag:
+    setXoptOption(val);
+    break;
+  case OptionKind::LLCFlag:
+    setXllcOption(val);
+    break;
+  case OptionKind::LLVMFlag:
+    setLLVMOption(val);
+    break;
+    // Ignore options that were added but are unknown.
   }
-  // In case there are options that were added but are unknown here, just ignore
-  // them.
 }
 
 // Set compiler context using a list of key/value pairs.
@@ -373,17 +400,11 @@ void loadMLIR(string inputFilename, mlir::MLIRContext &context,
 }
 
 static std::string getTargetCpuOption() {
-  string targetOptions = "";
-  if (mcpu != "")
-    targetOptions += "--mcpu=" + mcpu;
-  return targetOptions;
+  return (mcpu != "") ? "--mcpu=" + mcpu : "";
 }
 
 static std::string getTargetArchOption() {
-  string targetOptions = "";
-  if (march != "")
-    targetOptions += "--march=" + march;
-  return targetOptions;
+  return (march != "") ? "--march=" + march : "";
 }
 
 static std::string getTargetTripleOption() {
@@ -409,6 +430,18 @@ static std::string getOptimizationLevelOption() {
   }
   llvm_unreachable("Unexpected optimization level");
   return "";
+}
+
+static std::string getXoptOption() {
+  return (Xopt != "") ? Xopt : std::string();
+}
+
+static std::string getXllcOption() {
+  return (Xllc != "") ? Xllc : std::string();
+}
+
+static std::string getLLVMOption() {
+  return (mllvm != "") ? mllvm : std::string();
 }
 
 // Write LLVM optimized bitcode.
@@ -447,6 +480,8 @@ static void genLLVMBitcode(const mlir::OwningModuleRef &module,
       .appendStr(getTargetTripleOption())
       .appendStr(getTargetArchOption())
       .appendStr(getTargetCpuOption())
+      .appendStr(getXoptOption())
+      .appendStr(getLLVMOption())
       .appendList({"-o", optimizedBitcodePath})
       .appendStr(unoptimizedBitcodePath)
       .exec();
@@ -467,6 +502,8 @@ static std::string genModelObject(string bitcodePath, string outputBaseName) {
       .appendStr(getTargetTripleOption())
       .appendStr(getTargetArchOption())
       .appendStr(getTargetCpuOption())
+      .appendStr(getXllcOption())
+      .appendStr(getLLVMOption())
       .appendStr("-filetype=obj")
       .appendStr("-relocation-model=pic")
       .appendList({"-o", modelObjPath})

--- a/test/mlir/driver/check_passthrough_options.mlir
+++ b/test/mlir/driver/check_passthrough_options.mlir
@@ -1,0 +1,18 @@
+// RUN: onnx-mlir -Xopt --data-sections -v %s 2>&1 | FileCheck --check-prefix=OPT %s
+// RUN: onnx-mlir -Xllc --data-sections -v %s 2>&1 | FileCheck --check-prefix=LLC %s
+// RUN: onnx-mlir -mllvm --data-sections -v %s 2>&1 | FileCheck --check-prefix=LLVM %s
+
+// REQUIRES: system-linux || system-darwin
+// OPT:       opt{{.*}} --data-sections -o {{.*}}check_passthrough_options.bc
+// OPT-NOT:   llc{{.*}} --data-sections {{.*}} 
+// LLC-NOT:   opt{{.*}} --data-sections -o {{.*}}check_passthrough_options.bc
+// LLC:       llc{{.*}} --data-sections {{.*}} 
+// LLVM:      opt{{.*}} --data-sections -o {{.*}}check_passthrough_options.bc
+// LLVM-NEXT: llc{{.*}} --data-sections {{.*}} 
+module {
+  func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
+    %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+    return %0 : tensor<1x1xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 1 : i32, signature = ""} : () -> ()
+}


### PR DESCRIPTION
There are scenarios where a user of `onnx-mlir` might need to tune the behaviour of the LLVM `opt` and/or `llc` components.  This PR introduces three new options:
- -Xopt <valid opt's flag> -- the flag will be passed to `opt`
- -Xllc <valid llc's flag> -- the flag will be passed to `llc`
- -mllvm <valid opt and llc flag> -- the flag will be passed to both `opt` and `llc`
