### PR TITLE
Simplified interface for compile from programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_STANDARD 17)
 # etc.), by default some components (e.g., cmake) install into lib while
 # others (e.g., python) install into lib64.
 # This causes trouble when we try to figure out the runtime directory in
-# CompilerUtils.cpp::getRuntimeDir(). So we explicitly set CMAKE_INSTALL_LIBDIR
+# CompilerUtils.cpp::getLibraryPath(). So we explicitly set CMAKE_INSTALL_LIBDIR
 # to install into lib on all systems so we don't have to deal with lib64.
 set(CMAKE_INSTALL_LIBDIR lib)
 

--- a/docs/doc_example/CMakeLists.txt
+++ b/docs/doc_example/CMakeLists.txt
@@ -97,5 +97,5 @@ set_output_directory(OMRuntimeCppTest BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} LIB
 add_test(NAME OMRuntimeCppTest COMMAND OMRuntimeCppTest WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_property(TARGET OMRuntimeCppTest PROPERTY FOLDER "Docs")
 set_tests_properties(OMRuntimeCppTest PROPERTIES LABELS doc-example)
-set_tests_properties(OMRuntimeCppTest PROPERTIES ENVIRONMENT "ONNX_MLIR_RUNTIME_DIR=${ONNX_MLIR_LIBRARY_PATH}")
+set_tests_properties(OMRuntimeCppTest PROPERTIES ENVIRONMENT "ONNX_MLIR_LIBRARY_PATH=${ONNX_MLIR_LIBRARY_PATH}")
 add_dependencies(doc-example OMRuntimeCppTest)

--- a/docs/doc_example/CMakeLists.txt
+++ b/docs/doc_example/CMakeLists.txt
@@ -82,7 +82,6 @@ add_onnx_mlir_executable(OMRuntimeTest
   LINK_LIBS PRIVATE
   OnnxMlirCompiler
   ExecutionSession
-  OMRuntimeTestModelLibrary
   cruntime
   )
 

--- a/docs/doc_example/main.cpp
+++ b/docs/doc_example/main.cpp
@@ -8,11 +8,12 @@
 
 // Read the arguments from the command line and return a std::string
 std::string readArgs(int argc, char *argv[]) {
-  std::string commandLineStr = "";
+  std::string commandLineStr;
   for (int i = 1; i < argc; i++) {
-    commandLineStr.append(std::string(argv[i]).append(" "));
+    if (i > 1)
+      commandLineStr.append(" ");
+    commandLineStr.append(std::string(argv[i]));
   }
-  commandLineStr.append("\0");
   return commandLineStr;
 }
 
@@ -21,11 +22,10 @@ int main(int argc, char *argv[]) {
   // model library.
   const char *errorMessage = NULL;
   const char *compiledFilename;
-  std::string commandLineString = readArgs(argc, argv);
-  const char *flags = commandLineString.c_str();
-  int rc =
-      onnx_mlir::omCompileFromFileViaCommand("add.onnx", "add-cppinterface",
-          onnx_mlir::EmitLib, &compiledFilename, flags, &errorMessage);
+  std::string flags = readArgs(argc, argv);
+  flags += " -o add-cppinterface";
+  int rc = onnx_mlir::omCompileFromFileViaCommand("add.onnx",
+      onnx_mlir::EmitLib, flags.c_str(), &compiledFilename, &errorMessage);
   if (rc != onnx_mlir::CompilerSuccess) {
     std::cerr << "Failed to compile add.onnx with error code " << rc;
     if (errorMessage)

--- a/docs/doc_example/main.cpp
+++ b/docs/doc_example/main.cpp
@@ -23,9 +23,10 @@ int main(int argc, char *argv[]) {
   const char *errorMessage = NULL;
   const char *compiledFilename;
   std::string flags = readArgs(argc, argv);
-  flags += " -o add-cppinterface";
-  int rc = onnx_mlir::omCompileFromFileViaCommand("add.onnx",
-      onnx_mlir::EmitLib, flags.c_str(), &compiledFilename, &errorMessage);
+  flags += " -o add-cpp-interface";
+  std::cout << "hi alex: flags ."<<flags<<".\n";
+  int rc = onnx_mlir::omCompileFromFile("add.onnx", onnx_mlir::EmitLib,
+      flags.c_str(), &compiledFilename, &errorMessage);
   if (rc != onnx_mlir::CompilerSuccess) {
     std::cerr << "Failed to compile add.onnx with error code " << rc;
     if (errorMessage)

--- a/docs/doc_example/main.cpp
+++ b/docs/doc_example/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]) {
   const char *compiledFilename;
   std::string flags = readArgs(argc, argv);
   flags += " -o add-cpp-interface";
-  std::cout << "hi alex: flags ."<<flags<<".\n";
+  //std::cout << "hi alex: flags ."<<flags<<".\n";
   int rc = onnx_mlir::omCompileFromFile("add.onnx", onnx_mlir::EmitLib,
       flags.c_str(), &compiledFilename, &errorMessage);
   if (rc != onnx_mlir::CompilerSuccess) {

--- a/docs/doc_example/main.cpp
+++ b/docs/doc_example/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
   std::cout << "Compiled succeeded with results in file: " << libFilename
             << std::endl;
 
-  // Prepare the execution session and get input signature.
+  // Prepare the execution session.
   onnx_mlir::ExecutionSession *session;
   try {
     session = new onnx_mlir::ExecutionSession("./" + libFilename);
@@ -46,6 +46,7 @@ int main(int argc, char *argv[]) {
     return errno;
   }
 
+  // Get input signature and print it.
   std::string inputSignature;
   try {
     inputSignature = session->inputSignature();
@@ -84,19 +85,18 @@ int main(int argc, char *argv[]) {
 
   // Get the first omt as output.
   OMTensor *y = omTensorListGetOmtByIndex(outputList, 0);
-  omTensorPrint("%tResult tensor: ", y);
+  omTensorPrint("Result tensor: ", y);
   std::cout << std::endl;
   float *outputPtr = (float *)omTensorGetDataPtr(y);
   // Print its content, should be all 3.
   for (int i = 0; i < 6; i++) {
-    std::cout << outputPtr[i] << " ";
     if (outputPtr[i] != 3.0) {
       std::cerr << "Iteration " << i << ": expected 3.0, got " << outputPtr[i]
                 << "." << std::endl;
       return 100;
     }
   }
-  std::cout << std::endl << "Model verified successfully" << std::endl;
+  std::cout << "Model verified successfully" << std::endl;
   delete session;
   return 0;
 }

--- a/docs/mnist_example/README.md
+++ b/docs/mnist_example/README.md
@@ -111,7 +111,8 @@ A `mnist.jar` should appear, which corresponds to the compiled model object file
 onnx-mlir provides a multi-thread safe parallel compilation mode. Whether each thread is given a name or not by the user, onnx-mlir is multi-threaded safe. If you would like to give a name to a thread, use the `-customEnvFlags` keyword and an example can be found as follows.
 
 ```bash
-onnx-mlir -O3 -customEnvFlags mnistwith03 [--EmitLib] mnist.onnx -o mnist03
+export MNIST_WITH_O3="-O3"
+onnx-mlir -O3 -customEnvFlags=MNIST_WITH_O3 [--EmitLib] mnist.onnx -o mnist03
 ```
 
 A multi-threaded experiment from command line written in Python is provided.

--- a/include/OnnxMlirCompiler.h
+++ b/include/OnnxMlirCompiler.h
@@ -41,84 +41,20 @@ extern "C" {
 namespace onnx_mlir {
 #endif
 
-#if 0 // hi alex
-/*!
- *  Define ONNX-MLIR compiler options with options defined by
- *  the envVarName (default ONNX_MLIR_FLAGS) environment variable.
- *  Values not recognized as compiler options result in an error.
- *  Only a single call to omSetCompilerOptionsFromEnv,
- *  omSetCompilerOptionsFromArgs, or omSetCompilerOptionsFromEnvAndArgs
- *  is allowed.
- *  @param envVarName Environment variable name, use default when null.
- *  @return 0 on success or OnnxMlirCompilerErrorCodes on failure.
- */
-ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromEnv(const char *envVarName);
-
-/*!
- *  Define ONNX-MLIR compiler options with options defined by
- *  the argc/argv parameters. Call expects argv[0] to contain the program
- *  name. Values not recognized as compiler options result in an error.
- *  Only a single call to omSetCompilerOptionsFromEnv,
- *  omSetCompilerOptionsFromArgs, or omSetCompilerOptionsFromEnvAndArgs
- *  is allowed.
- *  @param argc Number of input parameters in argv.
- *  @param argv Array of strings, some of which may be compiler options.
- *  First argv is ignored as it contains the name of the program.
- *  @return 0 on success or OnnxMlirCompilerErrorCodes on failure.
- */
-ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromArgs(
-    int64_t argc, char *argv[]);
-
-/*!
- *  Define ONNX-MLIR compiler options with options defined by
- *  the envVarName (default ONNX_MLIR_FLAGS) environment variable
- *  and the argc/argv parameters. Call expects argv[0] to contain the program
- *  name. Values not recognized as compiler options result in an error.
- *  Only a single call to omSetCompilerOptionsFromEnv,
- *  omSetCompilerOptionsFromArgs, or omSetCompilerOptionsFromEnvAndArgs
- *  is allowed.
- *  @param argc Number of input parameters in argv.
- *  @param argv Array of strings, some of which may be compiler options.
- *  First argv is ignored as it contains the name of the program.
- *  @param envVarName Environment variable name, use default when null.
- *  @return 0 on success or OnnxMlirCompilerErrorCodes on failure.
- */
-ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromArgsAndEnv(
-    int64_t argc, char *argv[], const char *envVarName);
-
-/*!
- *  Overwrite the compiler option defined by input parameters.
- *  Set default value by calling this function before a call to
- *  omSetCompilerOptionsFromEnv, omSetCompilerOptionsFromArgs, or
- *  omSetCompilerOptionsFromEnvAndArgs. Or overwrite the current value
- *  by calling this function after one of the above 3 setter functions.
- *  @param kind Describe which option kind is being set.
- *  @param val Value of the option being set.
- *  @return 0 on success or OnnxMlirCompilerErrorCodes error code on failure.
- */
-ONNX_MLIR_EXPORT int64_t omSetCompilerOption(
-    const OptionKind kind, const char *val);
-
-/*!
- *  Clear the compiler option defined by the input parameter.
- */
-ONNX_MLIR_EXPORT void omClearCompilerOption(const OptionKind kind);
-
-/*!
- *  Get the compiler options.
- *  @param kind Describe which option kind is being set.
- *  @return A copy of the compiler option string. Caller is responsible for
- *  freeing the returned pointer.
- */
-ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind);
-#endif
-
 /*!
  *  C interface to compile an onnx model from a file via onnx-mlir command.
  *  This interface is thread safe, and does not take any flags from the
  *  current environment. All flags are passed by using the flags parameter,
  *  including the "-o output-file-name" option. All options that are available
  *  to onnx-mlir are also available here.
+ *
+ *  This call rely on executing onnx-mlir compiler. The user can override its
+ *  default location by using the ONNX_MLIR_BIN_PATH environment variable.
+ *
+ *  When generating libraries or jar files, the compiler will link in
+ *  lightweight runtimes / jar files. If these libraries / jar files are not in
+ *  the system wide directory (typically /usr/local/lib), the user can override
+ *  the default location using the ONNX_MLIR_LIBRARY_PATH environment variable.
  *
  *  @param inputFilename File name pointing onnx model protobuf or MLIR.
  *  Name may include a path, and must include the file name and its extention.
@@ -136,41 +72,17 @@ ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind);
  *
  *  @return 0 on success or OnnxMlirCompilerErrorCodes on failure.
  */
-ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
+ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
     EmissionTargetType emissionTarget, const char *flags,
     const char **outputFilename, const char **errorMessage);
 
-#if 0 // hi alex
 /*!
- *  Compile an onnx model from a file containing MLIR or ONNX protobuf. When
- *  generating libraries or jar files, the compiler will link in lightweight
- *  runtimes / jar files. If these libraries / jar files are not in the system
- *  wide directory (typically /usr/local/lib), the user can override the default
- *  location using the ONNX_MLIR_RUNTIME_DIR environment variable.
- *
- *  @param inputFilename File name pointing onnx model protobuf or MLIR.
- *  Name may include a path, and must include the file name and its extention.
- *  @param outputBaseName File name without extension to write output.
- *  Name may include a path, must include the file name, and should not include
- * an extention.
- *  @param emissionTarget Target format to compile to.
- *  @param outputFilename Output file name of the compiled output for the given
- * emission target. User is responsible for freeing the string.
- *  @param errorMessage Output error message, if any. User is responsible for
- * freeing the string.
- *  @return 0 on success or OnnxMlirCompilerErrorCodes on failure.
- */
-ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
-    const char *outputBaseName, EmissionTargetType emissionTarget,
-    const char **outputFilename, const char **errorMessage);
-#endif
-
-/*!
- *  Compile an onnx model from an ONNX protobuf array. When
- *  generating libraries or jar files, the compiler will link in lightweight
- *  runtimes / jar files. If these libraries / jar files are not in the system
- *  wide directory (typically /usr/local/lib), the user can override the default
- *  location using the ONNX_MLIR_RUNTIME_DIR environment variable.
+ *  Compile an onnx model from an ONNX protobuf array. This method is not thread
+ *  safe, and borrows the current compiler options currently defined in this
+ *  process. When generating libraries or jar files, the compiler will link in
+ *  lightweight runtimes / jar files. If these libraries / jar files are not in
+ *  the system wide directory (typically /usr/local/lib), the user can override
+ *  the default location using the ONNX_MLIR_LIBRARY_PATH environment variable.
  *
  *  @param inputBuffer ONNX protobuf array.
  *  @param bufferSize Size of ONNX protobuf array.

--- a/include/OnnxMlirCompiler.h
+++ b/include/OnnxMlirCompiler.h
@@ -113,6 +113,10 @@ ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind);
 
 /*!
  *  C interface to compile an onnx model from a file via onnx-mlir command.
+ *  This interface is thread safe, and does not take any flags from the
+ *  current environment. All flags are passed by using the flags parameter,
+ *  including the "-o output-file-name" option. All options that are available
+ *  to onnx-mlir are also available here.
  *
  *  @param inputFilename File name pointing onnx model protobuf or MLIR.
  *  Name may include a path, and must include the file name and its extention.
@@ -134,6 +138,7 @@ ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
     EmissionTargetType emissionTarget, const char *flags,
     const char **outputFilename, const char **errorMessage);
 
+#if 0 // hi alex
 /*!
  *  Compile an onnx model from a file containing MLIR or ONNX protobuf. When
  *  generating libraries or jar files, the compiler will link in lightweight
@@ -156,6 +161,7 @@ ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
 ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
     const char *outputBaseName, EmissionTargetType emissionTarget,
     const char **outputFilename, const char **errorMessage);
+#endif
 
 /*!
  *  Compile an onnx model from an ONNX protobuf array. When

--- a/include/OnnxMlirCompiler.h
+++ b/include/OnnxMlirCompiler.h
@@ -135,8 +135,8 @@ ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind);
  *  @return 0 on success or OnnxMlirCompilerErrorCodes on failure.
  */
 ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
-    const char *outputBaseName, EmissionTargetType emissionTarget,
-    const char **outputFilename, const char *flags, const char **errorMessage);
+    EmissionTargetType emissionTarget, const char *flags,
+    const char **outputFilename, const char **errorMessage);
 
 /*!
  *  Compile an onnx model from a file containing MLIR or ONNX protobuf. When

--- a/include/OnnxMlirCompiler.h
+++ b/include/OnnxMlirCompiler.h
@@ -117,10 +117,6 @@ ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind);
  *  @param inputFilename File name pointing onnx model protobuf or MLIR.
  *  Name may include a path, and must include the file name and its extention.
  *
- *  @param outputBaseName File name without extension to write output.
- *  Name may include a path, must include the file name, and should not include
- * an extention.
- *
  *  @param emissionTarget Target format to compile to.
  *
  *  @param outputFilename Output file name of the compiled output for the given

--- a/include/OnnxMlirCompiler.h
+++ b/include/OnnxMlirCompiler.h
@@ -41,6 +41,7 @@ extern "C" {
 namespace onnx_mlir {
 #endif
 
+#if 0 // hi alex
 /*!
  *  Define ONNX-MLIR compiler options with options defined by
  *  the envVarName (default ONNX_MLIR_FLAGS) environment variable.
@@ -110,6 +111,7 @@ ONNX_MLIR_EXPORT void omClearCompilerOption(const OptionKind kind);
  *  freeing the returned pointer.
  */
 ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind);
+#endif
 
 /*!
  *  C interface to compile an onnx model from a file via onnx-mlir command.

--- a/include/OnnxMlirCompiler.h
+++ b/include/OnnxMlirCompiler.h
@@ -45,8 +45,8 @@ namespace onnx_mlir {
  *  C interface to compile an onnx model from a file via onnx-mlir command.
  *  This interface is thread safe, and does not take any flags from the
  *  current environment. All flags are passed by using the flags parameter,
- *  including the "-o output-file-name" option. All options that are available
- *  to onnx-mlir are also available here.
+ *  including the "-o output-file-name" option or the "-EmitXXX" options. All
+ *  options that are available to onnx-mlir are also available here.
  *
  *  This call rely on executing onnx-mlir compiler. The user can override its
  *  default location by using the ONNX_MLIR_BIN_PATH environment variable.
@@ -58,8 +58,6 @@ namespace onnx_mlir {
  *
  *  @param inputFilename File name pointing onnx model protobuf or MLIR.
  *  Name may include a path, and must include the file name and its extention.
- *
- *  @param emissionTarget Target format to compile to.
  *
  *  @param outputFilename Output file name of the compiled output for the given
  * emission target. User is responsible for freeing the string.
@@ -73,8 +71,7 @@ namespace onnx_mlir {
  *  @return 0 on success or OnnxMlirCompilerErrorCodes on failure.
  */
 ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
-    EmissionTargetType emissionTarget, const char *flags,
-    const char **outputFilename, const char **errorMessage);
+    const char *flags, const char **outputFilename, const char **errorMessage);
 
 /*!
  *  Compile an onnx model from an ONNX protobuf array. This method is not thread

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_onnx_mlir_executable(onnx-mlir
   onnx-mlir.cpp
 
   LINK_LIBS PRIVATE
+  CompilerOptions
   CompilerUtils
   )
   

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -234,22 +234,22 @@ bool parseCustomEnvFlagsCommandLineOption(
       }
     }
     // The envVar is verified, use it.
-    customEnvFlags = envVar;
+    setCustomEnvVar(envVar);
   }
   return true;
 }
 
 // Support for customEnvFlags.
-void setTargetEnvVar(const std::string &envVarName) {
+void setCustomEnvVar(const std::string &envVarName) {
   assert(envVarName != "" && "Expecting valid target envVarName description");
   LLVM_DEBUG(
       llvm::dbgs() << DEBUG_TYPE << "Set envVarName\"" << envVarName << "\"\n");
   customEnvFlags = envVarName;
 }
 
-void clearTargetEnvVar() { customEnvFlags.clear(); }
+void clearCustomEnvVar() { customEnvFlags.clear(); }
 
-std::string getTargetEnvVarOption() {
+std::string getCustomEnvVarOption() {
   return (customEnvFlags != "") ? "--customEnvFlags=" + customEnvFlags : "";
 }
 

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -17,7 +17,6 @@
 #include "ExternalUtil.hpp"
 #include "onnx-mlir/Compiler/OMCompilerTypes.h"
 #include "src/Compiler/CompilerOptions.hpp"
-#include <iostream>
 
 #define DEBUG_TYPE "compiler_options"
 
@@ -78,10 +77,8 @@ llvm::cl::opt<std::string> shapeInformation("shapeInformation",
     llvm::cl::value_desc("value"), llvm::cl::cat(OnnxMlirOptions));
 
 llvm::cl::opt<std::string> customEnvFlags("customEnvFlags",
-    llvm::cl::desc(
-        "Override the default ONNX_MLIR_FLAGS env var name that is used to "
-        "provide the default compiler options:"
-        "ONNX_MLIR_FLAGS"),
+    llvm::cl::desc("Override default option env var OnnxMlirEnvOptionName: "
+                   "ONNX_MLIR_FLAGS"),
     llvm::cl::value_desc("option env var"), llvm::cl::init("ONNX_MLIR_FLAGS"),
     llvm::cl::cat(OnnxMlirOptions));
 
@@ -207,35 +204,37 @@ std::map<std::string, std::vector<std::string>> CompilerConfigMap;
 // =============================================================================
 // Methods for setting and getting compiler variables.
 
+// The customEnvFlags must be scanned before the normal options.
 bool parseCustomEnvFlagsCommandLineOption(
     int argc, const char *const *argv, llvm::raw_ostream *errs) {
-  // The customEnvFlags variable defaults to ONNX_MLIR_FLAGS but it might be
-  // assigned a different value in the argv. So scan first for the
-  // customEnvFlags and set global env var if available.
-  for (int i = argc - 1; i > 0; --i) {
-    std::string currStr(argv[i]);
-    if (currStr.find("--customEnvFlags=") == 0) {
-      currStr.erase(0, 17);
-      customEnvFlags = currStr;
+  // Find -customEnvFlags=val and save its value.
+  std::string envVar;
+  for (int i = argc - 1; i > 1; --i) {
+    std::string arg(argv[i]);
+    if (arg.find("--customEnvFlags") == 0) {
+      envVar = arg.substr(sizeof("--customEnvFlags"));
       break;
     }
-    if (currStr.find("-customEnvFlags=") == 0) {
-      currStr.erase(0, 16);
-      customEnvFlags = currStr;
+    if (arg.find("-customEnvFlags") == 0) {
+      envVar = arg.substr(sizeof("-customEnvFlags"));
       break;
     }
   }
-  // Now we do not tolerate having another -customEnvFlags in the env var
-  // itself, as it would lead to recursive reseting of this variable.
-  // Test and report error if we find this pattern.
-  if (const char *envValCstr = std::getenv(customEnvFlags.c_str())) {
-    std::string envVal(envValCstr);
-    if (envVal.find("-customEnvFlags") == 0) {
-      if (errs)
-        *errs << "Cannot have a \"---customEnvFlags\" in the env var that "
-                 "defines the default options\n";
-      return false;
+  if (!envVar.empty()) {
+    // We have a custom env var, verify that it does not recursively hold
+    // another -customEnvFlags.
+    const char *envValCstr;
+    if ((envValCstr = std::getenv(envVar.c_str()))) {
+      std::string envVal(envValCstr);
+      if (envVal.find("-customEnvFlags") != std::string::npos) {
+        if (errs)
+          *errs << "Warning: recursive use of --customEnvFlags in custom "
+                   "environment flag not permited\n";
+        return false;
+      }
     }
+    // The envVar is verified, use it.
+    customEnvFlags = envVar;
   }
   return true;
 }

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -230,7 +230,7 @@ bool parseCustomEnvFlagsCommandLineOption(
   // Test and report error if we find this pattern.
   if (const char *envValCstr = std::getenv(customEnvFlags.c_str())) {
     std::string envVal(envValCstr);
-    if (envVal.find("-customEnvFlags")==0) {
+    if (envVal.find("-customEnvFlags") == 0) {
       if (errs)
         *errs << "Cannot have a \"---customEnvFlags\" in the env var that "
                  "defines the default options\n";

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -62,9 +62,9 @@ extern llvm::cl::opt<bool> enableParallel;
 bool parseCustomEnvFlagsCommandLineOption(int argc, const char *const *argv,
     llvm::raw_ostream *errs = (llvm::raw_ostream *)nullptr);
 
-void setTargetEnvVar(const std::string &envVarName);
-void clearTargetEnvVar();
-std::string getTargetEnvVarOption();
+void setCustomEnvVar(const std::string &envVarName);
+void clearCustomEnvVar();
+std::string getCustomEnvVarOption();
 
 void setTargetTriple(const std::string &triple);
 void clearTargetTriple();

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -58,6 +58,10 @@ extern llvm::cl::opt<int> onnxOpTransformThreshold;
 extern llvm::cl::opt<bool> onnxOpTransformReport;
 extern llvm::cl::opt<bool> enableParallel;
 
+// The customEnvFlags must be scanned before the normal options.
+bool parseCustomEnvFlagsCommandLineOption(int argc, const char *const *argv,
+    llvm::raw_ostream *errs = (llvm::raw_ostream *)nullptr);
+
 void setTargetEnvVar(const std::string &envVarName);
 void clearTargetEnvVar();
 std::string getTargetEnvVarOption();

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -162,8 +162,8 @@ Command &Command::appendStr(const std::string &arg) {
 
 // Append a single optional string argument.
 Command &Command::appendStrOpt(const llvm::Optional<std::string> &arg) {
-  if (arg.hasValue())
-    _args.emplace_back(arg.getValue());
+  if (arg.has_value())
+    _args.emplace_back(arg.value());
   return *this;
 }
 

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -43,7 +43,7 @@ const std::string OnnxMlirEnvOptionName = "ONNX_MLIR_FLAGS";
 
 namespace onnx_mlir {
 
-static llvm::Optional<std::string> getEnvVar(std::string name) {
+llvm::Optional<std::string> getEnvVar(std::string name) {
   if (const char *envVerbose = std::getenv(name.c_str()))
     return std::string(envVerbose);
   return llvm::None;

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -51,6 +51,8 @@
 
 namespace onnx_mlir {
 
+llvm::Optional<std::string> getEnvVar(std::string name);
+
 struct Command {
 
   std::string _path;

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -69,8 +69,9 @@ struct Command {
 
 void registerDialects(mlir::MLIRContext &context);
 
-// get Tool path
-std::string getToolPath(std::string tool);
+// Get Tool path, see comments in CompilerUtils.cpp for more details.
+std::string getToolPath(
+    const std::string &tool, const std::string &systemToolPath);
 
 // ProcessInput* return 0 on success, OnnxMlirCompilerErrorCodes on error.
 int processInputFile(std::string inputFilename, mlir::MLIRContext &context,
@@ -92,7 +93,7 @@ int outputCode(mlir::OwningOpRef<mlir::ModuleOp> &module,
 // libraries or jar files, the compiler will link in lightweight runtimes / jar
 // files. If these libraries / jar files are not in the system wide directory
 // (typically /usr/local/lib), the user can override the default location using
-// the ONNX_MLIR_RUNTIME_DIR environment variable.
+// the ONNX_MLIR_LIBRARY_PATH environment variable.
 // Returns 0 on success,OnnxMlirCompilerErrorCodes on failure.
 int compileModule(mlir::OwningOpRef<mlir::ModuleOp> &module,
     mlir::MLIRContext &context, std::string outputNameNoExt,

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -116,6 +116,7 @@ ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
   return rc != 0 ? CompilerFailureInLLVMOpt : CompilerSuccess;
 }
 
+#if 0 // hi alex
 ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
     const char *outputBaseName, EmissionTargetType emissionTarget,
     const char **outputFilename, const char **errorMessage) {
@@ -141,6 +142,7 @@ ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
   }
   return rc;
 }
+#endif 
 
 ONNX_MLIR_EXPORT int64_t omCompileFromArray(const void *inputBuffer,
     int bufferSize, const char *outputBaseName,

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -53,7 +53,7 @@ ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
   std::string onnxMlirPath;
   char *onnxMlirPathFromEnv;
   if ((onnxMlirPathFromEnv = std::getenv("ONNX_MLIR_BIN_PATH")))
-    onnxMlirPath = std::string(onnxMlirPathFromEnv)+"/onnx-mlir";
+    onnxMlirPath = std::string(onnxMlirPathFromEnv) + "/onnx-mlir";
   else
     onnxMlirPath = getToolPath("onnx-mlir", kOnnxmlirPath);
   struct Command onnxMlirCompile(

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -19,50 +19,6 @@ using namespace onnx_mlir;
 extern "C" {
 namespace onnx_mlir {
 
-#if 0 // hi alex
-ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromEnv(const char *envVarName) {
-  // ParseCommandLineOptions needs at least one argument
-  std::string nameStr =
-      "onnx-mlir (options from env var \"" + std::string(envVarName) + "\")";
-  const char *argv[1];
-  argv[0] = nameStr.c_str();
-  const char *name = envVarName ? envVarName : OnnxMlirEnvOptionName.c_str();
-  bool success = llvm::cl::ParseCommandLineOptions(
-      1, argv, "SetCompilerOptionsFromEnv\n", nullptr, name);
-  return success ? CompilerSuccess : InvalidCompilerOption;
-}
-
-ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromArgs(
-    int64_t argc, char *argv[]) {
-  bool success = llvm::cl::ParseCommandLineOptions(
-      argc, argv, "SetCompilerOptionsFromArgs\n");
-  return success ? CompilerSuccess : InvalidCompilerOption;
-}
-
-ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromArgsAndEnv(
-    int64_t argc, char *argv[], const char *envVarName) {
-  const char *name = envVarName ? envVarName : OnnxMlirEnvOptionName.c_str();
-  bool success = llvm::cl::ParseCommandLineOptions(
-      argc, argv, "SetCompilerOptionsFromArgsAndEnv\n", nullptr, name);
-  return success ? CompilerSuccess : InvalidCompilerOption;
-}
-
-ONNX_MLIR_EXPORT int64_t omSetCompilerOption(
-    const OptionKind kind, const char *val) {
-  return setCompilerOption(kind, std::string(val));
-}
-
-ONNX_MLIR_EXPORT void omClearCompilerOption(const OptionKind kind) {
-  clearCompilerOption(kind);
-}
-
-ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind) {
-  std::string val = getCompilerOption(kind);
-  return strdup(val.c_str());
-}
-
-#endif
-
 static OnnxMlirCompilerErrorCodes pushErrorMessage(const char **errorMessage,
     const OnnxMlirCompilerErrorCodes error, const std::string &msg) {
   if (errorMessage)
@@ -74,10 +30,9 @@ static OnnxMlirCompilerErrorCodes pushErrorMessage(const char **errorMessage,
 #define strtok_r strtok_s
 #endif
 
-ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
+ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
     EmissionTargetType emissionTarget, const char *flags,
     const char **outputFilename, const char **errorMessage) {
-
   // Process the flags, saving each space-separated text in a separate
   // entry in the string vector flagsVector.
   std::vector<std::string> flagsVectorStr;
@@ -95,9 +50,14 @@ ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
   delete buffer;
 
   // Use 'onnx-mlir' command to compile the model.
-  std::string onnxMlirPath = getToolPath("onnx-mlir");
+  std::string onnxMlirPath;
+  char *onnxMlirPathFromEnv;
+  if ((onnxMlirPathFromEnv = std::getenv("ONNX_MLIR_BIN_PATH")))
+    onnxMlirPath = std::string(onnxMlirPathFromEnv)+"/onnx-mlir";
+  else
+    onnxMlirPath = getToolPath("onnx-mlir", kOnnxmlirPath);
   struct Command onnxMlirCompile(
-      /*exePath=*/!onnxMlirPath.empty() ? onnxMlirPath : kOnnxmlirPath);
+      /*exePath=*/onnxMlirPath);
   // Add each of the flags to the command, locating output base name if avail.
   std::string inputFilenameStr(inputFilename);
   std::string outputBasenameStr;
@@ -125,34 +85,6 @@ ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
   }
   return rc != 0 ? CompilerFailureInLLVMOpt : CompilerSuccess;
 }
-
-#if 0 // hi alex
-ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
-    const char *outputBaseName, EmissionTargetType emissionTarget,
-    const char **outputFilename, const char **errorMessage) {
-  mlir::OwningOpRef<mlir::ModuleOp> module;
-  mlir::MLIRContext context;
-  registerDialects(context);
-
-  std::string internalErrorMessage;
-  int rc = processInputFile(
-      std::string(inputFilename), context, module, &internalErrorMessage);
-  if (rc != CompilerSuccess) {
-    if (errorMessage != NULL)
-      *errorMessage = strdup(internalErrorMessage.c_str());
-    return rc;
-  }
-
-  std::string outputBaseNameStr(outputBaseName);
-  rc = compileModule(module, context, outputBaseNameStr, emissionTarget);
-  if (rc == CompilerSuccess && outputFilename) {
-    // Copy Filename
-    std::string name = getTargetFilename(outputBaseNameStr, emissionTarget);
-    *outputFilename = strdup(name.c_str());
-  }
-  return rc;
-}
-#endif
 
 ONNX_MLIR_EXPORT int64_t omCompileFromArray(const void *inputBuffer,
     int bufferSize, const char *outputBaseName,

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -2,6 +2,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+//===------- OnnxMlirCompiler.cpp - ONNX-MLIR Compiler API Declarations ---===//
+//
+// This file contains code for the onnx-mlir compiler functionality exported
+// from the OnnxMlirCompiler library
+//
+//===----------------------------------------------------------------------===//
+
 #include "include/OnnxMlirCompiler.h"
 #include "ExternalUtil.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
@@ -12,6 +19,7 @@ using namespace onnx_mlir;
 extern "C" {
 namespace onnx_mlir {
 
+#if 0 // hi alex
 ONNX_MLIR_EXPORT int64_t omSetCompilerOptionsFromEnv(const char *envVarName) {
   // ParseCommandLineOptions needs at least one argument
   std::string nameStr =
@@ -52,6 +60,8 @@ ONNX_MLIR_EXPORT const char *omGetCompilerOption(const OptionKind kind) {
   std::string val = getCompilerOption(kind);
   return strdup(val.c_str());
 }
+
+#endif
 
 static OnnxMlirCompilerErrorCodes pushErrorMessage(const char **errorMessage,
     const OnnxMlirCompilerErrorCodes error, const std::string &msg) {
@@ -142,7 +152,7 @@ ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
   }
   return rc;
 }
-#endif 
+#endif
 
 ONNX_MLIR_EXPORT int64_t omCompileFromArray(const void *inputBuffer,
     int bufferSize, const char *outputBaseName,

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -422,21 +422,21 @@ void omTensorPrint(const char *msg, const OMTensor *tensor) {
   bool signatureInfo = false;
   bool typeInfo = false;
   bool dataInfo = false;
+  bool hadFormat = false;
   while (strlen(msg) >= 2 && msg[0] == '%') {
     if (msg[1] == 's') // S for signature.
-      signatureInfo = true;
+      hadFormat = signatureInfo = true;
     else if (msg[1] == 't') // T for type only
-      typeInfo = true;
+      hadFormat = typeInfo = true;
     else if (msg[1] == 'd')
-      dataInfo = true;
-    else {
-      printf(
-          "warning: unknown format `%c`, print signature and data\n", msg[1]);
-      signatureInfo = dataInfo = true;
-    }
+      hadFormat = dataInfo = true;
+    else
+      printf("warning: unknown format `%c`\n", msg[1]);
     // Skip the format when printing message.
     msg += 2;
   }
+  if (!hadFormat)
+    signatureInfo = dataInfo = true;
 
   // Print message.
   if (msg)

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -166,22 +166,25 @@ int main(int argc, char **argv) {
 
   mlir::PassPipelineCLParser passPipeline("", "Compiler passes to run");
 
-  parseCustomEnvFlagsCommandLineOption(argc, argv);
-  llvm::cl::ParseCommandLineOptions(argc, argv,
-      "ONNX-MLIR modular optimizer driver\n", nullptr,
-      customEnvFlags.c_str());
+  if (!parseCustomEnvFlagsCommandLineOption(argc, argv, &llvm::errs()) ||
+      !llvm::cl::ParseCommandLineOptions(argc, argv,
+          "ONNX-MLIR modular optimizer driver\n", &llvm::errs(),
+          customEnvFlags.c_str())) {
+    llvm::errs() << "Failed to parse options\n";
+    return 1;
+  }
 
   // Set up the input file.
   std::string error_message;
   auto file = mlir::openInputFile(input_filename, &error_message);
   if (!error_message.empty()) {
-    fprintf(stderr, "%s\n", error_message.c_str());
+    llvm::errs() << "Failure to open file; " << error_message << "\n";
     return failed(LogicalResult::failure());
   }
 
   auto output = mlir::openOutputFile(output_filename, &error_message);
   if (!error_message.empty()) {
-    fprintf(stderr, "%s\n", error_message.c_str());
+    llvm::errs() << "Failure to compile file; " << error_message << "\n";
     return failed(LogicalResult::failure());
   }
 

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -94,13 +94,13 @@ void scanAndSetMAccel(int argc, char **argv) {
   // Scan accelerators and add them to the maccel option.
   for (int i = argc - 1; i > 0; --i) {
     std::string currStr(argv[i]);
-    if (currStr.find("--maccel=") != 0) {
+    if (currStr.find("--maccel=") == 0) {
       std::string accelKind(
           &argv[i][9]); // Get the string starting 9 chars down.
       setTargetAccel(accelKind);
       break;
     }
-    if (currStr.find("-maccel=") != 0) {
+    if (currStr.find("-maccel=") == 0) {
       std::string accelKind(
           &argv[i][8]); // Get the string starting 8 chars down.
       setTargetAccel(accelKind);
@@ -168,7 +168,7 @@ int main(int argc, char **argv) {
 
   parseCustomEnvFlagsCommandLineOption(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv,
-      "ONNX-MLIR-OPT modular optimizer driver\n", nullptr,
+      "ONNX-MLIR modular optimizer driver\n", nullptr,
       customEnvFlags.c_str());
 
   // Set up the input file.

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -11,6 +11,7 @@
 // Implements main for onnx-mlir driver.
 //===----------------------------------------------------------------------===//
 
+#include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 #include "src/Version/Version.hpp"
 #include <iostream>
@@ -58,7 +59,7 @@ int main(int argc, char *argv[]) {
 
   llvm::cl::SetVersionPrinter(getVersionPrinter);
 
-  // Parse options from argc/argv and default ONNX_MLIR_FLAG env var.
+  parseCustomEnvFlagsCommandLineOption(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv,
       "ONNX-MLIR modular optimizer driver\n", nullptr, customEnvFlags.c_str());
 

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -16,7 +16,6 @@
 #include "src/Version/Version.hpp"
 #include <iostream>
 
-using namespace std;
 using namespace onnx_mlir;
 
 extern llvm::cl::OptionCategory onnx_mlir::OnnxMlirOptions;

--- a/test/compilerlib/CompilerLibTest.cpp
+++ b/test/compilerlib/CompilerLibTest.cpp
@@ -63,10 +63,11 @@ void readCommandLineAndKeepUnused(int &argc, char *argv[]) {
 // be processed by the ONNX-MLIR compiler.
 void readArgsFromCommandLine(int argc, char *argv[]) {
   for (int i = 1; i < argc; i++) {
-    commandLineStr.append(std::string(argv[i]).append(" "));
+    if (i > 1)
+      commandLineStr.append(" ");
+    commandLineStr.append(std::string(argv[i]));
     readArg(std::string(argv[i]));
   }
-  commandLineStr.append("\0");
 }
 
 int main(int argc, char *argv[]) {
@@ -81,12 +82,13 @@ int main(int argc, char *argv[]) {
     outputBaseName = testFileName.substr(0, testFileName.find_last_of("."));
   }
 
-  const char *flags = commandLineStr.c_str();
-
   if (compileFromFile) {
+    // Add output file option to command line.
+    commandLineStr += " -o " + outputBaseName;
+    const char *flags = commandLineStr.c_str();
+    // Compile.
     retVal = onnx_mlir::omCompileFromFileViaCommand(testFileName.c_str(),
-        outputBaseName.c_str(), onnx_mlir::EmitLib, &compiledFilename, flags,
-        &errorMessage);
+        onnx_mlir::EmitLib, flags, &compiledFilename, &errorMessage);
     if (retVal != CompilerSuccess && errorMessage != NULL)
       std::cerr << errorMessage;
   } else {

--- a/test/compilerlib/CompilerLibTest.cpp
+++ b/test/compilerlib/CompilerLibTest.cpp
@@ -13,7 +13,7 @@ using namespace onnx_mlir;
 
 std::string testFileName;
 std::string outputBaseName;
-std::string commandLineStr;
+std::string flags;
 bool compileFromFile = false;
 
 #define IGNORE_ARG(FLAG)                                                       \
@@ -63,9 +63,7 @@ void readCommandLineAndKeepUnused(int &argc, char *argv[]) {
 // be processed by the ONNX-MLIR compiler.
 void readArgsFromCommandLine(int argc, char *argv[]) {
   for (int i = 1; i < argc; i++) {
-    if (i > 1)
-      commandLineStr.append(" ");
-    commandLineStr.append(std::string(argv[i]));
+    flags.append(std::string(argv[i]) + " ");
     readArg(std::string(argv[i]));
   }
 }
@@ -84,11 +82,10 @@ int main(int argc, char *argv[]) {
 
   if (compileFromFile) {
     // Add output file option to command line.
-    commandLineStr += " -o " + outputBaseName;
-    const char *flags = commandLineStr.c_str();
+    flags += "-o " + outputBaseName;
     // Compile.
-    retVal = onnx_mlir::omCompileFromFile(testFileName.c_str(),
-        onnx_mlir::EmitLib, flags, &compiledFilename, &errorMessage);
+    retVal = onnx_mlir::omCompileFromFile(
+        testFileName.c_str(), flags.c_str(), &compiledFilename, &errorMessage);
     if (retVal != CompilerSuccess && errorMessage != NULL)
       std::cerr << errorMessage;
   } else {

--- a/test/compilerlib/CompilerLibTest.cpp
+++ b/test/compilerlib/CompilerLibTest.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
     commandLineStr += " -o " + outputBaseName;
     const char *flags = commandLineStr.c_str();
     // Compile.
-    retVal = onnx_mlir::omCompileFromFileViaCommand(testFileName.c_str(),
+    retVal = onnx_mlir::omCompileFromFile(testFileName.c_str(),
         onnx_mlir::EmitLib, flags, &compiledFilename, &errorMessage);
     if (retVal != CompilerSuccess && errorMessage != NULL)
       std::cerr << errorMessage;

--- a/test/perf/PerfHelper.hpp
+++ b/test/perf/PerfHelper.hpp
@@ -34,7 +34,9 @@
     ::benchmark::Initialize(&argc, argv);                                      \
     onnx_mlir::omSetCompilerOption(                                            \
         onnx_mlir::OptionKind::CompilerOptLevel, O3.c_str());                  \
-    if (onnx_mlir::omSetCompilerOptionsFromEnv(envArgName.c_str()) != 0)       \
+    const char *myArgv[] = "perf-algo";                                        \
+    if (!llvm::cl::ParseCommandLineOptions(                                    \
+            1, myArgv, "set options for perf-algo", envArgName.c_str()))       \
       return 2;                                                                \
     if (::benchmark::ReportUnrecognizedArguments(argc, argv))                  \
       return 1;                                                                \

--- a/test/perf/PerfHelper.hpp
+++ b/test/perf/PerfHelper.hpp
@@ -27,16 +27,14 @@
 // Define performance main, with default opt level of 3, and scan PERF_ARGS to
 // override default onnx-mlir compiler options.
 #define PERF_MAIN()                                                            \
-  const std::string envArgName("PERF_ARGS");                                   \
-  const std::string O3("3");                                                   \
-                                                                               \
   int main(int argc, char **argv) {                                            \
     ::benchmark::Initialize(&argc, argv);                                      \
-    onnx_mlir::omSetCompilerOption(                                            \
-        onnx_mlir::OptionKind::CompilerOptLevel, O3.c_str());                  \
-    const char *myArgv[] = "perf-algo";                                        \
-    if (!llvm::cl::ParseCommandLineOptions(                                    \
-            1, myArgv, "set options for perf-algo", envArgName.c_str()))       \
+    int onnxMlirArgc = 2;                                                      \
+    const char *onnxMlirArgv[onnxMlirArgc];                                    \
+    onnxMlirArgv[0] = argv[0];                                                 \
+    onnxMlirArgv[1] = "-O3";                                                   \
+    if (!llvm::cl::ParseCommandLineOptions(onnxMlirArgc, onnxMlirArgv,         \
+            "set options for perf-algo", nullptr, /*env var*/ "PERF_ARGS"))    \
       return 2;                                                                \
     if (::benchmark::ReportUnrecognizedArguments(argc, argv))                  \
       return 1;                                                                \


### PR DESCRIPTION
New interface allows all of the onnx-mlir options to be used
```
ONNX_MLIR_EXPORT int64_t omCompileFromFileViaCommand(const char *inputFilename,
    const char *flags, const char **outputFilename, const char **errorMessage);
```

and, for example, if you need the output to be named after something special, we can simply add `-o output name` in the flag string. Or if you want to output a JNI, just add `-EmitJNI`.

Also, it is now possible to use the `"-customEnvFlags=MY_ONNX_MLIR_FLAGS"` so that the default is taken from a custom environment variable, not necessarily the default `ONNX_MLIR_FLAGS`. 

Full interface:
```C
/*!
 *  C interface to compile an onnx model from a file via onnx-mlir command.
 *  This interface is thread safe, and does not take any flags from the
 *  current environment. All flags are passed by using the flags parameter,
 *  including the "-o output-file-name" option or the "-EmitXXX" options. All
 *  options that are available to onnx-mlir are also available here.
 *
 *  This call rely on executing onnx-mlir compiler. The user can override its
 *  default location by using the ONNX_MLIR_BIN_PATH environment variable.
 *
 *  When generating libraries or jar files, the compiler will link in
 *  lightweight runtimes / jar files. If these libraries / jar files are not in
 *  the system wide directory (typically /usr/local/lib), the user can override
 *  the default location using the ONNX_MLIR_LIBRARY_PATH environment variable.
 *
 *  @param inputFilename File name pointing onnx model protobuf or MLIR.
 *  Name may include a path, and must include the file name and its extention.
 *
 *  @param outputFilename Output file name of the compiled output for the given
 * emission target. User is responsible for freeing the string.
 *
 *  @param flags A char * contains all the options provided to compile the
 * model.
 *
 *  @param errorMessage Output error message, if any. User is responsible for
 * freeing the string.
 *
 *  @return 0 on success or OnnxMlirCompilerErrorCodes on failure.
 */
ONNX_MLIR_EXPORT int64_t omCompileFromFile(const char *inputFilename,
    const char *flags, const char **outputFilename, const char **errorMessage);
```

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>