### PR TITLE
feat(bump): Bump 'onnx-mlir' to llvm '2dde4ba63974'

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -619,7 +619,7 @@ private:
       if (node.output()[i].empty()) {
         outputTypes.emplace_back(builder_.getNoneType());
       } else if (auto onnxModelType = ConvertOnnxType(node.output(i))) {
-        outputTypes.emplace_back(onnxModelType.getValue());
+        outputTypes.emplace_back(onnxModelType.value());
       } else {
         unsigned int j = i;
         // Variadic output is a single ODS result.

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -109,8 +109,8 @@ static std::string getExecPath() {
 // to deal with lib64 anymore.
 static std::string getRuntimeDir() {
   const auto &envDir = getEnvVar("ONNX_MLIR_RUNTIME_DIR");
-  if (envDir && llvm::sys::fs::exists(envDir.getValue()))
-    return envDir.getValue();
+  if (envDir && llvm::sys::fs::exists(envDir.value()))
+    return envDir.value();
 
   std::string execDir = llvm::sys::path::parent_path(getExecPath()).str();
   if (llvm::sys::path::stem(execDir).str().compare("bin") == 0) {
@@ -170,8 +170,8 @@ struct Command {
 
   // Append a single optional string argument.
   Command &appendStrOpt(const llvm::Optional<std::string> &arg) {
-    if (arg.hasValue())
-      _args.emplace_back(arg.getValue());
+    if (arg.has_value())
+      _args.emplace_back(arg.value());
     return *this;
   }
 

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -462,7 +462,7 @@ Value emitScalarOpFor<ONNXSoftsignOp>(ConversionPatternRewriter &rewriter,
   // ONNXSoftsignOp(%X) = DivFOp(ConstantOp 1, %X)
   Value operand = scalarOperands[0];
 
-  auto abs = rewriter.create<math::AbsOp>(loc, operand);
+  auto abs = rewriter.create<math::AbsFOp>(loc, operand);
   MathBuilder createMath(rewriter, loc);
   Value one = createMath.constant(elementType, 1);
   Value add = createMath.add(abs, one);
@@ -583,7 +583,7 @@ Value emitScalarOpFor<ONNXAbsOp>(ConversionPatternRewriter &rewriter,
   Value operand = scalarOperands[0];
 
   if (elementType.isa<FloatType>()) {
-    return rewriter.create<math::AbsOp>(loc, operand);
+    return rewriter.create<math::AbsFOp>(loc, operand);
   } else if (elementType.isa<IntegerType>()) {
     MathBuilder createMath(rewriter, loc);
     Value zero = createMath.constant(elementType, 0);

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -567,11 +567,11 @@ Value emitArgSort(ConversionPatternRewriter &rewriter, Location loc,
 DenseElementsAttr getDenseElementAttributeFromConstantValue(Value value) {
   auto definingOp = value.getDefiningOp();
   if (auto globalOp = dyn_cast_or_null<mlir::KrnlGlobalOp>(definingOp)) {
-    if (globalOp.value().hasValue())
+    if (globalOp.value().has_value())
       return globalOp.valueAttr().dyn_cast<DenseElementsAttr>();
   } else if (auto globalOp =
                  dyn_cast_or_null<mlir::ONNXConstantOp>(definingOp)) {
-    if (globalOp.value().hasValue())
+    if (globalOp.value().has_value())
       return globalOp.valueAttr().dyn_cast<DenseElementsAttr>();
   }
   return nullptr;

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -719,22 +719,22 @@ LogicalResult KrnlMatMulOp::verify() {
   if (operandAdaptor.loops().size() != 3)
     return emitOpError("loops rank should be 3 (i,j,k)");
 
-  if (operandAdaptor.computeTileSize().hasValue()) {
+  if (operandAdaptor.computeTileSize().has_value()) {
     ArrayAttr computeAttr = operandAdaptor.computeTileSize().getValue();
     if (!(computeAttr.size() == 0 || computeAttr.size() == 3))
       return emitOpError("computeTileSize rank should be 0 or 3");
   }
-  if (operandAdaptor.aTileSize().hasValue()) {
+  if (operandAdaptor.aTileSize().has_value()) {
     ArrayAttr aTileAttr = operandAdaptor.aTileSize().getValue();
     if (!(aTileAttr.size() == 0 || aTileAttr.size() == 2))
       return emitOpError("aTileSize rank should be 0 or 2");
   }
-  if (operandAdaptor.bTileSize().hasValue()) {
+  if (operandAdaptor.bTileSize().has_value()) {
     ArrayAttr bTileAttr = operandAdaptor.bTileSize().getValue();
     if (!(bTileAttr.size() == 0 || bTileAttr.size() == 2))
       return emitOpError("bTileSize rank should be 0 or 2");
   }
-  if (operandAdaptor.cTileSize().hasValue()) {
+  if (operandAdaptor.cTileSize().has_value()) {
     ArrayAttr cTileAttr = operandAdaptor.cTileSize().getValue();
     if (!(cTileAttr.size() == 0 || cTileAttr.size() == 2))
       return emitOpError("cTileSize rank should be 0 or 2");

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -877,7 +877,7 @@ Value LLVMBuilder::call(ArrayRef<Type> resultTypes, StringRef funcName,
   // CallOp may return either 0 or 1 value.
   if (resultTypes.empty())
     return nullptr;
-  return callOp.getResult(0);
+  return callOp.getResult();
 }
 
 Value LLVMBuilder::call(ArrayRef<Type> resultTypes,
@@ -889,7 +889,7 @@ Value LLVMBuilder::call(ArrayRef<Type> resultTypes,
   // CallOp may return either 0 or 1 value.
   if (resultTypes.empty())
     return nullptr;
-  return callOp.getResult(0);
+  return callOp.getResult();
 }
 
 void LLVMBuilder::condBr(Value cond, Block *trueBlock,
@@ -947,8 +947,7 @@ Value LLVMBuilder::constant(Type type, double val) const {
 
 Value LLVMBuilder::extractValue(
     Type resultType, Value container, ArrayRef<int64_t> position) const {
-  ArrayAttr posAttr = b.getI64ArrayAttr(position);
-  return b.create<LLVM::ExtractValueOp>(loc, resultType, container, posAttr);
+  return b.create<LLVM::ExtractValueOp>(loc, container, position);
 }
 
 LLVM::LLVMFuncOp LLVMBuilder::func(StringRef name, Type type) const {
@@ -973,9 +972,8 @@ Value LLVMBuilder::icmp(LLVM::ICmpPredicate cond, Value lhs, Value rhs) const {
 
 Value LLVMBuilder::insertValue(Type resultType, Value container, Value val,
     llvm::ArrayRef<int64_t> position) const {
-  ArrayAttr posAttr = b.getI64ArrayAttr(position);
   return b.create<LLVM::InsertValueOp>(
-      loc, resultType, container, val, posAttr);
+      loc, container, val, position);
 }
 
 Value LLVMBuilder::load(Value addr) const {

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
@@ -276,12 +276,12 @@ LogicalResult ONNXGenericPoolShapeHelper<OP_TYPE, OP_ADAPTOR>::computeShape(
   for (int i = 0; i < spatialRank; ++i) {
     // Strides, default 1.
     strides.emplace_back(
-        strideOpt.hasValue() ? ArrayAttrIntVal(strideOpt, i) : 1);
+        strideOpt.has_value() ? ArrayAttrIntVal(strideOpt, i) : 1);
     // Dilations, default 1.
     dilations.emplace_back(
-        dilationOpt.hasValue() ? ArrayAttrIntVal(dilationOpt, i) : 1);
+        dilationOpt.has_value() ? ArrayAttrIntVal(dilationOpt, i) : 1);
     // Kernel shape from attribute, default from Weight's spatial dims.
-    if (kernelShapeOpt.hasValue()) {
+    if (kernelShapeOpt.has_value()) {
       kernelShape.emplace_back(
           LiteralIndexExpr(ArrayAttrIntVal(kernelShapeOpt, i)));
     } else if (hasFilter) {
@@ -293,7 +293,7 @@ LogicalResult ONNXGenericPoolShapeHelper<OP_TYPE, OP_ADAPTOR>::computeShape(
   }
   // Pads, at this stage a given compile-time literal or default 0.
   for (int i = 0; i < 2 * spatialRank; ++i) {
-    int64_t p = padOpt.hasValue() ? ArrayAttrIntVal(padOpt, i) : 0;
+    int64_t p = padOpt.has_value() ? ArrayAttrIntVal(padOpt, i) : 0;
     pads.emplace_back(LiteralIndexExpr(p));
   }
 

--- a/src/Transform/EnableMemoryPool.cpp
+++ b/src/Transform/EnableMemoryPool.cpp
@@ -133,9 +133,9 @@ public:
       memPoolShape.emplace_back(totalSize);
       auto memPoolMemRefType =
           MemRefType::get(memPoolShape, rewriter.getIntegerType(8));
-      newAlloc = (allocOp.alignment().hasValue())
+      newAlloc = (allocOp.alignment().has_value())
                      ? create.mem.alignedAlloc(
-                           memPoolMemRefType, allocOp.alignment().getValue())
+                           memPoolMemRefType, allocOp.alignment().value())
                      : create.mem.alloc(memPoolMemRefType);
 
     } else {
@@ -145,7 +145,7 @@ public:
 
       Value dyanmicTotalSize =
           getDynamicMemRefSizeInBytes(memRefType, loc, rewriter, allocOp);
-      newAlloc = (allocOp.alignment().hasValue())
+      newAlloc = (allocOp.alignment().has_value())
                      ? create.mem.alignedAlloc(memPoolMemRefType,
                            dyanmicTotalSize, allocOp.alignment().getValue())
                      : create.mem.alloc(memPoolMemRefType, dyanmicTotalSize);

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -559,7 +559,7 @@ LogicalResult ConstPropSplitPatternCommon(Op splitOp, PatternRewriter &rewriter,
   // Compute split offsets.
   SmallVector<int64_t, 4> splitOffsets;
   {
-    if (!splitAttr.hasValue())
+    if (!splitAttr.has_value())
       // If split attribute is not specified, split size is equally divided.
       assert(inputShape[splitAxis] % numOfResults == 0 &&
              "The dimension at the split axis is expected to be divisible by "
@@ -567,7 +567,7 @@ LogicalResult ConstPropSplitPatternCommon(Op splitOp, PatternRewriter &rewriter,
     int64_t offset = 0;
     for (unsigned int i = 0; i < numOfResults; ++i) {
       splitOffsets.emplace_back(offset);
-      if (splitAttr.hasValue())
+      if (splitAttr.has_value())
         offset += splitAttr.getValue()[i].cast<IntegerAttr>().getInt();
       else
         offset += inputShape[splitAxis] / numOfResults;


### PR DESCRIPTION
Minor version bump for `onnx-mlir` to ensure compatibility with `torch-mlir`. Mostly passing still needs some work.

TODO:
* fix remaining `getValue` warnings
* some segfaults in the mlir tests