### PR TITLE
[NNPA] Rewrite ONNXPowOp and ONNXSoftmaxOp for NNPA

### DIFF
--- a/docs/SupportedONNXOps-NNPA.md
+++ b/docs/SupportedONNXOps-NNPA.md
@@ -3,7 +3,7 @@
 
 # Supported ONNX Operation for Target *NNPA*.
 
-Onnx-mlir currently supports ONNX operations targeting up to opset 14. Limitations are listed when applicable.
+Onnx-mlir currently supports ONNX operations targeting up to opset 15. Limitations are listed when applicable.
 
 * Operations are defined by the [ONNX Standard](https://github.com/onnx/onnx/blob/main/docs/Operators.md).
 * Opset indicates, for each operation, the ONNX opset that (1) last modified that operation and (2) is supported by the current version of onnx-mlir. For example, "Add" was modified in Opset 14 and carries on unmodified to Opset 16. If onnx-mlir supports Opset 14, we thus list "14" as the Opset associated with the "Add" operation.
@@ -16,7 +16,7 @@ NNPA has hardware limitations in dimension index size and tensor size, which are
 | --- |--- |--- |--- |
 | **Add** |14 |- Shape of input tensors must be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions. | |
 | **AveragePool** |11 |- `auto_pad` must be `NOTSET`, `VALID`, and `SAME_UPPER`. If `NOTSET` is used, `pads` must be set so that the padding valid type or same upper.<br>- `ceil_mode` must be default value(0) <br>- Input and output tensors must be 4D tensors (N x C x H x W).<br>- `kernel_shape` must be static.<br>- `count_include_pad` must be default value(0).<br>- `ceil_mode` must be default value(0). | |
-| **BatchNormalization** |14 |Input and output tensor must be 4D(N x C x H x W). | |
+| **BatchNormalization** |15 |Input and output tensor must be 4D(N x C x H x W). | |
 | **Conv** |11 |- `auto_pad` must be `NOTSET`, `VALID`, and `SAME_UPPER`. If `NOTSET` is used, `pads` must be set so that the padding valid type or same upper.<br>- Dimension in Height and weight must be static.<br>- `group` must be default value(1).<br>- `dilations` must be default value(1).<br>- Input and output tensors must have 4D (N x C x H x W).<br>- `kernel_shape` must be static. | |
 | **Div** |14 |- Shape of input tensors must be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions. | |
 | **Exp** |13 |Input tensor must have 4 dimensions. | |
@@ -31,10 +31,11 @@ NNPA has hardware limitations in dimension index size and tensor size, which are
 | **MaxPool** |12 |- `auto_pad` must be `NOTSET`, `VALID`, and `SAME_UPPER`. If `NOTSET` is used, `pads` must be set so that the padding valid type or same upper.<br>- `ceil_mode` must be default value(0) <br>- Input and output tensors must be 4D tensors(N x C x H x W).<br>- `kernel_shape` must be static.<br>- `ceil_mode` must be default value(0).<br>- `dilations` must be default value(1). | |
 | **Min** |13 |- Shape of input tensors must be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions. | |
 | **Mul** |14 |- Shape of input tensors should be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions. | |
+| **Pow** |15 |- Exponent should be a scalar integer and less or equal to 64. | |
 | **ReduceMean** |13 |- `keepdims` must be 1.<br>- Input tensor must be 4D tensors and `axis` must be [2, 3]. | |
 | **Relu** |14 |Input tensor must be less than or equal to 4 dimensions. | |
 | **Sigmoid** |13 |Input tensor must be less than or equal to 4 dimensions. | |
-| **Softmax** |13 |- Rank of input tensor must be 2.<br>- `axis` must be 1 or -1. | |
+| **Softmax** |13 |- `axis` must be the last dimension, i.e. `rank - 1` or -1. | |
 | **Sub** |14 |- Shape of input tensors should be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions. | |
 | **Sum** |13 |- All inputs must have the same static shape (Broadcasting not supported.)<br>- Single input not supported. | |
 | **Tanh** |13 |Input tensor must be less than or equal to 4 dimensions. | |

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -68,11 +68,16 @@ llvm::cl::list<std::string> execNodesOnCpu{"execNodesOnCpu",
 
 void addONNXToZHighPasses(
     mlir::PassManager &pm, ArrayRef<std::string> execNodesOnCpu) {
-  pm.addPass(onnx_mlir::createRewriteONNXForZHighPass(execNodesOnCpu));
-  pm.addPass(onnx_mlir::createShapeInferencePass());
-  pm.addPass(mlir::createCanonicalizerPass());
-  pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
-  pm.addPass(onnx_mlir::createShapeInferencePass());
+  for (unsigned i = 0; i < 3; i++) {
+    // Repeat this process so that shape-related ops such as Shape, Expand,
+    // Gather generated during RewriteONNXForZHigh will become constants.
+    pm.addPass(onnx_mlir::createRewriteONNXForZHighPass(execNodesOnCpu));
+    pm.addPass(onnx_mlir::createShapeInferencePass());
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
+    pm.addPass(onnx_mlir::createShapeInferencePass());
+    pm.addPass(mlir::createCanonicalizerPass());
+  }
   // Add instrumentation for Onnx Ops in the same way as onnx-mlir.
   if (instrumentZHighOps == "" || instrumentZHighOps == "NONE")
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXPass(

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -357,7 +357,6 @@ bool isSuitableForZDNN<ONNXMaxOp>(ONNXMaxOp op) {
 /// Check legality for ONNXSoftmax.
 /// zDNN softmax only supports axis = 1 (or -1 when rank = 2). If axis is not
 /// 1 (or -1 when rank = 2), keep ONNXSoftmax unchanged.
-/// TODO: support rank != 2.
 template <>
 bool isSuitableForZDNN<ONNXSoftmaxOp>(ONNXSoftmaxOp op) {
   if (!isValidElementType(op.input()))

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.td
@@ -226,4 +226,29 @@ def rewriteMatMulNDto3D_Broadcast_2: Pat<
   [(HasRankOf<2> $a), (HasRankGT<3> $b)]
 >;
 
+//===----------------------------------------------------------------------===//
+// Rules to turn ONNXSoftmaxOp with N-D inputs into the one with 2-D inputs.
+//===----------------------------------------------------------------------===//
+
+def ReshapeTo2DKeepLast: NativeCodeCall<
+  "reshapeTo2DKeepLast($_builder, $_loc, $0)"
+>;
+
+def SoftmaxAxisOne: NativeCodeCall<
+ "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), APInt(64, 1, /*isSigned=*/true))">;
+
+def GetShapeResultType: NativeCodeCall<
+ "RankedTensorType::get({getRank($0.getType())}, $_builder.getI64Type())">;
+
+def rewriteSoftmaxNDto2D: Pat<
+  (ONNXSoftmaxOp:$c $input, $axis),
+  (ONNXReshapeOp (ONNXSoftmaxOp
+                    (ReshapeTo2DKeepLast:$r $input),
+                    (SoftmaxAxisOne),
+                    (returnType $r)),
+                 (ONNXShapeOp $input, (returnType (GetShapeResultType $input))),
+                 (GetZeroI64Attr)),
+  [(HasRankGT<2> $input)]
+>;
+
 #endif // REWRITE_ONNX_FOR_ZHIGH

--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -126,6 +126,13 @@ Value OnnxBuilder::mul(Value A, Value B) const {
   return b.create<ONNXMulOp>(loc, toTensor(A), toTensor(B));
 }
 
+Value OnnxBuilder::mul(Type resultType, Value A, Value B) const {
+  assert((A.getType().cast<ShapedType>().getElementType() ==
+             B.getType().cast<ShapedType>().getElementType()) &&
+         "A and B must have the same element type");
+  return b.create<ONNXMulOp>(loc, resultType, toTensor(A), toTensor(B));
+}
+
 Value OnnxBuilder::reduceSum(Type outputType, Value data, Value axes,
     bool keepdims, bool noop_with_empty_axes) const {
   int64_t i_keepdims = keepdims; // 0 if false, 1 if true

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -56,6 +56,7 @@ struct OnnxBuilder : onnx_mlir::DialectBuilder {
 
   // ONNXMulOp
   mlir::Value mul(mlir::Value A, mlir::Value B) const;
+  mlir::Value mul(mlir::Type resultType, mlir::Value A, mlir::Value B) const;
 
   // ONNXReduceSumOp
   mlir::Value reduceSum(mlir::Type outputType, mlir::Value data,

--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -116,6 +116,7 @@ set(NNPA_TEST_LIST
     test_averagepool_2d_same_upper_cpu,zdnn_avgpool2d
     test_averagepool_2d_strides_cpu,zdnn_avgpool2d
     # test_averagepool_3d_default_cpu
+
     # ==OP== BatchNormalization
     # ==LIM== Input and output tensor must be 4D(N x C x H x W).
     test_batchnorm_epsilon_cpu,zdnn_mul
@@ -154,6 +155,7 @@ set(NNPA_TEST_LIST
     test_gemm_default_zero_bias_cpu,zdnn_matmul_op
     test_gemm_transposeA_cpu,zdnn_matmul_op
     test_gemm_transposeB_cpu,zdnn_matmul_op
+
     # ==OP== GlobalAveragePool
     # ==LIM== - Input shape must be 4D tensor(NCHW).<br>- Dimensions in `H` and `W` must be static.
     test_globalaveragepool_cpu,zdnn_meanreduce2d
@@ -161,6 +163,7 @@ set(NNPA_TEST_LIST
     # GlobalMaxPool
     # test_globalmaxpool_cpu
     # test_globalmaxpool_precomputed_cpu
+
     # ==OP== GRU
     # ==LIM== - `direction` and `hidden_size` in `W` must have static dimensions.<br>- `R` must have static dimensions.<br>- If `B` and `initial_h` are given, they must have static dimensions.<br>- `sequence_lens` is not supported.<br>- `activations` must be `["Sigmoid", "Tanh", "Tanh"]`.<br>- `clip` is not supported.<br>- `linear_before_reset` must be 1.<br>- `layout` is not supported.
     # test_gru_defaults_cpu
@@ -179,6 +182,7 @@ set(NNPA_TEST_LIST
     # test_logsoftmax_default_axis_cpu
     test_logsoftmax_negative_axis_cpu,zdnn_log
     # test_logsoftmax_large_number_cpu #  accuracy error in test_logsoftmax_large_number_cpu
+
     # ==OP== LSTM
     # ==LIM== - `direction` and `hidden_size` in `W` must have static dimensions.<br>- `R` must have static dimensions.<br>- `B` and `initial_h` have static dimensions if given. `B`'s direction dim must be 1 or 2.<br>- `P`(peepholes), `activation_alpha`, and `activation_beta` are not supported.<br>- `activations` must be `["Sigmoid", "Tanh", "Tanh"]`.<br>- `clip` is not supported.<br>- `input_forget` must be default value(0).<br>- `layout` is not supported.
     test_lstm_defaults_cpu,zdnn_lstm
@@ -245,6 +249,11 @@ set(NNPA_TEST_LIST
     test_mul_cpu,zdnn_mul
     # test_mul_bcast_cpu
     test_mul_example_cpu,zdnn_mul
+
+    # ==OP== Pow
+    # ==LIM== - Exponent should be a scalar integer and less or equal to 64.
+    test_pow_bcast_scalar_cpu
+
     # ==OP== ReduceMean
     # ==LIM== - `keepdims` must be 1.<br>- Input tensor must be 4D tensors and `axis` must be [2, 3].
     # test_reduce_mean_default_axes_keepdims_example_cpu
@@ -255,31 +264,38 @@ set(NNPA_TEST_LIST
     # test_reduce_mean_keepdims_random_cpu
     # test_reduce_mean_negative_axes_keepdims_example_cpu
     # test_reduce_mean_negative_axes_keepdims_random_cpu
+
     # ==OP== Relu
     # ==LIM== Input tensor must be less than or equal to 4 dimensions.
     test_relu_cpu,zdnn_relu
+
     # ==OP== Softmax
-    # ==LIM== - Rank of input tensor must be 2.<br>- `axis` must be 1 or -1.
+    # ==LIM== - `axis` must be the last dimension, i.e. `rank - 1` or -1.
     # test_softmax_axis_0_cpu
     # test_softmax_axis_1_cpu
     # test_softmax_axis_2_cpu
     # test_softmax_default_axis_cpu
     test_softmax_example_cpu,zdnn_softmax
     # test_softmax_large_number_cpu #  accuracy error
+
     # ==OP== Sub
     # ==LIM== - Shape of input tensors should be the same since broadcasting is not supported.<br>- Input tensors must have static dimensions.
     test_sub_cpu,zdnn_sub
     # test_sub_bcast_cpu
     test_sub_example_cpu,zdnn_sub
+
     # ==OP== Sum
     # ==LIM== - All inputs must have the same static shape (Broadcasting not supported.)<br>- Single input not supported.
     test_sum_example_cpu,zdnn_add
     # test_sum_one_input_cpu
     test_sum_two_inputs_cpu,zdnn_add
+
     # ==OP== Tanh
     # ==LIM== Input tensor must be less than or equal to 4 dimensions.
+
     # ==OP== Sigmoid
     # ==LIM== Input tensor must be less than or equal to 4 dimensions.
+
     # Model
     # test_densenet121_cpu  #  accurary error
     test_inception_v1_cpu,zdnn_conv2d

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -455,6 +455,20 @@ func.func @expand_pow_into_mul(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
 
 // -----
 
+func.func @expand_pow_into_constant(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
+    %cst = "onnx.Constant"() {value = dense<0.0> : tensor<f32>} : () -> tensor<f32>
+    %0 = "onnx.Pow"(%arg0, %cst) : (tensor<3x4x5xf32>, tensor<f32>) -> tensor<3x4x5xf32>
+    return %0 : tensor<3x4x5xf32>
+
+// CHECK-LABEL:  func.func @expand_pow_into_constant
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<3x4x5xf32>} : () -> tensor<3x4x5xf32>
+// CHECK:           return [[VAR_0_]] : tensor<3x4x5xf32>
+// CHECK:         }
+}
+
+// -----
+
 // COM: Rewrite N-D Softmax into 2-D softmax when axis is the last dim.
 
 func.func @softmax_nd_to_2d(%arg0: tensor<4x12x256x256xf32>) -> (tensor<4x12x256x256xf32>) {

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -1,5 +1,5 @@
 // RUN: onnx-mlir-opt --maccel=NNPA --shape-inference --rewrite-onnx-for-zhigh %s -split-input-file | FileCheck %s
-// RUN: onnx-mlir-opt --maccel=NNPA --rewrite-onnx-for-zhigh --shape-inference --canonicalize --constprop-onnx --shape-inference %s --split-input-file | FileCheck --check-prefix=MATMUL %s
+// RUN: onnx-mlir-opt --maccel=NNPA --rewrite-onnx-for-zhigh --shape-inference --canonicalize --constprop-onnx --shape-inference %s --split-input-file | FileCheck --check-prefix=CONSTPROP %s
 
 func.func @test_batchnorm_epsilon(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>, %arg3: tensor<3xf32>, %arg4: tensor<3xf32>) -> tensor<2x3x4x5xf32> {
   %0 = "onnx.BatchNormalizationInferenceMode"(%arg0, %arg1, %arg2, %arg3, %arg4) {epsilon = 0.00999999977 : f32} : (tensor<2x3x4x5xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x4x5xf32>
@@ -353,17 +353,17 @@ func.func @test_matmul(%arg0: tensor<4x12x256x256xf32>, %arg1: tensor<4x12x256x6
     %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<4x12x256x256xf32>, tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32>
     return %0 : tensor<4x12x256x64xf32>
 
-// MATMUL-LABEL:  func.func @test_matmul
-// MATMUL-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>, [[PARAM_1_:%.+]]: tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32> {
-// MATMUL:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256, 256]> : tensor<3xi64>} : () -> tensor<3xi64>
-// MATMUL-DAG:       [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
-// MATMUL-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256, 64]> : tensor<3xi64>} : () -> tensor<3xi64>
-// MATMUL:           [[VAR_3_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x12x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
-// MATMUL-DAG:       [[VAR_4_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_3_]]) : (tensor<48x256x256xf32>, tensor<48x256x64xf32>) -> tensor<48x256x64xf32>
-// MATMUL-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<[4, 12, 256, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
-// MATMUL:           [[VAR_6_:%.+]] = "onnx.Reshape"([[VAR_4_]], [[VAR_5_]]) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
-// MATMUL:           return [[VAR_6_]] : tensor<4x12x256x64xf32>
-// MATMUL:         }
+// CONSTPROP-LABEL:  func.func @test_matmul
+// CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>, [[PARAM_1_:%.+]]: tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32> {
+// CONSTPROP:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256, 256]> : tensor<3xi64>} : () -> tensor<3xi64>
+// CONSTPROP-DAG:       [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
+// CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256, 64]> : tensor<3xi64>} : () -> tensor<3xi64>
+// CONSTPROP:           [[VAR_3_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<4x12x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
+// CONSTPROP-DAG:       [[VAR_4_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_3_]]) : (tensor<48x256x256xf32>, tensor<48x256x64xf32>) -> tensor<48x256x64xf32>
+// CONSTPROP-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<[4, 12, 256, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CONSTPROP:           [[VAR_6_:%.+]] = "onnx.Reshape"([[VAR_4_]], [[VAR_5_]]) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
+// CONSTPROP:           return [[VAR_6_]] : tensor<4x12x256x64xf32>
+// CONSTPROP:         }
 }
 
 // -----
@@ -372,15 +372,15 @@ func.func @test_matmul_broadcast_1(%arg0: tensor<4x12x256x256xf32>, %arg1: tenso
     %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<4x12x256x256xf32>, tensor<256x64xf32>) -> tensor<4x12x256x64xf32>
     return %0 : tensor<4x12x256x64xf32>
 
-// MATMUL-LABEL:  func.func @test_matmul_broadcast_1
-// MATMUL-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>, [[PARAM_1_:%.+]]: tensor<256x64xf32>) -> tensor<4x12x256x64xf32> {
-// MATMUL:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256, 256]> : tensor<3xi64>} : () -> tensor<3xi64>
-// MATMUL:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
-// MATMUL-DAG:       [[VAR_2_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[PARAM_1_]]) : (tensor<48x256x256xf32>, tensor<256x64xf32>) -> tensor<48x256x64xf32>
-// MATMUL-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<[4, 12, 256, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
-// MATMUL:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
-// MATMUL:           return [[VAR_4_]] : tensor<4x12x256x64xf32>
-// MATMUL:         }
+// CONSTPROP-LABEL:  func.func @test_matmul_broadcast_1
+// CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>, [[PARAM_1_:%.+]]: tensor<256x64xf32>) -> tensor<4x12x256x64xf32> {
+// CONSTPROP:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256, 256]> : tensor<3xi64>} : () -> tensor<3xi64>
+// CONSTPROP:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
+// CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[PARAM_1_]]) : (tensor<48x256x256xf32>, tensor<256x64xf32>) -> tensor<48x256x64xf32>
+// CONSTPROP-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<[4, 12, 256, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CONSTPROP:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
+// CONSTPROP:           return [[VAR_4_]] : tensor<4x12x256x64xf32>
+// CONSTPROP:         }
 }
 
 // -----
@@ -389,15 +389,15 @@ func.func @test_matmul_broadcast_2(%arg0: tensor<256x256xf32>, %arg1: tensor<4x1
     %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<256x256xf32>, tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32>
     return %0 : tensor<4x12x256x64xf32>
 
-// MATMUL-LABEL:  func.func @test_matmul_broadcast_2
-// MATMUL-SAME:   ([[PARAM_0_:%.+]]: tensor<256x256xf32>, [[PARAM_1_:%.+]]: tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32> {
-// MATMUL:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256, 64]> : tensor<3xi64>} : () -> tensor<3xi64>
-// MATMUL:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
-// MATMUL-DAG:       [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<256x256xf32>, tensor<48x256x64xf32>) -> tensor<48x256x64xf32>
-// MATMUL-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<[4, 12, 256, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
-// MATMUL:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
-// MATMUL:           return [[VAR_4_]] : tensor<4x12x256x64xf32>
-// MATMUL:         }
+// CONSTPROP-LABEL:  func.func @test_matmul_broadcast_2
+// CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<256x256xf32>, [[PARAM_1_:%.+]]: tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32> {
+// CONSTPROP:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256, 64]> : tensor<3xi64>} : () -> tensor<3xi64>
+// CONSTPROP:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
+// CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<256x256xf32>, tensor<48x256x64xf32>) -> tensor<48x256x64xf32>
+// CONSTPROP-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<[4, 12, 256, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CONSTPROP:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
+// CONSTPROP:           return [[VAR_4_]] : tensor<4x12x256x64xf32>
+// CONSTPROP:         }
 }
 
 // -----
@@ -406,35 +406,35 @@ func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tenso
     %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<256x?xf32>, tensor<4x12x?x?xf32>) -> tensor<4x12x256x?xf32>
     return %0 : tensor<4x12x256x?xf32>
 
-// MATMUL-LABEL:  func.func @test_matmul_broadcast_dyn_dims
-// MATMUL-SAME:   ([[PARAM_0_:%.+]]: tensor<256x?xf32>, [[PARAM_1_:%.+]]: tensor<4x12x?x?xf32>) -> tensor<4x12x256x?xf32> {
-// MATMUL-DAG:       [[VAR_0_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
-// MATMUL-DAG:       [[VAR_1_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_4_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL:           [[VAR_6_:%.+]] = "onnx.Slice"([[VAR_0_]], [[VAR_4_]], [[VAR_5_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// MATMUL:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_3_]], [[VAR_6_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<2xi64>) -> tensor<3xi64>
-// MATMUL:           [[VAR_8_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_7_]]) {allowzero = 0 : si64} : (tensor<4x12x?x?xf32>, tensor<3xi64>) -> tensor<?x?x?xf32>
-// MATMUL-DAG:       [[VAR_9_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_8_]]) : (tensor<256x?xf32>, tensor<?x?x?xf32>) -> tensor<?x256x?xf32>
-// MATMUL-DAG:       [[VAR_10_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<256x?xf32>) -> tensor<2xi64>
-// MATMUL-DAG:       [[VAR_11_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
-// MATMUL-DAG:       [[VAR_12_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_13_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_14_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_15_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_16_:%.+]] = "onnx.Constant"() {value = dense<3> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_17_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_18_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
-// MATMUL-NOT: separator of consecutive DAGs
-// MATMUL-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_12_]], [[VAR_18_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// MATMUL-DAG:       [[VAR_20_:%.+]] = "onnx.Slice"([[VAR_10_]], [[VAR_17_]], [[VAR_14_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-// MATMUL-DAG:       [[VAR_21_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_16_]], [[VAR_15_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-// MATMUL:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_20_]], [[VAR_21_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
-// MATMUL:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_22_]]) {allowzero = 0 : si64} : (tensor<?x256x?xf32>, tensor<4xi64>) -> tensor<4x12x256x?xf32>
-// MATMUL:           return [[VAR_23_]] : tensor<4x12x256x?xf32>
-// MATMUL:         }
+// CONSTPROP-LABEL:  func.func @test_matmul_broadcast_dyn_dims
+// CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<256x?xf32>, [[PARAM_1_:%.+]]: tensor<4x12x?x?xf32>) -> tensor<4x12x256x?xf32> {
+// CONSTPROP-DAG:       [[VAR_0_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
+// CONSTPROP-DAG:       [[VAR_1_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_4_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP:           [[VAR_6_:%.+]] = "onnx.Slice"([[VAR_0_]], [[VAR_4_]], [[VAR_5_]], [[VAR_1_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// CONSTPROP:           [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_3_]], [[VAR_6_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<2xi64>) -> tensor<3xi64>
+// CONSTPROP:           [[VAR_8_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_7_]]) {allowzero = 0 : si64} : (tensor<4x12x?x?xf32>, tensor<3xi64>) -> tensor<?x?x?xf32>
+// CONSTPROP-DAG:       [[VAR_9_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_8_]]) : (tensor<256x?xf32>, tensor<?x?x?xf32>) -> tensor<?x256x?xf32>
+// CONSTPROP-DAG:       [[VAR_10_:%.+]] = "onnx.Shape"([[PARAM_0_]]) : (tensor<256x?xf32>) -> tensor<2xi64>
+// CONSTPROP-DAG:       [[VAR_11_:%.+]] = "onnx.Shape"([[PARAM_1_]]) : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
+// CONSTPROP-DAG:       [[VAR_12_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_13_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_14_:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_15_:%.+]] = "onnx.Constant"() {value = dense<4> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_16_:%.+]] = "onnx.Constant"() {value = dense<3> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_17_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_18_:%.+]] = "onnx.Constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
+// CONSTPROP-NOT: separator of consecutive DAGs
+// CONSTPROP-DAG:       [[VAR_19_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_12_]], [[VAR_18_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// CONSTPROP-DAG:       [[VAR_20_:%.+]] = "onnx.Slice"([[VAR_10_]], [[VAR_17_]], [[VAR_14_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_21_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_16_]], [[VAR_15_]], [[VAR_12_]], [[VAR_13_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// CONSTPROP:           [[VAR_22_:%.+]] = "onnx.Concat"([[VAR_19_]], [[VAR_20_]], [[VAR_21_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+// CONSTPROP:           [[VAR_23_:%.+]] = "onnx.Reshape"([[VAR_9_]], [[VAR_22_]]) {allowzero = 0 : si64} : (tensor<?x256x?xf32>, tensor<4xi64>) -> tensor<4x12x256x?xf32>
+// CONSTPROP:           return [[VAR_23_]] : tensor<4x12x256x?xf32>
+// CONSTPROP:         }
 }
 
 // -----
@@ -451,4 +451,23 @@ func.func @expand_pow_into_mul(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_1_]], [[PARAM_0_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
 // CHECK:           return [[VAR_2_]] : tensor<3x4x5xf32>
 // CHECK:        }
+}
+
+// -----
+
+// COM: Rewrite N-D Softmax into 2-D softmax when axis is the last dim.
+
+func.func @softmax_nd_to_2d(%arg0: tensor<4x12x256x256xf32>) -> (tensor<4x12x256x256xf32>) {
+    %0 = "onnx.Softmax"(%arg0) {axis = 3 : si64} : (tensor<4x12x256x256xf32>) -> tensor<4x12x256x256xf32>
+    return %0: tensor<4x12x256x256xf32>
+
+// CONSTPROP-LABEL:  func.func @softmax_nd_to_2d
+// CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>) -> tensor<4x12x256x256xf32> {
+// CONSTPROP:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[-1, 256]> : tensor<2xi64>} : () -> tensor<2xi64>
+// CONSTPROP:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<2xi64>) -> tensor<12288x256xf32>
+// CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.Softmax"([[VAR_1_]]) {axis = 1 : si64} : (tensor<12288x256xf32>) -> tensor<12288x256xf32>
+// CONSTPROP-DAG:       [[VAR_3_:%.+]] = "onnx.Constant"() {value = dense<[4, 12, 256, 256]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CONSTPROP:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<12288x256xf32>, tensor<4xi64>) -> tensor<4x12x256x256xf32>
+// CONSTPROP:           return [[VAR_4_]] : tensor<4x12x256x256xf32>
+// CONSTPROP:         }
 }

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -436,3 +436,19 @@ func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tenso
 // MATMUL:           return [[VAR_23_]] : tensor<4x12x256x?xf32>
 // MATMUL:         }
 }
+
+// -----
+
+// COM: Expand Pow into multiple Mul if exponent is an integer and <= 64.
+func.func @expand_pow_into_mul(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
+    %cst = "onnx.Constant"() {value = dense<3.0> : tensor<f32>} : () -> tensor<f32>
+    %0 = "onnx.Pow"(%arg0, %cst) : (tensor<3x4x5xf32>, tensor<f32>) -> tensor<3x4x5xf32>
+    return %0 : tensor<3x4x5xf32>
+
+// CHECK-LABEL:  func.func @expand_pow_into_mul
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[PARAM_0_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_1_]], [[PARAM_0_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
+// CHECK:           return [[VAR_2_]] : tensor<3x4x5xf32>
+// CHECK:        }
+}


### PR DESCRIPTION
NNPA does not support Pow op and Softmax with rank > 2. In some cases, we can rewrite these ops into the form that NNPA supports. 

This patch rewrites:
- ONNXPowOp into multiple Mul ops if exponent is an integer and <= 64, and 
- Softmax with rank > 2 into Softmax with rank = 2 if axis is the last dimension.

For example, 

```mlir
func.func @test_pow(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
    %cst = "onnx.Constant"() {value = dense<3.0> : tensor<f32>} : () -> tensor<f32>
    %0 = "onnx.Pow"(%arg0, %cst) : (tensor<3x4x5xf32>, tensor<f32>) -> tensor<3x4x5xf32>
    return %0 : tensor<3x4x5xf32>
}
```
will become
```mlir
func.func @test_pow(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
    %0 = "onnx.Mul"(%arg0, %arg0) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
    %1 = "onnx.Mul"(%0, %arg0) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
    return %1 : tensor<3x4x5xf32>
  }
```

and

```mlir
func.func @test_softmax(%arg0: tensor<4x12x256x256xf32>) -> (tensor<4x12x256x256xf32>) {
    %0 = "onnx.Softmax"(%arg0) {axis = 3 : si64} : (tensor<4x12x256x256xf32>) -> tensor<4x12x256x256xf32>
    return %0: tensor<4x12x256x256xf32>
}
```
will become
```mlir
func.func @test_softmax(%arg0: tensor<4x12x256x256xf32>) -> tensor<4x12x256x256xf32> {
    %0 = "onnx.Constant"() {value = dense<[-1, 256]> : tensor<2xi64>} : () -> tensor<2xi64>
    %1 = "onnx.Reshape"(%arg0, %0) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<2xi64>) -> tensor<12288x256xf32>
    %2 = "onnx.Softmax"(%1) {axis = 1 : si64} : (tensor<12288x256xf32>) -> tensor<12288x256xf32>
    %3 = "onnx.Constant"() {value = dense<[4, 12, 256, 256]> : tensor<4xi64>} : () -> tensor<4xi64>
    %4 = "onnx.Reshape"(%2, %3) {allowzero = 0 : si64} : (tensor<12288x256xf32>, tensor<4xi64>) -> tensor<4x12x256x256xf32>
    return %4 : tensor<4x12x256x256xf32>
}
```