### PR TITLE
Allow lowering ONNXGemm with dynamic dims to ZHigh and fix zDNN Conv condition

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -734,8 +734,8 @@ static bool checkConv2DParamRestrictions(int64_t inputDim, int64_t kernelDim,
       if (outputDim != ceil((float)inputDim / stride))
         return false;
     } else { // VALID_PADDING
-      // inputDim must be > kernelDim.
-      if (inputDim <= kernelDim)
+      // inputDim must be >= kernelDim.
+      if (inputDim < kernelDim)
         return false;
       // height_out restriction.
       if (outputDim != ceil((float)(inputDim - kernelDim + 1) / stride))

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -489,10 +489,6 @@ bool isSuitableForZDNN<ONNXGemmOp>(ONNXGemmOp op) {
   if ((aShape.size() != 2) || (bShape.size() != 2) ||
       (hasC && (cShape.size() != 1)))
     return false;
-  // Shape must be static.
-  if (!aType.hasStaticShape() || !bType.hasStaticShape() ||
-      (hasC && !cType.hasStaticShape()))
-    return false;
 
   ONNXGemmOp gemmOp = llvm::cast<ONNXGemmOp>(op);
   if ((gemmOp.alpha().convertToFloat() != 1.0) ||
@@ -502,7 +498,7 @@ bool isSuitableForZDNN<ONNXGemmOp>(ONNXGemmOp op) {
   auto bShape1 = gemmOp.transB() ? bShape[0] : bShape[1];
   // Only support B's second dim is the same with C's dim
   // (A(m, n) * B(n, p) + C(p))
-  if (hasC && (cShape[0] != bShape1))
+  if (hasC && (cShape[0] != -1) && (bShape1 != -1) && (cShape[0] != bShape1))
     return false;
   return true;
 }

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -498,8 +498,13 @@ bool isSuitableForZDNN<ONNXGemmOp>(ONNXGemmOp op) {
   auto bShape1 = gemmOp.transB() ? bShape[0] : bShape[1];
   // Only support B's second dim is the same with C's dim
   // (A(m, n) * B(n, p) + C(p))
-  if (hasC && (cShape[0] != -1) && (bShape1 != -1) && (cShape[0] != bShape1))
-    return false;
+  if (hasC) {
+    // Cannot check broadcasting at compile time.
+    if (cShape[0] == -1)
+      return false;
+    if (cShape[0] != bShape1)
+      return false;
+  }
   return true;
 }
 

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
@@ -91,6 +91,16 @@ func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tenso
 
 // -----
 
+func @test_onnx_conv2d_valid_padding_H_equal_KW(%arg0: tensor<?x1280x1x1xf32>, %arg1: tensor<448x1280x1x1xf32>, %arg2: tensor<448xf32>) -> tensor<*xf32> {
+    %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<?x1280x1x1xf32>, tensor<448x1280x1x1xf32>, tensor<448xf32>) -> tensor<*xf32>
+    return %0 : tensor<*xf32>
+  // CHECK-LABEL: test_onnx_conv2d_valid_padding_H_equal_KW
+  // CHECK: "zhigh.Conv2D"
+  // CHECK-NOT: "onnx.Conv"
+}
+
+// -----
+
 func @test_fuse_onnx_relu_conv2d(%arg0: tensor<5x3x32x32xf32>, %arg1 : tensor<2x3x2x2xf32>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {kernel_shape = [2, 2]} : (tensor<5x3x32x32xf32>, tensor<2x3x2x2xf32>, tensor<2xf32>) -> tensor<*xf32>
   %1 = "onnx.Relu"(%0) : (tensor<*xf32>) -> tensor<*xf32>

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/gemm.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/gemm.mlir
@@ -77,18 +77,30 @@ func @test_gemm_transAB(%arg0 : tensor<10x5xf32>, %arg1 : tensor<5x10xf32>, %arg
 // COM: Lower ONNXGemm to ZHigh without verifying the actual size of an unknown
 // COM: dimension. Accelerator will emit an error if the dimension size is
 // COM: beyond the supported value.
-func @test_gemm_unknown_dims(%arg0: tensor<?x2048xf32>, %arg1: tensor<2048x4096xf32>, %arg2: tensor<4096xf32>) -> tensor<*xf32> {
-  %0= "onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<?x2048xf32>, tensor<2048x4096xf32>, tensor<4096xf32>) -> tensor<*xf32>
+func @test_gemm_unknown_dims(%arg0: tensor<?x5xf32>, %arg1: tensor<5x10xf32>, %arg2: tensor<10xf32>) -> tensor<*xf32> {
+  %0= "onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<?x5xf32>, tensor<5x10xf32>, tensor<10xf32>) -> tensor<*xf32>
   "std.return"(%0) : (tensor<*xf32>) -> ()
 // CHECK-LABEL:  func @test_gemm_unknown_dims
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x2048xf32>, [[PARAM_1_:%.+]]: tensor<2048x4096xf32>, [[PARAM_2_:%.+]]: tensor<4096xf32>) -> tensor<?x4096xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "2D"} : (tensor<?x2048xf32>) -> tensor<?x2048xf32, #zhigh.encoding<{dataLayout = "2D"}>>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "2D"} : (tensor<2048x4096xf32>) -> tensor<2048x4096xf32, #zhigh.encoding<{dataLayout = "2D"}>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "zhigh.Stick"([[PARAM_2_]]) {layout = "1D"} : (tensor<4096xf32>) -> tensor<4096xf32, #zhigh.encoding<{dataLayout = "1D"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.MatMul"([[VAR_0_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<?x2048xf32, #zhigh.encoding<{dataLayout = "2D"}>>, tensor<2048x4096xf32, #zhigh.encoding<{dataLayout = "2D"}>>, tensor<4096xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "zhigh.Unstick"([[VAR_3_]]) : (tensor<*xf32>) -> tensor<?x4096xf32>
-// CHECK:           return [[VAR_4_]] : tensor<?x4096xf32>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x5xf32>, [[PARAM_1_:%.+]]: tensor<5x10xf32>, [[PARAM_2_:%.+]]: tensor<10xf32>) -> tensor<?x10xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "2D"} : (tensor<?x5xf32>) -> tensor<?x5xf32, #zhigh.encoding<{dataLayout = "2D"}>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "2D"} : (tensor<5x10xf32>) -> tensor<5x10xf32, #zhigh.encoding<{dataLayout = "2D"}>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "zhigh.Stick"([[PARAM_2_]]) {layout = "1D"} : (tensor<10xf32>) -> tensor<10xf32, #zhigh.encoding<{dataLayout = "1D"}>>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.MatMul"([[VAR_0_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<?x5xf32, #zhigh.encoding<{dataLayout = "2D"}>>, tensor<5x10xf32, #zhigh.encoding<{dataLayout = "2D"}>>, tensor<10xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<*xf32>
+// CHECK:           [[VAR_4_:%.+]] = "zhigh.Unstick"([[VAR_3_]]) : (tensor<*xf32>) -> tensor<?x10xf32>
+// CHECK:           return [[VAR_4_]] : tensor<?x10xf32>
 // CHECK:         }
+}
+
+// -----
+
+// COM: Not support because we cannot check bias broadcasting at compile time.
+
+func @test_gemm_unknown_dims_not_lowered(%arg0: tensor<?x5xf32>, %arg1: tensor<5x10xf32>, %arg2: tensor<?xf32>) -> tensor<*xf32> {
+  %0= "onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<?x5xf32>, tensor<5x10xf32>, tensor<?xf32>) -> tensor<*xf32>
+  "std.return"(%0) : (tensor<*xf32>) -> ()
+
+ // CHECK-LABEL: test_gemm_unknown_dims_not_lowered
+ // CHECK: onnx.Gemm
 }
 
 // -----

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/gemm.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/gemm.mlir
@@ -74,6 +74,25 @@ func @test_gemm_transAB(%arg0 : tensor<10x5xf32>, %arg1 : tensor<5x10xf32>, %arg
 
 // -----
 
+// COM: Lower ONNXGemm to ZHigh without verifying the actual size of an unknown
+// COM: dimension. Accelerator will emit an error if the dimension size is
+// COM: beyond the supported value.
+func @test_gemm_unknown_dims(%arg0: tensor<?x2048xf32>, %arg1: tensor<2048x4096xf32>, %arg2: tensor<4096xf32>) -> tensor<*xf32> {
+  %0= "onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<?x2048xf32>, tensor<2048x4096xf32>, tensor<4096xf32>) -> tensor<*xf32>
+  "std.return"(%0) : (tensor<*xf32>) -> ()
+// CHECK-LABEL:  func @test_gemm_unknown_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x2048xf32>, [[PARAM_1_:%.+]]: tensor<2048x4096xf32>, [[PARAM_2_:%.+]]: tensor<4096xf32>) -> tensor<?x4096xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "2D"} : (tensor<?x2048xf32>) -> tensor<?x2048xf32, #zhigh.encoding<{dataLayout = "2D"}>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "2D"} : (tensor<2048x4096xf32>) -> tensor<2048x4096xf32, #zhigh.encoding<{dataLayout = "2D"}>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "zhigh.Stick"([[PARAM_2_]]) {layout = "1D"} : (tensor<4096xf32>) -> tensor<4096xf32, #zhigh.encoding<{dataLayout = "1D"}>>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.MatMul"([[VAR_0_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<?x2048xf32, #zhigh.encoding<{dataLayout = "2D"}>>, tensor<2048x4096xf32, #zhigh.encoding<{dataLayout = "2D"}>>, tensor<4096xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<*xf32>
+// CHECK:           [[VAR_4_:%.+]] = "zhigh.Unstick"([[VAR_3_]]) : (tensor<*xf32>) -> tensor<?x4096xf32>
+// CHECK:           return [[VAR_4_]] : tensor<?x4096xf32>
+// CHECK:         }
+}
+
+// -----
+
 // COM: Not support since alpha != 1.0
 func @test_gemm_not_lowered(%arg0 : tensor<5x10xf32>, %arg1 : tensor<5x10xf32>, %arg2: tensor<10xf32>) -> tensor<*xf32> {
   %0 ="onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 2.0 : f32, beta = 1.0 : f32, transA = 1 : si64, transB = 0 : si64} : (tensor<5x10xf32>, tensor<5x10xf32>, tensor<10xf32>) -> tensor<*xf32>


### PR DESCRIPTION
This patch allows lowering ONNXGemm to ZHigh in case of dynamic dimensions. However, if the 1D bias has unknown dimension, we do not allow lowering because we cannot check it is broadcasting or not. 

This patch also fixes a condition for zDNN Conv2D where `height_input` should be "greater than or equal to" instead of just "greater than" `height_kernel`. Similarly for `width_input` and `width_kernel`.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>