### PR TITLE
[Reduction] Use builder based interface to generate Krnl loops

### DIFF
--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -447,7 +447,6 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
       Value zeroValue = emitConstantOp(rewriter, loc, axesElementType, 0);
       if (axesDim == -1) {
         // When axes is dynamic, generate a Krnl loop
-        auto axesLoopBody = rewriter.saveInsertionPoint();
         KrnlBuilder createKrnl(rewriter, loc);
         ValueRange loopDef = createKrnl.defineLoops(1);
         SmallVector<IndexExpr, 4> lbs(1, LiteralIndexExpr(0));
@@ -461,7 +460,6 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
                   loc, rewriter.getIndexType(), dim);
               createKrnl.store(trueVal, maskVal, jVal);
             });
-        rewriter.restoreInsertionPoint(axesLoopBody);
       } else {
         for (int64_t i = 0; i < axesDim; ++i) {
           Value indexVal = create.math.constantIndex(i);

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -648,13 +648,18 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
         llvm_unreachable("unsupported element type");
 
       // Compute mean
-      BuildKrnlLoop meanLoops(rewriter, loc, outRank);
-      meanLoops.createDefineAndIterateOp(alloc);
-      rewriter.setInsertionPointToStart(meanLoops.getIterateBlock());
-      auto meanIVs = meanLoops.getAllInductionVar();
-      Value loadData = create.krnl.load(alloc, meanIVs);
-      Value meanVal = create.math.div(loadData, divisor);
-      create.krnl.store(meanVal, alloc, meanIVs);
+      KrnlBuilder createKrnl(rewriter, loc);
+      ValueRange loopDef = createKrnl.defineLoops(outRank);
+      SmallVector<IndexExpr, 4> lbs(outRank, LiteralIndexExpr(0));
+      MemRefBoundsIndexCapture allocBounds(alloc);
+      SmallVector<IndexExpr, 4> ubs;
+      allocBounds.getDimList(ubs);
+      createKrnl.iterateIE(loopDef, loopDef, lbs, ubs,
+          [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
+            Value loadData = createKrnl.load(alloc, loopInd);
+            Value meanVal = create.math.div(loadData, divisor);
+            createKrnl.store(meanVal, alloc, loopInd);
+          });
     }
 
     rewriter.replaceOp(op, alloc);

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -377,14 +377,14 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
     int64_t outRank = memRefOutType.getRank();
 
     // KeepDims
-    auto keepdims = reduceSumOp.keepdims();
-    bool isKeepdims = (keepdims == 1) ? true : false;
+    int64_t keepdims = reduceSumOp.keepdims();
+    bool isKeepdims = (keepdims == 1);
 
     ONNXReduceSumOpShapeHelper shapeHelper(&reduceSumOp, &rewriter,
         getDenseElementAttributeFromKrnlValue,
         loadDenseElementArrayValueAtIndex);
-    auto shapecomputed = shapeHelper.computeShape(operandAdaptor);
-    assert(succeeded(shapecomputed));
+    LogicalResult shapecomputed = shapeHelper.computeShape(operandAdaptor);
+    assert(succeeded(shapecomputed) && "Could not compute output shape");
 
     // Get type information
     auto memRefOutShape = memRefOutType.getShape();

--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -38,6 +38,7 @@ add_onnx_mlir_library(OMONNXOps
   ShapeInference/ONNXShapeHelper.cpp  
   ShapeInference/OneHot.cpp
   ShapeInference/Pad.cpp
+  ShapeInference/Reduction.cpp
   ShapeInference/Reshape.cpp
   ShapeInference/ReverseSequence.cpp
   ShapeInference/RoiAlign.cpp

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
@@ -417,6 +417,7 @@ template struct ONNXOpShapeHelper<ONNXMatMulOp>;
 template struct ONNXOpShapeHelper<ONNXMaxPoolSingleOutOp>;
 template struct ONNXOpShapeHelper<ONNXOneHotOp>;
 template struct ONNXOpShapeHelper<ONNXPadOp>;
+template struct ONNXOpShapeHelper<ONNXReduceSumOp>;
 template struct ONNXOpShapeHelper<ONNXReshapeOp>;
 template struct ONNXOpShapeHelper<ONNXLRNOp>;
 template struct ONNXOpShapeHelper<ONNXReverseSequenceOp>;

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp
@@ -397,6 +397,15 @@ struct ONNXAveragePoolOpShapeHelper
   LogicalResult computeShape(ONNXAveragePoolOpAdaptor operandAdaptor);
 };
 
+// Shape for Reduction.
+struct ONNXReduceSumOpShapeHelper : public ONNXOpShapeHelper<ONNXReduceSumOp> {
+  ONNXReduceSumOpShapeHelper(ONNXReduceSumOp *newOp);
+  ONNXReduceSumOpShapeHelper(ONNXReduceSumOp *newOp, OpBuilder *rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal);
+  LogicalResult computeShape(ONNXReduceSumOpAdaptor operandAdaptor);
+};
+
 // Shape for ReshapeOp.
 struct ONNXReshapeOpShapeHelper : public ONNXOpShapeHelper<ONNXReshapeOp> {
   ONNXReshapeOpShapeHelper(ONNXReshapeOp *newOp);

--- a/src/Dialect/ONNX/ShapeInference/Reduction.cpp
+++ b/src/Dialect/ONNX/ShapeInference/Reduction.cpp
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------------- Reduction.cpp - Shape Inference for Reduction Op ------===//
+//
+// Copyright 2022 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file implements shape inference for the ONNX Reduction operator.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
+#include "src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp"
+
+ONNXReduceSumOpShapeHelper::ONNXReduceSumOpShapeHelper(ONNXReduceSumOp *newOp)
+    : ONNXOpShapeHelper<ONNXReduceSumOp>(
+          newOp, newOp->getOperation()->getNumResults()) {}
+
+ONNXReduceSumOpShapeHelper::ONNXReduceSumOpShapeHelper(ONNXReduceSumOp *newOp,
+    OpBuilder *rewriter, ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+    ArrayValueIndexCapture::LoadVal fLoadVal)
+    : ONNXOpShapeHelper<ONNXReduceSumOp>(newOp,
+          newOp->getOperation()->getNumResults(), rewriter, fGetDenseVal,
+          fLoadVal) {}
+
+LogicalResult ONNXReduceSumOpShapeHelper::computeShape(
+    ONNXReduceSumOpAdaptor operandAdaptor) {
+  Value axes = operandAdaptor.axes();
+  MemRefBoundsIndexCapture bounds(axes);
+  int64_t rank = bounds.getRank();
+
+  DimsExpr outputDims(rank);
+  for (int64_t i = 0; i < rank; ++i)
+    outputDims[i] = bounds.getDim(i);
+  dimsForOutput() = outputDims;
+
+  return success();
+}

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -762,6 +762,8 @@ func private @test_reducesumV11(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
     return %0 : tensor<3x1x2xf32>
 // CHECK-LABEL:       @test_reducesum1
 // CHECK-SAME:     ([[VAR_arg0:%.+]]: memref<3x2x2xf32>, [[VAR_arg1:%.+]]: memref<?xi64>) -> memref<3x1x2xf32> {
+// CHECK:           [[VAR_c0:%.+]] = arith.constant 0 : index
+// CHECK:           [[VAR_0:%.+]] = memref.dim [[VAR_arg1]], [[VAR_c0]] : memref<?xi64>
 // CHECK:           [[VAR_1:%.+]] = memref.alloc() {alignment = 16 : i64} : memref<3xi1>
 // CHECK:           [[VAR_false:%.+]] = arith.constant false
 // CHECK:           [[VAR_true:%.+]] = arith.constant true
@@ -775,10 +777,9 @@ func private @test_reducesumV11(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_c3_i64:%.+]] = arith.constant 3 : i64
 // CHECK:           [[VAR_c0_i64:%.+]] = arith.constant 0 : i64
 // CHECK:           [[VAR_2:%.+]] = krnl.define_loops 1
-// CHECK:           [[VAR_c0_1:%.+]] = arith.constant 0 : index
-// CHECK:           [[VAR_3:%.+]] = memref.dim [[VAR_arg1]], [[VAR_c0_1]] : memref<?xi64>
-// CHECK:           krnl.iterate([[VAR_2]]) with ([[VAR_2]] -> [[VAR_arg2:%.+]] = 0 to [[VAR_3]]){
-// CHECK:             [[VAR_6:%.+]] = krnl.load [[VAR_arg1]]{{.}}[[VAR_arg2]]{{.}} : memref<?xi64>
+// CHECK:           krnl.iterate([[VAR_2]]) with ([[VAR_2]] -> [[VAR_arg2:%.+]] = 0 to #map([[VAR_0]])){
+// CHECK:             [[IV:%.+]] = krnl.get_induction_var_value([[VAR_2]]) : (!krnl.loop) -> index
+// CHECK:             [[VAR_6:%.+]] = krnl.load [[VAR_arg1]]{{.*}}[[[IV]]{{.*}} : memref<?xi64>
 // CHECK:             [[VAR_7:%.+]] = arith.cmpi slt, [[VAR_6]], [[VAR_c0_i64]] : i64
 // CHECK:             [[VAR_8:%.+]] = arith.addi [[VAR_6]], [[VAR_c3_i64]] : i64
 // CHECK:             [[VAR_9:%.+]] = arith.select [[VAR_7]], [[VAR_8]], [[VAR_6]] : i64
@@ -822,6 +823,8 @@ func private @test_reducesumV11(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
     return %0 : tensor<3x1x2xf32>
 // CHECK-LABEL:     @test_reducesum2
 // CHECK-SAME:     ([[VAR_arg0:%.+]]: memref<3x2x2xf32>, [[VAR_arg1:%.+]]: memref<?xi64>) -> memref<3x1x2xf32> {
+// CHECK:           [[VAR_c0_3:%.+]] = arith.constant 0 : index
+// CHECK:           [[VAR_0:%.+]] = memref.dim [[VAR_arg1]], [[VAR_c0_3]] : memref<?xi64>
 // CHECK:           [[VAR_1:%.+]] = memref.alloc() {alignment = 16 : i64} : memref<3xi1>
 // CHECK:           [[VAR_false:%.+]] = arith.constant false
 // CHECK:           [[VAR_true:%.+]] = arith.constant true
@@ -840,10 +843,9 @@ func private @test_reducesumV11(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_c3_i64:%.+]] = arith.constant 3 : i64
 // CHECK:           [[VAR_c0_i64:%.+]] = arith.constant 0 : i64
 // CHECK:           [[VAR_5:%.+]] = krnl.define_loops 1
-// CHECK:           [[VAR_c0_3:%.+]] = arith.constant 0 : index
-// CHECK:           [[VAR_6:%.+]] = memref.dim [[VAR_arg1]], [[VAR_c0_3]] : memref<?xi64>
-// CHECK:           krnl.iterate([[VAR_5]]) with ([[VAR_5]] -> [[VAR_arg2:%.+]] = 0 to [[VAR_6]]){
-// CHECK:             [[VAR_9:%.+]] = krnl.load [[VAR_arg1]]{{.}}[[VAR_arg2]]{{.}} : memref<?xi64>
+// CHECK:           krnl.iterate([[VAR_5]]) with ([[VAR_5]] -> [[VAR_arg2:%.+]] = 0 to #map([[VAR_0]])){
+// CHECK:             [[IV:%.+]] = krnl.get_induction_var_value([[VAR_5]]) : (!krnl.loop) -> index
+// CHECK:             [[VAR_9:%.+]] = krnl.load [[VAR_arg1]]{{.}}[[IV]]{{.}} : memref<?xi64>
 // CHECK:             [[VAR_10:%.+]] = arith.cmpi slt, [[VAR_9]], [[VAR_c0_i64]] : i64
 // CHECK:             [[VAR_11:%.+]] = arith.addi [[VAR_9]], [[VAR_c3_i64]] : i64
 // CHECK:             [[VAR_12:%.+]] = arith.select [[VAR_10]], [[VAR_11]], [[VAR_9]] : i64

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -810,9 +810,10 @@ func private @test_reducemean_f32(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
 
   // CHECK: [[DEF_MEAN_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_MEAN_LOOPS]]#0, [[DEF_MEAN_LOOPS]]#1) with ([[DEF_MEAN_LOOPS]]#0 -> %arg1 = 0 to 3, [[DEF_MEAN_LOOPS]]#1 -> %arg2 = 0 to 2){
-  // CHECK:   [[LOAD3:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK:   [[IV:%.+]]:2 = krnl.get_induction_var_value([[DEF_MEAN_LOOPS]]#0, [[DEF_MEAN_LOOPS]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+  // CHECK:   [[LOAD3:%.+]] = krnl.load [[RES]][[[IV]]#0, [[IV]]#1] : memref<3x2xf32>
   // CHECK:   [[MEAN:%.+]] = arith.divf [[LOAD3]], [[DIVISOR]] : f32
-  // CHECK:   krnl.store [[MEAN]], [[RES]][%arg1, %arg2] : memref<3x2xf32>
+  // CHECK:   krnl.store [[MEAN]], [[RES]][[[IV]]#0, [[IV]]#1] : memref<3x2xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xf32>
 }
@@ -842,9 +843,10 @@ func private @test_reducemean_i32(%arg0 : tensor<3x2x2xi32>) -> tensor<*xi32> {
 
   // CHECK: [[DEF_MEAN_LOOPS:%.+]]:2 = krnl.define_loops 2
   // CHECK: krnl.iterate([[DEF_MEAN_LOOPS]]#0, [[DEF_MEAN_LOOPS]]#1) with ([[DEF_MEAN_LOOPS]]#0 -> %arg1 = 0 to 3, [[DEF_MEAN_LOOPS]]#1 -> %arg2 = 0 to 2){
-  // CHECK:   [[LOAD3:%.+]] = krnl.load [[RES]][%arg1, %arg2] : memref<3x2xi32>
+  // CHECK:   [[IV:%.+]]:2 = krnl.get_induction_var_value([[DEF_MEAN_LOOPS]]#0, [[DEF_MEAN_LOOPS]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+  // CHECK:   [[LOAD3:%.+]] = krnl.load [[RES]][[[IV]]#0, [[IV]]#1] : memref<3x2xi32>
   // CHECK:   [[MEAN:%.+]] = arith.divsi [[LOAD3]], [[DIVISOR]] : i32
-  // CHECK:   krnl.store [[MEAN]], [[RES]][%arg1, %arg2] : memref<3x2xi32>
+  // CHECK:   krnl.store [[MEAN]], [[RES]][[[IV]]#0, [[IV]]#1] : memref<3x2xi32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xi32>
 }


### PR DESCRIPTION
This PR updates code generation for `reduction.cpp` to use the builder based interfaces for generation of Krnl loops.