### PR TITLE
[NNPA] Support 4D in zhigh.concat

### DIFF
--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
@@ -596,9 +596,9 @@ def ZHighConcatOp:ZHigh_Op<"Concat", [NoSideEffect,
     "to concatenate on. Users must ensure that it is safe to concatenate"
     "stickified tensors for the given axis."
   }];
-  let arguments = (ins Variadic<AnyTypeOf<[ZTensor_NHWC, AnyMemRef]>>:$inputs,
+  let arguments = (ins Variadic<AnyTypeOf<[ZTensor_4D, ZTensor_NHWC, AnyMemRef]>>:$inputs,
                        SI64Attr:$axis);
-  let results = (outs AnyTypeOf<[ZTensor_NHWC, AnyMemRef]>:$concat_result);
+  let results = (outs AnyTypeOf<[ZTensor_4D, ZTensor_NHWC, AnyMemRef]>:$concat_result);
   let verifier = [{ return ::onnx_mlir::zhigh::verify(*this); }];
 }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighCombine.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighCombine.td
@@ -77,8 +77,8 @@ def StickUnstickRemovalPattern : Pat<
 >;
 
 def ProducedByUnstickOp: Constraint<
-  CPred<"areProducedByUnstickOp($0, $1)">,
-  "all values are produced by ZHighUnstickOp with the same layout"
+  CPred<"areProducedByUnstickOp($0)">,
+  "all values are produced by ZHighUnstickOp"
 >;
 
 def HaveNoPadsWhenStickified: Constraint<
@@ -106,7 +106,7 @@ def GetStickifiedInputs: NativeCodeCall<
 def ReplaceONNXConcatByZHighConcatPattern: Pat<
   (ZHighStickOp (ONNXConcatOp $inputs, $axis), $layout),
   (ZHighConcatOp (GetStickifiedInputs $inputs), $axis),
-  [(ProducedByUnstickOp $inputs, $layout),
+  [(ProducedByUnstickOp $inputs),
    (HaveNoPadsWhenStickified $inputs, $layout, $axis)]
 >;
 

--- a/test/mlir/accelerators/nnpa/transform/zhigh-combine.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zhigh-combine.mlir
@@ -109,3 +109,18 @@ func @replace_onnx_concat_by_zhigh_concat(%arg0: tensor<?x4x4x192xf32, #zhigh.en
   // CHECK:         }
 }
 
+// -----
+
+func @replace_onnx_concat_by_zhigh_concat_4d(%arg0: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, %arg1: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>> {
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<?x4x4x192xf32>
+  %1 = "zhigh.Unstick"(%arg1) : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x192xf32>
+  %2 = "onnx.Concat"(%0, %1) {axis = 3 : si64} : (tensor<?x4x4x192xf32>, tensor<?x4x4x192xf32>) -> tensor<?x4x4x384xf32>
+  %3 = "zhigh.Stick"(%2) {layout = "NHWC"} : (tensor<?x4x4x384xf32>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+  return %3 : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+  // CHECK-LABEL:  func @replace_onnx_concat_by_zhigh_concat_4d
+  // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, [[PARAM_1_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>> {
+  // CHECK:           [[VAR_0_:%.+]] = "zhigh.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 3 : si64} : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+  // CHECK:           return [[VAR_0_]] : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+  // CHECK:         }
+}
+


### PR DESCRIPTION
Stickifications for 4D and NHWC are the same, so we can support zhigh.concat with mix of 4D and NHWC stickified tensors.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>