### PR TITLE
Support MemRefs with affine_map in --convert-krnl-to-affine

### DIFF
--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.hpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.hpp
@@ -22,12 +22,39 @@
 namespace onnx_mlir {
 namespace krnl {
 
+//===----------------------------------------------------------------------===//
+// Type conversion
+//===----------------------------------------------------------------------===//
+class AffineTypeConverter : public mlir::TypeConverter {
+public:
+  using mlir::TypeConverter::TypeConverter;
+
+  AffineTypeConverter();
+
+  /// Return true if the inputs and outputs of the given function type are
+  /// legal. [Taken from MLIR and adapted to only check the legality of the
+  /// inputs. Once unranked results can be handled gracefully this
+  /// override needs to be removed in favour of the original MLIR one.]
+  bool isSignatureLegal(mlir::FunctionType funcType) {
+    return llvm::all_of(llvm::concat<const mlir::Type>(
+                            funcType.getInputs(), funcType.getResults()),
+        [this](mlir::Type type) { return isLegal(type); });
+  }
+
+  /// Return true if the operands/results of call have a legal type.
+  bool isSignatureLegal(mlir::CallOp call) {
+    auto f = [this](mlir::Type type) { return isLegal(type); };
+    return llvm::all_of(call.getOperandTypes(), f) &&
+           llvm::all_of(call.getResultTypes(), f);
+  }
+};
+
 // To assist unroll and jam
 using UnrollAndJamRecord = std::pair<mlir::AffineForOp, int64_t>;
 using UnrollAndJamList = llvm::SmallVector<UnrollAndJamRecord, 4>;
 using UnrollAndJamMap = std::map<mlir::Operation *, UnrollAndJamList *>;
 
-void populateKrnlToAffineConversion(mlir::LLVMTypeConverter &typeConverter,
+void populateKrnlToAffineConversion(mlir::TypeConverter &typeConverter,
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx);
 
 void populateLoweringKrnlCopyFromBufferOpPattern(

--- a/src/Dialect/Krnl/KrnlTypes.cpp
+++ b/src/Dialect/Krnl/KrnlTypes.cpp
@@ -20,22 +20,6 @@ using namespace onnx_mlir;
 namespace onnx_mlir {
 namespace krnl {
 
-void customizeTypeConverter(LLVMTypeConverter &typeConverter) {
-  typeConverter.addConversion([&](MemRefType type) -> llvm::Optional<Type> {
-    Type elementType = type.getElementType();
-    if (!elementType.isa<krnl::StringType>())
-      return llvm::None;
-
-    elementType =
-        elementType.cast<krnl::StringType>().getLLVMType(type.getContext());
-    return typeConverter.convertType(
-        MemRefType::get(type.getShape(), elementType));
-  });
-
-  typeConverter.addConversion([&](krnl::StringType type) -> Type {
-    return typeConverter.convertType(type.getLLVMType(type.getContext()));
-  });
-}
 
 } // namespace krnl
 } // namespace onnx_mlir

--- a/src/Dialect/Krnl/KrnlTypes.cpp
+++ b/src/Dialect/Krnl/KrnlTypes.cpp
@@ -20,6 +20,22 @@ using namespace onnx_mlir;
 namespace onnx_mlir {
 namespace krnl {
 
+void customizeTypeConverter(LLVMTypeConverter &typeConverter) {
+  typeConverter.addConversion([&](MemRefType type) -> llvm::Optional<Type> {
+    Type elementType = type.getElementType();
+    if (!elementType.isa<krnl::StringType>())
+      return llvm::None;
+
+    elementType =
+        elementType.cast<krnl::StringType>().getLLVMType(type.getContext());
+    return typeConverter.convertType(
+        MemRefType::get(type.getShape(), elementType));
+  });
+
+  typeConverter.addConversion([&](krnl::StringType type) -> Type {
+    return typeConverter.convertType(type.getLLVMType(type.getContext()));
+  });
+}
 
 } // namespace krnl
 } // namespace onnx_mlir

--- a/test/mlir/krnl/krnl_math_function_lowering.mlir
+++ b/test/mlir/krnl/krnl_math_function_lowering.mlir
@@ -1,6 +1,6 @@
 // RUN: onnx-mlir-opt -O3 --convert-krnl-to-affine --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
 
-// ----
+// -----
 
 /// Test lowering of krnl.erf to LLVM math function call.
 func @test_krnl_erf_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
@@ -23,6 +23,8 @@ func @test_krnl_erf_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
 // CHECK: [[DATA_OUT:%.+]] = llvm.getelementptr {{.*}} : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: llvm.store [[ERF_RES]], [[DATA_OUT]] : !llvm.ptr<f32>
 
+// -----
+
 /// Test lowering of krnl.acos to LLVM math function call.
 func @test_krnl_acos_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
   %0 = memref.alloc() : memref<10x10xf32>
@@ -44,7 +46,9 @@ func @test_krnl_acos_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
 // CHECK: [[DATA_OUT:%.+]] = llvm.getelementptr {{.*}} : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: llvm.store [[ACOS_RES]], [[DATA_OUT]] : !llvm.ptr<f32>
 
-/// Test lowering of krnl.acos to LLVM math function call.
+// -----
+
+/// Test lowering of krnl.acosh to LLVM math function call.
 func @test_krnl_acosh_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
   %0 = memref.alloc() : memref<10x10xf32>
   %1:2 = krnl.define_loops 2
@@ -64,6 +68,8 @@ func @test_krnl_acosh_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
 // CHECK: [[ACOS_RES:%.+]] = llvm.call @acoshf([[SCALAR_IN]]) : (f32) -> f32
 // CHECK: [[DATA_OUT:%.+]] = llvm.getelementptr {{.*}} : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: llvm.store [[ACOS_RES]], [[DATA_OUT]] : !llvm.ptr<f32>
+
+// -----
 
 /// Test lowering of krnl.asin to LLVM math function call.
 func @test_krnl_asin_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
@@ -86,6 +92,8 @@ func @test_krnl_asin_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
 // CHECK: [[DATA_OUT:%.+]] = llvm.getelementptr {{.*}} : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: llvm.store [[ACOS_RES]], [[DATA_OUT]] : !llvm.ptr<f32>
 
+// -----
+
 /// Test lowering of krnl.asinh to LLVM math function call.
 func @test_krnl_asinh_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
   %0 = memref.alloc() : memref<10x10xf32>
@@ -106,6 +114,8 @@ func @test_krnl_asinh_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
 // CHECK: [[ACOS_RES:%.+]] = llvm.call @asinhf([[SCALAR_IN]]) : (f32) -> f32
 // CHECK: [[DATA_OUT:%.+]] = llvm.getelementptr {{.*}} : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: llvm.store [[ACOS_RES]], [[DATA_OUT]] : !llvm.ptr<f32>
+
+// -----
 
 /// Test lowering of krnl.atan to LLVM math function call.
 func @test_krnl_atan_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
@@ -128,6 +138,8 @@ func @test_krnl_atan_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
 // CHECK: [[DATA_OUT:%.+]] = llvm.getelementptr {{.*}} : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: llvm.store [[ACOS_RES]], [[DATA_OUT]] : !llvm.ptr<f32>
 
+// -----
+
 func @test_krnl_atanh_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
   %0 = memref.alloc() : memref<10x10xf32>
   %1:2 = krnl.define_loops 2
@@ -148,6 +160,8 @@ func @test_krnl_atanh_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
 // CHECK: [[DATA_OUT:%.+]] = llvm.getelementptr {{.*}} : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: llvm.store [[ACOS_RES]], [[DATA_OUT]] : !llvm.ptr<f32>
 
+// -----
+
 func @test_krnl_tan_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
   %0 = memref.alloc() : memref<10x10xf32>
   %1:2 = krnl.define_loops 2
@@ -167,3 +181,4 @@ func @test_krnl_tan_lowering(%arg0: memref<10x10xf32>) -> memref<10x10xf32> {
 // CHECK: [[ACOS_RES:%.+]] = llvm.call @tanf([[SCALAR_IN]]) : (f32) -> f32
 // CHECK: [[DATA_OUT:%.+]] = llvm.getelementptr {{.*}} : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
 // CHECK: llvm.store [[ACOS_RES]], [[DATA_OUT]] : !llvm.ptr<f32>
+


### PR DESCRIPTION
Resolves #1355 : `--convert-krnl-to-affine` pass does not support MemRefType with affine map. This is because it uses LLVMTypeConverter. This patch replaces LLVMTypeConverter by a custom one which simply forwards the type because MemRefType is used both before and after  `--convert-krnl-to-affine`

Signed-off-by: Tung D. Le <tung@jp.ibm.com>