### PR TITLE
Optionally return the number of entry points in omQueryEntryPoints

### DIFF
--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -68,8 +68,9 @@ ExecutionSession::ExecutionSession(
   }
 }
 
-const std::string *ExecutionSession::queryEntryPoints() const {
-  return (const std::string *)_queryEntryPointsFunc();
+const std::string *ExecutionSession::queryEntryPoints(
+    int64_t *numOfEntryPoints) const {
+  return (const std::string *)_queryEntryPointsFunc(numOfEntryPoints);
 }
 
 void ExecutionSession::setEntryPoint(const std::string &entryPointName) {

--- a/src/Runtime/ExecutionSession.hpp
+++ b/src/Runtime/ExecutionSession.hpp
@@ -25,7 +25,7 @@
 namespace onnx_mlir {
 
 using entryPointFuncType = OMTensorList *(*)(OMTensorList *);
-using queryEntryPointsFuncType = const char **(*)();
+using queryEntryPointsFuncType = const char **(*)(int64_t *);
 using signatureFuncType = const char *(*)(const char *);
 using OMTensorUniquePtr = std::unique_ptr<OMTensor, decltype(&omTensorDestroy)>;
 
@@ -35,7 +35,9 @@ public:
 
   // Get a NULL-terminated array of entry point names.
   // For example {"run_addition, "run_substraction", NULL}
-  const std::string *queryEntryPoints() const;
+  // In order to get the number of entry points, pass an integer pointer to the
+  // function.
+  const std::string *queryEntryPoints(int64_t *numOfEntryPoints) const;
 
   // Set entry point for this session.
   // Call this before running the session or querying signatures if

--- a/src/Runtime/PyExecutionSession.cpp
+++ b/src/Runtime/PyExecutionSession.cpp
@@ -168,7 +168,7 @@ void PyExecutionSession::pySetEntryPoint(std::string entryPointName) {
 
 std::vector<std::string> PyExecutionSession::pyQueryEntryPoints() {
   assert(_queryEntryPointsFunc && "Query entry point not loaded.");
-  const char **entryPointArr = _queryEntryPointsFunc();
+  const char **entryPointArr = _queryEntryPointsFunc(NULL);
 
   std::vector<std::string> outputPyArrays;
   int i = 0;

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -25,21 +25,31 @@ module {
 
 // CHECK-LABEL:   llvm.func @run_main_graph({{.*}}: !llvm.ptr<i8>) -> !llvm.ptr<i8>
 
-// CHECK:         llvm.func @omQueryEntryPoints() -> !llvm.ptr<ptr<i8>> {
-// CHECK:           [[VAR_0_3_:%.+]] = llvm.mlir.addressof @_entry_point_arrays : !llvm.ptr<array<2 x ptr<i8>>>
-// CHECK:           [[VAR_1_4_:%.+]] = llvm.bitcast [[VAR_0_3_]] : !llvm.ptr<array<2 x ptr<i8>>> to !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_1_4_]] : !llvm.ptr<ptr<i8>>
+// CHECK:         llvm.func @omQueryEntryPoints([[arg0_:%.+]]: !llvm.ptr<i64>) -> !llvm.ptr<ptr<i8>> {
+// CHECK:           [[VAR_0_3_:%.+]] = llvm.mlir.null : !llvm.ptr<i64>
+// CHECK:           [[VAR_1_4_:%.+]] = llvm.icmp "ne" [[arg0_]], [[VAR_0_3_]] : !llvm.ptr<i64>
+// CHECK:           llvm.cond_br [[VAR_1_4_]], ^bb1, ^bb2
+// CHECK:         ^bb1:  // pred: ^bb0
+// CHECK:           [[VAR_2_4_:%.+]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:           llvm.store [[VAR_2_4_]], [[arg0_]] : !llvm.ptr<i64>
+// CHECK:           llvm.br ^bb3
+// CHECK:         ^bb2:  // pred: ^bb0
+// CHECK:           llvm.br ^bb3
+// CHECK:         ^bb3:  // 2 preds: ^bb1, ^bb2
+// CHECK:           [[VAR_3_3_:%.+]] = llvm.mlir.addressof @_entry_point_arrays : !llvm.ptr<array<2 x ptr<i8>>>
+// CHECK:           [[VAR_4_4_:%.+]] = llvm.bitcast [[VAR_3_3_]] : !llvm.ptr<array<2 x ptr<i8>>> to !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_4_4_]] : !llvm.ptr<ptr<i8>>
 // CHECK:         }
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_4_:%.+]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:       [[VAR_1_5_:%.+]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_4_:%.+]] = llvm.alloca [[VAR_1_5_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
-// CHECK-DAG:       [[VAR_3_3_:%.+]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-DAG:       [[VAR_4_4_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
+// CHECK-DAG:       [[VAR_2_5_:%.+]] = llvm.alloca [[VAR_1_5_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
+// CHECK-DAG:       [[VAR_3_4_:%.+]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-DAG:       [[VAR_4_5_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_4_:%.+]] = llvm.getelementptr [[VAR_4_4_]]{{.}}[[VAR_3_3_]], [[VAR_3_3_]]{{.}} : (!llvm.ptr<array<15 x i8>>, i64, i64) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_5_4_:%.+]] = llvm.getelementptr [[VAR_4_5_]]{{.}}[[VAR_3_4_]], [[VAR_3_4_]]{{.}} : (!llvm.ptr<array<15 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[VAR_6_3_:%.+]] = llvm.mlir.constant(15 : i64) : i64
 // CHECK:           [[VAR_7_1_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_4_]], [[VAR_6_3_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
 // CHECK:           [[VAR_8_1_:%.+]] = llvm.icmp "eq" [[VAR_7_1_]], [[VAR_0_4_]] : i32
@@ -47,24 +57,25 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_9_1_:%.+]] = llvm.mlir.addressof @_entry_point_0_in_sig : !llvm.ptr<array<9 x i8>>
 // CHECK:           [[VAR_10_1_:%.+]] = llvm.bitcast [[VAR_9_1_]] : !llvm.ptr<array<9 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[VAR_10_1_]], [[VAR_2_4_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.store [[VAR_10_1_]], [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.br ^bb3
 // CHECK:         ^bb2:  // pred: ^bb0
-// CHECK:           llvm.br ^bb3
-// CHECK:         ^bb3:  // 2 preds: ^bb1, ^bb2
-// CHECK:           [[VAR_11_1_:%.+]] = llvm.load [[VAR_2_4_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           [[VAR_11_1_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_11_1_]] : !llvm.ptr<i8>
+// CHECK:         ^bb3:  // pred: ^bb1
+// CHECK:           [[VAR_12_1_:%.+]] = llvm.load [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr<i8>
 // CHECK:         }
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_5_:%.+]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:       [[VAR_1_6_:%.+]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_5_:%.+]] = llvm.alloca [[VAR_1_6_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
-// CHECK-DAG:       [[VAR_3_4_:%.+]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-DAG:       [[VAR_4_5_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
+// CHECK-DAG:       [[VAR_2_6_:%.+]] = llvm.alloca [[VAR_1_6_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
+// CHECK-DAG:       [[VAR_3_5_:%.+]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-DAG:       [[VAR_4_6_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_5_:%.+]] = llvm.getelementptr [[VAR_4_5_]]{{.}}[[VAR_3_4_]], [[VAR_3_4_]]{{.}} : (!llvm.ptr<array<15 x i8>>, i64, i64) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_5_5_:%.+]] = llvm.getelementptr [[VAR_4_6_]]{{.}}[[VAR_3_5_]], [[VAR_3_5_]]{{.}} : (!llvm.ptr<array<15 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[VAR_6_4_:%.+]] = llvm.mlir.constant(15 : i64) : i64
 // CHECK:           [[VAR_7_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_5_]], [[VAR_6_4_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
 // CHECK:           [[VAR_8_2_:%.+]] = llvm.icmp "eq" [[VAR_7_2_]], [[VAR_0_5_]] : i32
@@ -72,14 +83,16 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_9_2_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr<array<10 x i8>>
 // CHECK:           [[VAR_10_2_:%.+]] = llvm.bitcast [[VAR_9_2_]] : !llvm.ptr<array<10 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[VAR_10_2_]], [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.store [[VAR_10_2_]], [[VAR_2_6_]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.br ^bb3
 // CHECK:         ^bb2:  // pred: ^bb0
-// CHECK:           llvm.br ^bb3
-// CHECK:         ^bb3:  // 2 preds: ^bb1, ^bb2
-// CHECK:           [[VAR_11_1_:%.+]] = llvm.load [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_11_1_]] : !llvm.ptr<i8>
+// CHECK:           [[VAR_11_2_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_11_2_]] : !llvm.ptr<i8>
+// CHECK:         ^bb3:  // pred: ^bb1
+// CHECK:           [[VAR_12_1_:%.+]] = llvm.load [[VAR_2_6_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr<i8>
 // CHECK:         }
+
 }
 
 // -----
@@ -120,21 +133,31 @@ module {
 // CHECK-LABEL:   llvm.func @run_first_entry({{.*}}: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-LABEL:   llvm.func @run_second_entry({{.*}}: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 
-// CHECK:         llvm.func @omQueryEntryPoints() -> !llvm.ptr<ptr<i8>> {
-// CHECK:           [[VAR_0_11_:%.+]] = llvm.mlir.addressof @_entry_point_arrays : !llvm.ptr<array<3 x ptr<i8>>>
-// CHECK:           [[VAR_1_14_:%.+]] = llvm.bitcast [[VAR_0_11_]] : !llvm.ptr<array<3 x ptr<i8>>> to !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_1_14_]] : !llvm.ptr<ptr<i8>>
+// CHECK:         llvm.func @omQueryEntryPoints([[arg0_:%.+]]: !llvm.ptr<i64>) -> !llvm.ptr<ptr<i8>> {
+// CHECK:           [[VAR_0_11_:%.+]] = llvm.mlir.null : !llvm.ptr<i64>
+// CHECK:           [[VAR_1_14_:%.+]] = llvm.icmp "ne" [[arg0_]], [[VAR_0_11_]] : !llvm.ptr<i64>
+// CHECK:           llvm.cond_br [[VAR_1_14_]], ^bb1, ^bb2
+// CHECK:         ^bb1:  // pred: ^bb0
+// CHECK:           [[VAR_2_14_:%.+]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:           llvm.store [[VAR_2_14_]], [[arg0_]] : !llvm.ptr<i64>
+// CHECK:           llvm.br ^bb3
+// CHECK:         ^bb2:  // pred: ^bb0
+// CHECK:           llvm.br ^bb3
+// CHECK:         ^bb3:  // 2 preds: ^bb1, ^bb2
+// CHECK:           [[VAR_3_11_:%.+]] = llvm.mlir.addressof @_entry_point_arrays : !llvm.ptr<array<3 x ptr<i8>>>
+// CHECK:           [[VAR_4_14_:%.+]] = llvm.bitcast [[VAR_3_11_]] : !llvm.ptr<array<3 x ptr<i8>>> to !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_4_14_]] : !llvm.ptr<ptr<i8>>
 // CHECK:         }
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_12_:%.+]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:       [[VAR_1_15_:%.+]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_13_:%.+]] = llvm.alloca [[VAR_1_15_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
-// CHECK-DAG:       [[VAR_3_10_:%.+]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-DAG:       [[VAR_4_13_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
+// CHECK-DAG:       [[VAR_2_15_:%.+]] = llvm.alloca [[VAR_1_15_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
+// CHECK-DAG:       [[VAR_3_12_:%.+]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-DAG:       [[VAR_4_15_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_13_:%.+]] = llvm.getelementptr [[VAR_4_13_]]{{.}}[[VAR_3_10_]], [[VAR_3_10_]]{{.}} : (!llvm.ptr<array<16 x i8>>, i64, i64) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_5_13_:%.+]] = llvm.getelementptr [[VAR_4_15_]]{{.}}[[VAR_3_12_]], [[VAR_3_12_]]{{.}} : (!llvm.ptr<array<16 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[VAR_6_10_:%.+]] = llvm.mlir.constant(16 : i64) : i64
 // CHECK:           [[VAR_7_6_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_13_]], [[VAR_6_10_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
 // CHECK:           [[VAR_8_6_:%.+]] = llvm.icmp "eq" [[VAR_7_6_]], [[VAR_0_12_]] : i32
@@ -142,13 +165,13 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_9_6_:%.+]] = llvm.mlir.addressof @_entry_point_0_in_sig : !llvm.ptr<array<11 x i8>>
 // CHECK:           [[VAR_10_6_:%.+]] = llvm.bitcast [[VAR_9_6_]] : !llvm.ptr<array<11 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[VAR_10_6_]], [[VAR_2_13_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.store [[VAR_10_6_]], [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.br ^bb5
 // CHECK:         ^bb2:  // pred: ^bb0
-// CHECK-DAG:       [[VAR_11_4_:%.+]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-DAG:       [[VAR_12_3_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr<array<17 x i8>>
+// CHECK-DAG:       [[VAR_11_5_:%.+]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-DAG:       [[VAR_12_4_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr<array<17 x i8>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_13_3_:%.+]] = llvm.getelementptr [[VAR_12_3_]]{{.}}[[VAR_11_4_]], [[VAR_11_4_]]{{.}} : (!llvm.ptr<array<17 x i8>>, i64, i64) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_13_3_:%.+]] = llvm.getelementptr [[VAR_12_4_]]{{.}}[[VAR_11_5_]], [[VAR_11_5_]]{{.}} : (!llvm.ptr<array<17 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[LOAD_VAR_12_MEM_1_1_:%.+]] = llvm.mlir.constant(17 : i64) : i64
 // CHECK:           [[VAR_15_3_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_13_3_]], [[LOAD_VAR_12_MEM_1_1_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
 // CHECK:           [[LOAD_VAR_13_MEM_1_1_:%.+]] = llvm.icmp "eq" [[VAR_15_3_]], [[VAR_0_12_]] : i32
@@ -156,24 +179,25 @@ module {
 // CHECK:         ^bb3:  // pred: ^bb2
 // CHECK:           [[VAR_17_3_:%.+]] = llvm.mlir.addressof @_entry_point_1_in_sig : !llvm.ptr<array<11 x i8>>
 // CHECK:           [[LOAD_VAR_2_3_MEM_1_1_:%.+]] = llvm.bitcast [[VAR_17_3_]] : !llvm.ptr<array<11 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[LOAD_VAR_2_3_MEM_1_1_]], [[VAR_2_13_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.store [[LOAD_VAR_2_3_MEM_1_1_]], [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.br ^bb5
 // CHECK:         ^bb4:  // pred: ^bb2
-// CHECK:           llvm.br ^bb5
-// CHECK:         ^bb5:  // 3 preds: ^bb1, ^bb3, ^bb4
-// CHECK:           [[VAR_19_2_:%.+]] = llvm.load [[VAR_2_13_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_19_2_]] : !llvm.ptr<i8>
+// CHECK:           [[VAR_19_3_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_19_3_]] : !llvm.ptr<i8>
+// CHECK:         ^bb5:  // 2 preds: ^bb1, ^bb3
+// CHECK:           [[VAR_20_2_:%.+]] = llvm.load [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_20_2_]] : !llvm.ptr<i8>
 // CHECK:         }
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_13_:%.+]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:       [[VAR_1_16_:%.+]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_14_:%.+]] = llvm.alloca [[VAR_1_16_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
-// CHECK-DAG:       [[VAR_3_11_:%.+]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-DAG:       [[VAR_4_14_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
+// CHECK-DAG:       [[VAR_2_16_:%.+]] = llvm.alloca [[VAR_1_16_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
+// CHECK-DAG:       [[VAR_3_13_:%.+]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-DAG:       [[VAR_4_16_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_5_14_:%.+]] = llvm.getelementptr [[VAR_4_14_]]{{.}}[[VAR_3_11_]], [[VAR_3_11_]]{{.}} : (!llvm.ptr<array<16 x i8>>, i64, i64) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_5_14_:%.+]] = llvm.getelementptr [[VAR_4_16_]]{{.}}[[VAR_3_13_]], [[VAR_3_13_]]{{.}} : (!llvm.ptr<array<16 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[VAR_6_11_:%.+]] = llvm.mlir.constant(16 : i64) : i64
 // CHECK:           [[VAR_7_7_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_14_]], [[VAR_6_11_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
 // CHECK:           [[VAR_8_7_:%.+]] = llvm.icmp "eq" [[VAR_7_7_]], [[VAR_0_13_]] : i32
@@ -181,13 +205,13 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_9_7_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr<array<12 x i8>>
 // CHECK:           [[VAR_10_7_:%.+]] = llvm.bitcast [[VAR_9_7_]] : !llvm.ptr<array<12 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[VAR_10_7_]], [[VAR_2_14_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.store [[VAR_10_7_]], [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.br ^bb5
 // CHECK:         ^bb2:  // pred: ^bb0
-// CHECK-DAG:       [[VAR_11_5_:%.+]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-DAG:       [[VAR_12_4_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr<array<17 x i8>>
+// CHECK-DAG:       [[VAR_11_6_:%.+]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-DAG:       [[VAR_12_5_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr<array<17 x i8>>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_13_4_:%.+]] = llvm.getelementptr [[VAR_12_4_]]{{.}}[[VAR_11_5_]], [[VAR_11_5_]]{{.}} : (!llvm.ptr<array<17 x i8>>, i64, i64) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_13_4_:%.+]] = llvm.getelementptr [[VAR_12_5_]]{{.}}[[VAR_11_6_]], [[VAR_11_6_]]{{.}} : (!llvm.ptr<array<17 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[LOAD_VAR_12_MEM_1_1_:%.+]] = llvm.mlir.constant(17 : i64) : i64
 // CHECK:           [[VAR_15_4_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_13_4_]], [[LOAD_VAR_12_MEM_1_1_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
 // CHECK:           [[LOAD_VAR_13_MEM_1_1_:%.+]] = llvm.icmp "eq" [[VAR_15_4_]], [[VAR_0_13_]] : i32
@@ -195,12 +219,13 @@ module {
 // CHECK:         ^bb3:  // pred: ^bb2
 // CHECK:           [[VAR_17_4_:%.+]] = llvm.mlir.addressof @_entry_point_1_out_sig : !llvm.ptr<array<12 x i8>>
 // CHECK:           [[LOAD_VAR_2_3_MEM_1_1_:%.+]] = llvm.bitcast [[VAR_17_4_]] : !llvm.ptr<array<12 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[LOAD_VAR_2_3_MEM_1_1_]], [[VAR_2_14_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.store [[LOAD_VAR_2_3_MEM_1_1_]], [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.br ^bb5
 // CHECK:         ^bb4:  // pred: ^bb2
-// CHECK:           llvm.br ^bb5
-// CHECK:         ^bb5:  // 3 preds: ^bb1, ^bb3, ^bb4
-// CHECK:           [[VAR_19_2_1_:%.+]] = llvm.load [[VAR_2_14_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_19_2_1_]] : !llvm.ptr<i8>
+// CHECK:           [[VAR_19_4_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_19_4_]] : !llvm.ptr<i8>
+// CHECK:         ^bb5:  // 2 preds: ^bb1, ^bb3
+// CHECK:           [[VAR_20_2_1_:%.+]] = llvm.load [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_20_2_1_]] : !llvm.ptr<i8>
 // CHECK:         }
 }


### PR DESCRIPTION
Resolve #1249 

This patch changes the function signature of `omQueryEntryPoints` from `**i8()` to `**i8(*i64)` to allow returning the number of entry points via its argument.

This patch also fixes an issue in functions `inputSignature(entryPointName)` and `outputSignature(entryPointName)` where NULL will be returned if the entry point name is not found.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>