### PR TITLE
fix(docker): pulling docker images scripts should be linux/amd64

### DIFF
--- a/docker/onnx-mlir.py
+++ b/docker/onnx-mlir.py
@@ -38,7 +38,7 @@ def main():
 
     # Pull the latest onnxmlirczar/onnx-mlir image, if image
     # is already up-to-date, pull will do nothing.
-    args = [ 'docker', 'pull', ONNX_MLIR_IMAGE ]
+    args = [ 'docker', 'pull', ONNX_MLIR_IMAGE, '--platform', 'linux/amd64' ]
     proc = subprocess.Popen(args,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)


### PR DESCRIPTION
This address running this file on m1 (arm-based machine) to pull correct image
from docker hub.

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
