### PR TITLE
Emit the onnx-mlir version as llvm.ident metadata.

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -103,7 +103,7 @@ static llvm::cl::opt<string> shapeInformation("shapeInformation",
 
 static llvm::cl::opt<std::string> mtriple("mtriple",
     llvm::cl::desc("Override target triple for module"),
-    llvm::cl::value_desc("LLVM target triple>"), llvm::cl::cat(OnnxMlirOptions),
+    llvm::cl::value_desc("LLVM target triple"), llvm::cl::cat(OnnxMlirOptions),
     llvm::cl::ValueRequired);
 
 static llvm::cl::opt<std::string> mcpu("mcpu", llvm::cl::desc("Target cpu"),
@@ -530,6 +530,14 @@ static void genLLVMBitcode(const mlir::OwningOpRef<ModuleOp> &module,
       llvmModule->addModuleFlag(llvm::Module::Error, charModeKey, val);
     }
   }
+
+  // Emit the onnx-mlir version as llvm.ident metadata.
+  llvm::NamedMDNode *identMetadata =
+      llvmModule->getOrInsertNamedMetadata("llvm.ident");
+  std::string version = "onnx-mlir version 1.0.0";
+  llvm::LLVMContext &ctx = llvmModule->getContext();
+  llvm::Metadata *identNode[] = {llvm::MDString::get(ctx, version)};
+  identMetadata->addOperand(llvm::MDNode::get(ctx, identNode));
 
   llvm::WriteBitcodeToFile(*llvmModule, moduleBitcodeStream);
   moduleBitcodeStream.flush();

--- a/test/mlir/driver/llvm.ident.mlir
+++ b/test/mlir/driver/llvm.ident.mlir
@@ -1,0 +1,14 @@
+// RUN: onnx-mlir --preserveBitcode %s -o %t
+// RUN: llvm-dis %t.bc -o %t.ll
+// RUN: cat %t.ll | FileCheck %s
+
+// REQUIRES: system-linux || system-darwin
+// CHECK: !llvm.ident = !{![[MD:[0-9]*]]}
+// CHECK: ![[MD]] = !{!"onnx-mlir version 1.0.0"}
+module {
+  func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
+    %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+    return %0 : tensor<1x1xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 1 : i32, signature = ""} : () -> ()
+}


### PR DESCRIPTION
Signed-off-by: Whitney Tsang <whitneyt@ca.ibm.com>