### PR TITLE
update llvm to a7ac120a9ad7

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -14,7 +14,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout d7f0083dcae45e6bf774af23533a2d5e18aaf253 && cd ..
+cd llvm-project && git checkout a7ac120a9ad784998a5527fc0a71b2d0fd55eccb && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -48,7 +48,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout d7f0083dcae45e6bf774af23533a2d5e18aaf253 && cd ..
+cd llvm-project && git checkout a7ac120a9ad784998a5527fc0a71b2d0fd55eccb && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -60,7 +60,7 @@ struct ONNXLoopOpLowering : public ConversionPattern {
     Value maxTripCount =
         rewriter.create<KrnlLoadOp>(loc, loopOpAdapter.M()).getResult();
     maxTripCount = rewriter.create<arith::IndexCastOp>(
-        loc, maxTripCount, rewriter.getIndexType());
+        loc, rewriter.getIndexType(), maxTripCount);
     loop.pushBounds(0, maxTripCount);
     loop.createIterateOp();
     rewriter.setInsertionPointToStart(loop.getIterateBlock());
@@ -77,7 +77,7 @@ struct ONNXLoopOpLowering : public ConversionPattern {
       Value origIV = loop.getInductionVar(0);
       auto iv =
           rewriter
-              .create<arith::IndexCastOp>(loc, origIV, rewriter.getI64Type())
+              .create<arith::IndexCastOp>(loc, rewriter.getI64Type(), origIV)
               .getResult();
       MemRefBuilder createMemRef(rewriter, loc);
       Value ivMemRef =
@@ -248,7 +248,7 @@ struct ONNXLoopOpLowering : public ConversionPattern {
                   rewriter.create<KrnlLoadOp>(loc, loopOpAdapter.M())
                       .getResult();
               allocParams.emplace_back(rewriter.create<arith::IndexCastOp>(
-                  loc, maxTripCount, rewriter.getIndexType()));
+                  loc, rewriter.getIndexType(), maxTripCount));
             } else {
               // TODO(tjingrant): we can support dynamic dimensions for scan
               // output, however, then we will be unable to allocate memory

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -326,11 +326,11 @@ struct ONNXReductionOpLowering : public ConversionPattern {
       Value divisor = divisorExpr.getValue();
       if (elementType.isa<FloatType>()) {
         divisor = rewriter.create<arith::IndexCastOp>(
-            loc, divisor, rewriter.getIntegerType(64));
+            loc, rewriter.getIntegerType(64), divisor);
         divisor = rewriter.create<arith::UIToFPOp>(loc, elementType, divisor);
       } else if (elementType.isa<IntegerType>()) {
         divisor =
-            rewriter.create<arith::IndexCastOp>(loc, divisor, elementType);
+            rewriter.create<arith::IndexCastOp>(loc, elementType, divisor);
       } else
         llvm_unreachable("unsupported element type");
 
@@ -662,11 +662,11 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
       Value divisor = divisorExpr.getValue();
       if (elementType.isa<FloatType>()) {
         divisor = rewriter.create<arith::IndexCastOp>(
-            loc, divisor, rewriter.getIntegerType(64));
+            loc, rewriter.getIntegerType(64), divisor);
         divisor = rewriter.create<arith::UIToFPOp>(loc, elementType, divisor);
       } else if (elementType.isa<IntegerType>()) {
         divisor =
-            rewriter.create<arith::IndexCastOp>(loc, divisor, elementType);
+            rewriter.create<arith::IndexCastOp>(loc, elementType, divisor);
       } else
         llvm_unreachable("unsupported element type");
 

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -135,9 +135,9 @@ void postProcessPoolingWindow<ONNXAveragePoolOp>(
       denominator =
           rewriter.create<arith::MulIOp>(loc, denominator, poolDimValues[i]);
     denominator = rewriter.create<arith::IndexCastOp>(
-        loc, denominator, rewriter.getIntegerType(64));
+        loc, rewriter.getIntegerType(64), denominator);
     denominator =
-        rewriter.create<arith::SIToFPOp>(loc, denominator, numerator.getType());
+        rewriter.create<arith::SIToFPOp>(loc, numerator.getType(), denominator);
   }
 
   Value average = rewriter.create<arith::DivFOp>(loc, numerator, denominator);
@@ -169,20 +169,20 @@ void postProcessPoolingWindow<ONNXAveragePoolOp>(
       kernelSize = kernelSize * kernelShape[i];
     denominator = kernelSize.getValue();
     denominator = rewriter.create<arith::IndexCastOp>(
-        loc, denominator, rewriter.getI64Type());
+        loc, rewriter.getI64Type(), denominator);
     // TODO: we are implying here that the dest type is a float.
     denominator =
-        rewriter.create<arith::SIToFPOp>(loc, denominator, numerator.getType());
+        rewriter.create<arith::SIToFPOp>(loc, numerator.getType(), denominator);
   } else {
     denominator = poolDimValues[0];
     for (unsigned int i = 1; i < poolDimValues.size(); ++i)
       denominator =
           rewriter.create<arith::MulIOp>(loc, denominator, poolDimValues[i]);
     denominator = rewriter.create<arith::IndexCastOp>(
-        loc, denominator, rewriter.getIntegerType(64));
+        loc, rewriter.getIntegerType(64), denominator);
     // TODO: we are implying here that the dest type is a float.
     denominator =
-        rewriter.create<arith::SIToFPOp>(loc, denominator, numerator.getType());
+        rewriter.create<arith::SIToFPOp>(loc, numerator.getType(), denominator);
   }
 
   Value average = rewriter.create<arith::DivFOp>(loc, numerator, denominator);

--- a/src/Conversion/ONNXToKrnl/Tensor/ArgMax.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ArgMax.cpp
@@ -127,7 +127,7 @@ struct ONNXArgMaxOpLowering : public ConversionPattern {
         maxLoopIVs.push_back(calcLoops.getInductionVar(i));
       else
         maxLoopIVs.push_back(rewriter.create<arith::IndexCastOp>(
-            loc, idx, rewriter.getIndexType()));
+            loc, rewriter.getIndexType(), idx));
     }
     Value maxVal = rewriter.create<KrnlLoadOp>(loc, data, maxLoopIVs);
 
@@ -135,7 +135,7 @@ struct ONNXArgMaxOpLowering : public ConversionPattern {
     Value greaterThanMax = rewriter.create<arith::CmpFOp>(
         loc, arith::CmpFPredicate::OGT, next, maxVal);
     Value pos = rewriter.create<arith::IndexCastOp>(
-        loc, inLoopIVs[axis], rewriter.getIntegerType(64));
+        loc, rewriter.getIntegerType(64), inLoopIVs[axis]);
     idx = rewriter.create<arith::SelectOp>(loc, greaterThanMax, pos, idx);
     rewriter.create<KrnlStoreOp>(loc, idx, alloc, outLoopIVs);
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
@@ -88,27 +88,28 @@ struct ONNXRangeOpLowering : public ConversionPattern {
                 rewriter.create<arith::SubFOp>(loc, loadedLimit, loadedStart),
                 loadedDelta);
             numberOfElements = rewriter.create<arith::IndexCastOp>(loc,
+                rewriter.getIndexType(),
                 rewriter.create<arith::FPToUIOp>(loc,
-                    rewriter.create<math::CeilOp>(loc, elements),
-                    rewriter.getIntegerType(64)),
-                rewriter.getIndexType());
+                    rewriter.getIntegerType(64),
+                    rewriter.create<math::CeilOp>(loc, elements)));
           })
           .Case<Float64Type>([&](Type) {
             Value elements = rewriter.create<arith::DivFOp>(loc,
                 rewriter.create<arith::SubFOp>(loc, loadedLimit, loadedStart),
                 loadedDelta);
             numberOfElements = rewriter.create<arith::IndexCastOp>(loc,
+                rewriter.getIndexType(),
                 rewriter.create<arith::FPToUIOp>(loc,
-                    rewriter.create<math::CeilOp>(loc, elements),
-                    rewriter.getIntegerType(64)),
-                rewriter.getIndexType());
+                    rewriter.getIntegerType(64),
+                    rewriter.create<math::CeilOp>(loc, elements)));
           })
           .Case<IntegerType>([&](Type) {
             Value elements = rewriter.create<arith::CeilDivSIOp>(loc,
                 rewriter.create<arith::SubIOp>(loc, loadedLimit, loadedStart),
                 loadedDelta);
+
             numberOfElements = rewriter.create<arith::IndexCastOp>(
-                loc, elements, rewriter.getIndexType());
+                loc, rewriter.getIndexType(), elements);
           });
 
       SmallVector<Value, 4> allocOperands;

--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -135,7 +135,7 @@ struct ONNXResizeOpLowering : public ConversionPattern {
       Value inIndexFloat;
       Value outIndex = outputLoops.getInductionVar(i);
       Value outIndexInteger = rewriter.create<arith::IndexCastOp>(
-          loc, outIndex, rewriter.getIntegerType(64));
+          loc, rewriter.getIntegerType(64), outIndex);
       Value outIndexFloat =
           create.math.cast(rewriter.getF32Type(), outIndexInteger);
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -164,7 +164,7 @@ struct ONNXTileOpLoweringAlternative : public ConversionPattern {
       auto repeatsLoadVal =
           rewriter.create<KrnlLoadOp>(loc, repeats, repeatsMemRefVal);
       auto repeatsElementVal = rewriter.create<arith::IndexCastOp>(
-          loc, repeatsLoadVal, rewriter.getIndexType());
+          loc, rewriter.getIndexType(), repeatsLoadVal);
       pack.pushOperandBound(repeatsElementVal);
     }
 

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -570,7 +570,7 @@ static LogicalResult foldMemRefCast(Operation *op) {
 }
 
 OpFoldResult KrnlVectorTypeCastOp::fold(ArrayRef<Attribute> operands) {
-  if (Value folded = impl::foldCastOp(*this))
+  if (OpFoldResult folded = OpFoldResult())
     return folded;
   return succeeded(foldMemRefCast(*this)) ? getResult() : Value();
 }

--- a/src/Dialect/ONNX/MLIRDialectBuilder.cpp
+++ b/src/Dialect/ONNX/MLIRDialectBuilder.cpp
@@ -426,7 +426,7 @@ memref::DeallocOp MemRefBuilder::dealloc(Value val) const {
 }
 
 memref::CastOp MemRefBuilder::cast(Value input, MemRefType outputType) const {
-  return b.create<memref::CastOp>(loc, input, outputType);
+  return b.create<memref::CastOp>(loc, outputType, input);
 }
 
 Value MemRefBuilder::dim(Value val, int64_t index) const {

--- a/src/Dialect/ONNX/ONNX.td
+++ b/src/Dialect/ONNX/ONNX.td
@@ -244,7 +244,7 @@ def ONNX_SeqType : ONNX_Type<"Seq", "Seq"> {
     $_printer << "<" << getImpl()->ElementType << ">";
   }];
   let parser = [{
-    if (parser.parseLess())
+    if ($_parser.parseLess())
       return Type();
     Type elementType;
     if ($_parser.parseType(elementType))

--- a/src/Support/KrnlSupport.cpp
+++ b/src/Support/KrnlSupport.cpp
@@ -298,7 +298,7 @@ Value getDynamicMemRefSizeInBytes(
       if (shape[i] == -1) {
         Value index = rewriter.create<memref::DimOp>(loc, val, i);
         Value dim = rewriter.create<arith::IndexCastOp>(
-            loc, index, rewriter.getI64Type());
+            loc, rewriter.getI64Type(), index);
         sizeInBytes = rewriter.create<arith::MulIOp>(loc, sizeInBytes, dim);
       }
     }

--- a/src/Transform/BundleMemoryPools.cpp
+++ b/src/Transform/BundleMemoryPools.cpp
@@ -447,7 +447,7 @@ public:
     // Current memory pool size is the offset for the newly bundled
     // internal MemRef.
     Value integerDynamicMemoryPoolSize = rewriter.create<arith::IndexCastOp>(
-        loc, dynamicMemoryPoolSize, rewriter.getIntegerType(64));
+        loc, rewriter.getIntegerType(64), dynamicMemoryPoolSize);
     integerDynamicMemoryPoolSize.getDefiningOp()->moveBefore(
         oldDynamicMemoryPool);
 

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout d7f0083dcae45e6bf774af23533a2d5e18aaf253 && cd ..
+cd llvm-project && git checkout a7ac120a9ad784998a5527fc0a71b2d0fd55eccb && cd ..


### PR DESCRIPTION
Ths PR updates the LLVM commit we use to `a7ac120a9ad784998a5527fc0a71b2d0fd55eccb`.

Signed-off-by: Ettore Tiotto <etiotto@ca.ibm.com>