### PR TITLE
Elide constant operations by setting elideLargeElementsAttrs of OpPrintingFlags

### DIFF
--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -48,8 +48,8 @@ onnx_mlir::InputIRLevelType determineInputIRLevel(
     mlir::OwningOpRef<mlir::ModuleOp> &module);
 
 // Returns 0 on success, OnnxMlirCompilerErrorCodes on failure.
-int outputCode(
-    mlir::OwningOpRef<mlir::ModuleOp> &module, std::string filenameWithExt);
+int outputCode(mlir::OwningOpRef<mlir::ModuleOp> &module,
+    std::string filenameWithExt, int64_t largeElementLimit = -1);
 
 // Process the input model given by its module and context into an output file
 // according to the emission target type. Name of the output file can be


### PR DESCRIPTION
When using `--EmitONNXBasic`, `--EmitONNXIR`, `--EmitMLIR`, a `.tmp` file is generated where ONNXConstantOp and KrnlGlobalOp are elided so that the generated file is small and easy to examine. However, the current approach is specific to ONNXConstantOp and KrnlGlobalOp, which is not scalable if, say, an accelerator has a new kind of constant op.

This patch uses another approach that just simply set the flag `elideLargeElementsAttrs` of OpPrintingFlags, so that all Attribute (no matter of which operation) will be elided. It should work for every operation.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>