### PR TITLE
Misc cmake updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if (ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS)
 endif()
 
 # Add third party subdirectories and define options appropriate to run their cmakes.
+set(CMAKE_MESSAGE_LOG_LEVEL NOTICE)
 set(pybind11_FIND_QUIETLY ON)
 set(BENCHMARK_USE_BUNDLED_GTEST OFF)
 set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
@@ -142,6 +143,7 @@ add_subdirectory(third_party/rapidcheck)
 if (NOT TARGET benchmark)
   add_subdirectory(third_party/benchmark)
 endif()
+set(CMAKE_MESSAGE_LOG_LEVEL STATUS)
 
 # Ensure warnings are reported for onnx-mlir code.
 if (ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS)

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -3,13 +3,9 @@
 # Must unset LLVM_DIR in cache. Otherwise, when MLIR_DIR changes LLVM_DIR
 # won't change accordingly.
 unset(LLVM_DIR CACHE)
-if (DEFINED ENV{MLIR_DIR})
-  set(MLIR_DIR $ENV{MLIR_DIR} CACHE PATH "Path to directory containing MLIRConfig.cmake" FORCE)
-elseif (NOT DEFINED MLIR_DIR)
+if (NOT DEFINED MLIR_DIR)
   message(FATAL_ERROR "MLIR_DIR is not configured but it is required. "
-    "Either set the environmental variable MLIR_DIR, e.g.,\n"
-    "    MLIR_DIR=/path/to/llvm-project/build/lib/cmake/mlir cmake ..\n"
-    "or set the cmake option MLIR_DIR, e.g.,\n"
+    "Set the cmake option MLIR_DIR, e.g.,\n"
     "    cmake -DMLIR_DIR=/path/to/llvm-project/build/lib/cmake/mlir ..\n"
     )
 endif()

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -1,10 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Must unset LLVM_DIR in cache. Otherwise, when MLIR_DIR changes LLVM_DIR
+# won't change accordingly.
+unset(LLVM_DIR CACHE)
 if (DEFINED ENV{MLIR_DIR})
-  set(MLIR_DIR $ENV{MLIR_DIR} CACHE PATH "Path to directory containing MLIRConfig.cmake")
+  set(MLIR_DIR $ENV{MLIR_DIR} CACHE PATH "Path to directory containing MLIRConfig.cmake" FORCE)
 elseif (NOT DEFINED MLIR_DIR)
   message(FATAL_ERROR "MLIR_DIR is not configured but it is required. "
-          "Please set the env variable MLIR_DIR or the corresponding cmake configuration option.")
+    "Either set the environmental variable MLIR_DIR, e.g.,\n"
+    "    MLIR_DIR=/path/to/llvm-project/build/lib/cmake/mlir cmake ..\n"
+    "or set the cmake option MLIR_DIR, e.g.,\n"
+    "    cmake -DMLIR_DIR=/path/to/llvm-project/build/lib/cmake/mlir ..\n"
+    )
 endif()
 
 find_package(MLIR REQUIRED CONFIG)

--- a/docker/Dockerfile.onnx-mlir
+++ b/docker/Dockerfile.onnx-mlir
@@ -40,8 +40,8 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
     && BUILD_NNPA=${BUILD_NNPA:-$([ "$(uname -m)" = "s390x" ] && echo NNPA || \
                                   [ "$(uname -m)" = "x86_64" ] &&  echo || \
                                   [ "$(uname -m)" = "ppc64le" ] && echo || echo)} \
-    && MLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
-       cmake -DCMAKE_BUILD_TYPE=Release \
+    && cmake -DMLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
+             -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_MESSAGE=NEVER \
              -DONNX_MLIR_ACCELERATORS=${BUILD_NNPA} .. \
     && make -j${NPROC} \

--- a/docker/Dockerfile.onnx-mlir
+++ b/docker/Dockerfile.onnx-mlir
@@ -43,7 +43,7 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
     && MLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
        cmake -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_MESSAGE=NEVER \
-             -DACCELERATORS_TO_BUILD=${BUILD_NNPA} .. \
+             -DONNX_MLIR_ACCELERATORS=${BUILD_NNPA} .. \
     && make -j${NPROC} \
     && make -j${NPROC} LIT_OPTS=-v check-onnx-lit \
 # User image is built with SIMD (currently on s390x only)

--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -34,8 +34,8 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
     && BUILD_NNPA=${BUILD_NNPA:-$([ "$(uname -m)" = "s390x" ] && echo NNPA || \
                                   [ "$(uname -m)" = "x86_64" ] &&  echo || \
                                   [ "$(uname -m)" = "ppc64le" ] && echo || echo)} \
-    && MLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
-       cmake -DCMAKE_BUILD_TYPE=Debug \
+    && cmake -DMLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
+             -DCMAKE_BUILD_TYPE=Debug \
              -DONNX_MLIR_ACCELERATORS=${BUILD_NNPA} .. \
     && make -j${NPROC} \
     && make -j${NPROC} LIT_OPTS=-v check-onnx-lit \

--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -36,7 +36,7 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
                                   [ "$(uname -m)" = "ppc64le" ] && echo || echo)} \
     && MLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
        cmake -DCMAKE_BUILD_TYPE=Debug \
-             -DACCELERATORS_TO_BUILD=${BUILD_NNPA} .. \
+             -DONNX_MLIR_ACCELERATORS=${BUILD_NNPA} .. \
     && make -j${NPROC} \
     && make -j${NPROC} LIT_OPTS=-v check-onnx-lit \
 # Dev image is built without SIMD, placeholder for easy SIMD enablement

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -47,14 +47,19 @@ To build ONNX-MLIR, use the following commands:
 ```bash
 git clone --recursive https://github.com/onnx/onnx-mlir.git
 
-# Export environment variables pointing to LLVM-Projects.
-export MLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir
-
+# MLIR_DIR must be set with cmake option now
 mkdir onnx-mlir/build && cd onnx-mlir/build
 if [[ -z "$pythonLocation" ]]; then
-  cmake -G Ninja -DCMAKE_CXX_COMPILER=/usr/bin/c++ ..
+  cmake -G Ninja \
+        -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
+        -DMLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir \
+        ..
 else
-  cmake -G Ninja -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DPython3_ROOT_DIR=$pythonLocation ..
+  cmake -G Ninja \
+        -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
+        -DPython3_ROOT_DIR=$pythonLocation \
+        -DMLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir \
+        ..
 fi
 cmake --build .
 

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -48,7 +48,8 @@ To build ONNX-MLIR, use the following commands:
 git clone --recursive https://github.com/onnx/onnx-mlir.git
 
 # MLIR_DIR must be set with cmake option now
-mkdir onnx-mlir/build && cd onnx-mlir/build
+mkdir -p onnx-mlir/build && cd onnx-mlir/build
+ls -l $(pwd)/llvm-project/build/lib/cmake/mlir
 if [[ -z "$pythonLocation" ]]; then
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -48,18 +48,18 @@ To build ONNX-MLIR, use the following commands:
 git clone --recursive https://github.com/onnx/onnx-mlir.git
 
 # MLIR_DIR must be set with cmake option now
-mkdir -p onnx-mlir/build && cd onnx-mlir/build
-ls -l $(pwd)/llvm-project/build/lib/cmake/mlir
+MLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir
+mkdir onnx-mlir/build && cd onnx-mlir/build
 if [[ -z "$pythonLocation" ]]; then
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
-        -DMLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir \
+        -DMLIR_DIR=${MLIR_DIR} \
         ..
 else
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
         -DPython3_ROOT_DIR=$pythonLocation \
-        -DMLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir \
+        -DMLIR_DIR=${MLIR_DIR} \
         ..
 fi
 cmake --build .

--- a/src/Accelerators/CMakeLists.txt
+++ b/src/Accelerators/CMakeLists.txt
@@ -1,17 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Populate the accelerator list and add the accelerator subdirectories.
-set(ACCEL_LIST "")
-if (ACCELERATORS_TO_BUILD)
-  foreach(t ${ACCELERATORS_TO_BUILD})
-    message(DEBUG "Targeting ${t}")
+# ONNX_MLIR_ACCELERATORS is the list of accelerators user specified
+# ACCEL_TARGET_LIST is the list of cmake targets
+# ACCEL_INCLUDE_LIST is the list passed to inc generator
+if (ONNX_MLIR_ACCELERATORS)
+  foreach(t ${ONNX_MLIR_ACCELERATORS})
     add_subdirectory(${t})
-    list(APPEND ACCEL_LIST "${t}Accel")
+
+    # If the accelerator can be built
+    if (${t}_ENABLED)
+      list(APPEND ACCEL_TARGET_LIST "${t}Accel")
+      list(APPEND ACCEL_INCLUDE_LIST "${t}")
+    endif()
   endforeach(t)
-  message(STATUS "Accelerators             : ${ACCEL_LIST}")
+endif (ONNX_MLIR_ACCELERATORS)
+if (ACCEL_INCLUDE_LIST)
+  message(STATUS "Accelerators             : ${ACCEL_INCLUDE_LIST}")
 else()
   message(STATUS "Accelerators             : NONE")
-endif (ACCELERATORS_TO_BUILD)
+endif()
 
 # Generate the Accelerators.inc file using a cmake script.
 set(accelerators_inc "${CMAKE_CURRENT_BINARY_DIR}/Accelerators.inc")
@@ -19,7 +27,7 @@ set(create_accelerators_inc_script "${CMAKE_CURRENT_SOURCE_DIR}/CreateAccelerato
 
 add_custom_command(OUTPUT "${accelerators_inc}"
   DEPENDS "${create_accelerators_inc_script}"
-  COMMAND ${CMAKE_COMMAND} "-DINC_FILE=${accelerators_inc}" "-DACCELERATORS=${ACCELERATORS_TO_BUILD}" 
+  COMMAND ${CMAKE_COMMAND} "-DINC_FILE=${accelerators_inc}" "-DACCELERATORS=${ACCEL_INCLUDE_LIST}"
     -P "${create_accelerators_inc_script}"
   )
 set_source_files_properties("${accelerators_inc}"
@@ -37,7 +45,7 @@ add_onnx_mlir_library(InitAccelerators
     AcceleratorsInc
 
   LINK_LIBS PUBLIC
-    ${ACCEL_LIST}
+    ${ACCEL_TARGET_LIST}
     LLVMSupport
   )
 

--- a/src/Accelerators/NNPA/CMakeLists.txt
+++ b/src/Accelerators/NNPA/CMakeLists.txt
@@ -1,54 +1,57 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(NNPA_ENABLED 1 CACHE BOOL "flag indicating NNPA enabled")
+# Build libdnn.a on s390x only
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "s390x")
+  set(NNPA_ENABLED 1 BOOL PARENT_SCOPE)
 
-set(NNPA_SRC_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
-set(NNPA_BIN_ROOT "${CMAKE_CURRENT_BINARY_DIR}")
+  set(NNPA_SRC_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
+  set(NNPA_BIN_ROOT "${CMAKE_CURRENT_BINARY_DIR}")
 
-set(NNPA_LIBRARY_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-set(NNPA_RUNTIME_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-set(NNPA_INCLUDE_PATH ${CMAKE_INCLUDE_OUTPUT_DIRECTORY})
+  set(NNPA_LIBRARY_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+  set(NNPA_RUNTIME_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+  set(NNPA_INCLUDE_PATH ${CMAKE_INCLUDE_OUTPUT_DIRECTORY})
 
-set(NNPA_ONNX_MLIR_SRC_ROOT ${ONNX_MLIR_SRC_ROOT})
-set(NNPA_ONNX_MLIR_BIN_ROOT ${ONNX_MLIR_BIN_ROOT})
+  set(NNPA_ONNX_MLIR_SRC_ROOT ${ONNX_MLIR_SRC_ROOT})
+  set(NNPA_ONNX_MLIR_BIN_ROOT ${ONNX_MLIR_BIN_ROOT})
 
-# The path to find the zDNN library.
-if (DEFINED ENV{ZDNN_LIBRARY_DIR} AND EXISTS $ENV{ZDNN_LIBRARY_DIR})
-  message(DEBUG "ZDNN_LIBRARY_DIR        : " $ENV{ZDNN_LIBRARY_DIR})
-  set(ZDNN_LIBRARY_DIR $ENV{ZDNN_LIBRARY_DIR})
-  set(ZDNN_LIBRARY_ENABLED 1)
-else()
-  message(DEBUG "ZDNN_LIBRARY_DIR not found. zDNN-related tests will be turned off.")
-  set(ZDNN_LIBRARY_ENABLED 0)
+  # The path to find the zDNN library.
+  if (DEFINED ENV{ZDNN_LIBRARY_DIR} AND EXISTS $ENV{ZDNN_LIBRARY_DIR})
+    message(DEBUG "ZDNN_LIBRARY_DIR        : " $ENV{ZDNN_LIBRARY_DIR})
+    set(ZDNN_LIBRARY_DIR $ENV{ZDNN_LIBRARY_DIR})
+    set(ZDNN_LIBRARY_ENABLED 1)
+  else()
+    message(DEBUG "ZDNN_LIBRARY_DIR not found. zDNN-related tests will be turned off.")
+    set(ZDNN_LIBRARY_ENABLED 0)
+  endif()
+
+  include(zdnn.cmake)
+  setup_zdnn(v1.0.0)
+
+  add_subdirectory(Dialect)
+  add_subdirectory(Conversion)
+  add_subdirectory(Support)
+  add_subdirectory(Transform)
+  add_subdirectory(Compiler)
+
+  add_onnx_mlir_library(NNPAAccel
+    NNPAAccelerator.cpp
+
+    EXCLUDE_FROM_OM_LIBS
+
+    INCLUDE_DIRS PUBLIC
+    ${ONNX_MLIR_SRC_ROOT}/include
+    ${ONNX_MLIR_SRC_ROOT}
+    ${NNPA_ONNX_MLIR_SRC_ROOT}
+    ${NNPA_SRC_ROOT}
+    ${NNPA_BIN_ROOT}
+
+    LINK_LIBS PUBLIC
+    onnx
+    NNPACompilerUtils
+    Accelerator
+    OMZHighOps
+    OMZHighToZLow
+    OMZLowOps
+    OMZLowToLLVM
+    )
 endif()
-
-include(zdnn.cmake)
-setup_zdnn(v1.0.0)
-
-add_subdirectory(Dialect)
-add_subdirectory(Conversion)
-add_subdirectory(Support)
-add_subdirectory(Transform)
-add_subdirectory(Compiler)
-
-add_onnx_mlir_library(NNPAAccel
-  NNPAAccelerator.cpp
-
-  EXCLUDE_FROM_OM_LIBS
-
-  INCLUDE_DIRS PUBLIC
-  ${ONNX_MLIR_SRC_ROOT}/include
-  ${ONNX_MLIR_SRC_ROOT}
-  ${NNPA_ONNX_MLIR_SRC_ROOT}
-  ${NNPA_SRC_ROOT}
-  ${NNPA_BIN_ROOT}
-  
-  LINK_LIBS PUBLIC
-  onnx
-  NNPACompilerUtils
-  Accelerator
-  OMZHighOps
-  OMZHighToZLow
-  OMZLowOps
-  OMZLowToLLVM
-  )

--- a/src/Accelerators/NNPA/zdnn.cmake
+++ b/src/Accelerators/NNPA/zdnn.cmake
@@ -26,9 +26,14 @@ function(setup_zdnn version)
     #
     # Set MAKEFLAGS to remove -j option passed down from the top
     # level make which produces a warning about jobserver unavailable.
-    BUILD_COMMAND sh -c "MAKEFLAGS=--no-print-directory \
-                         make -j$(nproc) -C zdnn lib/libzdnn.so && \
-                         ar -rc ${ZDNN_LIBDIR}/libzdnn.a ${ZDNN_OBJDIR}/*.o"
+    #
+    # Run make -q first to skip build if libzdnn.so is already
+    # up to date.
+    BUILD_COMMAND sh -c "export MAKEFLAGS=--no-print-directory && \
+                         make -q -C zdnn lib/libzdnn.so && true || \
+                         (MAKEFLAGS=--no-print-directory \
+                          make -j$(nproc) -C zdnn lib/libzdnn.so && \
+                          ar -rc ${ZDNN_LIBDIR}/libzdnn.a ${ZDNN_OBJDIR}/*.o)"
 
     INSTALL_COMMAND ""
     )

--- a/test/mlir/CMakeLists.txt
+++ b/test/mlir/CMakeLists.txt
@@ -1,5 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Turn on lit test for specified accelerators even if the
+# accelerator code itself cannot be built.
+if (ONNX_MLIR_ACCELERATORS)
+  foreach(t ${ONNX_MLIR_ACCELERATORS})
+    set(${t}_LIT_ENABLED 1)
+    list(APPEND ACCEL_LIT_LIST "${t}")
+  endforeach(t)
+endif(ONNX_MLIR_ACCELERATORS)
+if (ACCEL_LIT_LIST)
+  message(STATUS "Accelerator lit tests    : ${ACCEL_LIT_LIST}")
+else()
+  message(STATUS "Accelerator lit tests    : NONE")
+endif()
+
 # Set LLVM_DEFAULT_EXTERNAL_LIT to an empty string to avoid warnings about the path
 # when using multi-config generators such as VS or Xcode
 set(LLVM_DEFAULT_EXTERNAL_LIT "")

--- a/test/mlir/accelerators/CMakeFiles.txt
+++ b/test/mlir/accelerators/CMakeFiles.txt
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-if (ACCELERATORS_TO_BUILD)
-  foreach(t ${ACCELERATORS_TO_BUILD})
-    add_subdirectory(${t})
-  endforeach(t)
-endif(ACCELERATORS_TO_BUILD)

--- a/test/mlir/lit.site.cfg.py.in
+++ b/test/mlir/lit.site.cfg.py.in
@@ -10,7 +10,7 @@ config.onnx_mlir_obj_root = r"@ONNX_MLIR_BIN_ROOT@"
 
 config.onnx_mlir_vendor = r"@ONNX_MLIR_VENDOR@"
 
-config.enable_nnpa= 0x0@NNPA_ENABLED@
+config.enable_nnpa= 0x0@NNPA_LIT_ENABLED@
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/utils/install-onnx-mlir.sh
+++ b/utils/install-onnx-mlir.sh
@@ -1,5 +1,6 @@
 # MLIR_DIR must be set with cmake option now
-mkdir onnx-mlir/build && cd onnx-mlir/build
+mkdir -p onnx-mlir/build && cd onnx-mlir/build
+ls -l $(pwd)/llvm-project/build/lib/cmake/mlir
 if [[ -z "$pythonLocation" ]]; then
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \

--- a/utils/install-onnx-mlir.sh
+++ b/utils/install-onnx-mlir.sh
@@ -1,16 +1,16 @@
 # MLIR_DIR must be set with cmake option now
-mkdir -p onnx-mlir/build && cd onnx-mlir/build
-ls -l $(pwd)/llvm-project/build/lib/cmake/mlir
+MLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir
+mkdir onnx-mlir/build && cd onnx-mlir/build
 if [[ -z "$pythonLocation" ]]; then
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
-        -DMLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir \
+        -DMLIR_DIR=${MLIR_DIR} \
         ..
 else
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
         -DPython3_ROOT_DIR=$pythonLocation \
-        -DMLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir \
+        -DMLIR_DIR=${MLIR_DIR} \
         ..
 fi
 cmake --build .

--- a/utils/install-onnx-mlir.sh
+++ b/utils/install-onnx-mlir.sh
@@ -1,11 +1,16 @@
-# Export environment variables pointing to LLVM-Projects.
-export MLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir
-
+# MLIR_DIR must be set with cmake option now
 mkdir onnx-mlir/build && cd onnx-mlir/build
 if [[ -z "$pythonLocation" ]]; then
-  cmake -G Ninja -DCMAKE_CXX_COMPILER=/usr/bin/c++ ..
+  cmake -G Ninja \
+        -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
+        -DMLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir \
+        ..
 else
-  cmake -G Ninja -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DPython3_ROOT_DIR=$pythonLocation ..
+  cmake -G Ninja \
+        -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
+        -DPython3_ROOT_DIR=$pythonLocation \
+        -DMLIR_DIR=$(pwd)/llvm-project/build/lib/cmake/mlir \
+        ..
 fi
 cmake --build .
 


### PR DESCRIPTION
- force setting cached MLIR_DIR to honor command line argument
- unset cached LLVM_DIR so it changes along with MLIR_DIR
- surround third_party with set(CMAKE_MESSAGE_LOG_LEVEL NOTICE) and
  set(CMAKE_MESSAGE_LOG_LEVEL STATUS) to mask out their cmake
  output so we can see more clearly output by onnx-mlir only.
  third_party cmake output can still be turned on by the --log-level
  command line option
- rename cmake option ACCELERATORS_TO_BUILD to ONNX_MLIR_ACCELERATORS
  for consistency
- allow accelerator lit tests even if accelerator code itself
  cannot be built
- fix bug in zdnn.cmake where ar was run even though libzdnn.so was
  already up to date, causing concurrent builds to corrput libzdnn.a

Signed-off-by: Gong Su <gong_su@hotmail.com>