### PR TITLE
[NNPA] Directly stickify/unstickify from/to NCHW without data transpose

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -315,25 +315,20 @@ def replaceONNXLogSoftmaxPattern : Pattern<
 >;
 
 //===----------------------------------------------------------------------===//
-// ONNXReduceMeanOp %X = (NHWCtoNCHW
-//                         (ZHighUnstickOp
-//                            (ZHighMeanReduce2DOp
-//                               (ZHighStickOp (NCHWtoNHWC %X)))))
+// ONNXReduceMeanOp %X = (ZHighUnstickOp
+//                          (ZHighMeanReduce2DOp
+//                             (ZHighStickOp %X))))
 //===----------------------------------------------------------------------===//
 def replaceONNXReduceMeanPattern : Pat<
   (ONNXReduceMeanOp:$res $x, $_, $_),
-  (NHWCtoNCHW (GetTypeOf $res),
-     (ZHighUnstickOp
-        (ZHighMeanReduce2DOp
-           (ZHighStickOp (NCHWtoNHWC $x), (NHWCLayoutAttr)))))
+  (ZHighUnstickOp (ZHighMeanReduce2DOp (ZHighStickOp $x, (NHWCLayoutAttr))))
 >;
 
 //===----------------------------------------------------------------------===//
-// ONNXMaxPoolSingleOutOp %X
-//             = NHWCtoNCHW
+// ONNXMaxPoolSingleOutOp %X = 
 //                 (ZHighUnstickOp
 //                     (ZHighMaxPoolOp
-//                         (ZHighStickOp(NCHWtoNHWC %X)),
+//                         (ZHighStickOp %X),
 //                         $krnel_shape,
 //                         $strides,
 //		           $padding_type))
@@ -362,22 +357,20 @@ def replaceONNXMaxPoolSingleOutPattern : Pattern<
     (GetI64ArrayAttrKernelShapeMaxPool:$kernel_shape $res),
     (GetI64ArrayAttrStridesMaxPool:$strides $res),
 
-    (NHWCtoNCHW (GetTypeOf $res),
-       (ZHighUnstickOp
-          (ZHighMaxPool2DOp
-             (ZHighStickOp (NCHWtoNHWC $x), (NHWCLayoutAttr)),
-             $kernel_shape,
-             $strides,
-             $padtype)))
+    (ZHighUnstickOp
+       (ZHighMaxPool2DOp
+          (ZHighStickOp $x, (NHWCLayoutAttr)),
+          $kernel_shape,
+          $strides,
+          $padtype))
   ]
 >;
 
 //===----------------------------------------------------------------------===//
-// ONNXAveragePoolOp %X
-//             = NHWCtoNCHW
+// ONNXAveragePoolOp %X = 
 //                 (ZHighUnstickOp
 //                     (ZHighAvgPoolOp
-//                         (ZHighStickOp(NCHWtoNHWC %X)),
+//                         (ZHighStickOp %X),
 //                         $krnel_shape,
 //                         $strides,
 //		           $padding_type))
@@ -406,13 +399,12 @@ def replaceONNXAveragePoolPattern : Pattern<
     (GetI64ArrayAttrKernelShapeAveragePool:$kernel_shape $res),
     (GetI64ArrayAttrStridesAveragePool:$strides $res),
 
-    (NHWCtoNCHW (GetTypeOf $res),
-       (ZHighUnstickOp
-          (ZHighAvgPool2DOp
-             (ZHighStickOp (NCHWtoNHWC $x), (NHWCLayoutAttr)),
-             $kernel_shape,
-             $strides,
-             $padtype)))
+    (ZHighUnstickOp
+       (ZHighAvgPool2DOp
+          (ZHighStickOp $x, (NHWCLayoutAttr)),
+          $kernel_shape,
+          $strides,
+          $padtype))
   ]
 >;
 
@@ -913,16 +905,15 @@ def replaceONNXGRUPattern4 : Pattern<
 // 
 // to
 //
-// NHWCtoNCHW
-//   (ZHighUnstickOp
-//      (ZHighConvOp
-//        (ZHighStickOp (NCHWtoNHWC %X), "NHWC"),
-//        (ZHighStickOp (NCHWtoHWCK %W), "HWCK"),
-//        (ZHighStickOp %B, "1D"),
-//        kernel_shape,
-//        strides,
-//        GetPaddingType,
-//        ACT_NONE)))
+// (ZHighUnstickOp
+//    (ZHighConvOp
+//      (ZHighStickOp %X, "NHWC"),
+//      (ZHighStickOp (NCHWtoHWCK %W), "HWCK"),
+//      (ZHighStickOp %B, "1D"),
+//      kernel_shape,
+//      strides,
+//      GetPaddingType,
+//      ACT_NONE)))
 //        
 //===----------------------------------------------------------------------===//
 
@@ -946,16 +937,15 @@ def replaceONNXConv2DPattern : Pattern<
    (GetI64ArrayAttrKernelShapeConv:$kernel_shape $res),
    (GetI64ArrayAttrStridesConv:$strides $res),
  
-   (NHWCtoNCHW (GetTypeOf $res),
-     (ZHighUnstickOp
-      (ZHighConv2DOp
-         (ZHighStickOp (NCHWtoNHWC $x), (NHWCLayoutAttr)),
-         (ZHighStickOp (NCHWtoHWCK $w), (HWCKLayoutAttr)),
-         (ZHighStickOp $b, (_1DLayoutAttr)),
-         $kernel_shape,
-         $strides,
-         $padtype,
-         (ACT_NONEAttr))))
+   (ZHighUnstickOp
+    (ZHighConv2DOp
+       (ZHighStickOp $x, (NHWCLayoutAttr)),
+       (ZHighStickOp (NCHWtoHWCK $w), (HWCKLayoutAttr)),
+       (ZHighStickOp $b, (_1DLayoutAttr)),
+       $kernel_shape,
+       $strides,
+       $padtype,
+       (ACT_NONEAttr)))
   ]
 >;
 
@@ -966,16 +956,15 @@ def replaceONNXConv2DPattern : Pattern<
 //
 // to
 //
-// NHWCtoNCHW
-//   (ZHighUnstickOp
-//      (ZHighConvOp
-//        (ZHighStickOp (NCHWtoNHWC %X), "NHWC"),
-//        (ZHighStickOp (NCHWtoHWCK %W), "HWCK"),
-//        (ZHighStickOp %B, "1D"),
-//        kernel_shape,
-//        strides,
-//        GetPaddingType,
-//        ACT_RELU)))
+// (ZHighUnstickOp
+//    (ZHighConvOp
+//      (ZHighStickOp %X, "NHWC"),
+//      (ZHighStickOp (NCHWtoHWCK %W), "HWCK"),
+//      (ZHighStickOp %B, "1D"),
+//      kernel_shape,
+//      strides,
+//      GetPaddingType,
+//      ACT_RELU)))
 //
 //===----------------------------------------------------------------------===//
 
@@ -993,16 +982,15 @@ def replaceONNXReluConvPattern : Pattern<
    (GetI64ArrayAttrKernelShapeConv:$kernel_shape $res),
    (GetI64ArrayAttrStridesConv:$strides $res),
  
-   (NHWCtoNCHW (GetTypeOf $res),
-     (ZHighUnstickOp
-      (ZHighConv2DOp
-         (ZHighStickOp (NCHWtoNHWC $x), (NHWCLayoutAttr)),
-         (ZHighStickOp (NCHWtoHWCK $w), (HWCKLayoutAttr)),
-         (ZHighStickOp $b, (_1DLayoutAttr)),
-         $kernel_shape,
-         $strides,
-         $padtype,
-         (ACT_RELUAttr))))
+   (ZHighUnstickOp
+    (ZHighConv2DOp
+       (ZHighStickOp $x, (NHWCLayoutAttr)),
+       (ZHighStickOp (NCHWtoHWCK $w), (HWCKLayoutAttr)),
+       (ZHighStickOp $b, (_1DLayoutAttr)),
+       $kernel_shape,
+       $strides,
+       $padtype,
+       (ACT_RELUAttr)))
   ],
   [(IsConv2DLegalForZDNN $res)],
   (addBenefit 0)

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
@@ -45,13 +45,11 @@ def GetSqrtResultBatchNormA :
 // Rewrite
 //
 // ONNXBatchNormalizationInferenceModeOp %X
-//             = NHWCtoNCHW
-//                 (ZHighUnstickOp
-//                     (ZHighBatchNormOp
-//                         (ZHighStickOp
-//                             (NCHWtoNHWC %X)),
-//                         (ZHighStickOp %A),
-//                         (ZHighStickOp %B)))
+//   (ZHighUnstickOp
+//       (ZHighBatchNormOp
+//           (ZHighStickOp %X),
+//           (ZHighStickOp %A),
+//           (ZHighStickOp %B)))
 //
 // %A = $scale / sqrt($var + $epsilon))
 // %B = $b - $mean * %A
@@ -66,12 +64,11 @@ def replaceONNXBatchNormalizationInferenceModePattern : Pattern<
     (ONNXSubOp:$B $b, (ONNXMulOp $mean, $A)),
 
     // Calculate BatchNorm Op using $A and $B
-    (NHWCtoNCHW (GetTypeOf $res),
-        (ZHighUnstickOp
-            (ZHighBatchNormOp
-                (ZHighStickOp (NCHWtoNHWC $x), (NHWCLayoutAttr)),
-                (ZHighStickOp $A, (_1DLayoutAttr)),
-                (ZHighStickOp $B, (_1DLayoutAttr)))))
+    (ZHighUnstickOp
+        (ZHighBatchNormOp
+            (ZHighStickOp $x, (NHWCLayoutAttr)),
+            (ZHighStickOp $A, (_1DLayoutAttr)),
+            (ZHighStickOp $B, (_1DLayoutAttr))))
   ]
 >;
 

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/CMakeLists.txt
@@ -3,8 +3,12 @@ add_onnx_mlir_library(OMZHighToZLow
 
   LINK_LIBS PUBLIC
   MLIRMemRefTransforms
+  OMLayoutHelper
   OMONNXToKrnl
   OMZHighOps
   OMZLowOps
+
+  ACCEL_INCLUDE_DIRS PRIVATE
+  ${NNPA_INCLUDE_PATH}
   )
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
@@ -142,6 +142,7 @@ def ZHighStickOp:ZHigh_Op<"Stick", [NoSideEffect,
   let summary = "ZHigh Stick operation";
   let description = [{
     "ZHigh operation to perform a Stick."
+    "If layout=NHWC, input must be in NCHW and output will be in NHWC."
   }];
   let arguments = (ins AnyTypeOf<[TensorOf<[F32]>, NoneType]>:$In,
                        OptionalAttr<StrAttr>:$layout);

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighCombine.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighCombine.cpp
@@ -22,27 +22,33 @@
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
 using namespace mlir;
+using namespace onnx_mlir;
 
 namespace {
 
 // Check if all values are produced by ZHighUnstickOp.
-bool areProducedByUnstickOp(ValueRange values) {
-  return llvm::all_of(values, [](Value v) {
+bool areProducedByUnstickOp(
+    PatternRewriter &rewriter, ValueRange values, StringAttr layout) {
+  // Only support LAYOUT_4D and LAYOUT_NHWC at this moment. They have the same
+  // stickification scheme.
+  if (!(isNHWCLayout(layout) || is4DLayout(layout)))
+    return false;
+
+  return llvm::all_of(values, [&](Value v) {
     using namespace onnx_mlir::zhigh;
     // Block argument.
     if (v.isa<BlockArgument>())
       return false;
-    // Are produced by ZHighUnstickOp.
-    if (isa<ZHighUnstickOp>(v.getDefiningOp())) {
-      // Only support LAYOUT_4D and LAYOUT_NHWC at this moment. They have the
-      // same stickification scheme.
-      Value stickifiedVal = cast<ZHighUnstickOp>(v.getDefiningOp()).In();
-      ZTensorEncodingAttr::DataLayout layout =
-          getZTensorLayout(stickifiedVal.getType());
-      return (layout == ZTensorEncodingAttr::DataLayout::_4D ||
-              layout == ZTensorEncodingAttr::DataLayout::NHWC);
-    }
-    return false;
+    // Not produced by ZHighUnstickOp.
+    if (!isa<ZHighUnstickOp>(v.getDefiningOp()))
+      return false;
+
+    // Only support LAYOUT_4D and LAYOUT_NHWC at this moment. They have the
+    // same stickification scheme.
+    Value stickifiedVal = cast<ZHighUnstickOp>(v.getDefiningOp()).In();
+    StringAttr valueLayout = convertDataLayoutToStringAttr(
+        rewriter, getZTensorLayout(stickifiedVal.getType()));
+    return (valueLayout == layout);
   });
 }
 
@@ -54,20 +60,30 @@ bool haveNoPadsWhenStickified(
     return false;
   // Only support LAYOUT_4D and LAYOUT_NHWC at this moment. They have the same
   // stickification scheme.
-  if (!(layoutAttr.getValue().equals_insensitive(onnx_mlir::LAYOUT_NHWC) ||
-          layoutAttr.getValue().equals_insensitive(onnx_mlir::LAYOUT_4D)))
+  if (!(isNHWCLayout(layoutAttr) || is4DLayout(layoutAttr)))
     return false;
   // Only support C dimension at this moment.
-  if (axisAttr.getValue().getSExtValue() != 3)
+  int CAxis = 3; // C is at 3 for 4D and NHWC.
+  if (isNHWCLayout(layoutAttr))
+    // Value is NCHW that will be directly stickified to NHWC. So C is at 1.
+    CAxis = 1;
+  if (axisAttr.getValue().getSExtValue() != CAxis)
     return false;
+
   // C dimension is tiled by 64 when stickified. Hence, checking `C mod 64` for
   // padding.
   // TODO: get this info from affine_map that is used for stickiyfing NHWC.
-  return llvm::all_of(values, [](Value v) {
+  return llvm::all_of(values, [&layoutAttr](Value v) {
     if (v.getType().isa<ShapedType>() &&
         v.getType().cast<ShapedType>().hasRank()) {
       ArrayRef<int64_t> dims = v.getType().cast<ShapedType>().getShape();
-      return (dims[3] % 64 == 0);
+      if (isNHWCLayout(layoutAttr))
+        // Value is NCHW that will be directly unstickified from NHWC.
+        // NCHW, C is at 1.
+        return (dims[1] % 64 == 0);
+      else
+        // 4D (similar to NHWC), C is at 3.
+        return (dims[3] % 64 == 0);
     }
     return false;
   });
@@ -79,6 +95,17 @@ SmallVector<Value, 4> getStickifiedInputs(
   for (Value v : values)
     stickfiedValues.emplace_back(v.getDefiningOp()->getOperands()[0]);
   return stickfiedValues;
+}
+
+IntegerAttr getStickifiedConcatAxis(
+    PatternRewriter &rewriter, StringAttr layout, IntegerAttr axisAttr) {
+  int axis = axisAttr.getValue().getSExtValue();
+  if (isNHWCLayout(layout)) {
+    SmallVector<int, 4> NCHWtoNHWC = {0, 3, 1, 2};
+    return rewriter.getIntegerAttr(
+        rewriter.getIntegerType(64, true), NCHWtoNHWC[axis]);
+  }
+  return axisAttr;
 }
 
 /// Include the patterns defined in the Declarative Rewrite framework.

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighCombine.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighCombine.td
@@ -77,8 +77,8 @@ def StickUnstickRemovalPattern : Pat<
 >;
 
 def ProducedByUnstickOp: Constraint<
-  CPred<"areProducedByUnstickOp($0)">,
-  "all values are produced by ZHighUnstickOp"
+  CPred<"areProducedByUnstickOp($_builder, $0, $1)">,
+  "all values are produced by ZHighUnstickOp with the given layout"
 >;
 
 def HaveNoPadsWhenStickified: Constraint<
@@ -88,6 +88,10 @@ def HaveNoPadsWhenStickified: Constraint<
 
 def GetStickifiedInputs: NativeCodeCall<
   "getStickifiedInputs($_builder, $_loc, $0)"
+>;
+
+def GetStickifiedConcatAxis: NativeCodeCall<
+  "getStickifiedConcatAxis($_builder, $0, $1)"
 >;
 
 // The pattern
@@ -102,11 +106,11 @@ def GetStickifiedInputs: NativeCodeCall<
 // `zhigh.Concat` is used instead of `onnx.Concat` because `onnx.Concat` cannot 
 // allocate a 4K-aligned buffer for the output stickified tensor.
 //
-// Note: Support NHWC layout only at this moment.
+// Note: Support 4D/NHWC layout only at this moment.
 def ReplaceONNXConcatByZHighConcatPattern: Pat<
   (ZHighStickOp (ONNXConcatOp $inputs, $axis), $layout),
-  (ZHighConcatOp (GetStickifiedInputs $inputs), $axis),
-  [(ProducedByUnstickOp $inputs),
+  (ZHighConcatOp (GetStickifiedInputs $inputs), (GetStickifiedConcatAxis $layout, $axis)),
+  [(ProducedByUnstickOp $inputs, $layout),
    (HaveNoPadsWhenStickified $inputs, $layout, $axis)]
 >;
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighShapeHelper.hpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighShapeHelper.hpp
@@ -108,6 +108,32 @@ private:
   bool ownScope;
 };
 
+//===----------------------------------------------------------------------===//
+// Shape helper for StickOp.
+
+struct ZHighStickOpShapeHelper : public ZHighOpShapeHelper<ZHighStickOp> {
+  ZHighStickOpShapeHelper(ZHighStickOp *newOp);
+  ZHighStickOpShapeHelper(ZHighStickOp *newOp, mlir::OpBuilder *rewriter);
+  mlir::LogicalResult computeShape(ZHighStickOpAdaptor operandAdaptor);
+};
+
+//===----------------------------------------------------------------------===//
+// Shape helper for UnstickOp.
+
+struct ZHighUnstickOpShapeHelper : public ZHighOpShapeHelper<ZHighUnstickOp> {
+  ZHighUnstickOpShapeHelper(ZHighUnstickOp *newOp, mlir::StringAttr layout);
+  ZHighUnstickOpShapeHelper(ZHighUnstickOp *newOp, mlir::OpBuilder *rewriter,
+      mlir::StringAttr layout);
+  mlir::LogicalResult computeShape(ZHighUnstickOpAdaptor operandAdaptor);
+
+private:
+  // Store the layout of the input.
+  // - During shape inference, layout is obtained from zTensor input.
+  // - During lowering, layout is obtained from a dictionary that maps MemRef to
+  // layout.
+  mlir::StringAttr layout;
+};
+
 // =============================================================================
 // Shape helper for StickForLSTMOp.
 

--- a/src/Accelerators/NNPA/Support/LayoutHelper.cpp
+++ b/src/Accelerators/NNPA/Support/LayoutHelper.cpp
@@ -67,4 +67,16 @@ zdnn_data_layouts convertLayoutAttrToZDNNDataLayout(
   return zDNNDataLayout;
 }
 
+bool is4DLayout(StringAttr layout) {
+  return (layout && layout.getValue().equals_insensitive(LAYOUT_4D));
+}
+
+bool isNHWCLayout(StringAttr layout) {
+  return (layout && layout.getValue().equals_insensitive(LAYOUT_NHWC));
+}
+
+mlir::StringAttr getNCHWLayoutAttr(PatternRewriter &rewriter) {
+  return rewriter.getStringAttr(LAYOUT_NCHW);
+}
+
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Support/LayoutHelper.hpp
+++ b/src/Accelerators/NNPA/Support/LayoutHelper.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
 #include "zdnn.h"
 
 namespace onnx_mlir {
@@ -35,5 +36,10 @@ const std::string LAYOUT_BZRH = "BZRH";
 
 zdnn_data_layouts convertLayoutAttrToZDNNDataLayout(
     int64_t rank, mlir::StringAttr layoutAttr);
+
+bool is4DLayout(mlir::StringAttr layout);
+bool isNHWCLayout(mlir::StringAttr layout);
+
+mlir::StringAttr getNCHWLayoutAttr(mlir::PatternRewriter &rewriter);
 
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.td
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.td
@@ -73,128 +73,132 @@ def NHWCtoNCHW:
 // in NHWC layout, then use the original zAIU tensors for zhigh.add.
 // In other words, propagate the layout NHWC down, so that other rules can be
 // applied to remove stick/unstick pairs.
-def AddLayoutPropagatePattern1 : Pat<
+
+def AddLayoutPropagatePattern3 : Pat<
   (ZHighAddOp
-     (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $x), $perm), $_),
+     (ZHighStickOp (ZHighUnstickOp $x), $stickLayout),
      $y),
   (ZHighStickOp
-     (NHWCtoNCHW (ZHighUnstickOp (ZHighAddOp
-                                    $x,
-                                    (ZHighStickOp (NCHWtoNHWC (ZHighUnstickOp $y)),
-                                                  (GetLayout $x)),
-                                    (returnType $x)))),
-     (GetLayout $y)),
-  [(IsNHWC $x), (IsNotNHWC $y), (IsPermToNCHW:$perm)]
+     (ZHighUnstickOp
+       (ZHighAddOp
+         $x,
+         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x)),
+         (returnType $x))),
+     $stickLayout),
+  [(IsNHWC $x), (IsNotNHWC $y)]
 >;
 
-def AddLayoutPropagatePattern2 : Pat<
+def AddLayoutPropagatePattern4 : Pat<
   (ZHighAddOp
      $x,
-     (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $y), $perm), $_)),
+     (ZHighStickOp (ZHighUnstickOp $y), $stickLayout)),
   (ZHighStickOp
-     (NHWCtoNCHW (ZHighUnstickOp (ZHighAddOp
-                                    (ZHighStickOp (NCHWtoNHWC (ZHighUnstickOp $x)),
-                                                  (GetLayout $y)),
-                                    $y,
-                                    (returnType $y)))),
-     (GetLayout $x)),
-  [(IsNHWC $y), (IsNotNHWC $x), (IsPermToNCHW:$perm)]
+     (ZHighUnstickOp
+       (ZHighAddOp
+         $y,
+         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y)),
+         (returnType $y))),
+     $stickLayout),
+  [(IsNHWC $y), (IsNotNHWC $x)]
 >;
 
 // If the inputs of zhigh.sub transitively/originally come from zAIU tensors
 // in NHWC layout, then use the original zAIU tensors for zhigh.sub.
 // In other words, propagate the layout NHWC down, so that other rules can be
 // applied to remove stick/unstick pairs.
-def SubLayoutPropagatePattern1 : Pat<
+
+def SubLayoutPropagatePattern3 : Pat<
   (ZHighSubOp
-     (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $x), $perm), $_),
+     (ZHighStickOp (ZHighUnstickOp $x), $stickLayout),
      $y),
   (ZHighStickOp
-     (NHWCtoNCHW (ZHighUnstickOp (ZHighSubOp
-                                    $x,
-                                    (ZHighStickOp (NCHWtoNHWC (ZHighUnstickOp $y)),
-                                                  (GetLayout $x)),
-                                    (returnType $x)))),
-     (GetLayout $y)),
-  [(IsNHWC $x), (IsNotNHWC $y), (IsPermToNCHW:$perm)]
+     (ZHighUnstickOp
+       (ZHighSubOp
+         $x,
+         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x)),
+         (returnType $x))),
+     $stickLayout),
+  [(IsNHWC $x), (IsNotNHWC $y)]
 >;
 
-def SubLayoutPropagatePattern2 : Pat<
+def SubLayoutPropagatePattern4 : Pat<
   (ZHighSubOp
      $x,
-     (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $y), $perm), $_)),
+     (ZHighStickOp (ZHighUnstickOp $y), $stickLayout)),
   (ZHighStickOp
-     (NHWCtoNCHW (ZHighUnstickOp (ZHighSubOp
-                                    (ZHighStickOp (NCHWtoNHWC (ZHighUnstickOp $x)),
-                                                  (GetLayout $y)),
-                                    $y,
-                                    (returnType $y)))),
-     (GetLayout $x)),
-  [(IsNHWC $y), (IsNotNHWC $x), (IsPermToNCHW:$perm)]
+     (ZHighUnstickOp
+       (ZHighSubOp
+         $y,
+         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y)),
+         (returnType $y))),
+     $stickLayout),
+  [(IsNHWC $y), (IsNotNHWC $x)]
 >;
 
 // If the inputs of zhigh.mul transitively/originally come from zAIU tensors
 // in NHWC layout, then use the original zAIU tensors for zhigh.mul.
 // In other words, propagate the layout NHWC down, so that other rules can be
 // applied to remove stick/unstick pairs.
-def MulLayoutPropagatePattern1 : Pat<
+
+def MulLayoutPropagatePattern3 : Pat<
   (ZHighMulOp
-     (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $x), $perm), $_),
+     (ZHighStickOp (ZHighUnstickOp $x), $stickLayout),
      $y),
   (ZHighStickOp
-     (NHWCtoNCHW (ZHighUnstickOp (ZHighMulOp
-                                    $x,
-                                    (ZHighStickOp (NCHWtoNHWC (ZHighUnstickOp $y)),
-                                                  (GetLayout $x)),
-                                    (returnType $x)))),
-     (GetLayout $y)),
-  [(IsNHWC $x), (IsNotNHWC $y), (IsPermToNCHW:$perm)]
+     (ZHighUnstickOp
+       (ZHighMulOp
+         $x,
+         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x)),
+         (returnType $x))),
+     $stickLayout),
+  [(IsNHWC $x), (IsNotNHWC $y)]
 >;
 
-def MulLayoutPropagatePattern2 : Pat<
+def MulLayoutPropagatePattern4 : Pat<
   (ZHighMulOp
      $x,
-     (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $y), $perm), $_)),
+     (ZHighStickOp (ZHighUnstickOp $y), $stickLayout)),
   (ZHighStickOp
-     (NHWCtoNCHW (ZHighUnstickOp (ZHighMulOp
-                                    (ZHighStickOp (NCHWtoNHWC (ZHighUnstickOp $x)),
-                                                  (GetLayout $y)),
-                                    $y,
-                                    (returnType $y)))),
-     (GetLayout $x)),
-  [(IsNHWC $y), (IsNotNHWC $x), (IsPermToNCHW:$perm)]
+     (ZHighUnstickOp
+       (ZHighMulOp
+         $y,
+         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y)),
+         (returnType $y))),
+     $stickLayout),
+  [(IsNHWC $y), (IsNotNHWC $x)]
 >;
 
 // If the inputs of zhigh.div transitively/originally come from zAIU tensors
 // in NHWC layout, then use the original zAIU tensors for zhigh.div.
 // In other words, propagate the layout NHWC down, so that other rules can be
 // applied to remove stick/unstick pairs.
-def DivLayoutPropagatePattern1 : Pat<
+
+def DivLayoutPropagatePattern3 : Pat<
   (ZHighDivOp
-     (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $x), $perm), $_),
+     (ZHighStickOp (ZHighUnstickOp $x), $stickLayout),
      $y),
   (ZHighStickOp
-     (NHWCtoNCHW (ZHighUnstickOp (ZHighDivOp
-                                    $x,
-                                    (ZHighStickOp (NCHWtoNHWC (ZHighUnstickOp $y)),
-                                                  (GetLayout $x)),
-                                    (returnType $x)))),
-     (GetLayout $y)),
-  [(IsNHWC $x), (IsNotNHWC $y), (IsPermToNCHW:$perm)]
+     (ZHighUnstickOp
+       (ZHighDivOp
+         $x,
+         (ZHighStickOp (ZHighUnstickOp $y), (GetLayout $x)),
+         (returnType $x))),
+     $stickLayout),
+  [(IsNHWC $x), (IsNotNHWC $y)]
 >;
 
-def DivLayoutPropagatePattern2 : Pat<
+def DivLayoutPropagatePattern4 : Pat<
   (ZHighDivOp
      $x,
-     (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $y), $perm), $_)),
+     (ZHighStickOp (ZHighUnstickOp $y), $stickLayout)),
   (ZHighStickOp
-     (NHWCtoNCHW (ZHighUnstickOp (ZHighDivOp
-                                    (ZHighStickOp (NCHWtoNHWC (ZHighUnstickOp $x)),
-                                                  (GetLayout $y)),
-                                    $y,
-                                    (returnType $y)))),
-     (GetLayout $x)),
-  [(IsNHWC $y), (IsNotNHWC $x), (IsPermToNCHW:$perm)]
+     (ZHighUnstickOp
+       (ZHighDivOp
+         $y,
+         (ZHighStickOp (ZHighUnstickOp $x), (GetLayout $y)),
+         (returnType $y))),
+     $stickLayout),
+  [(IsNHWC $y), (IsNotNHWC $x)]
 >;
 
 
@@ -203,9 +207,9 @@ def DivLayoutPropagatePattern2 : Pat<
 // In other words, propagate the layout NHWC down, so that other rules can be
 // applied to remove stick/unstick pairs.
 def ReluLayoutPropagatePattern : Pat<
-  (ZHighReluOp (ZHighStickOp (ONNXTransposeOp (ZHighUnstickOp $x), $perm), $layout)),
-  (ZHighStickOp (NHWCtoNCHW (ZHighUnstickOp (ZHighReluOp $x, (returnType $x)))), $layout),
-  [(IsNHWC $x), (IsPermToNCHW:$perm)]
+  (ZHighReluOp (ZHighStickOp (ZHighUnstickOp $x), $layout)),
+  (ZHighStickOp (ZHighUnstickOp (ZHighReluOp $x, (returnType $x))), $layout),
+  [(IsNHWC $x)]
 >;
 
 #endif // ZHIGH_LAYOUT_PROPAGATION

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/conv.mlir
@@ -6,16 +6,14 @@ func.func @test_onnx_conv2d(%arg0: tensor<5x3x32x32xf32>, %arg1 : tensor<2x3x2x2
 
 // CHECK-LABEL:  func @test_onnx_conv2d
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x32x32xf32>, [[PARAM_1_:%.+]]: tensor<2x3x2x2xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<5x2x31x31xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<5x3x32x32xf32>) -> tensor<5x32x32x3xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<5x32x32x3xf32>) -> tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<5x3x32x32xf32>) -> tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 1, 0]} : (tensor<2x3x2x2xf32>) -> tensor<2x2x3x2xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "HWCK"} : (tensor<2x2x3x2xf32>) -> tensor<2x2x3x2xf32, #zhigh.encoding<{dataLayout = "HWCK"}>>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "zhigh.Stick"([[PARAM_2_]]) {layout = "1D"} : (tensor<2xf32>) -> tensor<2xf32, #zhigh.encoding<{dataLayout = "1D"}>>
 // CHECK:           [[VAR_5_:%.+]] = "zhigh.Conv2D"([[VAR_1_]], [[VAR_3_]], [[VAR_4_]]) {act_func = "ACT_NONE", kernel_shape = [2, 2], padding_type = "VALID_PADDING", strides = [1, 1]} : (tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<2x2x3x2xf32, #zhigh.encoding<{dataLayout = "HWCK"}>>, tensor<2xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_6_:%.+]] = "zhigh.Unstick"([[VAR_5_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<5x2x31x31xf32>
-// CHECK:           return [[VAR_7_]] : tensor<5x2x31x31xf32>
+// CHECK:           [[VAR_6_:%.+]] = "zhigh.Unstick"([[VAR_5_]]) : (tensor<*xf32>) -> tensor<5x2x31x31xf32>
+// CHECK:           return [[VAR_6_]] : tensor<5x2x31x31xf32>
 // CHECK:         }
 }
 
@@ -29,17 +27,15 @@ func.func @test_onnx_conv2d_nobias(%arg0: tensor<5x3x32x32xf32>, %arg1 : tensor<
 // CHECK-LABEL:  func @test_onnx_conv2d_nobias
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x32x32xf32>, [[PARAM_1_:%.+]]: tensor<2x3x2x2xf32>) -> tensor<5x2x31x31xf32> {
 // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
-// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<5x3x32x32xf32>) -> tensor<5x32x32x3xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<5x32x32x3xf32>) -> tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<5x3x32x32xf32>) -> tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 1, 0]} : (tensor<2x3x2x2xf32>) -> tensor<2x2x3x2xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "HWCK"} : (tensor<2x2x3x2xf32>) -> tensor<2x2x3x2xf32, #zhigh.encoding<{dataLayout = "HWCK"}>>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "zhigh.Stick"([[VAR_cst_]]) {layout = "1D"} : (none) -> none
 // CHECK:           [[VAR_5_:%.+]] = "zhigh.Conv2D"([[VAR_1_]], [[VAR_3_]], [[VAR_4_]]) {act_func = "ACT_NONE", kernel_shape = [2, 2], padding_type = "VALID_PADDING", strides = [1, 1]} : (tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<2x2x3x2xf32, #zhigh.encoding<{dataLayout = "HWCK"}>>, none) -> tensor<*xf32>
-// CHECK:           [[VAR_6_:%.+]] = "zhigh.Unstick"([[VAR_5_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<5x2x31x31xf32>
-// CHECK:           return [[VAR_7_]] : tensor<5x2x31x31xf32>
+// CHECK:           [[VAR_6_:%.+]] = "zhigh.Unstick"([[VAR_5_]]) : (tensor<*xf32>) -> tensor<5x2x31x31xf32>
+// CHECK:           return [[VAR_6_]] : tensor<5x2x31x31xf32>
 // CHECK:         }
 }
 
@@ -53,17 +49,15 @@ func.func @test_onnx_conv2d_no_bias_unknown_bias_dims(%arg0: tensor<5x3x32x32xf3
 // CHECK-LABEL:  func @test_onnx_conv2d_no_bias_unknown_bias_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x32x32xf32>, [[PARAM_1_:%.+]]: tensor<?x3x2x2xf32>) -> tensor<5x?x31x31xf32> {
 // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
-// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<5x3x32x32xf32>) -> tensor<5x32x32x3xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<5x32x32x3xf32>) -> tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<5x3x32x32xf32>) -> tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 1, 0]} : (tensor<?x3x2x2xf32>) -> tensor<2x2x3x?xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "HWCK"} : (tensor<2x2x3x?xf32>) -> tensor<2x2x3x?xf32, #zhigh.encoding<{dataLayout = "HWCK"}>>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "zhigh.Stick"([[VAR_cst_]]) {layout = "1D"} : (none) -> none
 // CHECK:           [[VAR_5_:%.+]] = "zhigh.Conv2D"([[VAR_1_]], [[VAR_3_]], [[VAR_4_]]) {act_func = "ACT_NONE", kernel_shape = [2, 2], padding_type = "VALID_PADDING", strides = [1, 1]} : (tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<2x2x3x?xf32, #zhigh.encoding<{dataLayout = "HWCK"}>>, none) -> tensor<*xf32>
-// CHECK:           [[VAR_6_:%.+]] = "zhigh.Unstick"([[VAR_5_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<5x?x31x31xf32>
-// CHECK:           return [[VAR_7_]] : tensor<5x?x31x31xf32>
+// CHECK:           [[VAR_6_:%.+]] = "zhigh.Unstick"([[VAR_5_]]) : (tensor<*xf32>) -> tensor<5x?x31x31xf32>
+// CHECK:           return [[VAR_6_]] : tensor<5x?x31x31xf32>
 // CHECK:         }
 }
 
@@ -108,16 +102,14 @@ func.func @test_fuse_onnx_relu_conv2d(%arg0: tensor<5x3x32x32xf32>, %arg1 : tens
 
 // CHECK-LABEL:  func @test_fuse_onnx_relu_conv2d
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x32x32xf32>, [[PARAM_1_:%.+]]: tensor<2x3x2x2xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<5x2x31x31xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<5x3x32x32xf32>) -> tensor<5x32x32x3xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<5x32x32x3xf32>) -> tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<5x3x32x32xf32>) -> tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 1, 0]} : (tensor<2x3x2x2xf32>) -> tensor<2x2x3x2xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "HWCK"} : (tensor<2x2x3x2xf32>) -> tensor<2x2x3x2xf32, #zhigh.encoding<{dataLayout = "HWCK"}>>
 // CHECK-DAG:       [[VAR_4_:%.+]] = "zhigh.Stick"([[PARAM_2_]]) {layout = "1D"} : (tensor<2xf32>) -> tensor<2xf32, #zhigh.encoding<{dataLayout = "1D"}>>
 // CHECK:           [[VAR_5_:%.+]] = "zhigh.Conv2D"([[VAR_1_]], [[VAR_3_]], [[VAR_4_]]) {act_func = "ACT_RELU", kernel_shape = [2, 2], padding_type = "VALID_PADDING", strides = [1, 1]} : (tensor<5x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<2x2x3x2xf32, #zhigh.encoding<{dataLayout = "HWCK"}>>, tensor<2xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_6_:%.+]] = "zhigh.Unstick"([[VAR_5_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_7_:%.+]] = "onnx.Transpose"([[VAR_6_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<5x2x31x31xf32>
-// CHECK:           return [[VAR_7_]] : tensor<5x2x31x31xf32>
+// CHECK:           [[VAR_6_:%.+]] = "zhigh.Unstick"([[VAR_5_]]) : (tensor<*xf32>) -> tensor<5x2x31x31xf32>
+// CHECK:           return [[VAR_6_]] : tensor<5x2x31x31xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/pool.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/pool.mlir
@@ -6,12 +6,10 @@ func.func @maxpool_should_lower_to_zhigh_padtype_valid(%arg0: tensor<1x3x32x32xf
 
 // CHECK-LABEL:  func @maxpool_should_lower_to_zhigh_padtype_valid
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x32x32xf32>) -> tensor<1x3x31x31xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x3x32x32xf32>) -> tensor<1x32x32x3xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x32x32x3xf32>) -> tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x3x32x32xf32>) -> tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.MaxPool2D"([[VAR_1_]]) {kernel_shape = [2, 2], padding_type = "VALID_PADDING", strides = [1, 1]} : (tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<1x3x31x31xf32>
-// CHECK:           return [[VAR_4_]] : tensor<1x3x31x31xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<1x3x31x31xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x3x31x31xf32>
 // CHECK:         }
 }
 
@@ -23,12 +21,10 @@ func.func @maxpool_should_lower_to_zhigh_padtype_same(%arg0: tensor<1x1x5x5xf32>
 
 // CHECK-LABEL:  func @maxpool_should_lower_to_zhigh_padtype_same
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x5x5xf32>) -> tensor<1x1x3x3xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x1x5x5xf32>) -> tensor<1x5x5x1xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x5x5x1xf32>) -> tensor<1x5x5x1xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x1x5x5xf32>) -> tensor<1x5x5x1xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.MaxPool2D"([[VAR_1_]]) {kernel_shape = [3, 3], padding_type = "SAME_PADDING", strides = [2, 2]} : (tensor<1x5x5x1xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<1x1x3x3xf32>
-// CHECK:           return [[VAR_4_]] : tensor<1x1x3x3xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<1x1x3x3xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x1x3x3xf32>
 // CHECK:         }
 }
 
@@ -40,12 +36,10 @@ func.func @maxpool_should_lower_to_zhigh_same_upper(%arg0: tensor<1x3x32x32xf32>
 
 // CHECK-LABEL:  func @maxpool_should_lower_to_zhigh_same_upper
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x32x32xf32>) -> tensor<1x3x32x32xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x3x32x32xf32>) -> tensor<1x32x32x3xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x32x32x3xf32>) -> tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x3x32x32xf32>) -> tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.MaxPool2D"([[VAR_1_]]) {kernel_shape = [2, 2], padding_type = "SAME_PADDING", strides = [1, 1]} : (tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<1x3x32x32xf32>
-// CHECK:           return [[VAR_4_]] : tensor<1x3x32x32xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<1x3x32x32xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x3x32x32xf32>
 // CHECK:         }
 }
 
@@ -57,12 +51,10 @@ func.func @averagepool_should_lower_to_zhigh_padtype_valid(%arg0: tensor<1x3x32x
 
 // CHECK-LABEL:  func @averagepool_should_lower_to_zhigh_padtype_valid
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x32x32xf32>) -> tensor<1x3x31x31xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x3x32x32xf32>) -> tensor<1x32x32x3xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x32x32x3xf32>) -> tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x3x32x32xf32>) -> tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.AvgPool2D"([[VAR_1_]]) {kernel_shape = [2, 2], padding_type = "VALID_PADDING", strides = [1, 1]} : (tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<1x3x31x31xf32>
-// CHECK:           return [[VAR_4_]] : tensor<1x3x31x31xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<1x3x31x31xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x3x31x31xf32>
 // CHECK:         }
 }
 
@@ -74,12 +66,10 @@ func.func @averagepool_should_lower_to_zhigh_padtype_same(%arg0: tensor<1x1x5x5x
 
 // CHECK-LABEL:  func @averagepool_should_lower_to_zhigh_padtype_same
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x5x5xf32>) -> tensor<1x1x3x3xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x1x5x5xf32>) -> tensor<1x5x5x1xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x5x5x1xf32>) -> tensor<1x5x5x1xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x1x5x5xf32>) -> tensor<1x5x5x1xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.AvgPool2D"([[VAR_1_]]) {kernel_shape = [3, 3], padding_type = "SAME_PADDING", strides = [2, 2]} : (tensor<1x5x5x1xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<1x1x3x3xf32>
-// CHECK:           return [[VAR_4_]] : tensor<1x1x3x3xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<1x1x3x3xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x1x3x3xf32>
 // CHECK:         }
 }
 
@@ -91,12 +81,10 @@ func.func @averagepool_should_lower_to_zhigh_same_upper(%arg0: tensor<1x3x32x32x
 
 // CHECK-LABEL:  func @averagepool_should_lower_to_zhigh_same_upper
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x32x32xf32>) -> tensor<1x3x32x32xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x3x32x32xf32>) -> tensor<1x32x32x3xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x32x32x3xf32>) -> tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x3x32x32xf32>) -> tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.AvgPool2D"([[VAR_1_]]) {kernel_shape = [2, 2], padding_type = "SAME_PADDING", strides = [1, 1]} : (tensor<1x32x32x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<1x3x32x32xf32>
-// CHECK:           return [[VAR_4_]] : tensor<1x3x32x32xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<1x3x32x32xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x3x32x32xf32>
 // CHECK:         }
 }
 
@@ -199,12 +187,10 @@ func.func @test_onnx_maxpool2d_computed_valid_dyn(%arg0: tensor<?x?x?x?xf32>) ->
 
 // CHECK-LABEL:  func @test_onnx_maxpool2d_computed_valid_dyn
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.MaxPool2D"([[VAR_1_]]) {kernel_shape = [2, 2], padding_type = "VALID_PADDING", strides = [1, 1]} : (tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           return [[VAR_4_]] : tensor<?x?x?x?xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<?x?x?x?xf32>
+// CHECK:           return [[VAR_3_]] : tensor<?x?x?x?xf32>
 // CHECK:         }
 }
 
@@ -216,12 +202,10 @@ func.func @test_maxpool_2d_same_upper_dyn(%arg0: tensor<?x?x?x?xf32>) -> tensor<
 
 // CHECK-LABEL:  func @test_maxpool_2d_same_upper_dyn
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.MaxPool2D"([[VAR_1_]]) {kernel_shape = [2, 2], padding_type = "SAME_PADDING", strides = [1, 1]} : (tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           return [[VAR_4_]] : tensor<?x?x?x?xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<?x?x?x?xf32>
+// CHECK:           return [[VAR_3_]] : tensor<?x?x?x?xf32>
 // CHECK:         }
 }
 
@@ -246,12 +230,10 @@ func.func @test_averagepool_2d_computed_valid_dyn(%arg0: tensor<?x?x?x?xf32>) ->
   return %0 : tensor<?x?x?x?xf32>
 // CHECK-LABEL:  func @test_averagepool_2d_computed_valid_dyn
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.AvgPool2D"([[VAR_1_]]) {kernel_shape = [2, 2], padding_type = "VALID_PADDING", strides = [1, 1]} : (tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           return [[VAR_4_]] : tensor<?x?x?x?xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<?x?x?x?xf32>
+// CHECK:           return [[VAR_3_]] : tensor<?x?x?x?xf32>
 // CHECK:         }
 }
 
@@ -263,12 +245,10 @@ func.func @test_averagepool_2d_same_upper_dyn(%arg0: tensor<?x?x?x?xf32>) -> ten
 
 // CHECK-LABEL:  func @test_averagepool_2d_same_upper_dyn
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.AvgPool2D"([[VAR_1_]]) {kernel_shape = [2, 2], padding_type = "SAME_PADDING", strides = [1, 1]} : (tensor<?x?x?x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           return [[VAR_4_]] : tensor<?x?x?x?xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<?x?x?x?xf32>
+// CHECK:           return [[VAR_3_]] : tensor<?x?x?x?xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/reducemean.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/reducemean.mlir
@@ -6,12 +6,10 @@ func.func @should_lower_to_zhigh(%arg0 : tensor<1x3x5x7xf32>) -> tensor<*xf32> {
 
 // CHECK-LABEL:  func @should_lower_to_zhigh
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x5x7xf32>) -> tensor<1x3x1x1xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<1x3x5x7xf32>) -> tensor<1x5x7x3xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x5x7x3xf32>) -> tensor<1x5x7x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x3x5x7xf32>) -> tensor<1x5x7x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_2_:%.+]] = "zhigh.MeanReduce2d"([[VAR_1_]]) : (tensor<1x5x7x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<*xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<*xf32>) -> tensor<1x3x1x1xf32>
-// CHECK:           return [[VAR_4_]] : tensor<1x3x1x1xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf32>) -> tensor<1x3x1x1xf32>
+// CHECK:           return [[VAR_3_]] : tensor<1x3x1x1xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -15,15 +15,13 @@ func.func @test_batchnorm_epsilon(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3xf3
 // CHECK:           [[VAR_5_:%.+]] = "onnx.Div"([[PARAM_1_]], [[VAR_4_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
 // CHECK:           [[VAR_6_:%.+]] = "onnx.Mul"([[PARAM_3_]], [[VAR_5_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
 // CHECK-DAG:       [[VAR_7_:%.+]] = "onnx.Sub"([[PARAM_2_]], [[VAR_6_]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.Transpose"([[PARAM_0_]]) {perm = [0, 2, 3, 1]} : (tensor<2x3x4x5xf32>) -> tensor<2x4x5x3xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_9_:%.+]] = "zhigh.Stick"([[VAR_8_]]) {layout = "NHWC"} : (tensor<2x4x5x3xf32>) -> tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK-DAG:       [[VAR_9_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<2x3x4x5xf32>) -> tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK-DAG:       [[VAR_10_:%.+]] = "zhigh.Stick"([[VAR_5_]]) {layout = "1D"} : (tensor<3xf32>) -> tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>
 // CHECK-DAG:       [[VAR_11_:%.+]] = "zhigh.Stick"([[VAR_7_]]) {layout = "1D"} : (tensor<3xf32>) -> tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>
 // CHECK:           [[VAR_12_:%.+]] = "zhigh.BatchNorm"([[VAR_9_]], [[VAR_10_]], [[VAR_11_]]) : (tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>, tensor<3xf32, #zhigh.encoding<{dataLayout = "1D"}>>) -> tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_13_:%.+]] = "zhigh.Unstick"([[VAR_12_]]) : (tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<2x4x5x3xf32>
-// CHECK:           [[VAR_14_:%.+]] = "onnx.Transpose"([[VAR_13_]]) {perm = [0, 3, 1, 2]} : (tensor<2x4x5x3xf32>) -> tensor<2x3x4x5xf32>
-// CHECK:           return [[VAR_14_]] : tensor<2x3x4x5xf32>
+// CHECK:           [[VAR_13_:%.+]] = "zhigh.Unstick"([[VAR_12_]]) : (tensor<2x4x5x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<2x3x4x5xf32>
+// CHECK:           return [[VAR_13_]] : tensor<2x3x4x5xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/stick-unstick.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/stick-unstick.mlir
@@ -8,10 +8,10 @@ func.func @should_lower_to_zlow(%arg0: tensor<1x3x5x7xf32>) -> tensor<*xf32> {
 // CHECK-DAG: #map = affine_map<(d0, d1, d2, d3) -> (d0, d3 floordiv 64, d1, d2 floordiv 32, d2 mod 32, d3 mod 64)>
 // CHECK-LABEL:  func @should_lower_to_zlow
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1x3x5x7xf32>) -> memref<1x3x5x7xf32> {
-// CHECK:           [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x3x5x7xf16, #map>
-// CHECK:           "zlow.stick"([[PARAM_0_]], [[RES_]]) {layout = "NHWC"} : (memref<1x3x5x7xf32>, memref<1x3x5x7xf16, #map>) -> ()
+// CHECK:           [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x5x7x3xf16, #map>
+// CHECK:           "zlow.stick"([[PARAM_0_]], [[RES_]]) {layout = "NCHW"} : (memref<1x3x5x7xf32>, memref<1x5x7x3xf16, #map>) -> ()
 // CHECK:           [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x3x5x7xf32>
-// CHECK:           "zlow.unstick"([[RES_]], [[RES_1_]]) {layout = "NHWC"} : (memref<1x3x5x7xf16, #map>, memref<1x3x5x7xf32>) -> ()
+// CHECK:           "zlow.unstick"([[RES_]], [[RES_1_]]) {layout = "NCHW"} : (memref<1x5x7x3xf16, #map>, memref<1x3x5x7xf32>) -> ()
 // CHECK:           return [[RES_1_]] : memref<1x3x5x7xf32>
 // CHECK:         }
 }
@@ -29,12 +29,12 @@ func.func @should_lower_to_zlow_unknown_dims(%arg0: tensor<1x?x?x7xf32>) -> tens
 // CHECK-DAG:       [[VAR_c2_:%.+]] = arith.constant 2 : index
 // CHECK-DAG:       [[VAR_c1_:%.+]] = arith.constant 1 : index
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.dim [[PARAM_0_]], [[VAR_c1_]] : memref<1x?x?x7xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.dim [[PARAM_0_]], [[VAR_c2_]] : memref<1x?x?x7xf32>
-// CHECK:           [[RES_:%.+]] = memref.alloc([[VAR_0_]], [[VAR_1_]]) {{.*}}: memref<1x?x?x7xf16, #map>
-// CHECK:           "zlow.stick"([[PARAM_0_]], [[RES_]]) {layout = "NHWC"} : (memref<1x?x?x7xf32>, memref<1x?x?x7xf16, #map>) -> ()
-// CHECK:           [[RES_1_:%.+]] = memref.alloc([[VAR_0_]], [[VAR_1_]]) {{.*}}: memref<1x?x?x7xf32>
-// CHECK:           "zlow.unstick"([[RES_]], [[RES_1_]]) {layout = "NHWC"} : (memref<1x?x?x7xf16, #map>, memref<1x?x?x7xf32>) -> ()
+// CHECK-DAG:       [[VAR_0_:%.+]] = memref.dim [[PARAM_0_]], [[VAR_c2_]] : memref<1x?x?x7xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = memref.dim [[PARAM_0_]], [[VAR_c1_]] : memref<1x?x?x7xf32>
+// CHECK:           [[RES_:%.+]] = memref.alloc([[VAR_0_]], [[VAR_1_]]) {{.*}}: memref<1x?x7x?xf16, #map>
+// CHECK:           "zlow.stick"([[PARAM_0_]], [[RES_]]) {layout = "NCHW"} : (memref<1x?x?x7xf32>, memref<1x?x7x?xf16, #map>) -> ()
+// CHECK:           [[RES_1_:%.+]] = memref.alloc([[VAR_1_]], [[VAR_0_]]) {{.*}}: memref<1x?x?x7xf32>
+// CHECK:           "zlow.unstick"([[RES_]], [[RES_1_]]) {layout = "NCHW"} : (memref<1x?x7x?xf16, #map>, memref<1x?x?x7xf32>) -> ()
 // CHECK:           return [[RES_1_]] : memref<1x?x?x7xf32>
 // CHECK:         }
 }

--- a/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/test-datalayout.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/test-datalayout.mlir
@@ -96,10 +96,10 @@ func.func @should_lower_to_zlow_nhwc(%arg0: tensor<1x3x5x7xf32>) -> tensor<*xf32
 
 // CHECK-DAG: #map = affine_map<(d0, d1, d2, d3) -> (d0, d3 floordiv 64, d1, d2 floordiv 32, d2 mod 32, d3 mod 64)>
 // CHECK-LABEL:  func @should_lower_to_zlow_nhwc
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1x3x5x7xf32>) -> memref<1x3x5x7xf16, #map> {
-// CHECK:           [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x3x5x7xf16, #map>
-// CHECK:           "zlow.stick"([[PARAM_0_]], [[RES_]]) {layout = "NHWC"} : (memref<1x3x5x7xf32>, memref<1x3x5x7xf16, #map>) -> ()
-// CHECK:           return [[RES_]] : memref<1x3x5x7xf16, #map>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1x3x5x7xf32>) -> memref<1x5x7x3xf16, #map> {
+// CHECK:           [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x5x7x3xf16, #map>
+// CHECK:           "zlow.stick"([[PARAM_0_]], [[RES_]]) {layout = "NCHW"} : (memref<1x3x5x7xf32>, memref<1x5x7x3xf16, #map>) -> ()
+// CHECK:           return [[RES_]] : memref<1x5x7x3xf16, #map>
 // CHECK:         }
 }
 

--- a/test/mlir/accelerators/nnpa/transform/zhigh-combine.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zhigh-combine.mlir
@@ -97,16 +97,17 @@ func.func @change_sigmoid_layout_to_remove_unstick_stick(%arg0: tensor<5x10x10xf
 // -----
 
 func.func @replace_onnx_concat_by_zhigh_concat(%arg0: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x192xf32>
-  %1 = "zhigh.Unstick"(%arg1) : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x192xf32>
-  %2 = "onnx.Concat"(%0, %1) {axis = 3 : si64} : (tensor<?x4x4x192xf32>, tensor<?x4x4x192xf32>) -> tensor<?x4x4x384xf32>
-  %3 = "zhigh.Stick"(%2) {layout = "NHWC"} : (tensor<?x4x4x384xf32>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x192x4x4xf32>
+  %1 = "zhigh.Unstick"(%arg1) : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x192x4x4xf32>
+  %2 = "onnx.Concat"(%0, %1) {axis = 1 : si64} : (tensor<?x192x4x4xf32>, tensor<?x192x4x4xf32>) -> tensor<?x384x4x4xf32>
+  %3 = "zhigh.Stick"(%2) {layout = "NHWC"} : (tensor<?x384x4x4xf32>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
   return %3 : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-  // CHECK-LABEL:  func @replace_onnx_concat_by_zhigh_concat
-  // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>> {
-  // CHECK:           [[VAR_0_:%.+]] = "zhigh.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 3 : si64} : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-  // CHECK:           return [[VAR_0_]] : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-  // CHECK:         }
+
+// CHECK-LABEL:  func.func @replace_onnx_concat_by_zhigh_concat
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>> {
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 3 : si64} : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           return [[VAR_0_]] : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:         }
 }
 
 // -----
@@ -117,25 +118,11 @@ func.func @replace_onnx_concat_by_zhigh_concat_4d(%arg0: tensor<?x4x4x192xf32, #
   %2 = "onnx.Concat"(%0, %1) {axis = 3 : si64} : (tensor<?x4x4x192xf32>, tensor<?x4x4x192xf32>) -> tensor<?x4x4x384xf32>
   %3 = "zhigh.Stick"(%2) {layout = "4D"} : (tensor<?x4x4x384xf32>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "4D"}>>
   return %3 : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  // CHECK-LABEL:  func @replace_onnx_concat_by_zhigh_concat_4d
-  // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, [[PARAM_1_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  // CHECK:           [[VAR_0_:%.+]] = "zhigh.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 3 : si64} : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  // CHECK:           return [[VAR_0_]] : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  // CHECK:         }
-}
 
-// -----
-
-func.func @replace_onnx_concat_by_zhigh_concat_4d_nhwc(%arg0: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, %arg1: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<?x4x4x192xf32>
-  %1 = "zhigh.Unstick"(%arg1) : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x192xf32>
-  %2 = "onnx.Concat"(%0, %1) {axis = 3 : si64} : (tensor<?x4x4x192xf32>, tensor<?x4x4x192xf32>) -> tensor<?x4x4x384xf32>
-  %3 = "zhigh.Stick"(%2) {layout = "NHWC"} : (tensor<?x4x4x384xf32>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-  return %3 : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-  // CHECK-LABEL:  func @replace_onnx_concat_by_zhigh_concat_4d_nhwc
-  // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, [[PARAM_1_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>> {
-  // CHECK:           [[VAR_0_:%.+]] = "zhigh.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 3 : si64} : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-  // CHECK:           return [[VAR_0_]] : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-  // CHECK:         }
+// CHECK-LABEL:  func.func @replace_onnx_concat_by_zhigh_concat_4d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, [[PARAM_1_:%.+]]: tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 3 : si64} : (tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<?x4x4x192xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_0_]] : tensor<?x4x4x384xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:         }
 }
 

--- a/test/mlir/accelerators/nnpa/transform/zhigh-layout-propagation.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zhigh-layout-propagation.mlir
@@ -1,197 +1,168 @@
 // RUN: onnx-mlir-opt --maccel=NNPA --zhigh-layout-prop --shape-inference %s -split-input-file | FileCheck %s
 
-// -----
-
 func.func @add_layout_propagate_nhwc_1(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
   %2 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %4 = "zhigh.Add"(%2, %3) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %4 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %3 = "zhigh.Add"(%1, %2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @add_layout_propagate_nhwc_1
+// CHECK-LABEL:  func.func @add_layout_propagate_nhwc_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 3, 1]} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.Add"([[VAR_1_]], [[PARAM_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_4_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_5_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "NHWC"} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Add"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }
 
 // -----
 
 func.func @add_layout_propagate_nhwc_2(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-  %2 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %4 = "zhigh.Add"(%3, %2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %4 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %2 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %3 = "zhigh.Add"(%2, %1) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @add_layout_propagate_nhwc_2
+// CHECK-LABEL:  func.func @add_layout_propagate_nhwc_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 3, 1]} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.Add"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_4_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_5_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "NHWC"} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Add"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }
 
 // -----
 
 func.func @sub_layout_propagate_nhwc_1(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
   %2 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %4 = "zhigh.Sub"(%2, %3) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %4 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %3 = "zhigh.Sub"(%1, %2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @sub_layout_propagate_nhwc_1
+// CHECK-LABEL:  func.func @sub_layout_propagate_nhwc_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 3, 1]} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.Sub"([[VAR_1_]], [[PARAM_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_4_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_5_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "NHWC"} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Sub"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }
 
 // -----
 
 func.func @sub_layout_propagate_nhwc_2(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-  %2 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %4 = "zhigh.Sub"(%3, %2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %4 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %2 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %3 = "zhigh.Sub"(%2, %1) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @sub_layout_propagate_nhwc_2
+// CHECK-LABEL:  func.func @sub_layout_propagate_nhwc_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 3, 1]} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.Sub"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_4_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_5_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "NHWC"} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Sub"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }
 
 // -----
 
 func.func @mul_layout_propagate_nhwc_1(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
   %2 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %4 = "zhigh.Mul"(%2, %3) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %4 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %3 = "zhigh.Mul"(%1, %2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @mul_layout_propagate_nhwc_1
+// CHECK-LABEL:  func.func @mul_layout_propagate_nhwc_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 3, 1]} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.Mul"([[VAR_1_]], [[PARAM_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_4_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_5_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "NHWC"} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Mul"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }
 
 // -----
 
 func.func @mul_layout_propagate_nhwc_2(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-  %2 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %4 = "zhigh.Mul"(%3, %2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %4 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %2 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %3 = "zhigh.Mul"(%2, %1) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @mul_layout_propagate_nhwc_2
+// CHECK-LABEL:  func.func @mul_layout_propagate_nhwc_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 3, 1]} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_4_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_5_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "NHWC"} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Mul"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }
 
 // -----
 
 func.func @div_layout_propagate_nhwc_1(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
   %2 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %4 = "zhigh.Div"(%2, %3) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %4 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %3 = "zhigh.Div"(%1, %2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @div_layout_propagate_nhwc_1
+// CHECK-LABEL:  func.func @div_layout_propagate_nhwc_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 3, 1]} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.Div"([[VAR_1_]], [[PARAM_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_4_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_5_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "NHWC"} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Div"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }
 
 // -----
 
 func.func @div_layout_propagate_nhwc_2(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, %arg1: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-  %2 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %4 = "zhigh.Div"(%3, %2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %4 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%arg1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %2 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %3 = "zhigh.Div"(%2, %1) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>, tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @div_layout_propagate_nhwc_2
+// CHECK-LABEL:  func.func @div_layout_propagate_nhwc_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, [[PARAM_1_:%.+]]: tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 3, 1]} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[VAR_0_]]) {layout = "NHWC"} : (tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.Div"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_4_:%.+]] = "onnx.Transpose"([[VAR_3_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_5_:%.+]] = "zhigh.Stick"([[VAR_4_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_5_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_1_]]) {layout = "NHWC"} : (tensor<1x256x56x56xf32>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Div"([[PARAM_0_]], [[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>, tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }
 
-
 // -----
 
-func.func @relu_layout_propagate_nhwc_2(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
-  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-  %1 = "onnx.Transpose"(%0) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-  %2 = "zhigh.Stick"(%1) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  %3 = "zhigh.Relu"(%2) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-  return %3 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+func.func @relu_layout_propagate_nhwc(%arg0: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+  %1 = "zhigh.Stick"(%0) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  %2 = "zhigh.Relu"(%1) : (tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+  return %2 : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 
-// CHECK-LABEL:  func @relu_layout_propagate_nhwc_2
+// CHECK-LABEL:  func.func @relu_layout_propagate_nhwc
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>> {
 // CHECK:           [[VAR_0_:%.+]] = "zhigh.Relu"([[PARAM_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x56x56x256xf32>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Transpose"([[VAR_1_]]) {perm = [0, 3, 1, 2]} : (tensor<1x56x56x256xf32>) -> tensor<1x256x56x56xf32>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Stick"([[VAR_2_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
-// CHECK:           return [[VAR_3_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x56x56x256xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x256x56x56xf32>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Stick"([[VAR_1_]]) {layout = "4D"} : (tensor<1x256x56x56xf32>) -> tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
+// CHECK:           return [[VAR_2_]] : tensor<1x256x56x56xf32, #zhigh.encoding<{dataLayout = "4D"}>>
 // CHECK:         }
 }

--- a/test/mlir/accelerators/nnpa/transform/zhigh-shape-inference/stick-unstick.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zhigh-shape-inference/stick-unstick.mlir
@@ -7,8 +7,8 @@ func.func @should_lower_to_zlow(%arg0: tensor<1x3x5x7xf32>) -> tensor<*xf32> {
 
 // CHECK-LABEL:  func @should_lower_to_zlow
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x5x7xf32>) -> tensor<1x3x5x7xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x3x5x7xf32>) -> tensor<1x3x5x7xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x3x5x7xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x3x5x7xf32>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x3x5x7xf32>) -> tensor<1x5x7x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x5x7x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x3x5x7xf32>
 // CHECK:           return [[VAR_1_]] : tensor<1x3x5x7xf32>
 // CHECK:         }
 }
@@ -22,8 +22,8 @@ func.func @should_lower_to_zlow_unknown_dims(%arg0: tensor<1x?x?x7xf32>) -> tens
 
 // CHECK-LABEL:  func @should_lower_to_zlow_unknown_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x?x?x7xf32>) -> tensor<1x?x?x7xf32> {
-// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x?x?x7xf32>) -> tensor<1x?x?x7xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x?x?x7xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x?x?x7xf32>
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x?x?x7xf32>) -> tensor<1x?x7x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x?x7x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x?x?x7xf32>
 // CHECK:           return [[VAR_1_]] : tensor<1x?x?x7xf32>
 // CHECK:         }
 }


### PR DESCRIPTION
ONNX uses NCHW layout by default and ZDNN stickify and unstickify can work directly with NCHW layout. It means we don't need to explicitly transpose from/to NCHW to/from NHWC before stickify/unstickify.

Before this patch, an ONNXConv (X: tensor<1x2x3x4xf32>) will be lowered to :
```mlir
X_NHWC = transpose(X)  {to = NHWC} : tensor<1x2x3x4xf32> -> tensor<1x4x2x3xf32>
X_NHWC_S = stick (X_NHWC) {layout = NHWC} : tensor<1x4x2x3xf32> -> tensor<1x4x2x3xf32, "NHWC">
Y_NHWC_S = zhigh.conv(X_NHWC_S) : tensor<1x4x2x3xf32, "NHWC"> -> tensor<1x4x2x3xf32, "NHWC">
Y_NHWC = unstick(Y_NHWC_S) : tensor<1x4x2x3xf32, "NHWC"> -> tensor<1x4x2x3xf32>
Y = transpose (Y_NHWC) {to = NCHW} : tensor<1x4x2x3xf32> -> tensor<1x2x3x4xf32>
```

With this patch an ONNXConv will be lowered to:
```mlir
X_NHWC_S = stick (X) {layout = NHWC} : tensor<1x2x3x4xf32> -> tensor<1x4x2x3xf32, "NHWC">
Y_NHWC_S = zhigh.conv(X_NHWC_S) : tensor<1x4x2x3xf32, "NHWC"> -> tensor<1x4x2x3xf32, "NHWC">
Y = unstick(Y_NHWC_S) : tensor<1x4x2x3xf32, "NHWC"> -> tensor<1x2x3x4xf32>
```

This patch was tested on a real accelerator by using `make check-onnx-backend-nnpa` and the numeriacl test `TestConvNNPA`. All tests were passed.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>