### PR TITLE
Fix output type when CategoryMapper is imported

### DIFF
--- a/src/Builder/OpBuildTable.inc
+++ b/src/Builder/OpBuildTable.inc
@@ -545,7 +545,7 @@ import_handler_map_["Binarizer"] =
 import_handler_map_["CastMap"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXCastMapOp>;
 import_handler_map_["CategoryMapper"] = 
-   &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXCategoryMapperOp>;
+   &onnx_mlir::detail::FrontendGenImpl::ImportCategoryMapper;
 import_handler_map_["DictVectorizer"] = 
    &onnx_mlir::detail::FrontendGenImpl::buildOperation<mlir::ONNXDictVectorizerOp>;
 import_handler_map_["FeatureVectorizer"] = 

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -248,6 +248,7 @@ special_attr_types = dict([("Cast.to", 'type')])
 # Special operation importing handlers.
 special_op_handler = dict([
     ("BatchNormalization", "ImportNodeBatchNormalization"),
+    ("CategoryMapper", "ImportCategoryMapper"),
     ("Dropout", "ImportNodeDropout"),
     ("Cast", "ImportNodeCast"),
     ("MaxPool", "ImportNodeMaxPool"),


### PR DESCRIPTION
Signed-off-by: Tong Chen <chentong@us.ibm.com>
The type inference for CategoryMapper in model importer is a special case: The element type of the output type is I64 if the input is string type, or string type if the input is I64 type. onnx-mlir did not handle such case. 
The fix is use a specialized importer for CategoryMapper to determine the output type. Pass the result to the type inference for the output tensor with an added parameter. 
With this PR, bidalf-9.onnx can be parsed by onnx-mlir. Now I got error related to shape inference: 
```
error: Invalid axis value
error: shape inference failed
```