### PR TITLE
[NNPA] Enabled Conv2D C != 1, kH=1, kW=1 on NNPA

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -829,7 +829,6 @@ bool isSuitableForZDNN<ONNXConvOp>(ONNXConvOp op) {
           [](IndexExpr val) { return !val.isLiteral(); }))
     return false;
 
-  int64_t inputShapeC = shapeInput[1];
   int64_t inputShapeH = shapeInput[2];
   int64_t inputShapeW = shapeInput[3];
   int64_t outputShapeH = shapeOutput[2];
@@ -847,12 +846,6 @@ bool isSuitableForZDNN<ONNXConvOp>(ONNXConvOp op) {
   bool isWOK = checkConv2DParamRestrictions(
       inputShapeW, kernelShapeW, stridesW, outputShapeW, paddingType);
   if (!isWOK)
-    return false;
-
-  // Currently disable the generation of Conv2D when parameters are C != 1, kH =
-  // 1, kW=1 because of current issue #1517.  When fixed, please remove lit test
-  // test_onnx_conv2d_not_lowered_c_not_1_kernel11.
-  if (inputShapeC != 1 && kernelShapeH == 1 && kernelShapeW == 1)
     return false;
 
   return true;

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
@@ -91,7 +91,7 @@ func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : 
 
 // -----
 
-func @test_onnx_conv2d_valid_padding_H_equal_KW(%arg0: tensor<?x1280x1x1xf32>, %arg1: tensor<448x1280x1x1xf32>, %arg2: tensor<448xf32>) -> tensor<*xf32> {
+func.func @test_onnx_conv2d_valid_padding_H_equal_KW(%arg0: tensor<?x1280x1x1xf32>, %arg1: tensor<448x1280x1x1xf32>, %arg2: tensor<448xf32>) -> tensor<*xf32> {
     %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<?x1280x1x1xf32>, tensor<448x1280x1x1xf32>, tensor<448xf32>) -> tensor<*xf32>
     return %0 : tensor<*xf32>
   // CHECK-LABEL: test_onnx_conv2d_valid_padding_H_equal_KW

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
@@ -91,8 +91,8 @@ func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : 
 
 // -----
 
-func.func @test_onnx_conv2d_valid_padding_H_equal_KW(%arg0: tensor<?x1280x2x2xf32>, %arg1: tensor<448x1280x2x2xf32>, %arg2: tensor<448xf32>) -> tensor<*xf32> {
-    %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<?x1280x2x2xf32>, tensor<448x1280x2x2xf32>, tensor<448xf32>) -> tensor<*xf32>
+func @test_onnx_conv2d_valid_padding_H_equal_KW(%arg0: tensor<?x1280x1x1xf32>, %arg1: tensor<448x1280x1x1xf32>, %arg2: tensor<448xf32>) -> tensor<*xf32> {
+    %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<?x1280x1x1xf32>, tensor<448x1280x1x1xf32>, tensor<448xf32>) -> tensor<*xf32>
     return %0 : tensor<*xf32>
   // CHECK-LABEL: test_onnx_conv2d_valid_padding_H_equal_KW
   // CHECK: "zhigh.Conv2D"
@@ -224,16 +224,4 @@ func.func @test_exceed_limit_conv2d(%arg0: tensor<32769x3x32x32xf32>, %arg1 : te
 
 // CHECK-LABEL:  func @test_exceed_limit_conv2d
 // CHECK:        "onnx.Conv"
-}
-
-// -----
-
-/// COM: Workaround for issue #1517
-/// COM: Not lowered to zhigh when C != 1, kH = 1, and kW = 1
-func.func @test_onnx_conv2d_not_lowered_c_not_1_kernel11(%arg0: tensor<5x3x32x32xf32>, %arg1 : tensor<2x3x1x1xf32>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {kernel_shape = [1, 1]} : (tensor<5x3x32x32xf32>, tensor<2x3x1x1xf32>, tensor<2xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
-
-  // CHECK-LABEL: test_onnx_conv2d_not_lowered_c_not_1_kernel11
-  // CHECK: "onnx.Conv"
 }


### PR DESCRIPTION
Issue https://github.com/onnx/onnx-mlir/issues/1517 was resolved by PR https://github.com/onnx/onnx-mlir/pull/1576 
So reverting PR https://github.com/onnx/onnx-mlir/pull/1518 to remove workaround. 

Test results of Conv2D on NNPA (C!=1, kH=1, Kw=1) :   [test-result.txt](https://github.com/onnx/onnx-mlir/files/9264913/conv-kh1xkw1.txt)

