### PR TITLE
Update llvm to e5d5146323ffaa13eb5185616c6ae5c36b69352d

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -14,7 +14,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 061e0189a3dab6b1831a80d489ff1b15ad93aafb && cd ..
+cd llvm-project && git checkout e5d5146323ffaa13eb5185616c6ae5c36b69352d && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 061e0189a3dab6b1831a80d489ff1b15ad93aafb && cd ..
+cd llvm-project && git checkout e5d5146323ffaa13eb5185616c6ae5c36b69352d && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -40,6 +40,12 @@ struct ScalarOp<ONNXAddOp> {
 };
 
 template <>
+struct ScalarOp<ONNXAbsOp> {
+  using FOp = math::AbsFOp;
+  using IOp = math::AbsIOp;
+};
+
+template <>
 struct ScalarOp<ONNXMulOp> {
   using FOp = arith::MulFOp;
   using IOp = arith::MulIOp;
@@ -462,8 +468,8 @@ Value emitScalarOpFor<ONNXSoftsignOp>(ConversionPatternRewriter &rewriter,
   // ONNXSoftsignOp(%X) = DivFOp(ConstantOp 1, %X)
   Value operand = scalarOperands[0];
 
-  auto abs = rewriter.create<math::AbsOp>(loc, operand);
   MathBuilder createMath(rewriter, loc);
+  Value abs = createMath.abs(operand);
   Value one = createMath.constant(elementType, 1);
   Value add = createMath.add(abs, one);
   return createMath.div(operand, add);
@@ -571,29 +577,6 @@ Value emitScalarOpFor<ONNXMinOp>(ConversionPatternRewriter &rewriter,
     llvm_unreachable("unsupported element type");
   }
   return rewriter.create<arith::SelectOp>(loc, min, lhs, rhs);
-}
-
-//===----------------------------------------------------------------------===//
-// Scalar unary ops for lowering ONNXAbsOp
-//===----------------------------------------------------------------------===//
-template <>
-Value emitScalarOpFor<ONNXAbsOp>(ConversionPatternRewriter &rewriter,
-    Location loc, Operation *op, Type elementType,
-    ArrayRef<Value> scalarOperands) {
-  Value operand = scalarOperands[0];
-
-  if (elementType.isa<FloatType>()) {
-    return rewriter.create<math::AbsOp>(loc, operand);
-  } else if (elementType.isa<IntegerType>()) {
-    MathBuilder createMath(rewriter, loc);
-    Value zero = createMath.constant(elementType, 0);
-    auto lessThanZero = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::slt, operand, zero);
-    Value negativeOperand = createMath.sub(zero, operand);
-    return createMath.select(lessThanZero, negativeOperand, operand);
-  } else {
-    llvm_unreachable("unsupported element type");
-  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -62,6 +62,8 @@ struct MathBuilder final : DialectBuilder {
       : DialectBuilder(b, loc) {}
   MathBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
 
+  mlir::Value abs(mlir::Value val) const;
+
   mlir::Value andi(mlir::Value lhs, mlir::Value rhs) const;
   mlir::Value ori(mlir::Value lhs, mlir::Value rhs) const;
 

--- a/test/mlir/conversion/onnx_to_mhlo/Math/GlobalPooling.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Math/GlobalPooling.mlir
@@ -7,7 +7,7 @@ func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x
   // CHECK-LABEL: test_global_average_pool
   // CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32> {
   // CHECK: [[VAR_2_:%.+]] = mhlo.reduce([[PARAM_0_]] init: [[VAR_1_:%.+]]) applies mhlo.add across dimensions = [2, 3] : (tensor<1x3x5x5xf32>, tensor<f32>) -> tensor<1x3xf32>
-  // CHECK: [[VAR_3_:%.+]] = "mhlo.reshape"([[VAR_2_]]) : (tensor<1x3xf32>) -> tensor<1x3x1x1xf32>
+  // CHECK: [[VAR_3_:%.+]] = mhlo.reshape [[VAR_2_]] : (tensor<1x3xf32>) -> tensor<1x3x1x1xf32>
 }
 
 // -----
@@ -18,11 +18,11 @@ func.func @test_global_average_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tens
   return %0 : tensor<1x?x1x1xf32>
   // CHECK-LABEL: test_global_average_pool_dyn_dims
   // CHECK: [[VAR_3_:%.+]] = mhlo.reduce([[PARAM_0_:%.+]] init: [[VAR_2_:%.+]]) applies mhlo.add across dimensions = [2, 3] : (tensor<1x?x?x5xf32>, tensor<f32>) -> tensor<1x?xf32>
-  // CHECK: [[VAR_4_:%.+]] = "mhlo.dynamic_reshape"([[VAR_3_]], [[VAR_0_:%.+]]) : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
+  // CHECK: [[VAR_4_:%.+]] = mhlo.dynamic_reshape [[VAR_3_]], [[VAR_0_:%.+]] : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
   // CHECK: [[VAR_5_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<1x?x?x5xf32> -> tensor<4xindex>
   // CHECK: [[VAR_6_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_1_:%.+]], [[VAR_5_]]) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<f32>, tensor<4xindex>) -> tensor<1x?x?x5xf32>
   // CHECK: [[VAR_7_:%.+]] = mhlo.reduce([[VAR_6_]] init: [[VAR_2_]]) applies mhlo.add across dimensions = [2, 3] : (tensor<1x?x?x5xf32>, tensor<f32>) -> tensor<1x?xf32>
-  // CHECK: [[VAR_8_:%.+]] = "mhlo.dynamic_reshape"([[VAR_7_]], [[VAR_0_]]) : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
+  // CHECK: [[VAR_8_:%.+]] = mhlo.dynamic_reshape [[VAR_7_]], [[VAR_0_]] : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
 }
 
 // -----
@@ -34,7 +34,7 @@ func.func @test_global_max_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf3
   // CHECK-LABEL: test_global_max_pool
   // CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32> {
   // CHECK: [[VAR_1_:%.+]] = mhlo.reduce([[PARAM_0_]] init: [[VAR_0_:%.+]]) applies mhlo.maximum across dimensions = [2, 3] : (tensor<1x3x5x5xf32>, tensor<f32>) -> tensor<1x3xf32>
-  // CHECK: [[VAR_2_:%.+]] = "mhlo.reshape"([[VAR_1_]]) : (tensor<1x3xf32>) -> tensor<1x3x1x1xf32>
+  // CHECK: [[VAR_2_:%.+]] = mhlo.reshape [[VAR_1_]] : (tensor<1x3xf32>) -> tensor<1x3x1x1xf32>
 }
 
 // -----
@@ -45,5 +45,5 @@ func.func @test_global_max_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tensor<1
   return %0 : tensor<1x?x1x1xf32>
   // CHECK-LABEL: test_global_max_pool_dyn_dims
   // CHECK:  [[VAR_2_:%.+]] = mhlo.reduce([[PARAM_0_:%.+]] init: [[VAR_1_:%.+]]) applies mhlo.maximum across dimensions = [2, 3] : (tensor<1x?x?x5xf32>, tensor<f32>) -> tensor<1x?xf32>
-  // CHECK:  [[VAR_3_:%.+]] = "mhlo.dynamic_reshape"([[VAR_2_]], [[VAR_0_:%.+]]) : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
+  // CHECK:  [[VAR_3_:%.+]] = mhlo.dynamic_reshape [[VAR_2_]], [[VAR_0_:%.+]] : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
 }

--- a/test/mlir/conversion/onnx_to_mhlo/Math/Reduction.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Math/Reduction.mlir
@@ -48,7 +48,7 @@ func.func @test_reducesum1(%arg0: tensor<3x2x2xf32>, %arg1: tensor<?xi64>) -> te
 // CHECK-DAG:     [[VAR_0:%.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK-DAG:     [[VAR_1:%.+]] = mhlo.reduce([[PARAM_0:%.+]] init: [[VAR_0]]) applies mhlo.add across dimensions = [1] : (tensor<3x2x2xf32>, tensor<f32>) -> tensor<3x2xf32>
 // CHECK-DAG:     [[VAR_2:%.+]] = mhlo.constant dense<[3, 1, 2]> : tensor<3xi64>
-// CHECK-DAG:     [[VAR_3:%.+]] = "mhlo.dynamic_reshape"([[VAR_1]], [[VAR_2]]) : (tensor<3x2xf32>, tensor<3xi64>) -> tensor<3x1x2xf32>
+// CHECK-DAG:     [[VAR_3:%.+]] = mhlo.dynamic_reshape [[VAR_1]], [[VAR_2]] : (tensor<3x2xf32>, tensor<3xi64>) -> tensor<3x1x2xf32>
 }
 
 // -----
@@ -60,7 +60,7 @@ func.func @test_reducesum2(%arg0: tensor<3x2x2xf32>, %arg1: tensor<?xi64>) -> te
 // CHECK-DAG:     [[VAR_0:%.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK-DAG:     [[VAR_1:%.+]] = mhlo.reduce([[PARAM_0:%.+]] init: [[VAR_0]]) applies mhlo.add across dimensions = [1] : (tensor<3x2x2xf32>, tensor<f32>) -> tensor<3x2xf32>
 // CHECK-DAG:     [[VAR_2:%.+]] = mhlo.constant dense<[3, 1, 2]> : tensor<3xi64>
-// CHECK-DAG:     [[VAR_3:%.+]] = "mhlo.dynamic_reshape"([[VAR_1]], [[VAR_2]]) : (tensor<3x2xf32>, tensor<3xi64>) -> tensor<3x1x2xf32>
+// CHECK-DAG:     [[VAR_3:%.+]] = mhlo.dynamic_reshape [[VAR_1]], [[VAR_2]] : (tensor<3x2xf32>, tensor<3xi64>) -> tensor<3x1x2xf32>
 }
 
 func.func @test_reducemean(%arg0 : tensor<3x2x2xf32>) -> tensor<3x2xf32> {

--- a/test/mlir/conversion/onnx_to_mhlo/Math/Softmax.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Math/Softmax.mlir
@@ -8,12 +8,12 @@ func.func @test_softmax(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
 // CHECK-DAG:     [[VAR_0_:%.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK-DAG:     [[VAR_1_:%.+]] = mhlo.constant dense<0xFF800000> : tensor<f32>
 // CHECK-NEXT:    [[VAR_2_:%.+]] = mhlo.reduce([[PARAM_0_]] init: [[VAR_1_]]) applies mhlo.maximum across dimensions = [1] : (tensor<10x20x30xf32>, tensor<f32>) -> tensor<10x30xf32>
-// CHECK-NEXT:    [[VAR_3_:%.+]] = "mhlo.reshape"([[VAR_2_]]) : (tensor<10x30xf32>) -> tensor<10x1x30xf32>
+// CHECK-NEXT:    [[VAR_3_:%.+]] = mhlo.reshape [[VAR_2_]] : (tensor<10x30xf32>) -> tensor<10x1x30xf32>
 // CHECK-NEXT:    [[VAR_4_:%.+]] = "mhlo.broadcast_in_dim"([[VAR_3_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<10x1x30xf32>) -> tensor<10x20x30xf32>
 // CHECK-NEXT:    [[VAR_5_:%.+]] = mhlo.subtract [[PARAM_0_]], [[VAR_4_]] : tensor<10x20x30xf32>
 // CHECK-NEXT:    [[VAR_6_:%.+]] = mhlo.exponential [[VAR_5_]] : tensor<10x20x30xf32>
 // CHECK-NEXT:    [[VAR_7_:%.+]] = mhlo.reduce([[VAR_6_]] init: [[VAR_0_]]) applies mhlo.add across dimensions = [1] : (tensor<10x20x30xf32>, tensor<f32>) -> tensor<10x30xf32>
-// CHECK-NEXT:    [[VAR_8_:%.+]] = "mhlo.reshape"([[VAR_7_]]) : (tensor<10x30xf32>) -> tensor<10x1x30xf32>
+// CHECK-NEXT:    [[VAR_8_:%.+]] = mhlo.reshape [[VAR_7_]] : (tensor<10x30xf32>) -> tensor<10x1x30xf32>
 // CHECK-NEXT:    [[VAR_9_:%.+]] = "mhlo.broadcast_in_dim"([[VAR_8_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<10x1x30xf32>) -> tensor<10x20x30xf32>
 // CHECK-NEXT:    [[VAR_10_:%.+]] = mhlo.divide [[VAR_6_]], [[VAR_9_]] : tensor<10x20x30xf32>
 // CHECK-NEXT:    return [[VAR_10_]] : tensor<10x20x30xf32>
@@ -28,7 +28,7 @@ func.func @test_softmax_dynamic(%arg0 : tensor<?x20x30xf32>) -> tensor<?x20x30xf
 // CHECK-DAG:     [[VAR_1_:%.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK-DAG:     [[VAR_2_:%.+]] = mhlo.constant dense<0xFF800000> : tensor<f32>
 // CHECK-NEXT:    [[VAR_3_:%.+]] = mhlo.reduce([[PARAM_0_]] init: [[VAR_2_]]) applies mhlo.maximum across dimensions = [1] : (tensor<?x20x30xf32>, tensor<f32>) -> tensor<?x30xf32>
-// CHECK-NEXT:    [[VAR_4_:%.+]] = "mhlo.dynamic_reshape"([[VAR_3_]], [[VAR_0_:%.+]]) : (tensor<?x30xf32>, tensor<3xi64>) -> tensor<?x1x30xf32>
+// CHECK-NEXT:    [[VAR_4_:%.+]] = mhlo.dynamic_reshape [[VAR_3_]], [[VAR_0_:%.+]] : (tensor<?x30xf32>, tensor<3xi64>) -> tensor<?x1x30xf32>
 // CHECK-DAG:     [[VAR_5_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<?x20x30xf32> -> tensor<3xindex>
 // CHECK-DAG:     [[VAR_6_:%.+]] = shape.shape_of [[VAR_4_]] : tensor<?x1x30xf32> -> tensor<3xindex>
 // CHECK-NEXT:    [[VAR_7_:%.+]] = shape.broadcast [[VAR_5_]], [[VAR_6_]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
@@ -37,7 +37,7 @@ func.func @test_softmax_dynamic(%arg0 : tensor<?x20x30xf32>) -> tensor<?x20x30xf
 // CHECK-NEXT:    [[VAR_10_:%.+]] = mhlo.subtract [[VAR_8_]], [[VAR_9_]] : tensor<?x20x30xf32>
 // CHECK-NEXT:    [[VAR_11_:%.+]] = mhlo.exponential [[VAR_10_]] : tensor<?x20x30xf32>
 // CHECK-NEXT:    [[VAR_12_:%.+]] = mhlo.reduce([[VAR_11_]] init: [[VAR_1_]]) applies mhlo.add across dimensions = [1] : (tensor<?x20x30xf32>, tensor<f32>) -> tensor<?x30xf32>
-// CHECK-NEXT:    [[VAR_13_:%.+]] = "mhlo.dynamic_reshape"([[VAR_12_]], [[VAR_0_]]) : (tensor<?x30xf32>, tensor<3xi64>) -> tensor<?x1x30xf32>
+// CHECK-NEXT:    [[VAR_13_:%.+]] = mhlo.dynamic_reshape [[VAR_12_]], [[VAR_0_]] : (tensor<?x30xf32>, tensor<3xi64>) -> tensor<?x1x30xf32>
 // CHECK-DAG:     [[VAR_14_:%.+]] = shape.shape_of [[VAR_11_]] : tensor<?x20x30xf32> -> tensor<3xindex>
 // CHECK-DAG:     [[VAR_15_:%.+]] = shape.shape_of [[VAR_13_]] : tensor<?x1x30xf32> -> tensor<3xindex>
 // CHECK-NEXT:    [[VAR_16_:%.+]] = shape.broadcast [[VAR_14_]], [[VAR_15_]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
@@ -53,10 +53,10 @@ func.func @test_softmax_2d(%arg0 : tensor<1x10xf32>) -> tensor<1x10xf32> {
 // CHECK-LABEL:  func @test_softmax_2d
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x10xf32>) -> tensor<1x10xf32> {
 // CHECK: [[VAR_2_:%.+]] = mhlo.reduce([[PARAM_0_]] init: [[VAR_1_:%.+]]) applies mhlo.maximum across dimensions = [1] : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
-// CHECK: [[VAR_3_:%.+]] = "mhlo.reshape"([[VAR_2_]]) : (tensor<1xf32>) -> tensor<1x1xf32>
+// CHECK: [[VAR_3_:%.+]] = mhlo.reshape [[VAR_2_]] : (tensor<1xf32>) -> tensor<1x1xf32>
 // CHECK: [[VAR_4_:%.+]] = "mhlo.broadcast_in_dim"([[VAR_3_]]) {broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x1xf32>) -> tensor<1x10xf32>
 // CHECK: [[VAR_7_:%.+]] = mhlo.reduce([[VAR_6_]] init: [[VAR_0_:%.+]]) applies mhlo.add across dimensions = [1] : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
-// CHECK: [[VAR_8_:%.+]] = "mhlo.reshape"([[VAR_7_]]) : (tensor<1xf32>) -> tensor<1x1xf32>
+// CHECK: [[VAR_8_:%.+]] = mhlo.reshape [[VAR_7_]] : (tensor<1xf32>) -> tensor<1x1xf32>
 // CHECK: [[VAR_9_:%.+]] = "mhlo.broadcast_in_dim"([[VAR_8_]]) {broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x1xf32>) -> tensor<1x10xf32>
 // CHECK: [[VAR_10_:%.+]] = mhlo.divide [[VAR_6_]], [[VAR_9_]] : tensor<1x10xf32> 
 }

--- a/test/mlir/conversion/onnx_to_mhlo/NN/Pooling.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/NN/Pooling.mlir
@@ -9,7 +9,7 @@ func.func @test_default_maxpoolsingleout(%arg0 : tensor<5x5x32x32xf32>) -> tenso
 // CHECK:                 %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:              ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:   }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : vector<4xi64>, window_strides = dense<1> : vector<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
 
 
@@ -24,7 +24,7 @@ func.func @test_default_maxpoolsingleout_defpad(%arg0 : tensor<5x5x32x32xf32>) -
 // CHECK:                 %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:              ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:   }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : vector<4xi64>, window_strides = dense<1> : vector<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
 
 
@@ -39,7 +39,7 @@ func.func @test_default_maxpoolsingleout_pad(%arg0 : tensor<5x5x32x32xf32>) -> t
 // CHECK:                  %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:               ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                 %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                 "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                 mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:    }) {padding = dense<[[0, 0], [0, 0], [1, 1], [1, 1]]> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : vector<4xi64>, window_strides = dense<1> : vector<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x32x32xf32>
 
 
@@ -54,7 +54,7 @@ func.func @test_default_maxpoolsingleout_pad_nonunif(%arg0 : tensor<5x5x32x32xf3
 // CHECK:                  %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:               ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                 %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                 "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                 mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:    }) {padding = dense<[[0, 0], [0, 0], [2, 1], [1, 0]]> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 5, 3]> : vector<4xi64>, window_strides = dense<1> : vector<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x31x31xf32>
 
 // -----
@@ -68,7 +68,7 @@ func.func @test_default_maxpoolsingleout_strides(%arg0 : tensor<5x5x32x32xf32>) 
 // CHECK:                  %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:               ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                 %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                 "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                 mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:    }) {padding = dense<[[0, 0], [0, 0], [1, 1], [1, 1]]> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : vector<4xi64>, window_strides = dense<[1, 1, 2, 2]> : vector<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x16x16xf32>
 
 // -----
@@ -82,7 +82,7 @@ func.func @test_default_maxpoolsingleout_strides_nonunifpad(%arg0 : tensor<5x5x3
 // CHECK:                  %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:               ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                 %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                 "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                 mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:    }) {padding = dense<[[0, 0], [0, 0], [1, 0], [0, 0]]> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 2, 2]> : vector<4xi64>, window_strides = dense<[1, 1, 2, 2]> : vector<4xi64>} : (tensor<5x5x30x32xf32>, tensor<f32>) -> tensor<5x5x15x16xf32>
 
 // -----
@@ -96,7 +96,7 @@ func.func @test_default_maxpoolsingleout_strides_nonunifpad_ceil(%arg0 : tensor<
 // CHECK:                  %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:               ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                 %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                 "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                 mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:    }) {padding = dense<[[0, 0], [0, 0], [1, 1], [0, 0]]> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 2, 2]> : vector<4xi64>, window_strides = dense<[1, 1, 2, 2]> : vector<4xi64>} : (tensor<5x5x30x32xf32>, tensor<f32>) -> tensor<5x5x16x16xf32>
 
 
@@ -111,7 +111,7 @@ func.func @test_default_maxpoolsingleout_strides_dilatation(%arg0 : tensor<5x5x8
 // CHECK:                  %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:               ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                 %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                 "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                 mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:    }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<[1, 1, 2, 2]> : vector<4xi64>, window_dimensions = dense<[1, 1, 2, 2]> : vector<4xi64>, window_strides = dense<[1, 1, 3, 3]> : vector<4xi64>} : (tensor<5x5x8x8xf32>, tensor<f32>) -> tensor<5x5x2x2xf32>
 
 // -----
@@ -125,7 +125,7 @@ func.func @test_default_maxpoolsingleout_upper(%arg0 : tensor<5x5x16x13xf32>) ->
 // CHECK:                  %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:                 ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                   %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                   "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                   mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:    }) {padding = dense<[[0, 0], [0, 0], [0, 0], [1, 2]]> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 4, 4]> : vector<4xi64>, window_strides = dense<[1, 1, 4, 4]> : vector<4xi64>} : (tensor<5x5x16x13xf32>, tensor<f32>) -> tensor<5x5x4x4xf32>
 
 
@@ -140,5 +140,5 @@ func.func @test_default_maxpoolsingleout_lower(%arg0 : tensor<5x5x16x13xf32>) ->
 // CHECK:                 %1 = "mhlo.reduce_window"(%arg0, %0) ({
 // CHECK-NEXT:              ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:                %2 = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:                "mhlo.return"(%2) : (tensor<f32>) -> ()
+// CHECK-NEXT:                mhlo.return %2 : tensor<f32>
 // CHECK-NEXT{LITERAL}:   }) {padding = dense<[[0, 0], [0, 0], [0, 0], [2, 1]]> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 4, 4]> : vector<4xi64>, window_strides = dense<[1, 1, 4, 4]> : vector<4xi64>} : (tensor<5x5x16x13xf32>, tensor<f32>) -> tensor<5x5x4x4xf32>

--- a/test/mlir/conversion/onnx_to_mhlo/Tensor/Reshape.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Tensor/Reshape.mlir
@@ -8,7 +8,7 @@ func.func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi
   %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_reshape_dynamic
-  // CHECK: %0 = "mhlo.dynamic_reshape"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
+  // CHECK: %0 = mhlo.dynamic_reshape %arg0, %arg1 : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
 }
 
 // -----
@@ -18,7 +18,7 @@ func.func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
   "func.return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_reshape_1
-  // CHECK: %1 = "mhlo.dynamic_reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
+  // CHECK: %1 = mhlo.dynamic_reshape %arg0, %0 : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
 }
 
 // -----
@@ -28,7 +28,7 @@ func.func @test_reshape_2(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
   "func.return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_reshape_2
-  // CHECK: %1 = "mhlo.dynamic_reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
+  // CHECK: %1 = mhlo.dynamic_reshape %arg0, %0 : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
 }
 
 // -----
@@ -38,7 +38,7 @@ func.func @test_reshape_3(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
   "func.return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_reshape_3
-  // CHECK: %1 = "mhlo.dynamic_reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
+  // CHECK: %1 = mhlo.dynamic_reshape %arg0, %0 : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
 }
 
 // -----

--- a/test/mlir/conversion/onnx_to_mhlo/models/mnist.onnx.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/models/mnist.onnx.mlir
@@ -18,9 +18,9 @@ func.func @main_graph(%arg0: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> attribut
 // CHECK:         [[VAR_7_:%.+]] = "mhlo.reduce_window"([[PARAM_0_]], [[VAR_0_:%.+]]) ({
 // CHECK-NEXT:        ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:          [[VAR_23_:%.+]] = mhlo.maximum %arg1, %arg2 : tensor<f32>
-// CHECK-NEXT:          "mhlo.return"([[VAR_23_]]) : (tensor<f32>) -> ()
+// CHECK-NEXT:          mhlo.return [[VAR_23_]] : tensor<f32>
 // CHECK-NEXT:        }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : vector<4xi64>, window_dimensions = dense<[1, 1, 2, 2]> : vector<4xi64>, window_strides = dense<[1, 1, 2, 2]> : vector<4xi64>} : (tensor<1x1x28x28xf32>, tensor<f32>) -> tensor<1x1x14x14xf32>
-// CHECK-DAG:     [[VAR_8_:%.+]] = "mhlo.reshape"([[VAR_7_]]) : (tensor<1x1x14x14xf32>) -> tensor<1x196xf32>
+// CHECK-DAG:     [[VAR_8_:%.+]] = mhlo.reshape [[VAR_7_]] : (tensor<1x1x14x14xf32>) -> tensor<1x196xf32>
 // CHECK-DAG:     [[VAR_9_:%.+]] = "mhlo.transpose"([[VAR_6_:%.+]]) {permutation = dense<[1, 0]> : vector<2xi64>} : (tensor<128x196xf32>) -> tensor<196x128xf32>
 // CHECK:         [[VAR_10_:%.+]] = "mhlo.dot"([[VAR_8_]], [[VAR_9_]]) : (tensor<1x196xf32>, tensor<196x128xf32>) -> tensor<1x128xf32>
 // CHECK-DAG:     [[VAR_11_:%.+]] = mhlo.add [[VAR_10_]], [[VAR_5_:%.+]] : tensor<1x128xf32>
@@ -29,12 +29,12 @@ func.func @main_graph(%arg0: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> attribut
 // CHECK-DAG:     [[VAR_14_:%.+]] = "mhlo.dot"([[VAR_12_]], [[VAR_13_]]) : (tensor<1x128xf32>, tensor<128x10xf32>) -> tensor<1x10xf32>
 // CHECK-NEXT:    [[VAR_15_:%.+]] = mhlo.add [[VAR_14_]], [[VAR_2_:%.+]] : tensor<1x10xf32>
 // CHECK-NEXT:    [[VAR_16_:%.+]] = mhlo.reduce([[VAR_15_]] init: [[VAR_0_:%.+]]) applies mhlo.maximum across dimensions = [1] : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
-// CHECK-NEXT:    [[VAR_17_:%.+]] = "mhlo.reshape"([[VAR_16_]]) : (tensor<1xf32>) -> tensor<1x1xf32>
+// CHECK-NEXT:    [[VAR_17_:%.+]] = mhlo.reshape [[VAR_16_]] : (tensor<1xf32>) -> tensor<1x1xf32>
 // CHECK-NEXT:    [[VAR_18_:%.+]] = "mhlo.broadcast_in_dim"([[VAR_17_]]) {broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x1xf32>) -> tensor<1x10xf32>
 // CHECK-NEXT:    [[VAR_19_:%.+]] = mhlo.subtract [[VAR_15_]], [[VAR_18_]] : tensor<1x10xf32>
 // CHECK-NEXT:    [[VAR_20_:%.+]] = mhlo.exponential [[VAR_19_]] : tensor<1x10xf32>
 // CHECK-NEXT:    [[VAR_21_:%.+]] = mhlo.reduce([[VAR_20_]] init: [[VAR_1_:%.+]]) applies mhlo.add across dimensions = [1] : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
-// CHECK-NEXT:    [[VAR_22_:%.+]] = "mhlo.reshape"([[VAR_21_]]) : (tensor<1xf32>) -> tensor<1x1xf32>
+// CHECK-NEXT:    [[VAR_22_:%.+]] = mhlo.reshape [[VAR_21_]] : (tensor<1xf32>) -> tensor<1x1xf32>
 // CHECK-NEXT:    [[VAR_23_:%.+]] = "mhlo.broadcast_in_dim"([[VAR_22_]]) {broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x1xf32>) -> tensor<1x10xf32>
 // CHECK-NEXT:    [[VAR_24_:%.+]] = mhlo.divide [[VAR_20_]], [[VAR_23_]] : tensor<1x10xf32>
 }

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -671,7 +671,7 @@ func.func private @test_softsign(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to #map([[DIM_2]]), [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10){
   // CHECK: [[IV:%.+]]:2 = krnl.get_induction_var_value([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
   // CHECK: [[LOAD:%.+]] = krnl.load %arg0[[[IV]]#0, [[IV]]#1] : memref<?x10xf32>
-  // CHECK: [[ABS:%.+]] = math.abs [[LOAD]] : f32
+  // CHECK: [[ABS:%.+]] = math.absf [[LOAD]] : f32
   // CHECK: [[ONE:%.+]] = arith.constant {{1.+}} : f32
   // CHECK: [[ADD:%.+]] = arith.addf [[ABS]], [[ONE]] : f32
   // CHECK: [[SOFTSIGN_RES:%.+]] = arith.divf [[LOAD]], [[ADD]] : f32
@@ -1354,7 +1354,7 @@ func.func private @test_abs_float(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to #map([[DIM_2]]), [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10){
   // CHECK: [[IV:%.+]]:2 = krnl.get_induction_var_value([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
   // CHECK: [[LOAD:%.+]] = krnl.load %arg0[[[IV]]#0, [[IV]]#1] : memref<?x10xf32>
-  // CHECK: [[ABS:%.+]] = math.abs [[LOAD]] : f32
+  // CHECK: [[ABS:%.+]] = math.absf [[LOAD]] : f32
   // CHECK: krnl.store [[ABS]], [[RES]][[[IV]]#0, [[IV]]#1] : memref<?x10xf32>
   // CHECK: return [[RES]] : memref<?x10xf32>
 }
@@ -1376,11 +1376,8 @@ func.func private @test_abs_int(%arg0 : tensor<?x10xi32>) -> tensor<*xi32> {
   // CHECK: krnl.iterate([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) with ([[DEF_LOOPS]]#0 -> %arg1 = 0 to #map([[DIM_2]]), [[DEF_LOOPS]]#1 -> %arg2 = 0 to 10){
   // CHECK: [[IV:%.+]]:2 = krnl.get_induction_var_value([[DEF_LOOPS]]#0, [[DEF_LOOPS]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
   // CHECK: [[LOAD:%.+]] = krnl.load %arg0[[[IV]]#0, [[IV]]#1] : memref<?x10xi32>
-  // CHECK: [[ZERO:%.+]] = arith.constant 0 : i32
-  // CHECK: [[LESS_THAN_ZERO:%.+]] = arith.cmpi slt, [[LOAD]], [[ZERO]] : i32
-  // CHECK: [[NEGATIVE_LOAD:%.+]] = arith.subi [[ZERO]], [[LOAD]] : i32
-  // CHECK: [[SELECT:%.+]] = arith.select [[LESS_THAN_ZERO]], [[NEGATIVE_LOAD]], [[LOAD]] : i32
-  // CHECK: krnl.store [[SELECT]], [[RES]][[[IV]]#0, [[IV]]#1] : memref<?x10xi32>
+  // CHECK: [[ABS:%.+]] = math.absi [[LOAD]] : i32
+  // CHECK: krnl.store [[ABS]], [[RES]][[[IV]]#0, [[IV]]#1] : memref<?x10xi32>
   // CHECK: return [[RES]] : memref<?x10xi32>
 }
 

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 061e0189a3dab6b1831a80d489ff1b15ad93aafb && cd ..
+cd llvm-project && git checkout e5d5146323ffaa13eb5185616c6ae5c36b69352d && cd ..


### PR DESCRIPTION
This updates LLVM to a green commit:
```
Week of 8/22/2022:
Green LLVM commit: e5d5146323ffaa13eb5185616c6ae5c36b69352d
Green MHLO commit: ace4030dd55fce2a74e46f71f1937feb61ed1e3f (branch greencommit/2022-08-22-e5d51463)
```

This update is to include a fix for memref normalization where non-normalizable operations with identity map layouts blocked  normalization of the entire function: https://github.com/llvm/llvm-project/commit/183c4a391ef344220664d1d103d43639468bf103

Signed-off-by: Tung D. Le <tung@jp.ibm.com>