### PR TITLE
Print signature in presence of operands with  none types

### DIFF
--- a/src/Conversion/ONNXToKrnl/Tensor/PrintSignature.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/PrintSignature.cpp
@@ -35,12 +35,11 @@ struct ONNXPrintSignatureLowering : public ConversionPattern {
     ONNXPrintSignatureOpAdaptor operandAdaptor(operands);
 
     std::string opName(printSignatureOp.op_name().data());
-    std::string msg = opName;
-    create.krnl.printf(msg);
-    for (Value oper : operandAdaptor.input()) {
-      msg = "%t ";
-      create.krnl.printTensor(msg, oper);
-    }
+    create.krnl.printf(opName);
+    std::string msg = "%t ";
+    for (Value oper : operandAdaptor.input())
+      if (!oper.getType().isa<NoneType>())
+        create.krnl.printTensor(msg, oper);
     Value noneValue;
     rewriter.replaceOpWithNewOp<KrnlPrintOp>(op, "\n", noneValue);
     return success();

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -105,5 +105,5 @@ def ONNXPrintSignatureOp:ONNX_Op<"PrintSignature", []> {
   "Print type signature of the op's input operands."
   }];
 
-  let arguments = (ins StrAttr:$op_name, Variadic<AnyTypeOf<[AnyTensor]>>:$input);
+  let arguments = (ins StrAttr:$op_name, Variadic<AnyTypeOf<[AnyTensor, NoneType]>>:$input);
 }

--- a/src/Transform/ONNX/InstrumentONNXSignaturePass.cpp
+++ b/src/Transform/ONNX/InstrumentONNXSignaturePass.cpp
@@ -77,8 +77,8 @@ public:
           if (isa<ONNXConstantOp>(op)) {
             // Constant has the type in the output, so use it.
             operands = op->getResults();
-            // Since we use the result of the constant operation, we must
-            // insert the print operation after the constant operation.
+            // Since we use the result of the constant operation, we must insert
+            // the print operation after the constant operation.
             builder.setInsertionPointAfter(op);
             builder.create<ONNXPrintSignatureOp>(loc, opNameAttr, operands);
           } else if (operands.size() > 0) {

--- a/src/Transform/ONNX/InstrumentONNXSignaturePass.cpp
+++ b/src/Transform/ONNX/InstrumentONNXSignaturePass.cpp
@@ -77,8 +77,8 @@ public:
           if (isa<ONNXConstantOp>(op)) {
             // Constant has the type in the output, so use it.
             operands = op->getResults();
-            // Since we use the result of the constant operation, we must insert
-            // the print operation after the constant operation.
+            // Since we use the result of the constant operation, we must
+            // insert the print operation after the constant operation.
             builder.setInsertionPointAfter(op);
             builder.create<ONNXPrintSignatureOp>(loc, opNameAttr, operands);
           } else if (operands.size() > 0) {

--- a/utils/RunONNXLib.cpp
+++ b/utils/RunONNXLib.cpp
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===----------------- RunONNXLub.cpp  ------------------------===//
+//===----------------- RunONNXLib.cpp  ------------------------===//
 //
 // Copyright 2019-2022 The IBM Research Authors.
 //

--- a/utils/RunONNXLib.cpp
+++ b/utils/RunONNXLib.cpp
@@ -2,15 +2,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===----------------- runmodel.cpp  ------------------------===//
+//===----------------- RunONNXLub.cpp  ------------------------===//
 //
-// Copyright 2019 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 /*
   This file help run a onnx model as simply as possible for testing.
   Compile as follows in the onnx-mlir build subdirectory. The tool is built as
-  follows. For dinamically loaded models:
+  follows. For dynamically loaded models:
 
 cd onnx-mlir/build
 . ../utils/build-run-onnx-lib.sh
@@ -60,7 +60,7 @@ Usage: run-onnx-lib [options] model.so
 #include <string>
 #include <vector>
 
-// Json reader & LLVM suport.
+// Json reader & LLVM support.
 #include "llvm/Support/JSON.h"
 
 // Include ONNX-MLIR Runtime support.
@@ -224,7 +224,7 @@ void parseArgs(int argc, char **argv) {
       for (int i = 0; i < inputNum; ++i) {
         auto JSONDimValue = (*JSONArray)[i].getAsInteger();
         assert(JSONDimValue && "failed to get value");
-        int64_t dim = JSONDimValue.getValue();
+        int64_t dim = JSONDimValue.value();
         dimKnownAtRuntime.push_back(dim);
       }
       break;
@@ -303,7 +303,7 @@ void parseArgs(int argc, char **argv) {
  * determine if data is to be allocated or not, using the sizes determined by
  * the signature.
  * @param trace If true, provide a printout of the signatures (input and
- * putput).
+ * output).
  * @return pointer to the TensorList just created, or null on error.
  */
 OMTensorList *omTensorListCreateFromInputSignature(
@@ -336,7 +336,7 @@ OMTensorList *omTensorListCreateFromInputSignature(
     auto JSONItem = (*JSONArray)[i].getAsObject();
     auto JSONItemType = JSONItem->getString("type");
     assert(JSONItemType && "failed to get type");
-    auto type = JSONItemType.getValue();
+    auto type = JSONItemType.value();
     auto JSONDimArray = JSONItem->getArray("dims");
     int rank = JSONDimArray->size();
     assert(rank > 0 && rank < 100 && "rank is out bound");
@@ -346,7 +346,7 @@ OMTensorList *omTensorListCreateFromInputSignature(
     for (int d = 0; d < rank; ++d) {
       auto JSONDimValue = (*JSONDimArray)[d].getAsInteger();
       assert(JSONDimValue && "failed to get value");
-      int64_t dim = JSONDimValue.getValue();
+      int64_t dim = JSONDimValue.value();
       if (dim < 0) {
         // we have a runtime value
         if (dimKnownAtRuntimeIndex >= dimKnownAtRuntime.size()) {

--- a/utils/build-run-onnx-lib.sh
+++ b/utils/build-run-onnx-lib.sh
@@ -25,7 +25,7 @@ echo $ONNX_MLIR_SRC
 
 if [ "$#" -eq 0 ] ; then
   echo "Compile run-onnx-lib for models passed at runtime"
-  g++ $ONNX_MLIR_UTIL/$DRIVERNAME -o $ONNX_MLIR_BIN/run-onnx-lib -std=c++14 \
+  g++ $ONNX_MLIR_UTIL/$DRIVERNAME -o $ONNX_MLIR_BIN/run-onnx-lib -std=c++17 \
   -D LOAD_MODEL_STATICALLY=0 -I $LLVM_PROJ_SRC/llvm/include \
   -I $LLVM_PROJ_BUILD/include -I $ONNX_MLIR_SRC/include \
   -L $LLVM_PROJ_BUILD/lib -lLLVMSupport -lLLVMDemangle -lcurses -lpthread -ldl &&


### PR DESCRIPTION
Yolo 4 has ops that have operands with none types. When trying to use `--instrument-onnx-signature` to trace at runtime the operand signatures, the verifier complained as the PrintSignature ONNX op did not support NONE type as one of its input types.

This PR remedy this issue.