### PR TITLE
Correctly build OnnxMlirCompiler as a static lib

### DIFF
--- a/include/OnnxMlirCompiler.h
+++ b/include/OnnxMlirCompiler.h
@@ -21,7 +21,6 @@
 
 #ifdef ONNX_MLIR_BUILT_AS_STATIC
 #define ONNX_MLIR_EXPORT
-#define ONNX_MLIR_NO_EXPORT
 #else
 #ifdef _MSC_VER
 #ifdef OnnxMlirCompiler_EXPORTS

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -71,5 +71,5 @@ add_onnx_mlir_library(OnnxMlirCompiler
   )
 
 if (NOT BUILD_SHARED_LIBS)
-  target_compile_definitions(OnnxMlirCompiler PUBLIC OnnxMlirCompiler_EXPORTS)
+  target_compile_definitions(OnnxMlirCompiler PUBLIC ONNX_MLIR_BUILT_AS_STATIC)
 endif()


### PR DESCRIPTION
When OnnxMlirCompiler is a static lib, the functions should not be marked for dllexport or dllimport.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>