### PR TITLE
Make NNPA-related options work

### DIFF
--- a/src/Accelerators/Accelerator.hpp
+++ b/src/Accelerators/Accelerator.hpp
@@ -30,7 +30,7 @@ public:
   virtual bool isActive() const = 0;
   virtual void prepareAccelerator(mlir::OwningOpRef<mlir::ModuleOp> &module,
       mlir::MLIRContext &context, mlir::PassManager &pm,
-      onnx_mlir::EmissionTargetType emissionTarget) const = 0;
+      onnx_mlir::EmissionTargetType &emissionTarget) const = 0;
 
 protected:
   // static llvm::SmallPtrSet<Accelerator *, 2> acceleratorTargets;

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.hpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.hpp
@@ -19,11 +19,11 @@
 
 namespace onnx_mlir {
 
-enum class NNPAEmissionTargetType {
+typedef enum {
   EmitZNONE,
   EmitZLowIR,
   EmitZHighIR,
-};
+} NNPAEmissionTargetType;
 
 void addMemoryPooling(mlir::PassManager &pm);
 

--- a/src/Accelerators/NNPA/NNPAAccelerator.cpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.cpp
@@ -56,7 +56,7 @@ bool NNPAAccelerator::isActive() const {
 
 void NNPAAccelerator::prepareAccelerator(mlir::OwningOpRef<ModuleOp> &module,
     mlir::MLIRContext &context, mlir::PassManager &pm,
-    onnx_mlir::EmissionTargetType emissionTarget) const {
+    onnx_mlir::EmissionTargetType &emissionTarget) const {
   LLVM_DEBUG(
       llvm::dbgs() << "preparing accelerator " << acceleratorTarget << "\n");
 

--- a/src/Accelerators/NNPA/NNPAAccelerator.hpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.hpp
@@ -30,7 +30,7 @@ public:
   bool isActive() const final;
   void prepareAccelerator(mlir::OwningOpRef<mlir::ModuleOp> &module,
       mlir::MLIRContext &context, mlir::PassManager &pm,
-      onnx_mlir::EmissionTargetType emissionTarget) const final;
+      onnx_mlir::EmissionTargetType &emissionTarget) const final;
 };
 
 } // namespace nnpa


### PR DESCRIPTION
Options for NNPA in command `onnx-mlir` like `--EmitZHighIR`, `--EmitZLowIR` do not work because `onnx_mlir::EmissionTargetType` is not modified to stop compilation when NNPA options exist. This patch fixes that issue and makes the options work.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>