### PR TITLE
Add Missing Dependency to ONNX-MLIR Builds

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -31,6 +31,7 @@ add_onnx_mlir_library(CompilerUtils
 
   DEPENDS
   ExternalUtil
+  MLIRIR
 
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}

--- a/src/Interface/CMakeLists.txt
+++ b/src/Interface/CMakeLists.txt
@@ -9,6 +9,7 @@ add_onnx_mlir_library(OMShapeInferenceOpInterface
   ShapeInferenceOpInterface.cpp
 
   DEPENDS
+  MLIRIR
   OMShapeInferenceOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
@@ -19,6 +20,7 @@ add_onnx_mlir_library(OMResultTypeInferenceOpInterface
   ResultTypeInferenceOpInterface.cpp
 
   DEPENDS
+  MLIRIR
   OMResultTypeInferenceOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
@@ -29,6 +31,7 @@ add_onnx_mlir_library(OMHasOnnxSubgraphOpInterface
   HasOnnxSubgraphOpInterface.cpp
 
   DEPENDS
+  MLIRIR
   OMHasOnnxSubgraphOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
@@ -39,6 +42,7 @@ add_onnx_mlir_library(OMSpecializedKernelOpInterface
   SpecializedKernelOpInterface.cpp
 
   DEPENDS
+  MLIRIR
   OMSpecializedKernelOpInterfaceIncGen
 
   LINK_LIBS PUBLIC


### PR DESCRIPTION
This change adds a missing dependency (`MLIRIR`) to the onnx-mlir build in a few places. My team found this while investigating building llvm-project and onnx-mlir in parallel using a single cmake command.

I've chosen to add the over-arching `MLIRIR` target rather than individual dependencies to avoid having to update these as interfaces are added/removed/moved within the MLIR IR. Below is the exact list of dependencies i found while researching this problem:

    MLIRCallInterfacesIncGen
    MLIRCastInterfacesIncGen
    MLIRDataLayoutInterfacesIncGen
    MLIROpAsmInterfaceIncGen
    MLIRRegionKindInterfaceIncGen
    MLIRSideEffectInterfacesIncGen
    MLIRSymbolInterfacesIncGen
    MLIRTensorEncodingIncGen
  ###ResultTypeInferenceOpInterface.cpp/HasOnnxSubgraphOpInterface.cpp/SpecializedKernelOpInterface.cpp
    MLIRBuiltinTypeInterfacesIncGen
    MLIRTensorEncodingIncGen

    MLIREmitCAttributesIncGen
    MLIRGPUOpsAttributesIncGen
    MLIRGPUOpsEnumsGen
    MLIROpenACCOpsIncGen
    MLIRSparseTensorAttrDefsIncGen
    MLIRTosaStructsIncGen

Signed-off-by: Ian Bearman <ianb@microsoft.com>