### PR TITLE
show onnx-mlir-opt CLI options

### DIFF
--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -42,31 +42,36 @@
 using namespace mlir;
 using namespace onnx_mlir;
 
-static llvm::cl::opt<std::string> input_filename(
-    llvm::cl::Positional, llvm::cl::desc("<input file>"), llvm::cl::init("-"));
+// Options for onnx-mlir-opt only.
+static llvm::cl::OptionCategory OnnxMlirOptOptions(
+    "ONNX-MLIR-OPT Options", "These are opt frontend options.");
+
+static llvm::cl::opt<std::string> input_filename(llvm::cl::Positional,
+    llvm::cl::desc("<input file>"), llvm::cl::init("-"),
+    llvm::cl::cat(OnnxMlirOptOptions));
 
 static llvm::cl::opt<std::string> output_filename("o",
     llvm::cl::desc("Output filename"), llvm::cl::value_desc("filename"),
-    llvm::cl::init("-"));
+    llvm::cl::init("-"), llvm::cl::cat(OnnxMlirOptOptions));
 
 static llvm::cl::opt<bool> split_input_file("split-input-file",
     llvm::cl::desc("Split the input file into pieces and process each "
                    "chunk independently"),
-    llvm::cl::init(false));
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptOptions));
 
 static llvm::cl::opt<bool> verify_diagnostics("verify-diagnostics",
     llvm::cl::desc("Check that emitted diagnostics match "
                    "expected-* lines on the corresponding line"),
-    llvm::cl::init(false));
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptOptions));
 
 static llvm::cl::opt<bool> verify_passes("verify-each",
     llvm::cl::desc("Run the verifier after each transformation pass"),
-    llvm::cl::init(true));
+    llvm::cl::init(true), llvm::cl::cat(OnnxMlirOptOptions));
 
 static llvm::cl::opt<bool> allowUnregisteredDialects(
     "allow-unregistered-dialect",
     llvm::cl::desc("Allow operation with no registered dialects"),
-    llvm::cl::init(false));
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptOptions));
 
 void scanAndSetOptLevel(int argc, char **argv) {
   // In decreasing order, so we pick the last one if there are many.
@@ -101,8 +106,10 @@ int main(int argc, char **argv) {
   // Scan maccel manually now as it is needed for initializing the OM Passes.
   scanAndSetMAccel(argc, argv);
 
-  // Hide unrelated options except common ones.
-  llvm::cl::HideUnrelatedOptions({&onnx_mlir::OnnxMlirCommonOptions});
+  // Hide unrelated options except common ones and the onnx-mlir-opt options
+  // defined above.
+  llvm::cl::HideUnrelatedOptions(
+      {&onnx_mlir::OnnxMlirCommonOptions, &OnnxMlirOptOptions});
 
   mlir::DialectRegistry registry;
   registry.insert<mlir::linalg::LinalgDialect>();


### PR DESCRIPTION
I noticed that `onnx-mlir-opt -h` wasn't displaying `--split-input-file` and some other options

this PR adds the following output to `onnx-mlir-opt -h`:
```
ONNX-MLIR-OPT Options:
These are opt frontend options.

  --allow-unregistered-dialect                         - Allow operation with no registered dialects
  -o <filename>                                        - Output filename
  --split-input-file                                   - Split the input file into pieces and process each chunk independently
  --verify-diagnostics                                 - Check that emitted diagnostics match expected-* lines on the corresponding line
  --verify-each                                        - Run the verifier after each transformation pass
```

Signed-off-by: Soren Lassen <sorenlassen@gmail.com>