### PR TITLE
Add fix to cmake file for multiple accelerators

### DIFF
--- a/src/Accelerators/CMakeLists.txt
+++ b/src/Accelerators/CMakeLists.txt
@@ -27,7 +27,7 @@ set(create_accelerators_inc_script "${CMAKE_CURRENT_SOURCE_DIR}/CreateAccelerato
 
 add_custom_command(OUTPUT "${accelerators_inc}"
   DEPENDS "${create_accelerators_inc_script}"
-  COMMAND ${CMAKE_COMMAND} "-DINC_FILE=${accelerators_inc}" "-DACCELERATORS=${ACCEL_INCLUDE_LIST}"
+  COMMAND ${CMAKE_COMMAND} "-DINC_FILE=${accelerators_inc}" "-DACCELERATORS=\"${ACCEL_INCLUDE_LIST}\""
     -P "${create_accelerators_inc_script}"
   )
 set_source_files_properties("${accelerators_inc}"


### PR DESCRIPTION
This PR includes a minor fix to one of the cmake files to support enabling multiple accelerators. Previously, the build system would fail if one added a new accelerator in `src/Accelerators/XXX` and enabled it in addition to `NNPA` via `-DONNX_MLIR_ACCELERATORS="NNPA;XXX"`