### PR TITLE
Don't include CompilerOptions in pass libraries

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -35,7 +35,7 @@ add_onnx_mlir_library(CompilerOptions
 
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}
-  
+
   INCLUDE_DIRS PUBLIC
   ${ONNX_MLIR_SRC_ROOT}/include
 
@@ -53,7 +53,7 @@ add_onnx_mlir_library(CompilerPasses
 
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}
-  
+
   INCLUDE_DIRS PUBLIC
   ${ONNX_MLIR_SRC_ROOT}/include
 
@@ -68,6 +68,8 @@ add_onnx_mlir_library(CompilerPasses
 add_onnx_mlir_library(CompilerUtils
   CompilerUtils.cpp
 
+  EXCLUDE_FROM_OM_LIBS
+
   DEPENDS
   ExternalUtil
   MLIRIR
@@ -75,7 +77,7 @@ add_onnx_mlir_library(CompilerUtils
 
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}
-  
+
   INCLUDE_DIRS PUBLIC
   ${ONNX_MLIR_SRC_ROOT}/include
 

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -43,8 +43,10 @@ add_onnx_mlir_library(OMShapeInference
 add_onnx_mlir_library(OMInstrumentONNX
   InstrumentONNXPass.cpp
 
+  INCLUDE_DIRS PUBLIC
+  ${ONNX_MLIR_SRC_ROOT}/include
+
   LINK_LIBS PUBLIC
-  CompilerOptions
   OMONNXOps
   OMKrnlOps
   MLIRPass
@@ -53,8 +55,10 @@ add_onnx_mlir_library(OMInstrumentONNX
 add_onnx_mlir_library(OMOpTransform
   ONNXOpTransformPass.cpp
 
+  INCLUDE_DIRS PUBLIC
+  ${ONNX_MLIR_SRC_ROOT}/include
+
   LINK_LIBS PUBLIC
-  CompilerOptions
   OMONNXOps
   MLIRPass
   OMONNXRewrite


### PR DESCRIPTION
My team links the onnx-mlir libraries into our own tool and we'd prefer not to pick up the onnx-mlir command-line options en-masse. Recent changes to refactoring the onnx-mlir options require additional changes to continue to allow this to work which i'm committing here.