### PR TITLE
Constant propagation for ONNXSliceOp

### DIFF
--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -58,6 +58,12 @@ def IsFromDenseONNXConstantOp:
     Constraint<CPred<"isFromDenseONNXConstantOp($_self)">,
   "Value is produced by a dense ONNXConstantOp">;
 
+def IsFromDenseONNXConstantOpOrNone:
+  Constraint<
+    CPred<"isFromDenseONNXConstantOp($_self) || ($_self.getType().isa<NoneType>())">,
+    "Value is none or produced by a dense ONNXConstantOp"
+  >;
+
 // Usefult code generation invokation.
 def GetNullAttr : NativeCodeCall<"Attribute()">;
 
@@ -97,6 +103,9 @@ def CreateUnsqueezeOfConst:
 
 def CreateSqueezeOfConst:
    NativeCodeCall<"ConstPropSqueeze($_builder, $0, $1)">;
+
+def CreateSliceOfConst:
+   NativeCodeCall<"ConstPropSlice($_builder, $0, $1)">;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise ADD operations.
@@ -305,7 +314,6 @@ def DivConstProp : Pat<
 // Patterns to enable opportunities with Transpose operations.
 //===----------------------------------------------------------------------===//
 
-// Neg of constant is simly -const
 def TransposeofConst :  Pat<
     // From TransposeOp(c, p)
     (ONNXTransposeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
@@ -348,5 +356,19 @@ def SqueezeV11ofConst :  Pat<
     // To c' where c' is the unsqueezed value.
     (CreateSqueezeOfConst $resOp, $input),
     [(IsFromDenseONNXConstantOp:$input)]>;
+
+//===----------------------------------------------------------------------===//
+// Patterns to enable opportunities with Slice operations.
+//===----------------------------------------------------------------------===//
+
+def SliceofConst :  Pat<
+    // From Slice (x, starts, ends, axes, steps)
+    (ONNXSliceOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_),
+                        $starts, $ends, $axes, $steps),
+    // To c' where c' is the sliced value.
+    (CreateSliceOfConst $resOp, $input),
+    [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$starts),
+     (IsFromDenseONNXConstantOp:$ends), (IsFromDenseONNXConstantOpOrNone:$axes),
+     (IsFromDenseONNXConstantOpOrNone:$steps)]>;
 
 #endif // ONNX_CONSTPROP

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -585,3 +585,39 @@ func @test_cast_i64_f32() -> tensor<3x2xf32> {
   // CHECK:           return [[VAR_0_]] : tensor<3x2xf32>
   // CHECK:         }
 }
+
+// -----
+
+func @test_slice() -> tensor<*xf32> {
+  %0 = "onnx.Constant"() {value = dense<[[2.0, 3.0], [4.0, 5.0], [6.0, 7.0]]> : tensor<3x2xf32>} : () -> tensor<3x2xf32>
+  %starts = "onnx.Constant"() {value = dense<[0, 0]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %ends = "onnx.Constant"() {value = dense<[1, 2]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %axes = "onnx.Constant"() {value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %steps = "onnx.Constant"() {value = dense<[1, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %1 = "onnx.Slice"(%0, %starts, %ends, %axes, %steps) : (tensor<3x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<*xf32>
+  "func.return"(%1) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL:  func @test_slice
+  // CHECK-SAME:   () -> tensor<1x2xf32> {
+  // CHECK:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<{{.}}[2.000000e+00, 3.000000e+00]{{.}}> : tensor<1x2xf32>} : () -> tensor<1x2xf32>
+  // CHECK:           return [[VAR_0_]] : tensor<1x2xf32>
+  // CHECK:         }
+}
+
+// -----
+
+func @test_slice_reversed() -> tensor<*xf32> {
+  %0 = "onnx.Constant"() {value = dense<[[2.0, 3.0], [4.0, 5.0], [6.0, 7.0]]> : tensor<3x2xf32>} : () -> tensor<3x2xf32>
+  %starts = "onnx.Constant"() {value = dense<[-1, 2]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %ends = "onnx.Constant"() {value = dense<[0, 0]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %axes = "onnx.Constant"() {value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %steps = "onnx.Constant"() {value = dense<[-1, -1]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %1 = "onnx.Slice"(%0, %starts, %ends, %axes, %steps) : (tensor<3x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<*xf32>
+  "func.return"(%1) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL:  func @test_slice_reversed
+  // CHECK-SAME:   () -> tensor<2x1xf32> {
+  // CHECK:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<{{.}}[7.000000e+00], [5.000000e+00]{{.}}> : tensor<2x1xf32>} : () -> tensor<2x1xf32>
+  // CHECK:           return [[VAR_0_]] : tensor<2x1xf32>
+  // CHECK:         }
+}


### PR DESCRIPTION
This patch implements constant propagation for ONNXSliceOp.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>