### PR TITLE
Reduce the number of parallel jobs to avoid OOM

### DIFF
--- a/.buildbot/jenkins-build-project.py
+++ b/.buildbot/jenkins-build-project.py
@@ -24,11 +24,11 @@ logging.basicConfig(
 # (128 threads) and only 32GB memory. So spawning off 128
 # cc/c++ processes is going to quickly exhaust the memory.
 #
-# Algorithm: NPROC = min(2, # of CPUs) if memory < 8GB, otherwise
-#            NPROC = min(memory / 4, # of CPUs)
+# Algorithm: NPROC = min(2, # of CPUs) if memory < 16GB, otherwise
+#            NPROC = min(memory / 8, # of CPUs)
 MEMORY_IN_GB                = (os.sysconf('SC_PAGE_SIZE') *
                                os.sysconf('SC_PHYS_PAGES') / (1024.**3))
-NPROC                       = str(math.ceil(min(max(2, MEMORY_IN_GB/4), os.cpu_count())))
+NPROC                       = str(math.ceil(min(max(2, MEMORY_IN_GB/8), os.cpu_count())))
 
 READ_CHUNK_SIZE             = 1024*1024
 BASE_BRANCH                 = 'main'

--- a/.buildbot/jenkins-check-model-zoo.py
+++ b/.buildbot/jenkins-check-model-zoo.py
@@ -17,7 +17,7 @@ logging.basicConfig(
 # (128 threads) and only 32GB memory. So spawning off 128
 # cc/c++ processes is going to quickly exhaust the memory.
 #
-# Algorithm: NPROC = min(2, # of CPUs) if memory < 8GB, otherwise
+# Algorithm: NPROC = min(2, # of CPUs) if memory < 16GB, otherwise
 #            NPROC = min(memory / 8, # of CPUs)
 MEMORY_IN_GB               = (os.sysconf('SC_PAGE_SIZE') *
                               os.sysconf('SC_PHYS_PAGES') / (1024.**3))

--- a/.buildbot/jenkins-watch-llvm-project.py
+++ b/.buildbot/jenkins-watch-llvm-project.py
@@ -29,11 +29,11 @@ logging.basicConfig(
 # (128 threads) and only 32GB memory. So spawning off 128
 # cc/c++ processes is going to quickly exhaust the memory.
 #
-# Algorithm: NPROC = min(2, # of CPUs) if memory < 8GB, otherwise
-#            NPROC = min(memory / 4, # of CPUs)
+# Algorithm: NPROC = min(2, # of CPUs) if memory < 16GB, otherwise
+#            NPROC = min(memory / 8, # of CPUs)
 MEMORY_IN_GB                = (os.sysconf('SC_PAGE_SIZE') *
                                os.sysconf('SC_PHYS_PAGES') / (1024.**3))
-NPROC                       = str(math.ceil(min(max(2, MEMORY_IN_GB/4), os.cpu_count())))
+NPROC                       = str(math.ceil(min(max(2, MEMORY_IN_GB/8), os.cpu_count())))
 
 CPU_ARCH                    = platform.uname().machine.replace('x86_64', 'amd64')
 EPOCH0                      = datetime.utcfromtimestamp(0).isoformat() + 'Z'
@@ -789,7 +789,7 @@ def compute_range_build_next():
             watch_state['build_history'] = hist
         else:
             watch_state['build_history'] += hist
-                   
+
     # Update watch state and write watch history
     watch_state['converged'] = converged
     watch_state['llvm_history_github'] = llvm_history_github

--- a/.buildbot/llvm-watch.html
+++ b/.buildbot/llvm-watch.html
@@ -80,25 +80,25 @@
 	xAxis.get("periodChangeDateFormats")["day"] = "MMM d, yyyy";
 
 	/* Create Y axis */
-	var yAxis = chart.yAxes.push( 
-	    am5xy.ValueAxis.new(root, { 
-		renderer: am5xy.AxisRendererY.new(root, {}) 
-	    }) 
+	var yAxis = chart.yAxes.push(
+	    am5xy.ValueAxis.new(root, {
+		renderer: am5xy.AxisRendererY.new(root, {})
+	    })
 	);
 
 	/* Set Y axis title */
 	yAxis.children.unshift(
-  	    am5.Label.new(root, {
+	    am5.Label.new(root, {
 		rotation: -90,
 		text: "Total Code Change (lines)",
 		y: am5.p50,
 		centerX: am5.p50
-  	    })
+	    })
 	);
 
 	/* Create cursor, required for tooltip */
 	var cursor = chart.set("cursor", am5xy.XYCursor.new(root, {
-  	    behavior: "zoomX"
+	    behavior: "zoomX"
 	}));
 	cursor.lineX.set("visible", false);
 	cursor.lineY.set("visible", false);


### PR DESCRIPTION
It appears that memory usage for compiling and/or running models are increasing, frequently causing OOM on the Jenkins CI servers. So reduce the number of parallel jobs to avoid OOM.

Signed-off-by: Gong Su <gong_su@hotmail.com>