### PR TITLE
Temporarily disable the doc tests in the Windows CI

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -148,8 +148,10 @@ jobs:
     displayName: Install onnx
     workingDirectory: $(Agent.BuildDirectory)
 
-  - script: |
-      call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-      call onnx-mlir\utils\check-docs.cmd
-    displayName: Run onnx-mlir doc tests
-    workingDirectory: $(Agent.BuildDirectory)
+# TODO: Temporarily disable the doc tests until we determine the correct way to deal with new versions of protobuf
+# that are automatically installed on the windows image in the pools.
+#  - script: |
+#      call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+#      call onnx-mlir\utils\check-docs.cmd
+#    displayName: Run onnx-mlir doc tests
+#    workingDirectory: $(Agent.BuildDirectory)


### PR DESCRIPTION
The Windows image in the pool now has a version of protobuf installed that does not work correctly with the rest of the build (it's too high).
To work around the issue, temporarily disable the doc tests.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>