### PR TITLE
fix compiler warnings about Optional::getValue and ArrayRef

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -533,7 +533,7 @@ bool isSuitableForZDNN<ONNXReduceMeanOp>(ONNXReduceMeanOp op) {
     return false;
 
   // Check axes.
-  mlir::ArrayAttr axesVal = axes.getValue();
+  mlir::ArrayAttr axesVal = axes.value();
   SmallVector<Attribute> axesAttrs(axesVal.begin(), axesVal.end());
   if ((axesAttrs.size() != 2) ||
       (axesAttrs[0].dyn_cast<IntegerAttr>().getInt() != 2) ||
@@ -601,21 +601,20 @@ bool isSuitableForZDNN<ONNXLSTMOp>(ONNXLSTMOp op) {
   if (!isNoneType(op.P()) || op.activation_alpha() || op.activation_beta())
     return false;
   // zDNN support the default activations (["Sigmoid", "Tanh", "Tanh"]) only.
-  if ((activations && (activations.getValue().size() > 0) &&
-          (activations.getValue()[0].cast<StringAttr>().getValue() !=
+  if ((activations && (activations.value().size() > 0) &&
+          (activations.value()[0].cast<StringAttr>().getValue() !=
               "Sigmoid")) ||
-      (activations && (activations.getValue().size() > 1) &&
-          (activations.getValue()[1].cast<StringAttr>().getValue() !=
-              "Tanh")) ||
-      (activations && (activations.getValue().size() > 2) &&
-          (activations.getValue()[2].cast<StringAttr>().getValue() != "Tanh")))
+      (activations && (activations.value().size() > 1) &&
+          (activations.value()[1].cast<StringAttr>().getValue() != "Tanh")) ||
+      (activations && (activations.value().size() > 2) &&
+          (activations.value()[2].cast<StringAttr>().getValue() != "Tanh")))
     return false;
   // zDNN does not supprt clip(Cell clip threshold).
   if (op.clip())
     return false;
   // zDNN does not support hidden_size not equal to the hidden size in
   // other inputs.
-  if (op.hidden_size() && (op.hidden_size().getValue() != hidden_size))
+  if (op.hidden_size() && (op.hidden_size().value() != hidden_size))
     return false;
   // zDNN does not support input_forget.
   if (op.input_forget() != 0)
@@ -673,21 +672,20 @@ bool isSuitableForZDNN<ONNXGRUOp>(ONNXGRUOp op) {
   if (op.activation_alpha() || op.activation_beta())
     return false;
   // zDNN support the default activations (["Sigmoid", "Tanh", "Tanh"]) only.
-  if ((activations && (activations.getValue().size() > 0) &&
-          (activations.getValue()[0].cast<StringAttr>().getValue() !=
+  if ((activations && (activations.value().size() > 0) &&
+          (activations.value()[0].cast<StringAttr>().getValue() !=
               "Sigmoid")) ||
-      (activations && (activations.getValue().size() > 1) &&
-          (activations.getValue()[1].cast<StringAttr>().getValue() !=
-              "Tanh")) ||
-      (activations && (activations.getValue().size() > 2) &&
-          (activations.getValue()[2].cast<StringAttr>().getValue() != "Tanh")))
+      (activations && (activations.value().size() > 1) &&
+          (activations.value()[1].cast<StringAttr>().getValue() != "Tanh")) ||
+      (activations && (activations.value().size() > 2) &&
+          (activations.value()[2].cast<StringAttr>().getValue() != "Tanh")))
     return false;
   // zDNN does not supprt clip(Cell clip threshold).
   if (op.clip())
     return false;
   // zDNN does not support hidden_size not equal to the hidden size in
   // other inputs.
-  if (op.hidden_size() && (op.hidden_size().getValue() != hidden_size))
+  if (op.hidden_size() && (op.hidden_size().value() != hidden_size))
     return false;
   // zDNN support the "linear_before_reset==1" case only.
   if (op.linear_before_reset() != 1)

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
@@ -218,7 +218,7 @@ Value insertAllocOrEmitZeroConstant(ArrayRef<IndexExpr> dims,
             ->getDialect()
             ->getNamespace(), // use the dialect as the blob "hint"
         HeapAsmResourceBlob::allocateAndCopy(
-            ArrayRef(rawData, sizeInBytes), alignof(char)));
+            llvm::makeArrayRef(rawData, sizeInBytes), alignof(char)));
     stickifiedConstant.valueAttr(valueAttr);
     free(rawData);
 

--- a/src/Accelerators/NNPA/Transform/FoldStdAlloc.cpp
+++ b/src/Accelerators/NNPA/Transform/FoldStdAlloc.cpp
@@ -126,7 +126,7 @@ public:
             expandAffineMap(rewriter, loc, op.getAffineMap(), indices);
         if (!maybeExpandedMap)
           continue;
-        storeIndex = maybeExpandedMap.getValue()[0];
+        storeIndex = maybeExpandedMap.value()[0];
         storeVal = op.getValueToStore();
       }
 

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighConstPropagation.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighConstPropagation.cpp
@@ -116,7 +116,8 @@ ZHighStickifiedConstantOp emitZHighStickifiedConstant(PatternRewriter &rewriter,
           ->getDialect()
           ->getNamespace(), // use the dialect as the blob "hint"
       HeapAsmResourceBlob::allocateAndCopy(
-          ArrayRef((char *)ztensor->buffer, sizeInBytes), alignof(char)));
+          llvm::makeArrayRef((char *)ztensor->buffer, sizeInBytes),
+          alignof(char)));
 
   stickifiedConstant.valueAttr(valueAttr);
 


### PR DESCRIPTION
fixes the warnings:
```
warning: 'ArrayRef' may not intend to support class template argument deduction [-Wctad-maybe-unsupported]

warning: 'getValue' is deprecated: Use value instead. [-Wdeprecated-declarations]
```

I overlooked these in PR #1622 because I didn't build with `-DONNX_MLIR_ACCELERATORS=NNPA`