### PR TITLE
build: fix path to test data directory

### DIFF
--- a/test/backend/setup_model_download.cmake
+++ b/test/backend/setup_model_download.cmake
@@ -37,7 +37,7 @@ function(setup_model_download backend_test variation)
   # Make sure MODEL_DIR is the same as ONNX_MODELS in CMakeLists.txt
   set(MODEL_DIR ${FILE_GENERATE_DIR}/models)
   set(TEST_DATA_DIR
-    ${CMAKE_SOURCE_DIR}/third_party/onnx/onnx/backend/test/data/real/)
+    ${ONNX_MLIR_SRC_ROOT}/third_party/onnx/onnx/backend/test/data/real/)
 
   foreach(m_cpu ${BACKEND_MODELS})
     # For each model, remove "_cpu" suffix, find its data.json,


### PR DESCRIPTION
Prior to this patch, in a repository setup where onnx-mlir is not
present in the top-level directory, the build failed because the
`setup_model_download()` function assumed that the `third_party/onnx`
directory is located at the root of the repository.

This patch fixes the problem by replacing the reference to
`CMAKE_SOURCE_DIR` with `ONNX_MLIR_SRC_ROOT`.

Signed-off-by: Ashay Rane <ashay@users.noreply.github.com>