### PR TITLE
fixes for SeqType and sequence ops

### DIFF
--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -449,8 +449,7 @@ private:
       dstream << elemTy;
       dstream.flush();
       int64_t dtype = krnl::mlirTypeToOnnxType(elemTy);
-      equalOrFailed(module, rewriter, loc,
-          create.llvm.constant(int64Ty, dtype),
+      equalOrFailed(module, rewriter, loc, create.llvm.constant(int64Ty, dtype),
           RuntimeAPI::callApi(rewriter, loc, apiRegistry,
               RuntimeAPI::API::GET_DATA_TYPE, {omTensorPtr}),
           "Wrong data type for the input " + std::to_string(i) + ": expect " +

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -448,9 +448,9 @@ private:
       llvm::raw_string_ostream dstream(elemTyStr);
       dstream << elemTy;
       dstream.flush();
-      onnx::TensorProto::DataType dtype = krnl::mlirTypeToOnnxType(elemTy);
+      int64_t dtype = krnl::mlirTypeToOnnxType(elemTy);
       equalOrFailed(module, rewriter, loc,
-          create.llvm.constant(int64Ty, (int64_t)dtype),
+          create.llvm.constant(int64Ty, dtype),
           RuntimeAPI::callApi(rewriter, loc, apiRegistry,
               RuntimeAPI::API::GET_DATA_TYPE, {omTensorPtr}),
           "Wrong data type for the input " + std::to_string(i) + ": expect " +

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Target/LLVMIR/TypeToLLVM.h"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/Mlir/DialectBuilder.hpp"
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
@@ -116,59 +117,8 @@ int64_t getRankFromMemRefType(LLVM::LLVMStructType memRefTy) {
 }
 
 // Convert an MLIR type to the correspoding ONNX type.
-onnx::TensorProto::DataType mlirTypeToOnnxType(Type elemType) {
-  onnx::TensorProto::DataType onnxType = onnx::TensorProto::UNDEFINED;
-
-  TypeSwitch<Type>(elemType)
-      .Case<BFloat16Type>(
-          [&](BFloat16Type) { onnxType = onnx::TensorProto::BFLOAT16; })
-      .Case<ComplexType>([&](ComplexType type) {
-        if (type.getElementType().isa<Float32Type>())
-          onnxType = onnx::TensorProto::COMPLEX64;
-        else if (type.getElementType().isa<Float64Type>())
-          onnxType = onnx::TensorProto::COMPLEX128;
-      })
-      .Case<Float16Type>(
-          [&](Float16Type) { onnxType = onnx::TensorProto::FLOAT16; })
-      .Case<Float32Type>(
-          [&](Float32Type) { onnxType = onnx::TensorProto::FLOAT; })
-      .Case<Float64Type>(
-          [&](Float64Type) { onnxType = onnx::TensorProto::DOUBLE; })
-      .Case<IntegerType>([&](IntegerType type) {
-        switch (type.getWidth()) {
-        case 1:
-          // only a signless type can be a bool.
-          onnxType = (type.isSigned() || type.isUnsigned())
-                         ? onnx::TensorProto::UNDEFINED
-                         : onnx::TensorProto::BOOL;
-          break;
-        case 8:
-          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT8
-                                       : onnx::TensorProto::INT8;
-          break;
-        case 16:
-          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT16
-                                       : onnx::TensorProto::INT16;
-          break;
-        case 32:
-          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT32
-                                       : onnx::TensorProto::INT32;
-          break;
-        case 64:
-          onnxType = type.isUnsigned() ? onnx::TensorProto::UINT64
-                                       : onnx::TensorProto::INT64;
-          break;
-        }
-      })
-      .Case<LLVM::LLVMStructType>(
-          [&](LLVM::LLVMStructType) { onnxType = onnx::TensorProto::STRING; });
-
-  if (onnxType == onnx::TensorProto::UNDEFINED) {
-    elemType.dump();
-    llvm_unreachable("MLIR type cannot be converted to ONNX type");
-  }
-
-  return onnxType;
+int64_t mlirTypeToOnnxType(Type elemType) {
+  return onnx_mlir::mlirTypeToOnnxType(elemType);
 }
 
 void fillOMTensorWithMemRef(Value &outMemRef, Value &outOMTensor,
@@ -199,8 +149,8 @@ void fillOMTensorWithMemRef(Value &outMemRef, Value &outOMTensor,
   Type elemTy =
       outMemRefTy.getBody()[0].cast<LLVM::LLVMPointerType>().getElementType();
 
-  onnx::TensorProto::DataType onnxTy = krnl::mlirTypeToOnnxType(elemTy);
-  Value onnxTyVal = create.llvm.constant(int64Ty, (int64_t)onnxTy);
+  int64_t onnxTy = krnl::mlirTypeToOnnxType(elemTy);
+  Value onnxTyVal = create.llvm.constant(int64Ty, onnxTy);
   RuntimeAPI::callApi(rewriter, loc, apiRegistry,
       RuntimeAPI::API::SET_DATA_TYPE, {outOMTensor, onnxTyVal});
 

--- a/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.hpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.hpp
@@ -17,7 +17,6 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "onnx/onnx_pb.h"
 #include "src/Conversion/KrnlToLLVM/RuntimeAPI.hpp"
 
 namespace onnx_mlir {
@@ -27,7 +26,7 @@ namespace krnl {
 int64_t getRankFromMemRefType(mlir::LLVM::LLVMStructType memRefTy);
 
 /// Get the ONNX type corresponding to an MLIR type.
-onnx::TensorProto::DataType mlirTypeToOnnxType(mlir::Type elemType);
+int64_t mlirTypeToOnnxType(mlir::Type elemType);
 
 /// Create an OMTensor from a memref.
 void fillOMTensorWithMemRef(mlir::Value &outMemRef, mlir::Value &outOMTensor,

--- a/src/Dialect/ONNX/ONNX.td
+++ b/src/Dialect/ONNX/ONNX.td
@@ -236,11 +236,11 @@ def ONNX_SeqType : ONNX_Type<"Seq", "Seq"> {
     An list of tensors which may have different shape
   }];
 
-  let parameters = (ins "::mlir::ShapedType":$ElementType, "int64_t":$Length);
+  let parameters = (ins "::mlir::Type":$ElementType, "int64_t":$Length);
 
   let hasCustomAssemblyFormat = 1;
   let builders = [
-    TypeBuilderWithInferredContext<(ins "::mlir::ShapedType":$elementType,
+    TypeBuilderWithInferredContext<(ins "::mlir::Type":$elementType,
                                         "int64_t":$length), [{
       return Base::get(elementType.getContext(), elementType, length);
     }]>

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -956,56 +956,50 @@ LogicalResult ONNXSeluOp::inferShapes(
 // Since the seq is usually used as a parameter of a graph (e.g. for LoopOp),
 // shape inference for region may need improvement.
 
+namespace {
+// Helper function used in Sequence ops shape inference
+ShapedType sequenceAddType(
+    ShapedType accumulatedType, ShapedType additionalType) {
+  Type elementType = accumulatedType.getElementType();
+  assert(elementType == additionalType.getElementType() &&
+         "types to merge must have the same data type");
+  // Pick the weaker attr: known dim > unknown dim > unranked
+  if (!accumulatedType.hasRank())
+    return accumulatedType;
+  if (!additionalType.hasRank())
+    return additionalType;
+  int64_t rank = accumulatedType.getRank();
+  if (rank != additionalType.getRank())
+    return UnrankedTensorType::get(elementType);
+  ArrayRef<int64_t> acc = accumulatedType.getShape();
+  ArrayRef<int64_t> add = additionalType.getShape();
+  SmallVector<int64_t, 4> dims;
+  for (int64_t i = 0; i < rank; i++) {
+    dims.push_back(acc[i] != add[i] ? -1 : add[i]);
+  }
+  return RankedTensorType::get(dims, elementType);
+}
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // SequenceInsertOp
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXSequenceInsertOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  SeqType seqType = input_sequence().getType().dyn_cast<mlir::SeqType>();
-  ShapedType tensorType = tensor().getType().dyn_cast<ShapedType>();
-  ShapedType seqTensorType = seqType.getElementType().cast<ShapedType>();
-
   // Merge the tensor type for the seq and the inserted tensor
-  // Pick the weaker attr: known dim > unknown dim > unranked
-  // If inference gets an unranked tensor, no need to update the result
-
-  // When the input seq is empty, inherit the tensor type
-  if (seqType.getLength() == 0) {
+  SeqType seqType = input_sequence().getType().cast<mlir::SeqType>();
+  ShapedType tensorType = tensor().getType().cast<ShapedType>();
+  int64_t length = seqType.getLength();
+  if (length == 0) {
+    // When the input seq is empty, inherit the tensor type
     getResult().setType(SeqType::get(tensorType, 1));
-    return success();
-  }
-
-  auto newLength = seqType.getLength() == -1 ? -1 : seqType.getLength() + 1;
-
-  // When one of the tensor is unranked
-  if (!tensorType.hasRank()) {
-    getResult().setType(SeqType::get(tensorType, newLength));
-    return success();
-  }
-  if (!seqTensorType.hasRank()) {
+  } else {
+    int64_t newLength = length == -1 ? -1 : length + 1;
+    ShapedType seqTensorType = seqType.getElementType().cast<ShapedType>();
+    seqTensorType = sequenceAddType(seqTensorType, tensorType);
     getResult().setType(SeqType::get(seqTensorType, newLength));
-    return success();
   }
-
-  // Merge when both are ranked
-  auto seqShape = seqTensorType.getShape();
-  auto seqRank = seqTensorType.getRank();
-  if (seqRank == -1)
-    return success();
-
-  auto tensorShape = tensorType.getShape();
-  auto tensorRank = tensorType.getRank();
-  if (tensorRank != seqRank)
-    return success();
-  SmallVector<int64_t, 4> dims;
-  for (auto i = 0; i < tensorRank; i++) {
-    dims.emplace_back(seqShape[i] != tensorShape[i] ? -1 : tensorShape[i]);
-  }
-  getResult().setType(SeqType::get(
-      mlir::RankedTensorType::get(dims, tensorType.getElementType()),
-      newLength));
-
   return success();
 }
 
@@ -1052,6 +1046,12 @@ LogicalResult ONNXSequenceAtOp::inferShapes(
 
 LogicalResult ONNXSequenceConstructOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
+  auto types = inputs().getTypes();
+  ShapedType seqTensorType = types[0].cast<ShapedType>();
+  for (size_t i = 1; i < types.size(); ++i) {
+    seqTensorType = sequenceAddType(seqTensorType, types[i].cast<ShapedType>());
+  }
+  getResult().setType(SeqType::get(seqTensorType, types.size()));
   return success();
 }
 
@@ -5484,8 +5484,10 @@ FunctionType ONNXCallOp::getCalleeType() {
 
 mlir::Type SeqType::parse(mlir::AsmParser &parser) {
   Type elementType;
-  if (parser.parseLess() || parser.parseType(elementType) || parser.parseGreater()) {
-    parser.emitError(parser.getCurrentLocation()) << "failed to parse !onnx.Seq type";
+  if (parser.parseLess() || parser.parseType(elementType) ||
+      parser.parseGreater()) {
+    parser.emitError(parser.getCurrentLocation())
+        << "failed to parse !onnx.Seq type";
     return Type();
   }
 

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -5484,8 +5484,10 @@ FunctionType ONNXCallOp::getCalleeType() {
 
 mlir::Type SeqType::parse(mlir::AsmParser &parser) {
   Type elementType;
-  if (parser.parseLess() || parser.parseType(elementType) || parser.parseGreater())
+  if (parser.parseLess() || parser.parseType(elementType) || parser.parseGreater()) {
+    parser.emitError(parser.getCurrentLocation()) << "failed to parse !onnx.Seq type";
     return Type();
+  }
 
   return get(elementType, -1);
 }

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -5484,12 +5484,10 @@ FunctionType ONNXCallOp::getCalleeType() {
 
 mlir::Type SeqType::parse(mlir::AsmParser &parser) {
   Type elementType;
-  if (parser.parseLess() || parser.parseType(elementType) ||
-      parser.parseGreater() || !elementType.isa<ShapedType>())
+  if (parser.parseLess() || parser.parseType(elementType) || parser.parseGreater())
     return Type();
 
-  ShapedType ty = elementType.cast<ShapedType>();
-  return get(ty.getContext(), ty, -1);
+  return get(elementType, -1);
 }
 
 void SeqType::print(mlir::AsmPrinter &printer) const {

--- a/src/Dialect/ONNX/ONNXOpsHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.cpp
@@ -357,11 +357,13 @@ bool AreTheSameConstantOpDenseAttr(
 /// Test if 'val' has shape and rank or not.
 bool hasShapeAndRank(Value val) {
   Type valType = val.getType();
-  if (!valType.isa<SeqType>())
-    return valType.isa<ShapedType>() && valType.cast<ShapedType>().hasRank();
-
-  // Check the element type for a Sequence.
-  return valType.cast<SeqType>().getElementType().hasRank();
+  ShapedType shapedType;
+  if (auto seqType = valType.dyn_cast<SeqType>()) {
+    shapedType = seqType.getElementType().dyn_cast<ShapedType>();
+  } else {
+    shapedType = valType.dyn_cast<ShapedType>();
+  }
+  return shapedType && shapedType.hasRank();
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXOpsHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.hpp
@@ -197,4 +197,7 @@ RESULT_TYPE getScalarValue(mlir::ONNXConstantOp constantOp, mlir::Type type);
 mlir::Type convertONNXTypeToMLIRType(
     mlir::OpBuilder &builder_, onnx::TensorProto_DataType onnxType);
 
+/// Get the ONNX type corresponding to an MLIR type.
+int64_t mlirTypeToOnnxType(mlir::Type elemType);
+
 } // namespace onnx_mlir

--- a/src/Transform/ONNX/Decompose.td
+++ b/src/Transform/ONNX/Decompose.td
@@ -86,6 +86,10 @@ def createArrayAttrFromConstantOp : NativeCodeCall<
 def createSequenceConstructOp : NativeCodeCall<
   "::onnx_mlir::createSequenceConstructOp($_builder, $0, $1)">;
 
+def ONNXDataType : NativeCodeCall<
+  "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), "
+  "::onnx_mlir::mlirTypeToOnnxType($0.getType().front().cast<ShapedType>().getElementType()))">;
+
 //===----------------------------------------------------------------------===//
 // ONNXReduceL1Op %X = ONNXReduceSumOp (ONNXAbsOp %X)
 //===----------------------------------------------------------------------===//
@@ -312,13 +316,10 @@ def ResizeV11Pattern: Pat<
                     $nearest_mode)
 >;
 
-// ToFix: Create type attribute for SequenceEmpty when type is not F32
-// There is a mlirTypeToOnnxType in KrnlToLLVM conversion. 
-// Need to move it into ONNXOpHelper
 def SequenceConstructPattern1: Pat<
     (ONNXSequenceConstructOp:$res $x1),
     (createSequenceConstructOp
-        (ONNXSequenceEmptyOp (GetNullIntegerAttr), (returnType $res)),
+        (ONNXSequenceEmptyOp (ONNXDataType $x1), (returnType $res)),
         $x1)
 >;
 

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -305,11 +305,23 @@ func.func @test_seqence_construct_1(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) 
 
   // CHECK-LABEL:  func @test_seqence_construct_1
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>) -> !onnx.Seq<tensor<*xf32>> {
-  // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
+  // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() {dtype = 1 : si64} : () -> !onnx.Seq<tensor<*xf32>>
   // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<*xf32>, none) -> !onnx.Seq<tensor<*xf32>>
   // CHECK:           [[VAR_2_:%.+]] = "onnx.SequenceInsert"([[VAR_1_]], [[PARAM_1_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<*xf32>, none) -> !onnx.Seq<tensor<*xf32>>
   // CHECK:           return [[VAR_2_]] : !onnx.Seq<tensor<*xf32>>
+}
+
+func.func @test_seqence_construct_2(%arg0: tensor<*xi16>) -> !onnx.Seq<tensor<*xi16>> {
+  %0 = "onnx.SequenceConstruct"(%arg0) : (tensor<*xi16>) -> !onnx.Seq<tensor<*xi16>>
+  return %0 : !onnx.Seq<tensor<*xi16>>
+
+  // CHECK-LABEL:  func @test_seqence_construct_2
+  // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xi16>) -> !onnx.Seq<tensor<*xi16>> {
+  // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() {dtype = 5 : si64} : () -> !onnx.Seq<tensor<*xi16>>
+  // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
+  // CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xi16>>, tensor<*xi16>, none) -> !onnx.Seq<tensor<*xi16>>
+  // CHECK:           return [[VAR_1_]] : !onnx.Seq<tensor<*xi16>>
 }
 
 // -----

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2541,6 +2541,17 @@ func.func @test_seqence_length(%arg0 : !onnx.Seq<tensor<*xf32>>) -> tensor<*xi64
 }
 
 // -----
+func.func @test_sequence_construct(%arg0 : tensor<2x3xf16>, %arg1 : tensor<4x3xf16>) -> !onnx.Seq<tensor<*xf16>> {
+  %0 = "onnx.SequenceConstruct"(%arg0, %arg1) : (tensor<2x3xf16>, tensor<4x3xf16>) -> !onnx.Seq<tensor<*xf16>>
+  return %0 : !onnx.Seq<tensor<*xf16>>
+// mlir2FileCheck.py
+// CHECK-LABEL:  func @test_sequence_construct
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3xf16>, [[PARAM_1_:%.+]]: tensor<4x3xf16>) -> !onnx.Seq<tensor<?x3xf16>> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceConstruct"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<2x3xf16>, tensor<4x3xf16>) -> !onnx.Seq<tensor<?x3xf16>>
+// CHECK:           return [[VAR_0_]] : !onnx.Seq<tensor<?x3xf16>>
+}
+
+// -----
 func.func @test_seqence_1(%arg0: tensor<2x4xf32>, %arg1: tensor<2x6xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %0 = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
   %cst = "onnx.NoValue"() {value} : () -> none

--- a/test/mlir/onnx/onnx_structure.mlir
+++ b/test/mlir/onnx/onnx_structure.mlir
@@ -74,3 +74,11 @@ func.func @check_optionalhaselement(%arg0: !onnx.Opt<tensor<*xf32>>) -> tensor<i
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.OptionalHasElement"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> tensor<i1>
   // CHECK-NEXT: return [[VAR_0_]] : tensor<i1>
 }
+
+// CHECK-LABEL: @check_seq_map(%arg0: tensor<*xf32>) -> !onnx.Seq<tuple<i64, f32>> {
+func.func @check_seq_map(%arg0: tensor<*xf32>) -> !onnx.Seq<tuple<i64, f32>> {
+  %0 = "onnx.ZipMap"(%arg0) {classlabels_int64s = [10, 20, 30]} : (tensor<*xf32>) -> !onnx.Seq<tuple<i64, f32>>
+  return %0 : !onnx.Seq<tuple<i64, f32>>
+  // CHECK-NEXT: %0 = "onnx.ZipMap"(%arg0) {classlabels_int64s = [10, 20, 30]} : (tensor<*xf32>) -> !onnx.Seq<tuple<i64, f32>>
+  // CHECK-NEXT: return %0 : !onnx.Seq<tuple<i64, f32>>
+}


### PR DESCRIPTION
As I implemented OptType in PR #1589 I noticed some issues with SeqType and sequence ops that are solved here:
1. SeqType required its element type to be a ShapedType, which conflicts with its use with a map element type in ZipMap
2. the SequenceConstruct op decomposition didn't support most data types
3. we didn't infer shapes for the SequenceConstruct op

Note that Conversion/KrnlToLLVM/KrnlToLLVMHelper now depends on Dialect/ONNX/ONNXOpsHelper for mlirTypeToOnnxType. Please let me know if there's a better way to reuse this logic.