### PR TITLE
Fix an issue about inserting instrument before op

### DIFF
--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -41,7 +41,7 @@ std::unique_ptr<mlir::Pass> createElideConstantValuePass();
 /// Pass for instrument the Onnx ops
 std::unique_ptr<mlir::Pass> createInstrumentONNXPass();
 std::unique_ptr<mlir::Pass> createInstrumentONNXPass(
-    llvm::StringRef ops, int actions);
+    llvm::StringRef ops, unsigned actions);
 
 /// Passes for instrumenting the ONNX ops to print their operand type
 /// signatures at runtime.

--- a/src/Transform/ONNX/InstrumentONNXPass.cpp
+++ b/src/Transform/ONNX/InstrumentONNXPass.cpp
@@ -67,12 +67,12 @@ public:
   InstrumentONNXPass() = default;
   InstrumentONNXPass(const InstrumentONNXPass &pass)
       : mlir::PassWrapper<InstrumentONNXPass, OperationPass<func::FuncOp>>() {}
-  InstrumentONNXPass(StringRef ops, int actions) {
+  InstrumentONNXPass(StringRef ops, unsigned actions) {
     this->instrumentONNXOps = ops.str();
-    this->instrumentBefore = actions & onnx_mlir::InstrumentBeforeOp;
-    this->instrumentAfter = actions & onnx_mlir::InstrumentAfterOp;
-    this->reportTime = actions & onnx_mlir::InstrumentReportTime;
-    this->reportMemory = actions & onnx_mlir::InstrumentReportMemory;
+    this->instrumentBefore = actions & (1 << onnx_mlir::InstrumentBeforeOp);
+    this->instrumentAfter = actions & (1 << onnx_mlir::InstrumentAfterOp);
+    this->reportTime = actions & (1 << onnx_mlir::InstrumentReportTime);
+    this->reportMemory = actions & (1 << onnx_mlir::InstrumentReportMemory);
   }
 
 private:
@@ -157,6 +157,6 @@ std::unique_ptr<mlir::Pass> onnx_mlir::createInstrumentONNXPass() {
 }
 
 std::unique_ptr<mlir::Pass> onnx_mlir::createInstrumentONNXPass(
-    StringRef ops, int actions) {
+    StringRef ops, unsigned actions) {
   return std::make_unique<InstrumentONNXPass>(ops, actions);
 }

--- a/test/mlir/accelerators/nnpa/conversion/instrument/add-onnx-level.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/instrument/add-onnx-level.mlir
@@ -1,20 +1,17 @@
-// RUN: onnx-mlir-opt --maccel=NNPA %s
-
-// COM: Enable when onnx-mlir driver works well with nnpa.
-// COM: RUN_: onnx-mlir --printIR --EmitZHighIR --instrument-onnx-ops=ALL --InstrumentBeforeOp --InstrumentAfterOp --InstrumentReportTime %s | FileCheck %s
+// RUN: onnx-mlir --maccel=NNPA --printIR --EmitZHighIR --instrument-onnx-ops=ALL --InstrumentBeforeOp --InstrumentAfterOp --InstrumentReportTime %s | FileCheck %s
 
 func.func @test_instrument_add_onnx(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
 }
 
-// CHECK-LABEL:  func @test_instrument_add_onnx
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_0_:.+]] : i64, tag = 5 : i64} : () -> ()
+// CHECK-LABEL:  func.func @test_instrument_add_onnx
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_0_:.+]] : i64, opName = "onnx.Add", tag = 5 : i64} : () -> ()
 // CHECK:           "zhigh.Stick"
 // CHECK:           "zhigh.Stick"
 // CHECK:           "zhigh.Add"
 // CHECK:           "zhigh.Unstick"
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_0_]] : i64, tag = 6 : i64} : () -> ()
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_0_]] : i64, opName = "onnx.Add", tag = 6 : i64} : () -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/mlir/accelerators/nnpa/conversion/instrument/add-zhigh-level.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/instrument/add-zhigh-level.mlir
@@ -1,31 +1,26 @@
-// RUN: onnx-mlir-opt --maccel=NNPA %s
-
-// COM: Enable when onnx-mlir driver works well with nnpa.
-// COM: RUN_: onnx-mlir --printIR --EmitZLowIR --instrument-onnx-ops=ALL --InstrumentBeforeOp --InstrumentAfterOp --InstrumentReportTime --instrument-zhigh-ops=ALL --InstrumentBeforeZHighOp --InstrumentAfterZHighOp --InstrumentReportTimeZHigh %s  | FileCheck %s
+// RUN: onnx-mlir --maccel=NNPA --printIR --EmitZLowIR --instrument-onnx-ops=ALL --InstrumentBeforeOp --InstrumentAfterOp --InstrumentReportTime --instrument-zhigh-ops=ALL --InstrumentBeforeZHighOp --InstrumentAfterZHighOp --InstrumentReportTimeZHigh %s  | FileCheck %s
 
 func.func @test_instrument_add_zhigh(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
 }
 
-// CHECK-LABEL:  func @test_instrument_add_zhigh
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_STICK_:.+]] : i64, tag = 5 : i64} : () -> ()
+// CHECK-LABEL:  func.func @test_instrument_add_zhigh
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_STICK_:.+]] : i64, opName = "zhigh.Stick", tag = 5 : i64} : () -> ()
 // CHECK:           memref.alloc()
 // CHECK:           "zlow.stick"
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_STICK_]] : i64, tag = 6 : i64} : () -> ()
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_STICK_]] : i64, tag = 5 : i64} : () -> ()
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_STICK_]] : i64, opName = "zhigh.Stick", tag = 6 : i64} : () -> ()
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_STICK_]] : i64, opName = "zhigh.Stick", tag = 5 : i64} : () -> ()
 // CHECK:           memref.alloc()
 // CHECK:           "zlow.stick"
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_STICK_]] : i64, tag = 6 : i64} : () -> ()
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_ADD_:.+]] : i64, tag = 5 : i64} : () -> ()
-// CHECK-DAG:       memref.alloc()
-// CHECK-DAG:       "krnl.global"()
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_STICK_]] : i64, opName = "zhigh.Stick", tag = 6 : i64} : () -> ()
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_ADD_:.+]] : i64, opName = "zhigh.Add", tag = 5 : i64} : () -> ()
 // CHECK:           "zlow.add"
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_ADD_]] : i64, tag = 6 : i64} : () -> ()
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_UNSTICK_:.+]] : i64, tag = 5 : i64} : () -> ()
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_ADD_]] : i64, opName = "zhigh.Add", tag = 6 : i64} : () -> ()
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_UNSTICK_:.+]] : i64, opName = "zhigh.Unstick", tag = 5 : i64} : () -> ()
 // CHECK:           memref.alloc()
 // CHECK:           "zlow.unstick"
-// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_UNSTICK_]] : i64, tag = 6 : i64} : () -> ()
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_UNSTICK_]] : i64, opName = "zhigh.Unstick", tag = 6 : i64} : () -> ()
 // CHECK:           return
 // CHECK:         }
 

--- a/test/mlir/conversion/instrument/add.mlir
+++ b/test/mlir/conversion/instrument/add.mlir
@@ -1,0 +1,23 @@
+// RUN: onnx-mlir --printIR --EmitMLIR --instrument-onnx-ops=ALL --InstrumentBeforeOp --InstrumentAfterOp --InstrumentReportTime %s | FileCheck %s
+
+func.func @test_instrument_add_onnx(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+}
+
+// CHECK-LABEL:  func.func @test_instrument_add_onnx
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_0_:.+]] : i64, opName = "onnx.Add", tag = 5 : i64} : () -> ()
+// CHECK:           [[RES_:%.+]] = memref.alloc()
+// CHECK:           affine.for [[I_0_:%.+]] = 0 to 10 {
+// CHECK:             affine.for [[I_1_:%.+]] = 0 to 10 {
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = affine.load
+// CHECK-DAG:           [[LOAD_PARAM_1_MEM_:%.+]] = affine.load
+// CHECK:               [[VAR_3_:%.+]] = arith.addf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK:               affine.store [[VAR_3_]], [[RES_]]{{.}}[[I_0_]], [[I_1_]]{{.}} : memref<10x10xf32>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           "krnl.runtime_instrument"() {opID = [[ID_0_]] : i64, opName = "onnx.Add", tag = 6 : i64} : () -> ()
+// CHECK:           return
+// CHECK:         }
+
+// -----


### PR DESCRIPTION
This PR fixes https://github.com/onnx/onnx-mlir/issues/1600 about instrumentation

- `krnl.runtime_instrument` was not inserted before target op for instrumentation. This PR fixes it and it is inserted before and after the op correctly.
- Add lit tests to avoid these bugs in the future.
