### PR TITLE
Fix warnings in onnx-mlir

### DIFF
--- a/src/Accelerators/NNPA/Transform/ZHigh/Stickify/Stickify.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/Stickify/Stickify.cpp
@@ -186,6 +186,8 @@ const char *get_data_layout_str(zdnn_data_layouts layout) {
     CASE_RTN_STR(ZDNN_BIDIR_FICO);
   }
 #undef CASE_RTN_STR
+
+  llvm_unreachable("Invalid data layout");
 }
 
 const char *get_data_format_str(zdnn_data_formats format) {
@@ -199,6 +201,8 @@ const char *get_data_format_str(zdnn_data_formats format) {
     CASE_RTN_STR(ZDNN_FORMAT_4DKERNEL);
   }
 #undef CASE_RTN_STR
+
+  llvm_unreachable("Invalid data format");
 }
 
 short get_data_type_size(zdnn_data_types type) {
@@ -214,6 +218,8 @@ short get_data_type_size(zdnn_data_types type) {
     CASE_RTN_SIZE(ZDNN_DLFLOAT16, 2);
   }
 #undef CASE_RTN_SIZE
+
+  llvm_unreachable("Invalid data type");
 } // End - Functions from third_party/zdnn-lib/zdnn/get.c
 
 // Functions from third_party/zdnn-lib/zdnn/malloc4k.c

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -752,7 +752,7 @@ Java_com_ibm_onnxmlir_OMModel_query_1entry_1points(JNIEnv *env, jclass cls) {
    */
   for (int64_t i = 0; i < neps; i++) {
     char ep[32];
-    sprintf(ep, "ep[" PRId64 "]", i);
+    sprintf(ep, "ep[%lld]", (long long)i);
     HEX_DEBUG(ep, jni_eps[i], strlen(jni_eps[i]));
     LOG_PRINTF(LOG_DEBUG, "ep[%d](%ld):%s", i, strlen(jni_eps[i]), jni_eps[i]);
 

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -752,7 +752,7 @@ Java_com_ibm_onnxmlir_OMModel_query_1entry_1points(JNIEnv *env, jclass cls) {
    */
   for (int64_t i = 0; i < neps; i++) {
     char ep[32];
-    sprintf(ep, "ep[%lld]", i);
+    sprintf(ep, "ep[" PRId64 "]", i);
     HEX_DEBUG(ep, jni_eps[i], strlen(jni_eps[i]));
     LOG_PRINTF(LOG_DEBUG, "ep[%d](%ld):%s", i, strlen(jni_eps[i]), jni_eps[i]);
 


### PR DESCRIPTION
```
onnx-mlir/src/Accelerators/NNPA/Transform/ZHigh/Stickify/Stickify.cpp:204:1: warning: control reaches end of non-void function [-Wreturn-type]
onnx-mlir/src/Accelerators/NNPA/Transform/ZHigh/Stickify/Stickify.cpp:219:1: warning: control reaches end of non-void function [-Wreturn-type]
onnx-mlir/src/Runtime/jni/jniwrapper.c:755:24: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 3 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
```
Signed-off-by: Whitney Tsang <whitneyt@ca.ibm.com>