### PR TITLE
Fix RuntimeNNPA and zdnn dependency order

### DIFF
--- a/src/Accelerators/NNPA/NNPAAccelerator.cpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.cpp
@@ -49,7 +49,8 @@ NNPAAccelerator *NNPAAccelerator::getInstance() {
 NNPAAccelerator::NNPAAccelerator() : Accelerator(Accelerator::Kind::NNPA) {
   LLVM_DEBUG(llvm::dbgs() << "Creating an NNPA accelerator\n");
   acceleratorTargets.push_back(this);
-  addCompilerConfig(CCM_SHARED_LIB_DEPS, {"zdnn", "RuntimeNNPA"});
+  // Order is important! libRuntimeNNPA depends on libzdnn
+  addCompilerConfig(CCM_SHARED_LIB_DEPS, {"RuntimeNNPA", "zdnn"});
 };
 
 NNPAAccelerator::~NNPAAccelerator() { delete instance; }

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -369,10 +369,9 @@ std::vector<std::string> getCompilerConfig(std::string k) {
 // with the specified key
 void addCompilerConfig(std::string k, std::vector<std::string> v) {
   std::vector<std::string> u = CompilerConfigMap[k];
-  std::vector<std::string> w;
 
-  std::set_union(u.begin(), u.end(), v.begin(), v.end(), std::back_inserter(w));
-  CompilerConfigMap[k] = w;
+  u.insert(u.end(), v.begin(), v.end());
+  CompilerConfigMap[k] = u;
 }
 
 // Delete strings in a vector from the string vector associated


### PR DESCRIPTION
- fix ordering of RuntimeNNPA and zdnn when calling addCompilerConfig
- don't use set_union since it sorts the vector

Signed-off-by: Gong Su <gong_su@hotmail.com>