### PR TITLE
Make checkConstantOutputs and populateAffineAndKrnlToLLVMConversion sharable for other drivers

### DIFF
--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -61,7 +61,7 @@ using namespace mlir;
 namespace onnx_mlir {
 namespace krnl {
 
-static void checkConstantOutputs(
+void checkConstantOutputs(
     ModuleOp &module, SmallVectorImpl<bool> &constantOutputs) {
   Operation *entryPointOp;
   auto walkResult = module->walk([&](mlir::Operation *op) -> WalkResult {
@@ -136,7 +136,7 @@ static void checkConstantOutputs(
   }
 }
 
-static void populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
+void populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
     LLVMTypeConverter &typeConverter, MLIRContext *ctx,
     ArrayRef<bool> constantOutputs, bool singleEntryPoint) {
   // TODO: look at what is done in

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.hpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.hpp
@@ -24,6 +24,10 @@ const std::string DEFAULT_DYN_ENTRY_POINT = "run_main_graph";
 namespace onnx_mlir {
 namespace krnl {
 
+void populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
+    LLVMTypeConverter &typeConverter, MLIRContext *ctx,
+    ArrayRef<bool> constantOutputs, bool singleEntryPoint);
+
 void populateKrnlToLLVMConversion(mlir::LLVMTypeConverter &typeConverter,
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx,
     llvm::ArrayRef<bool> constantOutputs, bool singleEntryPoint);
@@ -70,6 +74,9 @@ void populateLoweringKrnlUnaryMathOpPattern(mlir::TypeConverter &typeConverter,
 void populateLoweringKrnlVectorTypeCastOpPattern(
     LLVMTypeConverter &typeConverter, mlir::RewritePatternSet &patterns,
     mlir::MLIRContext *ctx);
+
+void checkConstantOutputs(
+    ModuleOp &module, SmallVectorImpl<bool> &constantOutputs);
 
 void recordEntryPointSignatures(mlir::ModuleOp &module,
     llvm::SmallVectorImpl<std::string> &entryPointNames,


### PR DESCRIPTION


Signed-off-by: Tung D. Le <tung@jp.ibm.com>