### PR TITLE
Upgrade LLVM level to 9778ec057cf4 

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -14,7 +14,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 23aa5a744666b281af807b1f598f517bf0d597cb && cd ..
+cd llvm-project && git checkout 4a3460a7917f1cf514575759e29590b388131fc6 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -14,7 +14,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 4a3460a7917f1cf514575759e29590b388131fc6 && cd ..
+cd llvm-project && git checkout 9778ec057cf4214241e4a970f3e764e3cf150181 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -48,7 +48,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 4a3460a7917f1cf514575759e29590b388131fc6 && cd ..
+cd llvm-project && git checkout 9778ec057cf4214241e4a970f3e764e3cf150181 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -48,7 +48,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 23aa5a744666b281af807b1f598f517bf0d597cb && cd ..
+cd llvm-project && git checkout 4a3460a7917f1cf514575759e29590b388131fc6 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -70,19 +70,19 @@ void addONNXToZHighPasses(
     mlir::PassManager &pm, ArrayRef<std::string> execNodesOnCpu) {
   pm.addPass(onnx_mlir::createRewriteONNXForZHighPass(execNodesOnCpu));
   pm.addPass(onnx_mlir::createShapeInferencePass());
-  pm.addNestedPass<FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
+  pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
   // Add instrumentation for Onnx Ops in the same way as onnx-mlir.
   if (instrumentZHighOps == "" || instrumentZHighOps == "NONE")
-    pm.addNestedPass<FuncOp>(onnx_mlir::createInstrumentONNXPass(
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXPass(
         instrumentONNXOps, instrumentControlBits.getBits()));
   pm.addPass(onnx_mlir::createONNXToZHighPass(execNodesOnCpu));
   pm.addPass(onnx_mlir::createShapeInferencePass());
   // There are more opportunities for const propagation once all zhigh ops were
   // generated.
-  pm.addNestedPass<FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
+  pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
   pm.addPass(mlir::createCanonicalizerPass());
   // Layout propagation at ZHighIR.
-  pm.addNestedPass<FuncOp>(
+  pm.addNestedPass<func::FuncOp>(
       onnx_mlir::zhigh::createZHighLayoutPropagationPass());
   pm.addPass(onnx_mlir::createShapeInferencePass());
   pm.addPass(mlir::createCanonicalizerPass());
@@ -91,7 +91,7 @@ void addONNXToZHighPasses(
   bool isBE = llvm::support::endian::system_endianness() ==
               llvm::support::endianness::big;
   if (isBE)
-    pm.addNestedPass<FuncOp>(
+    pm.addNestedPass<func::FuncOp>(
         onnx_mlir::zhigh::createZHighConstPropagationPass());
   // Remove common sub-expressions.
   pm.addPass(mlir::createCSEPass());
@@ -126,7 +126,7 @@ void addPassesNNPA(mlir::OwningOpRef<mlir::ModuleOp> &module,
     else {
       pm.addPass(mlir::createCanonicalizerPass());
       // Add instrumentation for ZHigh Ops
-      pm.addNestedPass<FuncOp>(zhigh::createInstrumentZHighPass());
+      pm.addNestedPass<func::FuncOp>(zhigh::createInstrumentZHighPass());
       // Lower all ONNX and ZHigh ops.
       std::string optStr = getCompilerOption(OptionKind::CompilerOptLevel);
       OptLevel optLevel = OptLevel::O0;
@@ -151,7 +151,7 @@ void addPassesNNPA(mlir::OwningOpRef<mlir::ModuleOp> &module,
         pm.addPass(zlow::createZLowRewritePass());
         pm.addPass(mlir::createCanonicalizerPass());
         // Constant folding for std.alloc.
-        pm.addNestedPass<FuncOp>(onnx_mlir::createFoldStdAllocPass());
+        pm.addNestedPass<func::FuncOp>(onnx_mlir::createFoldStdAllocPass());
       }
     }
   }

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp
@@ -260,7 +260,7 @@ public:
                      "specified nodes are forced to run on the CPU instead of "
                      "using the zDNN. The node name is an optional attribute "
                      "in onnx graph, which is `onnx_node_name` in ONNX IR"),
-      llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore};
+      llvm::cl::ZeroOrMore};
 };
 } // end anonymous namespace.
 

--- a/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.cpp
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.hpp"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
 #include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
-#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
-#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
@@ -267,7 +267,7 @@ FlatSymbolRefAttr getOrInsertExternFuncRef(PatternRewriter &rewriter,
     ModuleOp module, StringRef funcName, Type funcType) {
   auto *context = module.getContext();
   if (auto sym = module.lookupSymbol<LLVM::LLVMFuncOp>(funcName)) {
-    assert(sym.getType() == funcType && "wrong symbol type");
+    assert(sym.getFunctionType() == funcType && "wrong symbol type");
     return SymbolRefAttr::get(context, funcName);
   }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
@@ -13,6 +13,7 @@
 #ifndef ZHIGH_OPS
 #define ZHIGH_OPS
 
+include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "src/Interface/ShapeInferenceOpInterface.td"
@@ -37,6 +38,7 @@ class ZHigh_Attr<string name, list<Trait> traits = []>
 // ztensor encoding attribute.
 def ZTensorEncodingAttr : ZHigh_Attr<"ZTensorEncoding"> {
   let mnemonic = "encoding";
+  let hasCustomAssemblyFormat = 1;
 
   let description = [{
     An attribute to encode information on properties of ztensors. A tensor with
@@ -383,7 +385,7 @@ def ZHighMatMulOp:ZHigh_Op<"MatMul", [NoSideEffect,
       build($_builder, $_state, resType, X, Y, B);
     }]>
   ];
-  let verifier = [{ return ::onnx_mlir::zhigh::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ZHighLSTMOp:ZHigh_Op<"LSTM", [NoSideEffect,
@@ -429,7 +431,7 @@ def ZHighLSTMOp:ZHigh_Op<"LSTM", [NoSideEffect,
             hidden_bias, hidden_size, direction, return_all_steps);
     }]>
   ];
-  let verifier = [{ return ::onnx_mlir::zhigh::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ZHighGRUOp:ZHigh_Op<"GRU", [NoSideEffect,
@@ -471,7 +473,7 @@ def ZHighGRUOp:ZHigh_Op<"GRU", [NoSideEffect,
             hidden_bias, hidden_size, direction, return_all_steps);
     }]>
   ];
-  let verifier = [{ return ::onnx_mlir::zhigh::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ZHighStickForLSTMOp:ZHigh_Op<"StickForLSTM", [NoSideEffect,
@@ -553,7 +555,7 @@ def ZHighConv2DOp:ZHigh_Op<"Conv2D", [NoSideEffect,
             kernel_shape, strides, padding_type, act_func);
     }]>
   ];
-  let verifier = [{ return ::onnx_mlir::zhigh::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def ZHighBatchNormOp:ZHigh_Op<"BatchNorm", [NoSideEffect,
@@ -599,7 +601,7 @@ def ZHighConcatOp:ZHigh_Op<"Concat", [NoSideEffect,
   let arguments = (ins Variadic<AnyTypeOf<[ZTensor_4D, ZTensor_NHWC, AnyMemRef]>>:$inputs,
                        SI64Attr:$axis);
   let results = (outs AnyTypeOf<[ZTensor_4D, ZTensor_NHWC, AnyMemRef]>:$concat_result);
-  let verifier = [{ return ::onnx_mlir::zhigh::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 #endif // ZHIGH_OPS

--- a/src/Accelerators/NNPA/Dialect/ZLow/ZLowCombine.td
+++ b/src/Accelerators/NNPA/Dialect/ZLow/ZLowCombine.td
@@ -15,6 +15,7 @@
 #define ZLOW_COMBINE
 
 #ifndef OP_BASE
+include "mlir/IR/PatternBase.td"
 include "ZLow.td"
 #endif // OP_BASE
 

--- a/src/Accelerators/NNPA/Transform/FoldStdAlloc.cpp
+++ b/src/Accelerators/NNPA/Transform/FoldStdAlloc.cpp
@@ -196,7 +196,7 @@ public:
  *  Function pass that folds std.alloc.
  */
 class FoldStdAllocPass
-    : public PassWrapper<FoldStdAllocPass, OperationPass<FuncOp>> {
+    : public PassWrapper<FoldStdAllocPass, OperationPass<func::FuncOp>> {
 public:
   StringRef getArgument() const override { return "fold-std-alloc"; }
 

--- a/src/Accelerators/NNPA/Transform/ZHigh/InstrumentZHighPass.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/InstrumentZHighPass.cpp
@@ -60,8 +60,8 @@ llvm::cl::bits<InstrumentActions> InstrumentControlBits(
             "instrument runtime reports memory usage")),
     llvm::cl::cat(OMNNPAPassOptions));
 
-class InstrumentZHighPass
-    : public mlir::PassWrapper<InstrumentZHighPass, OperationPass<FuncOp>> {
+class InstrumentZHighPass : public mlir::PassWrapper<InstrumentZHighPass,
+                                OperationPass<func::FuncOp>> {
 
 private:
   bool allOpsAllowed;

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighConstPropagation.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighConstPropagation.cpp
@@ -297,7 +297,8 @@ namespace {
 
 struct ZHighConstPropagationPass
     //: public PassWrapper<ZHighConstPropagationPass, OperationPass<ModuleOp>> {
-    : public PassWrapper<ZHighConstPropagationPass, OperationPass<FuncOp>> {
+    : public PassWrapper<ZHighConstPropagationPass,
+          OperationPass<func::FuncOp>> {
 
   StringRef getArgument() const override { return "constprop-zhigh"; }
 

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.cpp
@@ -70,7 +70,8 @@ namespace {
 #include "src/Accelerators/NNPA/Transform/ZHigh/ONNXZHighLayoutPropagation.inc"
 
 struct ZHighLayoutPropagationPass
-    : public PassWrapper<ZHighLayoutPropagationPass, OperationPass<FuncOp>> {
+    : public PassWrapper<ZHighLayoutPropagationPass,
+          OperationPass<func::FuncOp>> {
 
   StringRef getArgument() const override { return "zhigh-layout-prop"; }
 

--- a/src/Accelerators/NNPA/Transform/ZLow/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Transform/ZLow/CMakeLists.txt
@@ -4,6 +4,7 @@ add_onnx_mlir_library(OMZLowRewrite
   ZLowRewrite.cpp
 
   LINK_LIBS PUBLIC
+  MLIRFunc
   MLIRRewrite
   MLIRTransformUtils
   MLIRViewLikeInterface

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowRewrite.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowRewrite.cpp
@@ -104,7 +104,7 @@ public:
  *  Function pass that optimizes ZLowIR.
  */
 class ZLowRewritePass
-    : public PassWrapper<ZLowRewritePass, OperationPass<FuncOp>> {
+    : public PassWrapper<ZLowRewritePass, OperationPass<func::FuncOp>> {
 public:
   StringRef getArgument() const override { return "zlow-rewrite"; }
 

--- a/src/Builder/CMakeLists.txt
+++ b/src/Builder/CMakeLists.txt
@@ -12,6 +12,7 @@ add_onnx_mlir_library(OMBuilder
   OMHasOnnxSubgraphOpInterface
   OMONNXOps
   OMResultTypeInferenceOpInterface
+  MLIRFunc
   onnx
   )
 

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1049,7 +1049,7 @@ private:
     return std::string("");
   }
 
-  FuncOp CreateFuncOp(
+  func::FuncOp CreateFuncOp(
       std::string namePrefix, TypeRange operandTypes, TypeRange resultTypes) {
     auto funcType = builder_.getFunctionType(operandTypes, resultTypes);
     if (namePrefix.empty())
@@ -1060,7 +1060,7 @@ private:
       funcName = namePrefix + "_" + std::to_string(suffix);
     }
 
-    auto funcOp = FuncOp::create(UnknownLoc(), funcName, funcType);
+    auto funcOp = func::FuncOp::create(UnknownLoc(), funcName, funcType);
     module_.insert(module_.begin(), funcOp);
     return funcOp;
   }
@@ -1388,16 +1388,16 @@ private:
    * @param graph onnx graph proto.
    * @return A function corresponding to the imported computation graph.
    */
-  FuncOp importGraph(const onnx::GraphProto &graph) {
+  func::FuncOp importGraph(const onnx::GraphProto &graph) {
     const std::string &name = "main_graph";
-    auto mainFunc = FuncOp::create(UnknownLoc(), name,
+    auto mainFunc = func::FuncOp::create(UnknownLoc(), name,
         /*type=*/builder_.getFunctionType({}, {}), /*attrs=*/{});
     module_.push_back(mainFunc);
     // Create and set insertion point to entry block.
-    mainFunc.body().push_back(new Block);
-    builder_.setInsertionPointToStart(&mainFunc.body().back());
+    mainFunc.getBody().push_back(new Block);
+    builder_.setInsertionPointToStart(&mainFunc.getBody().back());
 
-    auto funcType = importGraph(graph, /*region=*/mainFunc.body(),
+    auto funcType = importGraph(graph, /*region=*/mainFunc.getBody(),
         /*op=*/mainFunc.getOperation(), /*useStdReturn=*/true);
     mainFunc.setType(funcType);
 

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -520,7 +520,7 @@ private:
       if (attr.type() == onnx::AttributeProto_AttributeType_GRAPH)
         result.addRegion();
 
-    auto op = builder_.createOperation(result);
+    auto op = builder_.create(result);
     for (int i = 0; i < node.output().size(); i++) {
       auto r = op->getResult(i);
       frontend_symbols_.AddMapping(node.output()[i], r);

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -681,10 +681,10 @@ void emitOutputFiles(std::string outputBaseName,
     mlir::PassManager cleanSourcePM(
         &context, mlir::OpPassManager::Nesting::Implicit);
     if (emissionTarget == EmitONNXIR || emissionTarget == EmitONNXBasic)
-      cleanSourcePM.addNestedPass<FuncOp>(
+      cleanSourcePM.addNestedPass<func::FuncOp>(
           onnx_mlir::createElideConstantValuePass());
     if (emissionTarget == EmitMLIR)
-      cleanSourcePM.addNestedPass<FuncOp>(
+      cleanSourcePM.addNestedPass<func::FuncOp>(
           onnx_mlir::createElideConstGlobalValuePass());
 
     if (emissionTarget == EmitONNXBasic || emissionTarget == EmitONNXIR ||

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -21,7 +21,7 @@
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/InitAllDialects.h"
-#include "mlir/Parser.h"
+#include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/ADT/SmallVector.h"

--- a/src/Conversion/KrnlToLLVM/CMakeLists.txt
+++ b/src/Conversion/KrnlToLLVM/CMakeLists.txt
@@ -23,6 +23,7 @@ add_onnx_mlir_library(OMKrnlToLLVM
   OMSupport
   MLIRAffineToStandard
   MLIRFunc
+  MLIRFuncToLLVM
   MLIRFuncTransforms
   MLIRMathToLLVM
   MLIRMathTransforms
@@ -31,7 +32,6 @@ add_onnx_mlir_library(OMKrnlToLLVM
   MLIRReconcileUnrealizedCasts
   MLIRSCFToControlFlow
   MLIRShapeToStandard
-  MLIRStandardToLLVM
   MLIRVectorToLLVM
   onnx
   )

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/ArithmeticToLLVM/ArithmeticToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
@@ -24,7 +25,6 @@
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Conversion/ShapeToStandard/ShapeToStandard.h"
-#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arithmetic/Transforms/Passes.h"
@@ -87,7 +87,7 @@ void determineOwnershipForOutputOMTensors(
 
   // Get entry function op.
   Operation *entryFunc;
-  module->walk([&](FuncOp op) -> WalkResult {
+  module->walk([&](func::FuncOp op) -> WalkResult {
     if (SymbolRefAttr::get(op).getValue() == entryPointFuncName) {
       entryFunc = op;
       return WalkResult::interrupt();
@@ -166,7 +166,7 @@ void populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
   populateMathPolynomialApproximationPatterns(patterns);
   arith::populateArithmeticExpandOpsPatterns(patterns);
   populateMathToLLVMConversionPatterns(typeConverter, patterns);
-  populateStdToLLVMConversionPatterns(typeConverter, patterns);
+  populateFuncToLLVMConversionPatterns(typeConverter, patterns);
   populateMemRefToLLVMConversionPatterns(typeConverter, patterns);
   arith::populateArithmeticToLLVMConversionPatterns(typeConverter, patterns);
   cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -486,6 +486,7 @@ void genSignatureFunction(ModuleOp module,
 
 struct ConvertKrnlToLLVMPass
     : public PassWrapper<ConvertKrnlToLLVMPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvertKrnlToLLVMPass)
 
   StringRef getArgument() const override { return "convert-krnl-to-llvm"; }
 

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -148,7 +148,7 @@ public:
            isa<LLVM::LLVMFuncOp>(staticEntryPointFunc) &&
            "entry point func must exist and be an llvm func op");
     auto staticEntryPointTy = dyn_cast<LLVM::LLVMFuncOp>(staticEntryPointFunc)
-                                  .getType()
+                                  .getFunctionType()
                                   .dyn_cast<LLVM::LLVMFunctionType>();
 
     // Retrieve dynamic mem refs from wrapped input, and convert every one of

--- a/src/Conversion/KrnlToLLVM/RuntimeAPI.cpp
+++ b/src/Conversion/KrnlToLLVM/RuntimeAPI.cpp
@@ -54,7 +54,7 @@ FlatSymbolRefAttr RuntimeAPI::getOrInsertExternFunc(StringRef funcName,
     ModuleOp module, mlir::Type funcType, OpBuilder &builder) {
   MLIRContext *context = module.getContext();
   if (auto sym = module.lookupSymbol<LLVM::LLVMFuncOp>(funcName)) {
-    assert(sym.getType() == funcType && "wrong symbol type");
+    assert(sym.getFunctionType() == funcType && "wrong symbol type");
     return SymbolRefAttr::get(context, funcName);
   }
 

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -51,7 +51,7 @@ void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
   // Type conversion for function signatures.
   // Call MLIR FuncOp signature conversion when result type is
   // a ranked tensor.
-  populateFunctionOpInterfaceTypeConversionPattern<FuncOp>(
+  populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
       patterns, typeConverter);
   populateCallOpTypeConversionPattern(patterns, typeConverter);
   populateReturnOpTypeConversionPattern(patterns, typeConverter);
@@ -256,9 +256,9 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
 
   // Convert types to legal types for the Krnl dialect.
   KrnlTypeConverter krnlTypeConverter;
-  target.addDynamicallyLegalOp<FuncOp>([&](FuncOp op) {
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
     // FuncOp is legal only if types have been converted to Std types.
-    return krnlTypeConverter.isSignatureLegal(op.getType());
+    return krnlTypeConverter.isSignatureLegal(op.getFunctionType());
   });
 
   target.addDynamicallyLegalOp<func::CallOp>([&](func::CallOp op) {

--- a/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
+++ b/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
@@ -173,7 +173,7 @@ struct ONNXCategoryMapperOpLowering : public ConversionPattern {
     rewriter.replaceOp(op, alloc);
 
     LLVM_DEBUG({
-      FuncOp function = getContainingFunction(op);
+      func::FuncOp function = getContainingFunction(op);
       assert(function && "Could not find parent function");
       llvm::dbgs() << "function:\n" << function << "\n";
     });

--- a/src/Conversion/SeqToMemref/ConvertSeqToMemref.cpp
+++ b/src/Conversion/SeqToMemref/ConvertSeqToMemref.cpp
@@ -37,6 +37,7 @@ namespace krnl {
 
 struct ConvertSeqToMemrefPass
     : public PassWrapper<ConvertSeqToMemrefPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvertSeqToMemrefPass)
 
   StringRef getArgument() const override { return "convert-seq-to-memref"; }
 

--- a/src/Conversion/SeqToMemref/ConvertSeqToMemref.cpp
+++ b/src/Conversion/SeqToMemref/ConvertSeqToMemref.cpp
@@ -36,7 +36,7 @@ namespace onnx_mlir {
 namespace krnl {
 
 struct ConvertSeqToMemrefPass
-    : public PassWrapper<ConvertSeqToMemrefPass, OperationPass<FuncOp>> {
+    : public PassWrapper<ConvertSeqToMemrefPass, OperationPass<func::FuncOp>> {
 
   StringRef getArgument() const override { return "convert-seq-to-memref"; }
 
@@ -48,8 +48,8 @@ struct ConvertSeqToMemrefPass
 };
 
 void ConvertSeqToMemrefPass::runOnOperation() {
-  FuncOp funcOp = getOperation();
-  if (funcOp.body().empty()) // external function: nothing to do
+  func::FuncOp funcOp = getOperation();
+  if (funcOp.getBody().empty()) // external function: nothing to do
     return;
   MLIRContext *ctx = &getContext();
 

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -32,7 +32,7 @@ ParseResult KrnlDialectOperandParser::ParseOptionalOperand(
   // If operand queue is empty, parse more operands and cache them.
   if (operandRefQueue.empty()) {
     // Parse operand types:
-    llvm::SmallVector<OpAsmParser::OperandType, 2> operand_refs;
+    llvm::SmallVector<OpAsmParser::UnresolvedOperand, 2> operand_refs;
     parser.parseOperandList(operand_refs);
 
     // Record operands:

--- a/src/Dialect/Krnl/KrnlHelper.hpp
+++ b/src/Dialect/Krnl/KrnlHelper.hpp
@@ -64,7 +64,7 @@ private:
   mlir::Builder &builder;
 
   // A queue storing the parsed SSA id references.
-  std::queue<mlir::OpAsmParser::OperandType> operandRefQueue;
+  std::queue<mlir::OpAsmParser::UnresolvedOperand> operandRefQueue;
 };
 
 // Adapted from:

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -54,7 +54,7 @@ def ONNXCallOp : ONNX_Op<"ONNX_Call",
   let results = (outs Variadic<AnyTypeOf<[AnyTensor]>>);
 
   let builders = [
-    OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
+    OpBuilder<(ins "func::FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
       $_state.addOperands(operands);
       $_state.addAttribute("callee", SymbolRefAttr::get(callee));
       $_state.addTypes(callee.getFunctionType().getResults());

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -57,7 +57,7 @@ def ONNXCallOp : ONNX_Op<"ONNX_Call",
     OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
       $_state.addOperands(operands);
       $_state.addAttribute("callee", SymbolRefAttr::get(callee));
-      $_state.addTypes(callee.getType().getResults());
+      $_state.addTypes(callee.getFunctionType().getResults());
     }]>,
     OpBuilder<(ins "SymbolRefAttr":$callee, "TypeRange":$results,
       CArg<"ValueRange", "{}">:$operands), [{

--- a/src/Dialect/ONNX/ONNX.td
+++ b/src/Dialect/ONNX/ONNX.td
@@ -13,7 +13,9 @@
 #ifndef ONNX_OPS
 #define ONNX_OPS
 
+include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
+include "mlir/IR/PatternBase.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "src/Interface/ShapeInferenceOpInterface.td"
 include "src/Interface/ResultTypeInferenceOpInterface.td"
@@ -238,26 +240,7 @@ def ONNX_SeqType : ONNX_Type<"Seq", "Seq"> {
 
   let parameters = (ins "::mlir::ShapedType":$ElementType, "int64_t":$Length);
 
-  // Previous implementation did not print/parse the length field
-  // May add the field in future
-  let printer = [{
-    $_printer << "<" << getImpl()->ElementType << ">";
-  }];
-  let parser = [{
-    if ($_parser.parseLess())
-      return Type();
-    Type elementType;
-    if ($_parser.parseType(elementType))
-      return Type();
-    if ($_parser.parseGreater())
-      return Type();
-    if (!elementType.isa<ShapedType>()) 
-      return Type();
-    else {
-      ShapedType ty = elementType.cast<ShapedType>();
-      return get($_ctxt, ty, -1);
-    }
-  }];
+  let hasCustomAssemblyFormat = 1;
   let builders = [
     TypeBuilderWithInferredContext<(ins "::mlir::ShapedType":$elementType,
                                         "int64_t":$length), [{

--- a/src/Dialect/ONNX/ONNX.td
+++ b/src/Dialect/ONNX/ONNX.td
@@ -92,11 +92,11 @@ def ONNXEntryPointOp: ONNX_Op<"EntryPoint"> {
                        I32Attr:$numOutputs,
                        StrAttr:$signature);
 
-  let builders = [OpBuilder<(ins "FuncOp":$function, "int":$numInputs,
+  let builders = [OpBuilder<(ins "func::FuncOp":$function, "int":$numInputs,
                                  "int":$numOutputs, "std::string":$signature)>];
 
   let extraClassDeclaration = [{
-    static ONNXEntryPointOp create(Location location, FuncOp& func,
+    static ONNXEntryPointOp create(Location location, func::FuncOp& func,
                                    int numInputs, int numOutputs,
                                    std::string signature);
 

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -680,7 +680,7 @@ LogicalResult ONNXArgMinOp::inferShapes(
 //===----------------------------------------------------------------------===//
 
 void ONNXEntryPointOp::build(mlir::OpBuilder &builder,
-    mlir::OperationState &state, mlir::FuncOp function, int numInputs,
+    mlir::OperationState &state, mlir::func::FuncOp function, int numInputs,
     int numOutputs, std::string signature) {
   state.addAttribute(ONNXEntryPointOp::getEntryPointFuncAttrName(),
       SymbolRefAttr::get(function));
@@ -693,7 +693,8 @@ void ONNXEntryPointOp::build(mlir::OpBuilder &builder,
 }
 
 ONNXEntryPointOp ONNXEntryPointOp::create(mlir::Location location,
-    mlir::FuncOp &func, int numInputs, int numOutputs, std::string signature) {
+    mlir::func::FuncOp &func, int numInputs, int numOutputs,
+    std::string signature) {
   mlir::OperationState state(location, "onnx.EntryPoint");
   OpBuilder builder(location->getContext());
   mlir::ONNXEntryPointOp::build(
@@ -5274,13 +5275,14 @@ LogicalResult ONNXCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("callee");
   if (!fnAttr)
     return emitOpError("requires a 'callee' symbol reference attribute");
-  FuncOp fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(*this, fnAttr);
+  func::FuncOp fn =
+      symbolTable.lookupNearestSymbolFrom<func::FuncOp>(*this, fnAttr);
   if (!fn)
     return emitOpError() << "'" << fnAttr.getValue()
                          << "' does not reference a valid function";
 
   // Verify that the operand and result types match the callee.
-  auto fnType = fn.getType();
+  auto fnType = fn.getFunctionType();
   if (fnType.getNumInputs() != getNumOperands())
     return emitOpError("incorrect number of operands for callee");
 
@@ -5306,6 +5308,26 @@ LogicalResult ONNXCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
 FunctionType ONNXCallOp::getCalleeType() {
   return FunctionType::get(getContext(), getOperandTypes(), getResultTypes());
+}
+
+//===----------------------------------------------------------------------===//
+// SeqType
+//===---------------------------------------------------------------------===//
+
+mlir::Type SeqType::parse(mlir::AsmParser &parser) {
+  Type elementType;
+  if (parser.parseLess() || parser.parseType(elementType) ||
+      parser.parseGreater() || !elementType.isa<ShapedType>())
+    return Type();
+
+  ShapedType ty = elementType.cast<ShapedType>();
+  return get(ty.getContext(), ty, -1);
+}
+
+void SeqType::print(mlir::AsmPrinter &printer) const {
+  // Previous implementation did not print/parse the length field
+  // May add the field in future
+  printer << "<" << getElementType() << ">";
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Support/KrnlSupport.cpp
+++ b/src/Support/KrnlSupport.cpp
@@ -42,7 +42,7 @@ Block *getTopBlock(Operation *op) {
   Block *topBlock = op->getBlock();
   Operation *parentBlockOp = topBlock->getParentOp();
 
-  while (!llvm::dyn_cast_or_null<FuncOp>(parentBlockOp)) {
+  while (!llvm::dyn_cast_or_null<func::FuncOp>(parentBlockOp)) {
     topBlock = parentBlockOp->getBlock();
     parentBlockOp = topBlock->getParentOp();
   }
@@ -51,14 +51,14 @@ Block *getTopBlock(Operation *op) {
 }
 
 /// Retrieve function which contains the current operation.
-FuncOp getContainingFunction(Operation *op) {
+func::FuncOp getContainingFunction(Operation *op) {
   Operation *parentFuncOp = op->getParentOp();
 
   // While parent is not a FuncOp and its cast to a FuncOp is null.
-  while (!llvm::dyn_cast_or_null<FuncOp>(parentFuncOp))
+  while (!llvm::dyn_cast_or_null<func::FuncOp>(parentFuncOp))
     parentFuncOp = parentFuncOp->getParentOp();
 
-  return cast<FuncOp>(parentFuncOp);
+  return cast<func::FuncOp>(parentFuncOp);
 }
 
 /// Emit constant operation.
@@ -142,7 +142,7 @@ bool isBlockArgument(Operation *op, Value operand) {
     parentBlockOp = currentBlock->getParentOp();
     currentBlock = parentBlockOp->getBlock();
 
-  } while (!llvm::dyn_cast_or_null<FuncOp>(parentBlockOp));
+  } while (!llvm::dyn_cast_or_null<func::FuncOp>(parentBlockOp));
 
   return false;
 }
@@ -204,7 +204,7 @@ bool opInTopLevelBlock(Operation *op) {
 
   // If the parent operation of the current block is a FuncOp then
   // this operation is in the top-level block.
-  return llvm::dyn_cast_or_null<FuncOp>(currentBlock->getParentOp());
+  return llvm::dyn_cast_or_null<func::FuncOp>(currentBlock->getParentOp());
 }
 
 /// This function returns true if `beforeOp` is visited before `op` in a
@@ -224,7 +224,7 @@ bool opBeforeOp(Block *block, Operation *beforeOp, Operation *afterOp) {
 
 /// Check Alloc operation result is used by a krnl.getref.
 bool checkOpResultIsUsedByGetRef(memref::AllocOp *allocOp) {
-  FuncOp function = getContainingFunction(allocOp->getOperation());
+  func::FuncOp function = getContainingFunction(allocOp->getOperation());
 
   bool opIsUsedInGetRef = false;
   function.walk([&opIsUsedInGetRef, allocOp](KrnlGetRefOp op) {

--- a/src/Support/KrnlSupport.hpp
+++ b/src/Support/KrnlSupport.hpp
@@ -38,7 +38,7 @@ mlir::memref::AllocOp getAllocOfGetRef(mlir::KrnlGetRefOp *getRef);
 mlir::Block *getTopBlock(mlir::Operation *op);
 
 /// Retrieve function which contains the current operation.
-mlir::FuncOp getContainingFunction(mlir::Operation *op);
+mlir::func::FuncOp getContainingFunction(mlir::Operation *op);
 
 // Emit a constant of a specific type.
 // Use this function for small values only to avoid unexpected loss in type

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -27,7 +27,7 @@
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/FileUtilities.h>
-#include <mlir/Support/MlirOptMain.h>
+#include <mlir/Tools/mlir-opt/MlirOptMain.h>
 
 #include "src/Accelerators/Accelerator.hpp"
 #include "src/Compiler/CompilerOptions.hpp"

--- a/src/Transform/BundleMemoryPools.cpp
+++ b/src/Transform/BundleMemoryPools.cpp
@@ -50,14 +50,14 @@ typedef std::map<Block *, AlignmentToMemPool *> BlockToMemPool;
 //===----------------------------------------------------------------------===//
 
 /// Retrieve function which contains the current operation.
-ATTRIBUTE(unused) FuncOp getContainingFunction(memref::AllocOp op) {
+ATTRIBUTE(unused) func::FuncOp getContainingFunction(memref::AllocOp op) {
   Operation *parentFuncOp = op->getParentOp();
 
   // While parent is not a FuncOp and its cast to a FuncOp is null.
-  while (!llvm::dyn_cast_or_null<FuncOp>(parentFuncOp))
+  while (!llvm::dyn_cast_or_null<func::FuncOp>(parentFuncOp))
     parentFuncOp = parentFuncOp->getParentOp();
 
-  return cast<FuncOp>(parentFuncOp);
+  return cast<func::FuncOp>(parentFuncOp);
 }
 
 // Check if this value is an argument of one of the blocks nested
@@ -76,7 +76,7 @@ bool isBlockArgument(memref::AllocOp allocOp, Value operand) {
     parentBlockOp = currentBlock->getParentOp();
     currentBlock = parentBlockOp->getBlock();
 
-  } while (!llvm::dyn_cast_or_null<FuncOp>(parentBlockOp));
+  } while (!llvm::dyn_cast_or_null<func::FuncOp>(parentBlockOp));
 
   return false;
 }
@@ -505,7 +505,7 @@ public:
     auto parentBlock = constOp.getOperation()->getBlock();
 
     // Ensure it's the top block.
-    if (!llvm::dyn_cast_or_null<FuncOp>(parentBlock->getParentOp()))
+    if (!llvm::dyn_cast_or_null<func::FuncOp>(parentBlock->getParentOp()))
       return failure();
 
     // Move instruction to the top.
@@ -518,8 +518,8 @@ public:
  *  Function pass that enables memory pooling for MemRefs.
  */
 
-class KrnlBundleMemoryPoolsPass
-    : public PassWrapper<KrnlBundleMemoryPoolsPass, OperationPass<FuncOp>> {
+class KrnlBundleMemoryPoolsPass : public PassWrapper<KrnlBundleMemoryPoolsPass,
+                                      OperationPass<func::FuncOp>> {
 
   BlockToMemPool blockToStaticPool;
   BlockToMemPool blockToDynamicPool;

--- a/src/Transform/BundleMemoryPools.cpp
+++ b/src/Transform/BundleMemoryPools.cpp
@@ -525,6 +525,8 @@ class KrnlBundleMemoryPoolsPass : public PassWrapper<KrnlBundleMemoryPoolsPass,
   BlockToMemPool blockToDynamicPool;
 
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(KrnlBundleMemoryPoolsPass)
+
   StringRef getArgument() const override { return "bundle-memory-pools"; }
 
   StringRef getDescription() const override {

--- a/src/Transform/CMakeLists.txt
+++ b/src/Transform/CMakeLists.txt
@@ -15,6 +15,7 @@ add_onnx_mlir_library(OMEnableMemoryPool
 
   LINK_LIBS PUBLIC
   OMSupport
+  MLIRFunc
   MLIRTransformUtils
   )
 

--- a/src/Transform/DisconnectKrnlDimFromAlloc.cpp
+++ b/src/Transform/DisconnectKrnlDimFromAlloc.cpp
@@ -130,7 +130,7 @@ public:
  */
 class DisconnectKrnlDimFromAllocPass
     : public PassWrapper<DisconnectKrnlDimFromAllocPass,
-          OperationPass<FuncOp>> {
+          OperationPass<func::FuncOp>> {
 public:
   StringRef getArgument() const override { return "lower-krnl-shape-to-std"; }
 

--- a/src/Transform/DisconnectKrnlDimFromAlloc.cpp
+++ b/src/Transform/DisconnectKrnlDimFromAlloc.cpp
@@ -132,6 +132,8 @@ class DisconnectKrnlDimFromAllocPass
     : public PassWrapper<DisconnectKrnlDimFromAllocPass,
           OperationPass<func::FuncOp>> {
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DisconnectKrnlDimFromAllocPass)
+
   StringRef getArgument() const override { return "lower-krnl-shape-to-std"; }
 
   StringRef getDescription() const override {

--- a/src/Transform/ElideKrnlGlobalConstants.cpp
+++ b/src/Transform/ElideKrnlGlobalConstants.cpp
@@ -81,8 +81,8 @@ namespace {
 /*!
  *  Function pass that performs constant value elision of Krnl globals.
  */
-class ElideConstGlobalValuePass
-    : public PassWrapper<ElideConstGlobalValuePass, OperationPass<FuncOp>> {
+class ElideConstGlobalValuePass : public PassWrapper<ElideConstGlobalValuePass,
+                                      OperationPass<func::FuncOp>> {
 public:
   StringRef getArgument() const override { return "elide-krnl-constants"; }
 

--- a/src/Transform/ElideKrnlGlobalConstants.cpp
+++ b/src/Transform/ElideKrnlGlobalConstants.cpp
@@ -84,6 +84,8 @@ namespace {
 class ElideConstGlobalValuePass : public PassWrapper<ElideConstGlobalValuePass,
                                       OperationPass<func::FuncOp>> {
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ElideConstGlobalValuePass)
+
   StringRef getArgument() const override { return "elide-krnl-constants"; }
 
   StringRef getDescription() const override {

--- a/src/Transform/EnableMemoryPool.cpp
+++ b/src/Transform/EnableMemoryPool.cpp
@@ -193,6 +193,8 @@ public:
 class KrnlEnableMemoryPoolPass : public PassWrapper<KrnlEnableMemoryPoolPass,
                                      OperationPass<func::FuncOp>> {
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(KrnlEnableMemoryPoolPass)
+
   StringRef getArgument() const override { return "enable-memory-pool"; }
 
   StringRef getDescription() const override {

--- a/src/Transform/EnableMemoryPool.cpp
+++ b/src/Transform/EnableMemoryPool.cpp
@@ -31,7 +31,7 @@ using namespace onnx_mlir;
 namespace {
 
 static bool checkOpResultIsReturned(memref::AllocOp *allocOp) {
-  FuncOp function = getContainingFunction(allocOp->getOperation());
+  func::FuncOp function = getContainingFunction(allocOp->getOperation());
 
   bool opIsReturned = false;
 
@@ -113,7 +113,7 @@ public:
     Block *parentBlock = allocOp.getOperation()->getBlock();
 
     // Only enable pooling for top level memrefs.
-    if (!llvm::dyn_cast_or_null<FuncOp>(parentBlock->getParentOp()))
+    if (!llvm::dyn_cast_or_null<func::FuncOp>(parentBlock->getParentOp()))
       return failure();
 
     // For now only handle constant MemRefs.
@@ -190,8 +190,8 @@ public:
 /*!
  *  Function pass that enables memory pooling for MemRefs.
  */
-class KrnlEnableMemoryPoolPass
-    : public PassWrapper<KrnlEnableMemoryPoolPass, OperationPass<FuncOp>> {
+class KrnlEnableMemoryPoolPass : public PassWrapper<KrnlEnableMemoryPoolPass,
+                                     OperationPass<func::FuncOp>> {
 public:
   StringRef getArgument() const override { return "enable-memory-pool"; }
 

--- a/src/Transform/LowerKrnlRegion.cpp
+++ b/src/Transform/LowerKrnlRegion.cpp
@@ -55,6 +55,8 @@ public:
 class LowerKrnlRegionPass
     : public PassWrapper<LowerKrnlRegionPass, OperationPass<func::FuncOp>> {
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LowerKrnlRegionPass)
+
   StringRef getArgument() const override { return "lower-krnl-region"; }
 
   StringRef getDescription() const override {

--- a/src/Transform/LowerKrnlRegion.cpp
+++ b/src/Transform/LowerKrnlRegion.cpp
@@ -53,7 +53,7 @@ public:
  *  Function pass that lowers KrnlRegionOp
  */
 class LowerKrnlRegionPass
-    : public PassWrapper<LowerKrnlRegionPass, OperationPass<FuncOp>> {
+    : public PassWrapper<LowerKrnlRegionPass, OperationPass<func::FuncOp>> {
 public:
   StringRef getArgument() const override { return "lower-krnl-region"; }
 

--- a/src/Transform/LowerKrnlShape.cpp
+++ b/src/Transform/LowerKrnlShape.cpp
@@ -81,7 +81,7 @@ public:
  *  Function pass that emits the shape of a MemRef.
  */
 class LowerKrnlShapePass
-    : public PassWrapper<LowerKrnlShapePass, OperationPass<FuncOp>> {
+    : public PassWrapper<LowerKrnlShapePass, OperationPass<func::FuncOp>> {
 public:
   StringRef getArgument() const override { return "lower-krnl-shape"; }
 

--- a/src/Transform/LowerKrnlShape.cpp
+++ b/src/Transform/LowerKrnlShape.cpp
@@ -83,6 +83,8 @@ public:
 class LowerKrnlShapePass
     : public PassWrapper<LowerKrnlShapePass, OperationPass<func::FuncOp>> {
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LowerKrnlShapePass)
+
   StringRef getArgument() const override { return "lower-krnl-shape"; }
 
   StringRef getDescription() const override {

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -37,6 +37,7 @@ add_onnx_mlir_library(OMShapeInference
   LINK_LIBS PUBLIC
   OMONNXOps
   OMShapeInferenceOpInterface
+  MLIRFunc
   MLIRPass
   )
 

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -756,7 +756,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 struct ConstPropONNXToONNXPass
-    : public PassWrapper<ConstPropONNXToONNXPass, OperationPass<FuncOp>> {
+    : public PassWrapper<ConstPropONNXToONNXPass, OperationPass<func::FuncOp>> {
 
   StringRef getArgument() const override { return "constprop-onnx"; }
 

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -757,6 +757,7 @@ public:
 
 struct ConstPropONNXToONNXPass
     : public PassWrapper<ConstPropONNXToONNXPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConstPropONNXToONNXPass)
 
   StringRef getArgument() const override { return "constprop-onnx"; }
 

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -129,7 +129,7 @@ namespace {
 #include "src/Transform/ONNX/ONNXDecompose.inc"
 
 struct DecomposeONNXToONNXPass
-    : public PassWrapper<DecomposeONNXToONNXPass, OperationPass<FuncOp>> {
+    : public PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>> {
 
   StringRef getArgument() const override { return "decompose-onnx"; }
 
@@ -142,7 +142,7 @@ struct DecomposeONNXToONNXPass
 };
 
 void DecomposeONNXToONNXPass::runOnOperation() {
-  FuncOp function = getOperation();
+  func::FuncOp function = getOperation();
   MLIRContext *context = &getContext();
 
   ConversionTarget target(getContext());

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -130,6 +130,7 @@ namespace {
 
 struct DecomposeONNXToONNXPass
     : public PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DecomposeONNXToONNXPass)
 
   StringRef getArgument() const override { return "decompose-onnx"; }
 

--- a/src/Transform/ONNX/ElideConstants.cpp
+++ b/src/Transform/ONNX/ElideConstants.cpp
@@ -64,7 +64,7 @@ public:
  *  Function pass that performs constant value elision.
  */
 class ElideConstantValuePass
-    : public PassWrapper<ElideConstantValuePass, OperationPass<FuncOp>> {
+    : public PassWrapper<ElideConstantValuePass, OperationPass<func::FuncOp>> {
 public:
   StringRef getArgument() const override { return "elide-constants"; }
 

--- a/src/Transform/ONNX/ElideConstants.cpp
+++ b/src/Transform/ONNX/ElideConstants.cpp
@@ -66,6 +66,8 @@ public:
 class ElideConstantValuePass
     : public PassWrapper<ElideConstantValuePass, OperationPass<func::FuncOp>> {
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ElideConstantValuePass)
+
   StringRef getArgument() const override { return "elide-constants"; }
 
   StringRef getDescription() const override {

--- a/src/Transform/ONNX/InstrumentONNXPass.cpp
+++ b/src/Transform/ONNX/InstrumentONNXPass.cpp
@@ -41,6 +41,8 @@ class InstrumentONNXPass : public mlir::PassWrapper<InstrumentONNXPass,
                                OperationPass<func::FuncOp>> {
 
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InstrumentONNXPass)
+
   Option<std::string> instrumentONNXOps{*this, "instrument-onnx-ops",
       llvm::cl::desc("Specify onnx ops to be instrumented\n"
                      "\"NONE\" or \"\" for no instrument\n"

--- a/src/Transform/ONNX/InstrumentONNXPass.cpp
+++ b/src/Transform/ONNX/InstrumentONNXPass.cpp
@@ -37,8 +37,8 @@ namespace {
  * This pass insert KrnlInstrumentOp before and after each ONNX ops
  */
 
-class InstrumentONNXPass
-    : public mlir::PassWrapper<InstrumentONNXPass, OperationPass<FuncOp>> {
+class InstrumentONNXPass : public mlir::PassWrapper<InstrumentONNXPass,
+                               OperationPass<func::FuncOp>> {
 
 public:
   Option<std::string> instrumentONNXOps{*this, "instrument-onnx-ops",
@@ -64,7 +64,7 @@ public:
 
   InstrumentONNXPass() = default;
   InstrumentONNXPass(const InstrumentONNXPass &pass)
-      : mlir::PassWrapper<InstrumentONNXPass, OperationPass<FuncOp>>() {}
+      : mlir::PassWrapper<InstrumentONNXPass, OperationPass<func::FuncOp>>() {}
   InstrumentONNXPass(StringRef ops, int actions) {
     this->instrumentONNXOps = ops.str();
     this->instrumentBefore = actions & onnx_mlir::InstrumentBeforeOp;

--- a/src/Transform/ONNX/ONNXOpTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXOpTransformPass.cpp
@@ -132,10 +132,12 @@ void ONNXOpTransformPass::runOnOperation() {
   do {
     previousTag = currentTag;
     OpPassManager dynamicPM("builtin.module");
-    dynamicPM.addNestedPass<FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass());
+    dynamicPM.addNestedPass<func::FuncOp>(
+        onnx_mlir::createDecomposeONNXToONNXPass());
     dynamicPM.addPass(onnx_mlir::createShapeInferencePass());
     dynamicPM.addPass(mlir::createCanonicalizerPass());
-    dynamicPM.addNestedPass<FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
+    dynamicPM.addNestedPass<func::FuncOp>(
+        onnx_mlir::createConstPropONNXToONNXPass());
     if (failed(runPipeline(dynamicPM, module)))
       return signalPassFailure();
     currentTag = createTagForIR(module);

--- a/src/Transform/ONNX/ONNXOpTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXOpTransformPass.cpp
@@ -47,6 +47,7 @@ namespace {
 
 struct ONNXOpTransformPass : public mlir::PassWrapper<ONNXOpTransformPass,
                                  OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ONNXOpTransformPass)
 
   StringRef getArgument() const override { return "onnx-op-transform"; }
 

--- a/src/Transform/ONNX/ONNXPreKrnlVerifyPass.cpp
+++ b/src/Transform/ONNX/ONNXPreKrnlVerifyPass.cpp
@@ -36,8 +36,8 @@ namespace {
  * The current condition is that all input tensors have to be ranked
  */
 
-class ONNXPreKrnlVerifyPass
-    : public mlir::PassWrapper<ONNXPreKrnlVerifyPass, OperationPass<FuncOp>> {
+class ONNXPreKrnlVerifyPass : public mlir::PassWrapper<ONNXPreKrnlVerifyPass,
+                                  OperationPass<func::FuncOp>> {
 
 public:
   StringRef getArgument() const override { return "onnx-pre-krnl-verify"; }

--- a/src/Transform/ONNX/ONNXPreKrnlVerifyPass.cpp
+++ b/src/Transform/ONNX/ONNXPreKrnlVerifyPass.cpp
@@ -40,6 +40,8 @@ class ONNXPreKrnlVerifyPass : public mlir::PassWrapper<ONNXPreKrnlVerifyPass,
                                   OperationPass<func::FuncOp>> {
 
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ONNXPreKrnlVerifyPass)
+
   StringRef getArgument() const override { return "onnx-pre-krnl-verify"; }
 
   StringRef getDescription() const override { return "Verify onnx ops."; }

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -31,10 +31,10 @@ using namespace mlir;
 namespace onnx_mlir {
 namespace {
 
-static SmallVector<FuncOp, 4> lookUpFuncsMatching(
+static SmallVector<func::FuncOp, 4> lookUpFuncsMatching(
     ModuleOp module, std::regex pattern) {
-  SmallVector<FuncOp, 4> matchedFuncs;
-  module.walk([&](FuncOp funcOp) {
+  SmallVector<func::FuncOp, 4> matchedFuncs;
+  module.walk([&](func::FuncOp funcOp) {
     if (std::regex_search(funcOp.getName().str(), pattern))
       matchedFuncs.emplace_back(funcOp);
   });
@@ -87,7 +87,7 @@ public:
         return;
       }
     }
-    auto result = module.walk([&](FuncOp funcOp) -> WalkResult {
+    auto result = module.walk([&](func::FuncOp funcOp) -> WalkResult {
       return runShapeInferenceOn(funcOp);
     });
     if (result.wasInterrupted())
@@ -127,7 +127,7 @@ public:
     return success();
   }
 
-  static LogicalResult runShapeInferenceOn(FuncOp f) {
+  static LogicalResult runShapeInferenceOn(func::FuncOp f) {
     // Iterate on the operations that need shape inference i.e the operations
     // that return a dynamic shape or followed by a return op.
     auto &funcBody = f.getBody();
@@ -139,8 +139,9 @@ public:
         funcBody.back().back().hasTrait<OpTrait::IsTerminator>())
       if (auto returnOp = f.getBody().back().getTerminator()) {
         auto results = returnOp->getOperandTypes();
-        f.setType(FunctionType::get(f.getContext(), f.getType().getInputs(),
-            std::vector<Type>(results.begin(), results.end())));
+        f.setType(
+            FunctionType::get(f.getContext(), f.getFunctionType().getInputs(),
+                std::vector<Type>(results.begin(), results.end())));
       }
     return success();
   }

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -65,6 +65,8 @@ private:
   bool analyzeAllFunctions;
 
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ShapeInferencePass)
+
   ShapeInferencePass(bool analyzeAllFunctions)
       : analyzeAllFunctions(analyzeAllFunctions) {}
 

--- a/src/Transform/OptimizeMemoryPools.cpp
+++ b/src/Transform/OptimizeMemoryPools.cpp
@@ -310,7 +310,7 @@ Operation *getOutermostLoop(Operation *op) {
   // Compute parent operation of the current block. Every block has
   // a parent operation.
   Operation *parentBlockOp = currentBlock->getParentOp();
-  while (!llvm::dyn_cast_or_null<FuncOp>(parentBlockOp)) {
+  while (!llvm::dyn_cast_or_null<func::FuncOp>(parentBlockOp)) {
     if (llvm::dyn_cast_or_null<KrnlIterateOp>(parentBlockOp))
       outermostLoop = parentBlockOp;
     parentBlockOp = parentBlockOp->getBlock()->getParentOp();
@@ -520,7 +520,7 @@ public:
 
     // TODO: relax this condition.
     // If this is not the top block fail.
-    if (!llvm::dyn_cast_or_null<FuncOp>(parentBlock->getParentOp()))
+    if (!llvm::dyn_cast_or_null<func::FuncOp>(parentBlock->getParentOp()))
       return failure();
 
     // List of all GetRefs which share the slot with firstGetRef.
@@ -759,7 +759,7 @@ public:
       return failure();
 
     // If this is not the top block, fail.
-    if (!llvm::dyn_cast_or_null<FuncOp>(parentBlock->getParentOp()))
+    if (!llvm::dyn_cast_or_null<func::FuncOp>(parentBlock->getParentOp()))
       return failure();
 
     // Compute size of all krnl.getref operations that use this memory pool.
@@ -869,7 +869,8 @@ public:
  *  Function pass that optimizes memory pools.
  */
 class KrnlOptimizeMemoryPoolsPass
-    : public PassWrapper<KrnlOptimizeMemoryPoolsPass, OperationPass<FuncOp>> {
+    : public PassWrapper<KrnlOptimizeMemoryPoolsPass,
+          OperationPass<func::FuncOp>> {
   BlockToCompactedAlignments blockToStaticPoolAlignments;
   BlockToDiscardedGetRefs blockToDiscardedGetRefs;
 

--- a/src/Transform/OptimizeMemoryPools.cpp
+++ b/src/Transform/OptimizeMemoryPools.cpp
@@ -875,6 +875,8 @@ class KrnlOptimizeMemoryPoolsPass
   BlockToDiscardedGetRefs blockToDiscardedGetRefs;
 
 public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(KrnlOptimizeMemoryPoolsPass)
+
   StringRef getArgument() const override { return "optimize-memory-pools"; }
 
   StringRef getDescription() const override {

--- a/test/mlir/krnl/krnl_disconnect_dim_from_alloc.mlir
+++ b/test/mlir/krnl/krnl_disconnect_dim_from_alloc.mlir
@@ -12,8 +12,8 @@ func @test_krnl_dim_lowering(%arg0: memref<?x?xf32>) -> index {
   return %e : index
 
   // CHECK-LABEL: test_krnl_dim_lowering
-  // CHECK: [[CONST0:%.+]] = arith.constant 0 : index
-  // CHECK: [[CONST10:%.+]] = arith.constant 10 : index
+  // CHECK-DAG: [[CONST0:%.+]] = arith.constant 0 : index
+  // CHECK-DAG: [[CONST10:%.+]] = arith.constant 10 : index
   // CHECK: [[DIM:%.+]] = memref.dim %arg0, [[CONST0]] : memref<?x?xf32>
   // CHECK: [[SUM:%.+]] = arith.addi [[DIM]], [[CONST10]] : index
   // CHECK: return [[SUM]] : index
@@ -34,8 +34,8 @@ func @test_krnl_dim_lowering_with_map(%arg0: memref<?x?xf32>) -> index {
   return %e : index
 
   // CHECK-LABEL: test_krnl_dim_lowering_with_map
-  // CHECK: [[CONST0:%.+]] = arith.constant 0 : index
-  // CHECK: [[CONST10:%.+]] = arith.constant 10 : index
+  // CHECK-DAG: [[CONST0:%.+]] = arith.constant 0 : index
+  // CHECK-DAG: [[CONST10:%.+]] = arith.constant 10 : index
   // CHECK: [[DIM:%.+]] = memref.dim %arg0, [[CONST0]] : memref<?x?xf32>
   // CHECK: [[SUM:%.+]] = arith.addi [[DIM]], [[CONST10]] : index
   // CHECK: return [[SUM]] : index

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -2984,7 +2984,7 @@ func @test_cumsum_dynamic_dims(%arg0: tensor<?x?xf64>, %arg1:tensor<i32>) -> ten
 // -----
 // Compress on axis 0, with enough conditions, test elided
 
-builtin.func @compress_axis0(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<?x2xf32> {
+func.func @compress_axis0(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<?x2xf32> {
   %0 = "onnx.Compress"(%arg0, %arg1) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<?x2xf32>
   return %0 : tensor<?x2xf32>
 //  use arg names: ['input', 'condition']
@@ -3033,7 +3033,7 @@ builtin.func @compress_axis0(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> ten
 // -----
 // Compress on axis 0, with not enough conditions, test not elided
 
-builtin.func @compress_axis0_not_enough(%arg0: tensor<3x2xf32>, %arg1: tensor<2xi1>) -> tensor<?x2xf32> {
+func.func @compress_axis0_not_enough(%arg0: tensor<3x2xf32>, %arg1: tensor<2xi1>) -> tensor<?x2xf32> {
   %0 = "onnx.Compress"(%arg0, %arg1) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2xi1>) -> tensor<?x2xf32>
   return %0 : tensor<?x2xf32>
 // mlir2FileCheck.py -a'["input", "condition"]'
@@ -3085,7 +3085,7 @@ builtin.func @compress_axis0_not_enough(%arg0: tensor<3x2xf32>, %arg1: tensor<2x
 // -----
 // Compress on axis 1, with enough conditions, test elided
 
-builtin.func @compress_axis1(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<3x?xf32> {
+func.func @compress_axis1(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<3x?xf32> {
   %0 = "onnx.Compress"(%arg0, %arg1) {axis = 1 : si64} : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<3x?xf32>
   return %0 : tensor<3x?xf32>
 // mlir2FileCheck.py -a'["input", "condition"]'
@@ -3133,7 +3133,7 @@ builtin.func @compress_axis1(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> ten
 // -----
 // Compress witn no axis , with not enough conditions, test not elided
 
-builtin.func @compress_no_axis_not_elided(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<?xf32> {
+func.func @compress_no_axis_not_elided(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<?xf32> {
   %0 = "onnx.Compress"(%arg0, %arg1) : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 
@@ -3186,7 +3186,7 @@ builtin.func @compress_no_axis_not_elided(%arg0: tensor<3x2xf32>, %arg1: tensor<
 // -----
 // Compress witn no axis , with enough conditions, test elided
 
-builtin.func @compress_no_axis_enough_cond(%arg0: tensor<3x2xf32>, %arg1: tensor<6xi1>) -> tensor<?xf32> {
+func.func @compress_no_axis_enough_cond(%arg0: tensor<3x2xf32>, %arg1: tensor<6xi1>) -> tensor<?xf32> {
   %0 = "onnx.Compress"(%arg0, %arg1) : (tensor<3x2xf32>, tensor<6xi1>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 // CHECK-LABEL:  func @compress_no_axis_enough_cond

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -784,7 +784,7 @@ func @test_binary_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x5xf32>,
 func @test_variadic_elementwise_op_template_unknown_dims(%arg0: tensor<?x4x1xf32>, %arg1: tensor<?x?x5xf32>, %arg2: tensor<?x1x5xf32>) -> tensor<?x4x5xf32> {
   %0 = "onnx.Max"(%arg0, %arg1, %arg2) : (tensor<?x4x1xf32>, tensor<?x?x5xf32>, tensor<?x1x5xf32>) -> tensor<?x4x5xf32>
   return %0 : tensor<?x4x5xf32>
-// CHECK-DAG: #map0 = affine_map<()[s0, s1] -> (s0, s1)>
+// CHECK-DAG: #map0 = affine_map<()[s0, s1] -> (s1, s0)>
 // CHECK-DAG: #map1 = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func @test_variadic_elementwise_op_template_unknown_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x4x1xf32>, [[PARAM_1_:%.+]]: memref<?x?x5xf32>, [[PARAM_2_:%.+]]: memref<?x1x5xf32>) -> memref<?x4x5xf32> {

--- a/test/modellib/CategoryMapperModel.cpp
+++ b/test/modellib/CategoryMapperModel.cpp
@@ -90,14 +90,14 @@ template <typename T1, typename T2>
 void CategoryMapperLibBuilder<T1, T2>::createTestFunction(
     Type inputType, Type outputType, const CMAttributes &attributes) {
   SmallVector<Type, 1> inputsType{inputType}, outputsType{outputType};
-  FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
+  func::FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
   createCategoryMapper(outputType, attributes, funcOp);
   createEntryPoint(funcOp);
 }
 
 template <typename T1, typename T2>
 void CategoryMapperLibBuilder<T1, T2>::createCategoryMapper(
-    Type outputType, const CMAttributes &attributes, FuncOp &funcOp) {
+    Type outputType, const CMAttributes &attributes, func::FuncOp &funcOp) {
   Block &entryBlock = funcOp.getBody().front();
   BlockArgument input = entryBlock.getArgument(0);
   auto categoryMapperOp = builder.create<ONNXCategoryMapperOp>(loc, outputType,

--- a/test/modellib/ConvModel.cpp
+++ b/test/modellib/ConvModel.cpp
@@ -73,7 +73,7 @@ bool Conv2DLibBuilder::build() {
   llvm::SmallVector<Type, 2> inputsType{xTypeSymbol, wType};
   llvm::SmallVector<Type, 1> outputsType{yType};
 
-  FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
+  func::FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
   Block &entryBlock = funcOp.getBody().front();
 
   auto xVal = entryBlock.getArgument(0);

--- a/test/modellib/GRUModel.cpp
+++ b/test/modellib/GRUModel.cpp
@@ -70,7 +70,7 @@ bool GRULibBuilder::build() {
   SmallVector<Type, 2> inputsType{xType, hType};
   SmallVector<Type, 2> outputsType{yType, yHType};
 
-  FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
+  func::FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
   Block &entryBlock = funcOp.getBody().front();
 
   auto noneVal = builder.create<ONNXNoneOp>(loc).getResult();

--- a/test/modellib/GemmModel.cpp
+++ b/test/modellib/GemmModel.cpp
@@ -53,7 +53,7 @@ bool GemmLibBuilder::build() {
   llvm::SmallVector<Type, 3> inputsType{aType, bType, cType};
   llvm::SmallVector<Type, 1> outputsType{yType};
 
-  FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
+  func::FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
   Block &entryBlock = funcOp.getBody().front();
 
   auto aVal = entryBlock.getArgument(0);

--- a/test/modellib/LSTMModel.cpp
+++ b/test/modellib/LSTMModel.cpp
@@ -77,7 +77,7 @@ bool LSTMLibBuilder::build() {
   llvm::SmallVector<Type, 3> inputsType{xType, hType, cType};
   llvm::SmallVector<Type, 3> outputsType{yType, yHType, yCType};
 
-  FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
+  func::FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
   Block &entryBlock = funcOp.getBody().front();
 
   auto noneVal = builder.create<ONNXNoneOp>(loc).getResult();

--- a/test/modellib/MatMulModel.cpp
+++ b/test/modellib/MatMulModel.cpp
@@ -40,7 +40,7 @@ bool MatMul2DLibBuilder::build() {
   llvm::SmallVector<Type, 2> inputsType{aType, bType};
   llvm::SmallVector<Type, 1> outputsType{yType};
 
-  FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
+  func::FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
   Block &entryBlock = funcOp.getBody().front();
   auto aVal = entryBlock.getArgument(0);
   auto bVal = entryBlock.getArgument(1);

--- a/test/modellib/ModelLib.cpp
+++ b/test/modellib/ModelLib.cpp
@@ -94,7 +94,7 @@ void ModelLibBuilder::setRandomNumberGeneratorSeed(const std::string &envVar) {
   }
 }
 
-FuncOp ModelLibBuilder::createEmptyTestFunction(
+func::FuncOp ModelLibBuilder::createEmptyTestFunction(
     const llvm::SmallVectorImpl<Type> &inputsType,
     const llvm::SmallVectorImpl<Type> &outputsType) {
   assert(!inputsType.empty() && "Expecting inputsTypes to be non-empty");
@@ -103,15 +103,15 @@ FuncOp ModelLibBuilder::createEmptyTestFunction(
   FunctionType funcType = builder.getFunctionType(inputsType, outputsType);
 
   llvm::SmallVector<NamedAttribute, 1> attrs;
-  auto funcOp = builder.create<FuncOp>(loc, "main_graph", funcType, attrs);
+  auto funcOp = builder.create<func::FuncOp>(loc, "main_graph", funcType, attrs);
 
   Block *entryBlock = funcOp.addEntryBlock();
   builder.setInsertionPointToStart(entryBlock);
   return funcOp;
 }
 
-void ModelLibBuilder::createEntryPoint(FuncOp &funcOp) {
-  FunctionType funcType = funcOp.getType();
+void ModelLibBuilder::createEntryPoint(func::FuncOp &funcOp) {
+  FunctionType funcType = funcOp.getFunctionType();
   auto entryPoint = ONNXEntryPointOp::create(
       loc, funcOp, funcType.getNumInputs(), funcType.getNumResults(), "");
   module.push_back(entryPoint);

--- a/test/modellib/ModelLib.hpp
+++ b/test/modellib/ModelLib.hpp
@@ -105,11 +105,11 @@ public:
 protected:
   // Create a function with an empty body.
   // This function will contain the model to be tested.
-  mlir::FuncOp createEmptyTestFunction(
+  mlir::func::FuncOp createEmptyTestFunction(
       const llvm::SmallVectorImpl<mlir::Type> &inputsType,
       const llvm::SmallVectorImpl<mlir::Type> &outputsType);
   // Create the entry point function (used to call the model test function).
-  void createEntryPoint(mlir::FuncOp &funcOp);
+  void createEntryPoint(mlir::func::FuncOp &funcOp);
   // Create a onnx constant op loaded with values in the tensor omt.
   mlir::ONNXConstantOp buildONNXConstantOp(
       const OMTensor *omt, const mlir::RankedTensorType resultType);
@@ -168,7 +168,7 @@ private:
 
   // Create the category mapper operator, and insert it into the test function.
   void createCategoryMapper(mlir::Type outputType,
-      const CMAttributes &attributes, mlir::FuncOp &funcOp);
+      const CMAttributes &attributes, mlir::func::FuncOp &funcOp);
 
   // Verify that the output tensor has the expected rank.
   bool verifyRank(const OMTensor &out, int64_t rank) const;

--- a/test/modellib/RNNModel.cpp
+++ b/test/modellib/RNNModel.cpp
@@ -65,7 +65,7 @@ bool RNNLibBuilder::build() {
   llvm::SmallVector<Type, 5> inputsType{xType, hType};
   llvm::SmallVector<Type, 2> outputsType{yType, yHType};
 
-  FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
+  func::FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
   Block &entryBlock = funcOp.getBody().front();
 
   auto noneVal = builder.create<ONNXNoneOp>(loc).getResult();

--- a/test/numerical/TestLoop.cpp
+++ b/test/numerical/TestLoop.cpp
@@ -82,7 +82,7 @@ bool isOMLoopTheSameAsNaiveImplFor(std::string moduleIR,
   MLIRContext ctx;
   registerDialects(ctx);
 
-  auto module = mlir::parseSourceString(moduleIR, &ctx);
+  auto module = mlir::parseSourceString<ModuleOp>(moduleIR, &ctx);
   OwningOpRef<ModuleOp> moduleRef(std::move(module));
   compileModule(moduleRef, ctx, SHARED_LIB_BASE.str(), onnx_mlir::EmitLib);
   onnx_mlir::ExecutionSession sess(

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 4a3460a7917f1cf514575759e29590b388131fc6 && cd ..
+cd llvm-project && git checkout 9778ec057cf4214241e4a970f3e764e3cf150181 && cd ..

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 23aa5a744666b281af807b1f598f517bf0d597cb && cd ..
+cd llvm-project && git checkout 4a3460a7917f1cf514575759e29590b388131fc6 && cd ..


### PR DESCRIPTION
Updating LLVM to https://github.com/llvm/llvm-project/commit/9778ec057cf4214241e4a970f3e764e3cf150181 causes a number of build issues.
This patch attempts to modify `onnx-mlir` to use LLVM at https://github.com/llvm/llvm-project/commit/9778ec057cf4214241e4a970f3e764e3cf150181.

Including the following changes:
- ODS Op verifier/parser/printer code blocks are deprecated.
- must specify either 'assemblyFormat' or 'hasCustomAssemblyFormat' when 'mnemonic' is set
- Rename `OpAsmParser::OperandType` to `OpAsmParser::UnresolvedOperand`
- Rename the "type" attribute to "function_type"
- [Simplify LoopLikeOpInterface](https://github.com/llvm/llvm-project/commit/e51652f9bf2e63497ed1e007c4a8c31c7ec08930)
- When a pass is defined in an anonymous namespace, it now requires an explicit TypeID after https://github.com/llvm/llvm-project/commit/5e50dd048e3a20cde5da5d7a754dfee775ef35d6.
- etc.

Signed-off-by: Whitney Tsang <whitneyt@ca.ibm.com>