### PR TITLE
build: fix dependencies on MLIR libraries and tools

### DIFF
--- a/src/Accelerators/CMakeLists.txt
+++ b/src/Accelerators/CMakeLists.txt
@@ -43,6 +43,7 @@ add_onnx_mlir_library(InitAccelerators
 
   DEPENDS 
     AcceleratorsInc
+    MLIRIR
 
   LINK_LIBS PUBLIC
     ${ACCEL_TARGET_LIST}

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -123,6 +123,8 @@ add_onnx_mlir_library(CompilerUtils
   DEPENDS
   ExternalUtil
   MLIRIR
+  llc
+  opt
 
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}

--- a/src/Tools/onnx-mlir-opt/CMakeLists.txt
+++ b/src/Tools/onnx-mlir-opt/CMakeLists.txt
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 get_property(OMLibs GLOBAL PROPERTY ONNX_MLIR_LIBS)
+get_property(DialectLibs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(ConversionLibs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
 add_onnx_mlir_executable(onnx-mlir-opt
   onnx-mlir-opt.cpp
 
   LINK_LIBS PRIVATE
+  ${DialectLibs}
+  ${ConversionLibs}
   ${OMLibs}
   CompilerOptions
   Accelerator

--- a/src/Tools/onnx-mlir-reduce/CMakeLists.txt
+++ b/src/Tools/onnx-mlir-reduce/CMakeLists.txt
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 get_property(OMLibs GLOBAL PROPERTY ONNX_MLIR_LIBS)
+get_property(DialectLibs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(ConversionLibs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
 add_onnx_mlir_executable(onnx-mlir-reduce
   onnx-mlir-reduce.cpp
 
   LINK_LIBS PRIVATE
+  ${DialectLibs}
+  ${ConversionLibs}
   ${OMLibs}
   Accelerator
   InitAccelerators


### PR DESCRIPTION
An in-tree build, i.e. when all MLIR targets are not already built and are instead built on demand, exposes a handful of missing dependencies on various MLIR libraries and tools.  This patch adds the necessary dependencies.

In particular:

 - Both onnx-mlir-opt.cpp and onnx-mlir-reduce.cpp include InitAllPasses.h and InitAllDialects.h, thus requiring all dialect and conversion libraries to be linked into those targets.

 - CompilerUtils.cpp shells out to opt and llc tools, thus requiring the two binaries to be built.

 - InitAccelerators.cpp, just like Accelerator.cpp, includes Accelerators.hpp, which includes mlir/IR/BuiltinOps.h, this requring a dependency on MLIRIR, although this can probably be trimmed to be leaner.

Signed-off-by: Ashay Rane <ashay@users.noreply.github.com>