### PR TITLE
Fix a bug in MathBuilder::positiveInf and MathBuilder::negativeInf

### DIFF
--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -1041,7 +1041,7 @@ def KrnlInstrumentOp : Op<Krnl_Dialect, "runtime_instrument",
     May be used for gdb.
   }];
 
-  let arguments = (ins I64Attr:$opID, I64Attr:$tag);
+  let arguments = (ins StrAttr:$opName, I64Attr:$opID, I64Attr:$tag);
 
   let builders = [ OpBuilder<(ins "Operation *": $op, "int ": $tag)> ];
 }

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -479,6 +479,8 @@ void KrnlInstrumentOp::build(mlir::OpBuilder &builder, OperationState &state,
   strncpy((char *)&opID, opName + 5, sizeof(decltype(opID)) - 1);
   IntegerAttr attr = builder.getI64IntegerAttr(opID);
   auto tagAttr = builder.getI64IntegerAttr(tag);
+  StringAttr nameAttr = builder.getStringAttr(StringRef(opName));
+  state.addAttribute("opName", nameAttr);
   state.addAttribute("opID", attr);
   state.addAttribute("tag", tagAttr);
 }

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -224,23 +224,23 @@ Value MathBuilder::negativeInf(Type type) const {
           [&](Type) { value = -std::numeric_limits<double>::infinity(); })
       .Case<IntegerType>([&](IntegerType type) {
         unsigned width = type.getWidth();
-        bool isSigned = type.isSigned();
+        bool isSignless = type.isSignlessInteger();
         switch (width) {
         case 8:
-          value = (isSigned) ? std::numeric_limits<int8_t>::min()
-                             : std::numeric_limits<uint8_t>::min();
+          value = (isSignless) ? std::numeric_limits<int8_t>::min()
+                               : std::numeric_limits<uint8_t>::min();
           break;
         case 16:
-          value = (isSigned) ? std::numeric_limits<int16_t>::min()
-                             : std::numeric_limits<uint16_t>::min();
+          value = (isSignless) ? std::numeric_limits<int16_t>::min()
+                               : std::numeric_limits<uint16_t>::min();
           break;
         case 32:
-          value = (isSigned) ? std::numeric_limits<int32_t>::min()
-                             : std::numeric_limits<uint32_t>::min();
+          value = (isSignless) ? std::numeric_limits<int32_t>::min()
+                               : std::numeric_limits<uint32_t>::min();
           break;
         case 64:
-          value = (isSigned) ? std::numeric_limits<int64_t>::min()
-                             : std::numeric_limits<uint64_t>::min();
+          value = (isSignless) ? std::numeric_limits<int64_t>::min()
+                               : std::numeric_limits<uint64_t>::min();
           break;
         default:
           llvm_unreachable("unsupported element type");
@@ -262,24 +262,24 @@ Value MathBuilder::positiveInf(Type type) const {
           [&](Type) { value = std::numeric_limits<double>::infinity(); })
       .Case<IntegerType>([&](IntegerType type) {
         size_t width = type.getWidth();
-        bool isSigned = type.isSigned();
+        bool isSignless = type.isSignlessInteger();
         switch (width) {
         case 8:
-          value = (isSigned) ? std::numeric_limits<int8_t>::max()
-                             : std::numeric_limits<uint8_t>::max();
+          value = (isSignless) ? std::numeric_limits<int8_t>::max()
+                               : std::numeric_limits<uint8_t>::max();
           break;
         case 16:
-          value = (isSigned) ? std::numeric_limits<int16_t>::max()
-                             : std::numeric_limits<uint16_t>::max();
+          value = (isSignless) ? std::numeric_limits<int16_t>::max()
+                               : std::numeric_limits<uint16_t>::max();
           break;
         case 32:
-          value = (isSigned) ? std::numeric_limits<int32_t>::max()
-                             : std::numeric_limits<uint32_t>::max();
+          value = (isSignless) ? std::numeric_limits<int32_t>::max()
+                               : std::numeric_limits<uint32_t>::max();
           break;
         case 64:
           value = static_cast<double>(
-              (isSigned) ? std::numeric_limits<int64_t>::max()
-                         : std::numeric_limits<uint64_t>::max());
+              (isSignless) ? std::numeric_limits<int64_t>::max()
+                           : std::numeric_limits<uint64_t>::max());
           break;
         default:
           llvm_unreachable("unsupported element type");

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -705,6 +705,51 @@ func private @test_reducemax(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
 
 // -----
 
+func private @test_reducemax_negative_inf_f32(%arg0 : tensor<2x3xf32>) -> tensor<*xf32> {
+  %0 ="onnx.ReduceMax"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xf32>)-> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+  // CHECK-LABEL: test_reducemax_negative_inf_f32 
+  // CHECK: arith.constant 0xFF800000 : f32
+}
+
+// -----
+
+func private @test_reducemax_negative_inf_f64(%arg0 : tensor<2x3xf64>) -> tensor<*xf64> {
+  %0 ="onnx.ReduceMax"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xf64>)-> tensor<*xf64>
+  "func.return"(%0) : (tensor<*xf64>) -> ()
+  // CHECK-LABEL: test_reducemax_negative_inf_f64 
+  // CHECK: arith.constant 0xFFF0000000000000 : f64
+}
+
+// -----
+
+func private @test_reducemax_negative_inf_i8(%arg0 : tensor<2x3xi8>) -> tensor<*xi8> {
+  %0 ="onnx.ReduceMax"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xi8>)-> tensor<*xi8>
+  "func.return"(%0) : (tensor<*xi8>) -> ()
+  // CHECK-LABEL: test_reducemax_negative_inf_i8
+  // CHECK: arith.constant -128 : i8 
+}
+
+// -----
+
+func private @test_reducemax_negative_inf_i32(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
+  %0 ="onnx.ReduceMax"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xi32>)-> tensor<*xi32>
+  "func.return"(%0) : (tensor<*xi32>) -> ()
+  // CHECK-LABEL: test_reducemax_negative_inf_i32
+  // CHECK: arith.constant -2147483648 : i32 
+}
+
+// -----
+
+func private @test_reducemax_negative_inf_i64(%arg0 : tensor<2x3xi64>) -> tensor<*xi64> {
+  %0 ="onnx.ReduceMax"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xi64>)-> tensor<*xi64>
+  "func.return"(%0) : (tensor<*xi64>) -> ()
+  // CHECK-LABEL: test_reducemax_negative_inf_i64
+  // CHECK: arith.constant -9223372036854775808 : i64 
+}
+
+// -----
+
 func private @test_reducemin(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   %0 ="onnx.ReduceMin"(%arg0) {axes=[1], keepdims = 0 : si64} : (tensor<3x2x2xf32>)-> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
@@ -725,6 +770,51 @@ func private @test_reducemin(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
   // CHECK: krnl.store [[SELECT]], [[RES]][%arg1, %arg3] : memref<3x2xf32>
   // CHECK: }
   // CHECK: return [[RES]] : memref<3x2xf32>
+}
+
+// -----
+
+func private @test_reducemin_positive_inf_f32(%arg0 : tensor<2x3xf32>) -> tensor<*xf32> {
+  %0 ="onnx.ReduceMin"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xf32>)-> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+  // CHECK-LABEL: test_reducemin_positive_inf_f32 
+  // CHECK: arith.constant 0x7F800000 : f32
+}
+
+// -----
+
+func private @test_reducemin_positive_inf_f64(%arg0 : tensor<2x3xf64>) -> tensor<*xf64> {
+  %0 ="onnx.ReduceMin"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xf64>)-> tensor<*xf64>
+  "func.return"(%0) : (tensor<*xf64>) -> ()
+  // CHECK-LABEL: test_reducemin_positive_inf_f64 
+  // CHECK: arith.constant 0x7FF0000000000000 : f64
+}
+
+// -----
+
+func private @test_reducemin_positive_inf_i8(%arg0 : tensor<2x3xi8>) -> tensor<*xi8> {
+  %0 ="onnx.ReduceMin"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xi8>)-> tensor<*xi8>
+  "func.return"(%0) : (tensor<*xi8>) -> ()
+  // CHECK-LABEL: test_reducemin_positive_inf_i8
+  // CHECK: arith.constant 127 : i8 
+}
+
+// -----
+
+func private @test_reducemin_positive_inf_i32(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
+  %0 ="onnx.ReduceMin"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xi32>)-> tensor<*xi32>
+  "func.return"(%0) : (tensor<*xi32>) -> ()
+  // CHECK-LABEL: test_reducemin_positive_inf_i32
+  // CHECK: arith.constant 2147483647 : i32
+}
+
+// -----
+
+func private @test_reducemin_positive_inf_i64(%arg0 : tensor<2x3xi64>) -> tensor<*xi64> {
+  %0 ="onnx.ReduceMin"(%arg0) {axes=[0], keepdims = 0 : si64} : (tensor<2x3xi64>)-> tensor<*xi64>
+  "func.return"(%0) : (tensor<*xi64>) -> ()
+  // CHECK-LABEL: test_reducemin_positive_inf_i64
+  // CHECK: arith.constant 9223372036854775807 : i64 
 }
 
 // -----


### PR DESCRIPTION
`MathBuilder::positiveInf` and `MathBuilder::negativeInf` use `type.isSigned` to check an integer type, but the correct one should be `type.isSignlessInteger`.

This patch also adds op name in KrnlInstrumentOp, which helps know from which ONNX op the code is generated.

Resolves #1270 
 
Signed-off-by: Tung D. Le <tung@jp.ibm.com>