### PR TITLE
Rt error reporting

### DIFF
--- a/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
+++ b/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
@@ -152,17 +152,17 @@ uint64_t OMInitCompatibleAccelNNPA(uint64_t versionNum) {
     /* Release mutex. */
     pthread_mutex_unlock(&OMMutexForInitShutdownNNPA);
   }
-  /* If not compatible, generate an error here */
+  /* If not compatible, generate an error here. */
   if (!isCompatible) {
     /* Grab mutex. */
     pthread_mutex_lock(&OMMutexForInitShutdownNNPA);
-    /* Check again if we have a compatible model */ 
+    /* Check again if we have a compatible model. */
     if (zdnn_is_version_runnable((uint32_t)versionNum))
       isCompatible = 1;
     /* Release mutex. */
     pthread_mutex_unlock(&OMMutexForInitShutdownNNPA);
     if (!isCompatible) {
-      /* Code below has to agree with zdnn.h convention */
+      /* Code below has to agree with zdnn.h convention. */
       unsigned long long ver_major = versionNum >> 16;
       unsigned long long ver_minor = (versionNum >> 8) & 0xff;
       unsigned long long ver_patch = versionNum & 0xff;

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -13,6 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <errno.h>
+#include <string.h>
+
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -99,7 +102,13 @@ std::vector<OMTensorUniquePtr> ExecutionSession::run(
   auto *wrappedInput = omTensorListCreate(&omts[0], (int64_t)omts.size());
 
   auto *wrappedOutput = _entryPointFunc(wrappedInput);
-
+  if (!wrappedOutput) {
+    std::stringstream errStr;
+    std::string errMessageStr = std::string(strerror(errno));
+    errStr << "Runtime error during inference returning with ERRNO code '"
+           << errMessageStr << "'" << std::endl;
+    throw std::runtime_error(errStr.str());
+  }
   std::vector<OMTensorUniquePtr> outs;
 
   for (int64_t i = 0; i < omTensorListGetSize(wrappedOutput); i++) {
@@ -118,7 +127,15 @@ OMTensorList *ExecutionSession::run(OMTensorList *input) {
            << std::endl;
     throw std::runtime_error(errStr.str());
   }
-  return _entryPointFunc(input);
+  OMTensorList *output = _entryPointFunc(input);
+  if (!output) {
+    std::stringstream errStr;
+    std::string errMessageStr = std::string(strerror(errno));
+    errStr << "Runtime error during inference returning with ERRNO code '"
+           << errMessageStr << "'" << std::endl;
+    throw std::runtime_error(errStr.str());
+  }
+  return output;
 }
 
 const std::string ExecutionSession::inputSignature() const {


### PR DESCRIPTION
Use errno interface for failure encountered during inference evaluation. See Issue #1417 for discussions.
First version only generate an error when there is a mismatch of versions for the NNPA