### PR TITLE
[cmake] Support generating onnx-mlir with mlir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ CMakePresets.json
 # Filesystem
 .DS_Store
 
+# Nested build directory
+/build*
+
 # The following .gitignore content is taken from
 # https://github.com/github/gitignore/blob/main/Python.gitignore
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,9 @@ set(BENCHMARK_ENABLE_TESTING OFF)
 add_subdirectory(third_party/onnx)
 add_subdirectory(third_party/pybind11)
 add_subdirectory(third_party/rapidcheck)
-add_subdirectory(third_party/benchmark)
+if (NOT TARGET benchmark)
+  add_subdirectory(third_party/benchmark)
+endif()
 
 # Ensure warnings are reported for onnx-mlir code.
 if (ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS)

--- a/src/Builder/OpBuildTable.inc.dc.in
+++ b/src/Builder/OpBuildTable.inc.dc.in
@@ -1,1 +1,1 @@
-file-same-as-stdout({"file": "@CMAKE_CURRENT_SOURCE_DIR@/OpBuildTable.inc", "cmd": ["@Python3_EXECUTABLE@", "@CMAKE_SOURCE_DIR@/utils/gen_onnx_mlir.py", "--dry-run-op-build-table"]})
+file-same-as-stdout({"file": "@CMAKE_CURRENT_SOURCE_DIR@/OpBuildTable.inc", "cmd": ["@Python3_EXECUTABLE@", "@PROJECT_SOURCE_DIR@/utils/gen_onnx_mlir.py", "--dry-run-op-build-table"]})

--- a/src/Dialect/ONNX/ONNXOps.td.inc.dc.in
+++ b/src/Dialect/ONNX/ONNXOps.td.inc.dc.in
@@ -1,1 +1,1 @@
-file-same-as-stdout({"file": "@CMAKE_CURRENT_SOURCE_DIR@/ONNXOps.td.inc", "cmd": ["@Python3_EXECUTABLE@", "@CMAKE_SOURCE_DIR@/utils/gen_onnx_mlir.py", "--dry-run-onnx-ops"]})
+file-same-as-stdout({"file": "@CMAKE_CURRENT_SOURCE_DIR@/ONNXOps.td.inc", "cmd": ["@Python3_EXECUTABLE@", "@PROJECT_SOURCE_DIR@/utils/gen_onnx_mlir.py", "--dry-run-onnx-ops"]})

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -3,8 +3,8 @@
 # Invoke gen_onnx_mlir.py to obtain ONNXOps.td.inc, OpBuildTable.inc.
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/ONNXOps.td.inc
         ${CMAKE_CURRENT_SOURCE_DIR}/OpBuildTable.inc
-        COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py)
+        COMMAND Python3::Interpreter ${CMAKE_CURRENT_LIST_DIR}/gen_onnx_mlir.py
+        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/gen_onnx_mlir.py)
 
 # Move the generated files to respective destinations:
 # ONNXOps.td.inc -> src/Dialect/ONNX/ONNXOps.td.inc
@@ -26,4 +26,4 @@ add_custom_target(OMONNXOpsIncTranslation
         OMONNXOpsBuildTableIncGen)
 
 add_custom_target(OMONNXCheckVersion
-        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_onnx_mlir.py --check-operation-version)
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/gen_onnx_mlir.py --check-operation-version)


### PR DESCRIPTION
Changes required to support use cases where onnx-mlir and llvm-project/mlir are generated together.