### PR TITLE
Fix the static build of OnnxMlirCompiler lib on Windows and modify the pipeline to build all

### DIFF
--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -94,8 +94,10 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DCMAKE_PREFIX_PATH=%root_dir%\protobuf_install ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
-   -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir
+   -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir ^
+   -DONNX_MLIR_BUILD_TESTS=OFF
 
-call cmake --build . --config Release --target onnx-mlir
+call cmake --build . --config Release
 ```
+
 After the above commands succeed, an `onnx-mlir` executable should appear in the `Debug/bin` or `Release/bin` directory.

--- a/include/OnnxMlirCompiler.h
+++ b/include/OnnxMlirCompiler.h
@@ -19,7 +19,6 @@
 #include <stdint.h>
 #endif // #ifdef __cplusplus
 
-
 #ifdef ONNX_MLIR_BUILT_AS_STATIC
 #define ONNX_MLIR_EXPORT
 #define ONNX_MLIR_NO_EXPORT
@@ -52,8 +51,7 @@ namespace onnx_mlir {
  *  @param envVarName Environment variable name, use default when null.
  *  @return 0 on success or non-zero error code on failure.
  */
-ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromEnv(
-    const char *envVarName);
+ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromEnv(const char *envVarName);
 
 /*!
  *  Define ONNX-MLIR compiler options with options defined by
@@ -106,8 +104,7 @@ ONNX_MLIR_EXPORT int64_t omSetCompilerOption(
  *  @param kind Describe which option kind is being set.
  *  @return Value of compiler option.
  */
-ONNX_MLIR_EXPORT const char *omGetCompilerOption(
-    const OptionKind kind);
+ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind);
 
 /*!
  *  Compile an onnx model from a file containing MLIR or ONNX protobuf.

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -69,3 +69,7 @@ add_onnx_mlir_library(OnnxMlirCompiler
   LINK_LIBS PRIVATE
   CompilerUtils
   )
+
+if (NOT BUILD_SHARED_LIBS)
+  target_compile_definitions(OnnxMlirCompiler PUBLIC OnnxMlirCompiler_EXPORTS)
+endif()

--- a/utils/build-onnx-mlir.cmd
+++ b/utils/build-onnx-mlir.cmd
@@ -7,7 +7,7 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DCMAKE_PREFIX_PATH=%root_dir%\protobuf_install ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
-   -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir
+   -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir ^
    -DONNX_MLIR_BUILD_TESTS=OFF
 
 call cmake --build . --config Release

--- a/utils/build-onnx-mlir.cmd
+++ b/utils/build-onnx-mlir.cmd
@@ -8,5 +8,6 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
    -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir
+   -DONNX_MLIR_BUILD_TESTS=OFF
 
-call cmake --build . --config Release --target onnx-mlir
+call cmake --build . --config Release


### PR DESCRIPTION
The OnnxMlirCompiler static build was treating the export functions incorrectly - this change sets up the build to properly determine when they should be exported or not based on whether the libraries are built as static or shared libs.

It also now builds the `all` target in the Windows-CI.