### PR TITLE
Force check-doc to use Python3_EXECUTABLE

### DIFF
--- a/docs/doc_check/CMakeLists.txt
+++ b/docs/doc_check/CMakeLists.txt
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
+set(check_cmd ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check.py)
+
 add_custom_target(check-doc
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check.py
+  COMMAND ${check_cmd}
     ${ONNX_MLIR_SRC_ROOT}
     --exclude_dirs
       third_party
       docs/doc_check/test
       docs/_site
-      )
+  COMMAND ${check_cmd} ${CMAKE_BINARY_DIR}
+  )
 
 set_target_properties(check-doc PROPERTIES FOLDER "Docs")
 # Exclude the target from the default VS build

--- a/src/Builder/CMakeLists.txt
+++ b/src/Builder/CMakeLists.txt
@@ -14,3 +14,8 @@ add_onnx_mlir_library(OMBuilder
   OMResultTypeInferenceOpInterface
   onnx
   )
+
+configure_file(OpBuildTable.inc.dc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/OpBuildTable.inc.dc
+  @ONLY
+  )

--- a/src/Builder/OpBuildTable.inc.dc
+++ b/src/Builder/OpBuildTable.inc.dc
@@ -1,1 +1,0 @@
-file-same-as-stdout({"file": "src/Builder/OpBuildTable.inc", "cmd": ["python3", "utils/gen_onnx_mlir.py", "--dry-run-op-build-table"]})

--- a/src/Builder/OpBuildTable.inc.dc.in
+++ b/src/Builder/OpBuildTable.inc.dc.in
@@ -1,0 +1,1 @@
+file-same-as-stdout({"file": "@CMAKE_CURRENT_SOURCE_DIR@/OpBuildTable.inc", "cmd": ["@Python3_EXECUTABLE@", "@CMAKE_SOURCE_DIR@/utils/gen_onnx_mlir.py", "--dry-run-op-build-table"]})

--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -62,3 +62,8 @@ add_onnx_mlir_library(OMONNXOps
   MLIRAffine
   MLIRSCF
   )
+
+configure_file(ONNXOps.td.inc.dc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/ONNXOps.td.inc.dc
+  @ONLY
+  )

--- a/src/Dialect/ONNX/ONNXOps.td.inc.dc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc.dc
@@ -1,1 +1,0 @@
-file-same-as-stdout({"file": "src/Dialect/ONNX/ONNXOps.td.inc", "cmd": ["python3", "utils/gen_onnx_mlir.py", "--dry-run-onnx-ops"]})

--- a/src/Dialect/ONNX/ONNXOps.td.inc.dc.in
+++ b/src/Dialect/ONNX/ONNXOps.td.inc.dc.in
@@ -1,0 +1,1 @@
+file-same-as-stdout({"file": "@CMAKE_CURRENT_SOURCE_DIR@/ONNXOps.td.inc", "cmd": ["@Python3_EXECUTABLE@", "@CMAKE_SOURCE_DIR@/utils/gen_onnx_mlir.py", "--dry-run-onnx-ops"]})


### PR DESCRIPTION
In our team's subtree-merge of onnx-mlir, we configure a venv to give us precise control over the python configuration without messing with the system/user python install. The check-doc target fails in this mode, because it defaults to the python in the path. There are a couple of ways to resolve this: one would be to run the tests with 'cmake -E env' and inject the python dir at the head of the PATH. This has insidious potential side effects, as the test will always run with the value of PATH as it was at configure time. Subsequent changes to the PATH in a shell window will have no effect without rebuilding the cmake cache, and then _those_ changes will persist until the next cache rebuild.

The other approach, which is what I've implemented here, is to render the doc-check file as cmake templates via configure_file. While slightly more complex from an implementation point of view, it is more robust and the results more predictable.