### PR TITLE
Adds option to specify graph entry point name

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1339,7 +1339,7 @@ private:
    * @return A function corresponding to the imported computation graph.
    */
   func::FuncOp importGraph(const onnx::GraphProto &graph) {
-    const std::string &name = "main_graph";
+    const std::string &name = options_.graphName;
     auto mainFunc = func::FuncOp::create(UnknownLoc(), name,
         /*type=*/builder_.getFunctionType({}, {}), /*attrs=*/{});
     module_.push_back(mainFunc);

--- a/src/Builder/FrontendDialectTransformer.hpp
+++ b/src/Builder/FrontendDialectTransformer.hpp
@@ -55,6 +55,8 @@ struct ImportOptions {
   //   - (arg0: tensor<3x4x5xf32>, arg1: tensor<10x5xf32>)
   //
   std::string shapeInformation = "";
+  // The name of the graph specified in the model
+  std::string graphName = "main_graph";
 };
 
 /*!

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -77,7 +77,8 @@ llvm::cl::opt<std::string> shapeInformation("shapeInformation",
     llvm::cl::value_desc("value"), llvm::cl::cat(OnnxMlirOptions));
 
 llvm::cl::opt<std::string> graphName("graphName",
-    llvm::cl::desc("Specifies the name of the graph for the ONNX model. Defaults to \"main_graph\"."),
+    llvm::cl::desc("Specifies the name of the graph for the ONNX model. "
+                   "Defaults to \"main_graph\"."),
     llvm::cl::init("main_graph"), llvm::cl::cat(OnnxMlirOptions));
 
 llvm::cl::opt<std::string> mtriple("mtriple",

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -76,6 +76,10 @@ llvm::cl::opt<std::string> shapeInformation("shapeInformation",
         "unknown dimensions)"),
     llvm::cl::value_desc("value"), llvm::cl::cat(OnnxMlirOptions));
 
+llvm::cl::opt<std::string> graphName("graphName",
+    llvm::cl::desc("Specifies the name of the graph for the ONNX model. Defaults to \"main_graph\"."),
+    llvm::cl::init("main_graph"), llvm::cl::cat(OnnxMlirOptions));
+
 llvm::cl::opt<std::string> mtriple("mtriple",
     llvm::cl::desc("Override target triple for module"),
     llvm::cl::value_desc("LLVM target triple"), llvm::cl::cat(OnnxMlirOptions),

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -37,6 +37,7 @@ extern llvm::cl::opt<bool> preserveMLIR;
 extern llvm::cl::opt<bool> useOnnxModelTypes;
 extern llvm::cl::opt<int> repeatOnnxTransform;
 extern llvm::cl::opt<std::string> shapeInformation;
+extern llvm::cl::opt<std::string> graphName;
 extern llvm::cl::opt<onnx_mlir::OptLevel> OptimizationLevel;
 extern llvm::cl::opt<std::string> mtriple;
 extern llvm::cl::opt<std::string> mcpu;

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -639,6 +639,7 @@ int processInputFile(std::string inputFilename, mlir::MLIRContext &context,
     options.useOnnxModelTypes = useOnnxModelTypes;
     options.invokeOnnxVersionConverter = invokeOnnxVersionConverter;
     options.shapeInformation = shapeInformation;
+    options.graphName = graphName;
     return ImportFrontendModelFile(
         inputFilename, context, module, errorMessage, options);
   } else if (inputIsMLIR)
@@ -654,6 +655,7 @@ int processInputArray(const void *onnxBuffer, int bufferSize,
   options.useOnnxModelTypes = useOnnxModelTypes;
   options.invokeOnnxVersionConverter = invokeOnnxVersionConverter;
   options.shapeInformation = shapeInformation;
+  options.graphName = graphName;
   return ImportFrontendModelArray(
       onnxBuffer, bufferSize, context, module, errorMessage, options);
 }

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.hpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.hpp
@@ -19,8 +19,6 @@
 #include "src/Pass/Passes.hpp"
 #include "src/Support/Common.hpp"
 
-const std::string DEFAULT_DYN_ENTRY_POINT = "run_main_graph";
-
 namespace onnx_mlir {
 namespace krnl {
 

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -89,8 +89,6 @@ public:
             .getLeafReference()
             .getValue();
 
-    // When there is only a single entry point function in a model, use
-    // DEFAULT_DYN_ENTRY_POINT.
     std::string dynEntryPointName = "run_" + staticEntryPointFuncName.str();
 
     // Record entry point name, input and output signatures in order to emit

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -92,8 +92,6 @@ public:
     // When there is only a single entry point function in a model, use
     // DEFAULT_DYN_ENTRY_POINT.
     std::string dynEntryPointName = "run_" + staticEntryPointFuncName.str();
-    if (singleEntryPoint)
-      dynEntryPointName = DEFAULT_DYN_ENTRY_POINT;
 
     // Record entry point name, input and output signatures in order to emit
     // signature-related functions later.

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -1,7 +1,5 @@
 // RUN: onnx-mlir-opt --convert-krnl-to-llvm --canonicalize %s -split-input-file | FileCheck %s
 
-// COM: Generate the default entry point "run_main_graph" since there is only
-// COM: one single point.
 module {
   func.func private @first_entry(%arg0: memref<10xf32>) -> memref<10xf32> {
     return %arg0 : memref<10xf32>
@@ -13,7 +11,7 @@ module {
 // CHECK:         llvm.mlir.global external constant @_entry_point_0_in_sig("[in_sig]\00")
 // CHECK:         llvm.mlir.global external constant @_entry_point_0_out_sig("[out_sig]\00")
 
-// CHECK-LABEL:   llvm.func @run_main_graph
+// CHECK-LABEL:   llvm.func @run_first_entry
 // CHECK:             ([[ARG0:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           {{.*}} = llvm.call @omTensorListGetOmtArray([[ARG0]]) : (!llvm.ptr<i8>) -> !llvm.ptr<ptr<i8>>
 

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -1,6 +1,84 @@
 // RUN: onnx-mlir-opt --convert-krnl-to-llvm --canonicalize %s -split-input-file | FileCheck %s
 
 module {
+  func.func private @main_graph(%arg0: memref<10xf32>) -> memref<10xf32> {
+    return %arg0 : memref<10xf32>
+  }
+  "krnl.entry_point"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[in_sig]\00@[out_sig]\00"} : () -> ()
+
+// CHECK:         llvm.func @strncmp(!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
+// CHECK:         llvm.mlir.global external constant @_entry_point_0("run_main_graph\00")
+// CHECK:         llvm.mlir.global external constant @_entry_point_0_in_sig("[in_sig]\00")
+// CHECK:         llvm.mlir.global external constant @_entry_point_0_out_sig("[out_sig]\00")
+
+// CHECK-LABEL:   llvm.func @run_main_graph
+// CHECK:             ([[ARG0:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           {{.*}} = llvm.call @omTensorListGetOmtArray([[ARG0]]) : (!llvm.ptr<i8>) -> !llvm.ptr<ptr<i8>>
+
+// CHECK:         llvm.mlir.global internal constant @_entry_point_arrays() : !llvm.array<2 x ptr<i8>> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = llvm.mlir.undef : !llvm.array<2 x ptr<i8>>
+// CHECK-DAG:       [[VAR_2_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
+// CHECK:           [[VAR_3_:%.+]] = llvm.getelementptr [[VAR_2_]][0, 0] : (!llvm.ptr<array<15 x i8>>) -> !llvm.ptr<i8>
+// CHECK:           [[VAR_4_:%.+]] = llvm.insertvalue [[VAR_3_]], [[VAR_0_]][0] : !llvm.array<2 x ptr<i8>>
+// CHECK:           [[VAR_5_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK:           [[VAR_6_:%.+]] = llvm.insertvalue [[VAR_5_]], [[VAR_4_]][1] : !llvm.array<2 x ptr<i8>>
+// CHECK:           llvm.return [[VAR_6_]] : !llvm.array<2 x ptr<i8>>
+// CHECK:         }
+
+// CHECK:         llvm.func @omQueryEntryPoints([[arg0_:%.+]]: !llvm.ptr<i64>) -> !llvm.ptr<ptr<i8>> {
+// CHECK-DAG:       [[VAR_2_4_:%.+]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-DAG:       [[VAR_0_3_:%.+]] = llvm.mlir.null : !llvm.ptr<i64>
+// CHECK:           [[VAR_1_4_:%.+]] = llvm.icmp "ne" [[arg0_]], [[VAR_0_3_]] : !llvm.ptr<i64>
+// CHECK:           llvm.cond_br [[VAR_1_4_]], ^bb1, ^bb2
+// CHECK:         ^bb1:  // pred: ^bb0
+// CHECK:           llvm.store [[VAR_2_4_]], [[arg0_]] : !llvm.ptr<i64>
+// CHECK:           llvm.br ^bb2
+// CHECK:         ^bb2:  // 2 preds: ^bb0, ^bb1
+// CHECK:           [[VAR_3_3_:%.+]] = llvm.mlir.addressof @_entry_point_arrays : !llvm.ptr<array<2 x ptr<i8>>>
+// CHECK:           [[VAR_4_4_:%.+]] = llvm.bitcast [[VAR_3_3_]] : !llvm.ptr<array<2 x ptr<i8>>> to !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.return [[VAR_4_4_]] : !llvm.ptr<ptr<i8>>
+// CHECK:         }
+
+// CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
+// CHECK-DAG:       [[VAR_0_4_:%.+]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:       [[VAR_4_5_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
+// CHECK-DAG:       [[VAR_5_4_:%.+]] = llvm.getelementptr [[VAR_4_5_]][0, 0] : (!llvm.ptr<array<15 x i8>>) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_6_3_:%.+]] = llvm.mlir.constant(15 : i64) : i64
+// CHECK:           [[VAR_7_1_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_4_]], [[VAR_6_3_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
+// CHECK:           [[VAR_8_1_:%.+]] = llvm.icmp "eq" [[VAR_7_1_]], [[VAR_0_4_]] : i32
+// CHECK:           llvm.cond_br [[VAR_8_1_]], ^bb1, ^bb2
+// CHECK:         ^bb1:  // pred: ^bb0
+// CHECK:           [[VAR_9_1_:%.+]] = llvm.mlir.addressof @_entry_point_0_in_sig : !llvm.ptr<array<9 x i8>>
+// CHECK:           [[VAR_10_1_:%.+]] = llvm.bitcast [[VAR_9_1_]] : !llvm.ptr<array<9 x i8>> to !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_10_1_]] : !llvm.ptr<i8>
+// CHECK:         ^bb2:  // pred: ^bb0
+// CHECK:           [[VAR_11_1_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_11_1_]] : !llvm.ptr<i8>
+// CHECK:         }
+
+// CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
+// CHECK-DAG:       [[VAR_0_5_:%.+]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:       [[VAR_4_6_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
+// CHECK-DAG:       [[VAR_5_5_:%.+]] = llvm.getelementptr [[VAR_4_6_]][0, 0] : (!llvm.ptr<array<15 x i8>>) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_6_4_:%.+]] = llvm.mlir.constant(15 : i64) : i64
+// CHECK:           [[VAR_7_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_5_]], [[VAR_6_4_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
+// CHECK:           [[VAR_8_2_:%.+]] = llvm.icmp "eq" [[VAR_7_2_]], [[VAR_0_5_]] : i32
+// CHECK:           llvm.cond_br [[VAR_8_2_]], ^bb1, ^bb2
+// CHECK:         ^bb1:  // pred: ^bb0
+// CHECK:           [[VAR_9_2_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr<array<10 x i8>>
+// CHECK:           [[VAR_10_2_:%.+]] = llvm.bitcast [[VAR_9_2_]] : !llvm.ptr<array<10 x i8>> to !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_10_2_]] : !llvm.ptr<i8>
+// CHECK:         ^bb2:  // pred: ^bb0
+// CHECK:           [[VAR_11_2_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK:           llvm.return [[VAR_11_2_]] : !llvm.ptr<i8>
+// CHECK:         }
+
+}
+
+// -----
+
+// COM: Similar to above, but with a non-default entry point name
+module {
   func.func private @first_entry(%arg0: memref<10xf32>) -> memref<10xf32> {
     return %arg0 : memref<10xf32>
   }
@@ -25,20 +103,6 @@ module {
 // CHECK:           llvm.return [[VAR_6_]] : !llvm.array<2 x ptr<i8>>
 // CHECK:         }
 
-// CHECK:         llvm.func @omQueryEntryPoints([[arg0_:%.+]]: !llvm.ptr<i64>) -> !llvm.ptr<ptr<i8>> {
-// CHECK-DAG:       [[VAR_2_4_:%.+]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-DAG:       [[VAR_0_3_:%.+]] = llvm.mlir.null : !llvm.ptr<i64>
-// CHECK:           [[VAR_1_4_:%.+]] = llvm.icmp "ne" [[arg0_]], [[VAR_0_3_]] : !llvm.ptr<i64>
-// CHECK:           llvm.cond_br [[VAR_1_4_]], ^bb1, ^bb2
-// CHECK:         ^bb1:  // pred: ^bb0
-// CHECK:           llvm.store [[VAR_2_4_]], [[arg0_]] : !llvm.ptr<i64>
-// CHECK:           llvm.br ^bb2
-// CHECK:         ^bb2:  // 2 preds: ^bb0, ^bb1
-// CHECK:           [[VAR_3_3_:%.+]] = llvm.mlir.addressof @_entry_point_arrays : !llvm.ptr<array<2 x ptr<i8>>>
-// CHECK:           [[VAR_4_4_:%.+]] = llvm.bitcast [[VAR_3_3_]] : !llvm.ptr<array<2 x ptr<i8>>> to !llvm.ptr<ptr<i8>>
-// CHECK:           llvm.return [[VAR_4_4_]] : !llvm.ptr<ptr<i8>>
-// CHECK:         }
-
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_4_:%.+]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:       [[VAR_4_5_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
@@ -54,23 +118,6 @@ module {
 // CHECK:         ^bb2:  // pred: ^bb0
 // CHECK:           [[VAR_11_1_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return [[VAR_11_1_]] : !llvm.ptr<i8>
-// CHECK:         }
-
-// CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
-// CHECK-DAG:       [[VAR_0_5_:%.+]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:       [[VAR_4_6_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
-// CHECK-DAG:       [[VAR_5_5_:%.+]] = llvm.getelementptr [[VAR_4_6_]][0, 0] : (!llvm.ptr<array<16 x i8>>) -> !llvm.ptr<i8>
-// CHECK-DAG:       [[VAR_6_4_:%.+]] = llvm.mlir.constant(16 : i64) : i64
-// CHECK:           [[VAR_7_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_5_]], [[VAR_6_4_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
-// CHECK:           [[VAR_8_2_:%.+]] = llvm.icmp "eq" [[VAR_7_2_]], [[VAR_0_5_]] : i32
-// CHECK:           llvm.cond_br [[VAR_8_2_]], ^bb1, ^bb2
-// CHECK:         ^bb1:  // pred: ^bb0
-// CHECK:           [[VAR_9_2_:%.+]] = llvm.mlir.addressof @_entry_point_0_out_sig : !llvm.ptr<array<10 x i8>>
-// CHECK:           [[VAR_10_2_:%.+]] = llvm.bitcast [[VAR_9_2_]] : !llvm.ptr<array<10 x i8>> to !llvm.ptr<i8>
-// CHECK:           llvm.return [[VAR_10_2_]] : !llvm.ptr<i8>
-// CHECK:         ^bb2:  // pred: ^bb0
-// CHECK:           [[VAR_11_2_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
-// CHECK:           llvm.return [[VAR_11_2_]] : !llvm.ptr<i8>
 // CHECK:         }
 
 }

--- a/test/mlir/krnl/entry_point.mlir
+++ b/test/mlir/krnl/entry_point.mlir
@@ -7,7 +7,7 @@ module {
   "krnl.entry_point"() {func = @first_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[in_sig]\00@[out_sig]\00"} : () -> ()
 
 // CHECK:         llvm.func @strncmp(!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
-// CHECK:         llvm.mlir.global external constant @_entry_point_0("run_main_graph\00")
+// CHECK:         llvm.mlir.global external constant @_entry_point_0("run_first_entry\00")
 // CHECK:         llvm.mlir.global external constant @_entry_point_0_in_sig("[in_sig]\00")
 // CHECK:         llvm.mlir.global external constant @_entry_point_0_out_sig("[out_sig]\00")
 
@@ -17,8 +17,8 @@ module {
 
 // CHECK:         llvm.mlir.global internal constant @_entry_point_arrays() : !llvm.array<2 x ptr<i8>> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = llvm.mlir.undef : !llvm.array<2 x ptr<i8>>
-// CHECK-DAG:       [[VAR_2_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
-// CHECK:           [[VAR_3_:%.+]] = llvm.getelementptr [[VAR_2_]][0, 0] : (!llvm.ptr<array<15 x i8>>) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_2_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
+// CHECK:           [[VAR_3_:%.+]] = llvm.getelementptr [[VAR_2_]][0, 0] : (!llvm.ptr<array<16 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           [[VAR_4_:%.+]] = llvm.insertvalue [[VAR_3_]], [[VAR_0_]][0] : !llvm.array<2 x ptr<i8>>
 // CHECK:           [[VAR_5_:%.+]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           [[VAR_6_:%.+]] = llvm.insertvalue [[VAR_5_]], [[VAR_4_]][1] : !llvm.array<2 x ptr<i8>>
@@ -41,9 +41,9 @@ module {
 
 // CHECK:         llvm.func @omInputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_4_:%.+]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:       [[VAR_4_5_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
-// CHECK-DAG:       [[VAR_5_4_:%.+]] = llvm.getelementptr [[VAR_4_5_]][0, 0] : (!llvm.ptr<array<15 x i8>>) -> !llvm.ptr<i8>
-// CHECK-DAG:       [[VAR_6_3_:%.+]] = llvm.mlir.constant(15 : i64) : i64
+// CHECK-DAG:       [[VAR_4_5_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
+// CHECK-DAG:       [[VAR_5_4_:%.+]] = llvm.getelementptr [[VAR_4_5_]][0, 0] : (!llvm.ptr<array<16 x i8>>) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_6_3_:%.+]] = llvm.mlir.constant(16 : i64) : i64
 // CHECK:           [[VAR_7_1_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_4_]], [[VAR_6_3_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
 // CHECK:           [[VAR_8_1_:%.+]] = llvm.icmp "eq" [[VAR_7_1_]], [[VAR_0_4_]] : i32
 // CHECK:           llvm.cond_br [[VAR_8_1_]], ^bb1, ^bb2
@@ -58,9 +58,9 @@ module {
 
 // CHECK:         llvm.func @omOutputSignature([[arg0_:%.+]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
 // CHECK-DAG:       [[VAR_0_5_:%.+]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:       [[VAR_4_6_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<15 x i8>>
-// CHECK-DAG:       [[VAR_5_5_:%.+]] = llvm.getelementptr [[VAR_4_6_]][0, 0] : (!llvm.ptr<array<15 x i8>>) -> !llvm.ptr<i8>
-// CHECK-DAG:       [[VAR_6_4_:%.+]] = llvm.mlir.constant(15 : i64) : i64
+// CHECK-DAG:       [[VAR_4_6_:%.+]] = llvm.mlir.addressof @_entry_point_0 : !llvm.ptr<array<16 x i8>>
+// CHECK-DAG:       [[VAR_5_5_:%.+]] = llvm.getelementptr [[VAR_4_6_]][0, 0] : (!llvm.ptr<array<16 x i8>>) -> !llvm.ptr<i8>
+// CHECK-DAG:       [[VAR_6_4_:%.+]] = llvm.mlir.constant(16 : i64) : i64
 // CHECK:           [[VAR_7_2_:%.+]] = llvm.call @strncmp([[arg0_]], [[VAR_5_5_]], [[VAR_6_4_]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
 // CHECK:           [[VAR_8_2_:%.+]] = llvm.icmp "eq" [[VAR_7_2_]], [[VAR_0_5_]] : i32
 // CHECK:           llvm.cond_br [[VAR_8_2_]], ^bb1, ^bb2


### PR DESCRIPTION
This changes the behavior when a single entry point is specified. Prior to this change, the entry point would be ignored if there was only a single entry point and `run_main_graph` would be emitted. After this change, the entry point name is honored, even if there's only one entry point.