### PR TITLE
[NNPA] Turn a broadcasting BinaryOp whose one of the inputs is a constant into a non-broadcasting BinaryOp

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -70,6 +70,7 @@ void addONNXToZHighPasses(
     mlir::PassManager &pm, ArrayRef<std::string> execNodesOnCpu) {
   pm.addPass(onnx_mlir::createRewriteONNXForZHighPass(execNodesOnCpu));
   pm.addPass(onnx_mlir::createShapeInferencePass());
+  pm.addPass(mlir::createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
   // Add instrumentation for Onnx Ops in the same way as onnx-mlir.
   if (instrumentZHighOps == "" || instrumentZHighOps == "NONE")

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -28,6 +28,7 @@
 #include "src/Accelerators/NNPA/Pass/NNPAPasses.hpp"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Support/TypeUtilities.hpp"
 
 using namespace mlir;
 
@@ -53,6 +54,46 @@ Value getSqrtResultBatchNormA(
       rewriter.create<ONNXSqrtOp>(loc, var.getType(), var_plus_epsilon);
 
   return sqrtResult;
+}
+
+/// Check if A is unidirectionally broadcastable to B, e.g.
+/// A: [256], B: [128x256]
+/// A: [1], B: [128x256]
+/// More info about unidirectional broadcasting:
+/// https://github.com/onnx/onnx/blob/main/docs/Broadcasting.md
+/// Note: being differenct from ONNX broadcasting, we return false if A and B
+/// have exactly the same static shape.
+bool isUniBroadcatableFirstToSecond(Value A, Value B) {
+  if (!hasStaticShape(A.getType()) || !hasStaticShape(B.getType()))
+    return false;
+  ArrayRef<int64_t> aDims = getShape(A.getType());
+  ArrayRef<int64_t> bDims = getShape(B.getType());
+  // A and B have exactly the same static shape.
+  if (aDims == bDims)
+    return false;
+  // aDims size > bDims size: not unidirectional broadcasting from A to B, but B
+  // to A.
+  if (aDims.size() > bDims.size())
+    return false;
+  // Pre-pad A's shape with dims 1 so that two shapes have the same size.
+  SmallVector<int64_t> paddedADims(bDims.size(), 1);
+  for (unsigned i = 0; i < aDims.size(); ++i)
+    paddedADims[bDims.size() - aDims.size() + i] = aDims[i];
+  // Check unidirectional broadcasting.
+  bool isUniBroadcasting = true;
+  for (unsigned i = 0; i < paddedADims.size(); ++i)
+    if (paddedADims[i] > bDims[i]) {
+      isUniBroadcasting = false;
+      break;
+    }
+  return isUniBroadcasting;
+}
+
+/// Check a value is defined by ONNXConstantOp or not.
+bool isDefinedByONNXConstantOp(Value v) {
+  if (v.isa<BlockArgument>())
+    return false;
+  return isa<ONNXConstantOp>(v.getDefiningOp());
 }
 
 //===----------------------------------------------------------------------===//
@@ -100,6 +141,13 @@ void RewriteONNXForZHighPass::runOnOperation() {
   // and `ONNX.Sqrt` to calculate inputs(`a` and `b`)
   addDynamicallyLegalOpFor<ONNXBatchNormalizationInferenceModeOp>(
       &target, execNodesOnCpu);
+
+  target.addDynamicallyLegalOp<ONNXAddOp>([](ONNXAddOp op) {
+    return !((isDefinedByONNXConstantOp(op.B()) &&
+                 isUniBroadcatableFirstToSecond(op.B(), op.A())) ||
+             (isDefinedByONNXConstantOp(op.A()) &&
+                 isUniBroadcatableFirstToSecond(op.A(), op.B())));
+  });
 
   // With the target and rewrite patterns defined, we can now attempt the
   // conversion. The conversion will signal failure if any of our `illegal`

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
@@ -65,4 +65,39 @@ def replaceONNXBatchNormalizationInferenceModePattern : Pattern<
   ]
 >;
 
+//===----------------------------------------------------------------------===//
+// Rewrite AddOp if one of its inputs is a constant and the constant is
+// unidirectional broadcastable to X.
+// For example, X's shape is [1x4x8] and constant's shape is [8].
+// 
+// This is to eliminate broadcasting that is not supported by NNPA.
+//
+// ONNXAddOp %X, %constant = ONNXAddOp %X, (ONNXExpandOp %constant, (ONNXShapeOp %X))
+//
+// Assuming that ONNXAddOp has been canonicalized to the form of (X + constant)
+// 
+//===----------------------------------------------------------------------===//
+
+// Get a type for a tensor that stores the shape of another tensor.
+def GetShapeTypeOf: NativeCodeCall<
+  "RankedTensorType::get({$0.getType().cast<ShapedType>().getRank()}, $_builder.getIntegerType(64))"
+>;
+
+// Check unidirectional broadcasting from the first to second tensor.
+def IsUniBroadcastingFromFirstToSecond: Constraint<
+  CPred<"isUniBroadcatableFirstToSecond($0, $1)">,
+  "Is unidirectional broadcasting from the first to second tensor"
+>;
+
+def IsFromONNXConstantOp: Constraint<
+    CPred<"llvm::dyn_cast_or_null<ONNXConstantOp>($0.getDefiningOp())">,
+    "Is a value from ONNXConstantOp">;
+def expandConstantOperandForAddOp: Pat<
+  (ONNXAddOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
+  (ONNXAddOp $x, (ONNXExpandOp $c,
+                               (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
+                               (returnType $x))),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
 #endif // REWRITE_ONNX_FOR_ZHIGH

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
@@ -92,11 +92,72 @@ def IsUniBroadcastingFromFirstToSecond: Constraint<
 def IsFromONNXConstantOp: Constraint<
     CPred<"llvm::dyn_cast_or_null<ONNXConstantOp>($0.getDefiningOp())">,
     "Is a value from ONNXConstantOp">;
-def expandConstantOperandForAddOp: Pat<
+
+def expandConstantOperandForAddOp1: Pat<
   (ONNXAddOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
   (ONNXAddOp $x, (ONNXExpandOp $c,
                                (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
                                (returnType $x))),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForAddOp2: Pat<
+  (ONNXAddOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
+  (ONNXAddOp (ONNXExpandOp $c,
+                           (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
+                           (returnType $x)),
+             $x),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForDivOp1: Pat<
+  (ONNXDivOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
+  (ONNXDivOp $x, (ONNXExpandOp $c,
+                               (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
+                               (returnType $x))),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForDivOp2: Pat<
+  (ONNXDivOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
+  (ONNXDivOp (ONNXExpandOp $c,
+                           (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
+                           (returnType $x)),
+             $x),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForMulOp1: Pat<
+  (ONNXMulOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
+  (ONNXMulOp $x, (ONNXExpandOp $c,
+                               (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
+                               (returnType $x))),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForMulOp2: Pat<
+  (ONNXMulOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
+  (ONNXMulOp (ONNXExpandOp $c,
+                           (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
+                           (returnType $x)),
+             $x),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForSubOp1: Pat<
+  (ONNXSubOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
+  (ONNXSubOp $x, (ONNXExpandOp $c,
+                               (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
+                               (returnType $x))),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForSubOp2: Pat<
+  (ONNXSubOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
+  (ONNXSubOp (ONNXExpandOp $c,
+                           (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
+                           (returnType $x)),
+             $x),
   [(IsUniBroadcastingFromFirstToSecond $c, $x)]
 >;
 

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
@@ -66,15 +66,18 @@ def replaceONNXBatchNormalizationInferenceModePattern : Pattern<
 >;
 
 //===----------------------------------------------------------------------===//
-// Rewrite AddOp if one of its inputs is a constant and the constant is
-// unidirectional broadcastable to X.
-// For example, X's shape is [1x4x8] and constant's shape is [8].
+// These rules are to eliminate broadcasting that is not supported by NNPA.
+//
+// Rewrite `BinaryOp(lhs, rhs)` if one of the two inputs is a constant and
+// unidirectional broadcastable to the other input.
+// For example: lhs is a constant of shape [8] and rhs is of shape [1x4x8].
 // 
-// This is to eliminate broadcasting that is not supported by NNPA.
+// Taking ONNXAddOp as an example, we rewrite it as follows:
 //
-// ONNXAddOp %X, %constant = ONNXAddOp %X, (ONNXExpandOp %constant, (ONNXShapeOp %X))
+// 1. `ONNXAddOp %constant, %X` will be canonicalized to `ONNXAddOp %X, %constant`
+// 2. `ONNXAddOp %X, %constant` will be replaced by
+//       `ONNXAddOp %X, (ONNXExpandOp %constant, (ONNXShapeOp %X))`
 //
-// Assuming that ONNXAddOp has been canonicalized to the form of (X + constant)
 // 
 //===----------------------------------------------------------------------===//
 
@@ -89,11 +92,17 @@ def IsUniBroadcastingFromFirstToSecond: Constraint<
   "Is unidirectional broadcasting from the first to second tensor"
 >;
 
-def IsFromONNXConstantOp: Constraint<
-    CPred<"llvm::dyn_cast_or_null<ONNXConstantOp>($0.getDefiningOp())">,
-    "Is a value from ONNXConstantOp">;
+//===----------------------------------------------------------------------===//
+// For ONNXAddOp
+//===----------------------------------------------------------------------===//
 
 def expandConstantOperandForAddOp1: Pat<
+  (ONNXAddOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
+  (ONNXAddOp $x, $c),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForAddOp2: Pat<
   (ONNXAddOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
   (ONNXAddOp $x, (ONNXExpandOp $c,
                                (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
@@ -101,14 +110,9 @@ def expandConstantOperandForAddOp1: Pat<
   [(IsUniBroadcastingFromFirstToSecond $c, $x)]
 >;
 
-def expandConstantOperandForAddOp2: Pat<
-  (ONNXAddOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
-  (ONNXAddOp (ONNXExpandOp $c,
-                           (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
-                           (returnType $x)),
-             $x),
-  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
->;
+//===----------------------------------------------------------------------===//
+// For ONNXDivOp
+//===----------------------------------------------------------------------===//
 
 def expandConstantOperandForDivOp1: Pat<
   (ONNXDivOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -127,7 +131,17 @@ def expandConstantOperandForDivOp2: Pat<
   [(IsUniBroadcastingFromFirstToSecond $c, $x)]
 >;
 
+//===----------------------------------------------------------------------===//
+// For ONNXMulOp
+//===----------------------------------------------------------------------===//
+
 def expandConstantOperandForMulOp1: Pat<
+  (ONNXMulOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
+  (ONNXMulOp $x, $c),
+  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+def expandConstantOperandForMulOp2: Pat<
   (ONNXMulOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
   (ONNXMulOp $x, (ONNXExpandOp $c,
                                (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
@@ -135,14 +149,9 @@ def expandConstantOperandForMulOp1: Pat<
   [(IsUniBroadcastingFromFirstToSecond $c, $x)]
 >;
 
-def expandConstantOperandForMulOp2: Pat<
-  (ONNXMulOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
-  (ONNXMulOp (ONNXExpandOp $c,
-                           (ONNXShapeOp $x, (returnType (GetShapeTypeOf $x))),
-                           (returnType $x)),
-             $x),
-  [(IsUniBroadcastingFromFirstToSecond $c, $x)]
->;
+//===----------------------------------------------------------------------===//
+// For ONNXSubOp
+//===----------------------------------------------------------------------===//
 
 def expandConstantOperandForSubOp1: Pat<
   (ONNXSubOp $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),

--- a/src/Support/TypeUtilities.cpp
+++ b/src/Support/TypeUtilities.cpp
@@ -30,6 +30,13 @@ bool isRankedShapedType(Type ty) {
   return (ty.isa<ShapedType>() && ty.cast<ShapedType>().hasRank());
 }
 
+/// Check if a type has static shape.
+bool hasStaticShape(mlir::Type ty) {
+  if (!isRankedShapedType(ty))
+    return false;
+  return ty.cast<ShapedType>().hasStaticShape();
+}
+
 /// Get shape.
 ArrayRef<int64_t> getShape(Type ty) {
   assert(isRankedShapedType(ty) && "Type must be ranked");

--- a/src/Support/TypeUtilities.hpp
+++ b/src/Support/TypeUtilities.hpp
@@ -20,6 +20,8 @@ namespace onnx_mlir {
 mlir::Type getElementType(mlir::Type ty);
 /// Check if a type is ShapedType and has rank.
 bool isRankedShapedType(mlir::Type ty);
+/// Check if a type has static shape.
+bool hasStaticShape(mlir::Type ty);
 /// Get shape.
 llvm::ArrayRef<int64_t> getShape(mlir::Type ty);
 /// Get rank.

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -102,6 +102,20 @@ func.func @test_add_block_arg(%arg0: tensor<128x256xf32>, %arg1: tensor<1xf32>) 
 
 // -----
 
+func.func @test_add_dynamic_dims(%arg0: tensor<128x?xf32>) -> (tensor<128x2xf32>) {
+  %cst = "onnx.Constant"() {value = dense<1.0> : tensor<2xf32>} : () -> tensor<2xf32>
+  %0 = "onnx.Add"(%arg0, %cst) : (tensor<128x?xf32>, tensor<2xf32>) -> tensor<128x2xf32>
+  return %0 : tensor<128x2xf32>
+
+// CHECK-LABEL:  func.func @test_add_dynamic_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x?xf32>) -> tensor<128x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"({{.*}}, {{.*}}) : (tensor<128x?xf32>, tensor<2xf32>) -> tensor<128x2xf32>
+// CHECK:           return [[VAR_0_]] : tensor<128x2xf32>
+// CHECK:         }
+}
+
+// -----
+
 func.func @test_div_expand_constant_lhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
   %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
   %0 = "onnx.Div"(%cst, %arg0) : (tensor<1xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
@@ -161,6 +175,20 @@ func.func @test_div_block_arg(%arg0: tensor<128x256xf32>, %arg1: tensor<1xf32>) 
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<128x256xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Div"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
 // CHECK:           return [[VAR_0_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_div_dynamic_dims(%arg0: tensor<128x?xf32>) -> (tensor<128x2xf32>) {
+  %cst = "onnx.Constant"() {value = dense<1.0> : tensor<2xf32>} : () -> tensor<2xf32>
+  %0 = "onnx.Div"(%arg0, %cst) : (tensor<128x?xf32>, tensor<2xf32>) -> tensor<128x2xf32>
+  return %0 : tensor<128x2xf32>
+
+// CHECK-LABEL:  func.func @test_div_dynamic_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x?xf32>) -> tensor<128x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Div"({{.*}}, {{.*}}) : (tensor<128x?xf32>, tensor<2xf32>) -> tensor<128x2xf32>
+// CHECK:           return [[VAR_0_]] : tensor<128x2xf32>
 // CHECK:         }
 }
 
@@ -230,6 +258,20 @@ func.func @test_mul_block_arg(%arg0: tensor<128x256xf32>, %arg1: tensor<1xf32>) 
 
 // -----
 
+func.func @test_mul_dynamic_dims(%arg0: tensor<128x?xf32>) -> (tensor<128x2xf32>) {
+  %cst = "onnx.Constant"() {value = dense<1.0> : tensor<2xf32>} : () -> tensor<2xf32>
+  %0 = "onnx.Mul"(%arg0, %cst) : (tensor<128x?xf32>, tensor<2xf32>) -> tensor<128x2xf32>
+  return %0 : tensor<128x2xf32>
+
+// CHECK-LABEL:  func.func @test_mul_dynamic_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x?xf32>) -> tensor<128x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Mul"({{.*}}, {{.*}}) : (tensor<128x?xf32>, tensor<2xf32>) -> tensor<128x2xf32>
+// CHECK:           return [[VAR_0_]] : tensor<128x2xf32>
+// CHECK:         }
+}
+
+// -----
+
 func.func @test_sub_expand_constant_lhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
   %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
   %0 = "onnx.Sub"(%cst, %arg0) : (tensor<1xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
@@ -289,5 +331,19 @@ func.func @test_sub_block_arg(%arg0: tensor<128x256xf32>, %arg1: tensor<1xf32>) 
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<128x256xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Sub"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
 // CHECK:           return [[VAR_0_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_sub_dynamic_dims(%arg0: tensor<128x?xf32>) -> (tensor<128x2xf32>) {
+  %cst = "onnx.Constant"() {value = dense<1.0> : tensor<2xf32>} : () -> tensor<2xf32>
+  %0 = "onnx.Sub"(%arg0, %cst) : (tensor<128x?xf32>, tensor<2xf32>) -> tensor<128x2xf32>
+  return %0 : tensor<128x2xf32>
+
+// CHECK-LABEL:  func.func @test_sub_dynamic_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x?xf32>) -> tensor<128x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Sub"({{.*}}, {{.*}}) : (tensor<128x?xf32>, tensor<2xf32>) -> tensor<128x2xf32>
+// CHECK:           return [[VAR_0_]] : tensor<128x2xf32>
 // CHECK:         }
 }

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --maccel=NNPA --shape-inference --rewrite-onnx-for-zhigh --constprop-onnx %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --maccel=NNPA --shape-inference --rewrite-onnx-for-zhigh %s -split-input-file | FileCheck %s
 
 func.func @test_batchnorm_epsilon(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>, %arg3: tensor<3xf32>, %arg4: tensor<3xf32>) -> tensor<2x3x4x5xf32> {
   %0 = "onnx.BatchNormalizationInferenceMode"(%arg0, %arg1, %arg2, %arg3, %arg4) {epsilon = 0.00999999977 : f32} : (tensor<2x3x4x5xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x4x5xf32>
@@ -6,21 +6,23 @@ func.func @test_batchnorm_epsilon(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3xf3
 
 // CHECK-LABEL:  func @test_batchnorm_epsilon
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5xf32>, [[PARAM_1_:%.+]]: tensor<3xf32>, [[PARAM_2_:%.+]]: tensor<3xf32>, [[PARAM_3_:%.+]]: tensor<3xf32>, [[PARAM_4_:%.+]]: tensor<3xf32>) -> tensor<2x3x4x5xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<0.00999999977> : tensor<1xf32>} : () -> tensor<1xf32>
-// CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[PARAM_4_]], [[VAR_0_]]) : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Sqrt"([[VAR_1_]]) : (tensor<3xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_3_:%.+]] = "onnx.Div"([[PARAM_1_]], [[VAR_2_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Mul"([[PARAM_3_]], [[VAR_3_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
-// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Sub"([[PARAM_2_]], [[VAR_4_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
-// CHECK-DAG:       [[VAR_6_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<2x3x4x5xf32>) -> tensor<2x4x5x3xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<0.00999999977> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_4_]]) : (tensor<3xf32>) -> tensor<1xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<1xi64>) -> tensor<3xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[PARAM_4_]], [[VAR_2_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Sqrt"([[VAR_3_]]) : (tensor<3xf32>) -> tensor<3xf32>
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Div"([[PARAM_1_]], [[VAR_4_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK:           [[VAR_6_:%.+]] = "onnx.Mul"([[PARAM_3_]], [[VAR_5_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Sub"([[PARAM_2_]], [[VAR_6_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<2x3x4x5xf32>) -> tensor<2x4x5x3xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_7_:%.+]] = "zhigh.Stick"([[VAR_6_]]) {layout = "NHWC"} : (tensor<2x4x5x3xf32>) -> tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK-DAG:       [[VAR_8_:%.+]] = "zhigh.Stick"([[VAR_3_]]) {layout = "1D"} : (tensor<3xf32>) -> tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>
-// CHECK-DAG:       [[VAR_9_:%.+]] = "zhigh.Stick"([[VAR_5_]]) {layout = "1D"} : (tensor<3xf32>) -> tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>
-// CHECK:           [[VAR_10_:%.+]] = "zhigh.BatchNorm"([[VAR_7_]], [[VAR_8_]], [[VAR_9_]]) : (tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>, tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_11_:%.+]] = "zhigh.Unstick"([[VAR_10_]]) : (tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<2x4x5x3xf32>
-// CHECK:           [[VAR_12_:%.+]] = "onnx.Transpose"([[VAR_11_]]) {perm = [0, 3, 1, 2]} : (tensor<2x4x5x3xf32>) -> tensor<2x3x4x5xf32>
-// CHECK:           return [[VAR_12_]] : tensor<2x3x4x5xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "zhigh.Stick"([[VAR_8_]]) {layout = "NHWC"} : (tensor<2x4x5x3xf32>) -> tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK-DAG:       [[VAR_10_:%.+]] = "zhigh.Stick"([[VAR_5_]]) {layout = "1D"} : (tensor<3xf32>) -> tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>
+// CHECK-DAG:       [[VAR_11_:%.+]] = "zhigh.Stick"([[VAR_7_]]) {layout = "1D"} : (tensor<3xf32>) -> tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>
+// CHECK:           [[VAR_12_:%.+]] = "zhigh.BatchNorm"([[VAR_9_]], [[VAR_10_]], [[VAR_11_]]) : (tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>, tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_13_:%.+]] = "zhigh.Unstick"([[VAR_12_]]) : (tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<2x4x5x3xf32>
+// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [0, 3, 1, 2]} : (tensor<2x4x5x3xf32>) -> tensor<2x3x4x5xf32>
+// CHECK:           return [[VAR_14_]] : tensor<2x3x4x5xf32>
 // CHECK:         }
 }
 
@@ -29,32 +31,263 @@ func.func @test_batchnorm_epsilon(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3xf3
 func.func @test_batchnorm_5d_not_lowered(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>, %arg3: tensor<3xf32>, %arg4: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> {
   %0 = "onnx.BatchNormalizationInferenceMode"(%arg0, %arg1, %arg2, %arg3, %arg4) {epsilon = 0.00999999977 : f32} : (tensor<2x3x4x5x6xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x4x5x6xf32>
   return %0 : tensor<2x3x4x5x6xf32>
-  // CHECK-LABEL: test_batchnorm_5d_not_lowered
-  // CHECK: "onnx.BatchNormalizationInferenceMode"
+
+// CHECK-LABEL: test_batchnorm_5d_not_lowered
+// CHECK: "onnx.BatchNormalizationInferenceMode"
 }
 
 // -----
 
-func.func @test_batchnorm_constprop(%arg0: tensor<1x2x3x3xf32>) -> tensor<1x2x3x3xf32> {
-  %0 = "onnx.Constant"() {value = dense<[0.15, 0.2]> : tensor<2xf32>} : () -> tensor<2xf32>
-  %1 = "onnx.Constant"() {value = dense<[0.7, 0.8]> : tensor<2xf32>} : () -> tensor<2xf32>
-  %2 = "onnx.Constant"() {value = dense<[0.5, 0.6]> : tensor<2xf32>} : () -> tensor<2xf32>
-  %3 = "onnx.Constant"() {value = dense<[0.99001,3.99001]> : tensor<2xf32>} : () -> tensor<2xf32>
-  %4 = "onnx.BatchNormalizationInferenceMode"(%arg0, %0, %1, %2, %3) {epsilon = 0.00999 : f32} : (tensor<1x2x3x3xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<1x2x3x3xf32>
-  return %4 : tensor<1x2x3x3xf32>
+func.func @test_add_expand_constant_lhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %0 = "onnx.Add"(%cst, %arg0) : (tensor<1xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
 
-// CHECK-LABEL:  func @test_batchnorm_constprop
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x3x3xf32>) -> tensor<1x2x3x3xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[1.500000e-01, 1.000000e-01]> : tensor<2xf32>} : () -> tensor<2xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Constant"() {value = dense<[6.250000e-01, 7.400000e-01]> : tensor<2xf32>} : () -> tensor<2xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x2x3x3xf32>) -> tensor<1x3x3x2xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "NHWC"} : (tensor<1x3x3x2xf32>) -> tensor<1x3x3x2xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK-DAG:       [[VAR_4_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "1D"} : (tensor<2xf32>) -> tensor<2xf32, #zhigh.encoding<{dataLayout = "1D"}>>
-// CHECK-DAG:       [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_1_]]) {layout = "1D"} : (tensor<2xf32>) -> tensor<2xf32, #zhigh.encoding<{dataLayout = "1D"}>>
-// CHECK:           [[VAR_6_:%.+]] = "zhigh.BatchNorm"([[VAR_3_]], [[VAR_4_]], [[VAR_5_]]) : (tensor<1x3x3x2xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<2xf32, #zhigh.encoding<{dataLayout = "1D"}>>, tensor<2xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<1x3x3x2xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_7_:%.+]] = "zhigh.Unstick"([[VAR_6_]]) : (tensor<1x3x3x2xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x3x3x2xf32>
-// CHECK:           [[VAR_8_:%.+]] = "onnx.Transpose"([[VAR_7_]]) {perm = [0, 3, 1, 2]} : (tensor<1x3x3x2xf32>) -> tensor<1x2x3x3xf32>
-// CHECK:           return [[VAR_8_]] : tensor<1x2x3x3xf32>
+// CHECK-LABEL:  func.func @test_add_expand_constant_lhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_add_expand_constant_rhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %0 = "onnx.Add"(%arg0, %cst) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_add_expand_constant_rhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_add_expand_constant_scalar(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<1.0> : tensor<f32>} : () -> tensor<f32>
+  %0 = "onnx.Add"(%arg0, %cst) : (tensor<128x256xf32>, tensor<f32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_add_expand_constant_scalar
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<f32>} : () -> tensor<f32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<f32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_add_block_arg(%arg0: tensor<128x256xf32>, %arg1: tensor<1xf32>) -> (tensor<128x256xf32>) {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_add_block_arg
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<128x256xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_0_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_div_expand_constant_lhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %0 = "onnx.Div"(%cst, %arg0) : (tensor<1xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_div_expand_constant_lhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Div"([[VAR_2_]], [[PARAM_0_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_div_expand_constant_rhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %0 = "onnx.Div"(%arg0, %cst) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_div_expand_constant_rhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Div"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_div_expand_constant_scalar(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<1.0> : tensor<f32>} : () -> tensor<f32>
+  %0 = "onnx.Div"(%arg0, %cst) : (tensor<128x256xf32>, tensor<f32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_div_expand_constant_scalar
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<f32>} : () -> tensor<f32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<f32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Div"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_div_block_arg(%arg0: tensor<128x256xf32>, %arg1: tensor<1xf32>) -> (tensor<128x256xf32>) {
+  %0 = "onnx.Div"(%arg0, %arg1) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_div_block_arg
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<128x256xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Div"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_0_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_mul_expand_constant_lhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %0 = "onnx.Mul"(%cst, %arg0) : (tensor<1xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_mul_expand_constant_lhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_mul_expand_constant_rhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %0 = "onnx.Mul"(%arg0, %cst) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_mul_expand_constant_rhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_mul_expand_constant_scalar(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<1.0> : tensor<f32>} : () -> tensor<f32>
+  %0 = "onnx.Mul"(%arg0, %cst) : (tensor<128x256xf32>, tensor<f32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_mul_expand_constant_scalar
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<f32>} : () -> tensor<f32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<f32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_mul_block_arg(%arg0: tensor<128x256xf32>, %arg1: tensor<1xf32>) -> (tensor<128x256xf32>) {
+  %0 = "onnx.Mul"(%arg0, %arg1) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_mul_block_arg
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<128x256xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_0_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_sub_expand_constant_lhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %0 = "onnx.Sub"(%cst, %arg0) : (tensor<1xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_sub_expand_constant_lhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Sub"([[VAR_2_]], [[PARAM_0_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_sub_expand_constant_rhs(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<[1.0]> : tensor<1xf32>} : () -> tensor<1xf32>
+  %0 = "onnx.Sub"(%arg0, %cst) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_sub_expand_constant_rhs
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Sub"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_sub_expand_constant_scalar(%arg0: tensor<128x256xf32>) -> (tensor<128x256xf32>) {
+  %cst = "onnx.Constant"() {value = dense<1.0> : tensor<f32>} : () -> tensor<f32>
+  %0 = "onnx.Sub"(%arg0, %cst) : (tensor<128x256xf32>, tensor<f32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_sub_expand_constant_scalar
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>) -> tensor<128x256xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<f32>} : () -> tensor<f32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<128x256xf32>) -> tensor<2xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Expand"([[VAR_0_]], [[VAR_1_]]) : (tensor<f32>, tensor<2xi64>) -> tensor<128x256xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Sub"([[PARAM_0_]], [[VAR_2_]]) : (tensor<128x256xf32>, tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_3_]] : tensor<128x256xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_sub_block_arg(%arg0: tensor<128x256xf32>, %arg1: tensor<1xf32>) -> (tensor<128x256xf32>) {
+  %0 = "onnx.Sub"(%arg0, %arg1) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+  return %0 : tensor<128x256xf32>
+
+// CHECK-LABEL:  func.func @test_sub_block_arg
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x256xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>) -> tensor<128x256xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Sub"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<128x256xf32>, tensor<1xf32>) -> tensor<128x256xf32>
+// CHECK:           return [[VAR_0_]] : tensor<128x256xf32>
 // CHECK:         }
 }

--- a/utils/mlir2FileCheck.py
+++ b/utils/mlir2FileCheck.py
@@ -199,7 +199,7 @@ def process_line(i, line):
 
     # Process definition of variables.
     # Special handling of function header.
-    if re.match(r'\s+(builtin\.)?func', line) is not None:
+    if re.match(r'\s+(func\.)?func', line) is not None:
         # Have a function: reset dictionary and ref counts
         name_dict = prepare_name_dict.copy()
         refcount_dict.clear()
@@ -271,10 +271,10 @@ def process_line(i, line):
     new_line = re.sub(r'\[\[\s*-\s*(\d)', r'{{.}}[-\g<1>', new_line)
     # change a]] -> 1]*
     new_line = re.sub(r'(\d)\s*\]\]', '\g<1>]{{.}}', new_line)
-    if re.match(r'\s+(builtin\.)?func', line) is not None:
+    if re.match(r'\s+(func\.)?func', line) is not None:
         # Split function line into 2 lines. Should make private optional
         new_line = re.sub(
-            r'(\s+)((builtin\.)?func(\s+private)?\s+@[\w]+)\s*(\(.*)', 
+            r'(\s+)((func\.)?func(\s+private)?\s+@[\w]+)\s*(\(.*)', 
             r'// CHECK-LABEL:\1\2\n// CHECK-SAME: \1\5', new_line)
         print(new_line)
     elif squash_before_fct != 1:


### PR DESCRIPTION
In the bertsquad model, there are many broadcasting BinaryOp(s) whose one of its inputs is a constant, e.g. 
```mlir
%0 = "onnx.Constant"() {value = dense<1.0> : tensor<768xf32>} : () -> tensor<768xf32>
%1 = "onnx.Mul"(%arg0, %189) : (tensor<256x768xf32>, tensor<768xf32>) -> tensor<256x768xf32>
```

Since NNPA does not support broadcasting, these ops will not be executed on NNPA. To overcome this, we expand the constant to have the same shape as the other input, so that there is no broadcasting and the op can be run on NNPA. The above `onnx.Mul` will become:
```mlir
%0 = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<768xf32>} : () -> tensor<768xf32>
%1 = "onnx.Shape"(%arg0) : (tensor<256x768xf32>) -> tensor<2xi64>
%2 = "onnx.Expand"(%0, %1) : (tensor<768xf32>, tensor<2xi64>) -> tensor<256x768xf32>
%3 = "onnx.Add"(%arg0, %2) : (tensor<256x768xf32>, tensor<256x768xf32>) -> tensor<256x768xf32>
```

With `--canonicalize --constprop-onnx`, we get:
```mlir
%0 = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<256x768xf32>} : () -> tensor<256x768xf32>
%1 = "onnx.Add"(%arg0, %0) : (tensor<256x768xf32>, tensor<256x768xf32>) -> tensor<256x768xf32>
```