### PR TITLE
moved none first, with comment to make verifier happy

### DIFF
--- a/src/Accelerators/Accelerator.hpp
+++ b/src/Accelerators/Accelerator.hpp
@@ -42,8 +42,8 @@ public:
   /// Kinds of accelerators.
   enum class Kind {
     // clang-format off
-    APPLY_TO_ACCELERATORS(CREATE_ACCEL_ENUM) 
-    NONE
+    NONE,
+    APPLY_TO_ACCELERATORS(CREATE_ACCEL_ENUM)
     // clang-format on
   };
 


### PR DESCRIPTION
cppcheck verifier had an issue with the unconventional c++ code generated by the macro extensions. This PR trivially eliminates the issue. Also added "NONE" first so as to have a constant value for NONE regardless of the numbers of accelerators present in the cmake customization.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>