### PR TITLE
Enable numerical tests for LSTM whose initial_h, initial_c, and P are not specified

### DIFF
--- a/test/modellib/ModelLib.hpp
+++ b/test/modellib/ModelLib.hpp
@@ -255,7 +255,8 @@ class LSTMLibBuilder : public ModelLibBuilder {
 public:
   LSTMLibBuilder(const std::string &modelName, const int direction, const int S,
       const int B, const int I, const int H, const bool isDynamicS,
-      const bool isDynamicB);
+      const bool isDynamicB, const bool isNoneH = false,
+      const bool isNoneC = false, const bool isNoneP = false);
   ~LSTMLibBuilder();
   bool build() final;
   bool prepareInputs() final;
@@ -263,7 +264,8 @@ public:
 
 private:
   // Data that defines model.
-  const int direction, S, B, I, H, isDynamicS, isDynamicB;
+  const int direction, S, B, I, H;
+  const bool isDynamicS, isDynamicB, isNoneH, isNoneC, isNoneP;
   // Computed parameters.
   int D;
   llvm::SmallVector<int64_t, 3> xShape, hShape, cShape;

--- a/test/numerical/TestLSTM.cpp
+++ b/test/numerical/TestLSTM.cpp
@@ -22,10 +22,11 @@ namespace test {
 // parameters/configuration.
 bool isOMLSTMTheSameAsNaiveImplFor(const int direction, const int S,
     const int B, const int I, const int H, bool isDynamicS = false,
-    bool isDynamicB = false) {
+    bool isDynamicB = false, bool isNoneH = false, bool isNoneC = false,
+    bool isNoneP = false) {
 
-  LSTMLibBuilder lstm(
-      SHARED_LIB_BASE.str(), direction, S, B, I, H, isDynamicS, isDynamicB);
+  LSTMLibBuilder lstm(SHARED_LIB_BASE.str(), direction, S, B, I, H, isDynamicS,
+      isDynamicB, isNoneH, isNoneC, isNoneP);
   return lstm.build() && lstm.compileAndLoad() && lstm.prepareInputs() &&
          lstm.run() && lstm.verifyOutputs();
 }
@@ -62,9 +63,15 @@ int main(int argc, char *argv[]) {
     const auto isDynS = *rc::gen::element(0, 1);
     // Whether test dynamic dimension for batch size.
     const auto isDynB = *rc::gen::element(0, 1);
+    // Whether initial value of the hidden(initial_h) is specified.
+    const auto isNoneH = *rc::gen::element(0, 1);
+    // Whether initial value of the cell(initial_c) is specified.
+    const auto isNoneC = *rc::gen::element(0, 1);
+    // Whether the weight tensor for peepholes(P) is specified.
+    const auto isNoneP = *rc::gen::element(0, 1);
 
-    RC_ASSERT(
-        isOMLSTMTheSameAsNaiveImplFor(D, S, B, I, H, isDynS == 0, isDynB == 0));
+    RC_ASSERT(isOMLSTMTheSameAsNaiveImplFor(D, S, B, I, H, isDynS == 0,
+        isDynB == 0, isNoneH == 0, isNoneC == 0, isNoneP == 0));
   });
   if (!success)
     return 1;
@@ -89,6 +96,17 @@ int main(int argc, char *argv[]) {
           assert(isOMLSTMTheSameAsNaiveImplFor(-1, s, b, i, h, true, true));
           // bidirectional
           assert(isOMLSTMTheSameAsNaiveImplFor(2, s, b, i, h, true, true));
+
+          // Static dimensions (initial_h, initial_c and p are not specified)
+          // forward
+          assert(isOMLSTMTheSameAsNaiveImplFor(
+              1, s, b, i, h, false, false, true, true, true));
+          // reverse
+          assert(isOMLSTMTheSameAsNaiveImplFor(
+              -1, s, b, i, h, false, false, true, true, true));
+          // bidirectional
+          assert(isOMLSTMTheSameAsNaiveImplFor(
+              2, s, b, i, h, false, false, true, true, true));
         }
   return 0;
 }

--- a/test/numerical/TestLSTM.cpp
+++ b/test/numerical/TestLSTM.cpp
@@ -80,33 +80,22 @@ int main(int argc, char *argv[]) {
   for (int64_t s = 3; s < 4; s++)
     for (int64_t b = 3; b < 4; b++)
       for (int64_t i = 2; i < 5; i++)
-        for (int64_t h = 2; h < 5; h++) {
-          // Static dimensions.
-          // forward
-          assert(isOMLSTMTheSameAsNaiveImplFor(1, s, b, i, h));
-          // reverse
-          assert(isOMLSTMTheSameAsNaiveImplFor(-1, s, b, i, h));
-          // bidirectional
-          assert(isOMLSTMTheSameAsNaiveImplFor(2, s, b, i, h));
+        for (int64_t h = 2; h < 5; h++)
+          for (int64_t dyns = 0; dyns < 2; dyns++)
+            for (int64_t dynb = 0; dynb < 2; dynb++)
+              for (int64_t noneh = 0; noneh < 2; noneh++)
+                for (int64_t nonec = 0; nonec < 2; nonec++)
+                  for (int64_t nonep = 0; nonep < 2; nonep++) {
+                    // forward
+                    assert(isOMLSTMTheSameAsNaiveImplFor(
+                        1, s, b, i, h, dyns, dynb, noneh, nonec, nonep));
+                    // reverse
+                    assert(isOMLSTMTheSameAsNaiveImplFor(
+                        -1, s, b, i, h, dyns, dynb, noneh, nonec, nonep));
+                    // bidirectional
+                    assert(isOMLSTMTheSameAsNaiveImplFor(
+                        2, s, b, i, h, dyns, dynb, noneh, nonec, nonep));
+                  }
 
-          // Dynamic dimensions for sequence, batch size.
-          // forward
-          assert(isOMLSTMTheSameAsNaiveImplFor(1, s, b, i, h, true, true));
-          // reverse
-          assert(isOMLSTMTheSameAsNaiveImplFor(-1, s, b, i, h, true, true));
-          // bidirectional
-          assert(isOMLSTMTheSameAsNaiveImplFor(2, s, b, i, h, true, true));
-
-          // Static dimensions (initial_h, initial_c and p are not specified)
-          // forward
-          assert(isOMLSTMTheSameAsNaiveImplFor(
-              1, s, b, i, h, false, false, true, true, true));
-          // reverse
-          assert(isOMLSTMTheSameAsNaiveImplFor(
-              -1, s, b, i, h, false, false, true, true, true));
-          // bidirectional
-          assert(isOMLSTMTheSameAsNaiveImplFor(
-              2, s, b, i, h, false, false, true, true, true));
-        }
   return 0;
 }


### PR DESCRIPTION
In ONNX LSTM, `initial_h`, `initial_c`, and `P` are optional, but numerical tests didn't test the cases where these parameters are not specified. They always uses tensors with random values. This PR enables the tests with none value for them.


I need these tests for LSTM for NNPA. LSTM op in the zDNN library used in NNPA only supports LSTM whose weight tensor for peepholes is not specified.

Following tests are newly added as an example.
```
  func @main_graph(%arg0: tensor<3x3x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<1x\
3x2xf32>) -> (tensor<3x1x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x2xf32>) {
    %0 = "onnx.NoValue"() {value} : () -> none
   :
    %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %1, %2, %3, %0, %0, %0, %0) {direction = "forwa\
rd", hidden_size = 2 : si64, input_forget = 0 : si64} : (tensor<3x3x2xf32>, tensor<1x8x\
2xf32>, tensor<1x8x2xf32>, tensor<1x16xf32>, none, none, none, none) -> (tensor<3x1x3x2\
xf32>, tensor<1x3x2xf32>, tensor<1x3x2xf32>)
    return %Y, %Y_h, %Y_c : tensor<3x1x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x2xf32>
  }
```
