### PR TITLE
address Optional::{hasValue,getValue} deprecation compiler warnings

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -619,7 +619,7 @@ private:
       if (node.output()[i].empty()) {
         outputTypes.emplace_back(builder_.getNoneType());
       } else if (auto onnxModelType = ConvertOnnxType(node.output(i))) {
-        outputTypes.emplace_back(onnxModelType.getValue());
+        outputTypes.emplace_back(onnxModelType.value());
       } else {
         unsigned int j = i;
         // Variadic output is a single ODS result.

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -109,8 +109,8 @@ static std::string getExecPath() {
 // to deal with lib64 anymore.
 static std::string getRuntimeDir() {
   const auto &envDir = getEnvVar("ONNX_MLIR_RUNTIME_DIR");
-  if (envDir && llvm::sys::fs::exists(envDir.getValue()))
-    return envDir.getValue();
+  if (envDir && llvm::sys::fs::exists(envDir.value()))
+    return envDir.value();
 
   std::string execDir = llvm::sys::path::parent_path(getExecPath()).str();
   if (llvm::sys::path::stem(execDir).str().compare("bin") == 0) {
@@ -170,8 +170,8 @@ struct Command {
 
   // Append a single optional string argument.
   Command &appendStrOpt(const llvm::Optional<std::string> &arg) {
-    if (arg.hasValue())
-      _args.emplace_back(arg.getValue());
+    if (arg.has_value())
+      _args.emplace_back(arg.value());
     return *this;
   }
 

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -567,11 +567,11 @@ Value emitArgSort(ConversionPatternRewriter &rewriter, Location loc,
 DenseElementsAttr getDenseElementAttributeFromConstantValue(Value value) {
   auto definingOp = value.getDefiningOp();
   if (auto globalOp = dyn_cast_or_null<mlir::KrnlGlobalOp>(definingOp)) {
-    if (globalOp.value().hasValue())
+    if (globalOp.value().has_value())
       return globalOp.valueAttr().dyn_cast<DenseElementsAttr>();
   } else if (auto globalOp =
                  dyn_cast_or_null<mlir::ONNXConstantOp>(definingOp)) {
-    if (globalOp.value().hasValue())
+    if (globalOp.value().has_value())
       return globalOp.valueAttr().dyn_cast<DenseElementsAttr>();
   }
   return nullptr;

--- a/src/Conversion/ONNXToKrnl/RNN/GRU.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/GRU.cpp
@@ -75,7 +75,7 @@ getActivationPack<ONNXGRUOp, GruActivationPack>(ONNXGRUOp *op) {
   activationReverse.f.name = "sigmoid";
   activationReverse.g.name = "tanh";
   if (activations) {
-    ArrayAttr activationArrAttr = activations.getValue();
+    ArrayAttr activationArrAttr = activations.value();
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       // Forward activations.
       if (activationArrAttr.size() > 0) {
@@ -104,7 +104,7 @@ getActivationPack<ONNXGRUOp, GruActivationPack>(ONNXGRUOp *op) {
 
   // Get alpha attributes.
   if (activationAlpha) {
-    ArrayAttr activationArrAttr = activationAlpha.getValue();
+    ArrayAttr activationArrAttr = activationAlpha.value();
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       // Forward activations.
       if (activationArrAttr.size() > 0) {
@@ -131,7 +131,7 @@ getActivationPack<ONNXGRUOp, GruActivationPack>(ONNXGRUOp *op) {
 
   // Get beta attributes.
   if (activationBeta) {
-    ArrayAttr activationArrAttr = activationBeta.getValue();
+    ArrayAttr activationArrAttr = activationBeta.value();
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       // Forward activations.
       if (activationArrAttr.size() > 0) {

--- a/src/Conversion/ONNXToKrnl/RNN/LSTM.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/LSTM.cpp
@@ -85,7 +85,7 @@ getActivationPack<ONNXLSTMOp, LstmActivationPack>(ONNXLSTMOp *op) {
   activationReverse.g.name = "tanh";
   activationReverse.h.name = "tanh";
   if (activations) {
-    ArrayAttr activationArrAttr = activations.getValue();
+    ArrayAttr activationArrAttr = activations.value();
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       // Forward activations.
       if (activationArrAttr.size() > 0) {
@@ -122,7 +122,7 @@ getActivationPack<ONNXLSTMOp, LstmActivationPack>(ONNXLSTMOp *op) {
 
   // Get alpha attributes.
   if (activationAlpha) {
-    ArrayAttr activationArrAttr = activationAlpha.getValue();
+    ArrayAttr activationArrAttr = activationAlpha.value();
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       // Forward activations.
       if (activationArrAttr.size() > 0) {
@@ -156,7 +156,7 @@ getActivationPack<ONNXLSTMOp, LstmActivationPack>(ONNXLSTMOp *op) {
 
   // Get beta attributes.
   if (activationBeta) {
-    ArrayAttr activationArrAttr = activationBeta.getValue();
+    ArrayAttr activationArrAttr = activationBeta.value();
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       // Forward activations.
       if (activationArrAttr.size() > 0) {

--- a/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNN.cpp
@@ -84,7 +84,7 @@ getActivationPack<ONNXRNNOp, RnnActivationPack>(ONNXRNNOp *op) {
 
   // Get alpha attributes.
   if (activationAlpha) {
-    ArrayRef<Attribute> activationArrAttr = activationAlpha.getValue();
+    ArrayRef<Attribute> activationArrAttr = activationAlpha.value();
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       // Forward activations.
       if (activationArrAttr.size() > 0) {
@@ -104,7 +104,7 @@ getActivationPack<ONNXRNNOp, RnnActivationPack>(ONNXRNNOp *op) {
 
   // Get beta attributes.
   if (activationBeta) {
-    ArrayRef<Attribute> activationArrAttr = activationBeta.getValue();
+    ArrayRef<Attribute> activationArrAttr = activationBeta.value();
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       // Forward activations.
       if (activationArrAttr.size() > 0) {

--- a/src/Conversion/ONNXToKrnl/RNN/RNNBase.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNNBase.cpp
@@ -264,11 +264,11 @@ Value applyActivation(OpBuilder &rewriter, Location loc,
   std::vector<mlir::NamedAttribute> attributes;
   if (activation.alpha) {
     attributes.emplace_back(
-        rewriter.getNamedAttr("alpha", activation.alpha.getValue()));
+        rewriter.getNamedAttr("alpha", activation.alpha.value()));
   }
   if (activation.beta) {
     attributes.emplace_back(
-        rewriter.getNamedAttr("beta", activation.beta.getValue()));
+        rewriter.getNamedAttr("beta", activation.beta.value()));
   }
   Type resType = operand.getType();
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Compress.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Compress.cpp
@@ -79,12 +79,11 @@ struct ONNXCompressOpLowering : public ConversionPattern {
     // Now replace questionmark by actual computed size.
     Value sum = create.krnl.load(sumMemRef);
     DimIndexExpr dynDim(sum);
-    if (!axis.hasValue())
+    if (!axis.has_value()) {
       shapeHelper.dimsForOutput()[0] = dynDim;
-    else {
-      const int64_t axisValue = (axis.getValue() >= 0)
-                                    ? axis.getValue()
-                                    : axis.getValue() + inputRank;
+    } else {
+      const int64_t axisValue =
+          (axis.value() >= 0) ? axis.value() : axis.value() + inputRank;
       shapeHelper.dimsForOutput()[axisValue] = dynDim;
     }
 
@@ -110,7 +109,7 @@ struct ONNXCompressOpLowering : public ConversionPattern {
     inputBounds.getSymbolList(inputUbs);
 
     // Consider the cases.
-    if (!axis.hasValue()) {
+    if (!axis.has_value()) {
       // We iterate over the original loops, and in the innerblock we test for
       // the condition. The output is 1D.
       //
@@ -181,10 +180,9 @@ struct ONNXCompressOpLowering : public ConversionPattern {
             });
           });
     } else {
-      assert(axis.hasValue() && "Expecting axis to have a value");
-      const int64_t axisValue = (axis.getValue() >= 0)
-                                    ? axis.getValue()
-                                    : axis.getValue() + inputRank;
+      assert(axis.has_value() && "Expecting axis to have a value");
+      const int64_t axisValue =
+          (axis.value() >= 0) ? axis.value() : axis.value() + inputRank;
 
       // Handle case where output is multi-dimensional.
       //

--- a/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
@@ -28,7 +28,7 @@ struct ONNXConstantOpLowering : public ConversionPattern {
     Location loc = ONNXLoc<ONNXConstantOp>(op);
     auto constantOp = cast<ONNXConstantOp>(op);
 
-    if (constantOp.sparse_value().hasValue())
+    if (constantOp.sparse_value().has_value())
       return emitError(loc, "Only support dense values at this time");
 
     // Convert the output type to MemRefType.
@@ -40,7 +40,7 @@ struct ONNXConstantOpLowering : public ConversionPattern {
     // Emit the constant global in Krnl dialect.
     MultiDialectBuilder<KrnlBuilder> create(rewriter, loc);
     Value constantGlobal = create.krnl.constant(
-        memRefType, "constant_", constantOp.value().getValue());
+        memRefType, "constant_", constantOp.value().value());
 
     // Replace this operation with the generated krnl.global.
     rewriter.replaceOp(op, constantGlobal);

--- a/src/Conversion/ONNXToKrnl/Tensor/ConstantOfShape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConstantOfShape.cpp
@@ -30,7 +30,7 @@ struct ONNXConstantOfShapeOpLowering : public ConversionPattern {
 
     auto valueAttr = llvm::cast<ONNXConstantOfShapeOp>(op)
                          .value()
-                         .getValue()
+                         .value()
                          .cast<DenseElementsAttr>();
 
     // Convert the output type to MemRefType.

--- a/src/Conversion/ONNXToMhlo/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToMhlo/Tensor/Constant.cpp
@@ -31,11 +31,11 @@ struct ONNXConstantOpLoweringToMhlo : public ConversionPattern {
         op->getLoc());
     ONNXConstantOp constantOp = cast<ONNXConstantOp>(op);
 
-    if (constantOp.sparse_value().hasValue())
+    if (constantOp.sparse_value().has_value())
       return constantOp.emitWarning("Only support dense values at this time");
-    assert(constantOp.value().hasValue() && "Value is not set");
+    assert(constantOp.value().has_value() && "Value is not set");
     Value result =
-        rewriter.create<mhlo::ConstantOp>(loc, constantOp.value().getValue());
+        rewriter.create<mhlo::ConstantOp>(loc, constantOp.value().value());
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -210,9 +210,8 @@ Value KrnlBuilder::constant(MemRefType type, StringRef name,
   static int32_t constantID = 0;
   return b.create<KrnlGlobalOp>(loc, type, b.getI64ArrayAttr(type.getShape()),
       b.getStringAttr(name + std::to_string(constantID++)),
-      value.hasValue() ? value.getValue() : nullptr,
-      offset.hasValue() ? offset.getValue() : nullptr,
-      alignment.hasValue() ? alignment.getValue() : nullptr);
+      value.value_or(nullptr), offset.value_or(nullptr),
+      alignment.value_or(nullptr));
 }
 
 void KrnlBuilder::memcpy(Value dest, Value src, Value size) const {

--- a/src/Dialect/Krnl/KrnlHelper.cpp
+++ b/src/Dialect/Krnl/KrnlHelper.cpp
@@ -222,7 +222,7 @@ DenseElementsAttr getDenseElementAttributeFromKrnlValue(Value value) {
   KrnlGlobalOp globalOp =
       dyn_cast_or_null<mlir::KrnlGlobalOp>(value.getDefiningOp());
   if (globalOp)
-    if (globalOp.value().hasValue())
+    if (globalOp.value().has_value())
       return globalOp.valueAttr().dyn_cast<DenseElementsAttr>();
 
   return nullptr;

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -719,23 +719,23 @@ LogicalResult KrnlMatMulOp::verify() {
   if (operandAdaptor.loops().size() != 3)
     return emitOpError("loops rank should be 3 (i,j,k)");
 
-  if (operandAdaptor.computeTileSize().hasValue()) {
-    ArrayAttr computeAttr = operandAdaptor.computeTileSize().getValue();
+  if (operandAdaptor.computeTileSize().has_value()) {
+    ArrayAttr computeAttr = operandAdaptor.computeTileSize().value();
     if (!(computeAttr.size() == 0 || computeAttr.size() == 3))
       return emitOpError("computeTileSize rank should be 0 or 3");
   }
-  if (operandAdaptor.aTileSize().hasValue()) {
-    ArrayAttr aTileAttr = operandAdaptor.aTileSize().getValue();
+  if (operandAdaptor.aTileSize().has_value()) {
+    ArrayAttr aTileAttr = operandAdaptor.aTileSize().value();
     if (!(aTileAttr.size() == 0 || aTileAttr.size() == 2))
       return emitOpError("aTileSize rank should be 0 or 2");
   }
-  if (operandAdaptor.bTileSize().hasValue()) {
-    ArrayAttr bTileAttr = operandAdaptor.bTileSize().getValue();
+  if (operandAdaptor.bTileSize().has_value()) {
+    ArrayAttr bTileAttr = operandAdaptor.bTileSize().value();
     if (!(bTileAttr.size() == 0 || bTileAttr.size() == 2))
       return emitOpError("bTileSize rank should be 0 or 2");
   }
-  if (operandAdaptor.cTileSize().hasValue()) {
-    ArrayAttr cTileAttr = operandAdaptor.cTileSize().getValue();
+  if (operandAdaptor.cTileSize().has_value()) {
+    ArrayAttr cTileAttr = operandAdaptor.cTileSize().value();
     if (!(cTileAttr.size() == 0 || cTileAttr.size() == 2))
       return emitOpError("cTileSize rank should be 0 or 2");
   }
@@ -784,12 +784,12 @@ LogicalResult KrnlCopyToBufferOp::verify() {
   if (startRank != srcRank)
     return emitOpError("Rank of starts and memrefs must be identical");
   if (opAdaptor.tileSize()) {
-    int64_t tRank = opAdaptor.tileSize().getValue().size();
+    int64_t tRank = opAdaptor.tileSize().value().size();
     if (!(tRank == 0 || tRank == bufferRank))
       return emitOpError("Rank of tileSize must be identical to buffer");
   }
   if (opAdaptor.padToNext()) {
-    int64_t padRank = opAdaptor.padToNext().getValue().size();
+    int64_t padRank = opAdaptor.padToNext().value().size();
     if (!(padRank == 0 || padRank == bufferRank))
       return emitOpError("Rank of padToNext must be identical to buffer");
   }
@@ -839,7 +839,7 @@ LogicalResult KrnlCopyFromBufferOp::verify() {
   if (startRank != destRank)
     return emitOpError("Rank of starts and memrefs must be identical");
   if (opAdaptor.tileSize()) {
-    int64_t tRank = opAdaptor.tileSize().getValue().size();
+    int64_t tRank = opAdaptor.tileSize().value().size();
     if (!(tRank == 0 || tRank == bufferRank))
       return emitOpError("Rank of tileSize must be identical to buffer");
   }

--- a/src/Dialect/ONNX/ONNXOpsHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOpsHelper.cpp
@@ -162,14 +162,14 @@ AffineMap getWindowAffineMap(Builder &builder, bool ceilMode, bool isDilated) {
 
 size_t ArrayAttrSize(ArrayAttr a) { return a.size(); }
 
-size_t ArrayAttrSize(Optional<ArrayAttr> a) { return a.getValue().size(); }
+size_t ArrayAttrSize(Optional<ArrayAttr> a) { return a.value().size(); }
 
 int64_t ArrayAttrIntVal(ArrayAttr a, int i) {
   return (a.getValue()[i]).cast<IntegerAttr>().getInt();
 }
 
 int64_t ArrayAttrIntVal(Optional<ArrayAttr> a, int i) {
-  return (a.getValue().getValue()[i]).cast<IntegerAttr>().getInt();
+  return (a.value().getValue()[i]).cast<IntegerAttr>().getInt();
 }
 
 DenseElementsAttr getDenseElementAttributeFromONNXValue(Value value) {
@@ -218,7 +218,7 @@ bool isFromNone(Value v) {
   if (v.getDefiningOp() &&
       dyn_cast_or_null<ONNXConstantOp>(v.getDefiningOp())) {
     auto c = dyn_cast<ONNXConstantOp>(v.getDefiningOp());
-    if (c.value().hasValue() && c.valueAttr().isa<DenseElementsAttr>()) {
+    if (c.value().has_value() && c.valueAttr().isa<DenseElementsAttr>()) {
       auto d = c.valueAttr().cast<DenseElementsAttr>();
       auto shape = d.getType().dyn_cast<RankedTensorType>().getShape();
       if (shape.size() == 1 && shape[0] == 0)

--- a/src/Dialect/ONNX/ShapeInference/Compress.cpp
+++ b/src/Dialect/ONNX/ShapeInference/Compress.cpp
@@ -35,10 +35,9 @@ LogicalResult ONNXCompressOpShapeHelper::computeShape(
 
   // axis attribute (if specified) must be in the range [-r,r-1], where r =
   // rank(input).
-  assert(
-      (!optionalAxis.hasValue() || (-inputRank <= optionalAxis.getValue() &&
-                                       optionalAxis.getValue() < inputRank)) &&
-      "axis out of range");
+  assert((!optionalAxis.has_value() || (-inputRank <= optionalAxis.value() &&
+                                           optionalAxis.value() < inputRank)) &&
+         "axis out of range");
 
   // Get the dimension derived from the condition. Assume in shape helper that
   // it is only going to be a question mark. ONNX to Krnl lowering will compute
@@ -52,7 +51,7 @@ LogicalResult ONNXCompressOpShapeHelper::computeShape(
 
   // Compute dims for output.
   DimsExpr outputDims;
-  if (!optionalAxis.hasValue())
+  if (!optionalAxis.has_value())
     // Reduced to a single dimensional array, of dynamic size.
     outputDims.emplace_back(dynDim);
   else {
@@ -63,7 +62,7 @@ LogicalResult ONNXCompressOpShapeHelper::computeShape(
 
     // Negative axis means values are counted from the opposite side.
     // TODO: should be in normalization pass
-    int64_t axisValue = optionalAxis.getValue();
+    int64_t axisValue = optionalAxis.value();
     if (axisValue < 0)
       axisValue += inputRank;
 

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
@@ -276,12 +276,12 @@ LogicalResult ONNXGenericPoolShapeHelper<OP_TYPE, OP_ADAPTOR>::computeShape(
   for (int i = 0; i < spatialRank; ++i) {
     // Strides, default 1.
     strides.emplace_back(
-        strideOpt.hasValue() ? ArrayAttrIntVal(strideOpt, i) : 1);
+        strideOpt.has_value() ? ArrayAttrIntVal(strideOpt, i) : 1);
     // Dilations, default 1.
     dilations.emplace_back(
-        dilationOpt.hasValue() ? ArrayAttrIntVal(dilationOpt, i) : 1);
+        dilationOpt.has_value() ? ArrayAttrIntVal(dilationOpt, i) : 1);
     // Kernel shape from attribute, default from Weight's spatial dims.
-    if (kernelShapeOpt.hasValue()) {
+    if (kernelShapeOpt.has_value()) {
       kernelShape.emplace_back(
           LiteralIndexExpr(ArrayAttrIntVal(kernelShapeOpt, i)));
     } else if (hasFilter) {
@@ -293,7 +293,7 @@ LogicalResult ONNXGenericPoolShapeHelper<OP_TYPE, OP_ADAPTOR>::computeShape(
   }
   // Pads, at this stage a given compile-time literal or default 0.
   for (int i = 0; i < 2 * spatialRank; ++i) {
-    int64_t p = padOpt.hasValue() ? ArrayAttrIntVal(padOpt, i) : 0;
+    int64_t p = padOpt.has_value() ? ArrayAttrIntVal(padOpt, i) : 0;
     pads.emplace_back(LiteralIndexExpr(p));
   }
 

--- a/src/Dialect/ONNX/ShapeInference/Squeeze.cpp
+++ b/src/Dialect/ONNX/ShapeInference/Squeeze.cpp
@@ -63,8 +63,8 @@ LogicalResult ONNXSqueezeV11OpShapeHelper::computeShape(
     ONNXSqueezeV11OpAdaptor operandAdaptor) {
   auto axesAttr = op->axes();
   SmallVector<IndexExpr, 4> indexExprArray;
-  if (axesAttr.hasValue()) {
-    ArrayAttributeIndexCapture axesCapture(axesAttr.getValue());
+  if (axesAttr.has_value()) {
+    ArrayAttributeIndexCapture axesCapture(axesAttr.value());
     auto axesRank = axesCapture.size();
     for (unsigned i = 0; i < axesRank; ++i) {
       indexExprArray.emplace_back(axesCapture.getLiteral(i));

--- a/src/Transform/BundleMemoryPools.cpp
+++ b/src/Transform/BundleMemoryPools.cpp
@@ -241,9 +241,9 @@ public:
         MemRefType::get(newMemPoolShape, rewriter.getIntegerType(8));
 
     memref::AllocOp newStaticMemPoolAlloc =
-        (staticMemPoolAlloc.alignment().hasValue())
+        (staticMemPoolAlloc.alignment().has_value())
             ? create.mem.alignedAlloc(bundledMemPoolMemRefType,
-                  staticMemPoolAlloc.alignment().getValue())
+                  staticMemPoolAlloc.alignment().value())
             : create.mem.alloc(bundledMemPoolMemRefType);
 
     // The newly bundled MemRef expressed as a KrnlGetRefOp.
@@ -461,10 +461,10 @@ public:
 
     // We need to emit a new alloc which contains the additional MemRef.
     memref::AllocOp bundledAlloc =
-        (oldDynamicMemoryPool.alignment().hasValue())
+        (oldDynamicMemoryPool.alignment().has_value())
             ? create.mem.alignedAlloc(bundledMemPoolMemRefType,
                   bundledAllocOperand.getResult(),
-                  oldDynamicMemoryPool.alignment().getValue())
+                  oldDynamicMemoryPool.alignment().value())
             : create.mem.alloc(
                   bundledMemPoolMemRefType, bundledAllocOperand.getResult());
 

--- a/src/Transform/EnableMemoryPool.cpp
+++ b/src/Transform/EnableMemoryPool.cpp
@@ -133,9 +133,9 @@ public:
       memPoolShape.emplace_back(totalSize);
       auto memPoolMemRefType =
           MemRefType::get(memPoolShape, rewriter.getIntegerType(8));
-      newAlloc = (allocOp.alignment().hasValue())
+      newAlloc = (allocOp.alignment().has_value())
                      ? create.mem.alignedAlloc(
-                           memPoolMemRefType, allocOp.alignment().getValue())
+                           memPoolMemRefType, allocOp.alignment().value())
                      : create.mem.alloc(memPoolMemRefType);
 
     } else {
@@ -145,9 +145,9 @@ public:
 
       Value dyanmicTotalSize =
           getDynamicMemRefSizeInBytes(memRefType, loc, rewriter, allocOp);
-      newAlloc = (allocOp.alignment().hasValue())
+      newAlloc = (allocOp.alignment().has_value())
                      ? create.mem.alignedAlloc(memPoolMemRefType,
-                           dyanmicTotalSize, allocOp.alignment().getValue())
+                           dyanmicTotalSize, allocOp.alignment().value())
                      : create.mem.alloc(memPoolMemRefType, dyanmicTotalSize);
     }
 

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -559,7 +559,7 @@ LogicalResult ConstPropSplitPatternCommon(Op splitOp, PatternRewriter &rewriter,
   // Compute split offsets.
   SmallVector<int64_t, 4> splitOffsets;
   {
-    if (!splitAttr.hasValue())
+    if (!splitAttr.has_value())
       // If split attribute is not specified, split size is equally divided.
       assert(inputShape[splitAxis] % numOfResults == 0 &&
              "The dimension at the split axis is expected to be divisible by "
@@ -567,8 +567,8 @@ LogicalResult ConstPropSplitPatternCommon(Op splitOp, PatternRewriter &rewriter,
     int64_t offset = 0;
     for (unsigned int i = 0; i < numOfResults; ++i) {
       splitOffsets.emplace_back(offset);
-      if (splitAttr.hasValue())
-        offset += splitAttr.getValue()[i].cast<IntegerAttr>().getInt();
+      if (splitAttr.has_value())
+        offset += splitAttr.value()[i].cast<IntegerAttr>().getInt();
       else
         offset += inputShape[splitAxis] / numOfResults;
     }

--- a/src/Transform/ONNX/ElideConstants.cpp
+++ b/src/Transform/ONNX/ElideConstants.cpp
@@ -47,10 +47,10 @@ public:
     auto loc = op.getLoc();
     auto constOp = llvm::dyn_cast<ONNXConstantOp>(&op);
 
-    if (constOp->sparse_value().hasValue())
+    if (constOp->sparse_value().has_value())
       return emitError(loc, "Only support dense values at this time");
 
-    if (constOp->value().hasValue()) {
+    if (constOp->value().has_value()) {
       auto newConstOp = rewriter.create<ONNXConstantOp>(loc,
           constOp->getResult().getType(), nullptr, nullptr, nullptr, nullptr,
           nullptr, nullptr, nullptr, nullptr);

--- a/src/Transform/OptimizeMemoryPools.cpp
+++ b/src/Transform/OptimizeMemoryPools.cpp
@@ -784,9 +784,9 @@ public:
 
     // We need to emit a new alloc of smaller size.
     memref::AllocOp newStaticMemPool =
-        (allocOp.alignment().hasValue())
+        (allocOp.alignment().has_value())
             ? create.mem.alignedAlloc(
-                  newStaticMemPoolType, allocOp.alignment().getValue())
+                  newStaticMemPoolType, allocOp.alignment().value())
             : create.mem.alloc(newStaticMemPoolType);
 
     newStaticMemPool.getOperation()->moveBefore(allocOp);


### PR DESCRIPTION
the deprecation warnings were caused by the change "[ADT] Deprecate Optional::{hasValue,getValue} (NFC)" that was pulled in from llvm/mlir in PR #1599

the deprecation warnings are noisy so I'm thinking it's worth getting rid of them