### PR TITLE
Force protobuf 3.16.0 on Windows

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -16,6 +16,11 @@ jobs:
     vmImage: 'windows-2019'
 
   steps:
+  - checkout: self
+    clean: true
+    submodules: recursive
+    path: onnx-mlir
+
   - task: UsePythonVersion@0
     displayName: Set Python Version to 3.9
     inputs:
@@ -42,16 +47,19 @@ jobs:
         echo "Setting LitPath to $litPath"
         Write-Host "##vso[task.setvariable variable=LitPath;]$litPath"
 
-  - checkout: self
-    clean: true
-    submodules: recursive
-    path: onnx-mlir
-
   - script: |
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
       call onnx-mlir\utils\install-protobuf.cmd
     displayName: Install protobuf
     workingDirectory: $(Agent.BuildDirectory)
+
+  - task: PowerShell@2
+    displayName: Install protobuf python package
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo "Install protobuf python package"
+        python3 -m pip install protobuf==3.16
 
   - powershell: |
       $mlir_match = Select-String -Path onnx-mlir\utils\clone-mlir.sh -Pattern "git checkout ([\da-f]+)"

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -17,8 +17,8 @@ Build protobuf as a static library.
 ```shell
 git clone --recurse-submodules https://github.com/protocolbuffers/protobuf.git
 REM Check out a specific branch that is known to work with ONNX-MLIR.
-REM This corresponds to the v3.11.4 tag
-cd protobuf && git checkout d0bfd5221182da1a7cc280f3337b5e41a89539cf && cd ..
+REM This corresponds to the v3.16.0 tag which is the recommended version of onnx 1.11.0
+cd protobuf && git checkout 2dc747c574b68a808ea4699d26942c8132fe2b09 && cd ..
 
 set root_dir=%cd%
 md protobuf_build
@@ -39,6 +39,11 @@ call cmake --build . --config Release --target install
 Before running CMake for onnx-mlir, ensure that the bin directory to this protobuf is before any others in your PATH:
 ```shell
 set PATH=%root_dir%\protobuf_install\bin;%PATH%
+```
+
+If you wish to be able to run all the ONNX-MLIR tests, you will also need to install the matchin version of protobuf through pip:
+```shell
+python3 -m pip install protobuf==3.16
 ```
 
 #### MLIR
@@ -94,7 +99,7 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DCMAKE_PREFIX_PATH=%root_dir%\protobuf_install ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
-   -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir
+   -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir ^
    -DONNX_MLIR_BUILD_TESTS=OFF
 
 call cmake --build . --config Release --target onnx-mlir

--- a/utils/build-onnx-mlir.cmd
+++ b/utils/build-onnx-mlir.cmd
@@ -7,7 +7,7 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DCMAKE_PREFIX_PATH=%root_dir%\protobuf_install ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
-   -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir
+   -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir ^
    -DONNX_MLIR_BUILD_TESTS=OFF
 
 call cmake --build . --config Release --target onnx-mlir

--- a/utils/install-protobuf.cmd
+++ b/utils/install-protobuf.cmd
@@ -1,7 +1,7 @@
 git clone --recurse-submodules https://github.com/protocolbuffers/protobuf.git
 REM Check out a specific branch that is known to work with ONNX-MLIR.
-REM This corresponds to the v3.11.4 tag
-cd protobuf && git checkout d0bfd5221182da1a7cc280f3337b5e41a89539cf && cd ..
+REM This corresponds to the v3.16.0 tag which is the recommended version of onnx 1.11.0
+cd protobuf && git checkout 2dc747c574b68a808ea4699d26942c8132fe2b09 && cd ..
 
 set root_dir=%cd%
 md protobuf_build


### PR DESCRIPTION
This updates the protoc binary build to 3.16.0 and then installs the corresponding pip package.
3.16.0 is the recommended (though not minimum required) version of protobuf for onnx 1.11.0

Signed-off-by: Stella Stamenova <stilis@microsoft.com>