### PR TITLE
Doc fix for DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Up to date info on how to build the project is located in the top directory [REA
 
 Since you are interested in contributing code, you should look in the [Workflow](docs/Workflow.md) for detailed step by step directives on how to create a fork, compile it, and then push your changes for review.
 
- Contributors have to sign their code using the [Developer Certificate of Origin (DCO)](https://developercertificate.org); make sure to check our [instructions](docs/Workflow.md#step-7-commit--push) prior to committing code to our repo.
+Contributors have to sign their code using the [Developer Certificate of Origin (DCO)](https://developercertificate.org); make sure to check our [instructions](docs/Workflow.md#step-7-commit--push) prior to committing code to our repo.
 
 A comprehensive list of documents is found [here](docs/DocumentList.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Up to date info on how to build the project is located in the top directory [REA
 
 Since you are interested in contributing code, you should look in the [Workflow](docs/Workflow.md) for detailed step by step directives on how to create a fork, compile it, and then push your changes for review.
 
+ Contributors have to sign their code using the [Developer Certificate of Origin (DCO)](https://developercertificate.org); make sure to check our [instructions](docs/Workflow.md#step-7-commit--push) prior to committing code to our repo.
+
 A comprehensive list of documents is found [here](docs/DocumentList.md).
 
 ## Guides for code generation for ONNX operations

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ We are welcoming contributions from the community.
 Please consult the [CONTRIBUTING](CONTRIBUTING.md) page for help on how to proceed.
 Documentation is provided in the `docs` sub-directory; the [DocumentList](docs/DocumentList.md) page provides an organized list of documents.
 
+ONNX-MLIR requires committers to sign their code using the [Developer Certificate of Origin (DCO)](https://developercertificate.org).
+Practically, each `git commit` needs to be signed, see [here](docs/Workflow.md#step-7-commit--push) for specific instructions.
+
 ## Code of Conduct
 
 The ONNX-MLIR code of conduct is described at https://onnx.ai/codeofconduct.html.

--- a/docs/Workflow.md
+++ b/docs/Workflow.md
@@ -178,7 +178,7 @@ Specific testing help is provided in these pages to [run](TestingHighLevel.md) a
 
 ## Step 7: Commit & Push
 
-ONNX-MLIR requires committers to sign their code using the [Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco).
+ONNX-MLIR requires committers to sign their code using the [Developer Certificate of Origin (DCO)](https://developercertificate.org).
 THere is a one time setup to register your name and email.
 The commands are listed below, where you substitute your name and email address in the "John Doe" fields.
 


### PR DESCRIPTION
New contributors often miss the DCO requirements. Added it more visibly in our doc.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>