### PR TITLE
Edit entry points to return NULL if failed to initialize accelerators

### DIFF
--- a/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
+++ b/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
@@ -152,17 +152,17 @@ uint64_t OMInitCompatibleAccelNNPA(uint64_t versionNum) {
     /* Release mutex. */
     pthread_mutex_unlock(&OMMutexForInitShutdownNNPA);
   }
-  /* If not compatible, generate an error here */
+  /* If not compatible, generate an error here. */
   if (!isCompatible) {
     /* Grab mutex. */
     pthread_mutex_lock(&OMMutexForInitShutdownNNPA);
-    /* Check again if we have a compatible model */ 
+    /* Check again if we have a compatible model. */
     if (zdnn_is_version_runnable((uint32_t)versionNum))
       isCompatible = 1;
     /* Release mutex. */
     pthread_mutex_unlock(&OMMutexForInitShutdownNNPA);
     if (!isCompatible) {
-      /* Code below has to agree with zdnn.h convention */
+      /* Code below has to agree with zdnn.h convention. */
       unsigned long long ver_major = versionNum >> 16;
       unsigned long long ver_minor = (versionNum >> 8) & 0xff;
       unsigned long long ver_patch = versionNum & 0xff;

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -86,7 +86,7 @@ public:
 
     // Emit code to initialize accelerators by calling OMInitCompatibleAccelX
     // where X is the accelerator name.
-    // OMInitCompatibleAccelX's signature is `void (i64)`.
+    // OMInitCompatibleAccelX's signature is `i64 (i64)`.
     if (Attribute maccelAttr =
             module->getAttrOfType<::mlir::Attribute>("onnx-mlir.accels")) {
       assert(
@@ -103,7 +103,7 @@ public:
         LLVM::ConstantOp versionNumberVal = rewriter.create<LLVM::ConstantOp>(
             loc, int64Ty, rewriter.getI64IntegerAttr(versionNumberInHex));
         rewriter.create<LLVM::CallOp>(
-            loc, TypeRange(), funcRef, ArrayRef<Value>({versionNumberVal}));
+            loc, int64Ty, funcRef, ArrayRef<Value>({versionNumberVal}));
       }
     }
 
@@ -380,14 +380,14 @@ private:
   FlatSymbolRefAttr getOrInsertOMInitCompatibleAccel(
       PatternRewriter &rewriter, ModuleOp module, StringRef accelName) const {
     std::string funcName = "OMInitCompatibleAccel" + accelName.str();
-    // OMInitCompatibleAccelX's signature is `void (i64)`.
+    // OMInitCompatibleAccelX's signature is `i64 (i64)`.
     auto func = module.lookupSymbol<LLVM::LLVMFuncOp>(funcName);
     MLIRContext *ctx = rewriter.getContext();
     if (!func) {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(module.getBody());
       LLVM::LLVMFunctionType funcType =
-          LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx),
+          LLVM::LLVMFunctionType::get(IntegerType::get(ctx, 64),
               ArrayRef<mlir::Type>({IntegerType::get(ctx, 64)}),
               /*isVarArg=*/false);
       func = rewriter.create<LLVM::LLVMFuncOp>(

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -13,6 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <errno.h>
+#include <string.h>
+
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -99,7 +102,13 @@ std::vector<OMTensorUniquePtr> ExecutionSession::run(
   auto *wrappedInput = omTensorListCreate(&omts[0], (int64_t)omts.size());
 
   auto *wrappedOutput = _entryPointFunc(wrappedInput);
-
+  if (!wrappedOutput) {
+    std::stringstream errStr;
+    std::string errMessageStr = std::string(strerror(errno));
+    errStr << "Runtime error during inference returning with ERRNO code '"
+           << errMessageStr << "'" << std::endl;
+    throw std::runtime_error(errStr.str());
+  }
   std::vector<OMTensorUniquePtr> outs;
 
   for (int64_t i = 0; i < omTensorListGetSize(wrappedOutput); i++) {
@@ -118,7 +127,15 @@ OMTensorList *ExecutionSession::run(OMTensorList *input) {
            << std::endl;
     throw std::runtime_error(errStr.str());
   }
-  return _entryPointFunc(input);
+  OMTensorList *output = _entryPointFunc(input);
+  if (!output) {
+    std::stringstream errStr;
+    std::string errMessageStr = std::string(strerror(errno));
+    errStr << "Runtime error during inference returning with ERRNO code '"
+           << errMessageStr << "'" << std::endl;
+    throw std::runtime_error(errStr.str());
+  }
+  return output;
 }
 
 const std::string ExecutionSession::inputSignature() const {

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -242,7 +242,7 @@ module attributes {"onnx-mlir.accels" = ["Pseudo-0x10001", "NNPA-0x10000"]} {
 // CHECK: llvm.func @OMInitCompatibleAccelPseudo(i64)
 // CHECK-LABEL: llvm.func @run_main_graph({{.*}}: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-NEXT: [[VERSION_NUMBER_1:%.+]] = llvm.mlir.constant(65537 : i64) : i64
-// CHECK-NEXT: llvm.call @OMInitCompatibleAccelPseudo([[VERSION_NUMBER_1]]) : (i64) -> ()
+// CHECK-NEXT: llvm.call @OMInitCompatibleAccelPseudo([[VERSION_NUMBER_1]]) : (i64) -> i64
 // CHECK-NEXT: [[VERSION_NUMBER_2:%.+]] = llvm.mlir.constant(65536 : i64) : i64
-// CHECK-NEXT: llvm.call @OMInitCompatibleAccelNNPA([[VERSION_NUMBER_2]]) : (i64) -> ()
+// CHECK-NEXT: llvm.call @OMInitCompatibleAccelNNPA([[VERSION_NUMBER_2]]) : (i64) -> i64
 }

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -241,8 +241,19 @@ module attributes {"onnx-mlir.accels" = ["Pseudo-0x10001", "NNPA-0x10000"]} {
 // CHECK: llvm.func @OMInitCompatibleAccelNNPA(i64)
 // CHECK: llvm.func @OMInitCompatibleAccelPseudo(i64)
 // CHECK-LABEL: llvm.func @run_main_graph({{.*}}: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
-// CHECK-NEXT: [[VERSION_NUMBER_1:%.+]] = llvm.mlir.constant(65537 : i64) : i64
-// CHECK-NEXT: llvm.call @OMInitCompatibleAccelPseudo([[VERSION_NUMBER_1]]) : (i64) -> i64
-// CHECK-NEXT: [[VERSION_NUMBER_2:%.+]] = llvm.mlir.constant(65536 : i64) : i64
-// CHECK-NEXT: llvm.call @OMInitCompatibleAccelNNPA([[VERSION_NUMBER_2]]) : (i64) -> i64
+// CHECK-NEXT: [[FALSE:%.+]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT: [[VERSION_NUMBER:%.+]] = llvm.mlir.constant(65537 : i64) : i64
+// CHECK-NEXT: [[COMPATIBLE:%.+]] = llvm.call @OMInitCompatibleAccelPseudo([[VERSION_NUMBER]]) : (i64) -> i64
+// CHECK-NEXT: [[FAILED:%.+]] = llvm.icmp "eq" [[COMPATIBLE]], [[FALSE]] : i64
+// CHECK-NEXT: llvm.cond_br [[FAILED]], ^bb1, ^bb2
+// CHECK-NEXT: ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK-NEXT:   [[NULL:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK-NEXT:   llvm.return [[NULL]] : !llvm.ptr<i8>
+// CHECK-NEXT: ^bb2:  // pred: ^bb0
+// CHECK-NEXT:  [[VERSION_NUMBER:%.+]] = llvm.mlir.constant(65536 : i64) : i64
+// CHECK-NEXT:  [[COMPATIBLE:%.+]] = llvm.call @OMInitCompatibleAccelNNPA([[VERSION_NUMBER]]) : (i64) -> i64
+// CHECK-NEXT:  [[FAILED:%.+]] = llvm.icmp "eq" [[COMPATIBLE]], [[FALSE]] : i64
+// CHECK-NEXT:  llvm.cond_br [[FAILED]], ^bb1, ^bb3
+// CHECK-NEXT: ^bb3:  // pred: ^bb2
+// CHECK-NEXT:   {{.*}} = llvm.call @omTensorListGetOmtArray(%arg0) : (!llvm.ptr<i8>) -> !llvm.ptr<ptr<i8>>
 }


### PR DESCRIPTION
This patch edits the generated entry points, e.g. `run_main_graph` to return NULL when initializing an accelerator fails.

This patch based on PR #1426 (most of the changes are from #1426), so #1426 should be merged first.