### PR TITLE
`-DPACKAGE_VENDOR` can be used to show vendor-specific text as version information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ set(ONNX_MLIR_BIN_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 set(ONNX_MLIR_LIBRARY_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 set(ONNX_MLIR_RUNTIME_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
+if (PACKAGE_VENDOR)
+  set(ONNX_MLIR_VENDOR ${PACKAGE_VENDOR} CACHE STRING
+    "Vendor-specific text for showing with version information.")
+endif(PACKAGE_VENDOR)
+
 include(CTest)
 include(ExternalProject)
 include(MLIR.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,8 @@ set(ONNX_MLIR_BIN_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 set(ONNX_MLIR_LIBRARY_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 set(ONNX_MLIR_RUNTIME_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
-if (PACKAGE_VENDOR)
-  set(ONNX_MLIR_VENDOR ${PACKAGE_VENDOR} CACHE STRING
-    "Vendor-specific text for showing with version information.")
-endif(PACKAGE_VENDOR)
+set(ONNX_MLIR_VENDOR ${PACKAGE_VENDOR} CACHE STRING
+  "Vendor-specific text for showing with version information.")
 
 include(CTest)
 include(ExternalProject)

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -65,6 +65,11 @@ add_onnx_mlir_library(CompilerPasses
   MLIRLLVMToLLVMIRTranslation
   )
 
+if (ONNX_MLIR_VENDOR)
+  set_source_files_properties(CompilerUtils.cpp
+    PROPERTIES COMPILE_DEFINITIONS "ONNX_MLIR_VENDOR=\"${ONNX_MLIR_VENDOR} \"")
+endif()
+
 add_onnx_mlir_library(CompilerUtils
   CompilerUtils.cpp
 

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -40,19 +40,22 @@ using namespace mlir;
 using namespace onnx_mlir;
 
 const std::string OnnxMlirEnvOptionName = "ONNX_MLIR_FLAGS";
-static const std::string OnnxMlirVersion = "onnx-mlir version 1.0.0";
-static const std::string OnnxMlirVersionString =
-#ifdef ONNX_MLIR_VENDOR
-    ONNX_MLIR_VENDOR ", " + OnnxMlirVersion;
-#elif defined(ONNX_MLIR_REPOSITORY) && defined(ONNX_MLIR_REVISION) &&          \
-    defined(LLVM_REPOSITORY) && defined(LLVM_REVISION)
-    OnnxMlirVersion + " (" ONNX_MLIR_REPOSITORY " " ONNX_MLIR_REVISION
-                      ", " LLVM_REPOSITORY " " LLVM_REVISION ")";
-#else
-    OnnxMlirVersion;
-#endif
 
 namespace {
+
+static std::string getOnnxMlirFullVersion() {
+  const std::string OnnxMlirVersion = "onnx-mlir version 1.0.0";
+  return
+#ifdef ONNX_MLIR_VENDOR
+      ONNX_MLIR_VENDOR ", " + OnnxMlirVersion;
+#elif defined(ONNX_MLIR_REPOSITORY) && defined(ONNX_MLIR_REVISION) &&          \
+    defined(LLVM_REPOSITORY) && defined(LLVM_REVISION)
+      OnnxMlirVersion + " (" ONNX_MLIR_REPOSITORY " " ONNX_MLIR_REVISION
+                        ", " LLVM_REPOSITORY " " LLVM_REVISION ")";
+#else
+      OnnxMlirVersion;
+#endif
+}
 
 static llvm::Optional<std::string> getEnvVar(std::string name) {
   if (const char *envVerbose = std::getenv(name.c_str()))
@@ -287,7 +290,7 @@ static void tailorLLVMIR(llvm::Module &llvmModule) {
   llvm::NamedMDNode *identMetadata =
       llvmModule.getOrInsertNamedMetadata("llvm.ident");
   llvm::Metadata *identNode[] = {
-      llvm::MDString::get(ctx, OnnxMlirVersionString)};
+      llvm::MDString::get(ctx, getOnnxMlirFullVersion())};
   identMetadata->addOperand(llvm::MDNode::get(ctx, identNode));
 
   // Annotate functions to be accessible from DLL on Windows.

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -40,13 +40,16 @@ using namespace mlir;
 using namespace onnx_mlir;
 
 const std::string OnnxMlirEnvOptionName = "ONNX_MLIR_FLAGS";
-#if defined(ONNX_MLIR_REPOSITORY) && defined(ONNX_MLIR_REVISION) &&            \
+static const std::string OnnxMlirVersion = "onnx-mlir version 1.0.0";
+static const std::string OnnxMlirVersionString =
+#ifdef ONNX_MLIR_VENDOR
+    ONNX_MLIR_VENDOR ", " + OnnxMlirVersion;
+#elif defined(ONNX_MLIR_REPOSITORY) && defined(ONNX_MLIR_REVISION) &&          \
     defined(LLVM_REPOSITORY) && defined(LLVM_REVISION)
-static const std::string OnnxMlirVersion =
-    "onnx-mlir version 1.0.0 (" ONNX_MLIR_REPOSITORY " " ONNX_MLIR_REVISION
-    " " LLVM_REPOSITORY " " LLVM_REVISION ")";
+    OnnxMlirVersion + " (" ONNX_MLIR_REPOSITORY " " ONNX_MLIR_REVISION
+                      ", " LLVM_REPOSITORY " " LLVM_REVISION ")";
 #else
-const std::string OnnxMlirVersion = "onnx-mlir version 1.0.0";
+    OnnxMlirVersion;
 #endif
 
 namespace {
@@ -283,7 +286,8 @@ static void tailorLLVMIR(llvm::Module &llvmModule) {
   // Emit the onnx-mlir version as llvm.ident metadata.
   llvm::NamedMDNode *identMetadata =
       llvmModule.getOrInsertNamedMetadata("llvm.ident");
-  llvm::Metadata *identNode[] = {llvm::MDString::get(ctx, OnnxMlirVersion)};
+  llvm::Metadata *identNode[] = {
+      llvm::MDString::get(ctx, OnnxMlirVersionString)};
   identMetadata->addOperand(llvm::MDNode::get(ctx, identNode));
 
   // Annotate functions to be accessible from DLL on Windows.

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -43,20 +43,6 @@ const std::string OnnxMlirEnvOptionName = "ONNX_MLIR_FLAGS";
 
 namespace {
 
-static std::string getOnnxMlirFullVersion() {
-  const std::string OnnxMlirVersion = "onnx-mlir version 1.0.0";
-  return
-#ifdef ONNX_MLIR_VENDOR
-      ONNX_MLIR_VENDOR ", " + OnnxMlirVersion;
-#elif defined(ONNX_MLIR_REPOSITORY) && defined(ONNX_MLIR_REVISION) &&          \
-    defined(LLVM_REPOSITORY) && defined(LLVM_REVISION)
-      OnnxMlirVersion + " (" ONNX_MLIR_REPOSITORY " " ONNX_MLIR_REVISION
-                        ", " LLVM_REPOSITORY " " LLVM_REVISION ")";
-#else
-      OnnxMlirVersion;
-#endif
-}
-
 static llvm::Optional<std::string> getEnvVar(std::string name) {
   if (const char *envVerbose = std::getenv(name.c_str()))
     return std::string(envVerbose);
@@ -165,6 +151,20 @@ static std::string getToolPath(std::string tool) {
     return p;
   else
     return std::string();
+}
+
+static std::string getOnnxMlirFullVersion() {
+  const std::string OnnxMlirVersion = "onnx-mlir version 1.0.0";
+  return
+#ifdef ONNX_MLIR_VENDOR
+      ONNX_MLIR_VENDOR ", " + OnnxMlirVersion;
+#elif defined(ONNX_MLIR_REPOSITORY) && defined(ONNX_MLIR_REVISION) &&          \
+    defined(LLVM_REPOSITORY) && defined(LLVM_REVISION)
+      OnnxMlirVersion + " (" ONNX_MLIR_REPOSITORY " " ONNX_MLIR_REVISION
+                        ", " LLVM_REPOSITORY " " LLVM_REVISION ")";
+#else
+      OnnxMlirVersion;
+#endif
 }
 
 // Helper struct to make command construction and execution easy & readable.

--- a/test/mlir/driver/llvm.ident.mlir
+++ b/test/mlir/driver/llvm.ident.mlir
@@ -3,7 +3,7 @@
 // RUN: cat %t.ll | FileCheck %s
 
 // CHECK: !llvm.ident = !{![[MD:[0-9]*]]}
-// CHECK: ![[MD]] = !{!"onnx-mlir version 1.0.0 ({{.*}}/onnx-mlir{{.*}} {{[a-zA-Z0-9]+}} {{.*}}/llvm-project{{.*}} {{[a-zA-Z0-9]+}})"}
+// CHECK: ![[MD]] = !{!"onnx-mlir version 1.0.0 ({{.*}}/onnx-mlir{{.*}} {{[a-zA-Z0-9]+}}, {{.*}}/llvm-project{{.*}} {{[a-zA-Z0-9]+}})"}
 module {
   func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>

--- a/test/mlir/driver/llvm.ident.mlir
+++ b/test/mlir/driver/llvm.ident.mlir
@@ -1,6 +1,7 @@
 // RUN: onnx-mlir --preserveBitcode %s -o %t
 // RUN: llvm-dis %t.bc -o %t.ll
 // RUN: cat %t.ll | FileCheck %s
+// XFAIL: onnx-mlir-vendor
 
 // CHECK: !llvm.ident = !{![[MD:[0-9]*]]}
 // CHECK: ![[MD]] = !{!"onnx-mlir version 1.0.0 ({{.*}}/onnx-mlir{{.*}} {{[a-zA-Z0-9]+}}, {{.*}}/llvm-project{{.*}} {{[a-zA-Z0-9]+}})"}

--- a/test/mlir/lit.cfg.py
+++ b/test/mlir/lit.cfg.py
@@ -25,6 +25,9 @@ config.test_source_root = os.path.dirname(__file__)
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.onnx_mlir_obj_root, 'test', 'mlir')
 
+if config.onnx_mlir_vendor != '':
+    config.available_features.add('onnx-mlir-vendor')
+
 llvm_config.use_default_substitutions()
 
 # Tweak the PATH to include the tools dir.

--- a/test/mlir/lit.site.cfg.py.in
+++ b/test/mlir/lit.site.cfg.py.in
@@ -8,6 +8,8 @@ config.targets_to_build = "@TARGETS_TO_BUILD@"
 config.onnx_mlir_tools_dir = r"@ONNX_MLIR_TOOLS_DIR@"
 config.onnx_mlir_obj_root = r"@ONNX_MLIR_BIN_ROOT@"
 
+config.onnx_mlir_vendor = r"@ONNX_MLIR_VENDOR@"
+
 config.enable_nnpa= @NNPA_ENABLED@
 
 # Support substitution of the tools_dir with user parameters. This is


### PR DESCRIPTION
This change adds a `PACKAGE_VENDOR` variable. When set it makes the version output more closely resemble the `onnx-mlir` version output. The idea came from llvm-project: https://github.com/llvm/llvm-project/blob/ceadf6ee619ce610b269459b129996c4ac7173cb/clang/CMakeLists.txt#L340.

For example, when building with `-DPACKAGE_VENDOR="XL for Linux on Power"`, 
then output LLVMIR contains:
```
!llvm.ident = !{!0}
!0 = !{!"XL for Linux on Power, onnx-mlir version 1.0.0"}
```

Signed-off-by: Whitney Tsang <whitneyt@ca.ibm.com>