### PR TITLE
Run the onnx model zoo with test_data_set_0 by default

### DIFF
--- a/utils/RunONNXModelZoo.py
+++ b/utils/RunONNXModelZoo.py
@@ -285,9 +285,13 @@ def check_model(model_path, model_name, compile_args, report_dir):
         has_data_sets = False
         _, data_sets = execute_commands(
             ['find', tmpdir, '-type', 'd', '-name', 'test_data_set*'])
-        if (len(data_sets) > 0):
+        data_sets_list = [s for s in data_sets.split('\n') if s]
+        if (len(data_sets_list) > 0):
             has_data_sets = True
-            data_set = data_sets.split('\n')[0]
+            # Sort the list to get test_data_set_0 by default since other data
+            # sets are sometimes ill-formed.
+            data_sets_list.sort()
+            data_set = data_sets_list[0]
         else:
             # if there is no `test_data_set` subfolder, find a folder containing .pb files.
             _, pb_files = execute_commands(
@@ -297,7 +301,7 @@ def check_model(model_path, model_name, compile_args, report_dir):
                 data_set = pb_files.split('\n')[0]
         if (not has_data_sets):
             logger.warning(
-                "model {} does not have test data sets. Will check the model with random data."
+                "The model {} does not have test data sets. Will check the model with random data."
                 .format(model_name))
 
         # compile, run and verify.

--- a/utils/RunONNXModelZoo.py
+++ b/utils/RunONNXModelZoo.py
@@ -22,6 +22,7 @@ import sys
 import tarfile
 import tempfile
 
+from datetime import datetime
 from joblib import Parallel, delayed
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -319,7 +320,6 @@ def check_model(model_path, model_name, compile_args, report_dir):
         logger.debug("[{}] {}".format(model_name, msg))
 
         if args.Html:
-            from datetime import datetime
             with open(os.path.join(report_dir, model_name + '.html'), 'w') as out:
                 out.write('<html><body><pre>\n')
                 out.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + '\n\n')

--- a/utils/RunONNXModelZoo.py
+++ b/utils/RunONNXModelZoo.py
@@ -319,8 +319,10 @@ def check_model(model_path, model_name, compile_args, report_dir):
         logger.debug("[{}] {}".format(model_name, msg))
 
         if args.Html:
+            from datetime import datetime
             with open(os.path.join(report_dir, model_name + '.html'), 'w') as out:
                 out.write('<html><body><pre>\n')
+                out.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + '\n\n')
                 out.write(model_name + '\n\n')
                 out.write(msg)
                 out.write('</pre></body></html>\n')


### PR DESCRIPTION
This patch adds some small changes to RunONNXModelZoo.py, where:
- Use `test_data_set_0` for each model since other datasets, e.g. `test_data_set_1`, `test_data_set_1` are sometimes ill-formed. For example,`test_data_set_1` of `ssd_mobilenet_v1_10` contains `input_1.pb` instead of `input_0.pb` (The input index should start from 0).
- Print the date time when the HTML output is generated for each model's output.