### PR TITLE
Use LLVMBuider to simplify generating LLVM code - Part 2

### DIFF
--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -304,16 +304,11 @@ void genSignatureFunction(ModuleOp &module,
     b.setInsertionPointToStart(entryBlock);
 
     Value zeroI32 = create.llvm.constant(i32Type, (int64_t)0);
-    Value oneI64 = create.llvm.constant(i64Type, (int64_t)1);
 
-    // 2.1 A buffer to keep a pointer pointing to the return signature string.
-    Value ptrToReturnSig =
-        create.llvm._alloca(i8PtrPtrTy, oneI64, /*alignment=*/0);
-
-    // 2.2 The name of the entry point that we want to return its signature.
+    // 2.1 The name of the entry point that we want to return its signature.
     Value input = entryBlock->getArgument(0);
 
-    // 2.3 Emit code to find the signature of the given entry point.
+    // 2.2 Emit code to find the signature of the given entry point.
     // Iterate over the list of the entry points and check string equality.
     for (uint64_t j = 0; j < numOfEntryPoints; ++j) {
       LLVM::GlobalOp globalEntryPoint = entryGlobalOps[j];
@@ -345,9 +340,7 @@ void genSignatureFunction(ModuleOp &module,
           [&](LLVMBuilder &createLLVM) {
             Value sigAddr = createLLVM.addressOf(globalSignature);
             Value sigI8Ptr = createLLVM.bitcastI8Ptr(sigAddr);
-            createLLVM.store(sigI8Ptr, ptrToReturnSig);
-            Value res = createLLVM.load(ptrToReturnSig);
-            createLLVM._return(res);
+            createLLVM._return(sigI8Ptr);
           });
     }
 

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -267,36 +267,21 @@ void genSignatureFunction(ModuleOp &module,
     Value numOfEntryPoints = entryBlock->getArgument(0);
     // If the argument is not NULL, update its value to return the number of
     // entry points.
-    Block *condBlock = b.getInsertionBlock();
-    Block *trueBlock = condBlock->splitBlock(b.getInsertionPoint());
-    Block *falseBlock = b.createBlock(
-        trueBlock->getParent(), std::next(Region::iterator(trueBlock)));
-    Block *endBlock = b.createBlock(
-        falseBlock->getParent(), std::next(Region::iterator(falseBlock)));
-    // Emit code for the condition block: test NULL.
-    b.setInsertionPointToEnd(condBlock);
-    Value nullPtr = create.llvm.null(i64PtrTy);
-    Value found =
-        create.llvm.icmp(LLVM::ICmpPredicate::ne, numOfEntryPoints, nullPtr);
-    // Branch the block into the true and false blocks.
-    b.create<LLVM::CondBrOp>(
-        loc, found, trueBlock, ValueRange(), falseBlock, ValueRange());
-
-    // Emit code for the true block: update the value.
-    b.setInsertionPointToStart(trueBlock);
-    Value zero = create.llvm.constant(i64Type, (int64_t)0);
-    Value numOfEntryPointsPtr =
-        create.llvm.getElemPtr(i64PtrTy, numOfEntryPoints, {zero});
-    Value noep = create.llvm.constant(i64Type, (int64_t)entryGlobalOps.size());
-    create.llvm.store(noep, numOfEntryPointsPtr);
-    b.create<LLVM::BrOp>(loc, ValueRange(), endBlock);
-
-    // Emit code for the false block: do nothing.
-    b.setInsertionPointToStart(falseBlock);
-    b.create<LLVM::BrOp>(loc, ValueRange(), endBlock);
-
-    // Emit code for the end block to return the entry point array.
-    b.setInsertionPointToStart(endBlock);
+    create.llvm.ifThenElse(/*cond=*/
+        [&](LLVMBuilder &createLLVM) {
+          Value nullPtr = createLLVM.null(i64PtrTy);
+          return createLLVM.icmp(
+              LLVM::ICmpPredicate::ne, numOfEntryPoints, nullPtr);
+        }, /*then=*/
+        [&](LLVMBuilder &createLLVM) {
+          Value zero = createLLVM.constant(i64Type, (int64_t)0);
+          Value numOfEntryPointsPtr =
+              createLLVM.getElemPtr(i64PtrTy, numOfEntryPoints, {zero});
+          Value noep =
+              createLLVM.constant(i64Type, (int64_t)entryGlobalOps.size());
+          createLLVM.store(noep, numOfEntryPointsPtr);
+        });
+    // Emit code to return the entry point array.
     Value entryAddr = create.llvm.addressOf(entryArrayOp);
     Value entryI8Ptr = create.llvm.bitcastI8PtrPtr(entryAddr);
     create.llvm._return(entryI8Ptr);
@@ -330,25 +315,6 @@ void genSignatureFunction(ModuleOp &module,
 
     // 2.3 Emit code to find the signature of the given entry point.
     // Iterate over the list of the entry points and check string equality.
-
-    // Split the current block into condition, true, false, and end blocks.
-    // - If the user's entry point name is found, go to the true block, then the
-    // end block.
-    // - Otherwise, recursively split the false block.
-    Block *condBlock, *trueBlock, *falseBlock, *endBlock;
-    condBlock = b.getInsertionBlock();
-    trueBlock = condBlock->splitBlock(b.getInsertionPoint());
-    falseBlock = b.createBlock(
-        trueBlock->getParent(), std::next(Region::iterator(trueBlock)));
-    endBlock = b.createBlock(
-        falseBlock->getParent(), std::next(Region::iterator(falseBlock)));
-
-    // Emit code for the end block.
-    b.setInsertionPointToStart(endBlock);
-    Value res = create.llvm.load(ptrToReturnSig);
-    create.llvm._return(res);
-
-    // Emit code for the condition, true and false blocks.
     for (uint64_t j = 0; j < numOfEntryPoints; ++j) {
       LLVM::GlobalOp globalEntryPoint = entryGlobalOps[j];
       LLVM::GlobalOp globalSignature =
@@ -357,46 +323,36 @@ void genSignatureFunction(ModuleOp &module,
              "Entry point value is not StringAttr");
       StringAttr entryPointValueAttr =
           globalEntryPoint.getValueAttr().cast<StringAttr>();
-      // Emit code for the condition block.
-      b.setInsertionPointToEnd(condBlock);
-      // Read an entry point name.
-      Value address = create.llvm.addressOf(globalEntryPoint);
-      Value zeroI64 = create.llvm.constant(i64Type, (int64_t)0);
-      Value entryI8Ptr =
-          create.llvm.getElemPtr(i8PtrTy, address, {zeroI64, zeroI64});
-      // Compare it with the user's entry point name.
-      FlatSymbolRefAttr StrncmpRef = krnl::getOrInsertStrncmp(b, module);
-      Value length = create.llvm.constant(
-          i64Type, (int64_t)entryPointValueAttr.getValue().size());
-      Value strncmpResult = create.llvm.call(
-          i32Type, StrncmpRef, ArrayRef<Value>({input, entryI8Ptr, length}));
-      // Equal if strncmp returns `0`.
-      Value found =
-          create.llvm.icmp(LLVM::ICmpPredicate::eq, strncmpResult, zeroI32);
-      // Branch the block into the true and false blocks.
-      b.create<LLVM::CondBrOp>(
-          loc, found, trueBlock, ValueRange(), falseBlock, ValueRange());
 
-      // Emit code for the true block.
-      b.setInsertionPointToStart(trueBlock);
-      Value sigAddr = create.llvm.addressOf(globalSignature);
-      Value sigI8Ptr = create.llvm.bitcastI8Ptr(sigAddr);
-      create.llvm.store(sigI8Ptr, ptrToReturnSig);
-      b.create<LLVM::BrOp>(loc, ValueRange(), endBlock);
-
-      // Emit code for the false block.
-      b.setInsertionPointToStart(falseBlock);
-      if (j == numOfEntryPoints - 1) {
-        // Return NULL if the entry point name is not found.
-        create.llvm._return(create.llvm.nullI8Ptr());
-      } else {
-        // Recursively do with the other entry point names.
-        condBlock = b.getInsertionBlock();
-        trueBlock = condBlock->splitBlock(b.getInsertionPoint());
-        falseBlock = b.createBlock(
-            trueBlock->getParent(), std::next(Region::iterator(trueBlock)));
-      }
+      // Return the signature if found.
+      create.llvm.ifThenElse(/*cond=*/
+          [&](LLVMBuilder &createLLVM) {
+            // Read an entry point name.
+            Value address = createLLVM.addressOf(globalEntryPoint);
+            Value zeroI64 = createLLVM.constant(i64Type, (int64_t)0);
+            Value entryI8Ptr =
+                createLLVM.getElemPtr(i8PtrTy, address, {zeroI64, zeroI64});
+            // Compare it with the user's entry point name.
+            FlatSymbolRefAttr StrncmpRef = krnl::getOrInsertStrncmp(b, module);
+            Value length = createLLVM.constant(
+                i64Type, (int64_t)entryPointValueAttr.getValue().size());
+            Value strncmpResult = createLLVM.call(i32Type, StrncmpRef,
+                ArrayRef<Value>({input, entryI8Ptr, length}));
+            // Found if strncmp returns `0`.
+            return createLLVM.icmp(
+                LLVM::ICmpPredicate::eq, strncmpResult, zeroI32);
+          }, /*then=*/
+          [&](LLVMBuilder &createLLVM) {
+            Value sigAddr = createLLVM.addressOf(globalSignature);
+            Value sigI8Ptr = createLLVM.bitcastI8Ptr(sigAddr);
+            createLLVM.store(sigI8Ptr, ptrToReturnSig);
+            Value res = createLLVM.load(ptrToReturnSig);
+            createLLVM._return(res);
+          });
     }
+
+    // Return NULL if not found.
+    create.llvm._return(create.llvm.nullI8Ptr());
   }
 }
 

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -120,8 +120,6 @@ public:
       ArrayAttr accels = maccelAttr.cast<ArrayAttr>();
       Value zeroI64 = create.llvm.constant(int64Ty, (int64_t)0);
 
-      // Split the current block into IF, THEN, ELSE blocks.
-      Block *ifBlock, *thenBlock, *elseBlock;
       for (uint64_t i = 0; i < accels.size(); ++i) {
         assert(accels[i].isa<StringAttr>() && "Attribute must be StringAttr");
         StringRef accelStr = accels.getValue()[i].cast<StringAttr>().getValue();
@@ -131,32 +129,22 @@ public:
         FlatSymbolRefAttr funcRef = getOrInsertOMInitCompatibleAccel(
             rewriter, module, NameAndVersion.first);
 
-        // Split the current block into IF, THEN, ELSE blocks.
-        ifBlock = rewriter.getInsertionBlock();
-        thenBlock = ifBlock->splitBlock(rewriter.getInsertionPoint());
-        elseBlock = rewriter.createBlock(
-            thenBlock->getParent(), std::next(Region::iterator(thenBlock)));
-
-        // Emit code for the IF block.
-        rewriter.setInsertionPointToEnd(ifBlock);
-        // Call OMInitCompatibleAccelX.
-        Value versionNumberVal =
-            create.llvm.constant(int64Ty, (int64_t)versionNumberInHex);
-        Value isCompatible = create.llvm.call(
-            int64Ty, funcRef, ArrayRef<Value>({versionNumberVal}));
-        // Condition: if (OMInitCompatibleAccelX() != 0)
-        Value notCompatible =
-            create.llvm.icmp(LLVM::ICmpPredicate::eq, isCompatible, zeroI64);
-        // Branch the block into the THEN and ELSE blocks.
-        rewriter.create<LLVM::CondBrOp>(loc, notCompatible, thenBlock,
-            ValueRange(), elseBlock, ValueRange());
-
-        // Emit code for the THEN block: return NULL.
-        rewriter.setInsertionPointToStart(thenBlock);
-        create.llvm._return(create.llvm.nullI8Ptr());
-
-        // Emit code for thenELSE block: deal with other accelerators if any.
-        rewriter.setInsertionPointToStart(elseBlock);
+        // Emit code for `if (OMInitCompatibleAccelX() == 0) then return NULL`.
+        create.llvm.ifThenElse(/*cond=*/
+            [&](LLVMBuilder &createLLVM) {
+              // Call OMInitCompatibleAccelX.
+              Value versionNumberVal =
+                  createLLVM.constant(int64Ty, (int64_t)versionNumberInHex);
+              Value isCompatible = createLLVM.call(
+                  int64Ty, funcRef, ArrayRef<Value>({versionNumberVal}));
+              // Condition: if (OMInitCompatibleAccelX() == 0)
+              return createLLVM.icmp(
+                  LLVM::ICmpPredicate::eq, isCompatible, zeroI64);
+            }, /*then=*/
+            [&](LLVMBuilder &createLLVM) {
+              // return NULL.
+              createLLVM._return(createLLVM.nullI8Ptr());
+            });
       }
     }
 
@@ -400,36 +388,23 @@ private:
       Value lhs, Value rhs, std::string errorMsg = "",
       bool appendRHS = true) const {
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
-    // Split the current block into IF, THEN, END blocks.
-    Block *ifBlock, *thenBlock, *endBlock;
-    ifBlock = rewriter.getInsertionBlock();
-    thenBlock = ifBlock->splitBlock(rewriter.getInsertionPoint());
-    endBlock = rewriter.createBlock(
-        thenBlock->getParent(), std::next(Region::iterator(thenBlock)));
-
-    // Emit code for the IF block.
-    rewriter.setInsertionPointToEnd(ifBlock);
-    Value failed = create.llvm.icmp(LLVM::ICmpPredicate::ne, lhs, rhs);
-
-    // Branch the block into the THEN and END blocks.
-    rewriter.create<LLVM::CondBrOp>(
-        loc, failed, thenBlock, ValueRange(), endBlock, ValueRange());
-
-    // Emit code for the THEN block: return NULL.
-    rewriter.setInsertionPointToStart(thenBlock);
-    // Print an error message.
-    KrnlBuilder createKrnl(rewriter, loc);
-    if (appendRHS)
-      createKrnl.printf(StringRef(errorMsg), rhs, rewriter.getI64Type(), true);
-    else
-      createKrnl.printf(StringRef(errorMsg + "\n"));
-    // Set errno.
-    krnl::emitErrNo(module, rewriter, loc, EINVAL);
-    // Return NULL.
-    create.llvm._return(create.llvm.nullI8Ptr());
-
-    // Emit code for the END block: continue with other generated code.
-    rewriter.setInsertionPointToStart(endBlock);
+    create.llvm.ifThenElse(/*cond=*/
+        [&](LLVMBuilder &createLLVM) {
+          return createLLVM.icmp(LLVM::ICmpPredicate::ne, lhs, rhs);
+        }, /*then=*/
+        [&](LLVMBuilder &createLLVM) {
+          MultiDialectBuilder<LLVMBuilder, KrnlBuilder> create(createLLVM);
+          // Print an error message.
+          if (appendRHS)
+            create.krnl.printf(
+                StringRef(errorMsg), rhs, rewriter.getI64Type(), true);
+          else
+            create.krnl.printf(StringRef(errorMsg + "\n"));
+          // Set errno.
+          krnl::emitErrNo(module, rewriter, loc, EINVAL);
+          // Return NULL.
+          create.llvm._return(create.llvm.nullI8Ptr());
+        });
   }
 
   void emitVerificationCodeForInputTensors(ModuleOp &module,
@@ -499,11 +474,33 @@ private:
         auto JSONDimValue = (*JSONDimArray)[d].getAsInteger();
         assert(JSONDimValue && "failed to get value");
         int64_t dim = JSONDimValue.getValue();
-        if (dim == -1)
-          continue; // do not verify dynamic dimensions.
+        Value actualDim = create.llvm.constant(int64Ty, (int64_t)dim);
+        if (dim == -1) {
+          // In case of dynamic dimension, verify that the dimension size is
+          // a non-negative value.
+          create.llvm.ifThenElse(/*cond=*/
+              [&](LLVMBuilder &createLLVM) {
+                Value zero = createLLVM.constant(int64Ty, (int64_t)d);
+                return createLLVM.icmp(
+                    LLVM::ICmpPredicate::slt, actualDim, zero);
+              }, /*then=*/
+              [&](LLVMBuilder &createLLVM) {
+                MultiDialectBuilder<LLVMBuilder, KrnlBuilder> create(
+                    createLLVM);
+                // Print an error message.
+                StringRef errorMsg("Wrong size for the dimension " +
+                                   std::to_string(d) + " of the input " +
+                                   std::to_string(i) +
+                                   ": expect a non-nagative value\n");
+                create.krnl.printf(errorMsg);
+                // Set errno.
+                krnl::emitErrNo(module, rewriter, loc, EINVAL);
+                // Return NULL.
+                create.llvm._return(create.llvm.nullI8Ptr());
+              });
+        }
         Value dimIdx = create.llvm.constant(int64Ty, (int64_t)d);
-        equalOrFailed(module, rewriter, loc,
-            create.llvm.constant(int64Ty, (int64_t)dim),
+        equalOrFailed(module, rewriter, loc, actualDim,
             create.llvm.load(create.llvm.getElemPtr(
                 LLVM::LLVMPointerType::get(int64Ty), sizesArrayPtr, {dimIdx})),
             "Wrong size for the dimension " + std::to_string(d) +

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -493,10 +493,11 @@ private:
                 MultiDialectBuilder<LLVMBuilder, KrnlBuilder> create(
                     createLLVM);
                 // Print an error message.
-                StringRef errorMsg("Wrong size for the dimension " +
-                                   std::to_string(d) + " of the input " +
-                                   std::to_string(i) +
-                                   ": expect a non-negative value\n");
+                std::string msg = "Wrong size for the dimension " +
+                                  std::to_string(d) + " of the input " +
+                                  std::to_string(i) +
+                                  ": expect a non-negative value\n";
+                StringRef errorMsg(msg);
                 create.krnl.printf(errorMsg);
                 // Set errno.
                 krnl::emitErrNo(module, rewriter, loc, EINVAL);

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -954,9 +954,7 @@ FlatSymbolRefAttr LLVMBuilder::getOrInsertSymbolRef(ModuleOp module,
 }
 
 void LLVMBuilder::ifThenElse(
-    mlir::function_ref<Value(LLVMBuilder &createLLVM)> cond,
-    mlir::function_ref<void(LLVMBuilder &createLLVM)> thenFn,
-    mlir::function_ref<void(LLVMBuilder &createLLVM)> elseFn) const {
+    valueFuncRef cond, voidFuncRef thenFn, voidFuncRef elseFn) const {
   LLVMBuilder createLLVM(b, loc);
 
   // Split the current block into IF, THEN, ELSE and END blocks.
@@ -976,7 +974,7 @@ void LLVMBuilder::ifThenElse(
   Value condVal = cond(createLLVM);
 
   // Branch the block into the THEN and ELSE blocks.
-  condBr(condVal, thenBlock, {}, elseBlock, {});
+  createLLVM.condBr(condVal, thenBlock, {}, elseBlock, {});
 
   // Emit code for the THEN block.
   b.setInsertionPointToStart(thenBlock);

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -264,6 +264,9 @@ using AffineBuilder =
 //===----------------------------------------------------------------------===//
 
 struct LLVMBuilder final : DialectBuilder {
+  using voidFuncRef = mlir::function_ref<void(LLVMBuilder &createLLVM)>;
+  using valueFuncRef = mlir::function_ref<mlir::Value(LLVMBuilder &createLLVM)>;
+
   LLVMBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   LLVMBuilder(DialectBuilder &db) : DialectBuilder(db) {}
@@ -357,9 +360,8 @@ struct LLVMBuilder final : DialectBuilder {
   /// ^mainBlock
   ///   ...
   /// ```
-  void ifThenElse(mlir::function_ref<mlir::Value(LLVMBuilder &createLLVM)> cond,
-      mlir::function_ref<void(LLVMBuilder &createLLVM)> thenFn,
-      mlir::function_ref<void(LLVMBuilder &createLLVM)> elseFn = nullptr) const;
+  void ifThenElse(valueFuncRef cond, voidFuncRef thenFn,
+      voidFuncRef elseFn = nullptr) const;
 };
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -280,12 +280,21 @@ struct LLVMBuilder final : DialectBuilder {
   mlir::Value bitcastI8Ptr(mlir::Value val) const;
   mlir::Value bitcastI8PtrPtr(mlir::Value val) const;
 
+  // BrOp
+  void br(
+      llvm::ArrayRef<mlir::Value> destOperands, mlir::Block *destBlock) const;
+
   // CallOp
   mlir::Value call(mlir::ArrayRef<mlir::Type> resultTypes,
       llvm::StringRef funcName, mlir::ArrayRef<mlir::Value> inputs) const;
   mlir::Value call(mlir::ArrayRef<mlir::Type> resultTypes,
       mlir::FlatSymbolRefAttr funcSymbol,
       mlir::ArrayRef<mlir::Value> inputs) const;
+
+  // CondBrOp
+  void condBr(mlir::Value cond, mlir::Block *trueBlock,
+      llvm::ArrayRef<mlir::Value> trueOperands, mlir::Block *falseBlock,
+      llvm::ArrayRef<mlir::Value> falseOperands) const;
 
   // ConstantOp
   mlir::Value constant(mlir::Type type, int64_t val) const;
@@ -336,6 +345,21 @@ struct LLVMBuilder final : DialectBuilder {
   mlir::FlatSymbolRefAttr getOrInsertSymbolRef(mlir::ModuleOp module,
       llvm::StringRef symName, mlir::Type resultType,
       llvm::ArrayRef<mlir::Type> operandTypes, bool isVarArg = false) const;
+
+  /// Generate code that looks like "if then with optional else" at LLVM.
+  /// The following prototype code will be generated:
+  /// ```
+  /// llvm.condBr cond, ^thenBlock, ^elseBlock
+  /// ^thenBlock:
+  ///   thenBody
+  /// ^elseBlock:
+  ///   elseBody
+  /// ^mainBlock
+  ///   ...
+  /// ```
+  void ifThenElse(mlir::function_ref<mlir::Value(LLVMBuilder &createLLVM)> cond,
+      mlir::function_ref<void(LLVMBuilder &createLLVM)> thenFn,
+      mlir::function_ref<void(LLVMBuilder &createLLVM)> elseFn = nullptr) const;
 };
 
 //===----------------------------------------------------------------------===//

--- a/test/backend/input_verification_backend.py
+++ b/test/backend/input_verification_backend.py
@@ -102,7 +102,7 @@ class AddModel:
         node = helper.make_node("Add", inputs=["x1", "x2"], outputs=["y"])
 
         x1 = helper.make_tensor_value_info("x1", TensorProto.FLOAT, [3, 4, 5])
-        x2 = helper.make_tensor_value_info("x2", TensorProto.FLOAT, [3, 4, 5])
+        x2 = helper.make_tensor_value_info("x2", TensorProto.FLOAT, ["unknown", 4, 5])
         y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [3, 4, 5])
 
         # Create the graph (GraphProto)

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -35,10 +35,8 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_2_4_:%.+]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK:           llvm.store [[VAR_2_4_]], [[arg0_]] : !llvm.ptr<i64>
-// CHECK:           llvm.br ^bb3
-// CHECK:         ^bb2:  // pred: ^bb0
-// CHECK:           llvm.br ^bb3
-// CHECK:         ^bb3:  // 2 preds: ^bb1, ^bb2
+// CHECK:           llvm.br ^bb2
+// CHECK:         ^bb2:  // 2 preds: ^bb0, ^bb1
 // CHECK:           [[VAR_3_3_:%.+]] = llvm.mlir.addressof @_entry_point_arrays : !llvm.ptr<array<2 x ptr<i8>>>
 // CHECK:           [[VAR_4_4_:%.+]] = llvm.bitcast [[VAR_3_3_]] : !llvm.ptr<array<2 x ptr<i8>>> to !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.return [[VAR_4_4_]] : !llvm.ptr<ptr<i8>>
@@ -61,13 +59,11 @@ module {
 // CHECK:           [[VAR_9_1_:%.+]] = llvm.mlir.addressof @_entry_point_0_in_sig : !llvm.ptr<array<9 x i8>>
 // CHECK:           [[VAR_10_1_:%.+]] = llvm.bitcast [[VAR_9_1_]] : !llvm.ptr<array<9 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.store [[VAR_10_1_]], [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.br ^bb3
+// CHECK:           [[VAR_12_1_:%.+]] = llvm.load [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr<i8>
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_11_1_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_11_1_]] : !llvm.ptr<i8>
-// CHECK:         ^bb3:  // pred: ^bb1
-// CHECK:           [[VAR_12_1_:%.+]] = llvm.load [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr<i8>
 // CHECK:         }
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
@@ -87,13 +83,11 @@ module {
 // CHECK:           [[VAR_9_2_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr<array<10 x i8>>
 // CHECK:           [[VAR_10_2_:%.+]] = llvm.bitcast [[VAR_9_2_]] : !llvm.ptr<array<10 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.store [[VAR_10_2_]], [[VAR_2_6_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.br ^bb3
+// CHECK:           [[VAR_12_1_:%.+]] = llvm.load [[VAR_2_6_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr<i8>
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_11_2_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_11_2_]] : !llvm.ptr<i8>
-// CHECK:         ^bb3:  // pred: ^bb1
-// CHECK:           [[VAR_12_1_:%.+]] = llvm.load [[VAR_2_6_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr<i8>
 // CHECK:         }
 
 }
@@ -147,10 +141,8 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_2_14_:%.+]] = llvm.mlir.constant(2 : i64) : i64
 // CHECK:           llvm.store [[VAR_2_14_]], [[arg0_]] : !llvm.ptr<i64>
-// CHECK:           llvm.br ^bb3
-// CHECK:         ^bb2:  // pred: ^bb0
-// CHECK:           llvm.br ^bb3
-// CHECK:         ^bb3:  // 2 preds: ^bb1, ^bb2
+// CHECK:           llvm.br ^bb2
+// CHECK:         ^bb2:  // 2 preds: ^bb0, ^bb1
 // CHECK:           [[VAR_3_11_:%.+]] = llvm.mlir.addressof @_entry_point_arrays : !llvm.ptr<array<3 x ptr<i8>>>
 // CHECK:           [[VAR_4_14_:%.+]] = llvm.bitcast [[VAR_3_11_]] : !llvm.ptr<array<3 x ptr<i8>>> to !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.return [[VAR_4_14_]] : !llvm.ptr<ptr<i8>>
@@ -173,7 +165,8 @@ module {
 // CHECK:           [[VAR_9_6_:%.+]] = llvm.mlir.addressof @_entry_point_0_in_sig : !llvm.ptr<array<11 x i8>>
 // CHECK:           [[VAR_10_6_:%.+]] = llvm.bitcast [[VAR_9_6_]] : !llvm.ptr<array<11 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.store [[VAR_10_6_]], [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.br ^bb5
+// CHECK:           [[VAR_20_2_:%.+]] = llvm.load [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_20_2_]] : !llvm.ptr<i8>
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK-DAG:       [[VAR_11_5_:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       [[VAR_12_4_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr<array<17 x i8>>
@@ -187,13 +180,11 @@ module {
 // CHECK:           [[VAR_17_3_:%.+]] = llvm.mlir.addressof @_entry_point_1_in_sig : !llvm.ptr<array<11 x i8>>
 // CHECK:           [[LOAD_VAR_2_3_MEM_1_1_:%.+]] = llvm.bitcast [[VAR_17_3_]] : !llvm.ptr<array<11 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.store [[LOAD_VAR_2_3_MEM_1_1_]], [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.br ^bb5
+// CHECK:           [[VAR_20_2_:%.+]] = llvm.load [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_20_2_]] : !llvm.ptr<i8>
 // CHECK:         ^bb4:  // pred: ^bb2
 // CHECK:           [[VAR_19_3_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_19_3_]] : !llvm.ptr<i8>
-// CHECK:         ^bb5:  // 2 preds: ^bb1, ^bb3
-// CHECK:           [[VAR_20_2_:%.+]] = llvm.load [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_20_2_]] : !llvm.ptr<i8>
 // CHECK:         }
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
@@ -213,7 +204,8 @@ module {
 // CHECK:           [[VAR_9_7_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr<array<12 x i8>>
 // CHECK:           [[VAR_10_7_:%.+]] = llvm.bitcast [[VAR_9_7_]] : !llvm.ptr<array<12 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.store [[VAR_10_7_]], [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.br ^bb5
+// CHECK:           [[VAR_20_2_1_:%.+]] = llvm.load [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_20_2_1_]] : !llvm.ptr<i8>
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK-DAG:       [[VAR_11_6_:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       [[VAR_12_5_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr<array<17 x i8>>
@@ -227,13 +219,11 @@ module {
 // CHECK:           [[VAR_17_4_:%.+]] = llvm.mlir.addressof @_entry_point_1_out_sig : !llvm.ptr<array<12 x i8>>
 // CHECK:           [[LOAD_VAR_2_3_MEM_1_1_:%.+]] = llvm.bitcast [[VAR_17_4_]] : !llvm.ptr<array<12 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.store [[LOAD_VAR_2_3_MEM_1_1_]], [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.br ^bb5
+// CHECK:           [[VAR_20_2_1_:%.+]] = llvm.load [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_20_2_1_]] : !llvm.ptr<i8>
 // CHECK:         ^bb4:  // pred: ^bb2
 // CHECK:           [[VAR_19_4_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_19_4_]] : !llvm.ptr<i8>
-// CHECK:         ^bb5:  // 2 preds: ^bb1, ^bb3
-// CHECK:           [[VAR_20_2_1_:%.+]] = llvm.load [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_20_2_1_]] : !llvm.ptr<i8>
 // CHECK:         }
 }
 

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -44,12 +44,8 @@ module {
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_4_:%.+]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:       [[VAR_1_5_:%.+]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_5_:%.+]] = llvm.alloca [[VAR_1_5_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
 // CHECK-DAG:       [[VAR_3_4_:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       [[VAR_4_5_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
-// CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_5_4_:%.+]] = llvm.getelementptr [[VAR_4_5_]]{{.}}[[VAR_3_4_]], [[VAR_3_4_]]{{.}} : (!llvm.ptr<array<15 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[VAR_6_3_:%.+]] = llvm.mlir.constant(15 : i64) : i64
 // CHECK:           [[VAR_7_1_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_4_]], [[VAR_6_3_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
@@ -58,9 +54,7 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_9_1_:%.+]] = llvm.mlir.addressof @_entry_point_0_in_sig : !llvm.ptr<array<9 x i8>>
 // CHECK:           [[VAR_10_1_:%.+]] = llvm.bitcast [[VAR_9_1_]] : !llvm.ptr<array<9 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[VAR_10_1_]], [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           [[VAR_12_1_:%.+]] = llvm.load [[VAR_2_5_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_10_1_]] : !llvm.ptr<i8>
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_11_1_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_11_1_]] : !llvm.ptr<i8>
@@ -68,12 +62,8 @@ module {
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_5_:%.+]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:       [[VAR_1_6_:%.+]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_6_:%.+]] = llvm.alloca [[VAR_1_6_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
 // CHECK-DAG:       [[VAR_3_5_:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       [[VAR_4_6_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
-// CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_5_5_:%.+]] = llvm.getelementptr [[VAR_4_6_]]{{.}}[[VAR_3_5_]], [[VAR_3_5_]]{{.}} : (!llvm.ptr<array<15 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[VAR_6_4_:%.+]] = llvm.mlir.constant(15 : i64) : i64
 // CHECK:           [[VAR_7_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_5_]], [[VAR_6_4_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
@@ -82,9 +72,7 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_9_2_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr<array<10 x i8>>
 // CHECK:           [[VAR_10_2_:%.+]] = llvm.bitcast [[VAR_9_2_]] : !llvm.ptr<array<10 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[VAR_10_2_]], [[VAR_2_6_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           [[VAR_12_1_:%.+]] = llvm.load [[VAR_2_6_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_12_1_]] : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_10_2_]] : !llvm.ptr<i8>
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_11_2_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_11_2_]] : !llvm.ptr<i8>
@@ -150,12 +138,8 @@ module {
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_12_:%.+]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:       [[VAR_1_15_:%.+]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_15_:%.+]] = llvm.alloca [[VAR_1_15_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
 // CHECK-DAG:       [[VAR_3_12_:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       [[VAR_4_15_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
-// CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_5_13_:%.+]] = llvm.getelementptr [[VAR_4_15_]]{{.}}[[VAR_3_12_]], [[VAR_3_12_]]{{.}} : (!llvm.ptr<array<16 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[VAR_6_10_:%.+]] = llvm.mlir.constant(16 : i64) : i64
 // CHECK:           [[VAR_7_6_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_13_]], [[VAR_6_10_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
@@ -164,9 +148,7 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_9_6_:%.+]] = llvm.mlir.addressof @_entry_point_0_in_sig : !llvm.ptr<array<11 x i8>>
 // CHECK:           [[VAR_10_6_:%.+]] = llvm.bitcast [[VAR_9_6_]] : !llvm.ptr<array<11 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[VAR_10_6_]], [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           [[VAR_20_2_:%.+]] = llvm.load [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_20_2_]] : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_10_6_]] : !llvm.ptr<i8>
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK-DAG:       [[VAR_11_5_:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       [[VAR_12_4_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr<array<17 x i8>>
@@ -179,9 +161,7 @@ module {
 // CHECK:         ^bb3:  // pred: ^bb2
 // CHECK:           [[VAR_17_3_:%.+]] = llvm.mlir.addressof @_entry_point_1_in_sig : !llvm.ptr<array<11 x i8>>
 // CHECK:           [[LOAD_VAR_2_3_MEM_1_1_:%.+]] = llvm.bitcast [[VAR_17_3_]] : !llvm.ptr<array<11 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[LOAD_VAR_2_3_MEM_1_1_]], [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           [[VAR_20_2_:%.+]] = llvm.load [[VAR_2_15_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_20_2_]] : !llvm.ptr<i8>
+// CHECK:           llvm.return [[LOAD_VAR_2_3_MEM_1_1_]] : !llvm.ptr<i8>
 // CHECK:         ^bb4:  // pred: ^bb2
 // CHECK:           [[VAR_19_3_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_19_3_]] : !llvm.ptr<i8>
@@ -189,12 +169,8 @@ module {
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_13_:%.+]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:       [[VAR_1_16_:%.+]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_2_16_:%.+]] = llvm.alloca [[VAR_1_16_]] x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
 // CHECK-DAG:       [[VAR_3_13_:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       [[VAR_4_16_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
-// CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_5_14_:%.+]] = llvm.getelementptr [[VAR_4_16_]]{{.}}[[VAR_3_13_]], [[VAR_3_13_]]{{.}} : (!llvm.ptr<array<16 x i8>>, i64, i64) -> !llvm.ptr<i8>
 // CHECK-DAG:       [[VAR_6_11_:%.+]] = llvm.mlir.constant(16 : i64) : i64
 // CHECK:           [[VAR_7_7_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_14_]], [[VAR_6_11_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
@@ -203,9 +179,7 @@ module {
 // CHECK:         ^bb1:  // pred: ^bb0
 // CHECK:           [[VAR_9_7_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr<array<12 x i8>>
 // CHECK:           [[VAR_10_7_:%.+]] = llvm.bitcast [[VAR_9_7_]] : !llvm.ptr<array<12 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[VAR_10_7_]], [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           [[VAR_20_2_1_:%.+]] = llvm.load [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_20_2_1_]] : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_10_7_]] : !llvm.ptr<i8>
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK-DAG:       [[VAR_11_6_:%.+]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       [[VAR_12_5_:%.+]] = llvm.mlir.addressof @_entry_point_1 : !llvm.ptr<array<17 x i8>>
@@ -218,9 +192,7 @@ module {
 // CHECK:         ^bb3:  // pred: ^bb2
 // CHECK:           [[VAR_17_4_:%.+]] = llvm.mlir.addressof @_entry_point_1_out_sig : !llvm.ptr<array<12 x i8>>
 // CHECK:           [[LOAD_VAR_2_3_MEM_1_1_:%.+]] = llvm.bitcast [[VAR_17_4_]] : !llvm.ptr<array<12 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.store [[LOAD_VAR_2_3_MEM_1_1_]], [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           [[VAR_20_2_1_:%.+]] = llvm.load [[VAR_2_16_]] : !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_20_2_1_]] : !llvm.ptr<i8>
+// CHECK:           llvm.return [[LOAD_VAR_2_3_MEM_1_1_]] : !llvm.ptr<i8>
 // CHECK:         ^bb4:  // pred: ^bb2
 // CHECK:           [[VAR_19_4_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_19_4_]] : !llvm.ptr<i8>

--- a/test/mlir/krnl/input_verification.mlir
+++ b/test/mlir/krnl/input_verification.mlir
@@ -5,7 +5,7 @@ module {
   func @main_graph(%arg0: memref<3x4x5xf32>, %arg1: memref<?x4x5xf32>) -> memref<3x4x5xf32> {
     return %arg0 : memref<3x4x5xf32>
   }
-  "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 1 : i32, signature = "[    { \22type\22 : \22f32\22 , \22dims\22 : [3 , 4 , 5] , \22name\22 : \22input0\22 }\0A ,    { \22type\22 : \22f32\22 , \22dims\22 : [3 , 4 , 5] , \22name\22 : \22input1\22 }\0A\0A]\00@[   { \22type\22 : \22f32\22 , \22dims\22 : [? , 4 , 5] , \22name\22 : \22output0\22 }\0A\0A]\00"} : () -> ()
+  "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 1 : i32, signature = "[    { \22type\22 : \22f32\22 , \22dims\22 : [3 , 4 , 5] , \22name\22 : \22input0\22 }\0A ,    { \22type\22 : \22f32\22 , \22dims\22 : [-1 , 4 , 5] , \22name\22 : \22input1\22 }\0A\0A]\00@[   { \22type\22 : \22f32\22 , \22dims\22 : [3 , 4 , 5] , \22name\22 : \22output0\22 }\0A\0A]\00"} : () -> ()
 
 // CHECK-LABEL:   llvm.func @run_main_graph(
 // CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
@@ -60,15 +60,15 @@ module {
 //
 // CHECK:         ^bb6:
 // CHECK-DAG:       %[[VAL_30:.*]] = llvm.call @omTensorGetShape(%[[VAL_11]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i64>
-// CHECK-DAG:       %[[VAL_31:.*]] = llvm.mlir.constant(3 : i64) : i64
-// CHECK-DAG:       %[[VAL_32:.*]] = llvm.load %[[VAL_30]] : !llvm.ptr<i64>
-// CHECK:           %[[VAL_33:.*]] = llvm.icmp "ne" %[[VAL_31]], %[[VAL_32]] : i64
+// CHECK-DAG:       %[[VAL_31:.*]] = llvm.load %[[VAL_30]] : !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_32:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-DAG:       %[[VAL_33:.*]] = llvm.icmp "ne" %[[VAL_32]], %[[VAL_31]] : i64
 // CHECK:           llvm.cond_br %[[VAL_33]], ^bb7, ^bb8
 // CHECK:         ^bb7:
 // CHECK-DAG:       %[[VAL_34:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 0 of the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_35:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       %[[VAL_36:.*]] = llvm.getelementptr %[[VAL_34]]{{\[}}%[[VAL_35]], %[[VAL_35]]] : (!llvm.ptr<array<70 x i8>>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           llvm.call @printf(%[[VAL_36]], %[[VAL_32]]) : (!llvm.ptr<i8>, i64) -> ()
+// CHECK:           llvm.call @printf(%[[VAL_36]], %[[VAL_31]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_37:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       %[[VAL_38:.*]] = llvm.mlir.constant(22 : i32) : i32
 // CHECK-DAG:       llvm.store %[[VAL_38]], %[[VAL_37]] : !llvm.ptr<i32>
@@ -77,16 +77,16 @@ module {
 //
 // CHECK:         ^bb8:
 // CHECK-DAG:       %[[VAL_40:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-DAG:       %[[VAL_41:.*]] = llvm.mlir.constant(4 : i64) : i64
-// CHECK-DAG:       %[[VAL_42:.*]] = llvm.getelementptr %[[VAL_30]]{{\[}}%[[VAL_40]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-// CHECK-DAG:       %[[VAL_43:.*]] = llvm.load %[[VAL_42]] : !llvm.ptr<i64>
-// CHECK:           %[[VAL_44:.*]] = llvm.icmp "ne" %[[VAL_41]], %[[VAL_43]] : i64
+// CHECK-DAG:       %[[VAL_41:.*]] = llvm.getelementptr %[[VAL_30]]{{\[}}%[[VAL_40]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_42:.*]] = llvm.load %[[VAL_41]] : !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_43:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK-DAG:       %[[VAL_44:.*]] = llvm.icmp "ne" %[[VAL_43]], %[[VAL_42]] : i64
 // CHECK:           llvm.cond_br %[[VAL_44]], ^bb9, ^bb10
 // CHECK:         ^bb9:
 // CHECK-DAG:       %[[VAL_45:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 1 of the input 0: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_46:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       %[[VAL_47:.*]] = llvm.getelementptr %[[VAL_45]]{{\[}}%[[VAL_46]], %[[VAL_46]]] : (!llvm.ptr<array<70 x i8>>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           llvm.call @printf(%[[VAL_47]], %[[VAL_43]]) : (!llvm.ptr<i8>, i64) -> ()
+// CHECK:           llvm.call @printf(%[[VAL_47]], %[[VAL_42]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_48:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       %[[VAL_49:.*]] = llvm.mlir.constant(22 : i32) : i32
 // CHECK-DAG:       llvm.store %[[VAL_49]], %[[VAL_48]] : !llvm.ptr<i32>
@@ -95,16 +95,16 @@ module {
 //
 // CHECK:         ^bb10:
 // CHECK-DAG:       %[[VAL_51:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-DAG:       %[[VAL_52:.*]] = llvm.mlir.constant(5 : i64) : i64
-// CHECK-DAG:       %[[VAL_53:.*]] = llvm.getelementptr %[[VAL_30]]{{\[}}%[[VAL_51]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-// CHECK-DAG:       %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr<i64>
-// CHECK:           %[[VAL_55:.*]] = llvm.icmp "ne" %[[VAL_52]], %[[VAL_54]] : i64
+// CHECK-DAG:       %[[VAL_52:.*]] = llvm.getelementptr %[[VAL_30]]{{\[}}%[[VAL_51]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_53:.*]] = llvm.load %[[VAL_52]] : !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_54:.*]] = llvm.mlir.constant(5 : i64) : i64
+// CHECK-DAG:       %[[VAL_55:.*]] = llvm.icmp "ne" %[[VAL_54]], %[[VAL_53]] : i64
 // CHECK:           llvm.cond_br %[[VAL_55]], ^bb11, ^bb12
 // CHECK:         ^bb11:
 // CHECK-DAG:       %[[VAL_56:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 2 of the input 0: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_57:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       %[[VAL_58:.*]] = llvm.getelementptr %[[VAL_56]]{{\[}}%[[VAL_57]], %[[VAL_57]]] : (!llvm.ptr<array<70 x i8>>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           llvm.call @printf(%[[VAL_58]], %[[VAL_54]]) : (!llvm.ptr<i8>, i64) -> ()
+// CHECK:           llvm.call @printf(%[[VAL_58]], %[[VAL_53]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_59:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       %[[VAL_60:.*]] = llvm.mlir.constant(22 : i32) : i32
 // CHECK-DAG:       llvm.store %[[VAL_60]], %[[VAL_59]] : !llvm.ptr<i32>
@@ -133,7 +133,7 @@ module {
 // CHECK:         ^bb14:
 // CHECK-DAG:       %[[VAL_74:.*]] = llvm.mlir.constant(3 : i64) : i64
 // CHECK-DAG:       %[[VAL_75:.*]] = llvm.call @omTensorGetRank(%[[VAL_64]]) : (!llvm.ptr<i8>) -> i64
-// CHECK:           %[[VAL_76:.*]] = llvm.icmp "ne" %[[VAL_74]], %[[VAL_75]] : i64
+// CHECK-DAG:       %[[VAL_76:.*]] = llvm.icmp "ne" %[[VAL_74]], %[[VAL_75]] : i64
 // CHECK:           llvm.cond_br %[[VAL_76]], ^bb15, ^bb16
 // CHECK:         ^bb15:
 // CHECK-DAG:       %[[VAL_77:.*]] = llvm.mlir.addressof @"Wrong rank for the input 1: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
@@ -147,16 +147,16 @@ module {
 // CHECK:           llvm.return %[[VAL_82]] : !llvm.ptr<i8>
 //
 // CHECK:         ^bb16:
-// CHECK-DAG:       %[[VAL_83:.*]] = llvm.call @omTensorGetShape(%[[VAL_64]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i64>
-// CHECK-DAG:       %[[VAL_84:.*]] = llvm.mlir.constant(3 : i64) : i64
-// CHECK-DAG:       %[[VAL_85:.*]] = llvm.load %[[VAL_83]] : !llvm.ptr<i64>
-// CHECK:           %[[VAL_86:.*]] = llvm.icmp "ne" %[[VAL_84]], %[[VAL_85]] : i64
+// CHECK:           %[[VAL_83:.*]] = llvm.call @omTensorGetShape(%[[VAL_64]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_84:.*]] = llvm.load %[[VAL_83]] : !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_85:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-DAG:       %[[VAL_86:.*]] = llvm.icmp "slt" %[[VAL_84]], %[[VAL_85]] : i64
 // CHECK:           llvm.cond_br %[[VAL_86]], ^bb17, ^bb18
 // CHECK:         ^bb17:
-// CHECK-DAG:       %[[VAL_87:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 0 of the input 1: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
+// CHECK-DAG:       %[[VAL_87:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 0 of the input 1: expect a non-negative value\0A" : !llvm.ptr<array<75 x i8>>
 // CHECK-DAG:       %[[VAL_88:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-DAG:       %[[VAL_89:.*]] = llvm.getelementptr %[[VAL_87]]{{\[}}%[[VAL_88]], %[[VAL_88]]] : (!llvm.ptr<array<70 x i8>>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           llvm.call @printf(%[[VAL_89]], %[[VAL_85]]) : (!llvm.ptr<i8>, i64) -> ()
+// CHECK-DAG:       %[[VAL_89:.*]] = llvm.getelementptr %[[VAL_87]]{{\[}}%[[VAL_88]], %[[VAL_88]]] : (!llvm.ptr<array<75 x i8>>, i64, i64) -> !llvm.ptr<i8>
+// CHECK:           llvm.call @printf(%[[VAL_89]]) : (!llvm.ptr<i8>) -> ()
 // CHECK-DAG:       %[[VAL_90:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       %[[VAL_91:.*]] = llvm.mlir.constant(22 : i32) : i32
 // CHECK-DAG:       llvm.store %[[VAL_91]], %[[VAL_90]] : !llvm.ptr<i32>
@@ -165,16 +165,16 @@ module {
 //
 // CHECK:         ^bb18:
 // CHECK-DAG:       %[[VAL_93:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-DAG:       %[[VAL_94:.*]] = llvm.mlir.constant(4 : i64) : i64
-// CHECK-DAG:       %[[VAL_95:.*]] = llvm.getelementptr %[[VAL_83]]{{\[}}%[[VAL_93]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-// CHECK-DAG:       %[[VAL_96:.*]] = llvm.load %[[VAL_95]] : !llvm.ptr<i64>
-// CHECK:           %[[VAL_97:.*]] = llvm.icmp "ne" %[[VAL_94]], %[[VAL_96]] : i64
+// CHECK-DAG:       %[[VAL_94:.*]] = llvm.getelementptr %[[VAL_83]]{{\[}}%[[VAL_93]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_95:.*]] = llvm.load %[[VAL_94]] : !llvm.ptr<i64>
+// CHECK-DAG:       %[[VAL_96:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK-DAG:       %[[VAL_97:.*]] = llvm.icmp "ne" %[[VAL_96]], %[[VAL_95]] : i64
 // CHECK:           llvm.cond_br %[[VAL_97]], ^bb19, ^bb20
 // CHECK:         ^bb19:
 // CHECK-DAG:       %[[VAL_98:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 1 of the input 1: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_99:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       %[[VAL_100:.*]] = llvm.getelementptr %[[VAL_98]]{{\[}}%[[VAL_99]], %[[VAL_99]]] : (!llvm.ptr<array<70 x i8>>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           llvm.call @printf(%[[VAL_100]], %[[VAL_96]]) : (!llvm.ptr<i8>, i64) -> ()
+// CHECK:           llvm.call @printf(%[[VAL_100]], %[[VAL_95]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_101:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       %[[VAL_102:.*]] = llvm.mlir.constant(22 : i32) : i32
 // CHECK-DAG:       llvm.store %[[VAL_102]], %[[VAL_101]] : !llvm.ptr<i32>
@@ -182,17 +182,17 @@ module {
 // CHECK:           llvm.return %[[VAL_103]] : !llvm.ptr<i8>
 //
 // CHECK:         ^bb20:
-// CHECK-DAG:       %[[VAL_104:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-DAG:       %[[VAL_105:.*]] = llvm.mlir.constant(5 : i64) : i64
-// CHECK-DAG:       %[[VAL_106:.*]] = llvm.getelementptr %[[VAL_83]]{{\[}}%[[VAL_104]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-// CHECK-DAG:       %[[VAL_107:.*]] = llvm.load %[[VAL_106]] : !llvm.ptr<i64>
-// CHECK:           %[[VAL_108:.*]] = llvm.icmp "ne" %[[VAL_105]], %[[VAL_107]] : i64
+// CHECK-DAG:      %[[VAL_104:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-DAG:      %[[VAL_105:.*]] = llvm.getelementptr %[[VAL_83]]{{\[}}%[[VAL_104]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK-DAG:      %[[VAL_106:.*]] = llvm.load %[[VAL_105]] : !llvm.ptr<i64>
+// CHECK-DAG:      %[[VAL_107:.*]] = llvm.mlir.constant(5 : i64) : i64
+// CHECK-DAG:      %[[VAL_108:.*]] = llvm.icmp "ne" %[[VAL_107]], %[[VAL_106]] : i64
 // CHECK:           llvm.cond_br %[[VAL_108]], ^bb21, ^bb22
 // CHECK:         ^bb21:
 // CHECK-DAG:       %[[VAL_109:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 2 of the input 1: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_110:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       %[[VAL_111:.*]] = llvm.getelementptr %[[VAL_109]]{{\[}}%[[VAL_110]], %[[VAL_110]]] : (!llvm.ptr<array<70 x i8>>, i64, i64) -> !llvm.ptr<i8>
-// CHECK:           llvm.call @printf(%[[VAL_111]], %[[VAL_107]]) : (!llvm.ptr<i8>, i64) -> ()
+// CHECK:           llvm.call @printf(%[[VAL_111]], %[[VAL_106]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_112:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       %[[VAL_113:.*]] = llvm.mlir.constant(22 : i32) : i32
 // CHECK-DAG:       llvm.store %[[VAL_113]], %[[VAL_112]] : !llvm.ptr<i32>


### PR DESCRIPTION
Thi patch continues PR #1498 and creates a helper function IfThenElse in LLVMBuilder.

This patch also adds a check to verify non-negative dimensions of the input tensors, reported here #1506

Signed-off-by: Tung D. Le <tung@jp.ibm.com>