### PR TITLE
Add BufferLoopHoistingPass after LowerAffinePass

### DIFF
--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -102,6 +102,9 @@ void addKrnlToLLVMPasses(mlir::OpPassManager &pm, bool enableCSE) {
   pm.addNestedPass<func::FuncOp>(mlir::createConvertVectorToSCFPass());
   pm.addPass(mlir::createLowerAffinePass());
 
+  // Hoist allocations out of loop nests to avoid stack overflow.
+  pm.addPass(bufferization::createBufferLoopHoistingPass());
+
   // Use MLIR buffer deallocation pass to emit buffer deallocs.
   // Currently this has to be done *after* lowering the affine dialect because
   // operations in that dialect do not conform to the requirements explained in

--- a/test/mlir/driver/buffer_loop_hoisting.mlir
+++ b/test/mlir/driver/buffer_loop_hoisting.mlir
@@ -1,0 +1,31 @@
+// RUN: onnx-mlir --EmitLLVMIR --printIR %s | FileCheck %s
+
+// Test that llvm.alloca is hoisted out of the loop nest.
+
+// CHECK-LABEL: test_buffer_loop_hoisting
+// CHECK-NOT: llvm.br
+// CHECK-NOT: llvm.cond_br
+// CHECK: llvm.alloca
+// CHECK-NEXT: llvm.br
+// CHECK: llvm.cond_br
+
+func @test_buffer_loop_hoisting() {
+  %c0_i64 = arith.constant 0 : i64
+  %c0 = arith.constant 0 : index
+  %c32 = arith.constant 32 : index
+  %c8 = arith.constant 8 : index
+  scf.for %arg0 = %c0 to %c32 step %c8 {
+    %c18 = arith.constant 18 : index
+    %c6 = arith.constant 6 : index
+    scf.for %arg1 = %c0 to %c18 step %c6 {
+      %c20 = arith.constant 20 : index
+      %c5 = arith.constant 5 : index
+      scf.for %arg2 = %c0 to %c20 step %c5 {
+        %0 = memref.alloca() : memref<10x10xf32>
+        %1 = "krnl.getref"(%0, %c0_i64, %c0) : (memref<10x10xf32>, i64, index) -> memref<2x10xf32>
+        memref.dealloc %0 : memref<10x10xf32>
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
According to https://llvm.org/docs/LangRef.html#alloca-instruction, the alloca instruction allocates memory on the stack frame of the currently executing function, to be automatically released when this function returns to its caller.

We can avoid over allocing by placing alloca instruction at the function scope and outside of any loops. 

https://github.com/onnx/onnx-mlir/pull/1397 and https://github.com/onnx/onnx-mlir/pull/1437 attempted to create the allocas outside of loops directly. However, it is not always possible to create outside of the whole loop nest. For example, when lowering an operation that is already in a loop nest, or when the outer loop is only created after the placement of the alloca. 

This PR adds BufferLoopHoistingPass after LowerAffinePass to hoist allocations out of loop nests to avoid stack overflow.

Signed-off-by: Whitney Tsang <whitneyt@ca.ibm.com>