### PR TITLE
Fix JNI wrapper entry point name encoding on z/OS

### DIFF
--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -763,17 +763,24 @@ Java_com_ibm_onnxmlir_OMModel_query_1entry_1points(JNIEnv *env, jclass cls) {
     HEX_DEBUG(ep, jni_eps[i], strlen(jni_eps[i]));
     LOG_PRINTF(LOG_DEBUG, "ep[%d](%ld):%s", i, strlen(jni_eps[i]), jni_eps[i]);
 
+    /* On z/OS, convert entry point name in EBCDIC to ASCII */
 #ifdef __MVS__
     CHECK_CALL(
-        char *, epptr, sig_e2a(jni_eps[i]), epptr != NULL, "epptr=%p", epptr);
+        char *, epptr, __e2a(jni_eps[i]), epptr != NULL, "epptr=%p", epptr);
 #else
     const char *epptr = jni_eps[i];
 #endif
+
+    /* Convert to Java String object */
     JNI_TYPE_VAR_CALL(env, jstring, jstr_ep, (*env)->NewStringUTF(env, epptr),
         jstr_ep != NULL, jecpt_cls, "jstr_ep=%p", jstr_ep);
+
+    /* On z/OS, free the ASCII entry point name no longer needed */
 #ifdef __MVS__
     free(epptr);
 #endif
+
+    /* Put Java String object into the String array */
     JNI_CALL(env, (*env)->SetObjectArrayElement(env, java_eps, i, jstr_ep), 1,
         NULL, "");
   }
@@ -835,6 +842,7 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_input_1signature_1jni(
   JNI_TYPE_VAR_CALL(env, jstring, java_isig, (*env)->NewStringUTF(env, sigptr),
       java_isig != NULL, jecpt_cls, "java_isig=%p", java_isig);
 
+  /* On z/OS, free the ASCII input signature no longer needed */
 #ifdef __MVS__
   free(sigptr);
 #endif
@@ -896,6 +904,7 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_output_1signature_1jni(
   JNI_TYPE_VAR_CALL(env, jstring, java_osig, (*env)->NewStringUTF(env, sigptr),
       java_osig != NULL, jecpt_cls, "java_osig=%p", java_osig);
 
+  /* On z/OS, free the ASCII output signature no longer needed */
 #ifdef __MVS__
   free(sigptr);
 #endif

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -796,14 +796,22 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_input_1signature_1jni(
       (*env)->GetStringUTFChars(env, ep, NULL), jni_ep != NULL, jecpt_cls,
       "jni_ep=%p", jni_ep);
 
-  /* Call model input signature API */
+  /* On z/OS, convert entry point name in UTF-8 to EBCDIC */
 #ifdef __MVS__
   CHECK_CALL(char *, epptr, __a2e(jni_ep), epptr != NULL, "epptr=%p", epptr);
 #else
   const char *epptr = jni_ep;
 #endif
+
+  /* Entry point name in hex and string format for debugging */
+  HEX_DEBUG("ep", epptr, strlen(epptr));
+  LOG_PRINTF(LOG_DEBUG, "ep(%d):%s", strlen(epptr), epptr);
+
+  /* Call model input signature API */
   CHECK_CALL(const char *, jni_isig, omInputSignature(epptr), jni_isig != NULL,
       "jni_isig=%p", jni_isig);
+
+  /* On z/OS, free the EBCDIC entry point name no longer needed */
 #ifdef __MVS__
   free(epptr);
 #endif
@@ -815,15 +823,18 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_input_1signature_1jni(
   HEX_DEBUG("isig", jni_isig, strlen(jni_isig));
   LOG_PRINTF(LOG_DEBUG, "isig(%d):%s", strlen(jni_isig), jni_isig);
 
-  /* Convert to Java String object */
+  /* On z/OS, convert input signature in EBCDIC to ASCII */
 #ifdef __MVS__
   CHECK_CALL(
       char *, sigptr, __e2a(jni_isig), sigptr != NULL, "sigptr=%p", sigptr);
 #else
   const char *sigptr = jni_isig;
 #endif
+
+  /* Convert to Java String object */
   JNI_TYPE_VAR_CALL(env, jstring, java_isig, (*env)->NewStringUTF(env, sigptr),
       java_isig != NULL, jecpt_cls, "java_isig=%p", java_isig);
+
 #ifdef __MVS__
   free(sigptr);
 #endif
@@ -846,14 +857,22 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_output_1signature_1jni(
       (*env)->GetStringUTFChars(env, ep, NULL), jni_ep != NULL, jecpt_cls,
       "jni_ep=%p", jni_ep);
 
+  /* On z/OS, convert entry point name in UTF-8 to EBCDIC */
 #ifdef __MVS__
   CHECK_CALL(char *, epptr, __a2e(jni_ep), epptr != NULL, "epptr=%p", epptr);
 #else
   const char *epptr = jni_ep;
 #endif
+
+  /* Entry point name in hex and string format for debugging */
+  HEX_DEBUG("ep", epptr, strlen(epptr));
+  LOG_PRINTF(LOG_DEBUG, "ep(%d):%s", strlen(epptr), epptr);
+
   /* Call model output signature API */
   CHECK_CALL(const char *, jni_osig, omOutputSignature(epptr), jni_osig != NULL,
       "jni_osig=%p", jni_osig);
+
+  /* On z/OS, free the EBCDIC entry point name no longer needed */
 #ifdef __MVS__
   free(epptr);
 #endif
@@ -865,15 +884,18 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_output_1signature_1jni(
   HEX_DEBUG("osig", jni_osig, strlen(jni_osig));
   LOG_PRINTF(LOG_DEBUG, "osig(%d):%s", strlen(jni_osig), jni_osig);
 
-  /* Convert to Java String object */
+  /* On z/OS, convert output signature in EBCDIC to ASCII */
 #ifdef __MVS__
   CHECK_CALL(
       char *, sigptr, __e2a(jni_osig), sigptr != NULL, "sigptr=%p", sigptr);
 #else
   const char *sigptr = jni_osig;
 #endif
+
+  /* Convert to Java String object */
   JNI_TYPE_VAR_CALL(env, jstring, java_osig, (*env)->NewStringUTF(env, sigptr),
       java_osig != NULL, jecpt_cls, "java_osig=%p", java_osig);
+
 #ifdef __MVS__
   free(sigptr);
 #endif


### PR DESCRIPTION
When Java API inputSignature()/outputSignature() calls
input_signature_jni("run_main_graph")/output_signature_jni("run_main_graph"),
"run_main_graph" needs to be converted from ASCII to EBCDIC before being
fed into omInputSignature(epptr)/omOutputSignature(epptr)

Signed-off-by: Gong Su <gong_su@hotmail.com>