### PR TITLE
Add the llvm source version to VCSVersion.inc even if we don't have access to the llvm source

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -32,6 +32,7 @@ add_onnx_mlir_library(CompilerUtils
   DEPENDS
   ExternalUtil
   MLIRIR
+  OMVersion
 
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}

--- a/test/mlir/driver/llvm.ident.mlir
+++ b/test/mlir/driver/llvm.ident.mlir
@@ -1,8 +1,8 @@
+// RUN: cp %s.def %t.def
 // RUN: onnx-mlir --preserveBitcode %s -o %t
 // RUN: llvm-dis %t.bc -o %t.ll
 // RUN: cat %t.ll | FileCheck %s
 
-// REQUIRES: system-linux || system-darwin
 // CHECK: !llvm.ident = !{![[MD:[0-9]*]]}
 // CHECK: ![[MD]] = !{!"onnx-mlir version 1.0.0 ({{.*}}/onnx-mlir{{.*}}/llvm-project{{.*}})"}
 module {

--- a/test/mlir/driver/llvm.ident.mlir.def
+++ b/test/mlir/driver/llvm.ident.mlir.def
@@ -1,0 +1,5 @@
+EXPORTS 
+run_main_graph
+omInputSignature
+omOutputSignature
+

--- a/version/AddLLVMVersionHeader.cmake
+++ b/version/AddLLVMVersionHeader.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# We need to do this in a stand-alone cmake script because there's no
+# cross-platform way to append to a file through add_custom_command.
+
+file(APPEND
+  ${HEADER_FILE}
+  "#include \"llvm/Support/VCSRevision.h\""
+  )

--- a/version/AddLLVMVersionHeader.cmake
+++ b/version/AddLLVMVersionHeader.cmake
@@ -5,5 +5,5 @@
 
 file(APPEND
   ${HEADER_FILE}
-  "#include \"llvm/Support/VCSRevision.h\""
+  "#include \"llvm/Support/VCSRevision.h\"\n"
   )

--- a/version/CMakeLists.txt
+++ b/version/CMakeLists.txt
@@ -31,7 +31,7 @@ if (llvm_vc OR NOT LLVM_APPEND_VC_REV)
   add_custom_command(OUTPUT "${version_inc}"
     DEPENDS "${version_inc}.tmp"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${version_inc}.tmp" "${version_inc}"
-    COMMAND ${CMAKE_COMMAND} -E rm "${version_inc}.tmp"
+    COMMAND ${CMAKE_COMMAND} -E remove "${version_inc}.tmp"
     )
 else()
   set(add_llvm_version_header_script "${CMAKE_CURRENT_SOURCE_DIR}/AddLLVMVersionHeader.cmake")
@@ -40,7 +40,7 @@ else()
     COMMAND ${CMAKE_COMMAND} "-DHEADER_FILE=${version_inc}.tmp"
                              -P "${add_llvm_version_header_script}"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${version_inc}.tmp" "${version_inc}"
-    COMMAND ${CMAKE_COMMAND} -E rm "${version_inc}.tmp"
+    COMMAND ${CMAKE_COMMAND} -E remove "${version_inc}.tmp"
     )
 endif()
 

--- a/version/CMakeLists.txt
+++ b/version/CMakeLists.txt
@@ -13,7 +13,7 @@ set(vcs_depends "${generate_vcs_version_script}")
 find_first_existing_vc_file("${ONNX_MLIR_SRC_ROOT}" onnx_mlir_vc)
 list(APPEND vcs_depends "${onnx_mlir_vc}")
 
-find_first_existing_vc_file("${LLVM_BUILD_MAIN_SRC_DIR1}" llvm_vc)
+find_first_existing_vc_file("${LLVM_BUILD_MAIN_SRC_DIR}" llvm_vc)
 if (llvm_vc)
   list(APPEND vcs_depends "${llvm_vc}")
 endif()
@@ -21,7 +21,7 @@ endif()
 add_custom_command(OUTPUT "${version_inc}.tmp"
   DEPENDS "${vcs_depends}"
   COMMAND ${CMAKE_COMMAND} "-DNAMES=\"LLVM;ONNX_MLIR\""
-                           "-DLLVM_SOURCE_DIR=${LLVM_BUILD_MAIN_SRC_DIR1}"
+                           "-DLLVM_SOURCE_DIR=${LLVM_BUILD_MAIN_SRC_DIR}"
                            "-DONNX_MLIR_SOURCE_DIR=${ONNX_MLIR_SRC_ROOT}"
                            "-DHEADER_FILE=${version_inc}.tmp"
                            -P "${generate_vcs_version_script}"

--- a/version/CMakeLists.txt
+++ b/version/CMakeLists.txt
@@ -1,25 +1,52 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(llvm_source_dir ${LLVM_DIR})
-set(onnx_mlir_source_dir ${ONNX_MLIR_SRC_ROOT})
-
-find_first_existing_vc_file("${onnx_mlir_source_dir}" onnx_mlir_vc)
-find_first_existing_vc_file("${llvm_source_dir}" llvm_vc)
+# We would like the VCSVersion.inc file to contain both the llvm and onnx-mlir
+# git revision. This is trivial for onnx-mlir, however, we cannot guarantee
+# that we will have access to the llvm source. If the source directory exists,
+# we attempt to use it to get the version. Otherwise, we rely on LLVM_APPEND_VC_REV
+# and VCSRevision.h.
 
 set(version_inc "${ONNX_MLIR_BIN_ROOT}/VCSVersion.inc")
 set(generate_vcs_version_script "${LLVM_CMAKE_DIR}/GenerateVersionFromVCS.cmake")
+set(vcs_depends "${generate_vcs_version_script}")
 
-add_custom_command(OUTPUT "${version_inc}"
-  DEPENDS "${llvm_vc}" "${onnx_mlir_vc}" "${generate_vcs_version_script}"
+find_first_existing_vc_file("${ONNX_MLIR_SRC_ROOT}" onnx_mlir_vc)
+list(APPEND vcs_depends "${onnx_mlir_vc}")
+
+find_first_existing_vc_file("${LLVM_BUILD_MAIN_SRC_DIR1}" llvm_vc)
+if (llvm_vc)
+  list(APPEND vcs_depends "${llvm_vc}")
+endif()
+
+add_custom_command(OUTPUT "${version_inc}.tmp"
+  DEPENDS "${vcs_depends}"
   COMMAND ${CMAKE_COMMAND} "-DNAMES=\"LLVM;ONNX_MLIR\""
-                           "-DLLVM_SOURCE_DIR=${llvm_source_dir}"
-                           "-DONNX_MLIR_SOURCE_DIR=${onnx_mlir_source_dir}"
-                           "-DHEADER_FILE=${version_inc}"
-                           -P "${generate_vcs_version_script}")
+                           "-DLLVM_SOURCE_DIR=${LLVM_BUILD_MAIN_SRC_DIR1}"
+                           "-DONNX_MLIR_SOURCE_DIR=${ONNX_MLIR_SRC_ROOT}"
+                           "-DHEADER_FILE=${version_inc}.tmp"
+                           -P "${generate_vcs_version_script}"
+  )
+
+if (llvm_vc OR NOT LLVM_APPEND_VC_REV)
+  add_custom_command(OUTPUT "${version_inc}"
+    DEPENDS "${version_inc}.tmp"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${version_inc}.tmp" "${version_inc}"
+    COMMAND ${CMAKE_COMMAND} -E rm "${version_inc}.tmp"
+    )
+else()
+  set(add_llvm_version_header_script "${CMAKE_CURRENT_SOURCE_DIR}/AddLLVMVersionHeader.cmake")
+  add_custom_command(OUTPUT "${version_inc}"
+    DEPENDS "${version_inc}.tmp" "${add_llvm_version_header_script}"
+    COMMAND ${CMAKE_COMMAND} "-DHEADER_FILE=${version_inc}.tmp"
+                             -P "${add_llvm_version_header_script}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${version_inc}.tmp" "${version_inc}"
+    COMMAND ${CMAKE_COMMAND} -E rm "${version_inc}.tmp"
+    )
+endif()
 
 set_source_files_properties("${version_inc}"
   PROPERTIES GENERATED TRUE
-             HEADER_FILE_ONLY TRUE)
+             HEADER_FILE_ONLY TRUE
+  )
 
-add_custom_target(Version ALL DEPENDS ${version_inc})
-add_dependencies(CompilerUtils Version)
+add_custom_target(OMVersion ALL DEPENDS ${version_inc})

--- a/version/CMakeLists.txt
+++ b/version/CMakeLists.txt
@@ -13,36 +13,35 @@ set(vcs_depends "${generate_vcs_version_script}")
 find_first_existing_vc_file("${ONNX_MLIR_SRC_ROOT}" onnx_mlir_vc)
 list(APPEND vcs_depends "${onnx_mlir_vc}")
 
-find_first_existing_vc_file("${LLVM_BUILD_MAIN_SRC_DIR}" llvm_vc)
-if (llvm_vc)
-  list(APPEND vcs_depends "${llvm_vc}")
-endif()
-
-add_custom_command(OUTPUT "${version_inc}.tmp"
-  DEPENDS "${vcs_depends}"
-  COMMAND ${CMAKE_COMMAND} "-DNAMES=\"LLVM;ONNX_MLIR\""
+list(APPEND vcs_generate_commands
+  COMMAND ${CMAKE_COMMAND} [[-DNAMES="LLVM\;ONNX_MLIR"]]
                            "-DLLVM_SOURCE_DIR=${LLVM_BUILD_MAIN_SRC_DIR}"
                            "-DONNX_MLIR_SOURCE_DIR=${ONNX_MLIR_SRC_ROOT}"
                            "-DHEADER_FILE=${version_inc}.tmp"
                            -P "${generate_vcs_version_script}"
   )
 
-if (llvm_vc OR NOT LLVM_APPEND_VC_REV)
-  add_custom_command(OUTPUT "${version_inc}"
-    DEPENDS "${version_inc}.tmp"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${version_inc}.tmp" "${version_inc}"
-    COMMAND ${CMAKE_COMMAND} -E remove "${version_inc}.tmp"
-    )
-else()
+find_first_existing_vc_file("${LLVM_BUILD_MAIN_SRC_DIR}" llvm_vc)
+if (llvm_vc)
+  list(APPEND vcs_depends "${llvm_vc}")
+elseif (LLVM_APPEND_VC_REV)
   set(add_llvm_version_header_script "${CMAKE_CURRENT_SOURCE_DIR}/AddLLVMVersionHeader.cmake")
-  add_custom_command(OUTPUT "${version_inc}"
-    DEPENDS "${version_inc}.tmp" "${add_llvm_version_header_script}"
+  list(APPEND vcs_depends "${add_llvm_version_header_script}")
+  list(APPEND vcs_generate_commands
     COMMAND ${CMAKE_COMMAND} "-DHEADER_FILE=${version_inc}.tmp"
                              -P "${add_llvm_version_header_script}"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${version_inc}.tmp" "${version_inc}"
-    COMMAND ${CMAKE_COMMAND} -E remove "${version_inc}.tmp"
     )
 endif()
+
+list(APPEND vcs_generate_commands
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${version_inc}.tmp" "${version_inc}"
+  COMMAND ${CMAKE_COMMAND} -E remove "${version_inc}.tmp"
+  )
+
+add_custom_command(OUTPUT "${version_inc}"
+  DEPENDS "${vcs_depends}"
+  ${vcs_generate_commands}
+  )
 
 set_source_files_properties("${version_inc}"
   PROPERTIES GENERATED TRUE


### PR DESCRIPTION
Right now the version is only appended when the source is explicitly available. This is not always the case since onnx-mlir can be built against a build directory as well as against an install directory of llvm. This change tries to check for the llvm source version and if it not found, includes the VCSRevision.h header generated by llvm instead.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>