### PR TITLE
Update LLVM to commit d7f0083d and remove explicit usage of parser and printer

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -14,7 +14,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b3b129f11f3c09f1f6b43fc9ddf55abdbe98271c && cd ..
+cd llvm-project && git checkout d7f0083dcae45e6bf774af23533a2d5e18aaf253 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -48,7 +48,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b3b129f11f3c09f1f6b43fc9ddf55abdbe98271c && cd ..
+cd llvm-project && git checkout d7f0083dcae45e6bf774af23533a2d5e18aaf253 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -48,8 +48,7 @@ def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
   let skipDefaultBuilders = 1;
   let builders = [ OpBuilder<(ins "int64_t":$num_loops)> ];
 
-  let printer = [{ return ::print(p, *this); }];
-  let parser = [{ return ::parse$cppClass(parser, result); }];
+  let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
     static StringRef getNumLoopsAttrName() { return "num_loops"; }
@@ -111,9 +110,7 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator,
       CArg<"function_ref<void(OpBuilder &, Location, ValueRange)>">:$bodyBuilderFn)>
   ];
 
-  let printer = [{ return ::print(p, *this); }];
-  let parser = [{ return ::parse$cppClass(parser, result); }];
-
+  let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
@@ -148,10 +145,6 @@ def KrnlTerminatorOp : Op<Krnl_Dialect, "terminate", [Terminator]> {
     This operation does _not_ have a custom syntax. However, krnl control
     operations omit the terminator in their custom syntax for brevity.
   }];
-
-  // No custom parsing/printing form.
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlEntryPointOp : Op<Krnl_Dialect, "entry_point"> {
@@ -167,10 +160,6 @@ def KrnlEntryPointOp : Op<Krnl_Dialect, "entry_point"> {
     static StringRef getNumOutputsAttrName() { return "numOutputs"; }
     static StringRef getSignatureAttrName() { return "signature"; }
   }];
-
-  // No custom parsing/printing form.
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlMemcpyOp : Op<Krnl_Dialect, "memcpy", [MemRefsNormalizable]> {
@@ -181,9 +170,6 @@ def KrnlMemcpyOp : Op<Krnl_Dialect, "memcpy", [MemRefsNormalizable]> {
   }];
 
   let arguments = (ins AnyMemRef:$dest, AnyMemRef:$src, AnyInteger:$size);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlGlobalOp : Op<Krnl_Dialect, "global", [NoSideEffect, MemRefsNormalizable]> {
@@ -198,9 +184,6 @@ def KrnlGlobalOp : Op<Krnl_Dialect, "global", [NoSideEffect, MemRefsNormalizable
     StrAttr:$name, OptionalAttr<AnyAttr>:$value, OptionalAttr<I64Attr>:$offset,
     OptionalAttr<I64Attr>:$alignment);
   let results = (outs AnyTypeOf<[AnyMemRef]>:$output);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlGetRefOp : Op<Krnl_Dialect, "getref", [MemRefsNormalizable]> {
@@ -223,9 +206,6 @@ def KrnlGetRefOp : Op<Krnl_Dialect, "getref", [MemRefsNormalizable]> {
       build($_builder, $_state, resultType, mempool, offset, {});
     }]>,
     ];
-
-  let parser = ?;
-  let printer = ?;
 
   let extraClassDeclaration = [{
     /// Returns the symbolic operands (the ones in square brackets), which bind
@@ -353,9 +333,6 @@ def KrnlDimOp : Op<Krnl_Dialect, "dim", [MemRefsNormalizable]> {
 
   let arguments = (ins AnyTypeOf<[AnyMemRef]>:$alloc, Index:$index);
   let results = (outs Index:$dimension);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlShapeOp : Op<Krnl_Dialect, "shape", [MemRefsNormalizable]> {
@@ -370,9 +347,6 @@ def KrnlShapeOp : Op<Krnl_Dialect, "shape", [MemRefsNormalizable]> {
 
   let arguments = (ins AnyTypeOf<[AnyMemRef]>:$alloc);
   let results = (outs AnyTypeOf<[AnyMemRef]>:$shape);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlErfOp : Op<Krnl_Dialect, "erf"> {
@@ -383,9 +357,6 @@ def KrnlErfOp : Op<Krnl_Dialect, "erf"> {
 
   let arguments = (ins AnyFloat:$in);
   let results = (outs AnyFloat:$out);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlAcosOp : Op<Krnl_Dialect, "acos"> {
@@ -396,9 +367,6 @@ def KrnlAcosOp : Op<Krnl_Dialect, "acos"> {
 
   let arguments = (ins AnyFloat:$in);
   let results = (outs AnyFloat:$out);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlAcoshOp : Op<Krnl_Dialect, "acosh"> {
@@ -409,9 +377,6 @@ def KrnlAcoshOp : Op<Krnl_Dialect, "acosh"> {
 
   let arguments = (ins AnyFloat:$in);
   let results = (outs AnyFloat:$out);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlAsinOp : Op<Krnl_Dialect, "asin"> {
@@ -422,9 +387,6 @@ def KrnlAsinOp : Op<Krnl_Dialect, "asin"> {
 
   let arguments = (ins AnyFloat:$in);
   let results = (outs AnyFloat:$out);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlAsinhOp : Op<Krnl_Dialect, "asinh"> {
@@ -435,9 +397,6 @@ def KrnlAsinhOp : Op<Krnl_Dialect, "asinh"> {
 
   let arguments = (ins AnyFloat:$in);
   let results = (outs AnyFloat:$out);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlAtanOp : Op<Krnl_Dialect, "atan"> {
@@ -448,9 +407,6 @@ def KrnlAtanOp : Op<Krnl_Dialect, "atan"> {
 
   let arguments = (ins AnyFloat:$in);
   let results = (outs AnyFloat:$out);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlAtanhOp : Op<Krnl_Dialect, "atanh"> {
@@ -461,9 +417,6 @@ def KrnlAtanhOp : Op<Krnl_Dialect, "atanh"> {
 
   let arguments = (ins AnyFloat:$in);
   let results = (outs AnyFloat:$out);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 def KrnlTanOp : Op<Krnl_Dialect, "tan"> {
@@ -474,9 +427,6 @@ def KrnlTanOp : Op<Krnl_Dialect, "tan"> {
 
   let arguments = (ins AnyFloat:$in);
   let results = (outs AnyFloat:$out);
-
-  let parser = ?;
-  let printer = ?;
 }
 
 

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -86,13 +86,13 @@ void KrnlDefineLoopsOp::build(
       getNumLoopsAttrName(), builder.getI64IntegerAttr(num_loops));
 }
 
-void print(OpAsmPrinter &p, KrnlDefineLoopsOp &op) {
-  auto numLoopAttr =
-      op->getAttrOfType<IntegerAttr>(KrnlDefineLoopsOp::getNumLoopsAttrName());
-  p << ' ' << numLoopAttr.getValue().getSExtValue();
+void KrnlDefineLoopsOp::print(OpAsmPrinter &printer) {
+  auto numLoopAttr = (*this)->getAttrOfType<IntegerAttr>(
+      KrnlDefineLoopsOp::getNumLoopsAttrName());
+  printer << ' ' << numLoopAttr.getValue().getSExtValue();
 }
 
-ParseResult parseKrnlDefineLoopsOp(
+ParseResult KrnlDefineLoopsOp::parse(
     OpAsmParser &parser, OperationState &result) {
   // Parse the attribute indicating number of loops defined.
   IntegerAttr numLoops;
@@ -209,46 +209,47 @@ void KrnlIterateOp::build(OpBuilder &builder, OperationState &result,
   build(builder, result, pack, iterArgs, bodyBuilderFn);
 }
 
-void print(OpAsmPrinter &p, KrnlIterateOp &op) {
-  p << "(";
+void KrnlIterateOp::print(OpAsmPrinter &printer) {
+  printer << "(";
   // Print optimized loops:
-  auto numOptimizedLoops = op.getNumOptimizedLoops();
-  p.printOperands(op.operand_begin(), op.operand_begin() + numOptimizedLoops);
-  p << ") with (";
+  auto numOptimizedLoops = getNumOptimizedLoops();
+  printer.printOperands(operand_begin(), operand_begin() + numOptimizedLoops);
+  printer << ") with (";
 
   // In the event where body region has been lowered, do not print body.
-  if (op.bodyRegion().empty()) {
-    p << ")";
+  if (bodyRegion().empty()) {
+    printer << ")";
     return;
   }
-  auto inductionVars = op.bodyRegion().begin()->getArguments();
+  auto inductionVars = bodyRegion().begin()->getArguments();
   auto boundItr =
-      op->getAttrOfType<ArrayAttr>(KrnlIterateOp::getBoundsAttrName())
+      (*this)
+          ->getAttrOfType<ArrayAttr>(KrnlIterateOp::getBoundsAttrName())
           .getValue()
           .begin();
-  auto operandItr = op.operand_begin() + numOptimizedLoops;
+  auto operandItr = operand_begin() + numOptimizedLoops;
 
   std::string delimiter;
   for (auto &var : inductionVars) {
-    p << delimiter;
-    p.printOperand(*operandItr++);
-    p << " -> ";
-    p.printOperand(var);
-    p << " = ";
+    printer << delimiter;
+    printer.printOperand(*operandItr++);
+    printer << " -> ";
+    printer.printOperand(var);
+    printer << " = ";
     onnx_mlir::printBound(
-        (*boundItr++).cast<AffineMapAttr>(), operandItr, "max", p);
-    p << " to ";
+        (*boundItr++).cast<AffineMapAttr>(), operandItr, "max", printer);
+    printer << " to ";
     onnx_mlir::printBound(
-        (*boundItr++).cast<AffineMapAttr>(), operandItr, "min", p);
+        (*boundItr++).cast<AffineMapAttr>(), operandItr, "min", printer);
     delimiter = ", ";
   }
 
-  p << ")";
-  p.printRegion(op.bodyRegion(), /*printEntryBlockArgs=*/false,
+  printer << ")";
+  printer.printRegion(bodyRegion(), /*printEntryBlockArgs=*/false,
       /*printBlockTerminators=*/false);
 }
 
-ParseResult parseKrnlIterateOp(OpAsmParser &parser, OperationState &result) {
+ParseResult KrnlIterateOp::parse(OpAsmParser &parser, OperationState &result) {
   auto builder = parser.getBuilder();
   auto context = builder.getContext();
   onnx_mlir::KrnlDialectOperandParser operandParser(parser);

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b3b129f11f3c09f1f6b43fc9ddf55abdbe98271c && cd ..
+cd llvm-project && git checkout d7f0083dcae45e6bf774af23533a2d5e18aaf253 && cd ..


### PR DESCRIPTION
This updates LLVM to commit d7f0083d (just about a day ahead from the existing commit) when parser and printer were made obsolete. Then we leverage the new `hasCustomAssemblyFormat` property to replace parser and printer.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>