### PR TITLE
Fix an error in check-onnx-backend-compilerlib

### DIFF
--- a/test/compilerlib/CompilerLibTest.cpp
+++ b/test/compilerlib/CompilerLibTest.cpp
@@ -28,11 +28,16 @@ bool compileFromFile = false;
     NAME = true;                                                               \
     return true;                                                               \
   }
+#define PARSE_UNSUPPORTED_FLAG(FLAG)                                           \
+  if (arg.find(FLAG) == 0) {                                                   \
+    return true;                                                               \
+  }
 
 // Return 1 if arg used, 0 if unused.
 bool readArg(const std::string &arg) {
   PARSE_ARG(outputBaseName, "-o");
   PARSE_FLAG(compileFromFile, "--fromfile");
+  PARSE_UNSUPPORTED_FLAG("--EmitLib");
   IGNORE_ARG("-"); // Ignore all other options.
   testFileName = arg;
   return true;


### PR DESCRIPTION
I got an error in backend test for compilerlib when used following command. The error issued because `--EmitLib` is not supported in `CompilerLibTest`. Since `--EmitLib` is default option, we don't have to pass it.
This PR ignores the option by using similar way with other options.  

- Command

```
cmake --build . --config Release --target check-onnx-backend-compilerlib
```
- Error message 
```
CompilerLibTest: Unknown command line argument '--EmitLib'.  Try: '/home/imaihal/work/onnx-mlir/build/Debug/bin/CompilerLibTest --help'
CompilerLibTest: Did you mean '--EmitZLowIR'?
Test info:
  temporary results are in dir:/tmp/tmp4q6xlu_9/
Failed /home/imaihal/work/onnx-mlir/build/Debug/bin/CompilerLibTest: test_abs
: 
: 

```