### PR TITLE
Do transpose on concat's inputs instead of output

### DIFF
--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -130,7 +130,7 @@ void ONNXTransposeOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<FuseTransposePattern>(context);
   result.insert<RemoveIdentityTransposePattern>(context);
-  result.insert<SwapTransposeConcat>(context);
+  result.insert<SwapTransposeConcatPattern>(context);
 }
 
 /// on the ONNXReshapeOp.

--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -91,6 +91,12 @@ SmallVector<Value, 4> transposeVariadicInput(PatternRewriter &rewriter,
   return transposedInputs;
 }
 
+// Check if all values are produced by ONNXTransposeOp.
+bool areProducedByTransposeOp(ValueRange values) {
+  return llvm::all_of(
+      values, [](Value v) { return isa<ONNXTransposeOp>(v.getDefiningOp()); });
+}
+
 /// Include the patterns defined in the Declarative Rewrite framework.
 #include "src/Dialect/ONNX/ONNXRewrite.inc"
 

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -317,12 +317,19 @@ def GetIndexOfAxisInPerm: NativeCodeCall<
   "getIndexOfAxisInPerm($_builder, $0, $1)"
 >;
 
+def ProducedByTransposeOp: Constraint<
+  CPred<"areProducedByTransposeOp($_self)">,
+  "all values are produced by ONNXTransposeOp"
+>;
+
 // Do transpose on concat's inputs instead of output in order to propagate
-// tranpose ops together, which allows more chance for tranpose fusion.
+// tranpose operations together, which allows more chance for tranpose fusion.
+// Do this only when all inputs are produced by tranpose operations.
 def SwapTransposeConcat: Pat<
   (ONNXTransposeOp:$res (ONNXConcatOp $inputs, $axis), $perm),
   (ONNXConcatOp (TransposeVariadicInput $inputs, $perm),
-                (GetIndexOfAxisInPerm $perm, $axis))
+                (GetIndexOfAxisInPerm $perm, $axis)),
+  [(ProducedByTransposeOp:$inputs)]
 >;
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -174,6 +174,10 @@ class RankXMinusRankYIs<int diff>: Constraint<
           " - $1.getType().cast<ShapedType>().getRank() == " # diff # ")">,
     "X' rank is greater than Y's rank dif units">;
 
+def TransposeVariadicInput: NativeCodeCall<
+  "transposeVariadicInput($_builder, $_loc, $0, $1)"
+>;
+
 //===----------------------------------------------------------------------===//
 // Pattern-Match and Rewrite
 //===----------------------------------------------------------------------===//
@@ -308,6 +312,28 @@ def RemoveIdentityTransposePattern:  Pat<
   (replaceWithValue $val),
   // Check that we have indeed a identity transpose pattern.
   [(IsIdentityPermuteAttribute:$p)]>;
+
+def GetIndexOfAxisInPerm: NativeCodeCall<
+"[](PatternRewriter &rewriter, ArrayAttr permAttr, IntegerAttr axis) {"#
+"  IntegerAttr result;"#
+"  for (uint64_t i = 0; i < permAttr.getValue().size(); ++i) {"#
+"    if (permAttr.getValue()[i].cast<IntegerAttr>().getValue().getSExtValue()"#
+"        == axis.getValue().getSExtValue())" #
+"      return rewriter.getIntegerAttr(rewriter.getIntegerType(64, true), i);"#
+"  }"#
+"  return result;"#
+"}($_builder, $0, $1)"
+>;
+
+// Do transpose on concat's inputs instead of output because of the following
+// reasons:
+//   - the inputs can be produced in parallel (if the compiler supports).
+//   - tranpose ops are propagated together, which enables transpose fusion.
+def SwapTransposeConcat: Pat<
+  (ONNXTransposeOp:$res (ONNXConcatOp $inputs, $axis), $perm),
+  (ONNXConcatOp (TransposeVariadicInput $inputs, $perm),
+                (GetIndexOfAxisInPerm $perm, $axis))
+>;
 
 //===----------------------------------------------------------------------===//
 // Canonicalization for ONNXReshapeOp

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -325,7 +325,7 @@ def ProducedByTransposeOp: Constraint<
 // Do transpose on concat's inputs instead of output in order to propagate
 // transpose operations together, which allows more chance for transpose fusion.
 // Do this only when all inputs are produced by transpose operations.
-def SwapTransposeConcat: Pat<
+def SwapTransposeConcatPattern: Pat<
   (ONNXTransposeOp:$res (ONNXConcatOp $inputs, $axis), $perm),
   (ONNXConcatOp (TransposeVariadicInput $inputs, $perm),
                 (GetIndexOfAxisInPerm $perm, $axis)),

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -314,21 +314,11 @@ def RemoveIdentityTransposePattern:  Pat<
   [(IsIdentityPermuteAttribute:$p)]>;
 
 def GetIndexOfAxisInPerm: NativeCodeCall<
-"[](PatternRewriter &rewriter, ArrayAttr permAttr, IntegerAttr axis) {"#
-"  IntegerAttr result;"#
-"  for (uint64_t i = 0; i < permAttr.getValue().size(); ++i) {"#
-"    if (permAttr.getValue()[i].cast<IntegerAttr>().getValue().getSExtValue()"#
-"        == axis.getValue().getSExtValue())" #
-"      return rewriter.getIntegerAttr(rewriter.getIntegerType(64, true), i);"#
-"  }"#
-"  return result;"#
-"}($_builder, $0, $1)"
+  "getIndexOfAxisInPerm($_builder, $0, $1)"
 >;
 
-// Do transpose on concat's inputs instead of output because of the following
-// reasons:
-//   - the inputs can be produced in parallel (if the compiler supports).
-//   - tranpose ops are propagated together, which enables transpose fusion.
+// Do transpose on concat's inputs instead of output in order to propagate
+// tranpose ops together, which allows more chance for tranpose fusion.
 def SwapTransposeConcat: Pat<
   (ONNXTransposeOp:$res (ONNXConcatOp $inputs, $axis), $perm),
   (ONNXConcatOp (TransposeVariadicInput $inputs, $perm),

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -323,8 +323,8 @@ def ProducedByTransposeOp: Constraint<
 >;
 
 // Do transpose on concat's inputs instead of output in order to propagate
-// tranpose operations together, which allows more chance for tranpose fusion.
-// Do this only when all inputs are produced by tranpose operations.
+// transpose operations together, which allows more chance for transpose fusion.
+// Do this only when all inputs are produced by transpose operations.
 def SwapTransposeConcat: Pat<
   (ONNXTransposeOp:$res (ONNXConcatOp $inputs, $axis), $perm),
   (ONNXConcatOp (TransposeVariadicInput $inputs, $perm),

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -169,10 +169,10 @@ func @test_transpose_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x
 
 // -----
 
-// Check the fusion of tranposes when tranposes at the output side are moved
-// to the input side. This is only done when there are tranposes at the input side.
-// CHECK-LABEL: func @test_tranpose_concat_reversed
-func @test_tranpose_concat_reversed(%arg0: tensor<?x5x5x1xf32>, %arg1: tensor<?x5x5x2xf32>) -> tensor<?x5x5x3xf32> {
+// Check the fusion of transposes when transposes at the output side are moved
+// to the input side. This is only done when there are transposes at the input side.
+// CHECK-LABEL: func @test_transpose_concat_reversed
+func @test_transpose_concat_reversed(%arg0: tensor<?x5x5x1xf32>, %arg1: tensor<?x5x5x2xf32>) -> tensor<?x5x5x3xf32> {
     %0 = "onnx.Transpose"(%arg0) {perm = [0, 3, 1, 2]} : (tensor<?x5x5x1xf32>) -> tensor<?x1x5x5xf32>
     %1 = "onnx.Transpose"(%arg1) {perm = [0, 3, 1, 2]} : (tensor<?x5x5x2xf32>) -> tensor<?x2x5x5xf32>
     %2 = "onnx.Concat"(%0, %1) {axis = 1 : si64} : (tensor<?x1x5x5xf32>, tensor<?x2x5x5xf32>) -> tensor<?x3x5x5xf32>

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -169,6 +169,22 @@ func @test_transpose_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x
 
 // -----
 
+// Tranpose the inputs instead of the output of Concat.
+// CHECK-LABEL: func @test_tranpose_concat_reversed
+func @test_tranpose_concat_reversed(%arg0: tensor<?x1x5x5xf32>, %arg1: tensor<?x2x5x5xf32>, %arg2: tensor<?x3x5x5xf32>, %arg3: tensor<?x4x5x5xf32>) -> tensor<?x5x5x10xf32> {
+    %4 = "onnx.Concat"(%arg0, %arg1, %arg2, %arg3) {axis = 1 : si64} : (tensor<?x1x5x5xf32>, tensor<?x2x5x5xf32>, tensor<?x3x5x5xf32>, tensor<?x4x5x5xf32>) -> tensor<?x10x5x5xf32>
+    %5 = "onnx.Transpose"(%4) {perm = [0, 2, 3, 1]} : (tensor<?x10x5x5xf32>) -> tensor<?x5x5x10xf32>
+    return %5 : tensor<?x5x5x10xf32>
+
+    // CHECK-NEXT: [[TRANSPOSE_0:%.+]] = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} : (tensor<?x1x5x5xf32>) -> tensor<?x5x5x1xf32>
+    // CHECK-NEXT: [[TRANSPOSE_1:%.+]] = "onnx.Transpose"(%arg1) {perm = [0, 2, 3, 1]} : (tensor<?x2x5x5xf32>) -> tensor<?x5x5x2xf32>
+    // CHECK-NEXT: [[TRANSPOSE_2:%.+]] = "onnx.Transpose"(%arg2) {perm = [0, 2, 3, 1]} : (tensor<?x3x5x5xf32>) -> tensor<?x5x5x3xf32>
+    // CHECK-NEXT: [[TRANSPOSE_3:%.+]] = "onnx.Transpose"(%arg3) {perm = [0, 2, 3, 1]} : (tensor<?x4x5x5xf32>) -> tensor<?x5x5x4xf32>
+    // CHECK-NEXT: "onnx.Concat"([[TRANSPOSE_0]], [[TRANSPOSE_1]], [[TRANSPOSE_2]], [[TRANSPOSE_3]]) {axis = 3 : si64} : (tensor<?x5x5x1xf32>, tensor<?x5x5x2xf32>, tensor<?x5x5x3xf32>, tensor<?x5x5x4xf32>) -> tensor<?x5x5x10xf32>
+}
+
+// -----
+
 // Check the removal of identity reshapes.
 // CHECK-LABEL: func @test_reshape_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
 func @test_reshape_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {


### PR DESCRIPTION
This patch adds on canonicalization rule to ONNXTranposeOp which does tranpose on concat's inputs instead of output.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>