### PR TITLE
Matmul broadcast when the broadcast dims of A & B are identical

### DIFF
--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -440,7 +440,7 @@ public:
   bool isLiteralAndGreaterThan(IndexExpr const b) const;   // Values unequal.
   bool isLiteralAndSmallerThan(int64_t b) const;           // Values unequal.
   bool isLiteralAndSmallerThan(IndexExpr const b) const;   // Values unequal.
-  // All element in list are literals.
+  // Test if all element in list are literals.
   static bool isLiteral(llvm::SmallVectorImpl<IndexExpr> &list);
 
   // Getters.
@@ -453,7 +453,9 @@ public:
       mlir::AffineMap &map, llvm::SmallVectorImpl<mlir::Value> &operands) const;
   mlir::Value getValue() const;
 
-  // Helpers for list of IndexExpressions
+  // Helpers for list of IndexExpressions: given a (list of) IndexExpr, provide
+  // the (list of) Shape/Value/OpFoldResult corresponding to the original (list
+  // of) IndexExpr.
   static void getShape(llvm::SmallVectorImpl<IndexExpr> &indexExprList,
       llvm::SmallVectorImpl<int64_t> &intDimList);
   static void getValues(mlir::ArrayRef<IndexExpr> indexExprArray,

--- a/test/modellib/MatMulModel.cpp
+++ b/test/modellib/MatMulModel.cpp
@@ -115,28 +115,26 @@ bool MatMul2DLibBuilder::verifyOutputs() {
 // Matmul with broadcast in A or B but not both.
 
 MatMulSingleBroadcastLibBuilder::MatMulSingleBroadcastLibBuilder(
-    const std::string &modelName, bool broadcastingB,
+    const std::string &modelName, bool broadcastingB, bool sameStaticBroadcast,
     std::vector<int64_t> broadcastDims, const int I, const int J, const int K)
     : ModelLibBuilder(modelName), broadcastingB(broadcastingB),
-      broadcastDims(broadcastDims), I(I), J(J), K(K) {}
+      broadcastDims(broadcastDims), sameStaticBroadcast(sameStaticBroadcast),
+      I(I), J(J), K(K) {}
 
 bool MatMulSingleBroadcastLibBuilder::build() {
   // Create shapes for a, b, and result y with broadcast.
   aShape.clear();
   bShape.clear();
   yShape.clear();
-  if (broadcastingB) {
-    // B is being broadcasted, so B has a higher rank.
-    for (long int s : broadcastDims) {
-      bShape.emplace_back(s);
-      yShape.emplace_back(s);
-    }
-  } else {
-    // A is being broadcasted, so A has a higher rank.
-    for (long int s : broadcastDims) {
+  // Init shapes of A, B, and Y.
+  for (long int s : broadcastDims) {
+    if (sameStaticBroadcast || !broadcastingB)
+      // A is being broadcasted, so A has a higher rank.
       aShape.emplace_back(s);
-      yShape.emplace_back(s);
-    }
+    if (sameStaticBroadcast || broadcastingB)
+      // B is being broadcasted, so B has a higher rank.
+      bShape.emplace_back(s);
+    yShape.emplace_back(s);
   }
   // Add I, K for A.
   aShape.emplace_back(I);
@@ -193,7 +191,19 @@ void MatMulSingleBroadcastLibBuilder::computeOneMatMul(OMTensor *a, OMTensor *b,
   if (yIndex < broadcastRank) {
     int64_t num = yShape[yIndex]; // Size that we need to iterate over.
     yIndexValues.emplace_back(0); // Add broadcast index value.
-    if (broadcastingB) {
+    if (sameStaticBroadcast) {
+      // A & B have higher dim.
+      aIndexValues.emplace_back(0); // Add broadcast index value.
+      bIndexValues.emplace_back(0); // Add broadcast index value.
+      for (int64_t i = 0; i < num; i++) {
+        // Set the index of the matrix we are computing right now for the
+        // index values a, b, & c and recurse.
+        aIndexValues[aIndex] = bIndexValues[bIndex] = yIndexValues[bIndex] = i;
+        computeOneMatMul(a, b, y, aIndexValues, bIndexValues, yIndexValues);
+      }
+      aIndexValues.pop_back(); // Remove broadcast index value.
+      bIndexValues.pop_back(); // Remove broadcast index value.
+    } else if (broadcastingB) {
       // B has higher dim.
       bIndexValues.emplace_back(0); // Add broadcast index value.
       for (int64_t i = 0; i < num; i++) {

--- a/test/modellib/MatMulModel.cpp
+++ b/test/modellib/MatMulModel.cpp
@@ -25,7 +25,7 @@ using namespace mlir;
 namespace onnx_mlir {
 namespace test {
 
-#define DEBUG 1
+#define DEBUG 0
 
 // =============================================================================
 // 2D matmul without broadcast

--- a/test/modellib/ModelLib.hpp
+++ b/test/modellib/ModelLib.hpp
@@ -270,12 +270,16 @@ private:
 // higher rank.
 class MatMulSingleBroadcastLibBuilder : public ModelLibBuilder {
 public:
-  // If broadcastingB is true, then the rank of B > rank of A=2. The broadcasted
-  // dimensions are given by broadcastDims, and the traditional 2D matrix
-  // multiplication dims are given by I, J, and K.
+  // When broadcastingB is true, then the rank of B > rank of A=2. When
+  // broadcastingB is false, then the rank of A > rank of B=2.
+  // But when sameStaticBroadcast, then both A & B's rank >2, and they must have
+  // the same static broadcasting ranks. The broadcasted dimensions are given by
+  // broadcastDims, and the traditional 2D matrix multiplication dims are given
+  // by I, J, and K.
   MatMulSingleBroadcastLibBuilder(const std::string &modelName,
-      bool broadcastingB, std::vector<int64_t> broadcastDims, const int I,
-      const int J, const int K);
+      bool broadcastingB, bool sameStaticBroadcast,
+      std::vector<int64_t> broadcastDims, const int I, const int J,
+      const int K);
   bool build() final;
   bool prepareInputs() final;
   bool prepareInputs(float dataRange);
@@ -288,6 +292,7 @@ private:
       std::vector<int64_t> &yIndexValues);
   // Data that defines model.
   bool broadcastingB;
+  bool sameStaticBroadcast;
   std::vector<int64_t> broadcastDims;
   const int I, J, K;
   // Computed data from inputs.

--- a/test/numerical/TestMatMulBroadcast.cpp
+++ b/test/numerical/TestMatMulBroadcast.cpp
@@ -31,25 +31,28 @@ namespace test {
 // parameters/configuration. Matmul: A[IxK] * B[KxJ] = C[IxJ].
 // Include broadcasting in either A or B.
 static bool isOMMatmulTheSameAsNaiveImplFor(bool broadcastingB,
-    std::vector<int64_t> &broadcastDims, const int I, const int J,
-    const int K) {
+    bool sameStaticBroadcast, std::vector<int64_t> &broadcastDims, const int I,
+    const int J, const int K) {
   static int testNum = 0;
-  printf("attempt %d with i %d, j %d, k %d and broadcasting %c with rank %i "
+  printf("attempt %d with i %d, j %d, k %d and broadcasting %s with rank %i "
          "and sizes (",
-      ++testNum, I, J, K, broadcastingB ? 'B' : 'A', (int)broadcastDims.size());
+      ++testNum, I, J, K,
+      sameStaticBroadcast ? "both" : (broadcastingB ? "B" : "A"),
+      (int)broadcastDims.size());
   for (unsigned int i = 0; i < broadcastDims.size(); ++i)
     printf("%s%lld", i > 0 ? ", " : "", (long long int)broadcastDims[i]);
   printf(")\n");
-  MatMulSingleBroadcastLibBuilder matmul(
-      SHARED_LIB_BASE.str(), broadcastingB, broadcastDims, I, J, K);
+  MatMulSingleBroadcastLibBuilder matmul(SHARED_LIB_BASE.str(), broadcastingB,
+      sameStaticBroadcast, broadcastDims, I, J, K);
   return matmul.build() && matmul.compileAndLoad() && matmul.prepareInputs() &&
          matmul.run() && matmul.verifyOutputs();
 }
 } // namespace test
 } // namespace onnx_mlir
 
-bool broadcastB; // indicates if we broadcast on B (true) or A (false).
-
+bool broadcastB;          // Indicates if we broadcast on B (true) or A (false).
+bool sameStaticBroadcast; // Indicates if both A and B have the same static
+                          // broadcast dims.
 int main(int argc, char *argv[]) {
   using namespace onnx_mlir;
   using namespace onnx_mlir::test;
@@ -65,25 +68,34 @@ int main(int argc, char *argv[]) {
             << getCompilerOption(OptionKind::TargetAccel) << "\"\n";
 
   bool success;
-  for (int broadcastDim = 0; broadcastDim < 2; ++broadcastDim) {
-    broadcastB = (broadcastDim == 0);
-    printf("RapidCheck Matrix-vector/Matrix with broadcast %c test case generation.\n",
-        broadcastB ? 'B' : 'A');
-    success =
-        rc::check("Matrix-vector/Matrix Matmul implementation correctness", []() {
+  for (int i = 0; i < 3; ++i) {
+    // Define same static, broadcast A, or broadcast B.
+    broadcastB = sameStaticBroadcast = false;
+    if (i == 0)
+      sameStaticBroadcast = true; // Same static broadcast.
+    else if (i == 1)              // Broadcast A.
+      broadcastB = false;
+    else if (i == 2) // Broadcast B.
+      broadcastB = true;
+    printf("RapidCheck Matrix-vector/Matrix with broadcast %s test case "
+           "generation.\n",
+        sameStaticBroadcast ? "same static" : (broadcastB ? "B" : "A"));
+    success = rc::check(
+        "Matrix-vector/Matrix Matmul implementation correctness", []() {
           // There is some tiling up to 64, so pick up a large UB number .
           const int I = *rc::gen::inRange(2, 80);
-          const int J = *rc::gen::inRange(1, 80);
+          const int J = *rc::gen::inRange(1, 80); // From 1 for mat-vect.
           const int K = *rc::gen::inRange(2, 80);
           const int broadcastRank =
               *rc::gen::inRange(1, 5); // Additional rank for broadcast.
           std::vector<int64_t> broadcastDims;
           for (int i = 0; i < broadcastRank; ++i)
-            // No need for large dims, as broadcast of 2 is enough to uncover bugs.
+            // No need for large dims, as broadcast of 2 is enough to uncover
+            // bugs.
             broadcastDims.emplace_back((int64_t)*rc::gen::inRange(2, 4));
 
           RC_ASSERT(isOMMatmulTheSameAsNaiveImplFor(
-              broadcastB, broadcastDims, I, J, K));
+              broadcastB, sameStaticBroadcast, broadcastDims, I, J, K));
         });
     if (!success)
       return 1;

--- a/test/perf/PerfGemm.cpp
+++ b/test/perf/PerfGemm.cpp
@@ -65,8 +65,8 @@ static void BM_MatmulSquareBroadcastB4x(benchmark::State &state) {
   int I = state.range(0);
   int J = state.range(0);
   int K = state.range(0);
-  onnx_mlir::test::MatMulSingleBroadcastLibBuilder model(
-      modelName, /*broadcast B*/ true, {4}, I, J, K);
+  onnx_mlir::test::MatMulSingleBroadcastLibBuilder model(modelName,
+      /*broadcast B*/ true, /*same static broadcast*/ false, {4}, I, J, K);
   assert(model.build() && model.compileAndLoad() && model.prepareInputs() &&
          "failed matmul");
   for (auto _ : state)


### PR DESCRIPTION
Extension suggested by @tungld to support more broadcast patterns for matmul, namely when both A &B have the same identical broadcast dimensions (cannot handle dynamic dimension as we cannot rule out that one would be `1` and the other `100`, for example, thus needing an actual broadcast pattern.

This is an example of what this PR adds, where both broadcast dim of arg0 and arg1 (for A and B) are `2x3`.

```mlir
func.func private @test_matmul3(%arg0 : tensor<2x3x10x5xf32>, %arg1 : tensor<2x3x5x10xf32>) -> tensor<*xf32> {
  %0 ="onnx.MatMul"(%arg0, %arg1) : (tensor<2x3x10x5xf32>, tensor<2x3x5x10xf32>) -> tensor<*xf32>
  "func.return"(%0) : (tensor<*xf32>) -> ()
// mlir2FileCheck.py -a'["A", "B"]' -n'{"0": "RES"}'
// CHECK-LABEL:  func.func private @test_matmul3
// CHECK-SAME:   ([[A_:%.+]]: memref<2x3x10x5xf32>, [[B_:%.+]]: memref<2x3x5x10xf32>) -> memref<2x3x10x10xf32> {
// CHECK-DAG:       [[VAR_c0_:%.+]] = arith.constant 0 : index
// CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant 0.000000e+00 : f32
// CHECK-DAG:       [[VAR_c2_:%.+]] = arith.constant 2 : index
// CHECK-DAG:       [[VAR_c3_:%.+]] = arith.constant 3 : index
// CHECK-DAG:       [[VAR_c10_:%.+]] = arith.constant 10 : index
// CHECK-DAG:       [[VAR_c5_:%.+]] = arith.constant 5 : index
// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x3x10x10xf32>
// CHECK:           krnl.memset [[RES_]], [[VAR_cst_]] {delayed = false} : memref<2x3x10x10xf32>
// CHECK:           [[LOOP_0_:%.+]]:2 = krnl.define_loops 2

// broadcast iterate

// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = [[VAR_c0_]] to [[VAR_c2_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = [[VAR_c0_]] to [[VAR_c3_]]){
// CHECK-DAG:         [[VAR_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
// CHECK-DAG:         [[LOOP_1_:%.+]]:3 = krnl.define_loops 3
// CHECK:             [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_1_]]#0 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
// CHECK:             [[BLOCK_TILE__1_:%.+]], [[BLOCK_IN__1_:%.+]] = krnl.block [[LOOP_1_]]#1 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
// CHECK:             [[BLOCK_TILE__2_:%.+]], [[BLOCK_IN__2_:%.+]] = krnl.block [[LOOP_1_]]#2 5 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
// CHECK:             krnl.permute([[BLOCK_TILE__0_]], [[BLOCK_IN__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_IN__0_]]_1, [[BLOCK_TILE__0_]]_2, [[BLOCK_IN__0_]]_3) [0, 3, 1, 4, 2, 5] : !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop

// blocking for locality

// CHECK:             krnl.iterate([[BLOCK_TILE__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_TILE__0_]]_2) with ([[LOOP_1_]]#0 -> [[I_2_:%.+]] = [[VAR_c0_]] to [[VAR_c10_]], [[LOOP_1_]]#1 -> [[I_3_:%.+]] = [[VAR_c0_]] to [[VAR_c10_]], [[LOOP_1_]]#2 -> [[I_4_:%.+]] = [[VAR_c0_]] to [[VAR_c5_]]){
// CHECK:               [[VAR_4_:%.+]]:3 = krnl.get_induction_var_value([[BLOCK_TILE__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_TILE__0_]]_2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
// CHECK:               krnl.matmul [[A_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_c0_]], [[VAR_c0_]]{{.}}, [[B_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_c0_]], [[VAR_c0_]]{{.}}, [[RES_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_c0_]], [[VAR_c0_]]{{.}}, ([[BLOCK_IN__0_]], [[BLOCK_IN__0_]]_1, [[BLOCK_IN__0_]]_3), ([[VAR_4_]]#0, [[VAR_4_]]#1, [[VAR_4_]]#2), ([[VAR_c10_]], [[VAR_c10_]], [[VAR_c5_]]) {aTileSize = [], bTileSize = [], cTileSize = [], computeTileSize = [4, 8, 5], overcompute = false, simdize = true, unroll = true} : memref<2x3x10x5xf32>, memref<2x3x5x10xf32>, memref<2x3x10x10xf32>, (!krnl.loop, !krnl.loop, !krnl.loop)
// CHECK:             }
// CHECK:           }
// CHECK:           return [[RES_]] : memref<2x3x10x10xf32>
// CHECK:         }
}
```