### PR TITLE
Add MemRefNormalizable trait to the newly added KrnlSeqExtractOp

### DIFF
--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -163,7 +163,7 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator,
   }];
 }
 
-def KrnlSeqExtractOp : Op<Krnl_Dialect, "seqextract", [
+def KrnlSeqExtractOp : Op<Krnl_Dialect, "seqextract", [MemRefsNormalizable,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     DeclareOpInterfaceMethods<AllocationOpInterface, ["buildDealloc", "buildClone"]>]> {
   let summary = "Krnl load from a seq";


### PR DESCRIPTION
Krnl operations whose inputs or outputs are of MemRefType have MemRefNormalizable trait, but the newly added KrnlSeqExtractOp is missing. This patch is to add the trait to KrnlSeqExtractOp.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>