### PR TITLE
Update gen_onnx_mlir.py to use the new hasVerifier form

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -921,8 +921,9 @@ LogicalResult ONNXSequenceInsertOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXSequenceInsertOp op) {
-  ONNXSequenceInsertOpAdaptor operandAdaptor = ONNXSequenceInsertOpAdaptor(op);
+LogicalResult ONNXSequenceInsertOp::verify() {
+  ONNXSequenceInsertOpAdaptor operandAdaptor =
+      ONNXSequenceInsertOpAdaptor(*this);
 
   // These cast should be guaranteed by default verifier
   Type seqElementType = operandAdaptor.input_sequence()
@@ -935,8 +936,8 @@ static LogicalResult verify(ONNXSequenceInsertOp op) {
   Type elementType2 = insertType.getElementType();
 
   if (elementType1 != elementType2) {
-    return op.emitError("Element types of the tensor in seqence and input "
-                        "have to be the same");
+    return emitError("Element types of the tensor in seqence and input "
+                     "have to be the same");
   }
   return success();
 }
@@ -1862,16 +1863,16 @@ static LogicalResult verifyPadding(T *op, int64_t spatialRank) {
   return success();
 }
 
-static LogicalResult verify(ONNXConvOp op) {
-  ONNXConvOpAdaptor operandAdaptor = ONNXConvOpAdaptor(op);
+LogicalResult ONNXConvOp::verify() {
+  ONNXConvOpAdaptor operandAdaptor = ONNXConvOpAdaptor(*this);
   // Get operands.
   auto X = operandAdaptor.X();
   auto W = operandAdaptor.W();
   auto B = operandAdaptor.B();
   bool hasBias = !B.getType().isa<NoneType>();
-  int64_t g = op.group();
+  int64_t g = group();
   if (g < 1)
-    return op.emitError("group must be strictly positive");
+    return emitOpError("group must be strictly positive");
   // Get spatial rank.
   if (!hasShapeAndRank(W)) {
     // Won't be able to do any checking at this stage.
@@ -1881,7 +1882,7 @@ static LogicalResult verify(ONNXConvOp op) {
   int64_t spatialRank = wShape.size() - 2;
   // If ranked, verify ranks of inputs.
   if (spatialRank < 1)
-    return op->emitError("Spatial rank must be strictly positive");
+    return emitOpError("Spatial rank must be strictly positive");
 
   if (wShape[0] >= 0 && wShape[0] % g != 0) {
     // This rule is not enforced in the spec but is present in Keras,
@@ -1896,38 +1897,38 @@ static LogicalResult verify(ONNXConvOp op) {
     // Keras also specifies it: Input channels and filters must both be
     // divisible by groups.
     // https://www.tensorflow.org/api_docs/python/tf/keras/layers/Conv2D
-    return op->emitError(
+    return emitOpError(
         "Channel Out (M) must be a multiple of the number of groups");
   }
   if (hasShapeAndRank(X)) {
     auto xShape = X.getType().cast<ShapedType>().getShape();
     if ((int64_t)xShape.size() - 2 != spatialRank)
-      return op->emitError("Input and filter rank mismatch");
+      return emitOpError("Input and filter rank mismatch");
     if (xShape[1] >= 0 && xShape[1] % g != 0)
-      return op->emitError(
+      return emitOpError(
           "Channel In (C) must be a multiple of the number of groups");
     if (xShape[1] >= 0 && wShape[1] >= 0 && xShape[1] != wShape[1] * g) {
-      return op->emitError("Channel In (C) of input must be equal 2nd dim "
-                           "of weights times g");
+      return emitOpError("Channel In (C) of input must be equal 2nd dim "
+                         "of weights times g");
     }
   }
   if (hasBias && hasShapeAndRank(B)) {
     auto bShape = B.getType().cast<ShapedType>().getShape();
     if (bShape.size() != 1)
-      return op->emitError("Bias should have a rank of one");
+      return emitOpError("Bias should have a rank of one");
     if (bShape[0] >= 0 && wShape[0] >= 0 && wShape[0] != bShape[0])
-      return op->emitError(
+      return emitOpError(
           "Bias should have same dimension as first dimension of weights");
   }
   // Verify parameters.
-  if (failed(verifyKernelShape<ONNXConvOp>(
-          &op, W, op.kernel_shape(), spatialRank)))
+  if (failed(
+          verifyKernelShape<ONNXConvOp>(this, W, kernel_shape(), spatialRank)))
     return failure();
-  if (failed(verifyStrides<ONNXConvOp>(&op, spatialRank)))
+  if (failed(verifyStrides<ONNXConvOp>(this, spatialRank)))
     return failure();
-  if (failed(verifyDilations<ONNXConvOp>(&op, spatialRank)))
+  if (failed(verifyDilations<ONNXConvOp>(this, spatialRank)))
     return failure();
-  if (failed(verifyPadding<ONNXConvOp>(&op, spatialRank)))
+  if (failed(verifyPadding<ONNXConvOp>(this, spatialRank)))
     return failure();
   return success();
 }
@@ -2221,32 +2222,32 @@ LogicalResult ONNXQLinearConvOp::inferShapes(
 // AveragePool
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verify(ONNXAveragePoolOp op) {
-  ONNXAveragePoolOpAdaptor operandAdaptor = ONNXAveragePoolOpAdaptor(op);
+LogicalResult ONNXAveragePoolOp::verify() {
+  ONNXAveragePoolOpAdaptor operandAdaptor = ONNXAveragePoolOpAdaptor(*this);
 
   // Mandatory and unsupported parameters.
-  if (!op.kernel_shape())
-    return op.emitError("kernel_shape is a mandatory attribute");
+  if (!kernel_shape())
+    return emitOpError("kernel_shape is a mandatory attribute");
   // Get spatial rank from mandatory kernel_shape parameter.
-  int64_t spatialRank = op.kernel_shape().size();
+  int64_t spatialRank = kernel_shape().size();
   if (spatialRank < 1)
-    return op.emitError("Spatial rank must be strictly positive");
+    return emitOpError("Spatial rank must be strictly positive");
 
   // Get operands.
   auto X = operandAdaptor.X();
   if (hasShapeAndRank(X)) {
     auto xShape = X.getType().cast<ShapedType>().getShape();
     if ((int64_t)xShape.size() - 2 != spatialRank)
-      return op->emitError("Input and kernel shape rank mismatch");
+      return emitOpError("Input and kernel shape rank mismatch");
   }
 
   // Verify parameters.
   if (failed(verifyKernelShape<ONNXAveragePoolOp>(
-          &op, nullptr, op.kernel_shape(), spatialRank)))
+          this, nullptr, kernel_shape(), spatialRank)))
     return failure();
-  if (failed(verifyStrides<ONNXAveragePoolOp>(&op, spatialRank)))
+  if (failed(verifyStrides<ONNXAveragePoolOp>(this, spatialRank)))
     return failure();
-  if (failed(verifyPadding<ONNXAveragePoolOp>(&op, spatialRank)))
+  if (failed(verifyPadding<ONNXAveragePoolOp>(this, spatialRank)))
     return failure();
   return success();
 }
@@ -2293,7 +2294,7 @@ LogicalResult ONNXMaxPoolSingleOutOp::verify() {
   if (hasShapeAndRank(X)) {
     auto xShape = X.getType().cast<ShapedType>().getShape();
     if (static_cast<int64_t>(xShape.size()) - 2 != spatialRank)
-      return (*this)->emitError("Input and kernel shape rank mismatch");
+      return emitOpError("Input and kernel shape rank mismatch");
   }
 
   // Verify parameters.
@@ -2703,8 +2704,8 @@ LogicalResult ONNXConstantOp::inferShapes(
 // Concat
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verify(ONNXConcatOp op) {
-  ONNXConcatOpAdaptor operandAdaptor(op);
+LogicalResult ONNXConcatOp::verify() {
+  ONNXConcatOpAdaptor operandAdaptor(*this);
   // Check all inputs.
   for (const auto &operand : operandAdaptor.getOperands()) {
     if (!hasShapeAndRank(operand)) {
@@ -2717,23 +2718,23 @@ static LogicalResult verify(ONNXConcatOp op) {
       operandAdaptor.getOperands().front().getType().cast<RankedTensorType>();
   ArrayRef<int64_t> commonShape = commonType.getShape();
   int64_t commonRank = commonShape.size();
-  int64_t axisIndex = op.axis();
+  int64_t axisIndex = axis();
   if (axisIndex < 0)
     axisIndex = commonRank + axisIndex;
   if (axisIndex >= commonRank)
-    return op->emitError("Concat axis value out of bound");
+    return emitOpError("Concat axis value out of bound");
 
   for (const auto &operand : operandAdaptor.getOperands()) {
     ArrayRef<int64_t> currShape =
         operand.getType().cast<RankedTensorType>().getShape();
     if ((int64_t)currShape.size() != commonRank)
-      return op->emitError("Concat input must all have the same rank");
+      return emitOpError("Concat input must all have the same rank");
     for (int j = 0; j < commonRank; ++j) {
       if (j == axisIndex)
         continue;
       if (currShape[j] != -1 && commonShape[j] != -1 &&
           currShape[j] != commonShape[j]) {
-        return op->emitError(
+        return emitOpError(
                    "Concat input dimensions must be all identical, "
                    "except for dimension on the axis of the "
                    "concatenation. Expected something compatible with: ")
@@ -2835,22 +2836,22 @@ LogicalResult ONNXSplitV11Op::inferShapes(
 // Flatten
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verify(ONNXFlattenOp op) {
+LogicalResult ONNXFlattenOp::verify() {
 
-  if (!hasShapeAndRank(op.input())) {
+  if (!hasShapeAndRank(input())) {
     return success();
   }
-  auto inTy = op.input().getType().dyn_cast<ShapedType>();
+  auto inTy = input().getType().dyn_cast<ShapedType>();
   if (!inTy) {
     return success();
   }
 
-  int64_t axisValue = op.axis();
+  int64_t axisValue = axis();
   auto inputShape = inTy.getShape();
   int64_t inputRank = inputShape.size();
 
   if (axisValue < -1 * inputRank || axisValue > inputRank) {
-    return op.emitError("ONNXFlattenOP: axis() value is out of range");
+    return emitOpError("ONNXFlattenOP: axis() value is out of range");
   }
 
   return success();
@@ -3367,15 +3368,15 @@ LogicalResult ONNXSliceOp::inferShapes(
 // Expand
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verify(ONNXExpandOp op) {
-  ONNXExpandOpAdaptor operandAdaptor = ONNXExpandOpAdaptor(op);
+LogicalResult ONNXExpandOp::verify() {
+  ONNXExpandOpAdaptor operandAdaptor = ONNXExpandOpAdaptor(*this);
   // Get operands.
   auto shape = operandAdaptor.shape();
   // Check input.
   auto shapeType = shape.getType().dyn_cast_or_null<ShapedType>();
   if (shapeType && shapeType.hasRank()) {
     if (shapeType.getRank() != 1)
-      return op.emitError("Shape has a rank of 1");
+      return emitOpError("Shape has a rank of 1");
   }
   return success();
 }
@@ -3577,9 +3578,9 @@ LogicalResult ONNXClipOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXInstanceNormalizationOp op) {
+LogicalResult ONNXInstanceNormalizationOp::verify() {
   ONNXInstanceNormalizationOpAdaptor operandAdaptor =
-      ONNXInstanceNormalizationOpAdaptor(op);
+      ONNXInstanceNormalizationOpAdaptor(*this);
   // Get operands.
   auto input = operandAdaptor.input();
   auto scale = operandAdaptor.scale();
@@ -3596,7 +3597,7 @@ static LogicalResult verify(ONNXInstanceNormalizationOp op) {
   int64_t spatialRank = inputShape.size() - 2;
   // If ranked, verify ranks of inputs.
   if (spatialRank < 1)
-    return op->emitError("Spatial rank must be strictly positive");
+    return emitOpError("Spatial rank must be strictly positive");
 
   // Check bias B.
   if (hasShapeAndRank(B)) {
@@ -3604,12 +3605,12 @@ static LogicalResult verify(ONNXInstanceNormalizationOp op) {
     auto bType = B.getType().cast<ShapedType>();
     auto bShape = bType.getShape();
     if (bShape.size() != 1)
-      return op->emitError("Bias should have a rank of one");
+      return emitOpError("Bias should have a rank of one");
     if (bShape[0] >= 0 && inputShape[1] >= 0 && bShape[0] != inputShape[1])
-      return op->emitError(
+      return emitOpError(
           "Bias should have same dimension as the second dimension of input");
     if (bType.getElementType() != inputElementType)
-      return op->emitError("Bias should have same element type as input");
+      return emitOpError("Bias should have same element type as input");
   }
 
   // Check scale.
@@ -3618,13 +3619,13 @@ static LogicalResult verify(ONNXInstanceNormalizationOp op) {
     auto scaleType = scale.getType().cast<ShapedType>();
     auto scaleShape = scaleType.getShape();
     if (scaleShape.size() != 1)
-      return op->emitError("Scale should have a rank of one");
+      return emitOpError("Scale should have a rank of one");
     if (scaleShape[0] >= 0 && inputShape[1] >= 0 &&
         scaleShape[0] != inputShape[1])
-      return op->emitError(
+      return emitOpError(
           "Scale should have same dimension as the second dimension of input");
     if (scaleType.getElementType() != inputElementType)
-      return op->emitError("Scale should have same element type as input");
+      return emitOpError("Scale should have same element type as input");
   }
 
   return success();
@@ -3643,27 +3644,27 @@ LogicalResult ONNXInstanceNormalizationOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXCompressOp op) {
+LogicalResult ONNXCompressOp::verify() {
   // Look up input.
-  if (!hasShapeAndRank(op.input()))
+  if (!hasShapeAndRank(input()))
     // Too early to verify.
     return success();
-  int64_t inputRank = op.input().getType().cast<ShapedType>().getRank();
+  int64_t inputRank = input().getType().cast<ShapedType>().getRank();
   // Check axis.
-  auto optionalAxis = op.axis();
+  auto optionalAxis = axis();
   if (optionalAxis.hasValue()) {
     // We have an axis, make sure its in the range
     int64_t axis = optionalAxis.getValue();
     if (!(axis >= -inputRank && axis < inputRank))
-      return op.emitError("axis is out of bound");
+      return emitOpError("axis is out of bound");
   }
   // Check condition.
-  if (!hasShapeAndRank(op.condition()))
+  if (!hasShapeAndRank(condition()))
     // Too early to verify.
     return success();
-  int64_t condRank = op.condition().getType().cast<ShapedType>().getRank();
+  int64_t condRank = condition().getType().cast<ShapedType>().getRank();
   if (condRank != 1)
-    return op.emitError("condition's rank must be one");
+    return emitOpError("condition's rank must be one");
   return success();
 }
 
@@ -3693,8 +3694,8 @@ LogicalResult ONNXCumSumOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXDepthToSpaceOp op) {
-  ONNXDepthToSpaceOpAdaptor operandAdaptor(op);
+LogicalResult ONNXDepthToSpaceOp::verify() {
+  ONNXDepthToSpaceOpAdaptor operandAdaptor(*this);
 
   // Check input.
   Value input = operandAdaptor.input();
@@ -3705,22 +3706,22 @@ static LogicalResult verify(ONNXDepthToSpaceOp op) {
   auto inputType = input.getType().cast<ShapedType>();
   auto inputShape = inputType.getShape();
   if (inputShape.size() != 4)
-    return op.emitError("Input should have a rank of four");
+    return emitOpError("Input should have a rank of four");
 
   // Check blocksize.
   int64_t blocksize = operandAdaptor.blocksize();
   if (blocksize < 0)
-    return op.emitError("Blocksize should be non negative");
+    return emitOpError("Blocksize should be non negative");
 
   int64_t C = inputShape[1];
   if (C != -1 && C % (blocksize * blocksize) != 0)
-    return op.emitError("The input tensor depth must be divisible by the "
-                        "(blocksize * blocksize)");
+    return emitOpError("The input tensor depth must be divisible by the "
+                       "(blocksize * blocksize)");
 
   // Check mode.
   StringRef mode = operandAdaptor.mode();
   if (mode != "DCR" && mode != "CRD")
-    return op.emitError("Mode must be DCR or CRD");
+    return emitOpError("Mode must be DCR or CRD");
 
   return success();
 }
@@ -3807,17 +3808,17 @@ LogicalResult ONNXGreaterOrEqualOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXHardmaxOp op) {
-  ONNXHardmaxOpAdaptor hmOp = ONNXHardmaxOpAdaptor(op);
+LogicalResult ONNXHardmaxOp::verify() {
+  ONNXHardmaxOpAdaptor hmOp = ONNXHardmaxOpAdaptor(*this);
   auto input = hmOp.input();
-  int64_t axis = op.axis();
+  int64_t axis = this->axis();
 
   // Verify that axis must be in range [-r, r - 1], where r is the rank of
   // input.
   if (hasShapeAndRank(input)) {
     int64_t rank = input.getType().cast<ShapedType>().getRank();
     if (axis < -rank || axis > rank - 1)
-      return op.emitError("axis value is out of range");
+      return emitOpError("axis value is out of range");
   }
 
   return success();
@@ -3913,17 +3914,17 @@ LogicalResult ONNXMeanVarianceNormalizationOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
-static LogicalResult verify(ONNXModOp op) {
+LogicalResult ONNXModOp::verify() {
   Type elementType;
-  if (op.A().getType().isa<ShapedType>())
-    elementType = op.A().getType().cast<ShapedType>().getElementType();
+  if (A().getType().isa<ShapedType>())
+    elementType = A().getType().cast<ShapedType>().getElementType();
   else
-    return op.emitError("Input type must be TensorType or MemRefType");
+    return emitOpError("Input type must be TensorType or MemRefType");
 
   // Verify that when the input type is floating point, then `fmod` attribute
   // must be set to 1.
-  if (elementType.isa<FloatType>() && (op.fmod() != 1))
-    return op.emitError("fmod must be 1 when the input type is floating point");
+  if (elementType.isa<FloatType>() && (fmod() != 1))
+    return emitOpError("fmod must be 1 when the input type is floating point");
 
   return success();
 }
@@ -3944,9 +3945,9 @@ LogicalResult ONNXMultinomialOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
-static LogicalResult verify(ONNXNonMaxSuppressionOp op) {
+LogicalResult ONNXNonMaxSuppressionOp::verify() {
   ONNXNonMaxSuppressionOpAdaptor operandAdaptor =
-      ONNXNonMaxSuppressionOpAdaptor(op);
+      ONNXNonMaxSuppressionOpAdaptor(*this);
   // Get operands.
   auto boxes = operandAdaptor.boxes();
   auto scores = operandAdaptor.scores();
@@ -3958,27 +3959,27 @@ static LogicalResult verify(ONNXNonMaxSuppressionOp op) {
   if (hasShapeAndRank(boxes)) {
     auto shape = boxes.getType().cast<ShapedType>().getShape();
     if (shape.size() != 3)
-      return op.emitError("boxes should have a rank of three");
+      return emitOpError("boxes should have a rank of three");
     if (shape[2] != -1 && shape[2] != 4)
-      return op.emitError("The last dim of Boxes should be four");
+      return emitOpError("The last dim of Boxes should be four");
   }
 
   if (hasShapeAndRank(scores))
     if (scores.getType().cast<ShapedType>().getRank() != 3)
-      return op.emitError("scores should have a rank of three");
+      return emitOpError("scores should have a rank of three");
 
   if (hasShapeAndRank(MOPC))
     if (MOPC.getType().cast<ShapedType>().getRank() > 1)
-      return op.emitError(
+      return emitOpError(
           "max_output_boxex_per_class should have a rank of zero or one");
 
   if (hasShapeAndRank(scoreThreshold))
     if (scoreThreshold.getType().cast<ShapedType>().getRank() > 1)
-      return op.emitError("score_threshold should have a rank of zero or one");
+      return emitOpError("score_threshold should have a rank of zero or one");
 
   if (hasShapeAndRank(iouThreshold))
     if (iouThreshold.getType().cast<ShapedType>().getRank() > 1)
-      return op.emitError("iou_threshold should have a rank of zero or one");
+      return emitOpError("iou_threshold should have a rank of zero or one");
 
   return success();
 }
@@ -4012,31 +4013,31 @@ LogicalResult ONNXNotOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXOneHotOp op) {
-  ONNXOneHotOpAdaptor operandAdaptor = ONNXOneHotOpAdaptor(op);
+LogicalResult ONNXOneHotOp::verify() {
+  ONNXOneHotOpAdaptor operandAdaptor = ONNXOneHotOpAdaptor(*this);
   // Check indices.
   Value indices = operandAdaptor.indices();
   if (hasShapeAndRank(indices)) {
     // Get rank.
     int64_t indicesRank = indices.getType().cast<ShapedType>().getRank();
     // Verify axis.
-    int64_t axisValue = op.axis();
+    int64_t axisValue = axis();
     // Unusually, with a rank of 3, acceptable values are 0 (before first) to 3
     // (after last).
     if (axisValue < 0)
       axisValue += indicesRank + 1;
     if (!(axisValue >= 0 && axisValue <= indicesRank))
-      return op->emitError("OneHot axis value is out of range");
+      return emitOpError("OneHot axis value is out of range");
   }
   // Check that values is a rank 2 with 2 elements
   Value values = operandAdaptor.values();
   if (hasShapeAndRank(values)) {
     ShapedType valuesShape = values.getType().cast<ShapedType>();
     if (valuesShape.getRank() != 1)
-      return op->emitError("OneHot values must be 1D tensor");
+      return emitOpError("OneHot values must be 1D tensor");
     int64_t dim = valuesShape.getDimSize(0);
     if (dim >= 0 && dim != 2)
-      return op->emitError("OneHot values must be 1D tensor with 2 elements");
+      return emitOpError("OneHot values must be 1D tensor with 2 elements");
   }
   // Depth is a scalar, check when its a tensor of rank 0 or 1.
   Value depth = operandAdaptor.depth();
@@ -4045,10 +4046,10 @@ static LogicalResult verify(ONNXOneHotOp op) {
     if (depthShape.getRank() == 1) {
       int64_t dim = depthShape.getDimSize(0);
       if (dim >= 0 && dim != 1)
-        return op->emitError("OneHot depth can be 1D tensor with 1 elements");
+        return emitOpError("OneHot depth can be 1D tensor with 1 elements");
     } else {
       if (depthShape.getRank() > 1)
-        return op->emitError("OneHot depth must be 0 or 1D tensor");
+        return emitOpError("OneHot depth must be 0 or 1D tensor");
     }
   }
   return success();
@@ -4101,12 +4102,12 @@ LogicalResult ONNXRandomNormalOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXRandomNormalLikeOp op) {
-  ONNXRandomNormalLikeOpAdaptor operandAdaptor(op);
+LogicalResult ONNXRandomNormalLikeOp::verify() {
+  ONNXRandomNormalLikeOpAdaptor operandAdaptor(*this);
   mlir::Value input = operandAdaptor.input();
   if (!hasShapeAndRank(input))
     return success();
-  mlir::Value output = op.output();
+  mlir::Value output = this->output();
   if (!hasShapeAndRank(output))
     return success();
 
@@ -4117,18 +4118,18 @@ static LogicalResult verify(ONNXRandomNormalLikeOp op) {
   if (elementTypeIDDType) {
     int64_t elementTypeID = elementTypeIDDType.getValue();
     if (elementTypeID < 0 || elementTypeID > 2) {
-      return op->emitError("dtype not 0, 1 or 2.");
+      return emitOpError("dtype not 0, 1 or 2.");
     }
-    if (elementTypeID == 0 && outputType != FloatType::getF16(op.getContext()))
-      return op->emitError("output tensor does match 0 dtype.");
+    if (elementTypeID == 0 && outputType != FloatType::getF16(getContext()))
+      return emitOpError("output tensor does match 0 dtype.");
     else if (elementTypeID == 1 &&
-             outputType != FloatType::getF32(op.getContext()))
-      return op->emitError("output tensor does match 1 dtype.");
+             outputType != FloatType::getF32(getContext()))
+      return emitOpError("output tensor does match 1 dtype.");
     else if (elementTypeID == 2 &&
-             outputType != FloatType::getF64(op.getContext()))
-      return op->emitError("output tensor does match 2 dtype.");
+             outputType != FloatType::getF64(getContext()))
+      return emitOpError("output tensor does match 2 dtype.");
   } else if (inputType != outputType) {
-    return op->emitError("output and input element types do not match.");
+    return emitOpError("output and input element types do not match.");
   }
 
   return success();
@@ -4270,9 +4271,9 @@ LogicalResult ONNXReverseSequenceOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXReverseSequenceOp op) {
+LogicalResult ONNXReverseSequenceOp::verify() {
   ONNXReverseSequenceOpAdaptor operandAdaptor =
-      ONNXReverseSequenceOpAdaptor(op);
+      ONNXReverseSequenceOpAdaptor(*this);
 
   auto sequence_lensTy =
       operandAdaptor.sequence_lens().getType().dyn_cast<RankedTensorType>();
@@ -4281,23 +4282,22 @@ static LogicalResult verify(ONNXReverseSequenceOp op) {
   // sequence_lens should be 1D tensor
   if (sequence_lensTy) {
     if (sequence_lensTy.getRank() != 1)
-      return op.emitError(
-          "sequence_lens of ReverseSequnce should be 1D tensor");
+      return emitOpError("sequence_lens of ReverseSequnce should be 1D tensor");
   }
 
   if (inputTy) {
     if (inputTy.getRank() < 2)
-      return op.emitError(
+      return emitOpError(
           "input of Reversesequence should be 2D or higher rank tensor");
   }
 
   if (sequence_lensTy && inputTy) {
-    int64_t batchAxis = op.batch_axis();
+    int64_t batchAxis = batch_axis();
     if (sequence_lensTy.getShape()[0] != -1 &&
         inputTy.getShape()[batchAxis] != -1) {
       if (sequence_lensTy.getShape()[0] != inputTy.getShape()[batchAxis]) {
-        return op.emitError("Length of sequence_lens should match the sizeof  "
-                            "batch axis of the input");
+        return emitOpError("Length of sequence_lens should match the sizeof  "
+                           "batch axis of the input");
       }
     }
   }
@@ -4341,8 +4341,8 @@ LogicalResult ONNXRoiAlignOp::inferShapes(
       ONNXRoiAlignOpAdaptor>(this, X());
 }
 
-static LogicalResult verify(ONNXRoiAlignOp op) {
-  ONNXRoiAlignOpAdaptor operandAdaptor = ONNXRoiAlignOpAdaptor(op);
+LogicalResult ONNXRoiAlignOp::verify() {
+  ONNXRoiAlignOpAdaptor operandAdaptor = ONNXRoiAlignOpAdaptor(*this);
   // get input info.
   mlir::Value X = operandAdaptor.X();
   mlir::Value batch_indices = operandAdaptor.batch_indices();
@@ -4356,9 +4356,9 @@ static LogicalResult verify(ONNXRoiAlignOp op) {
 
   // Test ranks.
   if (x_rank != 4)
-    return op->emitError("RoiAlign with X should be a 4D tensor");
+    return emitOpError("RoiAlign with X should be a 4D tensor");
   if (batch_indices_rank != 1)
-    return op->emitError("RoiAlign with batch_indices should be a 1D tensor");
+    return emitOpError("RoiAlign with batch_indices should be a 1D tensor");
 
   return success();
 }
@@ -4478,8 +4478,8 @@ LogicalResult ONNXScatterOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
-static LogicalResult verify(ONNXScatterElementsOp op) {
-  ONNXScatterElementsOpAdaptor operandAdaptor(op);
+LogicalResult ONNXScatterElementsOp::verify() {
+  ONNXScatterElementsOpAdaptor operandAdaptor(*this);
   // Get operands.
   mlir::Value data = operandAdaptor.data();
   mlir::Value indices = operandAdaptor.indices();
@@ -4493,21 +4493,21 @@ static LogicalResult verify(ONNXScatterElementsOp op) {
   int64_t data_rank = data.getType().cast<mlir::ShapedType>().getRank();
   int64_t indices_rank = indices.getType().cast<mlir::ShapedType>().getRank();
   int64_t updates_rank = updates.getType().cast<mlir::ShapedType>().getRank();
-  int64_t axis = op.axis();
+  int64_t axis = this->axis();
 
   if (data_rank < 1)
-    return op->emitError("data rank should >= 1");
+    return emitOpError("data rank should >= 1");
   if (indices_rank < 1)
-    return op->emitError("indices rank should >= 1");
+    return emitOpError("indices rank should >= 1");
   if (updates_rank < 1)
-    return op->emitError("updates rank rank should >= 1");
+    return emitOpError("updates rank rank should >= 1");
   if (data_rank != indices_rank || data_rank != updates_rank ||
       indices_rank != updates_rank) {
-    return op->emitError("data, indices, updates rank should equal");
+    return emitOpError("data, indices, updates rank should equal");
   }
 
   if (axis >= data_rank || axis < 0)
-    return op->emitError("axis value out of bound");
+    return emitOpError("axis value out of bound");
 
   return success();
 }
@@ -4521,8 +4521,8 @@ LogicalResult ONNXScatterElementsOp::inferShapes(
   return success();
 }
 
-static LogicalResult verify(ONNXScatterNDOp op) {
-  ONNXScatterNDOpAdaptor operandAdaptor(op);
+LogicalResult ONNXScatterNDOp::verify() {
+  ONNXScatterNDOpAdaptor operandAdaptor(*this);
   // Get operands.
   mlir::Value data = operandAdaptor.data();
   mlir::Value indices = operandAdaptor.indices();
@@ -4540,11 +4540,11 @@ static LogicalResult verify(ONNXScatterNDOp op) {
       indices.getType().cast<mlir::ShapedType>().getShape()[indices_rank - 1];
 
   if (data_rank < 1)
-    return op->emitError("data rank should >= 1");
+    return emitOpError("data rank should >= 1");
   if (indices_rank < 1)
-    return op->emitError("indices rank should >= 1");
+    return emitOpError("indices rank should >= 1");
   if (updates_rank != (data_rank + indices_rank - indices_last_dim - 1))
-    return op->emitError("updates rank not meet the op spec");
+    return emitOpError("updates rank not meet the op spec");
 
   return success();
 }
@@ -4563,8 +4563,8 @@ LogicalResult ONNXShrinkOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
-static LogicalResult verify(ONNXSpaceToDepthOp op) {
-  ONNXSpaceToDepthOpAdaptor operandAdaptor(op);
+LogicalResult ONNXSpaceToDepthOp::verify() {
+  ONNXSpaceToDepthOpAdaptor operandAdaptor(*this);
 
   // Check input.
   Value input = operandAdaptor.input();
@@ -4575,21 +4575,21 @@ static LogicalResult verify(ONNXSpaceToDepthOp op) {
   auto inputType = input.getType().cast<ShapedType>();
   auto inputShape = inputType.getShape();
   if (inputShape.size() != 4)
-    return op.emitError("Input should have a rank of four");
+    return emitOpError("Input should have a rank of four");
 
   // Check blocksize.
   int64_t blocksize = operandAdaptor.blocksize();
   if (blocksize < 0)
-    return op.emitError("Blocksize should be non negative");
+    return emitOpError("Blocksize should be non negative");
 
   int64_t H = inputShape[2];
   int64_t W = inputShape[3];
 
   if (H != -1 && H % blocksize != 0)
-    return op.emitError(
+    return emitOpError(
         "The input tensor height must be divisible by the block size");
   if (W != -1 && W % blocksize != 0)
-    return op.emitError(
+    return emitOpError(
         "The input tensor width must be divisible by the block size");
 
   return success();
@@ -4635,8 +4635,8 @@ LogicalResult ONNXThresholdedReluOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
-static LogicalResult verify(ONNXTopKOp op) {
-  ONNXTopKOpAdaptor operandAdaptor = ONNXTopKOpAdaptor(op);
+LogicalResult ONNXTopKOp::verify() {
+  ONNXTopKOpAdaptor operandAdaptor = ONNXTopKOpAdaptor(*this);
   // Get operands.
   auto X = operandAdaptor.X();
   auto K = operandAdaptor.K();
@@ -4645,16 +4645,16 @@ static LogicalResult verify(ONNXTopKOp op) {
   if (hasShapeAndRank(X)) {
     ArrayRef<int64_t> shape = X.getType().cast<ShapedType>().getShape();
     int64_t rank = shape.size();
-    int64_t axis = op.axis();
+    int64_t axis = this->axis();
     axis = axis < 0 ? axis + rank : axis;
     if (axis < 0 || axis >= rank)
-      return op.emitError("axis must be in range [-rank, rank -1]");
+      return emitOpError("axis must be in range [-rank, rank -1]");
   }
 
   // Verify that K's rank must be zero or one.
   if (hasShapeAndRank(K))
     if (K.getType().cast<ShapedType>().getRank() > 1)
-      return op.emitError("K should have a rank of zero or one");
+      return emitOpError("K should have a rank of zero or one");
 
   return success();
 }
@@ -4722,8 +4722,8 @@ LogicalResult ONNXCastMapOp::inferShapes(
   return emitError(NOT_IMPLEMENTED_MESSAGE);
 }
 
-static LogicalResult verify(ONNXCategoryMapperOp op) {
-  ONNXCategoryMapperOpAdaptor operandAdaptor(op);
+LogicalResult ONNXCategoryMapperOp::verify() {
+  ONNXCategoryMapperOpAdaptor operandAdaptor(*this);
 
   // Check input.
   const Value X = operandAdaptor.X();
@@ -4735,21 +4735,20 @@ static LogicalResult verify(ONNXCategoryMapperOp op) {
   ShapedType inputType = X.getType().cast<ShapedType>();
   Type elementType = inputType.getElementType();
   if (!elementType.isInteger(64) && !elementType.isa<ONNXStringType>())
-    return op.emitError("input must be a tensor of int64 or string");
+    return emitOpError("input must be a tensor of int64 or string");
 
   // Check attributes.
-  if (!op.cats_int64s())
-    return op.emitError("cats_int64 attribute must be present");
-  if (!op.cats_strings())
-    return op.emitError("cats_strings attribute must be present");
-  if (ArrayAttrSize(op.cats_int64s()) != ArrayAttrSize(op.cats_strings()))
-    return op.emitError(
-        "cats_int64 and cats_strings should have the same size");
+  if (!cats_int64s())
+    return emitOpError("cats_int64 attribute must be present");
+  if (!cats_strings())
+    return emitOpError("cats_strings attribute must be present");
+  if (ArrayAttrSize(cats_int64s()) != ArrayAttrSize(cats_strings()))
+    return emitOpError("cats_int64 and cats_strings should have the same size");
 
-  if (elementType.isInteger(64) && !op.default_stringAttr())
-    return op.emitError("'default_string' attribute is missing.");
-  if (elementType.isa<ONNXStringType>() && !op.default_int64Attr())
-    return op.emitError("'default_int64' attribute is missing.");
+  if (elementType.isInteger(64) && !default_stringAttr())
+    return emitOpError("'default_string' attribute is missing.");
+  if (elementType.isa<ONNXStringType>() && !default_int64Attr())
+    return emitOpError("'default_int64' attribute is missing.");
 
   return success();
 }

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -380,7 +380,7 @@ def ONNXAveragePoolOp:ONNX_Op<"AveragePool",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXBatchNormalizationOp:ONNX_Op<"BatchNormalization",
@@ -685,7 +685,7 @@ def ONNXCompressOp:ONNX_Op<"Compress",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXConcatOp:ONNX_Op<"Concat",
@@ -708,7 +708,7 @@ def ONNXConcatOp:ONNX_Op<"Concat",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXConcatFromSequenceOp:ONNX_Op<"ConcatFromSequence",
@@ -850,7 +850,7 @@ def ONNXConvOp:ONNX_Op<"Conv",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXConvIntegerOp:ONNX_Op<"ConvInteger",
@@ -1060,7 +1060,7 @@ def ONNXDepthToSpaceOp:ONNX_Op<"DepthToSpace",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXDequantizeLinearOp:ONNX_Op<"DequantizeLinear",
@@ -1448,7 +1448,7 @@ def ONNXExpandOp:ONNX_Op<"Expand",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXEyeLikeOp:ONNX_Op<"EyeLike",
@@ -1502,7 +1502,7 @@ def ONNXFlattenOp:ONNX_Op<"Flatten",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXFloorOp:ONNX_Op<"Floor",
@@ -2140,7 +2140,7 @@ def ONNXHardmaxOp:ONNX_Op<"Hardmax",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXIdentityOp:ONNX_Op<"Identity",
@@ -2232,7 +2232,7 @@ def ONNXInstanceNormalizationOp:ONNX_Op<"InstanceNormalization",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXIsInfOp:ONNX_Op<"IsInf",
@@ -3096,7 +3096,7 @@ def ONNXModOp:ONNX_Op<"Mod",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXMulOp:ONNX_Op<"Mul",
@@ -3349,7 +3349,7 @@ def ONNXNonMaxSuppressionOp:ONNX_Op<"NonMaxSuppression",
       return {4};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXNonZeroOp:ONNX_Op<"NonZero",
@@ -3437,7 +3437,7 @@ def ONNXOneHotOp:ONNX_Op<"OneHot",
       return {22};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXOrOp:ONNX_Op<"Or",
@@ -4070,7 +4070,7 @@ def ONNXRandomNormalLikeOp:ONNX_Op<"RandomNormalLike",
       return {-1};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXRandomUniformOp:ONNX_Op<"RandomUniform",
@@ -4767,7 +4767,7 @@ def ONNXReverseSequenceOp:ONNX_Op<"ReverseSequence",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXRoiAlignOp:ONNX_Op<"RoiAlign",
@@ -4806,7 +4806,7 @@ def ONNXRoiAlignOp:ONNX_Op<"RoiAlign",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXRoundOp:ONNX_Op<"Round",
@@ -5146,7 +5146,7 @@ def ONNXScatterElementsOp:ONNX_Op<"ScatterElements",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXScatterNDOp:ONNX_Op<"ScatterND",
@@ -5225,7 +5225,7 @@ def ONNXScatterNDOp:ONNX_Op<"ScatterND",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXSeluOp:ONNX_Op<"Selu",
@@ -5371,7 +5371,7 @@ def ONNXSequenceInsertOp:ONNX_Op<"SequenceInsert",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXSequenceLengthOp:ONNX_Op<"SequenceLength",
@@ -5775,7 +5775,7 @@ def ONNXSpaceToDepthOp:ONNX_Op<"SpaceToDepth",
       return {20};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXSplitOp:ONNX_Op<"Split",
@@ -6261,7 +6261,7 @@ def ONNXTopKOp:ONNX_Op<"TopK",
       return {20,4};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXTransposeOp:ONNX_Op<"Transpose",
@@ -6722,7 +6722,7 @@ def ONNXCategoryMapperOp:ONNX_Op<"CategoryMapper",
       return {-1};
     }
   }];
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ONNXDictVectorizerOp:ONNX_Op<"DictVectorizer",

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -1059,7 +1059,7 @@ def gen_op_def(schema, with_version = False):
 
     # Generate decl for verifier.
     if opName in OpsWithVerifier:
-        s += indent + 'let verifier = [{ return ::verify(*this); }];\n'
+        s += indent + 'let hasVerifier = 1;\n'
 
     s += '}\n\n'
     return s


### PR DESCRIPTION
`verifier` will be obsolete soon to be replaced by `hasVerifier`. This updated the script to use the new form and then applies the updates to the appropriate files.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>