### PR TITLE
fix lit test zlow-normalize-by-using-dummyop.mlir

### DIFF
--- a/test/mlir/accelerators/nnpa/transform/zlow-normalize-by-using-dummyop.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zlow-normalize-by-using-dummyop.mlir
@@ -3,7 +3,6 @@
 // COM: Current MLIR normalize-memres does not support multiple dereferencing uses
 // in a single op, check expected failure emitted by MLIR. 
 
-// FAILED-LABEL: onnx-mlir-opt 
 // FAILED: "multiple dereferencing uses in a single op not supported"
 
 // RUN: onnx-mlir-opt --maccel=NNPA --zlow-dummyop-for-multideref --normalize-memrefs --canonicalize %s | FileCheck --check-prefix=PASSED %s


### PR DESCRIPTION
the output starts with the failed assert message so
there is no label we can use with `FAILED-LABEL:`

closes #1645

Signed-off-by: Soren Lassen <sorenlassen@gmail.com>