### PR TITLE
Move onnx-mlir version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Releases are extensively tested, including the following steps.
 
 # Current releases
 
+## Prerelease 0.3.0
+
+This prerelease was cut on May TBD, 2022.
+There are no security issues that we know of.
+
 ## Prerelease 0.2.0
 
 This prerelease was cut on September 7th, 2021.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Releases are extensively tested, including the following steps.
 
 ## Prerelease 0.3.0
 
-This prerelease was cut on May TBD, 2022.
+This prerelease was cut on May 20th, 2022.
 There are no security issues that we know of.
 
 ## Prerelease 0.2.0

--- a/docs/docker-example/.vscode/launch.json
+++ b/docs/docker-example/.vscode/launch.json
@@ -2,7 +2,7 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
+    "version": "0.3.0",
     "configurations": [
         {
             "name": "Debug onnx-mlir",

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -154,7 +154,7 @@ static std::string getToolPath(std::string tool) {
 }
 
 static std::string getOnnxMlirFullVersion() {
-  const std::string OnnxMlirVersion = "onnx-mlir version 1.0.0";
+  const std::string OnnxMlirVersion = "onnx-mlir version 0.2.0";
   return
 #ifdef ONNX_MLIR_VENDOR
       ONNX_MLIR_VENDOR ", " + OnnxMlirVersion;

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -154,7 +154,7 @@ static std::string getToolPath(std::string tool) {
 }
 
 static std::string getOnnxMlirFullVersion() {
-  const std::string OnnxMlirVersion = "onnx-mlir version 0.2.0";
+  const std::string OnnxMlirVersion = "onnx-mlir version 0.3.0";
   return
 #ifdef ONNX_MLIR_VENDOR
       ONNX_MLIR_VENDOR ", " + OnnxMlirVersion;

--- a/test/mlir/driver/llvm.ident.mlir
+++ b/test/mlir/driver/llvm.ident.mlir
@@ -4,7 +4,7 @@
 // XFAIL: onnx-mlir-vendor
 
 // CHECK: !llvm.ident = !{![[MD:[0-9]*]]}
-// CHECK: ![[MD]] = !{!"onnx-mlir version 0.2.0 ({{.*}}/onnx-mlir{{.*}} {{[a-zA-Z0-9]+}}, {{.*}}/llvm-project{{.*}} {{[a-zA-Z0-9]+}})"}
+// CHECK: ![[MD]] = !{!"onnx-mlir version 0.3.0 ({{.*}}/onnx-mlir{{.*}} {{[a-zA-Z0-9]+}}, {{.*}}/llvm-project{{.*}} {{[a-zA-Z0-9]+}})"}
 module {
   func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>

--- a/test/mlir/driver/llvm.ident.mlir
+++ b/test/mlir/driver/llvm.ident.mlir
@@ -4,7 +4,7 @@
 // XFAIL: onnx-mlir-vendor
 
 // CHECK: !llvm.ident = !{![[MD:[0-9]*]]}
-// CHECK: ![[MD]] = !{!"onnx-mlir version 1.0.0 ({{.*}}/onnx-mlir{{.*}} {{[a-zA-Z0-9]+}}, {{.*}}/llvm-project{{.*}} {{[a-zA-Z0-9]+}})"}
+// CHECK: ![[MD]] = !{!"onnx-mlir version 0.2.0 ({{.*}}/onnx-mlir{{.*}} {{[a-zA-Z0-9]+}}, {{.*}}/llvm-project{{.*}} {{[a-zA-Z0-9]+}})"}
 module {
   func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>


### PR DESCRIPTION
Move `onnx-mlir` version to `0.3.0` from `0.2.0`. `1.0.0` was a mistake.

Signed-off-by: Whitney Tsang <whitneyt@ca.ibm.com>