### PR TITLE
fix leak when failing to allocate data

### DIFF
--- a/include/onnx-mlir/Runtime/OMTensor.h
+++ b/include/onnx-mlir/Runtime/OMTensor.h
@@ -106,9 +106,6 @@ OMTensor *omTensorCreateWithOwnership(void *data_ptr, int64_t *shape,
 /**
  * Create an OMTensor with the specified shape, rank and element type,
  * allocate uninitialized data for the specified shape.
- * This function is intentionally left out from the header because it is only
- * used by the wrapper code we emit around inference function that converts
- * MemRefs to OMTensors for user convenience.
  *
  * The OMTensor created using this constructor owns the underlying memory
  * space allocated to the content of the tensor.

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -276,8 +276,11 @@ OMTensor *omTensorCreateEmpty(
     return NULL;
 
   void *dataPtr = malloc(omTensorGetNumElems(tensor) * getDataTypeSize(dtype));
-  if (!dataPtr)
+  if (!dataPtr) {
+    // It is safe to free a null pointer (_allocatedPtr is null).
+    omTensorDestroy(tensor);
     return NULL;
+  }
 
   tensor->_alignedPtr = dataPtr;
   tensor->_allocatedPtr = dataPtr;


### PR DESCRIPTION
Fix leak and also remove "this is not part of the interface" comment, as it is currently part of the interface.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>