### PR TITLE
build: decouple CompilerOptions from ONNXToKrnl pass

### DIFF
--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -115,7 +115,7 @@ void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
   if (enableInstrumentONNXSignature)
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::createInstrumentONNXSignaturePass());
-  pm.addPass(onnx_mlir::createLowerToKrnlPass(optLevel));
+  pm.addPass(onnx_mlir::createLowerToKrnlPass(optLevel, enableParallel));
   // An additional pass of canonicalization is helpful because lowering
   // from ONNX dialect to Standard dialect exposes additional canonicalization
   // opportunities.

--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -69,7 +69,6 @@ add_onnx_mlir_library(OMONNXToKrnl
 
   LINK_LIBS PUBLIC
   Accelerator
-  CompilerOptions
   OMConstPropHelper
   OMONNXOps
   OMSupport

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -279,12 +279,12 @@ struct FrontendToKrnlLoweringPass
     // Option<bool>.
     this->emitDealloc = emitDealloc;
     this->enableTiling = enableTiling;
-    // this->enableParallel = enableParallel;
+    this->enableParallel = enableParallel;
   }
-  FrontendToKrnlLoweringPass(int optLevel)
+  FrontendToKrnlLoweringPass(int optLevel, bool enableParallel)
       : FrontendToKrnlLoweringPass(
             /*emitDealloc=*/false, /*enableTiling=*/optLevel >= 3,
-            /*enableParallel*/ false) {}
+            enableParallel) {}
 
   void runOnOperation() final;
 
@@ -310,6 +310,8 @@ public:
   Option<bool> enableTiling{*this, "enable-tiling",
       llvm::cl::desc("Enable loop tiling and unrolling optimizations"),
       llvm::cl::init(false)};
+  Option<bool> enableParallel{*this, "enable-parallel",
+      llvm::cl::desc("Enable parallelization"), llvm::cl::init(false)};
 };
 
 void FrontendToKrnlLoweringPass::runOnOperation() {
@@ -415,8 +417,8 @@ std::unique_ptr<Pass> createLowerToKrnlPass() {
   return std::make_unique<FrontendToKrnlLoweringPass>();
 }
 
-std::unique_ptr<Pass> createLowerToKrnlPass(int optLevel) {
-  return std::make_unique<FrontendToKrnlLoweringPass>(optLevel);
+std::unique_ptr<Pass> createLowerToKrnlPass(int optLevel, bool enableParallel) {
+  return std::make_unique<FrontendToKrnlLoweringPass>(optLevel, enableParallel);
 }
 
 std::unique_ptr<Pass> createLowerToKrnlPass(

--- a/src/InitOMPasses.hpp
+++ b/src/InitOMPasses.hpp
@@ -71,7 +71,7 @@ void initOMPasses(int optLevel) {
   });
 
   mlir::registerPass([optLevel]() -> std::unique_ptr<mlir::Pass> {
-    return createLowerToKrnlPass(optLevel);
+    return createLowerToKrnlPass(optLevel, /* enableParallel */ false);
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -54,7 +54,8 @@ std::unique_ptr<mlir::Pass> createONNXPreKrnlVerifyPass();
 
 /// Add pass for lowering to Krnl IR.
 std::unique_ptr<mlir::Pass> createLowerToKrnlPass();
-std::unique_ptr<mlir::Pass> createLowerToKrnlPass(int optLevel);
+std::unique_ptr<mlir::Pass> createLowerToKrnlPass(
+    int optLevel, bool enableParallel);
 std::unique_ptr<mlir::Pass> createLowerToKrnlPass(
     bool emitDealloc, bool enableTiling, bool enableParallel);
 


### PR DESCRIPTION
Prior to this patch, any consumer of the ONNXToKrnl pass (transitively)
depended on the CompilerOptions library.  This dependency caused
conflicts in identically-named command line options between the
CompilerOptions library and the consumers of the ONNXToKrnl pass.

This patch introduces a local option to the ONNXToKrnl pass so that its
dependency on CompilerOptions is removed, thus eliminating the symbol
conflicts.  When its time to pass a command line option to enable
parallelization in the ONNXTOKrnl pass, the call to
`createLowerToKrnlPass()` in CompilerPasses.cpp, which correctly depends
on the CompilerOptions library, will be able to pass the command line
value to the ONNXToKrnl pass.