### PR TITLE
[NNPA] Rewrite N-D MatMul into 3-D MatMul so that it can run on NNPA

### DIFF
--- a/docs/SupportedONNXOps-NNPA.md
+++ b/docs/SupportedONNXOps-NNPA.md
@@ -1,5 +1,5 @@
 <!--- Automatically generated, do not edit. -->
-<!--- python documentOps.py --arch NNPA --input test/accelerators/NNPA/backend/CMakeLists.txt --path utils --notes --unsupported -->
+<!--- python documentOps.py --arch NNPA --input test/accelerators/NNPA/backend/CMakeLists.txt --path utils --notes -->
 
 # Supported ONNX Operation for Target *NNPA*.
 
@@ -26,7 +26,7 @@ NNPA has hardware limitations in dimension index size and tensor size, which are
 | **LSTM** |14 |- `direction` and `hidden_size` in `W` must have static dimensions.<br>- `R` must have static dimensions.<br>- `B` and `initial_h` have static dimensions if given. `B`'s direction dim must be 1 or 2.<br>- `P`(peepholes), `activation_alpha`, and `activation_beta` are not supported.<br>- `activations` must be `["Sigmoid", "Tanh", "Tanh"]`.<br>- `clip` is not supported.<br>- `input_forget` must be default value(0).<br>- `layout` is not supported. | |
 | **Log** |13 |Input tensor must have 4 dimensions. | |
 | **LogSoftmax** |13 | | |
-| **MatMul** |13 |Ranks of input tensors must be (Rank of A, Rank of B) = (2, 2), (3, 3), and (3, 2). | |
+| **MatMul** |13 |Ranks of input tensors must be (Rank of A, Rank of B) = (M, N), where M >= 2 and N >= 2. If M or N > 3, only supports static shape at this moment. | |
 | **Max** |13 |- Shape of input tensors must be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions. | |
 | **MaxPool** |12 |- `auto_pad` must be `NOTSET`, `VALID`, and `SAME_UPPER`. If `NOTSET` is used, `pads` must be set so that the padding valid type or same upper.<br>- `ceil_mode` must be default value(0) <br>- Input and output tensors must be 4D tensors(N x C x H x W).<br>- `kernel_shape` must be static.<br>- `ceil_mode` must be default value(0).<br>- `dilations` must be default value(1). | |
 | **Min** |13 |- Shape of input tensors must be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions. | |

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -72,6 +72,7 @@ void addONNXToZHighPasses(
   pm.addPass(onnx_mlir::createShapeInferencePass());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
+  pm.addPass(onnx_mlir::createShapeInferencePass());
   // Add instrumentation for Onnx Ops in the same way as onnx-mlir.
   if (instrumentZHighOps == "" || instrumentZHighOps == "NONE")
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXPass(

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -509,10 +509,6 @@ def IsTransposed: Constraint<CPred<"($_self.cast<IntegerAttr>().getSInt() == 1)"
 def Transpose2D: NativeCodeCall<
   "emitONNXTranspose($_loc, $_builder, $0, SmallVector<int64_t, 2>({1, 0}))">;
 
-def GetZeroI64Attr: NativeCodeCall<
-  "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), APInt(64, 0, /*isSigned=*/true))"
->;
-
 //===----------------------------------------------------------------------===//
 // NNPA does not directly support cases with alpha != 1.0 or beta != 1.0 or bias's rank == 2.
 // Since alpha and beta were legalized by the pass configuration, we check rank only. 

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.td
@@ -57,4 +57,10 @@ def ACT_RELUAttr: NativeCodeCall<"$_builder.getStringAttr(\"ACT_RELU\")">;
 
 def GetTypeOf : NativeCodeCall<"$0.getType()" >;
 
+def GetNullAttr : NativeCodeCall<"Attribute()">;
+
+def GetZeroI64Attr: NativeCodeCall<
+  "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), APInt(64, 0, /*isSigned=*/true))"
+>;
+
 #endif // ONNX_TO_ZHIGH_COMMON

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -64,22 +64,21 @@ Value reshapeTo3D(PatternRewriter &rewriter, Location loc, Value val) {
   ArrayRef<int64_t> shape = getShape(val.getType());
   Type elementType = getElementType(val.getType());
   Type shapeType = RankedTensorType::get({rank}, rewriter.getI64Type());
-  Type oneI64Type = RankedTensorType::get({1}, rewriter.getI64Type());
   Type twoI64Type = RankedTensorType::get({2}, rewriter.getI64Type());
   Type threeI64Type = RankedTensorType::get({3}, rewriter.getI64Type());
 
   Value shapeVal = create.onnx.shape(shapeType, val);
 
-  Value zero = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({0})));
-  Value one = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({1})));
-  Value minusOne = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({-1})));
+  Value zero =
+      create.onnx.constant(rewriter.getI64TensorAttr(ArrayRef<int64_t>({0})));
+  Value one =
+      create.onnx.constant(rewriter.getI64TensorAttr(ArrayRef<int64_t>({1})));
+  Value minusOne =
+      create.onnx.constant(rewriter.getI64TensorAttr(ArrayRef<int64_t>({-1})));
   Value r2Const = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rank - 2})));
+      rewriter.getI64TensorAttr(ArrayRef<int64_t>({rank - 2})));
   Value rConst = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rank})));
+      rewriter.getI64TensorAttr(ArrayRef<int64_t>({rank})));
   Value lastTwoDimVal =
       create.onnx.slice(twoI64Type, shapeVal, r2Const, rConst, zero, one);
 
@@ -122,16 +121,16 @@ Value getMatMulResultShape(
   Value lhsShape = create.onnx.shape(lhsRType, lhs);
   Value rhsShape = create.onnx.shape(rhsRType, rhs);
 
-  Value zero = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({0})));
-  Value one = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({1})));
+  Value zero =
+      create.onnx.constant(rewriter.getI64TensorAttr(ArrayRef<int64_t>({0})));
+  Value one =
+      create.onnx.constant(rewriter.getI64TensorAttr(ArrayRef<int64_t>({1})));
   Value lhsR1Const = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({lhsRank - 1})));
+      rewriter.getI64TensorAttr(ArrayRef<int64_t>({lhsRank - 1})));
   Value rhsRConst = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rhsRank})));
+      rewriter.getI64TensorAttr(ArrayRef<int64_t>({rhsRank})));
   Value rhsR1Const = create.onnx.constant(
-      DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rhsRank - 1})));
+      rewriter.getI64TensorAttr(ArrayRef<int64_t>({rhsRank - 1})));
 
   // if lhsRank >= rhsRank:
   //   - get B1xB2x...xBkxM from lhs shape, then append P from rhs shape.
@@ -148,9 +147,9 @@ Value getMatMulResultShape(
         create.onnx.concat(rI64Type, ValueRange({bmVal, pVal}), concatAxisAttr);
   } else {
     Value lhsR2Const = create.onnx.constant(
-        DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({lhsRank - 2})));
+        rewriter.getI64TensorAttr(ArrayRef<int64_t>({lhsRank - 2})));
     Value rhsR2Const = create.onnx.constant(
-        DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rhsRank - 2})));
+        rewriter.getI64TensorAttr(ArrayRef<int64_t>({rhsRank - 2})));
     Value bVal =
         create.onnx.slice(rhsR2Type, rhsShape, zero, rhsR2Const, zero, one);
     Value mVal = create.onnx.slice(
@@ -317,6 +316,25 @@ void RewriteONNXForZHighPass::runOnOperation() {
     Type aType = op.A().getType();
     Type bType = op.B().getType();
     if (!isRankedShapedType(aType) || !isRankedShapedType(bType))
+      return true;
+
+    // Only support static shape at this moment though the code supports dynamic
+    // shape as well.
+    //
+    // The reason is that lowering (3Dx3D) ONNXMatMul of dynamic shape to NNPA
+    // led to wrong results for the bertsquad-12 model. In particular, the final
+    // output values were shifted, e.g.
+    // clang-format off
+    // at (0, 252) mismatch -0.7646484375 (actual) vs -6.084146022796631 (reference)
+    // at (0, 253) mismatch -0.7646484375 (actual) vs -6.100776195526123 (reference)
+    // at (0, 254) mismatch -0.7646484375 (actual) vs -6.13942813873291 (reference)
+    // at (0, 255) mismatch -0.7646484375 (actual) vs -6.0835771560668945 (reference)
+    // clang-format on
+    //
+    // It is unclear why it happened to dynamic shape.
+    // There is no accuracy issue if (3Dx3D) ONNXMatMul runs on CPU or has
+    // static shape.
+    if (!hasStaticShape(aType) || !hasStaticShape(bType))
       return true;
 
     int64_t aRank = getRank(aType);

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -61,39 +61,40 @@ Value reshapeTo3D(PatternRewriter &rewriter, Location loc, Value val) {
   MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
   int64_t rank = getRank(val.getType());
   assert(rank > 3 && "Require rank > 3");
+  ArrayRef<int64_t> shape = getShape(val.getType());
   Type elementType = getElementType(val.getType());
   Type shapeType = RankedTensorType::get({rank}, rewriter.getI64Type());
   Type oneI64Type = RankedTensorType::get({1}, rewriter.getI64Type());
   Type twoI64Type = RankedTensorType::get({2}, rewriter.getI64Type());
   Type threeI64Type = RankedTensorType::get({3}, rewriter.getI64Type());
 
-  Value shape = rewriter.create<ONNXShapeOp>(loc, shapeType, val);
+  Value shapeVal = create.onnx.shape(shapeType, val);
 
   Value zero = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({0})));
-
   Value one = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({1})));
-
   Value minusOne = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({-1})));
-
   Value r2Const = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rank - 2})));
   Value rConst = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rank})));
-  Value lastTwoDimVal = rewriter.create<ONNXSliceOp>(
-      loc, twoI64Type, shape, r2Const, rConst, zero, one);
+  Value lastTwoDimVal =
+      create.onnx.slice(twoI64Type, shapeVal, r2Const, rConst, zero, one);
 
   IntegerAttr concatAxis =
       IntegerAttr::get(rewriter.getIntegerType(64, /*isSigned=*/true),
           APInt(64, 0, /*isSigned=*/true));
-  Value shapeVal = rewriter.create<ONNXConcatOp>(
-      loc, threeI64Type, ValueRange({minusOne, lastTwoDimVal}), concatAxis);
+  // newShapeVal is [-1, M, N] where M and N are the last dims in the input.
+  Value newShapeVal = create.onnx.concat(
+      threeI64Type, ValueRange({minusOne, lastTwoDimVal}), concatAxis);
 
   // Shape inference will infer the correct shape later.
   return create.onnx.reshape(
-      RankedTensorType::get({-1, -1, -1}, elementType), val, shapeVal);
+      RankedTensorType::get(
+          {-1, shape[rank - 2], shape[rank - 1]}, elementType),
+      val, newShapeVal);
 }
 
 // Get a value that store the shape of the matmul result.
@@ -111,30 +112,24 @@ Value getMatMulResultShape(
       IntegerAttr::get(rewriter.getIntegerType(64, /*isSigned=*/true),
           APInt(64, 0, /*isSigned=*/true));
 
-  Type shapeType = RankedTensorType::get({rank}, rewriter.getI64Type());
-  Type lhsShapeType = RankedTensorType::get({lhsRank}, rewriter.getI64Type());
-  Type lhsShape1Type =
-      RankedTensorType::get({lhsRank - 1}, rewriter.getI64Type());
-  Type rhsShapeType = RankedTensorType::get({rhsRank}, rewriter.getI64Type());
-  Type rhsShape2Type =
-      RankedTensorType::get({rhsRank - 2}, rewriter.getI64Type());
+  Type rI64Type = RankedTensorType::get({rank}, rewriter.getI64Type());
+  Type lhsRType = RankedTensorType::get({lhsRank}, rewriter.getI64Type());
+  Type lhsR1Type = RankedTensorType::get({lhsRank - 1}, rewriter.getI64Type());
+  Type rhsRType = RankedTensorType::get({rhsRank}, rewriter.getI64Type());
+  Type rhsR2Type = RankedTensorType::get({rhsRank - 2}, rewriter.getI64Type());
   Type oneI64Type = RankedTensorType::get({1}, rewriter.getI64Type());
 
-  Value lhsShape = rewriter.create<ONNXShapeOp>(loc, lhsShapeType, lhs);
-  Value rhsShape = rewriter.create<ONNXShapeOp>(loc, rhsShapeType, rhs);
+  Value lhsShape = create.onnx.shape(lhsRType, lhs);
+  Value rhsShape = create.onnx.shape(rhsRType, rhs);
 
   Value zero = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({0})));
-
   Value one = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({1})));
-
   Value lhsR1Const = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({lhsRank - 1})));
-
   Value rhsRConst = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rhsRank})));
-
   Value rhsR1Const = create.onnx.constant(
       DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rhsRank - 1})));
 
@@ -145,25 +140,25 @@ Value getMatMulResultShape(
   //   from rhs shape.
   Value shapeVal;
   if (lhsRank >= rhsRank) {
-    Value bmVal = rewriter.create<ONNXSliceOp>(
-        loc, lhsShape1Type, lhsShape, zero, lhsR1Const, zero, one);
-    Value pVal = rewriter.create<ONNXSliceOp>(
-        loc, oneI64Type, rhsShape, rhsR1Const, rhsRConst, zero, one);
-    shapeVal = rewriter.create<ONNXConcatOp>(
-        loc, shapeType, ValueRange({bmVal, pVal}), concatAxisAttr);
+    Value bmVal =
+        create.onnx.slice(lhsR1Type, lhsShape, zero, lhsR1Const, zero, one);
+    Value pVal = create.onnx.slice(
+        oneI64Type, rhsShape, rhsR1Const, rhsRConst, zero, one);
+    shapeVal =
+        create.onnx.concat(rI64Type, ValueRange({bmVal, pVal}), concatAxisAttr);
   } else {
     Value lhsR2Const = create.onnx.constant(
         DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({lhsRank - 2})));
     Value rhsR2Const = create.onnx.constant(
         DenseElementsAttr::get(oneI64Type, ArrayRef<int64_t>({rhsRank - 2})));
-    Value bVal = rewriter.create<ONNXSliceOp>(
-        loc, rhsShape2Type, rhsShape, zero, rhsR2Const, zero, one);
-    Value mVal = rewriter.create<ONNXSliceOp>(
-        loc, oneI64Type, lhsShape, lhsR2Const, lhsR1Const, zero, one);
-    Value pVal = rewriter.create<ONNXSliceOp>(
-        loc, oneI64Type, rhsShape, rhsR1Const, rhsRConst, zero, one);
-    shapeVal = rewriter.create<ONNXConcatOp>(
-        loc, shapeType, ValueRange({bVal, mVal, pVal}), concatAxisAttr);
+    Value bVal =
+        create.onnx.slice(rhsR2Type, rhsShape, zero, rhsR2Const, zero, one);
+    Value mVal = create.onnx.slice(
+        oneI64Type, lhsShape, lhsR2Const, lhsR1Const, zero, one);
+    Value pVal = create.onnx.slice(
+        oneI64Type, rhsShape, rhsR1Const, rhsRConst, zero, one);
+    shapeVal = create.onnx.concat(
+        rI64Type, ValueRange({bVal, mVal, pVal}), concatAxisAttr);
   }
   return shapeVal;
 }
@@ -171,6 +166,7 @@ Value getMatMulResultShape(
 // Get result type of matmul.
 Type getMatMulResultType(
     PatternRewriter &rewriter, Location loc, Value lhs, Value rhs) {
+  Type elementType = getElementType(lhs.getType());
   int64_t lhsRank = getRank(lhs.getType());
   int64_t rhsRank = getRank(rhs.getType());
   assert((lhsRank >= 2 && rhsRank >= 2) && "Input rank must be >= 2");
@@ -189,13 +185,13 @@ Type getMatMulResultType(
   if (lhsRank >= rhsRank) {
     SmallVector<int64_t, 4> resultShape(lhsShape.begin(), lhsShape.end());
     resultShape[rank - 1] = rhsShape[rhsRank - 1];
-    return RankedTensorType::get(resultShape, getElementType(lhs.getType()));
+    return RankedTensorType::get(resultShape, elementType);
   }
 
   SmallVector<int64_t, 4> resultShape(rhsShape.begin(), rhsShape.end());
-  resultShape[rank - 2] = lhsShape[0];
+  resultShape[rank - 2] = lhsShape[lhsRank - 2];
   resultShape[rank - 1] = rhsShape[rhsRank - 1];
-  return RankedTensorType::get(resultShape, getElementType(lhs.getType()));
+  return RankedTensorType::get(resultShape, elementType);
 }
 
 /// Check if A is unidirectionally broadcastable to B, e.g.

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
@@ -28,6 +28,16 @@ include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.td"
 ///    dag benefitsAdded = (addBenefit 0)
 /// >;
 
+// Check the rank of a value is greater than a given integer.
+class HasRankGT<int rank> :
+  Constraint<CPred<"isRankedShapedType($0.getType()) && "
+                   "(getRank($0.getType()) > " # rank # ")">>;
+
+// Check the rank of a value is of a given integer.
+class HasRankOf<int rank> :
+  Constraint<CPred<"isRankedShapedType($0.getType()) && "
+                   "(getRank($0.getType()) == " # rank # ")">>;
+
 def GetSqrtResultBatchNormA :
       NativeCodeCall<"getSqrtResultBatchNormA($_loc, $_builder, $0, $1)">;
 
@@ -168,6 +178,33 @@ def expandConstantOperandForSubOp2: Pat<
                            (returnType $x)),
              $x),
   [(IsUniBroadcastingFromFirstToSecond $c, $x)]
+>;
+
+//===----------------------------------------------------------------------===//
+// Rules to turn ONNXMatMulOp with N-D inputs into the one with 3-D inputs.
+//===----------------------------------------------------------------------===//
+
+def ReshapeTo3D: NativeCodeCall<
+  "reshapeTo3D($_builder, $_loc, $0)"
+>;
+
+def GetMatMulResultShape: NativeCodeCall<
+  "getMatMulResultShape($_builder, $_loc, $0, $1)"
+>;
+
+def GetMatMulResultType: NativeCodeCall<
+  "getMatMulResultType($_builder, $_loc, $0, $1)"
+>;
+
+def shrinkMatMulNDto3D: Pat<
+  (ONNXMatMulOp:$c $a, $b),
+  (ONNXReshapeOp (ONNXMatMulOp
+                    (ReshapeTo3D:$a_r $a),
+                    (ReshapeTo3D:$b_r $b),
+                    (returnType (GetMatMulResultType $a_r, $b_r))),
+                 (GetMatMulResultShape $a, $b),
+                 (GetZeroI64Attr)),
+  [(HasRankGT<3> $a), (HasRankGT<3> $b)]
 >;
 
 #endif // REWRITE_ONNX_FOR_ZHIGH

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
@@ -196,7 +196,7 @@ def GetMatMulResultType: NativeCodeCall<
   "getMatMulResultType($_builder, $_loc, $0, $1)"
 >;
 
-def shrinkMatMulNDto3D: Pat<
+def rewriteMatMulNDto3D_NonBroadcast: Pat<
   (ONNXMatMulOp:$c $a, $b),
   (ONNXReshapeOp (ONNXMatMulOp
                     (ReshapeTo3D:$a_r $a),
@@ -205,6 +205,28 @@ def shrinkMatMulNDto3D: Pat<
                  (GetMatMulResultShape $a, $b),
                  (GetZeroI64Attr)),
   [(HasRankGT<3> $a), (HasRankGT<3> $b)]
+>;
+
+def rewriteMatMulNDto3D_Broadcast_1: Pat<
+  (ONNXMatMulOp:$c $a, $b),
+  (ONNXReshapeOp (ONNXMatMulOp
+                    (ReshapeTo3D:$a_r $a),
+                    $b,
+                    (returnType (GetMatMulResultType $a_r, $b))),
+                 (GetMatMulResultShape $a, $b),
+                 (GetZeroI64Attr)),
+  [(HasRankGT<3> $a), (HasRankOf<2> $b)]
+>;
+
+def rewriteMatMulNDto3D_Broadcast_2: Pat<
+  (ONNXMatMulOp:$c $a, $b),
+  (ONNXReshapeOp (ONNXMatMulOp
+                    $a,
+                    (ReshapeTo3D:$b_r $b),
+                    (returnType (GetMatMulResultType $a, $b_r))),
+                 (GetMatMulResultShape $a, $b),
+                 (GetZeroI64Attr)),
+  [(HasRankOf<2> $a), (HasRankGT<3> $b)]
 >;
 
 #endif // REWRITE_ONNX_FOR_ZHIGH

--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -47,6 +47,11 @@ Value OnnxBuilder::ceil(Value input) const {
   return b.create<ONNXCeilOp>(loc, toTensor(input.getType()), input);
 }
 
+Value OnnxBuilder::concat(
+    Type outputType, ValueRange inputs, IntegerAttr axis) const {
+  return b.create<ONNXConcatOp>(loc, toTensor(outputType), inputs, axis);
+}
+
 Value OnnxBuilder::constant(Attribute denseAttr) const {
   return b.create<ONNXConstantOp>(loc, Attribute(), denseAttr);
 }
@@ -120,6 +125,16 @@ Value OnnxBuilder::reduceSum(Type outputType, Value data, Value axes,
 Value OnnxBuilder::reshape(Type outputType, Value input, Value shape) const {
   return b.create<ONNXReshapeOp>(
       loc, toTensor(outputType), toTensor(input), toTensor(shape));
+}
+
+Value OnnxBuilder::shape(Type outputType, Value input) const {
+  return b.create<ONNXShapeOp>(loc, toTensor(outputType), toTensor(input));
+}
+
+Value OnnxBuilder::slice(Type outputType, Value input, Value starts, Value ends,
+    Value axes, Value steps) const {
+  return b.create<ONNXSliceOp>(loc, toTensor(outputType), toTensor(input),
+      toTensor(starts), toTensor(ends), toTensor(axes), toTensor(steps));
 }
 
 Value OnnxBuilder::squeeze(Type outputType, Value data, Value axes) const {

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -35,6 +35,10 @@ struct OnnxBuilder : onnx_mlir::DialectBuilder {
   // ONNXCeilOp
   mlir::Value ceil(mlir::Value input) const;
 
+  // ONNXConcatOp
+  mlir::Value concat(mlir::Type outputType, mlir::ValueRange inputs,
+      mlir::IntegerAttr axis) const;
+
   // ONNXConstantOp
   mlir::Value constant(mlir::Attribute denseAttr) const;
   mlir::Value constantFromRawBuffer(mlir::Type resultType, char *buf) const;
@@ -60,6 +64,14 @@ struct OnnxBuilder : onnx_mlir::DialectBuilder {
   // ONNXReshapeOp
   mlir::Value reshape(
       mlir::Type outputType, mlir::Value input, mlir::Value shape) const;
+
+  // ONNXShapeOp
+  mlir::Value shape(mlir::Type outputType, mlir::Value input) const;
+
+  // ONNXSliceOp
+  mlir::Value slice(mlir::Type outputType, mlir::Value input,
+      mlir::Value starts, mlir::Value ends, mlir::Value axes,
+      mlir::Value steps) const;
 
   // ONNXSqueezeOp
   mlir::Value squeeze(

--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -186,10 +186,10 @@ set(NNPA_TEST_LIST
     # test_lstm_with_peepholes_cpu
 
     # ==OP== MatMul
-    # ==LIM== Ranks of input tensors must be (Rank of A, Rank of B) = (2, 2), (3, 3), and (3, 2).
+    # ==LIM== Ranks of input tensors must be (Rank of A, Rank of B) = (M, N), where M >= 2 and N >= 2. If M or N > 3, only supports static shape at this moment.
     test_matmul_2d_cpu,zdnn_matmul_op
     test_matmul_3d_cpu,zdnn_matmul_op
-    # test_matmul_4d_cpu,zdnn_matmul_op # 4d not supported
+    test_matmul_4d_cpu,zdnn_matmul_op
 
     # ==OP== Max
     # ==LIM== - Shape of input tensors must be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions.

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -404,37 +404,38 @@ func.func @test_matmul_broadcast_2(%arg0: tensor<256x256xf32>, %arg1: tensor<4x1
 
 // -----
 
-func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tensor<4x12x?x?xf32>) -> (tensor<4x12x256x?xf32>) {
-    %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<256x?xf32>, tensor<4x12x?x?xf32>) -> tensor<4x12x256x?xf32>
-    return %0 : tensor<4x12x256x?xf32>
-
-// MATMUL-LABEL:  func.func @test_matmul_broadcast_dyn_dims
-// MATMUL-SAME:   ([[PARAM_0_:%.+]]: tensor<256x?xf32>, [[PARAM_1_:%.+]]: tensor<4x12x?x?xf32>) -> tensor<?x?x?x?xf32> {
-// MATMUL-DAG:       [[VAR_0_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
-// MATMUL-DAG:       [[VAR_1_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_4_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL:           [[VAR_6_:%.+]] = "onnx.Slice"([[VAR_0_]], [[VAR_4_]], [[VAR_5_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// MATMUL:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_3_]], [[VAR_6_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<2xi64>) -> tensor<3xi64>
-// MATMUL:           [[VAR_8_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_7_]]) {allowzero = 0 : si64} : (tensor<4x12x?x?xf32>, tensor<3xi64>) -> tensor<?x?x?xf32>
-// MATMUL-DAG:       [[VAR_9_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_8_]]) : (tensor<256x?xf32>, tensor<?x?x?xf32>) -> tensor<?x256x?xf32>
-// MATMUL-DAG:       [[VAR_10_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<256x?xf32>) -> tensor<2xi64>
-// MATMUL-DAG:       [[VAR_11_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
-// MATMUL-DAG:       [[VAR_12_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_13_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_14_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_15_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_16_:%.+]] = "onnx.Constant"() {value = dense<3> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_17_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_18_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-NOT: separator of consecutive DAGs
-// MATMUL-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_12_]], [[VAR_18_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// MATMUL-DAG:       [[VAR_20_:%.+]] = "onnx.Slice"([[VAR_10_]], [[VAR_17_]], [[VAR_14_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_21_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_16_]], [[VAR_15_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-// MATMUL:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_20_]], [[VAR_21_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
-// MATMUL:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_22_]]) {allowzero = 0 : si64} : (tensor<?x256x?xf32>, tensor<4xi64>) -> tensor<?x?x?x?xf32>
-// MATMUL:           return [[VAR_23_]] : tensor<?x?x?x?xf32>
-// MATMUL:         }
-}
+// COM: enable this when the bug about dynamic shape is fixed.
+// COM: func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tensor<4x12x?x?xf32>) -> (tensor<4x12x256x?xf32>) {
+// COM:     %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<256x?xf32>, tensor<4x12x?x?xf32>) -> tensor<4x12x256x?xf32>
+// COM:     return %0 : tensor<4x12x256x?xf32>
+// COM: 
+// COM: // MATMUL-LABEL:  func.func @test_matmul_broadcast_dyn_dims
+// COM: // MATMUL-SAME:   ([[PARAM_0_:%.+]]: tensor<256x?xf32>, [[PARAM_1_:%.+]]: tensor<4x12x?x?xf32>) -> tensor<?x?x?x?xf32> {
+// COM: // MATMUL-DAG:       [[VAR_0_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
+// COM: // MATMUL-DAG:       [[VAR_1_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_4_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL:           [[VAR_6_:%.+]] = "onnx.Slice"([[VAR_0_]], [[VAR_4_]], [[VAR_5_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// COM: // MATMUL:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_3_]], [[VAR_6_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<2xi64>) -> tensor<3xi64>
+// COM: // MATMUL:           [[VAR_8_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_7_]]) {allowzero = 0 : si64} : (tensor<4x12x?x?xf32>, tensor<3xi64>) -> tensor<?x?x?xf32>
+// COM: // MATMUL-DAG:       [[VAR_9_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_8_]]) : (tensor<256x?xf32>, tensor<?x?x?xf32>) -> tensor<?x256x?xf32>
+// COM: // MATMUL-DAG:       [[VAR_10_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<256x?xf32>) -> tensor<2xi64>
+// COM: // MATMUL-DAG:       [[VAR_11_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
+// COM: // MATMUL-DAG:       [[VAR_12_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_13_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_14_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_15_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_16_:%.+]] = "onnx.Constant"() {value = dense<3> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_17_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_18_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
+// COM: // MATMUL-NOT: separator of consecutive DAGs
+// COM: // MATMUL-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_12_]], [[VAR_18_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// COM: // MATMUL-DAG:       [[VAR_20_:%.+]] = "onnx.Slice"([[VAR_10_]], [[VAR_17_]], [[VAR_14_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// COM: // MATMUL-DAG:       [[VAR_21_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_16_]], [[VAR_15_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// COM: // MATMUL:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_20_]], [[VAR_21_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+// COM: // MATMUL:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_22_]]) {allowzero = 0 : si64} : (tensor<?x256x?xf32>, tensor<4xi64>) -> tensor<?x?x?x?xf32>
+// COM: // MATMUL:           return [[VAR_23_]] : tensor<?x?x?x?xf32>
+// COM: // MATMUL:         }
+// COM: }

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -401,3 +401,38 @@ func.func @test_matmul_broadcast_2(%arg0: tensor<256x256xf32>, %arg1: tensor<4x1
 // MATMUL:           return [[VAR_4_]] : tensor<4x12x256x64xf32>
 // MATMUL:         }
 }
+
+// -----
+
+func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tensor<4x12x?x?xf32>) -> (tensor<4x12x256x?xf32>) {
+    %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<256x?xf32>, tensor<4x12x?x?xf32>) -> tensor<4x12x256x?xf32>
+    return %0 : tensor<4x12x256x?xf32>
+
+// MATMUL-LABEL:  func.func @test_matmul_broadcast_dyn_dims
+// MATMUL-SAME:   ([[PARAM_0_:%.+]]: tensor<256x?xf32>, [[PARAM_1_:%.+]]: tensor<4x12x?x?xf32>) -> tensor<?x?x?x?xf32> {
+// MATMUL-DAG:       [[VAR_0_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
+// MATMUL-DAG:       [[VAR_1_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_4_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<3> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL:           [[VAR_6_:%.+]] = "onnx.Slice"([[VAR_0_]], [[VAR_4_]], [[VAR_5_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// MATMUL:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_3_]], [[VAR_6_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<2xi64>) -> tensor<3xi64>
+// MATMUL:           [[VAR_8_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_7_]]) {allowzero = 0 : si64} : (tensor<4x12x?x?xf32>, tensor<3xi64>) -> tensor<?x?x?xf32>
+// MATMUL-DAG:       [[VAR_9_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_8_]]) : (tensor<256x?xf32>, tensor<?x?x?xf32>) -> tensor<?x256x?xf32>
+// MATMUL-DAG:       [[VAR_10_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<256x?xf32>) -> tensor<2xi64>
+// MATMUL-DAG:       [[VAR_11_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
+// MATMUL-DAG:       [[VAR_12_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_13_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_14_:%.+]] = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_15_:%.+]] = "onnx.Constant"() {value = dense<-2> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_16_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-NOT: separator of consecutive DAGs
+// MATMUL-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_12_]], [[VAR_15_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// MATMUL-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_10_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_14_]], [[VAR_16_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// MATMUL:           [[VAR_20_:%.+]] = "onnx.Concat"([[VAR_17_]], [[VAR_18_]], [[VAR_19_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+// MATMUL:           [[VAR_21_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_20_]]) {allowzero = 0 : si64} : (tensor<?x256x?xf32>, tensor<4xi64>) -> tensor<?x?x?x?xf32>
+// MATMUL:           return [[VAR_21_]] : tensor<?x?x?x?xf32>
+// MATMUL:         }
+}

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -415,7 +415,7 @@ func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tenso
 // MATMUL-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
 // MATMUL-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
 // MATMUL-DAG:       [[VAR_4_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<3> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
 // MATMUL:           [[VAR_6_:%.+]] = "onnx.Slice"([[VAR_0_]], [[VAR_4_]], [[VAR_5_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
 // MATMUL:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_3_]], [[VAR_6_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<2xi64>) -> tensor<3xi64>
 // MATMUL:           [[VAR_8_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_7_]]) {allowzero = 0 : si64} : (tensor<4x12x?x?xf32>, tensor<3xi64>) -> tensor<?x?x?xf32>
@@ -424,15 +424,17 @@ func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tenso
 // MATMUL-DAG:       [[VAR_11_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
 // MATMUL-DAG:       [[VAR_12_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
 // MATMUL-DAG:       [[VAR_13_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_14_:%.+]] = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_15_:%.+]] = "onnx.Constant"() {value = dense<-2> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_16_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_14_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_15_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_16_:%.+]] = "onnx.Constant"() {value = dense<3> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_17_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_18_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
 // MATMUL-NOT: separator of consecutive DAGs
-// MATMUL-DAG:       [[VAR_17_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_12_]], [[VAR_15_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// MATMUL-DAG:       [[VAR_18_:%.+]] = "onnx.Slice"([[VAR_10_]], [[VAR_12_]], [[VAR_13_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_14_]], [[VAR_16_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-// MATMUL:           [[VAR_20_:%.+]] = "onnx.Concat"([[VAR_17_]], [[VAR_18_]], [[VAR_19_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
-// MATMUL:           [[VAR_21_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_20_]]) {allowzero = 0 : si64} : (tensor<?x256x?xf32>, tensor<4xi64>) -> tensor<?x?x?x?xf32>
-// MATMUL:           return [[VAR_21_]] : tensor<?x?x?x?xf32>
+// MATMUL-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_12_]], [[VAR_18_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// MATMUL-DAG:       [[VAR_20_:%.+]] = "onnx.Slice"([[VAR_10_]], [[VAR_17_]], [[VAR_14_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// MATMUL-DAG:       [[VAR_21_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_16_]], [[VAR_15_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// MATMUL:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_20_]], [[VAR_21_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+// MATMUL:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_22_]]) {allowzero = 0 : si64} : (tensor<?x256x?xf32>, tensor<4xi64>) -> tensor<?x?x?x?xf32>
+// MATMUL:           return [[VAR_23_]] : tensor<?x?x?x?xf32>
 // MATMUL:         }
 }


### PR DESCRIPTION
This patch is to rewrite N-D MatMul into 3-D MatMul so that it can run on NNPA. For example, the following MatMul:
```mlir
func.func @test_matmul(%arg0: tensor<4x12x256x256xf32>, %arg1: tensor<4x12x256x64xf32>) -> (tensor<4x12x256x64xf32>) {
    %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<4x12x256x256xf32>, tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32>
    return %0 : tensor<4x12x256x64xf32>
}
```
will become:
```mlir
func.func @test_matmul(%arg0: tensor<4x12x256x256xf32>, %arg1: tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32> {
    %0 = "onnx.Constant"() {value = dense<[-1, 256, 256]> : tensor<3xi64>} : () -> tensor<3xi64>
    %1 = "onnx.Reshape"(%arg0, %0) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
    %2 = "onnx.Constant"() {value = dense<[-1, 256, 64]> : tensor<3xi64>} : () -> tensor<3xi64>
    %3 = "onnx.Reshape"(%arg1, %2) {allowzero = 0 : si64} : (tensor<4x12x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
    %4 = "onnx.MatMul"(%1, %3) : (tensor<48x256x256xf32>, tensor<48x256x64xf32>) -> tensor<48x256x64xf32>
    %5 = "onnx.Constant"() {value = dense<[4, 12, 256, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
    %6 = "onnx.Reshape"(%4, %5) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
    return %6 : tensor<4x12x256x64xf32>
  }
```