### PR TITLE
[NNPA] - Only update the output shape if the infered shape is better

### DIFF
--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.cpp
@@ -33,6 +33,7 @@
 #include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.hpp"
 #include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighShapeHelper.hpp"
 #include "src/Accelerators/NNPA/Support/LayoutHelper.hpp"
+#include "src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp"
 #include "src/Support/Diagnostic.hpp"
 #include "zdnn.h"
 
@@ -406,6 +407,10 @@ LogicalResult ZHighUnstickOp::inferShapes(
   SmallVector<int64_t, 4> outputDims;
   IndexExpr::getShape(shapeHelper.dimsForOutput(0), outputDims);
 
+  // Do nothing if the inferred shape does not improve the current shape.
+  if (!isInferredShapeBetter(outputDims, getResult()))
+    return success();
+
   ShapedType inputType = In().getType().cast<ShapedType>();
   RankedTensorType resType =
       RankedTensorType::get(outputDims, inputType.getElementType());
@@ -418,11 +423,7 @@ LogicalResult ZHighUnstickOp::inferShapes(
 
 LogicalResult ZHighAddOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()) || !hasRankedType(Y()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -430,11 +431,7 @@ LogicalResult ZHighAddOp::inferShapes(
 
 LogicalResult ZHighSubOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()) || !hasRankedType(Y()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -442,11 +439,7 @@ LogicalResult ZHighSubOp::inferShapes(
 
 LogicalResult ZHighMulOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()) || !hasRankedType(Y()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -454,11 +447,7 @@ LogicalResult ZHighMulOp::inferShapes(
 
 LogicalResult ZHighDivOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()) || !hasRankedType(Y()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -466,11 +455,7 @@ LogicalResult ZHighDivOp::inferShapes(
 
 LogicalResult ZHighMinOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()) || !hasRankedType(Y()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -478,11 +463,7 @@ LogicalResult ZHighMinOp::inferShapes(
 
 LogicalResult ZHighMaxOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()) || !hasRankedType(Y()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -490,11 +471,7 @@ LogicalResult ZHighMaxOp::inferShapes(
 
 LogicalResult ZHighLogOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -502,11 +479,7 @@ LogicalResult ZHighLogOp::inferShapes(
 
 LogicalResult ZHighExpOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -514,11 +487,7 @@ LogicalResult ZHighExpOp::inferShapes(
 
 LogicalResult ZHighReluOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -526,11 +495,7 @@ LogicalResult ZHighReluOp::inferShapes(
 
 LogicalResult ZHighTanhOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -538,11 +503,7 @@ LogicalResult ZHighTanhOp::inferShapes(
 
 LogicalResult ZHighSigmoidOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//
@@ -550,11 +511,7 @@ LogicalResult ZHighSigmoidOp::inferShapes(
 
 LogicalResult ZHighSoftmaxOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
-  if (!hasRankedType(X()))
-    return success();
-
-  getResult().setType(X().getType());
-  return success();
+  return inferShapeForUnaryElementwiseOps(this->getOperation());
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -152,23 +152,6 @@ static RankedTensorType getReductionOutputType(ShapedType operandTy,
   return RankedTensorType::get(dims, operandTy.getElementType());
 }
 
-static bool isInferedShapeBetter(
-    ArrayRef<int64_t> inferedShape, ArrayRef<int64_t> userShape) {
-  // Only get the infered shape if unknown dims in userShape get static values
-  // in inferedShape.
-  for (unsigned i = 0; i < userShape.size(); ++i) {
-    int64_t inferedDim = inferedShape[i];
-    int64_t userDim = userShape[i];
-    // userDim is static but inferedDim is unknown: not good.
-    if ((userDim != -1) && (inferedDim == -1))
-      return false;
-    // inferedDim is different from userDim. Believe in userDim.
-    if ((userDim != -1) && (inferedDim != -1) && (userDim != inferedDim))
-      return false;
-  }
-  return true;
-}
-
 // Handle shapes for operations with a single output.
 template <class SHAPE_HELPER, class OP, class ADAPTOR>
 static LogicalResult shapeHelperInferShapes(OP &op, Type elementType) {
@@ -235,27 +218,6 @@ static LogicalResult inferShapeForReductionOps(OP &op) {
   auto operandTy = op.getOperand().getType().template cast<ShapedType>();
   auto resultTy = getReductionOutputType(operandTy, op.axes(), op.keepdims());
   op.getResult().setType(resultTy);
-  return success();
-}
-
-// Handle shape inference for unary element-wise operators.
-static LogicalResult inferShapeForUnaryElementwiseOps(Operation *op) {
-  if (!hasShapeAndRank(op->getOperand(0)))
-    return success();
-
-  // When the output has ranked, see if its shape is better than the input's
-  // shape.
-  if (hasShapeAndRank(op->getResult(0))) {
-    ArrayRef<int64_t> inputShape =
-        op->getOperand(0).getType().cast<ShapedType>().getShape();
-    ArrayRef<int64_t> userOutputShape =
-        op->getResult(0).getType().cast<ShapedType>().getShape();
-    if (!isInferedShapeBetter(inputShape, userOutputShape))
-      // The current output shape is good, do nothing.
-      return success();
-  }
-
-  op->getResult(0).setType(op->getOperand(0).getType());
   return success();
 }
 

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp
@@ -378,4 +378,10 @@ DECLARE_POOL_SHAPE_HELPER(ONNXMaxPoolSingleOutOp)
 DECLARE_BROADCASTED_SHAPE_HELPER(ONNXExpandOp)
 #undef DECLARE_BROADCASTED_SHAPE_HELPER
 
+/// Check if the given inferredShape is better than the existing shape of val.
+bool isInferredShapeBetter(
+    llvm::ArrayRef<int64_t> inferredShape, mlir::Value val);
+/// Handle shape inference for unary element-wise operators.
+mlir::LogicalResult inferShapeForUnaryElementwiseOps(mlir::Operation *op);
+
 } // namespace onnx_mlir

--- a/test/mlir/accelerators/nnpa/transform/zhigh-shape-inference/stick-unstick.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zhigh-shape-inference/stick-unstick.mlir
@@ -1,11 +1,11 @@
 // RUN: onnx-mlir-opt --maccel=NNPA --shape-inference %s -split-input-file | FileCheck %s
 
-func.func @should_lower_to_zlow(%arg0: tensor<1x3x5x7xf32>) -> tensor<*xf32> {
+func.func @stick_unstick_static_dims(%arg0: tensor<1x3x5x7xf32>) -> tensor<*xf32> {
   %0 = "zhigh.Stick"(%arg0) {layout = "NHWC"} : (tensor<1x3x5x7xf32>) -> tensor<*xf32>
   %1 = "zhigh.Unstick"(%0) : (tensor<*xf32>) -> tensor<*xf32>
   return %1 : tensor<*xf32>
 
-// CHECK-LABEL:  func @should_lower_to_zlow
+// CHECK-LABEL:  func @stick_unstick_static_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x5x7xf32>) -> tensor<1x3x5x7xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x3x5x7xf32>) -> tensor<1x5x7x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x5x7x3xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x3x5x7xf32>
@@ -15,15 +15,30 @@ func.func @should_lower_to_zlow(%arg0: tensor<1x3x5x7xf32>) -> tensor<*xf32> {
 
 // -----
 
-func.func @should_lower_to_zlow_unknown_dims(%arg0: tensor<1x?x?x7xf32>) -> tensor<*xf32> {
+func.func @stick_unstick_unknown_dims(%arg0: tensor<1x?x?x7xf32>) -> tensor<*xf32> {
   %0 = "zhigh.Stick"(%arg0) {layout = "NHWC"} : (tensor<1x?x?x7xf32>) -> tensor<*xf32>
   %1 = "zhigh.Unstick"(%0) : (tensor<*xf32>) -> tensor<*xf32>
   return %1 : tensor<*xf32>
 
-// CHECK-LABEL:  func @should_lower_to_zlow_unknown_dims
+// CHECK-LABEL:  func @stick_unstick_unknown_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x?x?x7xf32>) -> tensor<1x?x?x7xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x?x?x7xf32>) -> tensor<1x?x7x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
 // CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x?x7x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x?x?x7xf32>
 // CHECK:           return [[VAR_1_]] : tensor<1x?x?x7xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @stick_unstick_use_existing_shape(%arg0: tensor<1x?x?x7xf32>) -> tensor<1x3x5x7xf32> {
+  %0 = "zhigh.Stick"(%arg0) {layout = "NHWC"} : (tensor<1x?x?x7xf32>) -> tensor<*xf32>
+  %1 = "zhigh.Unstick"(%0) : (tensor<*xf32>) -> tensor<1x3x5x7xf32>
+  return %1 : tensor<1x3x5x7xf32>
+
+// CHECK-LABEL:  func @stick_unstick_use_existing_shape
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x?x?x7xf32>) -> tensor<1x3x5x7xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "NHWC"} : (tensor<1x?x?x7xf32>) -> tensor<1x?x7x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Unstick"([[VAR_0_]]) : (tensor<1x?x7x?xf32, #zhigh.encoding<{dataLayout = "NHWC"}>>) -> tensor<1x3x5x7xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1x3x5x7xf32>
 // CHECK:         }
 }


### PR DESCRIPTION
This patch continues PR #1654 and updates shape inference for ZHigh element-wise ops.

Functions `inferShapeForUnaryElementwiseOps` and `isInferredShapeBetter` are moved from `ONNXOps.cpp` to `ONNXShapeHelper.cpp` so that ZHigh can call them.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>