### PR TITLE
Calling accelerator initialization in entry points functions

### DIFF
--- a/src/Accelerators/Accelerator.hpp
+++ b/src/Accelerators/Accelerator.hpp
@@ -31,6 +31,10 @@
 #define INVOKE_ACCEL_INIT_FUNCTION(name) create##name();
 #define CREATE_ACCEL_CL_ENUM(name)                                             \
   clEnumValN(accel::Accelerator::Kind::name, #name, #name " accelerator"),
+#define GET_ACCEL_NAME(name)                                                   \
+  case accel::Accelerator::Kind::name:                                         \
+    return llvm::StringRef(#name);                                             \
+    break;
 
 namespace onnx_mlir {
 namespace accel {
@@ -55,6 +59,15 @@ public:
 
   /// Returns the set of accelerators available.
   static const llvm::SmallVectorImpl<Accelerator *> &getAccelerators();
+
+  /// Returns the accelerator name of the give kind.
+  static const llvm::StringRef getName(Kind kind) {
+    switch (kind) {
+      APPLY_TO_ACCELERATORS(GET_ACCEL_NAME)
+    default:
+      return llvm::StringRef();
+    }
+  }
 
   /// Returns whether the accelerator is active.
   virtual bool isActive() const = 0;

--- a/test/mlir/accelerators/nnpa/module_op_be/lit.local.cfg
+++ b/test/mlir/accelerators/nnpa/module_op_be/lit.local.cfg
@@ -1,3 +1,1 @@
 root = config.root
-# TODO: enable when onnx-mlir driver works well with nnpa.
-config.unsupported = True

--- a/test/mlir/accelerators/nnpa/module_op_be/module_op.mlir
+++ b/test/mlir/accelerators/nnpa/module_op_be/module_op.mlir
@@ -1,6 +1,6 @@
-// RUN: onnx-mlir --accel=NNPA --printIR %s | FileCheck %s
+// RUN: onnx-mlir --maccel=NNPA --printIR %s | FileCheck %s
 
-// CHECK: module attributes {llvm.data_layout = "E-{{.*}}"}
+// CHECK: module attributes {llvm.data_layout = "E-{{.*}}", llvm.target_triple = "{{.*}}", "onnx-mlir.accels" = ["NNPA"]} {
 module {
 }
 

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -229,3 +229,18 @@ module {
 // CHECK:           llvm.return [[VAR_20_2_1_]] : !llvm.ptr<i8>
 // CHECK:         }
 }
+
+// -----
+
+// COM: Generate calls for initializing accelerators.
+module attributes {"onnx-mlir.accels" = ["Pseudo", "NNPA"]} {
+  func private @main_graph(%arg0: memref<10xf32>) -> memref<10xf32> {
+    return %arg0 : memref<10xf32>
+  }
+  "krnl.entry_point"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[in_sig]\00@[out_sig]\00"} : () -> ()
+// CHECK: llvm.func @OMInitAccelNNPA()
+// CHECK: llvm.func @OMInitAccelPseudo()
+// CHECK-LABEL: llvm.func @run_main_graph({{.*}}: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
+// CHECK-NEXT:  llvm.call @OMInitAccelPseudo() : () -> ()
+// CHECK-NEXT:  llvm.call @OMInitAccelNNPA() : () -> ()
+}


### PR DESCRIPTION
This patch inserts accelerator initialization functions at the beginning of each entry point function.

This patch depends on PR #1357 that defines initialization functions.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>