### PR TITLE
Missing dot in the output file name

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -360,7 +360,7 @@ std::string getTargetFilename(
   case EmitONNXBasic:
   case EmitONNXIR:
   case EmitMLIR:
-    return filenameNoExt + "onnx.mlir";
+    return filenameNoExt + ".onnx.mlir";
   }
   llvm_unreachable("all cases should be handled in switch");
 }


### PR DESCRIPTION
PR #1463 accidentally removed `.` (dot) in the output file name when `--EmitMLIR`.  This patch adds dot back.
 
Signed-off-by: Tung D. Le <tung@jp.ibm.com>