### PR TITLE
Remove test binaries in dev image

### DIFF
--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -62,6 +62,7 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
             check-onnx-backend-input-verification\
             check-onnx-numerical \
     && make check-docs \
+    && rm -f Debug/bin/*Test Debug/bin/Perf* Debug/bin/Test* \
 # When building for push event to publish the image, unshallow and
 # rename origin to upstream to make the repo a bit more dev friendly.
     && if [ "${ONNX_MLIR_PR_NUMBER}" != "${ONNX_MLIR_PR_NUMBER2}" ]; then \


### PR DESCRIPTION
Dev image is getting too big (>20GB), remove test binaries (~6GB) to reduce its size

Signed-off-by: Gong Su <gong_su@hotmail.com>