### PR TITLE
Initial omp support

### DIFF
--- a/docker/Dockerfile.llvm-project
+++ b/docker/Dockerfile.llvm-project
@@ -97,3 +97,4 @@ RUN git clone -n https://github.com/llvm/llvm-project.git \
     && echo "llvm-project commit $(git rev-parse HEAD) successfully built"
 
 LABEL llvm_project_successfully_built=yes
+vvvvvvvv

--- a/docker/Dockerfile.llvm-project
+++ b/docker/Dockerfile.llvm-project
@@ -84,11 +84,12 @@ RUN git clone -n https://github.com/llvm/llvm-project.git \
     && git checkout ${LLVM_PROJECT_SHA1} \
     && mkdir -p build && cd build \
     && cmake -G Ninja ../llvm \
-             -DLLVM_ENABLE_PROJECTS=mlir \
+             -DLLVM_ENABLE_PROJECTS="clang;mlir" \
              -DLLVM_TARGETS_TO_BUILD="host" \
              -DCMAKE_BUILD_TYPE=Release \
              -DLLVM_ENABLE_ASSERTIONS=ON \
              -DLLVM_ENABLE_RTTI=ON \
+             -DLLVM_ENABLE_RUNTIMES="openmp" \
              -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
     && cmake --build . --parallel ${NPROC} -- ${MAKEFLAGS} \
     && (cmake --build . --parallel ${NPROC} --target check-mlir || \
@@ -97,4 +98,3 @@ RUN git clone -n https://github.com/llvm/llvm-project.git \
     && echo "llvm-project commit $(git rev-parse HEAD) successfully built"
 
 LABEL llvm_project_successfully_built=yes
-vvvvvvvv

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -1,4 +1,4 @@
-<!--- SPDX-License-Identifier: Apache-2.0 -->
+<!--- SPDX-License-Identifier: Apache-2.0 --> xxxx
 
 # Installation of ONNX-MLIR on Linux / OSX
 

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -1,4 +1,4 @@
-<!--- SPDX-License-Identifier: Apache-2.0 --> xxxx
+<!--- SPDX-License-Identifier: Apache-2.0 -->
 
 # Installation of ONNX-MLIR on Linux / OSX
 
@@ -22,11 +22,12 @@ cd llvm-project && git checkout 9778ec057cf4214241e4a970f3e764e3cf150181 && cd .
 mkdir llvm-project/build
 cd llvm-project/build
 cmake -G Ninja ../llvm \
-   -DLLVM_ENABLE_PROJECTS=mlir \
+   -DLLVM_ENABLE_PROJECTS="clang;mlir" \
    -DLLVM_TARGETS_TO_BUILD="host" \
    -DCMAKE_BUILD_TYPE=Release \
    -DLLVM_ENABLE_ASSERTIONS=ON \
-   -DLLVM_ENABLE_RTTI=ON
+   -DLLVM_ENABLE_RTTI=ON \
+   -DLLVM_ENABLE_RUNTIMES="openmp"
 
 cmake --build . -- ${MAKEFLAGS}
 cmake --build . --target check-mlir

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -1,4 +1,4 @@
-<!--- SPDX-License-Identifier: Apache-2.0 --> xxxx
+<!--- SPDX-License-Identifier: Apache-2.0 -->
 
 # Installation of ONNX-MLIR on Windows
 
@@ -63,11 +63,12 @@ md llvm-project\build
 cd llvm-project\build
 call cmake %root_dir%\llvm-project\llvm -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX="%root_dir%\llvm-project\build\install" ^
-   -DLLVM_ENABLE_PROJECTS=mlir ^
+   -DLLVM_ENABLE_PROJECTS="clang;mlir" ^
    -DLLVM_TARGETS_TO_BUILD="host" ^
    -DCMAKE_BUILD_TYPE=Release ^
    -DLLVM_ENABLE_ASSERTIONS=ON ^
    -DLLVM_ENABLE_RTTI=ON ^
+   -DLLVM_ENABLE_RUNTIMES="openmp" ^
    -DLLVM_ENABLE_ZLIB=OFF ^
    -DLLVM_INSTALL_UTILS=ON
 

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -1,4 +1,4 @@
-<!--- SPDX-License-Identifier: Apache-2.0 -->
+<!--- SPDX-License-Identifier: Apache-2.0 --> xxxx
 
 # Installation of ONNX-MLIR on Windows
 

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -135,6 +135,7 @@ add_onnx_mlir_library(CompilerUtils
   CompilerPasses
   Accelerator
   InitAccelerators
+  MLIROpenMP
   OMVersion
 
   # Link LLVM libraries necessary to query which target architectures are configured.

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -164,6 +164,12 @@ llvm::cl::opt<bool> onnxOpTransformReport("onnx-op-transform-report",
     llvm::cl::desc("Report diagnostic info for op transform passes."),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
 
+llvm::cl::opt<bool> enableParallel("parallel",
+    llvm::cl::desc(
+        "Control whether compiler will parallelize model (default=false)\n"
+        "Set to 'true' if you want to enable parallelization."),
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
+
 llvm::cl::opt<bool> verifyInputTensors("verifyInputTensors",
     llvm::cl::desc(
         "Verify input tensors whenever the entry point function is called.\n"

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -53,6 +53,7 @@ extern llvm::cl::bits<InstrumentActions> instrumentControlBits;
 extern llvm::cl::opt<bool> enableMemoryBundling;
 extern llvm::cl::opt<int> onnxOpTransformThreshold;
 extern llvm::cl::opt<bool> onnxOpTransformReport;
+extern llvm::cl::opt<bool> enableParallel;
 
 void setTargetTriple(const std::string &triple);
 void clearTargetTriple();

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -491,7 +491,7 @@ static int genSharedLib(std::string sharedLibNameWithExt,
   std::vector<std::string> outputOpt = {"-o", sharedLibNameWithExt};
   //std::vector<std::string> sharedLibOpts = {"-shared", "-fPIC"};
   std::vector<std::string> sharedLibOpts = {
-    　"-shared", "-fPIC", "-Wl,-rpath=" + getRuntimeDir()};
+    "-shared", "-fPIC", "-Wl,-rpath=" + getRuntimeDir()};
   llvm::for_each(libs, [](std::string &lib) { lib = "-l" + lib; });
   llvm::for_each(libDirs, [](std::string &libDir) { libDir = "-L" + libDir; });
 #endif

--- a/src/Conversion/KrnlToLLVM/CMakeLists.txt
+++ b/src/Conversion/KrnlToLLVM/CMakeLists.txt
@@ -30,6 +30,7 @@ add_onnx_mlir_library(OMKrnlToLLVM
   MLIRMathTransforms
   MLIRMemRefToLLVM
   MLIRMemRefTransforms
+  MLIROpenMP
   MLIRReconcileUnrealizedCasts
   MLIRSCFToControlFlow
   MLIRShapeToStandard

--- a/src/Conversion/KrnlToLLVM/CMakeLists.txt
+++ b/src/Conversion/KrnlToLLVM/CMakeLists.txt
@@ -31,6 +31,8 @@ add_onnx_mlir_library(OMKrnlToLLVM
   MLIRMemRefToLLVM
   MLIRMemRefTransforms
   MLIROpenMP
+  MLIROpenMPToLLVM
+  MLIROpenMPToLLVMIRTranslation
   MLIRReconcileUnrealizedCasts
   MLIRSCFToControlFlow
   MLIRShapeToStandard

--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -68,9 +68,11 @@ add_onnx_mlir_library(OMONNXToKrnl
 
   LINK_LIBS PUBLIC
   Accelerator
+  CompilerOptions
   OMConstPropHelper
   OMONNXOps
   OMSupport
   MLIRFunc
   MLIRFuncTransforms
+  MLIROpenMP
   )

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/SCF.h"
 
 #include "src/Accelerators/Accelerator.hpp"
@@ -318,7 +319,8 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   target
       .addLegalDialect<KrnlOpsDialect, AffineDialect, arith::ArithmeticDialect,
           func::FuncDialect, linalg::LinalgDialect, math::MathDialect,
-          memref::MemRefDialect, shape::ShapeDialect, scf::SCFDialect>();
+          memref::MemRefDialect, shape::ShapeDialect, scf::SCFDialect,
+          omp::OpenMPDialect>();
   // Needed to support unsigned int computations. To be removed if we use a
   // scheme that does not rely on the UnrealizedConversionCastOp.
   target.addLegalOp<::mlir::UnrealizedConversionCastOp>();

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -112,6 +112,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::shape::ShapeDialect>();
   registry.insert<mlir::math::MathDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
+  registry.insert<mlir::omp::OpenMPDialect>();
   registry.insert<mlir::ONNXDialect>();
   registry.insert<mlir::KrnlOpsDialect>();
   registry.insert<mlir::tosa::TosaDialect>();

--- a/utils/build-mlir.cmd
+++ b/utils/build-mlir.cmd
@@ -3,11 +3,12 @@ md llvm-project\build
 cd llvm-project\build
 call cmake %root_dir%\llvm-project\llvm -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX="%root_dir%\llvm-project\build\install" ^
-   -DLLVM_ENABLE_PROJECTS=mlir ^
+   -DLLVM_ENABLE_PROJECTS="clang;mlir" ^
    -DLLVM_TARGETS_TO_BUILD="host" ^
    -DCMAKE_BUILD_TYPE=Release ^
    -DLLVM_ENABLE_ASSERTIONS=ON ^
    -DLLVM_ENABLE_RTTI=ON ^
+   -DLLVM_ENABLE_RUNTIMES="openmp" ^
    -DLLVM_ENABLE_ZLIB=OFF ^
    -DLLVM_INSTALL_UTILS=ON
 

--- a/utils/build-mlir.sh
+++ b/utils/build-mlir.sh
@@ -1,11 +1,12 @@
 mkdir llvm-project/build
 cd llvm-project/build
 cmake -G Ninja ../llvm \
-   -DLLVM_ENABLE_PROJECTS=mlir \
+   -DLLVM_ENABLE_PROJECTS="clang;mlir" \
    -DLLVM_TARGETS_TO_BUILD="host" \
    -DCMAKE_BUILD_TYPE=Release \
    -DLLVM_ENABLE_ASSERTIONS=ON \
-   -DLLVM_ENABLE_RTTI=ON
+   -DLLVM_ENABLE_RTTI=ON \
+   -DLLVM_ENABLE_RUNTIMES="openmp"
 
 cmake --build . -- ${MAKEFLAGS}
 cmake --build . --target check-mlir


### PR DESCRIPTION
This is most of what was in PR #1233
The actual attempt to generate OpenMP code for the Loop op is not here. Loop op has changed dramatically in the interim, and anyway arbitrary Loops are not necessarily parallel, but #1233 assumed that.

I will add a use of OpenMP in a future PR.