### PR TITLE
[NNPA] Update CMakeLists.txt for backend tests for NNPA

### DIFF
--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -24,6 +24,11 @@ file(GENERATE
   )
 
 file(GENERATE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/input_verification_backend.py
+  INPUT ${ONNX_BACKENDTEST_SRC_DIR}/input_verification_backend.py
+  )
+
+file(GENERATE
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/variables.py
   INPUT ${ONNX_BACKENDTEST_SRC_DIR}/variables.py
   )


### PR DESCRIPTION
This PR updates CMakeLists.txt for backend tests for NNPA to catch up with update in PR https://github.com/onnx/onnx-mlir/pull/1472

No need to run input verification test on NNPA, but we needed to copy `input_verification_backend.py` to use `test/backend/test.py` for NNPA.