### PR TITLE
Don't crash on negative axis in ONNXGatherElementsOp::verify

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -3373,6 +3373,8 @@ LogicalResult ONNXGatherElementsOp::verify() {
     return onnx_mlir::Diagnostic::emitAttributeOutOfRangeError(
         *this->getOperation(), "axis", axis,
         onnx_mlir::Diagnostic::Range<int64_t>(-dataRank, dataRank - 1));
+  if (axis < 0)
+    axis += dataRank;
 
   // All index values in 'indices' are expected to be within bounds [-s, s-1]
   // along axis of size s.

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -1592,6 +1592,16 @@ func @test_gather_negative_axis(%arg0 : tensor<3x3xf32>, %arg1 : tensor<1x2xi64>
   // CHECK: return [[RES]] : tensor<3x1x2xf32>
 }
 
+// -----
+
+func @test_gather_elements_negative_axis(%arg0 : tensor<2x2xf32>, %arg1 : tensor<2x2xi64>) -> tensor<*xf32> {
+  %0 = "onnx.GatherElements"(%arg0, %arg1) {axis = -1 : si64} : (tensor<2x2xf32>, tensor<2x2xi64>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: test_gather_elements_negative_axis
+  // CHECK: [[RES:%.+]] = "onnx.GatherElements"(%arg0, %arg1) {axis = -1 : si64} : (tensor<2x2xf32>, tensor<2x2xi64>) -> tensor<2x2xf32>
+  // CHECK: return [[RES]] : tensor<2x2xf32>
+}
 
 // -----
 


### PR DESCRIPTION
Closes #1543

Added @test_gather_elements_negative_axis in onnx_shape_inference.mlir

Signed-off-by: Soren Lassen <sorenlassen@gmail.com>