### PR TITLE
[NFC]: Fix warnings in Stickify.cpp and jniwrapper.c

### DIFF
--- a/src/Accelerators/NNPA/Transform/ZHigh/Stickify/Stickify.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/Stickify/Stickify.cpp
@@ -81,7 +81,6 @@ DECLARE_DATA_LAYOUT_STR(ZDNN_FICO)
 DECLARE_DATA_LAYOUT_STR(ZDNN_HWCK)
 DECLARE_DATA_LAYOUT_STR(ZDNN_BIDIR_ZRH)
 DECLARE_DATA_LAYOUT_STR(ZDNN_BIDIR_FICO)
-static const char *UNDEFINED_STR = "UNDEFINED";
 
 #define DECLARE_DATA_FORMAT_STR(a) static const char *DATA_FORMAT_STR_##a = #a;
 
@@ -185,8 +184,6 @@ const char *get_data_layout_str(zdnn_data_layouts layout) {
     CASE_RTN_STR(ZDNN_HWCK);
     CASE_RTN_STR(ZDNN_BIDIR_ZRH);
     CASE_RTN_STR(ZDNN_BIDIR_FICO);
-  default:
-    return UNDEFINED_STR;
   }
 #undef CASE_RTN_STR
 }
@@ -200,8 +197,6 @@ const char *get_data_format_str(zdnn_data_formats format) {
   switch (format) {
     CASE_RTN_STR(ZDNN_FORMAT_4DFEATURE);
     CASE_RTN_STR(ZDNN_FORMAT_4DKERNEL);
-  default:
-    return UNDEFINED_STR;
   }
 #undef CASE_RTN_STR
 }
@@ -217,8 +212,6 @@ short get_data_type_size(zdnn_data_types type) {
     CASE_RTN_SIZE(FP16, 2);
     CASE_RTN_SIZE(FP32, 4);
     CASE_RTN_SIZE(ZDNN_DLFLOAT16, 2);
-  default:
-    return 0;
   }
 #undef CASE_RTN_SIZE
 } // End - Functions from third_party/zdnn-lib/zdnn/get.c
@@ -284,9 +277,6 @@ uint64_t get_num_elements(const zdnn_ztensor *ztensor, elements_mode mode) {
     // For example: 2D gets dim2 and dim1. 3D gets dim3, dim2, and dim1.
     i = ZDNN_MAX_DIMS -
         get_data_layout_dims(ztensor->pre_transformed_desc->layout);
-    break;
-  default:
-    return 0;
     break;
   }
 
@@ -403,9 +393,6 @@ zdnn_status verify_transformed_descriptor(const zdnn_tensor_desc *tfrmd_desc) {
       return ZDNN_INVALID_LAYOUT;
     }
     break;
-  default:
-    // unrecognized
-    return ZDNN_INVALID_FORMAT;
   }
 
   // for right now only ZDNN_DLFLOAT16 is valid

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -752,7 +752,7 @@ Java_com_ibm_onnxmlir_OMModel_query_1entry_1points(JNIEnv *env, jclass cls) {
    */
   for (int64_t i = 0; i < neps; i++) {
     char ep[32];
-    sprintf(ep, "ep[%ld]", i);
+    sprintf(ep, "ep[%lld]", i);
     HEX_DEBUG(ep, jni_eps[i], strlen(jni_eps[i]));
     LOG_PRINTF(LOG_DEBUG, "ep[%d](%ld):%s", i, strlen(jni_eps[i]), jni_eps[i]);
 


### PR DESCRIPTION
This PR fixes the following compiler warnings: 
 - jniwrapper.c:755:28: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'int64_t' (aka 'long long') [-Wformat]
 -  Stickify.cpp:201:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
- Stickify.cpp:218:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
- Stickify.cpp:286:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
- Stickify.cpp:404:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]

Signed-off-by: Ettore Tiotto <etiotto@ca.ibm.com>