### PR TITLE
Krnl cleanup

### DIFF
--- a/docs/LoweringCode.md
+++ b/docs/LoweringCode.md
@@ -38,7 +38,7 @@ In general, this and all other builders can be created as follows.
 // Constructors in class declaration.
 struct MathBuilder : DialectBuilder {
   MathBuilder(OpBuilder &b, Location loc);
-  MathBuilder(DialectBuilder &db);
+  MathBuilder(const DialectBuilder &db);
 };
 
 // Usage.
@@ -51,7 +51,7 @@ The Math builder contains the operations listed below. Most are self explanatory
 ```C++
 struct MathBuilder : DialectBuilder {
   MathBuilder(OpBuilder &b, Location loc);
-  MathBuilder(DialectBuilder &db);
+  MathBuilder(const DialectBuilder &db);
 
   Value andi(Value lhs, Value rhs);
   Value add(Value lhs, Value rhs);
@@ -76,7 +76,7 @@ An equivalent builder exists for some MemRef operation. At a high level, the fol
 ``` C++
 struct MemRefBuilder : DialectBuilder {
   MemRefBuilder(OpBuilder &b, Location loc);
-  MemRefBuilder(DialectBuilder &db);
+  MemRefBuilder(const DialectBuilder &db);
 
   memref::AllocOp alloc(MemRefType type, ValueRange dynSymbols);
   memref::AllocaOp alloca(MemRefType type);

--- a/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
@@ -40,12 +40,12 @@ extern std::mutex unrollAndJamMutex;
 
 // Affine expressions compared to >= 0
 static IndexExpr isFullTile(IndexExpr UB, IndexExpr block, IndexExpr GI) {
-  // Determine if the current tile is full. It is full if the begining of
+  // Determine if the current tile is full. It is full if the beginning of
   // the tile (nGI) is smaller or equal to UB - bloc, namely
   //   PredicateIndexExpr nIsFullTile = (nGI <= (nUB - nBlock));
   // However, if UB is divisible by Block, then its full no matter what.
   if (UB.isLiteral() && (UB.getLiteral() % block.getLiteral() == 0)) {
-    // Last tile is guaranteed to be full because UB is divisable by block.
+    // Last tile is guaranteed to be full because UB is divisible by block.
     return LiteralIndexExpr(1); // 1 >= 0 is true
   }
   // true if GI <= (UB - block), namely UB - block - GI >= 0
@@ -57,7 +57,7 @@ static IndexExpr partialTrip(IndexExpr UB, IndexExpr block, IndexExpr GI) {
   // Trip count for partial tiles: leftover = UB - GI in general. If UB is
   // known at compile time, then without loss of generality, leftover = (UB-
   // GI) % Block, and since GI is by definition a multiple of Block (GI is
-  // index at begining of tile), then leftover = UB % Block.
+  // index at beginning of tile), then leftover = UB % Block.
   //   IndexExpr nPartialTrip = nUB.isLiteral() ? nUB % nBlock : nUB - nGI;
   if (UB.isLiteral()) {
     IndexExpr partialTrip = UB % block;
@@ -119,7 +119,7 @@ public:
 
     // Gather N, M, K compute tile size. This is the size of the computations,
     // if the tile is full. Because computation in the buffers could be further
-    // subtiled, the default size can be overridden from the tile sizes using
+    // sub-tiled, the default size can be overridden from the tile sizes using
     // the computeTileSize attribute. Tiles may not be full if they are at the
     // outer boundaries of the original data.
     IndexExpr iComputeTileSize = cTileSize[0];
@@ -220,7 +220,7 @@ public:
     // Now determine if we have full/partial tiles. This is determined by the
     // outer dimensions of the original computations, as by definition tiling
     // within the buffer always results in full tiles. In other words, partial
-    // tiles only occurs because of "runing out" of the original data.
+    // tiles only occurs because of "running out" of the original data.
     IndexExpr iIsFullTile =
         isFullTile(iGlobalUB, iComputeTileSize, iGlobalIndexComputeStart);
     IndexExpr jIsFullTile =
@@ -232,7 +232,7 @@ public:
 
     SmallVector<IndexExpr, 1> jFullTiles = {jIsFullTile};
     // And if the tiles are not full, determine how many elements to compute.
-    // With overcompute, this could be relaxed.
+    // With over-compute, this could be relaxed.
     IndexExpr iTrip = trip(iGlobalUB, iComputeTileSize,
         iGlobalIndexComputeStart); // May or may not be full.
     IndexExpr jTrip = trip(jGlobalUB, jComputeTileSize,
@@ -313,7 +313,6 @@ private:
     MemRefBuilder createMemRef(createAffine);
 
     Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(operandAdaptor.C());
-    // int64_t aRank(aStart.size()), bRank(bStart.size()), cRank(cStart.size());
     int64_t unrollFactor = (unrollJam && J.isLiteral()) ? J.getLiteral() : 1;
     // Have to privatize CTmpType by unroll factor (1 if none).
     MemRefType CTmpType = MemRefType::get({unrollFactor}, elementType);
@@ -331,44 +330,25 @@ private:
                 // Defines induction variables, and possibly initialize C.
                 jSaved = j;
                 // Alloc and init temp c storage.
-                // SmallVector<Value, 4> cAccess;
-                // CC(i + cStart0.getValue(), j + cStart1.getValue());
-                // IndexExpr::getValues(cStart, cAccess);
-                // cAccess[cRank - 2] = createMath.add(i, cAccess[cRank - 2]);
-                // cAccess[cRank - 1] = createMath.add(j, cAccess[cRank - 1]);
                 Value initVal = createAffine.loadIE(C, cStart, {i, j});
                 Value tmpCAccess = (unrollFactor > 1) ? j : zeroIE.getValue();
-                createAffine.store(initVal, TmpC, tmpCAccess);
                 // TTmpC() = affine_load(C, cAccess);
+                createAffine.store(initVal, TmpC, tmpCAccess);
                 // Sum over k.
                 createAffine.forIE(zeroIE, K, 1,
                     [&](AffineBuilderKrnlMem &createAffine, Value k) {
                       MathBuilder createMath(createAffine);
-                      // SmallVector<Value, 4> aAccess, bAccess;
-                      // AA(i + aStart0.getValue(), k + aStart1.getValue())
-                      // IndexExpr::getValues(aStart, aAccess);
-                      // aAccess[aRank - 2] =
-                      //    createMath.add(i, aAccess[aRank - 2]);
-                      // aAccess[aRank - 1] =
-                      //    createMath.add(k, aAccess[aRank - 1]);
                       Value a = createAffine.loadIE(A, aStart, {i, k});
-                      // BB(k + bStart0.getValue(), j + bStart1.getValue())
-                      // IndexExpr::getValues(bStart, bAccess);
-                      // bAccess[bRank - 2] =
-                      //    createMath.add(k, bAccess[bRank - 2]);
-                      // bAccess[bRank - 1] =
-                      //    createMath.add(j, bAccess[bRank - 1]);
                       Value b = createAffine.loadIE(B, bStart, {k, j});
                       Value res = createMath.mul(a, b);
                       res = createMath.add(
                           res, createAffine.load(TmpC, tmpCAccess));
-                      createAffine.store(res, TmpC, tmpCAccess);
                       // TTmpC() = a * b + TTmpC();
+                      createAffine.store(res, TmpC, tmpCAccess);
                     });
                 // Store temp result into C(i, j)
                 Value finalVal = createAffine.load(TmpC, tmpCAccess);
                 createAffine.storeIE(finalVal, C, cStart, {i, j});
-                // affine_store(TTmpC(), C, cAccess);
               });
         });
     if (unrollJam && J.isLiteral()) {
@@ -395,7 +375,6 @@ private:
     // Get operands.
     KrnlMatMulOpAdaptor operandAdaptor = KrnlMatMulOpAdaptor(op);
     Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(operandAdaptor.C());
-    // int64_t aRank(aStart.size()), bRank(bStart.size()), cRank(cStart.size());
 
     // Generate the vector type conversions.
     assert(VL == mVL && "vector length and VL must be identical for now");
@@ -409,7 +388,7 @@ private:
            "alignment of buffers cannot be smaller than the default alignment "
            "(which is set for SIMD correctness");
     // TODO: alloca is good as it help simplify away this data structures (as it
-    // is only used as local temp, basically extentions of registers). However,
+    // is only used as local temp, basically extensions of registers). However,
     // there might be issues with non-removed alloca when they are not in the
     // innermost loop. Still think its worth it having alloca as we want
     // eventually all the refs to alloca to be register/spill access, not memory
@@ -419,7 +398,6 @@ private:
     Value fZero = create.math.constant(elementType, 0);
     Value vFZero = create.vec.broadcast(vecType, fZero);
     create.krnl.memset(TmpProd, vFZero);
-
     LiteralIndexExpr zeroIE(0);
     Value iZero = create.math.constantIndex(0);
 
@@ -429,18 +407,10 @@ private:
           // Iterates over the I indices (K is SIMD dim).
           // First compute A[i,k]*B[k, 1] for i=0..iUnrollFactor explicitly.
           // We reuse B[k][0] vector for each iteration of i.
-          // SmallVector<Value, 4> bAccess;
-          // IndexExpr::getValues(bStart, bAccess);
-          // bAccess = {k + bStart0.getValue(), bStart1.getValue()};
-          // bAccess[bRank - 2] = create.math.add(k, bAccess[bRank - 2]);
           Value vb = create.vec.loadIE(vecType, B, bStart, {k, iZero});
           // Generate computation for each i, manually unrolled for simplicity.
           for (int64_t i = 0; i < iUnrollFactor; ++i) {
-            // SmallVector<Value, 4> aAccess;
-            // IndexExpr::getValues(aStart, aAccess);
             Value iVal = create.math.constantIndex(i);
-            // aAccess[aRank - 2] = create.math.add(aAccess[aRank - 2], iVal);
-            // aAccess[aRank - 1] = create.math.add(k, aAccess[aRank - 1]);
             Value va = create.vec.loadIE(vecType, A, aStart, {iVal, k});
             Value vTmpProd = create.vec.load(vecType, TmpProd, {iVal});
             Value vres = create.vec.fma(va, vb, vTmpProd);
@@ -461,10 +431,8 @@ private:
     // reduction, and store C.
     uint64_t size = vReductionList.size();
     for (uint64_t i = 0; i < size; ++i) {
-      // SmallVector<Value, 4> cAccess;
       // IndexExpr::getValues(cStart, cAccess);
       Value iVal = create.math.constantIndex(i * VL);
-      // cAccess[cRank - 2] = create.math.add(cAccess[cRank - 2], iVal);
       Value vc = create.vec.loadIE(vecType, C, cStart, {iVal, iZero});
       vc = create.math.add(vc, vReductionList[i]);
       create.vec.storeIE(vc, C, cStart, {iVal, iZero});
@@ -484,7 +452,6 @@ private:
     // Get operands.
     KrnlMatMulOpAdaptor operandAdaptor = KrnlMatMulOpAdaptor(op);
     Value A(operandAdaptor.A()), B(operandAdaptor.B()), C(operandAdaptor.C());
-    // int64_t aRank(aStart.size()), bRank(bStart.size()), cRank(cStart.size());
 
     // Generate the vector type conversions.
     int64_t VL = vectorLen.getLiteral();
@@ -494,7 +461,7 @@ private:
     MemRefType CTmpType = MemRefType::get({unrollFactor}, vecType);
     assert(BUFFER_ALIGN >= gDefaultAllocAlign);
     // TODO: alloca is good as it help simplify away this data structures (as it
-    // is only used as local temp, basically extentions of registers). However,
+    // is only used as local temp, basically extensions of registers). However,
     // there might be issues with non-removed alloca when they are not in the
     // innermost loop. Still think its worth it having alloca as we want
     // eventually all the refs to alloca to be register/spill access, not memory
@@ -511,10 +478,6 @@ private:
           MultiDialectBuilder<MathBuilder, VectorBuilder> create(createAffine);
           iSaved = i; // Saved for unroll and jam.
           // Alloca temp vector TmpC and save C(i)/0.0 into it.
-          // SmallVector<Value, 4> cAccess;
-          // cAccess = {i + cStart0.getValue(), cStart1.getValue()};
-          // IndexExpr::getValues(cStart, cAccess);
-          // cAccess[cRank - 2] = create.math.add(i, cAccess[cRank - 2]);
           Value initVal = create.vec.loadIE(vecType, C, cStart, {i, iZero});
           Value tmpCAccess = (unrollFactor > 1) ? i : zeroIE.getValue();
           createAffine.store(initVal, TmpC, tmpCAccess);
@@ -524,17 +487,8 @@ private:
                 MultiDialectBuilder<MathBuilder, VectorBuilder> create(
                     createAffine);
                 kSaved = k;
-                // Value a = AA(i + aStart0.getValue(), k + aStart1.getValue());
-                // SmallVector<Value, 4> aAccess, bAccess;
-                // IndexExpr::getValues(aStart, aAccess);
-                // aAccess[aRank - 2] = create.math.add(i, aAccess[aRank - 2]);
-                // aAccess[aRank - 1] = create.math.add(k, aAccess[aRank - 1]);
                 Value a = createAffine.loadIE(A, aStart, {i, k});
-                // Value va = vector_broadcast(vecType, a);
                 Value va = create.vec.broadcast(vecType, a);
-                // bAccess = {k + bStart0.getValue(), bStart1.getValue()};
-                // IndexExpr::getValues(bStart, bAccess);
-                // bAccess[bRank - 2] = create.math.add(k, bAccess[bRank - 2]);
                 Value vb = create.vec.loadIE(vecType, B, bStart, {k, iZero});
                 // TTmpC() = vector_fma(va, vb, TTmpC());
                 Value tmpVal = createAffine.load(TmpC, tmpCAccess);
@@ -554,7 +508,6 @@ private:
                 create.vec.loadIE(vecType, C, cStart, {i, iZero});
             tmpResults = create.vec.shuffle(tmpResults, originalCvec, mask);
           }
-          // CCvec(i + CStart0.getValue(), CStart1.getValue()) = tmpResults;
           create.vec.storeIE(tmpResults, C, cStart, {i, iZero});
         });
 

--- a/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
+++ b/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
@@ -394,7 +394,7 @@ struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
                 create.krnl.store(create.math.add(currentMOPC, one),
                     effectiveMaxOutputPerClass, {});
 
-                // Update the effective number of seleted indices.
+                // Update the effective number of selected indices.
                 // effective_num_selected_indices += 1
                 create.krnl.store(create.math.add(soVal, one),
                     effectiveNumSelectedIndices, {});
@@ -434,7 +434,7 @@ struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
                       rewriter.setInsertionPointToStart(
                           &if2Op.getThenRegion().front());
 
-                      // If IOU is satified, mark the current box as removed.
+                      // If IOU is satisfied, mark the current box as removed.
                       createKrnl.store(trueVal, removedIndices, {o});
                     });
               });

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -63,26 +63,13 @@ Value KrnlBuilder::load(Value memref, ValueRange indices) const {
   return b.create<KrnlLoadOp>(loc, memref, indices);
 }
 
-mlir::Value KrnlBuilder::loadWithOffset(mlir::Value memref,
-    mlir::ValueRange indices, mlir::ValueRange indexOffsets) const {
-  int64_t indexRank = indices.size();
-  int64_t offsetRank = indexOffsets.size();
-  int64_t firstOffsetI = indexRank - offsetRank;
-  assert(firstOffsetI >= 0 && "indexOffset should not have a higher rank than "
-                              "the indices in the memref");
+mlir::Value KrnlBuilder::load(mlir::Value memref, mlir::ValueRange indices,
+    mlir::ValueRange offsets) const {
+  SmallVector<Value, 4> computedIndices;
   MathBuilder createMath(*this);
-  SmallVector<Value, 4> computedIndices();
-  for (int64_t i = 0; i < indexRank; i++) {
-    if (i < firstOffsetI) {
-      computedIndices.append(indices[i]);
-    } else {
-      computedIndices.append(createMath.add(indexOffset[i-firstOffset], indices[i]);
-    }
-  }
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
   return load(memref, computedIndices);
 }
-
-} // namespace onnx_mlir
 
 Value KrnlBuilder::loadIE(Value memref, ArrayRef<IndexExpr> indices) const {
   SmallVector<Value, 4> indexValues;
@@ -94,22 +81,11 @@ void KrnlBuilder::store(Value val, Value memref, ValueRange indices) const {
   b.create<KrnlStoreOp>(loc, val, memref, indices);
 }
 
-void KrnlBuilder::storeWithOffset(mlir::Value val, mlir::Value memref,
-    mlir::ValueRange indices, mlir::ValueRange indexOffsets) const {
-  int64_t indexRank = indices.size();
-  int64_t offsetRank = indexOffsets.size();
-  int64_t firstOffsetI = indexRank - offsetRank;
-  assert(firstOffsetI >= 0 && "indexOffset should not have a higher rank than "
-                              "the indices in the memref");
+void KrnlBuilder::store(mlir::Value val, mlir::Value memref,
+    mlir::ValueRange indices, mlir::ValueRange offsets) const {
+  SmallVector<Value, 4> computedIndices;
   MathBuilder createMath(*this);
-  SmallVector<Value, 4> computedIndices();
-  for (int64_t i = 0; i < indexRank; i++) {
-    if (i < firstOffsetI) {
-      computedIndices.append(indices[i]);
-    } else {
-      computedIndices.append(createMath.add(indexOffset[i-firstOffset], indices[i]);
-    }
-  }
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
   store(val, memref, computedIndices);
 }
 

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -27,12 +27,14 @@ struct KrnlBuilder : public DialectBuilder {
   KrnlBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
+  // When ranks of offsets<indices, add offsets to the least significant dims.
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices,
       mlir::ValueRange offsets) const;
   mlir::Value loadIE(
       mlir::Value memref, mlir::ArrayRef<IndexExpr> indices) const;
   void store(
       mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
+  // When ranks of offsets<indices, add offsets to the least significant dims.
   void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
       mlir::ValueRange offsets) const;
   void storeIE(mlir::Value val, mlir::Value memref,

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -24,23 +24,17 @@ namespace onnx_mlir {
 struct KrnlBuilder : public DialectBuilder {
   KrnlBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
-  KrnlBuilder(DialectBuilder &db) : DialectBuilder(db) {}
+  KrnlBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
-  // Offset are added to the list significant indices, e.g. if rank(indices)=4
-  // and rank(indexOffsets)=2, then the offsets are added to the last 2 index
-  // dimensions.
-  mlir::Value loadWithOffset(mlir::Value memref, mlir::ValueRange indices,
-      mlir::ValueRange indexOffsets) const;
+  mlir::Value load(mlir::Value memref, mlir::ValueRange indices,
+      mlir::ValueRange offsets) const;
   mlir::Value loadIE(
       mlir::Value memref, mlir::ArrayRef<IndexExpr> indices) const;
   void store(
       mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
-  // Offset are added to the list significant indices, e.g. if rank(indices)=4
-  // and rank(indexOffsets)=2, then the offsets are added to the last 2 index
-  // dimensions.
-  void storeWithOffset(mlir::Value val, mlir::Value memref,
-      mlir::ValueRange indices, mlir::ValueRange indexOffsets) const;
+  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
+      mlir::ValueRange offsets) const;
   void storeIE(mlir::Value val, mlir::Value memref,
       mlir::ArrayRef<IndexExpr> indices) const;
 
@@ -161,7 +155,7 @@ template <class... Ts>
 struct MultiDialectBuilder<KrnlBuilder, Ts...> : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), krnl(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), krnl(db) {}
   KrnlBuilder krnl;
 };
@@ -182,7 +176,7 @@ struct MultiDialectBuilder<AffineBuilderKrnlMem, Ts...>
     : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), affineKMem(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), affineKMem(db) {}
   AffineBuilderKrnlMem affineKMem;
 };

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -27,10 +27,20 @@ struct KrnlBuilder : public DialectBuilder {
   KrnlBuilder(DialectBuilder &db) : DialectBuilder(db) {}
 
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
+  // Offset are added to the list significant indices, e.g. if rank(indices)=4
+  // and rank(indexOffsets)=2, then the offsets are added to the last 2 index
+  // dimensions.
+  mlir::Value loadWithOffset(mlir::Value memref, mlir::ValueRange indices,
+      mlir::ValueRange indexOffsets) const;
   mlir::Value loadIE(
       mlir::Value memref, mlir::ArrayRef<IndexExpr> indices) const;
   void store(
       mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
+  // Offset are added to the list significant indices, e.g. if rank(indices)=4
+  // and rank(indexOffsets)=2, then the offsets are added to the last 2 index
+  // dimensions.
+  void storeWithOffset(mlir::Value val, mlir::Value memref,
+      mlir::ValueRange indices, mlir::ValueRange indexOffsets) const;
   void storeIE(mlir::Value val, mlir::Value memref,
       mlir::ArrayRef<IndexExpr> indices) const;
 

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -488,6 +488,34 @@ Value MathBuilder::castToIndex(Value src) const {
   return cast(b.getIndexType(), src);
 }
 
+// Add offsets to least significant values in indices. So if indices has 4
+// values, (i, j, k, l) and offsets has 2 values (K, L), the results will be (i,
+// j, k+K, l+L).
+void MathBuilder::addOffsetToLeastSignificant(mlir::ValueRange indices,
+    mlir::ValueRange offsets,
+    llvm::SmallVectorImpl<mlir::Value> &computedIndices) const {
+  int64_t indexRank = indices.size();
+  int64_t offsetRank = offsets.size();
+  int64_t firstOffset = indexRank - offsetRank;
+  assert(firstOffset >= 0 && "indexOffset should not have a higher rank than "
+                             "the indices in the memref");
+  computedIndices.clear();
+  for (int64_t i = 0; i < indexRank; i++) {
+    if (i < firstOffset) {
+      computedIndices.emplace_back(indices[i]);
+    } else {
+      computedIndices.emplace_back(add(offsets[i - firstOffset], indices[i]));
+    }
+  }
+}
+
+void MathBuilder::addOffsetToLeastSignificant(mlir::ArrayRef<IndexExpr> indices,
+    ValueRange offsets, llvm::SmallVectorImpl<Value> &computedIndices) const {
+  SmallVector<Value, 4> indexValues;
+  IndexExpr::getValues(indices, indexValues);
+  addOffsetToLeastSignificant(indexValues, offsets, computedIndices);
+}
+
 //===----------------------------------------------------------------------===//
 // Memref support, including inserting default alignment.
 //===----------------------------------------------------------------------===//
@@ -648,9 +676,40 @@ Value VectorBuilder::load(
     VectorType vecType, Value memref, ValueRange indices) const {
   return b.create<vector::LoadOp>(loc, vecType, memref, indices);
 }
+mlir::Value VectorBuilder::load(mlir::VectorType vecType, mlir::Value memref,
+    mlir::ValueRange indices, mlir::ValueRange offsets) const {
+  llvm::SmallVector<mlir::Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  return load(vecType, memref, computedIndices);
+}
+
+mlir::Value VectorBuilder::loadIE(mlir::VectorType vecType, mlir::Value memref,
+    llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const {
+  llvm::SmallVector<mlir::Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  return load(vecType, memref, computedIndices);
+}
 
 void VectorBuilder::store(Value val, Value memref, ValueRange indices) const {
   b.create<vector::StoreOp>(loc, val, memref, indices);
+}
+
+void VectorBuilder::store(mlir::Value val, mlir::Value memref,
+    mlir::ValueRange indices, mlir::ValueRange offsets) const {
+  llvm::SmallVector<mlir::Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  store(val, memref, computedIndices);
+}
+
+void VectorBuilder::storeIE(mlir::Value val, mlir::Value memref,
+    llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const {
+  llvm::SmallVector<mlir::Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  store(val, memref, computedIndices);
 }
 
 Value VectorBuilder::fma(Value lhs, Value rhs, Value acc) const {

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -196,12 +196,14 @@ struct VectorBuilder final : DialectBuilder {
 
   mlir::Value load(mlir::VectorType vecType, mlir::Value memref,
       mlir::ValueRange indices = {}) const;
+  // When ranks of offsets<indices, add offsets to the least significant dims.
   mlir::Value load(mlir::VectorType vecType, mlir::Value memref,
       mlir::ValueRange indices, mlir::ValueRange offsets) const;
   mlir::Value loadIE(mlir::VectorType vecType, mlir::Value memref,
       llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
   void store(
       mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
+  // When ranks of offsets<indices, add offsets to the least significant dims.
   void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
       mlir::ValueRange offsets) const;
   void storeIE(mlir::Value val, mlir::Value memref,
@@ -234,6 +236,7 @@ struct GenericAffineBuilder final : DialectBuilder {
   GenericAffineBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
+  // When ranks of offsets<indices, add offsets to the least significant dims.
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices,
       mlir::ValueRange offsets) const;
   mlir::Value loadIE(mlir::Value memref, llvm::ArrayRef<IndexExpr> indices,
@@ -241,6 +244,7 @@ struct GenericAffineBuilder final : DialectBuilder {
 
   void store(
       mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
+  // When ranks of offsets<indices, add offsets to the least significant dims.
   void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
       mlir::ValueRange offsets) const;
   void storeIE(mlir::Value val, mlir::Value memref,

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -25,7 +25,7 @@ namespace onnx_mlir {
 
 struct DialectBuilder {
   DialectBuilder(mlir::OpBuilder &b, mlir::Location loc) : b(b), loc(loc) {}
-  DialectBuilder(DialectBuilder &db) : b(db.b), loc(db.loc) {}
+  DialectBuilder(const DialectBuilder &db) : b(db.b), loc(db.loc) {}
   virtual ~DialectBuilder() {}
   DialectBuilder(DialectBuilder &&) = delete;
   DialectBuilder &operator=(const DialectBuilder &) = delete;
@@ -51,7 +51,7 @@ protected:
 //===----------------------------------------------------------------------===//
 // Original code for MathBuilder is copied from LLVM MLIR Utils.cpp
 // Modified here to add operations, add super class.
-// Liscense added here for this class for completness.
+// License added here for this class for completeness.
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -60,7 +60,7 @@ protected:
 struct MathBuilder final : DialectBuilder {
   MathBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
-  MathBuilder(DialectBuilder &db) : DialectBuilder(db) {}
+  MathBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   mlir::Value andi(mlir::Value lhs, mlir::Value rhs) const;
   mlir::Value ori(mlir::Value lhs, mlir::Value rhs) const;
@@ -104,6 +104,15 @@ struct MathBuilder final : DialectBuilder {
   mlir::Value cast(mlir::Type destType, mlir::Value val) const;
   mlir::Value castToIndex(mlir::Value val) const;
 
+  // Add indexOffsets to the least significant indices. So if indices are (i, j,
+  // k, l) and offsets are (K, L), the results will be (i, j, k+K, l+L).
+  void addOffsetToLeastSignificant(mlir::ValueRange indices,
+      mlir::ValueRange offsets,
+      llvm::SmallVectorImpl<mlir::Value> &computedIndices) const;
+  void addOffsetToLeastSignificant(mlir::ArrayRef<IndexExpr> indices,
+      mlir::ValueRange offsets,
+      llvm::SmallVectorImpl<mlir::Value> &computedIndices) const;
+
 private:
   mlir::Value createArithCmp(
       mlir::Value lhs, mlir::Value rhs, mlir::arith::CmpIPredicate pred) const;
@@ -120,7 +129,7 @@ private:
 struct MemRefBuilder final : DialectBuilder {
   MemRefBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
-  MemRefBuilder(DialectBuilder &db) : DialectBuilder(db) {}
+  MemRefBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   mlir::memref::AllocOp alloc(mlir::MemRefType type) const;
   mlir::memref::AllocOp alloc(
@@ -159,7 +168,7 @@ static constexpr int64_t gDefaultAllocAlign = 16;
 
 struct SCFBuilder final : DialectBuilder {
   SCFBuilder(mlir::OpBuilder &b, mlir::Location loc) : DialectBuilder(b, loc) {}
-  SCFBuilder(DialectBuilder &db) : DialectBuilder(db) {}
+  SCFBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   /// Create an if then with optional else. Construct does not generate a result
   /// (unlike some scf::if) and introduces the yields automatically.
@@ -177,7 +186,7 @@ struct SCFBuilder final : DialectBuilder {
 struct VectorBuilder final : DialectBuilder {
   VectorBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
-  VectorBuilder(DialectBuilder &db) : DialectBuilder(db) {}
+  VectorBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   // Get the machine SIMD vector length for the given elementary type.
   // This can help guide certain optimizations.
@@ -187,8 +196,16 @@ struct VectorBuilder final : DialectBuilder {
 
   mlir::Value load(mlir::VectorType vecType, mlir::Value memref,
       mlir::ValueRange indices = {}) const;
+  mlir::Value load(mlir::VectorType vecType, mlir::Value memref,
+      mlir::ValueRange indices, mlir::ValueRange offsets) const;
+  mlir::Value loadIE(mlir::VectorType vecType, mlir::Value memref,
+      llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
   void store(
       mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
+  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
+      mlir::ValueRange offsets) const;
+  void storeIE(mlir::Value val, mlir::Value memref,
+      llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
 
   mlir::Value broadcast(mlir::VectorType vecType, mlir::Value val) const;
   mlir::Value shuffle(mlir::Value lhs, mlir::Value rhs,
@@ -214,11 +231,20 @@ template <class LOAD_OP, class STORE_OP>
 struct GenericAffineBuilder final : DialectBuilder {
   GenericAffineBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
-  GenericAffineBuilder(DialectBuilder &db) : DialectBuilder(db) {}
+  GenericAffineBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
+  mlir::Value load(mlir::Value memref, mlir::ValueRange indices,
+      mlir::ValueRange offsets) const;
+  mlir::Value loadIE(mlir::Value memref, llvm::ArrayRef<IndexExpr> indices,
+      mlir::ValueRange offsets) const;
+
   void store(
       mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
+  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
+      mlir::ValueRange offsets) const;
+  void storeIE(mlir::Value val, mlir::Value memref,
+      llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
 
   void forIE(IndexExpr lb, IndexExpr ub, int64_t step,
       mlir::function_ref<void(GenericAffineBuilder &, mlir::Value)> builderFn)
@@ -269,7 +295,7 @@ struct LLVMBuilder final : DialectBuilder {
 
   LLVMBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
-  LLVMBuilder(DialectBuilder &db) : DialectBuilder(db) {}
+  LLVMBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   // AddressOfOp
   mlir::Value addressOf(mlir::LLVM::GlobalOp op) const;
@@ -403,7 +429,7 @@ struct LLVMBuilder final : DialectBuilder {
 template <class... Ts>
 struct MultiDialectBuilder {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc) {}
-  MultiDialectBuilder(DialectBuilder &db) {}
+  MultiDialectBuilder(const DialectBuilder &db) {}
 };
 
 // Recursive class specialized for MathBuilder refereed to as math.
@@ -411,7 +437,7 @@ template <class... Ts>
 struct MultiDialectBuilder<MathBuilder, Ts...> : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), math(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), math(db) {}
   MathBuilder math;
 };
@@ -421,7 +447,7 @@ template <class... Ts>
 struct MultiDialectBuilder<MemRefBuilder, Ts...> : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), mem(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), mem(db) {}
   MemRefBuilder mem;
 };
@@ -431,7 +457,7 @@ template <class... Ts>
 struct MultiDialectBuilder<AffineBuilder, Ts...> : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), affine(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), affine(db) {}
   AffineBuilder affine;
 };
@@ -441,7 +467,7 @@ template <class... Ts>
 struct MultiDialectBuilder<SCFBuilder, Ts...> : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), scf(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), scf(db) {}
   SCFBuilder scf;
 };
@@ -451,7 +477,7 @@ template <class... Ts>
 struct MultiDialectBuilder<VectorBuilder, Ts...> : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), vec(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), vec(db) {}
   VectorBuilder vec;
 };
@@ -461,7 +487,7 @@ template <class... Ts>
 struct MultiDialectBuilder<LLVMBuilder, Ts...> : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), llvm(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), llvm(db) {}
   LLVMBuilder llvm;
 };

--- a/src/Dialect/Mlir/DialectBuilder.hpp.inc
+++ b/src/Dialect/Mlir/DialectBuilder.hpp.inc
@@ -16,9 +16,47 @@ mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::load(
 }
 
 template <class LOAD_OP, class STORE_OP>
+mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::load(mlir::Value memref,
+    mlir::ValueRange indices, mlir::ValueRange offsets) const {
+  llvm::SmallVector<mlir::Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  return load(memref, computedIndices);
+}
+
+template <class LOAD_OP, class STORE_OP>
+mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::loadIE(mlir::Value memref,
+    llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const {
+  llvm::SmallVector<mlir::Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  return load(memref, computedIndices);
+}
+
+template <class LOAD_OP, class STORE_OP>
 inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::store(
     mlir::Value val, mlir::Value memref, mlir::ValueRange indices) const {
   b.create<STORE_OP>(loc, val, memref, indices);
+}
+
+template <class LOAD_OP, class STORE_OP>
+inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::store(mlir::Value val,
+    mlir::Value memref, mlir::ValueRange indices,
+    mlir::ValueRange offsets) const {
+  llvm::SmallVector<mlir::Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  store(val, memref, computedIndices);
+}
+
+template <class LOAD_OP, class STORE_OP>
+inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::storeIE(mlir::Value val,
+    mlir::Value memref, llvm::ArrayRef<IndexExpr> indices,
+    mlir::ValueRange offsets) const {
+  llvm::SmallVector<mlir::Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  store(val, memref, computedIndices);
 }
 
 template <class LOAD_OP, class STORE_OP>

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -24,7 +24,7 @@ namespace onnx_mlir {
 struct OnnxBuilder : onnx_mlir::DialectBuilder {
   OnnxBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
-  OnnxBuilder(DialectBuilder &db) : DialectBuilder(db) {}
+  OnnxBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
   // ONNXAddOp
   mlir::Value add(mlir::Value A, mlir::Value B) const;
@@ -94,7 +94,7 @@ template <class... Ts>
 struct MultiDialectBuilder<OnnxBuilder, Ts...> : MultiDialectBuilder<Ts...> {
   MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : MultiDialectBuilder<Ts...>(b, loc), onnx(b, loc) {}
-  MultiDialectBuilder(DialectBuilder &db)
+  MultiDialectBuilder(const DialectBuilder &db)
       : MultiDialectBuilder<Ts...>(db), onnx(db) {}
   OnnxBuilder onnx;
 };


### PR DESCRIPTION
added load/store with base index and  offset to simplify the reading of the optimized code.

basically, most of our builder's load and store were of the kind
``` C++
create.*.load(memref, indices)
```

I added a version that does this

``` C++
create.*.load(memref, indices, offsets)
```
where the rank of offsets can be smaller than the rank of the memref & indices. When that is the case, the offsets are added to the least significant dimensions of indices.

So if indices are (i, j, k, l) and offsets are (K, L), the results will be (i, j, k+K, l+L).
 