### PR TITLE
Update t5-encoder model accoring to the latest onnx model zoo

### DIFF
--- a/utils/RunONNXModelZoo.py
+++ b/utils/RunONNXModelZoo.py
@@ -202,9 +202,8 @@ int8_models = {
 excluded_models = deprecated_models.union(int8_models)
 
 # Additional information passed to RunONNXModel.py.
+# For example: "t5-encoder-12": ['--shape-info=0:1x2,1:1x2x768']
 RunONNXModel_additional_options = {
-    "t5-decoder-with-lm-head-12": ['--shape-info=0:1x2,1:1x2x768'],
-    "t5-encoder-12": ['--shape-info=0:1x2,1:1x2x768']
 }
 
 # States


### PR DESCRIPTION
[A recent commit in onnx](https://github.com/onnx/models/pull/534) updates some broken test_data_sets including `t5-decoder-with-lm-head-12`, `t5-encoder-12`.

This patch updates the configuration for `t5-decoder-with-lm-head-12`, `t5-encoder-12` to use the provided test_data_set instead of randomly generate input data by passing shape_info.

With this patch, `t5-decoder-with-lm-head-12`, `t5-encoder-12` are now passed.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>