### PR TITLE
Add explicit instantiation of getScalarValue for more types

### DIFF
--- a/src/Dialect/ONNX/ONNXOpsHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.cpp
@@ -555,7 +555,10 @@ RESULT_TYPE getScalarValue(ONNXConstantOp constantOp, Type type) {
 // Template instantiation for getScalarValue
 
 template double getScalarValue<double>(ONNXConstantOp constantOp, Type type);
+template float getScalarValue<float>(ONNXConstantOp constantOp, Type type);
 template int64_t getScalarValue<int64_t>(ONNXConstantOp constantOp, Type type);
+template int32_t getScalarValue<int32_t>(ONNXConstantOp constantOp, Type type);
+template int16_t getScalarValue<int16_t>(ONNXConstantOp constantOp, Type type);
 
 // Convert type to MLIR type.
 // A complete list of types can be found in:


### PR DESCRIPTION
I was trying to use the `getScalarValue` helper function for `int16_t`, `int32_t`, and `float`, but wasn't able to.

I have added explicit instantiations for them in this MR.