### PR TITLE
Fix Missing Dependency

### DIFF
--- a/src/Accelerators/CMakeLists.txt
+++ b/src/Accelerators/CMakeLists.txt
@@ -10,6 +10,8 @@ endif (ACCELERATORS_TO_BUILD)
 
 add_onnx_mlir_library(Accelerator
     Accelerator.cpp
+    DEPENDS
+      MLIRIR
     INCLUDE_DIRS PUBLIC
       ${ONNX_MLIR_SRC_ROOT}/include
     LINK_LIBS PUBLIC


### PR DESCRIPTION
The Accelerators project pulls in some headers that are table-gen generated in llvm-project/mlir. Add an explicit dependency so parallel building works correctly.

Signed-off-by: Ian Bearman <ianb@microsoft.com>