### PR TITLE
[NNPA] Run Conv2D on CPU when input parameters are C != 1, kH = 1, kW=1

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -850,7 +850,7 @@ bool isSuitableForZDNN<ONNXConvOp>(ONNXConvOp op) {
     return false;
 
   // Workaround for issue #1517 Accuracy issue  at C != 1, kH = 1, kW=1
-  if (inputShapeC > 1 && kernelShapeH == 1 && kernelShapeW == 1)
+  if (inputShapeC != 1 && kernelShapeH == 1 && kernelShapeW == 1)
     return false;
 
   return true;

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -849,7 +849,9 @@ bool isSuitableForZDNN<ONNXConvOp>(ONNXConvOp op) {
   if (!isWOK)
     return false;
 
-  // Workaround for issue #1517 Accuracy issue  at C != 1, kH = 1, kW=1
+  // Currently disable the generation of Conv2D when parameters are C != 1, kH =
+  // 1, kW=1 because of current issue #1517.  When fixed, please remove lit test
+  // test_onnx_conv2d_not_lowered_c_not_1_kernel11.
   if (inputShapeC != 1 && kernelShapeH == 1 && kernelShapeW == 1)
     return false;
 

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -829,6 +829,7 @@ bool isSuitableForZDNN<ONNXConvOp>(ONNXConvOp op) {
           [](IndexExpr val) { return !val.isLiteral(); }))
     return false;
 
+  int64_t inputShapeC = shapeInput[1];
   int64_t inputShapeH = shapeInput[2];
   int64_t inputShapeW = shapeInput[3];
   int64_t outputShapeH = shapeOutput[2];
@@ -846,6 +847,10 @@ bool isSuitableForZDNN<ONNXConvOp>(ONNXConvOp op) {
   bool isWOK = checkConv2DParamRestrictions(
       inputShapeW, kernelShapeW, stridesW, outputShapeW, paddingType);
   if (!isWOK)
+    return false;
+
+  // Workaround for issue #1517 Accuracy issue  at C != 1, kH = 1, kW=1
+  if (inputShapeC > 1 && kernelShapeH == 1 && kernelShapeW == 1)
     return false;
 
   return true;

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
@@ -91,8 +91,8 @@ func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tenso
 
 // -----
 
-func @test_onnx_conv2d_valid_padding_H_equal_KW(%arg0: tensor<?x1280x1x1xf32>, %arg1: tensor<448x1280x1x1xf32>, %arg2: tensor<448xf32>) -> tensor<*xf32> {
-    %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<?x1280x1x1xf32>, tensor<448x1280x1x1xf32>, tensor<448xf32>) -> tensor<*xf32>
+func @test_onnx_conv2d_valid_padding_H_equal_KW(%arg0: tensor<?x1280x2x2xf32>, %arg1: tensor<448x1280x2x2xf32>, %arg2: tensor<448xf32>) -> tensor<*xf32> {
+    %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<?x1280x2x2xf32>, tensor<448x1280x2x2xf32>, tensor<448xf32>) -> tensor<*xf32>
     return %0 : tensor<*xf32>
   // CHECK-LABEL: test_onnx_conv2d_valid_padding_H_equal_KW
   // CHECK: "zhigh.Conv2D"
@@ -224,4 +224,16 @@ func @test_exceed_limit_conv2d(%arg0: tensor<32769x3x32x32xf32>, %arg1 : tensor<
 
 // CHECK-LABEL:  func @test_exceed_limit_conv2d
 // CHECK:        "onnx.Conv"
+}
+
+// -----
+
+/// COM: Workaround for issue #1517
+/// COM: Not lowered to zhigh when C != 1, kH = 1, and kW = 1
+func @test_onnx_conv2d_not_lowered_c_not_1_kernel11(%arg0: tensor<5x3x32x32xf32>, %arg1 : tensor<2x3x1x1xf32>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {kernel_shape = [1, 1]} : (tensor<5x3x32x32xf32>, tensor<2x3x1x1xf32>, tensor<2xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+  // CHECK-LABEL: test_onnx_conv2d_not_lowered_c_not_1_kernel11
+  // CHECK: "onnx.Conv"
 }


### PR DESCRIPTION
As written in  issue #1517 , we get wrong results on NNPA at C(the number of channels) != 1,  kernel height = 1, and kernel width = 1.  This PR avoids this issue by running CPU instead of NNPA when using the parameter. 

Signed-off-by: Haruki Imai <imaihal@jp.ibm.com>