### PR TITLE
Remove explicit verifier usage as it is about to be obsolete

### DIFF
--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -19,6 +19,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Dialect/Shape/IR/ShapeBase.td"
+include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
@@ -42,8 +43,8 @@ def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
     intend to optimize.
   }];
 
-  let arguments = (ins);
   let results = (outs Variadic<AnyType>);
+
   let skipDefaultBuilders = 1;
   let builders = [ OpBuilder<(ins "int64_t":$num_loops)> ];
 
@@ -53,14 +54,14 @@ def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
   let extraClassDeclaration = [{
     static StringRef getNumLoopsAttrName() { return "num_loops"; }
 
-  // Helper function to extract the number of loops being defined.
-  int64_t getNumLoops() {
-    auto num_loops = (*this)->getAttrOfType<IntegerAttr>(getNumLoopsAttrName())
-                         .getValue()
-                         .getSExtValue();
-    return num_loops;
-  }
-}];
+    // Helper function to extract the number of loops being defined.
+    int64_t getNumLoops() {
+      auto num_loops = (*this)->getAttrOfType<IntegerAttr>(getNumLoopsAttrName())
+                           .getValue()
+                           .getSExtValue();
+      return num_loops;
+    }
+  }];
 }
 
 def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator,
@@ -88,7 +89,9 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator,
   }];
 
   let arguments = (ins Variadic<AnyType>);
+
   let regions = (region SizedRegion<1>:$bodyRegion);
+
   let skipDefaultBuilders = 1;
   let builders = [
     // Main builder.
@@ -106,7 +109,12 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator,
       CArg<"ArrayRef<IndexExpr>">:$lbs, CArg<"ArrayRef<IndexExpr>">:$ubs, 
       CArg<"ValueRange">:$iterArgs,
       CArg<"function_ref<void(OpBuilder &, Location, ValueRange)>">:$bodyBuilderFn)>
- ];
+  ];
+
+  let printer = [{ return ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     // In krnl.iterate operation, operands are stored as such
@@ -127,11 +135,7 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator,
 
     // Get name of the attribute for storing bound represented using affine maps.
       static StringRef getBoundsAttrName() { return "bounds"; }
-    }];
-
-    let printer = [{ return ::print(p, *this); }];
-    let parser = [{ return ::parse$cppClass(parser, result); }];
-    let verifier = [{ return ::verify(*this); }];
+  }];
 }
 
 def KrnlTerminatorOp : Op<Krnl_Dialect, "terminate", [Terminator]> {
@@ -148,9 +152,6 @@ def KrnlTerminatorOp : Op<Krnl_Dialect, "terminate", [Terminator]> {
   // No custom parsing/printing form.
   let parser = ?;
   let printer = ?;
-
-  // Fully specified by traits.
-  let verifier = ?;
 }
 
 def KrnlEntryPointOp : Op<Krnl_Dialect, "entry_point"> {
@@ -223,6 +224,9 @@ def KrnlGetRefOp : Op<Krnl_Dialect, "getref", [MemRefsNormalizable]> {
     }]>,
     ];
 
+  let parser = ?;
+  let printer = ?;
+
   let extraClassDeclaration = [{
     /// Returns the symbolic operands (the ones in square brackets), which bind
     /// to the symbols of the memref's layout map.
@@ -230,9 +234,6 @@ def KrnlGetRefOp : Op<Krnl_Dialect, "getref", [MemRefsNormalizable]> {
       return {operand_begin() + 2, operand_end()};
     }
   }];
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlBlockOp : Op<Krnl_Dialect, "block"> {
@@ -243,9 +244,9 @@ def KrnlBlockOp : Op<Krnl_Dialect, "block"> {
     means to block the for loop referred to by %i using a tile size of 4.
   }];
 
-  let arguments = (ins
-    AnyType:$loop, I64Attr:$tile_size);
+  let arguments = (ins AnyType:$loop, I64Attr:$tile_size);
   let results = (outs AnyType:$loop_block, AnyType:$loop_local);
+
   let builders = [ OpBuilder<(ins "Value": $loop, "int64_t":$tile_size)> ];
   let assemblyFormat = [{
       $loop $tile_size attr-dict `:` functional-type($loop, results)
@@ -312,7 +313,7 @@ def KrnlPermuteOp : Op<Krnl_Dialect, "permute"> {
   }];
 
   let arguments = (ins Variadic<AnyType>:$loops, I64ArrayAttr:$map);
-  let results = (outs);
+
   let builders = [ OpBuilder<(ins "ValueRange": $loops, "ArrayRef<int64_t>":$map)> ];
   let assemblyFormat = [{
       `(` $loops `)` $map attr-dict `:` type($loops)
@@ -330,7 +331,7 @@ def KrnlUnrollOp : Op<Krnl_Dialect, "unroll"> {
   }];
 
   let arguments = (ins AnyType:$loop);
-  let results = (outs);
+
   let assemblyFormat = [{
       $loop attr-dict `:` type($loop)
   }];
@@ -507,6 +508,8 @@ def KrnlLoadOp : Op<Krnl_Dialect, "load",
       $_state.types.push_back(memrefType.getElementType());
     }]>];
 
+  let assemblyFormat = [{$memref `[` $indices `]` attr-dict `:` type($memref)}];
+
   let extraClassDeclaration = [{
     Value getMemRef() { return getOperand(0); }
     void setMemRef(Value value) { setOperand(0, value); }
@@ -516,8 +519,6 @@ def KrnlLoadOp : Op<Krnl_Dialect, "load",
 
     operand_range getIndices() { return {operand_begin() + 1, operand_end()}; }
   }];
-
-  let assemblyFormat = [{$memref `[` $indices `]` attr-dict `:` type($memref)}];
 }
 
 def KrnlStoreOp : Op<Krnl_Dialect, "store",
@@ -544,6 +545,10 @@ def KrnlStoreOp : Op<Krnl_Dialect, "store",
       $_state.addOperands(memref);
     }]>];
 
+  let assemblyFormat = [{
+    $value `,` $memref `[` $indices `]` attr-dict `:` type($memref)
+  }];
+
   let extraClassDeclaration = [{
       Value getValueToStore() { return getOperand(0); }
 
@@ -556,10 +561,6 @@ def KrnlStoreOp : Op<Krnl_Dialect, "store",
       operand_range getIndices() {
         return {operand_begin() + 2, operand_end()};
       }
-  }];
-
-  let assemblyFormat = [{
-    $value `,` $memref `[` $indices `]` attr-dict `:` type($memref)
   }];
 }
 
@@ -575,8 +576,6 @@ def KrnlMovableOp : Op<Krnl_Dialect, "movable", [ImplicitKrnlTerminator]> {
      This construct is particularly helpful, for example, for lowering statements that
      are nested imperfectly between an "eager" and a "lazy" loop.
   }];
-
-  let arguments = (ins );
 
   let regions = (region AnyRegion:$region);
 
@@ -600,6 +599,7 @@ def KrnlGetInductionVariableValueOp : Op<Krnl_Dialect, "get_induction_var_value"
 
   let arguments = (ins Variadic<AnyType> : $loops);
   let results = (outs Variadic<AnyType> : $ind_var_vals);
+
   let builders = [ OpBuilder<(ins "ValueRange": $loops)>];
 
   let assemblyFormat = [{
@@ -611,7 +611,7 @@ def KrnlGetInductionVariableValueOp : Op<Krnl_Dialect, "get_induction_var_value"
 // =============================================================================
 
 def KrnlVectorTypeCastOp : Op<Krnl_Dialect, "vector_type_cast", [NoSideEffect,
-    MemRefsNormalizable, ViewLikeOpInterface]> {
+    MemRefsNormalizable, DeclareOpInterfaceMethods<CastOpInterface>, ViewLikeOpInterface]> {
   let summary = "vector type cast operation";
   let description = [{
     The "vector_type_cast" operation converts a memref from an non-vector
@@ -627,23 +627,6 @@ def KrnlVectorTypeCastOp : Op<Krnl_Dialect, "vector_type_cast", [NoSideEffect,
   let arguments = (ins AnyMemRef:$source);
   let results = (outs AnyMemRef:$result);
 
-  let parser = ?;
-  let printer = ?;
-
-  let verifier = [{ return impl::verifyCastOp(*this, areCastCompatible); }];
-
-  let extraClassDeclaration = [{
-    /// Return true if `a` and `b` are valid operand and result pairs for
-    /// the operation.
-    static bool areCastCompatible(Type a, Type b);
-
-    /// The result of a vector_type_cast is always a memref.
-    MemRefType getType() { return getResult().getType().cast<MemRefType>(); }
-
-    /// Return the view source.
-    Value getViewSource() { return source(); }
-  }];
-
   let hasFolder = 1;
   let builders = [ OpBuilder<(ins "Value": $source, "int64_t": $vectorLen)> ];
 
@@ -651,6 +634,13 @@ def KrnlVectorTypeCastOp : Op<Krnl_Dialect, "vector_type_cast", [NoSideEffect,
     $source attr-dict `:` type($source) `to` type($result)
   }];
 
+  let extraClassDeclaration = [{
+    /// The result of a vector_type_cast is always a memref.
+    MemRefType getType() { return getResult().getType().cast<MemRefType>(); }
+
+    /// Return the view source.
+    Value getViewSource() { return source(); }
+  }];
 }
 
 // =============================================================================
@@ -663,7 +653,6 @@ def KrnlSpecializedKernel : Op<Krnl_Dialect, "specialized_kernel",
   }];
 
   let arguments = (ins Variadic<AnyType> : $loops);
-  let results = (outs );
 
   let assemblyFormat = [{
       `(` $loops `)` attr-dict `:` type($loops)
@@ -841,7 +830,7 @@ def KrnlMatMulOp : Op<Krnl_Dialect, "matmul", [AttrSizedOperandSegments,
       "bool": $overcompute)>
     ];
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     $A `[` $aMemStart `]` `,`
@@ -922,8 +911,9 @@ def KrnlCopyToBufferOp : Op<Krnl_Dialect, "copy_to_tile_buffer", [
       "bool": $transpose)>
   ];
 
-  let verifier = [{ return ::verify(*this); }];
-    let assemblyFormat = [{
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
     $buffer `,` $source `[` $starts `]` `,`  $padValue  attr-dict
      `:` type($buffer) `,` type($source)
   }];
@@ -955,8 +945,9 @@ def KrnlCopyFromBufferOp : Op<Krnl_Dialect, "copy_from_tile_buffer",
     OpBuilder<(ins "Value": $buffer, "Value": $dest, "ValueRange": $starts)>
   ];
 
-  let verifier = [{ return ::verify(*this); }];
-    let assemblyFormat = [{
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
     $buffer `,` $dest `[` $starts `]`  attr-dict `:` type($buffer) `,` type($dest)
   }];
 }
@@ -984,6 +975,7 @@ def KrnlMemsetOp : Op<Krnl_Dialect, "memset", [MemRefsNormalizable,
   }];
 
   let arguments = (ins AnyMemRef:$dest, AnyType: $value); 
+
   let assemblyFormat = [{ $dest `,` $value attr-dict `:` type($dest) }];
 }
 
@@ -1019,8 +1011,6 @@ def KrnlRandomNormalOp : Op<Krnl_Dialect, "random_normal",
     AnyFloat:$mean,
     AnyFloat:$scale,
     AnyFloat:$seed);
-
-  let results = (outs );
 }
 
 def KrnlFindIndexOp : Op<Krnl_Dialect, "find_index",

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -495,7 +495,8 @@ void KrnlVectorTypeCastOp::build(OpBuilder &builder, OperationState &state,
   build(builder, state, resultType, sourceMemRef);
 }
 
-bool KrnlVectorTypeCastOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
+bool KrnlVectorTypeCastOp::areCastCompatible(
+    TypeRange inputs, TypeRange outputs) {
   if (inputs.size() != 1 || outputs.size() != 1)
     return false;
   Type a = inputs.front(), b = outputs.front();

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -4,7 +4,7 @@ include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 
 def ONNXCustomOp:ONNX_Op<"Custom",
-  [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
+    [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
   let summary = "ONNX Custom operation";
   let description = [{
   "Allow call-out to a user defined operation. A single attribute"
@@ -12,8 +12,10 @@ def ONNXCustomOp:ONNX_Op<"Custom",
   "passed to the user operation."
   "The number of inputs and outputs can vary."
   }];
+
   let arguments = (ins Variadic<AnyTypeOf<[AnyTensor, AnyMemRef]>>:$input, StrAttr:$function_name);
   let results = (outs Variadic<AnyTypeOf<[AnyTensor, AnyMemRef]>>:$outputs);
+
   let extraClassDeclaration = [{
     static int getNumberOfOperands() {
       return -1;
@@ -49,9 +51,7 @@ def ONNXCallOp : ONNX_Op<"ONNX_Call",
   // TODO I would rather have <anyTypeOf<AnyTensor>> here, but the testcase for CustomOps supplies an empty parameter which fails that test --
   //will try to figure out why and revert, leaving this old style as a reminder
   //let results = (outs Variadic<AnyType>);
-
   let results = (outs Variadic<AnyTypeOf<[AnyTensor]>>);
-
 
   let builders = [
     OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
@@ -75,6 +75,10 @@ def ONNXCallOp : ONNX_Op<"ONNX_Call",
             results, operands);
     }]>];
 
+  let assemblyFormat = [{
+    $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
+  }];
+
   let extraClassDeclaration = [{
     StringRef getCallee() { return callee(); }
     StringAttr getCalleeAttr() { return calleeAttr().getAttr(); }
@@ -93,10 +97,4 @@ def ONNXCallOp : ONNX_Op<"ONNX_Call",
       return (*this)->getAttrOfType<SymbolRefAttr>("callee");
     }
   }];
-
-  let assemblyFormat = [{
-    $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
-  }];
-  let verifier = ?;
 }
-

--- a/src/Dialect/ONNX/ONNX.td
+++ b/src/Dialect/ONNX/ONNX.td
@@ -51,7 +51,7 @@ def ONNX_Dialect : Dialect {
 //   * The mnemonic for the operation, or the name without the dialect prefix.
 //   * A list of traits for the operation.
 class ONNX_Op<string mnemonic, list<Trait> traits = []> :
-    Op<ONNX_Dialect, mnemonic, traits> ;
+  Op<ONNX_Dialect, mnemonic, traits> ;
 
 //===----------------------------------------------------------------------===//
 // ONNX Operations
@@ -84,10 +84,11 @@ def ONNXEntryPointOp: ONNX_Op<"EntryPoint"> {
   let description = [{
     The "onnx.EntryPoint" function indicates the main entry point of ONNX model.
   }];
+
   let arguments = (ins SymbolRefAttr:$func,
-           I32Attr:$numInputs,
-           I32Attr:$numOutputs,
-           StrAttr:$signature);
+                       I32Attr:$numInputs,
+                       I32Attr:$numOutputs,
+                       StrAttr:$signature);
 
   let builders = [OpBuilder<(ins "FuncOp":$function, "int":$numInputs,
                                  "int":$numOutputs, "std::string":$signature)>];
@@ -142,27 +143,29 @@ def ONNXMaxPoolSingleOutOp: ONNX_Op<"MaxPoolSingleOut",
     "ONNX MaxPool operation with a single output."
     "See ONNXMaxPoolOp for a full description of the MaxPool semantics."
   }];
+
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
-           DefaultValuedStrAttr<StrAttr, "NOTSET">:$auto_pad,
-           DefaultValuedAttr<SI64Attr, "0">:$ceil_mode,
-           OptionalAttr<I64ArrayAttr>:$dilations,
-           DefaultValuedAttr<I64ArrayAttr, "{}">:$kernel_shape,
-           OptionalAttr<I64ArrayAttr>:$pads,
-           DefaultValuedAttr<SI64Attr, "0">:$storage_order,
-           OptionalAttr<I64ArrayAttr>:$strides);
+                       DefaultValuedStrAttr<StrAttr, "NOTSET">:$auto_pad,
+                       DefaultValuedAttr<SI64Attr, "0">:$ceil_mode,
+                       OptionalAttr<I64ArrayAttr>:$dilations,
+                       DefaultValuedAttr<I64ArrayAttr, "{}">:$kernel_shape,
+                       OptionalAttr<I64ArrayAttr>:$pads,
+                       DefaultValuedAttr<SI64Attr, "0">:$storage_order,
+                       OptionalAttr<I64ArrayAttr>:$strides);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
+
+  let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     static int getNumberOfOperands() { return 1; }
     static int getNumberOfResults() { return 1; }
     static std::vector<int> getTypeMap() { return {20}; }
   }];
-  let verifier = [{ return ::verify(*this); }];
 }
 
 def ONNXBatchNormalizationInferenceModeOp: ONNX_Op<"BatchNormalizationInferenceMode",
     [NoSideEffect, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
   let summary = "ONNX BatchNormalization operation in test mode";
-  let hasCanonicalizer = 1;
   let description = [{
     "Carries out batch normalization as described in the paper"
     "https://arxiv.org/abs/1502.03167. Depending on the mode it is being run,"
@@ -175,14 +178,18 @@ def ONNXBatchNormalizationInferenceModeOp: ONNX_Op<"BatchNormalizationInferenceM
     "to flatten the input shape to (N x C*D1*D2 ..*Dn) before a BatchNormalization Op."
     "This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted."
   }];
+
   let arguments = (ins AnyTypeOf<[AnyMemRef, AnyTensor]>:$X,
-           AnyTypeOf<[AnyMemRef, AnyTensor]>:$scale,
-           AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
-           AnyTypeOf<[AnyMemRef, AnyTensor]>:$mean,
-           AnyTypeOf<[AnyMemRef, AnyTensor]>:$var,
-           DefaultValuedAttr<F32Attr, "1e-05">:$epsilon,
-           DefaultValuedAttr<F32Attr, "0.9">:$momentum);
+                       AnyTypeOf<[AnyMemRef, AnyTensor]>:$scale,
+                       AnyTypeOf<[AnyMemRef, AnyTensor]>:$B,
+                       AnyTypeOf<[AnyMemRef, AnyTensor]>:$mean,
+                       AnyTypeOf<[AnyMemRef, AnyTensor]>:$var,
+                       DefaultValuedAttr<F32Attr, "1e-05">:$epsilon,
+                       DefaultValuedAttr<F32Attr, "0.9">:$momentum);
   let results = (outs AnyTypeOf<[AnyMemRef, AnyTensor]>:$o_Y);
+
+  let hasCanonicalizer = 1;
+
   let extraClassDeclaration = [{
     static int getNumberOfOperands() { return 5; }
     static int getNumberOfResults() { return 1; }
@@ -202,6 +209,7 @@ def ONNXNoneOp : ONNX_Op<"NoValue", [ConstantLike, NoSideEffect]> {
 
   let arguments = (ins UnitAttr:$value);
   let results = (outs NoneType:$none_val);
+
   let hasFolder = 1;
   let builders = [
     OpBuilder<(ins),[{ 
@@ -227,6 +235,7 @@ def ONNX_SeqType : ONNX_Type<"Seq", "Seq"> {
   let description = [{
     An list of tensors which may have different shape
   }];
+
   let parameters = (ins "::mlir::ShapedType":$ElementType, "int64_t":$Length);
 
   // Previous implementation did not print/parse the length field

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -2273,38 +2273,38 @@ LogicalResult ONNXAveragePoolOp::inferShapes(
 // MaxPoolSingleOut
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verify(ONNXMaxPoolSingleOutOp op) {
+LogicalResult ONNXMaxPoolSingleOutOp::verify() {
   ONNXMaxPoolSingleOutOpAdaptor operandAdaptor =
-      ONNXMaxPoolSingleOutOpAdaptor(op);
+      ONNXMaxPoolSingleOutOpAdaptor(*this);
 
   // Mandatory and unsupported parameters.
-  if (!op.kernel_shape())
-    return op.emitError("kernel_shape is a mandatory attribute");
+  if (!kernel_shape())
+    return emitOpError("kernel_shape is a mandatory attribute");
   // Get spatial rank from mandatory kernel_shape parameter.
-  int64_t spatialRank = op.kernel_shape().size();
+  int64_t spatialRank = kernel_shape().size();
   if (spatialRank < 1)
-    return op.emitError("Spatial rank must be strictly positive");
+    return emitOpError("Spatial rank must be strictly positive");
   // Not supported for storage order in column major mode.
-  if (op.storage_order() != 0)
-    return op.emitError("Column major storage order not implemented yet");
+  if (storage_order() != 0)
+    return emitOpError("Column major storage order not implemented yet");
 
   // Get operands.
   auto X = operandAdaptor.X();
   if (hasShapeAndRank(X)) {
     auto xShape = X.getType().cast<ShapedType>().getShape();
-    if ((int64_t)xShape.size() - 2 != spatialRank)
-      return op->emitError("Input and kernel shape rank mismatch");
+    if (static_cast<int64_t>(xShape.size()) - 2 != spatialRank)
+      return (*this)->emitError("Input and kernel shape rank mismatch");
   }
 
   // Verify parameters.
   if (failed(verifyKernelShape<ONNXMaxPoolSingleOutOp>(
-          &op, nullptr, op.kernel_shape(), spatialRank)))
+          this, nullptr, kernel_shape(), spatialRank)))
     return failure();
-  if (failed(verifyStrides<ONNXMaxPoolSingleOutOp>(&op, spatialRank)))
+  if (failed(verifyStrides<ONNXMaxPoolSingleOutOp>(this, spatialRank)))
     return failure();
-  if (failed(verifyDilations<ONNXMaxPoolSingleOutOp>(&op, spatialRank)))
+  if (failed(verifyDilations<ONNXMaxPoolSingleOutOp>(this, spatialRank)))
     return failure();
-  if (failed(verifyPadding<ONNXMaxPoolSingleOutOp>(&op, spatialRank)))
+  if (failed(verifyPadding<ONNXMaxPoolSingleOutOp>(this, spatialRank)))
     return failure();
   return success();
 }


### PR DESCRIPTION
Several properties (such as verifier, printer & parser) are going to be obsolete in main mlir soon. This change removes the explicit usage of verifier and instead uses the `hasVerifier` option instead.

Also, some minor whitespace cleanup.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>