### PR TITLE
Fix condition where reinterpret_cast is used in lowering of transpose op.

### DIFF
--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -34,12 +34,19 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
     Value data = operandAdaptor.data();
     auto permAttr = transposeOp.perm();
 
-    // Convert the output type to MemRefType.
-    Type convertedType = typeConverter->convertType(*op->result_type_begin());
-    assert(convertedType && convertedType.isa<MemRefType>() &&
+    // Convert the input type to MemRefType.
+    Type inConvertedType = typeConverter->convertType(data.getType());
+    assert(inConvertedType && inConvertedType.isa<MemRefType>() &&
            "Failed to convert type to MemRefType");
-    MemRefType memRefType = convertedType.cast<MemRefType>();
-    uint64_t rank = memRefType.getShape().size();
+    MemRefType inMemRefType = inConvertedType.cast<MemRefType>();
+    uint64_t inRank = inMemRefType.getShape().size();
+    // Convert the output type to MemRefType.
+    Type outConvertedType =
+        typeConverter->convertType(*op->result_type_begin());
+    assert(outConvertedType && outConvertedType.isa<MemRefType>() &&
+           "Failed to convert type to MemRefType");
+    MemRefType outMemRefType = outConvertedType.cast<MemRefType>();
+    uint64_t outRank = outMemRefType.getShape().size();
 
     // Get a shape helper.
     ONNXTransposeOpShapeHelper shapeHelper(&transposeOp, &rewriter,
@@ -51,17 +58,18 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
 
     // If the order of the dimensions whose value is not 1 does not change after
     // transpose, it is safe to lower transpose to a view op.
-    ArrayRef<int64_t> dims = memRefType.getShape();
+    ArrayRef<int64_t> dims = inMemRefType.getShape();
     SmallVector<int64_t, 4> originalAxes;
     for (uint64_t axis = 0; axis < dims.size(); ++axis)
       if (dims[axis] != 1)
         originalAxes.emplace_back(axis);
     SmallVector<int64_t, 4> permutedAxes;
-    for (uint64_t i = 0; i < rank; ++i) {
+    for (uint64_t i = 0; i < inRank; ++i) {
       int64_t axis = ArrayAttrIntVal(permAttr, i);
       if (dims[axis] != 1)
         permutedAxes.emplace_back(axis);
     }
+
     if (originalAxes == permutedAxes) {
       // It is safe to lower to a view op.
       MemRefBuilder createMemRef(rewriter, loc);
@@ -73,11 +81,11 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
 
     // Insert an allocation and deallocation for the result of this operation.
     Value alloc = insertAllocAndDeallocSimple(
-        rewriter, op, memRefType, loc, shapeHelper.dimsForOutput());
+        rewriter, op, outMemRefType, loc, shapeHelper.dimsForOutput());
 
     KrnlBuilder createKrnl(rewriter, loc);
-    ValueRange loopDef = createKrnl.defineLoops(rank);
-    SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+    ValueRange loopDef = createKrnl.defineLoops(outRank);
+    SmallVector<IndexExpr, 4> lbs(outRank, LiteralIndexExpr(0));
 
     MemRefBoundsIndexCapture dataBounds(data);
     SmallVector<IndexExpr, 4> ubs;
@@ -87,7 +95,7 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
         [&](KrnlBuilder &createKrnl, ValueRange indices) {
           // Compute the indices used by the load operation.
           SmallVector<IndexExpr, 4> storeIndices;
-          for (uint64_t i = 0; i < rank; ++i) {
+          for (uint64_t i = 0; i < outRank; ++i) {
             Value index = indices[ArrayAttrIntVal(permAttr, i)];
             storeIndices.emplace_back(DimIndexExpr(index));
           }

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -3566,3 +3566,16 @@ func.func @test_transpose_lowered_to_a_view_op(%arg0: tensor<?x1x1x384xf32>) -> 
   // CHECK:         }
 }
 
+// -----
+
+// Check lowering transpose to a view op when the order of the dimensions whose
+// value is not 1 is unchanged.
+// The order of the dimension whose value is not 1 is changed by transpose.
+func.func @test_transpose_lowered_to_a_view_op_inv(%arg0: tensor<?x1x1x384xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Transpose"(%arg0) {perm = [3, 0, 1, 2]} : (tensor<?x1x1x384xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+  // CHECK-LABEL:  func @test_transpose_lowered_to_a_view_op_inv
+  // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x1x1x384xf32>) -> memref<384x?x1x1xf32> {
+  // CHECK-NOT:       memref.reinterpret_cast
+
+}


### PR DESCRIPTION
Output MemRefType are used to check the conditions where `reinterpret_cast` can be used, but the MemRefType should be that of input. This is fixed by this PR.

When output MemRefType is used, `reinterpret_cast` is used in following example in onnx-to-krnl lowering, but this is not correct. This issue occurs when the order of dimension where the value is not 1 is changed by transpose.
```
%3 = "onnx.Transpose"(%arg1) {perm = [2, 3, 1, 0]} : (tensor<2x3x1x1xf32>) -> tensor<1x1x3x2xf32>
```
