### PR TITLE
parse Optional op's TYPE_PROTO attribute

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1069,7 +1069,7 @@ private:
         }
       }
     } else {
-      llvm::outs() << node.op_type();
+      llvm::errs() << node.op_type();
       if (op_dialect_top_version_map_.find(node.op_type()) !=
           op_dialect_top_version_map_.end()) {
         llvm_unreachable(

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -274,6 +274,16 @@ private:
     llvm_unreachable("unexpected type");
   }
 
+  OptType ImportOptionalType(const onnx::TypeProto &type_proto) {
+    auto input_opt_type = type_proto.optional_type();
+    if (input_opt_type.has_elem_type()) {
+      onnx::TypeProto elem_type = input_opt_type.elem_type();
+      Type mlir_elem_type = ImportType(elem_type);
+      return mlir::OptType::get(mlir_elem_type);
+    }
+    llvm_unreachable("unexpected type");
+  }
+
   Type ImportType(const onnx::TypeProto &type_proto) {
     switch (type_proto.value_case()) {
     case onnx::TypeProto::kTensorType:
@@ -281,6 +291,9 @@ private:
       break;
     case onnx::TypeProto::kSequenceType:
       return ImportSequenceType(type_proto);
+      break;
+    case onnx::TypeProto::kOptionalType:
+      return ImportOptionalType(type_proto);
       break;
     default:
       llvm_unreachable("unexpected type");
@@ -343,10 +356,12 @@ private:
       }
       mlirAttr = builder_.getStrArrayAttr(llvm::makeArrayRef(vectorStringRef));
     } break;
-    case onnx::AttributeProto::GRAPH: {
+    case onnx::AttributeProto::TYPE_PROTO:
+      mlirAttr = TypeAttr::get(ImportType(attr.tp()));
+      break;
+    case onnx::AttributeProto::GRAPH:
       llvm_unreachable("Subgraph attribute is imported as regions.");
       break;
-    }
     default:
       llvm_unreachable("datatype for attribute is not implemented");
       break;
@@ -1279,28 +1294,28 @@ private:
   }
 
   /*!
-   * Import output tensor, by doing the following:
-   * - Add the t/yp this output tensor to a list of tensor
+   * Import output value, by doing the following:
+   * - Add the type of this output tensor to a list of
    *   types representing return types of this graph function.
-   * - Add this output tensor to the list of Value
+   * - Add this output value to the list of values
    *   to be returned by the function representing computation graph.
-   * @param output onnx output tensor ValueInfoProto.
-   * @param ret_types a vector of tensor types representing graph's
-   *   output tensor types.
-   * @param ret_vals a vector of mlir Value  representing graph's
-   *   output tensor.
+   * @param output onnx output ValueInfoProto.
+   * @param ret_types a vector of types representing graph's output types.
+   * @param ret_vals a vector of mlir Value representing graph's output.
    */
   void ImportOutputTensor(const onnx::ValueInfoProto &output,
       llvm::SmallVectorImpl<Type> &ret_types,
       llvm::SmallVectorImpl<Value> &ret_vals) {
-    Value tensor_val = frontend_symbols_.GetTensorByOnnxName(output.name());
+    Value val = frontend_symbols_.GetTensorByOnnxName(output.name());
     if (output.type().value_case() == onnx::TypeProto::kTensorType) {
       if (output.type().tensor_type().has_shape()) {
-        tensor_val.setType(ImportType(output.type()));
+        val.setType(ImportType(output.type()));
       }
+      ret_types.emplace_back(val.getType());
+    } else {
+      ret_types.emplace_back(ImportType(output.type()));
     }
-    ret_types.emplace_back(tensor_val.getType());
-    ret_vals.push_back(tensor_val);
+    ret_vals.push_back(val);
   }
 
   /*!


### PR DESCRIPTION
this PR solves the problem that the onnx parser cannot parse Optional op's type_proto attribute (it crashes in `ImportType` or `convertOnnxAttributeProtoToMlirNamedAttribute` in FrontendDialectTransformer, depending on whether the `--useOnnxModelTypes` flag is used)

this PR was tested by running:
```bash
Debug/bin/onnx-mlir -v --EmitONNXBasic --useOnnxModelTypes ../third_party/onnx/onnx/backend/test/data/node/test_if_opt/model.onnx -o /tmp/test_if_opt
```
and then:
```bash
Debug/bin/onnx-mlir-opt /tmp/test_if_opt.onnx.mlir
```
to verify that the resulting mlir assembly is well-formed