### PR TITLE
Add OMTensorPrint and KrnlPrintTensorOp

### DIFF
--- a/docs/DebuggingNumericalError.md
+++ b/docs/DebuggingNumericalError.md
@@ -82,3 +82,21 @@ optional arguments:
   --rtol RTOL           Relative tolerance for verification
   --atol ATOL           Absolute tolerance for verification
 ```
+
+## Debugging the Code Generated for an Operator.
+
+If you know, or suspect, that a particular ONNX MLIR operator produces an incorrect result, and want to narrow down the problem, we provide a couple of useful Krnl operators that allow printing (at runtime) the value of a tensor, or a value that has a primitive data type. 
+
+To print out the value of a tensor at a particular program point, inject the following code (where `X` is the tensor to be printed):
+
+```code
+create.krnl.printTensor("Tensor X: ", X);
+```
+
+Note: currently the content of the tensor is printed only when the tensor rank is less than four.
+
+To print a message followed by one value, inject the following code (where `val` is the value to be printed and `valType` is its type):
+
+```code
+create.krnl.printf("inputElem: ", val, valType);
+```

--- a/include/onnx-mlir/Runtime/OMTensor.h
+++ b/include/onnx-mlir/Runtime/OMTensor.h
@@ -284,6 +284,14 @@ int64_t omTensorGetOwning(const OMTensor *tensor);
  */
 void omTensorSetOwning(OMTensor *tensor, int64_t owning);
 
+/**
+ * Print an OMTensor to stdout.
+ *
+ * @param msg, pointer to descriptive string
+ * @param tensor, pointer to the OMTensor to print
+ */
+void omTensorPrint(const char *msg, const OMTensor *tensor);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/onnx-mlir/Runtime/OnnxDataType.h
+++ b/include/onnx-mlir/Runtime/OnnxDataType.h
@@ -26,7 +26,7 @@
 #endif
 
 enum OM_DATA_TYPE {
-#define OM_TYPE_METADATA_DEF(ENUM_NAME, ENUM_VAL, DTYPE_SIZE)                  \
+#define OM_TYPE_METADATA_DEF(ENUM_NAME, ENUM_VAL, DTYPE_SIZE, DTYPE_NAME)      \
   ENUM_NAME = ENUM_VAL,
 #include "OnnxDataTypeMetaData.inc"
 
@@ -38,6 +38,7 @@ typedef enum OM_DATA_TYPE OM_DATA_TYPE;
 #endif
 
 extern const int OM_DATA_TYPE_SIZE[];
+extern const char *OM_DATA_TYPE_NAME[];
 
 #ifdef __cplusplus
 // Note by design const map has no [] operator since [] creates a default
@@ -55,6 +56,9 @@ const std::map<std::string, OM_DATA_TYPE> OM_DATA_TYPE_CPP_TO_ONNX = {
     {"m", ONNX_TYPE_UINT64}, // uint64_t -> UINT64, unsigned long  -> UINT64
     {"f", ONNX_TYPE_FLOAT},  // float    -> FLOAT
     {"d", ONNX_TYPE_DOUBLE}, // double   -> DOUBLE
+    {"PKc", ONNX_TYPE_STRING},    // const char * -> STRING
+    {"Cf", ONNX_TYPE_COMPLEX64},  // _Complex float -> COMPLEX64
+    {"Cd", ONNX_TYPE_COMPLEX128}, // _Complex double -> COMPLEX128
 };
 #endif //__cplusplus
 

--- a/include/onnx-mlir/Runtime/OnnxDataTypeMetaData.inc
+++ b/include/onnx-mlir/Runtime/OnnxDataTypeMetaData.inc
@@ -3,28 +3,28 @@
  */
 
 #if defined(OM_TYPE_METADATA_DEF)
+// clang-format off
 // Data type metadata declared in the following format:
-// OM_TYPE_METADATA_DEF( dtype enum name, dtype enum value, dtype size)
+// OM_TYPE_METADATA_DEF(dtype enum name, dtype enum value, dtype size, dtype name) 
 // dtype enum values are standard ONNX data types defined in
 // https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L484
-// clang-format off
-OM_TYPE_METADATA_DEF(ONNX_TYPE_UNDEFINED,   0,  0)
-OM_TYPE_METADATA_DEF(ONNX_TYPE_FLOAT,       1,  sizeof(float))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_UINT8,       2,  sizeof(uint8_t))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_INT8,        3,  sizeof(int8_t))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_UINT16,      4,  sizeof(uint16_t))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_INT16,       5,  sizeof(int16_t))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_INT32,       6,  sizeof(int32_t))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_INT64,       7,  sizeof(int64_t))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_STRING,      8,  0)
-OM_TYPE_METADATA_DEF(ONNX_TYPE_BOOL,        9,  sizeof(bool))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_FLOAT16,     10, 2)
-OM_TYPE_METADATA_DEF(ONNX_TYPE_DOUBLE,      11, sizeof(double))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_UINT32,      12, sizeof(uint32_t))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_UINT64,      13, sizeof(uint64_t))
-OM_TYPE_METADATA_DEF(ONNX_TYPE_COMPLEX64,   14, 8)
-OM_TYPE_METADATA_DEF(ONNX_TYPE_COMPLEX128,  15, 16)
-OM_TYPE_METADATA_DEF(ONNX_TYPE_BFLOAT16,    16, 2)
+OM_TYPE_METADATA_DEF(ONNX_TYPE_UNDEFINED,   0,  0,                "undefined")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_FLOAT,       1,  sizeof(float),    "float")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_UINT8,       2,  sizeof(uint8_t),  "uint8_t")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_INT8,        3,  sizeof(int8_t),   "int8_t")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_UINT16,      4,  sizeof(uint16_t), "uint16_t")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_INT16,       5,  sizeof(int16_t),  "int16_t")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_INT32,       6,  sizeof(int32_t),  "int32_t")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_INT64,       7,  sizeof(int64_t),  "int64_t")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_STRING,      8,  0,                "const char *")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_BOOL,        9,  sizeof(bool),     "_Bool")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_FLOAT16,     10, 2,                "")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_DOUBLE,      11, sizeof(double),   "double")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_UINT32,      12, sizeof(uint32_t), "uint32_t")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_UINT64,      13, sizeof(uint64_t), "uint64_t")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_COMPLEX64,   14, 8,                "_Complex float")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_COMPLEX128,  15, 16,               "_Complex double")
+OM_TYPE_METADATA_DEF(ONNX_TYPE_BFLOAT16,    16, 2,                "")
 // clang-format on
 #else
 #error "Must define OM_TYPE_METADATA_DEF macro."

--- a/src/Conversion/KrnlToLLVM/CMakeLists.txt
+++ b/src/Conversion/KrnlToLLVM/CMakeLists.txt
@@ -2,6 +2,9 @@
 
 add_onnx_mlir_library(OMKrnlToLLVM
   KrnlToLLVM.cpp
+  KrnlToLLVMHelper.cpp  
+  KrnlPrintTensor.cpp
+  KrnlPrint.cpp  
   RuntimeAPI.cpp
 
   LINK_LIBS PUBLIC

--- a/src/Conversion/KrnlToLLVM/KrnlPrint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlPrint.cpp
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------ KrnlPrint.cpp - Lower KrnlPrintOp -----------------------------===//
+//
+// Copyright 2022 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file lowers the KrnlPrintOp operator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+
+#include "src/Conversion/KrnlToLLVM/KrnlPrint.hpp"
+#include "src/Conversion/KrnlToLLVM/KrnlToLLVM.hpp"
+#include "src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.hpp"
+#include "src/Dialect/Krnl/KrnlHelper.hpp"
+#include "src/Dialect/Krnl/KrnlOps.hpp"
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "krnl_to_llvm"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+LogicalResult KrnlPrintOpLowering::matchAndRewrite(Operation *op,
+    ArrayRef<Value> operands, ConversionPatternRewriter &rewriter) const {
+  auto printOp = cast<KrnlPrintOp>(op);
+  Location loc = printOp.getLoc();
+  KrnlPrintOpAdaptor operandAdaptor(operands);
+
+  Value input = operandAdaptor.input();
+  StringRef format = printOp.format();
+  ModuleOp module = printOp->getParentOfType<ModuleOp>();
+
+  // Get a symbol reference to the runtime function to use, creating one if
+  // necessary.
+  auto printfFuncRef = getOrInsertPrintf(rewriter, module);
+
+  // Printf call.
+  LLVM::GlobalOp formatSpec = getOrCreateGlobalString(format, loc, rewriter,
+      module, static_cast<LLVMTypeConverter *>(getTypeConverter()));
+  Value formatSpecPtr = getPtrToGlobalString(formatSpec, loc, rewriter);
+
+  if (input)
+    rewriter.create<CallOp>(loc, printfFuncRef, ArrayRef<Type>({}),
+        ArrayRef<Value>({formatSpecPtr, input}));
+  else
+    rewriter.create<CallOp>(loc, printfFuncRef, ArrayRef<Type>({}),
+        ArrayRef<Value>({formatSpecPtr}));
+
+  rewriter.eraseOp(op);
+  return success();
+}
+
+FlatSymbolRefAttr KrnlPrintOpLowering::getOrInsertPrintf(
+    PatternRewriter &rewriter, ModuleOp module) {
+  // Insert the printf declaration if it is not already present.
+  auto printfFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("printf");
+  MLIRContext *ctx = rewriter.getContext();
+
+  if (!printfFunc) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(module.getBody());
+    auto voidType = LLVM::LLVMVoidType::get(ctx);
+    Type i8Type = IntegerType::get(ctx, 8);
+    Type i8PtrType = LLVM::LLVMPointerType::get(i8Type);
+    printfFunc =
+        rewriter.create<LLVM::LLVMFuncOp>(rewriter.getUnknownLoc(), "printf",
+            LLVM::LLVMFunctionType::get(voidType, i8PtrType,
+                /*isVarArg=*/true));
+  }
+  return SymbolRefAttr::get(ctx, "printf");
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/KrnlToLLVM/KrnlPrint.hpp
+++ b/src/Conversion/KrnlToLLVM/KrnlPrint.hpp
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------ KrnlPrint.hpp - Lower KrnlPrintOp -----------------------------===//
+//
+// Copyright 2022 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file declares the lowering class for the KrnlPrintOp operator.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+
+#include "src/Conversion/KrnlToLLVM/RuntimeAPI.hpp"
+#include "src/Dialect/Krnl/KrnlOps.hpp"
+#include "src/Support/Common.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+class KrnlPrintOpLowering : public ConversionPattern {
+public:
+  explicit KrnlPrintOpLowering(
+      MLIRContext *context, TypeConverter &typeConverter)
+      : ConversionPattern(
+            typeConverter, KrnlPrintOp::getOperationName(), 1, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override;
+
+private:
+  static FlatSymbolRefAttr getOrInsertPrintf(
+      PatternRewriter &rewriter, ModuleOp module);
+};
+
+} // namespace onnx_mlir

--- a/src/Conversion/KrnlToLLVM/KrnlPrintTensor.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlPrintTensor.cpp
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------ KrnlPrintTensor.cpp - Lower KrnlPrintTensorOp ----------------===//
+//
+// Copyright 2022 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file lowers the KrnlPrintTensorOp operator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+
+#include "onnx/onnx_pb.h"
+
+#include "src/Conversion/KrnlToLLVM/KrnlPrintTensor.hpp"
+#include "src/Conversion/KrnlToLLVM/KrnlToLLVM.hpp"
+#include "src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.hpp"
+#include "src/Conversion/KrnlToLLVM/RuntimeAPI.hpp"
+#include "src/Dialect/Krnl/KrnlHelper.hpp"
+#include "src/Dialect/Krnl/KrnlOps.hpp"
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "krnl_to_llvm"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+LogicalResult KrnlPrintTensorOpLowering::matchAndRewrite(Operation *op,
+    ArrayRef<Value> operands, ConversionPatternRewriter &rewriter) const {
+  auto printTensorOp = cast<KrnlPrintTensorOp>(op);
+  MLIRContext *context = printTensorOp.getContext();
+  Location loc = printTensorOp.getLoc();
+  KrnlPrintTensorOpAdaptor operandAdaptor(operands);
+
+  StringRef msg = printTensorOp.msg();
+  Value input = operandAdaptor.input();
+  assert(input.getType().isa<LLVM::LLVMStructType>() &&
+         "expecting LLVMStructType");
+
+  ModuleOp module = printTensorOp->getParentOfType<ModuleOp>();
+  const auto &apiRegistry = RuntimeAPIRegistry::build(module, rewriter);
+
+  // Get a symbol reference to the runtime function to use, creating one if
+  // necessary.
+  auto int64Ty = IntegerType::get(context, 64);
+  auto memRefTy = input.getType().dyn_cast<LLVM::LLVMStructType>();
+  auto memRefRank = onnx_mlir::getRankFromMemRefType(memRefTy);
+  auto memRefRankVal = rewriter.create<LLVM::ConstantOp>(
+      loc, int64Ty, rewriter.getI64IntegerAttr(memRefRank));
+  Value omTensor = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
+      RuntimeAPI::API::CREATE_OMTENSOR, {memRefRankVal});
+
+  onnx_mlir::fillOMTensorWithMemRef(
+      input, omTensor, false /*outOwning*/, rewriter, loc, apiRegistry, module);
+  LLVM::GlobalOp globalStr = getOrCreateGlobalString(msg, loc, rewriter, module,
+      static_cast<LLVMTypeConverter *>(getTypeConverter()));
+  Value strPtr = getPtrToGlobalString(globalStr, loc, rewriter);
+
+  RuntimeAPI::callApi(rewriter, loc, apiRegistry,
+      RuntimeAPI::API::PRINT_OMTENSOR, {strPtr, omTensor});
+
+  rewriter.eraseOp(op);
+  return success();
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/KrnlToLLVM/KrnlPrintTensor.hpp
+++ b/src/Conversion/KrnlToLLVM/KrnlPrintTensor.hpp
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------ KrnlPrintTensor.hpp - Lower KrnlPrintTensorOp -----------------===//
+//
+// Copyright 2022 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file declares the lowering class for the KrnlPrintTensorOp operator.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+
+#include "src/Conversion/KrnlToLLVM/RuntimeAPI.hpp"
+#include "src/Dialect/Krnl/KrnlOps.hpp"
+#include "src/Support/Common.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+class KrnlPrintTensorOpLowering : public ConversionPattern {
+public:
+  explicit KrnlPrintTensorOpLowering(
+      MLIRContext *context, TypeConverter &typeConverter)
+      : ConversionPattern(
+            typeConverter, KrnlPrintTensorOp::getOperationName(), 1, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override;
+};
+
+} // namespace onnx_mlir

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVM.cpp
@@ -44,7 +44,10 @@
 
 #include "onnx/onnx_pb.h"
 
+#include "src/Conversion/KrnlToLLVM/KrnlPrint.hpp"
+#include "src/Conversion/KrnlToLLVM/KrnlPrintTensor.hpp"
 #include "src/Conversion/KrnlToLLVM/KrnlToLLVM.hpp"
+#include "src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.hpp"
 #include "src/Conversion/KrnlToLLVM/RuntimeAPI.hpp"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
@@ -54,80 +57,8 @@
 #define DEBUG_TYPE "krnl_to_llvm"
 
 using namespace mlir;
+
 namespace {
-
-// Convert an MLIR  type to the correspoding ONNX type.
-static onnx::TensorProto::DataType mlirTypeToOnnxType(mlir::Type elemType) {
-  onnx::TensorProto::DataType onnxType = onnx::TensorProto::UNDEFINED;
-
-  TypeSwitch<mlir::Type>(elemType)
-      .Case<mlir::BFloat16Type>(
-          [&](mlir::BFloat16Type) { onnxType = onnx::TensorProto::BFLOAT16; })
-      .Case<mlir::ComplexType>([&](mlir::ComplexType type) {
-        if (type.getElementType().isa<mlir::Float32Type>())
-          onnxType = onnx::TensorProto::COMPLEX64;
-        else if (type.getElementType().isa<mlir::Float64Type>())
-          onnxType = onnx::TensorProto::COMPLEX128;
-      })
-      .Case<mlir::Float16Type>(
-          [&](mlir::Float16Type) { onnxType = onnx::TensorProto::FLOAT16; })
-      .Case<mlir::Float32Type>(
-          [&](mlir::Float32Type) { onnxType = onnx::TensorProto::FLOAT; })
-      .Case<mlir::Float64Type>(
-          [&](mlir::Float64Type) { onnxType = onnx::TensorProto::DOUBLE; })
-      .Case<mlir::IntegerType>([&](mlir::IntegerType type) {
-        switch (type.getWidth()) {
-        case 1:
-          // only a signless type can be a bool.
-          onnxType = (type.isSigned() || type.isUnsigned())
-                         ? onnx::TensorProto::UNDEFINED
-                         : onnx::TensorProto::BOOL;
-          break;
-        case 8:
-          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT8
-                                       : onnx::TensorProto::INT8;
-          break;
-        case 16:
-          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT16
-                                       : onnx::TensorProto::INT16;
-          break;
-        case 32:
-          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT32
-                                       : onnx::TensorProto::INT32;
-          break;
-        case 64:
-          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT64
-                                       : onnx::TensorProto::INT64;
-          break;
-        }
-      })
-      .Case<mlir::StringType>(
-          [&](mlir::StringType) { onnxType = onnx::TensorProto::STRING; });
-
-  if (onnxType == onnx::TensorProto::UNDEFINED) {
-    elemType.dump();
-    llvm_unreachable("MLIR type cannot be converted to ONNX type");
-  }
-
-  return onnxType;
-}
-
-static int64_t getRankFromMemRefType(LLVM::LLVMStructType memRefTy) {
-  // Usually a MemRef is a 5-element struct, where the 4th and 5th elements in
-  // this struct are arrays whose size is the rank of the tensor. In the event
-  // that the corresponding tensor of this MemRef is a scalar, the 4th and 5th
-  // elements will have 0-length, which in turn causes the MemRef struct to
-  // degenerate into a 3-element struct. For more information, refer to
-  // https://github.com/llvm/llvm-project/blob/main/mlir/docs/ConversionToLLVMDialect.md#memref-types.
-  auto numElems = memRefTy.getBody().size();
-  assert((numElems == 3 || numElems == 5) &&
-         "Expect MemRef type to contain either 3 or 5 elements.");
-
-  if (numElems == 3)
-    return 0; // MemRef refers to a scalar.
-  else
-    return memRefTy.getBody()[3].cast<LLVM::LLVMArrayType>().getNumElements();
-}
 
 // Create a function declaration for OMInstrumentPoint, the signature is:
 //   `void (i64, i64)`
@@ -456,8 +387,9 @@ public:
 
     // Set the global alignment based on the alignment attribute if it exists,
     // otherwise use the module datalayout info.
-    setAlignment(global, krnlGlobalOp.alignmentAttr(),
-        krnlGlobalOp->getParentOfType<ModuleOp>(), rewriter);
+    onnx_mlir::setAlignment(global, krnlGlobalOp.alignmentAttr(),
+        krnlGlobalOp->getParentOfType<ModuleOp>(), rewriter,
+        *getTypeConverter());
 
     // Prepare data to be inserted into a MemRefDescriptor (a struct).
     Value globalOpAddr =
@@ -553,25 +485,6 @@ private:
     return global;
   }
 
-  // If the operation has a valid alignment attribute use it, otherwise
-  // attempt to set the alignment based on the module datalayout (if it
-  // exists).
-  void setAlignment(LLVM::GlobalOp &global, IntegerAttr alignmentAttr,
-      ModuleOp module, OpBuilder &builder) const {
-    if (alignmentAttr && alignmentAttr.getValue().getSExtValue() != 0)
-      global.setAlignmentAttr(alignmentAttr);
-    else if (module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName())) {
-      // TODO: use MLIR data layout when it becomes available.
-      llvm::LLVMContext llvmContext;
-      int32_t align = LLVM::TypeToLLVMIRTranslator(llvmContext)
-                          .getPreferredAlignment(global.getType(),
-                              getTypeConverter()->getDataLayout());
-      align = std::max(align, MinGlobalAlign);
-      global.setAlignmentAttr(builder.getI64IntegerAttr(align));
-    } else
-      global.setAlignmentAttr(builder.getI64IntegerAttr(MinGlobalAlign));
-  }
-
   int64_t computeSizeInBytes(KrnlGlobalOp &krnlGlobalOp) const {
     // Compute total number of elements.
     const auto shape = (krnlGlobalOp.shape()).dyn_cast<ArrayAttr>();
@@ -619,22 +532,16 @@ private:
     int64_t numStrings = denseAttr.getValues<StringRef>().size();
     if (numStrings == 1) {
       StringRef str = *denseAttr.getValues<StringRef>().begin();
-      LLVM::GlobalOp global =
-          getOrCreateGlobalString(str, loc, builder, module);
-
-      //      return builder.create<LLVM::GlobalOp>(loc, globalType,
-      //        /*isConstant=*/true, LLVM::Linkage::Internal,
-      //        krnlGlobalOp.name(),
-      //      StringAttr::get(builder.getContext(), str));
-      return global;
+      return onnx_mlir::getOrCreateGlobalString(
+          str, loc, builder, module, getTypeConverter());
     }
 
     // Generate LLVM GlobalOps for each string in the KrnlGlobalOp dense
     // attribute.
     SmallVector<LLVM::GlobalOp> globalOps;
     for (StringRef str : denseAttr.getValues<StringRef>()) {
-      LLVM::GlobalOp globalOp =
-          getOrCreateGlobalString(str, loc, builder, module);
+      LLVM::GlobalOp globalOp = onnx_mlir::getOrCreateGlobalString(
+          str, loc, builder, module, getTypeConverter());
       globalOps.push_back(globalOp);
     }
 
@@ -654,7 +561,7 @@ private:
     int32_t index = 0;
     Value lastValue = array;
     for (const LLVM::GlobalOp &globalOp : globalOps) {
-      LLVM::GEPOp strAddr = getPtrToGlobalString(globalOp, loc, builder);
+      Value strAddr = onnx_mlir::getPtrToGlobalString(globalOp, loc, builder);
       lastValue = builder.create<LLVM::InsertValueOp>(loc, arrayType, lastValue,
           strAddr, builder.getArrayAttr({builder.getIndexAttr(index++)}));
     }
@@ -662,42 +569,6 @@ private:
     builder.create<LLVM::ReturnOp>(loc, ArrayRef<Value>({lastValue}));
     return global;
   }
-
-  // Return the GlobalOp for the given string, creating one if not found.
-  LLVM::GlobalOp getOrCreateGlobalString(
-      StringRef str, Location loc, OpBuilder &builder, ModuleOp module) const {
-    LLVM::GlobalOp global = module.lookupSymbol<LLVM::GlobalOp>(str);
-    if (!global) {
-      // Create the global at the entry of the module.
-      OpBuilder::InsertionGuard insertGuard(builder);
-      builder.setInsertionPointToStart(module.getBody());
-
-      Type i8Type = IntegerType::get(builder.getContext(), 8);
-      Type type = LLVM::LLVMArrayType::get(i8Type, str.size());
-      global = builder.create<LLVM::GlobalOp>(loc, type, /*isConstant=*/true,
-          LLVM::Linkage::Internal, str, builder.getStringAttr(str));
-
-      setAlignment(global, nullptr, module, builder);
-    }
-    return global;
-  }
-
-  // Return a pointer to the first character in a global string.
-  LLVM::GEPOp getPtrToGlobalString(
-      const LLVM::GlobalOp &global, Location loc, OpBuilder &builder) const {
-    Type i8Type = IntegerType::get(builder.getContext(), 8);
-    Type i8PtrType = LLVM::LLVMPointerType::get(i8Type);
-    Type llvmIndexType =
-        getTypeConverter()->convertType(builder.getIndexType());
-
-    Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, global);
-    Value zero = builder.create<LLVM::ConstantOp>(
-        loc, llvmIndexType, builder.getIndexAttr(0));
-    return builder.create<LLVM::GEPOp>(
-        loc, i8PtrType, globalPtr, ArrayRef<Value>({zero, zero}));
-  }
-
-  const int32_t MinGlobalAlign = 16;
 };
 
 class KrnlInstrumentOpLowering : public ConversionPattern {
@@ -714,13 +585,6 @@ public:
 
     // Get a symbol reference to the memcpy function, inserting it if necessary.
     ModuleOp parentModule = op->getParentOfType<ModuleOp>();
-    // auto llvmVoidTy = LLVM::LLVMVoidType::get(context);
-    // auto llvmI8PtrTy = LLVM::LLVMPointerType::get(IntegerType::get(context,
-    // 8));
-    // auto llvmI64Ty = IntegerType::get(context, 64); auto llvmFnType =
-    // LLVM::LLVMFunctionType::get(
-    //    llvmVoidTy, ArrayRef<mlir::Type>({llvmI64Ty, llvmI64Ty}), false);
-
     auto instrumentRef = getOrInsertInstrument(rewriter, parentModule);
 
     Value nodeName =
@@ -731,9 +595,6 @@ public:
         rewriter.create<LLVM::ConstantOp>(loc, IntegerType::get(context, 64),
             rewriter.getIntegerAttr(
                 rewriter.getIntegerType(64), instrumentOp.tag()));
-    // StringRef txt = instrumentOp->op_name();
-    // Value nodeName = rewriter.create<LLVM::ConstantOp>(loc, llvmI8PtrTy,
-    // instrumentOp->op_name());
 
     rewriter.create<CallOp>(loc, instrumentRef, ArrayRef<Type>({}),
         ArrayRef<Value>({nodeName, tag}));
@@ -1287,16 +1148,16 @@ public:
 
       auto memRef = outMemRefList.at(i);
       auto outMemRefTy = memRef.getType().dyn_cast<LLVM::LLVMStructType>();
-      auto outMemRefRank = getRankFromMemRefType(outMemRefTy);
+      auto outMemRefRank = onnx_mlir::getRankFromMemRefType(outMemRefTy);
       auto outMemRefRankVal = rewriter.create<LLVM::ConstantOp>(
           loc, int64Ty, rewriter.getI64IntegerAttr(outMemRefRank));
       Value outOMTensor = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
           RuntimeAPI::API::CREATE_OMTENSOR, {outMemRefRankVal});
       // If output is a constant tensor, OMTensor does not own it.
-      auto outOwning = constantOutputs[i] ? 0 : 1;
+      bool outOwning = constantOutputs[i] ? false : true;
       LLVM_DEBUG(llvm::dbgs() << "Output OMTensor " << i
                               << " with owning = " << outOwning << "\n");
-      fillOMTensorWithMemRef(
+      onnx_mlir::fillOMTensorWithMemRef(
           memRef, outOMTensor, outOwning, rewriter, loc, apiRegistry, module);
 
       auto idxVal = rewriter.create<LLVM::ConstantOp>(
@@ -1366,7 +1227,8 @@ private:
         rewriter.getArrayAttr({rewriter.getI64IntegerAttr(2)}));
 
     // Get rank, sizes array ptr and strides array ptr.
-    auto rank = getRankFromMemRefType(memRefTy.cast<LLVM::LLVMStructType>());
+    auto rank =
+        onnx_mlir::getRankFromMemRefType(memRefTy.cast<LLVM::LLVMStructType>());
     Value sizesArrayPtr = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
         RuntimeAPI::API::GET_DATA_SHAPE, {rtMemRef});
     Value stridesArrayPtr = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
@@ -1399,84 +1261,6 @@ private:
     }
 
     rewriter.create<LLVM::StoreOp>(loc, memRef, ptrToMemRef);
-  }
-
-  void fillOMTensorWithMemRef(Value &outMemRef, Value &outOMTensor,
-      int64_t outOwning, PatternRewriter &rewriter, const Location &loc,
-      const RuntimeAPIRegistry &apiRegistry, ModuleOp &module) const {
-    auto *context = module.getContext();
-    auto outMemRefTy = outMemRef.getType().dyn_cast<LLVM::LLVMStructType>();
-    auto int64Ty = IntegerType::get(context, 64);
-
-    // Set ownership, i.e., free after OMTensor is destroyed.
-    Value owning = rewriter.create<LLVM::ConstantOp>(
-        loc, int64Ty, rewriter.getI64IntegerAttr(outOwning));
-
-    // Extract the allocated pointer.
-    Value outMemRefAllocatedPtr =
-        rewriter.create<LLVM::ExtractValueOp>(loc, outMemRefTy.getBody()[0],
-            outMemRef, rewriter.getArrayAttr({rewriter.getI64IntegerAttr(0)}));
-    outMemRefAllocatedPtr = rewriter.create<LLVM::BitcastOp>(loc,
-        LLVM::LLVMPointerType::get(IntegerType::get(context, 8)),
-        outMemRefAllocatedPtr);
-
-    // Extract the aligned pointer.
-    Value outMemRefAlignedPtr =
-        rewriter.create<LLVM::ExtractValueOp>(loc, outMemRefTy.getBody()[1],
-            outMemRef, rewriter.getArrayAttr({rewriter.getI64IntegerAttr(1)}));
-    outMemRefAlignedPtr = rewriter.create<LLVM::BitcastOp>(loc,
-        LLVM::LLVMPointerType::get(IntegerType::get(context, 8)),
-        outMemRefAlignedPtr);
-
-    // Set ownership, allocated and aligned pointer.
-    RuntimeAPI::callApi(rewriter, loc, apiRegistry, RuntimeAPI::API::SET_DATA,
-        {outOMTensor, owning, outMemRefAllocatedPtr, outMemRefAlignedPtr});
-
-    Type elemTy =
-        outMemRefTy.getBody()[0].cast<LLVM::LLVMPointerType>().getElementType();
-
-    if (auto structType = elemTy.dyn_cast_or_null<LLVM::LLVMStructType>()) {
-      elemTy = structType.getBody()[0]
-                   .cast<LLVM::LLVMPointerType>()
-                   .getElementType();
-    }
-
-    onnx::TensorProto::DataType onnxTy = mlirTypeToOnnxType(elemTy);
-    auto onnxTyVal = rewriter.create<LLVM::ConstantOp>(
-        loc, int64Ty, rewriter.getI64IntegerAttr(onnxTy));
-    RuntimeAPI::callApi(rewriter, loc, apiRegistry,
-        RuntimeAPI::API::SET_DATA_TYPE, {outOMTensor, onnxTyVal});
-
-    int64_t rank = getRankFromMemRefType(outMemRefTy);
-    Value sizesArrayPtr = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
-        RuntimeAPI::API::GET_DATA_SHAPE, {outOMTensor});
-    Value stridesArrayPtr = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
-        RuntimeAPI::API::GET_DATA_STRIDES, {outOMTensor});
-
-    for (decltype(rank) i = 0; i < rank; i++) {
-      auto dimIdx = rewriter.create<LLVM::ConstantOp>(
-          loc, int64Ty, rewriter.getI64IntegerAttr(i));
-
-      // Transfer size of dimension from memref to dynamic memref.
-      auto dimSize = rewriter.create<LLVM::ExtractValueOp>(loc, int64Ty,
-          outMemRef,
-          rewriter.getArrayAttr(
-              {rewriter.getI64IntegerAttr(3), rewriter.getI64IntegerAttr(i)}));
-      auto dimSizePtr =
-          rewriter.create<LLVM::GEPOp>(loc, LLVM::LLVMPointerType::get(int64Ty),
-              sizesArrayPtr, ArrayRef<Value>({dimIdx}));
-      rewriter.create<LLVM::StoreOp>(loc, dimSize, dimSizePtr);
-
-      // Transfer stride of dimension from memref to dynamic memref.
-      auto dimStride = rewriter.create<LLVM::ExtractValueOp>(loc, int64Ty,
-          outMemRef,
-          rewriter.getArrayAttr(
-              {rewriter.getI64IntegerAttr(4), rewriter.getI64IntegerAttr(i)}));
-      auto dimStridePtr =
-          rewriter.create<LLVM::GEPOp>(loc, LLVM::LLVMPointerType::get(int64Ty),
-              stridesArrayPtr, ArrayRef<Value>({dimIdx}));
-      rewriter.create<LLVM::StoreOp>(loc, dimStride, dimStridePtr);
-    }
   }
 };
 
@@ -1807,6 +1591,8 @@ void mlir::populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
 
   patterns.insert<KrnlRandomNormalOpLowering>(ctx);
   patterns.insert<KrnlFindIndexOpLowering>(ctx);
+  patterns.insert<onnx_mlir::KrnlPrintTensorOpLowering>(ctx, typeConverter);
+  patterns.insert<onnx_mlir::KrnlPrintOpLowering>(ctx, typeConverter);
 
   // Math library functions.
   patterns.insert<KrnlUnaryMathOpLowering<KrnlErfOp>>(ctx);

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.cpp
@@ -1,0 +1,221 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------ KrnlToLLVMHelper.cpp ------------------------------------------===//
+//
+// Copyright 2022 The IBM Research Authors.
+//
+// =============================================================================
+//
+// Implements utility functions for the Krnl to LLVM dialect conversion.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.hpp"
+#include "mlir/Target/LLVMIR/TypeToLLVM.h"
+#include "src/Dialect/Krnl/KrnlOps.hpp"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+static const int32_t MinGlobalAlign = 16;
+
+int64_t getRankFromMemRefType(LLVM::LLVMStructType memRefTy) {
+  // Usually a MemRef is a 5-element struct, where the 4th and 5th elements in
+  // this struct are arrays whose size is the rank of the tensor. In the event
+  // that the corresponding tensor of this MemRef is a scalar, the 4th and 5th
+  // elements will have 0-length, which in turn causes the MemRef struct to
+  // degenerate into a 3-element struct. For more information, refer to
+  // https://github.com/llvm/llvm-project/blob/main/mlir/docs/ConversionToLLVMDialect.md#memref-types.
+  auto numElems = memRefTy.getBody().size();
+  assert((numElems == 3 || numElems == 5) &&
+         "Expect MemRef type to contain either 3 or 5 elements.");
+
+  if (numElems == 3)
+    return 0; // MemRef refers to a scalar.
+  else
+    return memRefTy.getBody()[3].cast<LLVM::LLVMArrayType>().getNumElements();
+}
+
+// Convert an MLIR type to the correspoding ONNX type.
+onnx::TensorProto::DataType mlirTypeToOnnxType(Type elemType) {
+  onnx::TensorProto::DataType onnxType = onnx::TensorProto::UNDEFINED;
+
+  TypeSwitch<Type>(elemType)
+      .Case<BFloat16Type>(
+          [&](BFloat16Type) { onnxType = onnx::TensorProto::BFLOAT16; })
+      .Case<mlir::ComplexType>([&](ComplexType type) {
+        if (type.getElementType().isa<Float32Type>())
+          onnxType = onnx::TensorProto::COMPLEX64;
+        else if (type.getElementType().isa<Float64Type>())
+          onnxType = onnx::TensorProto::COMPLEX128;
+      })
+      .Case<Float16Type>(
+          [&](Float16Type) { onnxType = onnx::TensorProto::FLOAT16; })
+      .Case<Float32Type>(
+          [&](Float32Type) { onnxType = onnx::TensorProto::FLOAT; })
+      .Case<Float64Type>(
+          [&](Float64Type) { onnxType = onnx::TensorProto::DOUBLE; })
+      .Case<IntegerType>([&](IntegerType type) {
+        switch (type.getWidth()) {
+        case 1:
+          // only a signless type can be a bool.
+          onnxType = (type.isSigned() || type.isUnsigned())
+                         ? onnx::TensorProto::UNDEFINED
+                         : onnx::TensorProto::BOOL;
+          break;
+        case 8:
+          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT8
+                                       : onnx::TensorProto::INT8;
+          break;
+        case 16:
+          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT16
+                                       : onnx::TensorProto::INT16;
+          break;
+        case 32:
+          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT32
+                                       : onnx::TensorProto::INT32;
+          break;
+        case 64:
+          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT64
+                                       : onnx::TensorProto::INT64;
+          break;
+        }
+      })
+      .Case<LLVM::LLVMStructType>(
+          [&](LLVM::LLVMStructType) { onnxType = onnx::TensorProto::STRING; });
+
+  if (onnxType == onnx::TensorProto::UNDEFINED) {
+    elemType.dump();
+    llvm_unreachable("MLIR type cannot be converted to ONNX type");
+  }
+
+  return onnxType;
+}
+
+void fillOMTensorWithMemRef(Value &outMemRef, Value &outOMTensor,
+    int64_t outOwning, PatternRewriter &rewriter, const Location &loc,
+    const RuntimeAPIRegistry &apiRegistry, ModuleOp &module) {
+  auto *context = module.getContext();
+  auto outMemRefTy = outMemRef.getType().dyn_cast<LLVM::LLVMStructType>();
+  auto int64Ty = IntegerType::get(context, 64);
+
+  // Set ownership, i.e., free after OMTensor is destroyed.
+  Value owning = rewriter.create<LLVM::ConstantOp>(
+      loc, int64Ty, rewriter.getI64IntegerAttr(outOwning));
+
+  // Extract the allocated pointer.
+  Value outMemRefAllocatedPtr =
+      rewriter.create<LLVM::ExtractValueOp>(loc, outMemRefTy.getBody()[0],
+          outMemRef, rewriter.getArrayAttr({rewriter.getI64IntegerAttr(0)}));
+  outMemRefAllocatedPtr = rewriter.create<LLVM::BitcastOp>(loc,
+      LLVM::LLVMPointerType::get(IntegerType::get(context, 8)),
+      outMemRefAllocatedPtr);
+
+  // Extract the aligned pointer.
+  Value outMemRefAlignedPtr =
+      rewriter.create<LLVM::ExtractValueOp>(loc, outMemRefTy.getBody()[1],
+          outMemRef, rewriter.getArrayAttr({rewriter.getI64IntegerAttr(1)}));
+  outMemRefAlignedPtr = rewriter.create<LLVM::BitcastOp>(loc,
+      LLVM::LLVMPointerType::get(IntegerType::get(context, 8)),
+      outMemRefAlignedPtr);
+
+  // Set ownership, allocated and aligned pointer.
+  RuntimeAPI::callApi(rewriter, loc, apiRegistry, RuntimeAPI::API::SET_DATA,
+      {outOMTensor, owning, outMemRefAllocatedPtr, outMemRefAlignedPtr});
+
+  Type elemTy =
+      outMemRefTy.getBody()[0].cast<LLVM::LLVMPointerType>().getElementType();
+
+  onnx::TensorProto::DataType onnxTy = onnx_mlir::mlirTypeToOnnxType(elemTy);
+  auto onnxTyVal = rewriter.create<LLVM::ConstantOp>(
+      loc, int64Ty, rewriter.getI64IntegerAttr(onnxTy));
+  RuntimeAPI::callApi(rewriter, loc, apiRegistry,
+      RuntimeAPI::API::SET_DATA_TYPE, {outOMTensor, onnxTyVal});
+
+  int64_t rank = onnx_mlir::getRankFromMemRefType(outMemRefTy);
+  Value sizesArrayPtr = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
+      RuntimeAPI::API::GET_DATA_SHAPE, {outOMTensor});
+  Value stridesArrayPtr = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
+      RuntimeAPI::API::GET_DATA_STRIDES, {outOMTensor});
+
+  for (decltype(rank) i = 0; i < rank; i++) {
+    auto dimIdx = rewriter.create<LLVM::ConstantOp>(
+        loc, int64Ty, rewriter.getI64IntegerAttr(i));
+
+    // Transfer size of dimension from memref to dynamic memref.
+    auto dimSize = rewriter.create<LLVM::ExtractValueOp>(loc, int64Ty,
+        outMemRef,
+        rewriter.getArrayAttr(
+            {rewriter.getI64IntegerAttr(3), rewriter.getI64IntegerAttr(i)}));
+    auto dimSizePtr =
+        rewriter.create<LLVM::GEPOp>(loc, LLVM::LLVMPointerType::get(int64Ty),
+            sizesArrayPtr, ArrayRef<Value>({dimIdx}));
+    rewriter.create<LLVM::StoreOp>(loc, dimSize, dimSizePtr);
+
+    // Transfer stride of dimension from memref to dynamic memref.
+    auto dimStride = rewriter.create<LLVM::ExtractValueOp>(loc, int64Ty,
+        outMemRef,
+        rewriter.getArrayAttr(
+            {rewriter.getI64IntegerAttr(4), rewriter.getI64IntegerAttr(i)}));
+    auto dimStridePtr =
+        rewriter.create<LLVM::GEPOp>(loc, LLVM::LLVMPointerType::get(int64Ty),
+            stridesArrayPtr, ArrayRef<Value>({dimIdx}));
+    rewriter.create<LLVM::StoreOp>(loc, dimStride, dimStridePtr);
+  }
+}
+
+LLVM::GlobalOp getOrCreateGlobalString(StringRef str, Location loc,
+    OpBuilder &builder, ModuleOp module, LLVMTypeConverter *typeConverter) {
+  assert(typeConverter && "Expecting a valid LLVM type converter");
+  LLVM::GlobalOp global = module.lookupSymbol<LLVM::GlobalOp>(str);
+  if (!global) {
+    // Create the global at the entry of the module.
+    OpBuilder::InsertionGuard insertGuard(builder);
+    builder.setInsertionPointToStart(module.getBody());
+
+    auto i8Type = IntegerType::get(builder.getContext(), 8);
+    auto type = LLVM::LLVMArrayType::get(i8Type, str.size());
+    global = builder.create<LLVM::GlobalOp>(loc, type, /*isConstant=*/true,
+        LLVM::Linkage::Internal, str, builder.getStringAttr(str));
+
+    setAlignment(global, nullptr, module, builder, *typeConverter);
+  }
+
+  return global;
+}
+
+// Return a pointer to the first character in a global string.
+Value getPtrToGlobalString(
+    const LLVM::GlobalOp &global, Location loc, OpBuilder &builder) {
+  Type i8Type = IntegerType::get(builder.getContext(), 8);
+  Type i8PtrType = LLVM::LLVMPointerType::get(i8Type);
+  Type i64Type = IntegerType::get(builder.getContext(), 64);
+  Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, global);
+  Value zero =
+      builder.create<LLVM::ConstantOp>(loc, i64Type, builder.getIndexAttr(0));
+
+  return builder.create<LLVM::GEPOp>(
+      loc, i8PtrType, globalPtr, ArrayRef<Value>({zero, zero}));
+}
+
+void setAlignment(LLVM::GlobalOp &global, IntegerAttr alignmentAttr,
+    ModuleOp module, OpBuilder &builder, LLVMTypeConverter &typeConverter) {
+  if (alignmentAttr && alignmentAttr.getValue().getSExtValue() != 0)
+    global.setAlignmentAttr(alignmentAttr);
+  else if (module->getAttr(LLVM::LLVMDialect::getDataLayoutAttrName())) {
+    // TODO: use MLIR data layout when it becomes available.
+    llvm::LLVMContext llvmContext;
+    int32_t align = LLVM::TypeToLLVMIRTranslator(llvmContext)
+                        .getPreferredAlignment(
+                            global.getType(), typeConverter.getDataLayout());
+    align = std::max(align, MinGlobalAlign);
+    global.setAlignmentAttr(builder.getI64IntegerAttr(align));
+  } else
+    global.setAlignmentAttr(builder.getI64IntegerAttr(MinGlobalAlign));
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.hpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.hpp
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------ KrnlToLLVMHelper.hpp ------------------------------------------===//
+//
+// Copyright 2022 The IBM Research Authors.
+//
+// =============================================================================
+//
+// Declare utility functions for the Krnl to LLVM dialect conversion.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "onnx/onnx_pb.h"
+#include "src/Conversion/KrnlToLLVM/RuntimeAPI.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+/// Get the rank of the given tensor (represented as a memref).
+int64_t getRankFromMemRefType(LLVM::LLVMStructType memRefTy);
+
+/// Get the ONNX type corresponding to an MLIR type.
+onnx::TensorProto::DataType mlirTypeToOnnxType(Type elemType);
+
+/// Create an OMTensor from a memref.
+void fillOMTensorWithMemRef(Value &outMemRef, Value &outOMTensor,
+    int64_t outOwning, PatternRewriter &rewriter, const Location &loc,
+    const RuntimeAPIRegistry &apiRegistry, ModuleOp &module);
+
+/// Return the GlobalOp for the given string, creating one if not found.
+LLVM::GlobalOp getOrCreateGlobalString(StringRef str, Location loc,
+    OpBuilder &builder, ModuleOp module, LLVMTypeConverter *typeConverter);
+
+/// Return a pointer to the first character in a global string.
+Value getPtrToGlobalString(
+    const LLVM::GlobalOp &global, Location loc, OpBuilder &builder);
+
+/// If the operation has a valid alignment attribute use it, otherwise attempt
+/// to set the alignment based on the module datalayout (if it exists).
+void setAlignment(LLVM::GlobalOp &global, IntegerAttr alignmentAttr,
+    ModuleOp module, OpBuilder &builder, LLVMTypeConverter &typeConverter);
+
+} // namespace onnx_mlir

--- a/src/Conversion/KrnlToLLVM/RuntimeAPI.cpp
+++ b/src/Conversion/KrnlToLLVM/RuntimeAPI.cpp
@@ -87,7 +87,8 @@ RuntimeAPIRegistry::RuntimeAPIRegistry(ModuleOp &module, OpBuilder &builder)
     : registry() {
   MLIRContext *context = module.getContext();
   auto voidTy = LLVM::LLVMVoidType::get(context);
-  auto opaquePtrTy = LLVM::LLVMPointerType::get(IntegerType::get(context, 8));
+  auto int8Ty = IntegerType::get(context, 8);
+  auto opaquePtrTy = LLVM::LLVMPointerType::get(int8Ty);
   auto opaquePtrPtrTy = LLVM::LLVMPointerType::get(opaquePtrTy);
   auto int64Ty = IntegerType::get(context, 64);
   auto int64PtrTy = LLVM::LLVMPointerType::get(int64Ty);
@@ -106,7 +107,7 @@ RuntimeAPIRegistry::RuntimeAPIRegistry(ModuleOp &module, OpBuilder &builder)
     RuntimeAPI(API::GET_DATA_TYPE, "omTensorGetDataType", int64Ty, {opaquePtrTy}),
     RuntimeAPI(API::SET_DATA_TYPE, "omTensorSetDataType", voidTy, {opaquePtrTy, int64Ty}),
     RuntimeAPI(API::GET_OMT_ARRAY, "omTensorListGetOmtArray", opaquePtrPtrTy, {opaquePtrTy}),
-    RuntimeAPI(API::PRINT_OMTENSOR, "omTensorPrint", voidTy, {opaquePtrTy}),
+    RuntimeAPI(API::PRINT_OMTENSOR, "omTensorPrint", voidTy, {opaquePtrTy, opaquePtrTy}),
   };
   // clang-format on
 

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -1026,3 +1026,23 @@ def KrnlFindIndexOp : Op<Krnl_Dialect, "find_index",
   let arguments = (ins AnyTypeOf<[StringType, I64]>:$input, I32MemRef:$G, I32MemRef:$V, I32:$len);
   let results = (outs Index:$index);
 }
+
+def KrnlPrintTensorOp : Op<Krnl_Dialect, "print_tensor", [MemRefsNormalizable]> {
+  let summary = "Print a tensor.";
+  let description = [{
+    This operation can be used to generate a call to a runtime function which prints a tensor.
+  }];
+
+  let arguments = (ins StrAttr:$msg, AnyMemRef:$input);
+} 
+
+def KrnlPrintOp : Op<Krnl_Dialect, "print", [MemRefsNormalizable]> {
+  let summary = "Print a value.";
+  let description = [{
+    This operation can be used to print the input value. The user needs to provide a 
+    format string (à la printf) to specify how to print the input value. 
+    If the input value is not specified the operator will print the format string.
+  }];
+
+  let arguments = (ins StrAttr:$format, Optional<AnyType>:$input);
+} 

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -364,9 +364,12 @@ struct KrnlBuilder : public DialectBuilder {
   void memset(Value dest, Value val) const;
   Value strncmp(Value str1, Value str2, Value len) const;
   Value strlen(Value str) const;
+  void printf(StringRef msg) const;
+  void printf(StringRef msg, Value input, Type inputType) const;
 
   // Onnx-mlir runtime functions.
   Value findIndex(Value input, Value G, Value V, Value len) const;
+  void printTensor(StringRef msg, Value input) const;
 };
 
 // Recursive class specialized for KrnlBuilder refereed to as krnl.

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -15,6 +15,7 @@
 
 #ifdef __cplusplus
 #include <cassert>
+#include <complex>
 #include <map>
 #include <numeric>
 #include <random>
@@ -23,6 +24,7 @@
 #include <vector>
 #else
 #include <assert.h>
+#include <complex.h>
 #endif
 
 #if defined(__APPLE__) || defined(__MVS__)
@@ -112,11 +114,78 @@ struct OMTensor {
 };
 
 /* Helper function to compute the number of data elements */
-static inline int64_t getNumElems(int64_t *shape, int64_t rank) {
+static inline int64_t getNumElems(const int64_t *shape, int64_t rank) {
   int64_t numElem = 1;
   for (int64_t i = 0; i < rank; i++)
     numElem *= shape[i];
   return numElem;
+}
+
+/* Helper function to get the ONNX data type C name string */
+static inline const char *getDataTypeName(OM_DATA_TYPE dataType) {
+  return OM_DATA_TYPE_NAME[dataType];
+}
+
+/* Helper function to print an element of a tensor */
+static inline void printElement(
+    void *dataPtr, int64_t elemOffset, OM_DATA_TYPE dataType) {
+  assert(dataPtr && "Expecting a valid data pointer");
+  assert(elemOffset >= 0 && "Expecting a valid element offset");
+
+  switch (dataType) {
+  case ONNX_TYPE_BOOL:
+    printf("%d", ((bool *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_UINT8:
+    printf("%hhu", ((uint8_t *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_INT8:
+    printf("%hhd", ((int8_t *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_UINT16:
+    printf("%hu", ((uint16_t *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_INT16:
+    printf("%hd", ((int16_t *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_UINT32:
+    printf("%u", ((uint32_t *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_INT32:
+    printf("%d", ((int32_t *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_UINT64:
+    printf("%llu", (unsigned long long)((uint64_t *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_INT64:
+    printf("%lld", (long long)((int64_t *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_FLOAT:
+    printf("%g", ((float *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_DOUBLE:
+    printf("%g", ((double *)dataPtr)[elemOffset]);
+    break;
+  case ONNX_TYPE_STRING:
+    printf("%s", ((const char **)dataPtr)[elemOffset]);
+    break;
+  default:
+    assert(false && "unexpected data type");
+  }
+}
+
+/* Helper function to compute the inner product of 2 arrays (of equal size) */
+static inline int64_t inner_product(
+    const int64_t v[], const int64_t u[], int64_t len, int64_t init) {
+  int64_t result = init;
+  for (int64_t i = 0; i < len; i++)
+    result += v[i] * u[i];
+  return result;
+}
+
+static inline int64_t computeElemOffset(
+    const int64_t strides[], const int64_t indexes[], int64_t rank) {
+  return inner_product(strides, indexes, rank, 0ll);
 }
 
 // Create a OMTensor.
@@ -344,6 +413,80 @@ void *omTensorGetAllocatedPtr(const OMTensor *tensor) {
   return tensor->_allocatedPtr;
 }
 
+void omTensorPrint(const char *msg, const OMTensor *tensor) {
+  assert(tensor && "attempt to print a null OMTensor");
+
+  const OM_DATA_TYPE dataType = omTensorGetDataType(tensor);
+  const int64_t rank = omTensorGetRank(tensor);
+  const int64_t *shape = omTensorGetShape(tensor);
+  const int64_t *strides = omTensorGetStrides(tensor);
+  void *dataPtr = omTensorGetDataPtr(tensor);
+
+  if (msg)
+    printf("%s", msg);
+
+  printf("\trank = %lld\n", (long long)rank);
+  printf("\tdataType = %s\n", getDataTypeName(dataType));
+  printf("\tnumElems = %lld\n", (long long)omTensorGetNumElems(tensor));
+  printf("\tstrides: ");
+  for (int64_t i = 0; i < rank; i++)
+    printf("[%lld]", (long long)strides[i]);
+  printf("\n");
+
+  printf("\tdata: ([");
+  switch (rank) {
+  case 1:
+    for (int64_t i = 0; i < shape[0]; ++i) {
+      if (i)
+        printf(", ");
+      int64_t indexes[] = {i};
+      int64_t elemOffset = computeElemOffset(tensor->_strides, indexes, rank);
+      printElement(dataPtr, elemOffset, dataType);
+    }
+    break;
+  case 2:
+    for (int64_t i = 0; i < shape[0]; ++i) {
+      if (i)
+        printf(", ");
+      printf("[");
+      for (int64_t j = 0; j < shape[1]; ++j) {
+        if (j)
+          printf(", ");
+        int64_t indexes[] = {i, j};
+        int64_t elemOffset = computeElemOffset(tensor->_strides, indexes, rank);
+        printElement(dataPtr, elemOffset, dataType);
+      }
+      printf("]");
+    }
+    break;
+  case 3:
+    for (int64_t i = 0; i < shape[0]; ++i) {
+      if (i)
+        printf(", ");
+      printf("[");
+      for (int64_t j = 0; j < shape[1]; ++j) {
+        if (j)
+          printf(", ");
+        printf("[");
+        for (int64_t k = 0; k < shape[2]; ++k) {
+          if (k)
+            printf(", ");
+          int64_t indexes[] = {i, j, k};
+          int64_t elemOffset =
+              computeElemOffset(tensor->_strides, indexes, rank);
+          printElement(dataPtr, elemOffset, dataType);
+        }
+        printf("]");
+      }
+      printf("]");
+    }
+    break;
+  default:
+    assert(false && "not implemented");
+  }
+  printf("])\n");
+}
+
 #ifdef __cplusplus
 /* For C++ methods, which are not used in the time critical runtime,
  * asserts are present to ensure that we do not perform a null ptr access.
@@ -351,7 +494,7 @@ void *omTensorGetAllocatedPtr(const OMTensor *tensor) {
 
 /* OMTensor creator with data shape and element type  */
 template <typename T>
-OMTensor *omTensorCreateWithShape(std::vector<int64_t> shape) {
+OMTensor *omTensorCreateWithShape(const std::vector<int64_t> &shape) {
   /* Create a OMTensor with data shape and strides allocated */
   auto omt = omTensorCreateUntyped(shape.size());
   if (omt == NULL)
@@ -392,7 +535,7 @@ OMTensor *omTensorCreateWithShape(std::vector<int64_t> shape) {
 /* OMTensor creator with data shape, element type and random data */
 template <typename T>
 OMTensor *omTensorCreateWithRandomData(
-    std::vector<int64_t> shape, T lbound, T ubound) {
+    const std::vector<int64_t> &shape, T lbound, T ubound) {
   // Will be used to obtain a seed for the random number engine
   std::random_device rd;
   // Standard mersenne_twister_engine seeded with rd()
@@ -411,7 +554,7 @@ OMTensor *omTensorCreateWithRandomData(
 
 /* Access an element (by reference) at offset computed by index array */
 template <typename T>
-T &omTensorGetElem(const OMTensor *omt, std::vector<int64_t> indexes) {
+T &omTensorGetElem(const OMTensor *omt, const std::vector<int64_t> &indexes) {
   assert(omt && "attempt to access element of null OMTensor");
   int64_t elemOffset = omTensorComputeElemOffset(omt, indexes);
   return ((T *)omt->_alignedPtr)[elemOffset];
@@ -432,7 +575,7 @@ std::vector<int64_t> omTensorComputeStridesFromShape(const OMTensor *omt) {
 
 /* Compute linear element offset from multi-dimensional index array */
 int64_t omTensorComputeElemOffset(
-    const OMTensor *omt, std::vector<int64_t> &indexes) {
+    const OMTensor *omt, const std::vector<int64_t> &indexes) {
   assert(omt && "attempt to access element of null OMTensor");
   return computeElemOffset(omt->_strides, omt->_rank, indexes);
 }
@@ -529,30 +672,34 @@ inline bool omTensorAreTwoOmtsClose(
 
 // Explicit instantiation of all templated API functions.
 
-template OMTensor *omTensorCreateWithShape<int32_t>(std::vector<int64_t> shape);
-template OMTensor *omTensorCreateWithShape<int64_t>(std::vector<int64_t> shape);
-template OMTensor *omTensorCreateWithShape<float>(std::vector<int64_t> shape);
-template OMTensor *omTensorCreateWithShape<double>(std::vector<int64_t> shape);
+template OMTensor *omTensorCreateWithShape<int32_t>(
+    const std::vector<int64_t> &shape);
+template OMTensor *omTensorCreateWithShape<int64_t>(
+    const std::vector<int64_t> &shape);
+template OMTensor *omTensorCreateWithShape<float>(
+    const std::vector<int64_t> &shape);
+template OMTensor *omTensorCreateWithShape<double>(
+    const std::vector<int64_t> &shape);
 
 template OMTensor *omTensorCreateWithRandomData<int32_t>(
-    std::vector<int64_t> shape, int32_t lbound, int32_t ubound);
+    const std::vector<int64_t> &shape, int32_t lbound, int32_t ubound);
 template OMTensor *omTensorCreateWithRandomData<int64_t>(
-    std::vector<int64_t> shape, int64_t lbound, int64_t ubound);
+    const std::vector<int64_t> &shape, int64_t lbound, int64_t ubound);
 template OMTensor *omTensorCreateWithRandomData<float>(
-    std::vector<int64_t> shape, float lbound, float ubound);
+    const std::vector<int64_t> &shape, float lbound, float ubound);
 template OMTensor *omTensorCreateWithRandomData<double>(
-    std::vector<int64_t> shape, double lbound, double ubound);
+    const std::vector<int64_t> &shape, double lbound, double ubound);
 
 template bool &omTensorGetElem<bool>(
-    const OMTensor *, std::vector<int64_t> indexes);
+    const OMTensor *, const std::vector<int64_t> &indexes);
 template int32_t &omTensorGetElem<int32_t>(
-    const OMTensor *, std::vector<int64_t> indexes);
+    const OMTensor *, const std::vector<int64_t> &indexes);
 template int64_t &omTensorGetElem<int64_t>(
-    const OMTensor *, std::vector<int64_t> indexes);
+    const OMTensor *, const std::vector<int64_t> &indexes);
 template float &omTensorGetElem<float>(
-    const OMTensor *, std::vector<int64_t> indexes);
+    const OMTensor *, const std::vector<int64_t> &indexes);
 template double &omTensorGetElem<double>(
-    const OMTensor *, std::vector<int64_t> indexes);
+    const OMTensor *, const std::vector<int64_t> &indexes);
 
 template int32_t &omTensorGetElemByOffset<int32_t>(
     const OMTensor *, int64_t index);
@@ -571,4 +718,4 @@ template bool omTensorAreTwoOmtsClose<float>(
     const OMTensor *a, const OMTensor *b, float rtol, float atol);
 template bool omTensorAreTwoOmtsClose<double>(
     const OMTensor *a, const OMTensor *b, float rtol, float atol);
-#endif
+#endif // __cplusplus

--- a/src/Runtime/OMTensorHelper.h
+++ b/src/Runtime/OMTensorHelper.h
@@ -36,7 +36,7 @@ static inline std::vector<std::vector<int64_t>> CartProduct(
 
 /* Helper function to compute data strides from sizes */
 static inline std::vector<int64_t> computeStridesFromShape(
-    int64_t *dataSizes, int rank) {
+    const int64_t *dataSizes, int rank) {
   // Shift dimension sizes one to the left, fill in the vacated rightmost
   // element with 1; this gets us a vector that'll be more useful for computing
   // strides of memory access along each dimension using prefix product (aka
@@ -54,17 +54,15 @@ static inline std::vector<int64_t> computeStridesFromShape(
 /* Helper function to compute linear offset from a multi-dimensional index array
  */
 static inline int64_t computeElemOffset(
-    int64_t *dataStrides, int rank, std::vector<int64_t> &indexes) {
-  auto dimStrides = std::vector<int64_t>(dataStrides, dataStrides + rank);
-  int64_t elemOffset = inner_product(
-      indexes.begin(), indexes.end(), dimStrides.begin(), (int64_t)0);
-  return elemOffset;
+    const int64_t *dataStrides, int rank, const std::vector<int64_t> &indexes) {
+  std::vector<int64_t> dimStrides(dataStrides, dataStrides + rank);
+  return inner_product(indexes.begin(), indexes.end(), dimStrides.begin(), 0);
 }
 
 /* Helper function to print a vector with delimiter */
 template <typename T>
-static inline void printVector(std::vector<T> vec, std::string _delimiter = ",",
-    std::ostream &stream = std::cout) {
+static inline void printVector(const std::vector<T> &vec,
+    const std::string &_delimiter = ",", std::ostream &stream = std::cout) {
   std::string delimiter;
   for (const auto &elem : vec) {
     stream << delimiter << elem;
@@ -82,7 +80,7 @@ static inline void printVector(std::vector<T> vec, std::string _delimiter = ",",
  * data fields initialized to proper values and data pointers malloc'ed.
  */
 template <typename T>
-OMTensor *omTensorCreateWithShape(std::vector<int64_t> dataSizes);
+OMTensor *omTensorCreateWithShape(const std::vector<int64_t> &dataSizes);
 
 /**
  * OMTensor creator with data sizes, element type and random data
@@ -98,7 +96,7 @@ OMTensor *omTensorCreateWithShape(std::vector<int64_t> dataSizes);
  */
 template <typename T>
 OMTensor *omTensorCreateWithRandomData(
-    std::vector<int64_t> dataSizes, T lbound = -1.0, T ubound = 1.0);
+    const std::vector<int64_t> &dataSizes, T lbound = -1.0, T ubound = 1.0);
 
 /**
  * OMTensor data element getter by offset
@@ -108,7 +106,7 @@ OMTensor *omTensorCreateWithRandomData(
  * @return typed element by reference at the offset computed by the index array.
  */
 template <typename T>
-T &omTensorGetElem(const OMTensor *omt, std::vector<int64_t> indexes);
+T &omTensorGetElem(const OMTensor *omt, const std::vector<int64_t> &indexes);
 
 /**
  * OMTensor data element getter by index
@@ -136,7 +134,7 @@ std::vector<int64_t> omTensorComputeStridesFromShape(const OMTensor *omt);
  * @return linear offset.
  */
 int64_t omTensorComputeElemOffset(
-    const OMTensor *omt, std::vector<int64_t> &indexes);
+    const OMTensor *omt, const std::vector<int64_t> &indexes);
 
 /**
  * OMTensor index set computation

--- a/src/Runtime/OnnxDataType.inc
+++ b/src/Runtime/OnnxDataType.inc
@@ -5,7 +5,16 @@
 #include "onnx-mlir/Runtime/OnnxDataType.h"
 
 const int OM_DATA_TYPE_SIZE[] = {
-#define OM_TYPE_METADATA_DEF(ENUM_NAME, ENUM_VAL, DTYPE_SIZE) DTYPE_SIZE,
+#define OM_TYPE_METADATA_DEF(ENUM_NAME, ENUM_VAL, DTYPE_SIZE, DTYPE_NAME)      \
+  DTYPE_SIZE,
+#include "onnx-mlir/Runtime/OnnxDataTypeMetaData.inc"
+
+#undef OM_TYPE_METADATA_DEF
+};
+
+const char *OM_DATA_TYPE_NAME[] = {
+#define OM_TYPE_METADATA_DEF(ENUM_NAME, ENUM_VAL, DTYPE_SIZE, DTYPE_NAME)      \
+  DTYPE_NAME,
 #include "onnx-mlir/Runtime/OnnxDataTypeMetaData.inc"
 
 #undef OM_TYPE_METADATA_DEF


### PR DESCRIPTION
This PR introduces the ability to generate a call to a runtime function `omTensorPrint` while generating code. This function allows printing the content of the supplied tensor. This is intended as an aid for debugging runtime failures.

To use it write:
``` 
LLVM_DEBUG(llvm::dbgs() << "Input tensor:\n"; create.krnl.printTensor(X););
```

In addition is sometime useful to print a primitive value at some program point in the code generated. For that purpose I have also introduced the `krnlPrintOp` Krnl dialect operator. This operator is lowered to a call to `printf` with the appropriate format specifier for the value to be printed. 

To use it write:
```
create.krnl.printf("inputElem: ", inputElem, elementType);
```

where `inputElem` is the value to be printed, and `elementType` is the type of the value to be printed.