### PR TITLE
Enable warnings as errors by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(onnx-mlir)
 
 option(ONNX_MLIR_BUILD_TESTS "Build ONNX-MLIR test executables. If OFF, just generate build targets." ON)
 option(ONNX_MLIR_CCACHE_BUILD "Set to ON for a ccache enabled build." OFF)
-option(ONNX_MLIR_ENABLE_WERROR "Enable warnings as errors." OFF)
+option(ONNX_MLIR_ENABLE_WERROR "Enable warnings as errors." ON)
 option(ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS "Suppress warning in third_party code." ON)
 
 # On systems that still have legacy lib64 directories (e.g., rhel/fedora,


### PR DESCRIPTION
This turns on warnings as errors in onnx-mlir by default. I expect there will be (many) failures and this is mostly to observe where there are failures in the online builds.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>