### PR TITLE
Make MHLO Optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(onnx-mlir)
 
 option(ONNX_MLIR_BUILD_TESTS "Build ONNX-MLIR test executables. If OFF, just generate build targets." ON)
 option(ONNX_MLIR_CCACHE_BUILD "Set to ON for a ccache enabled build." OFF)
+option(ONNX_MLIR_ENABLE_MHLO "Enable MHLO support." ON)
 option(ONNX_MLIR_ENABLE_WERROR "Enable warnings as errors." OFF)
 option(ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS "Suppress warning in third_party code." ON)
 
@@ -146,7 +147,10 @@ set(pybind11_FIND_QUIETLY ON)
 add_subdirectory(third_party/onnx)
 add_subdirectory(third_party/pybind11)
 add_subdirectory(third_party/rapidcheck)
-add_subdirectory(third_party/mlir-hlo EXCLUDE_FROM_ALL)
+
+if (ONNX_MLIR_ENABLE_MHLO)
+  add_subdirectory(third_party/mlir-hlo EXCLUDE_FROM_ALL)
+endif()
 
 if (NOT TARGET benchmark)
   set(BENCHMARK_USE_BUNDLED_GTEST OFF)
@@ -175,6 +179,10 @@ if (ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS)
   set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_COPY})
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSUPPRESS_THIRD_PARTY_WARNINGS")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSUPPRESS_THIRD_PARTY_WARNINGS")
+endif()
+
+if (ONNX_MLIR_ENABLE_MHLO)
+  add_compile_definitions(ONNX_MLIR_ENABLE_MHLO)
 endif()
 
 add_subdirectory(utils)

--- a/src/Conversion/CMakeLists.txt
+++ b/src/Conversion/CMakeLists.txt
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(ONNXToKrnl)
-add_subdirectory(ONNXToMhlo)
 add_subdirectory(KrnlToLLVM)
 add_subdirectory(KrnlToAffine)
 add_subdirectory(SeqToMemref)
 add_subdirectory(ONNXToTOSA)
+
+if (ONNX_MLIR_ENABLE_MHLO)
+  add_subdirectory(ONNXToMhlo)
+endif()

--- a/src/Conversion/ONNXToMhlo/ConvertONNXToMhlo.cpp
+++ b/src/Conversion/ONNXToMhlo/ConvertONNXToMhlo.cpp
@@ -53,6 +53,10 @@ struct FrontendToMhloLoweringPass
   FrontendToMhloLoweringPass(const FrontendToMhloLoweringPass &pass)
       : PassWrapper<FrontendToMhloLoweringPass, OperationPass<ModuleOp>>() {}
 
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<mlir::mhlo::MhloDialect>();
+  }
+
   void runOnOperation() final;
 };
 

--- a/src/InitOMPasses.hpp
+++ b/src/InitOMPasses.hpp
@@ -102,8 +102,10 @@ void initOMPasses(int optLevel) {
     return createConvertONNXToTOSAPass();
   });
 
+#ifdef ONNX_MLIR_ENABLE_MHLO
   mlir::registerPass(
       []() -> std::unique_ptr<mlir::Pass> { return createLowerToMhloPass(); });
+#endif
 }
 
 } // namespace onnx_mlir

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -59,8 +59,10 @@ std::unique_ptr<mlir::Pass> createLowerToKrnlPass(
 std::unique_ptr<mlir::Pass> createLowerToKrnlPass(
     bool emitDealloc, bool enableTiling, bool enableParallel);
 
+#ifdef ONNX_MLIR_ENABLE_MHLO
 /// Add pass for lowering to Mhlo IR.
 std::unique_ptr<mlir::Pass> createLowerToMhloPass();
+#endif
 
 /// Pass for lowering krnl.dim operations to standard dialect.
 std::unique_ptr<mlir::Pass> createDisconnectKrnlDimFromAllocPass();

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -37,8 +37,6 @@
 #include "src/InitOMPasses.hpp"
 #include "src/Pass/Passes.hpp"
 
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
-
 using namespace mlir;
 using namespace onnx_mlir;
 
@@ -124,7 +122,6 @@ int main(int argc, char **argv) {
   registry.insert<mlir::ONNXDialect>();
   registry.insert<mlir::KrnlDialect>();
   registry.insert<mlir::tosa::TosaDialect>();
-  registry.insert<mlir::mhlo::MhloDialect>();
 
   // Initialize accelerators if they exist.
   onnx_mlir::accel::initAccelerators(maccel);

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -192,10 +192,12 @@ struct SoftmaxPattern : public ConversionPattern {
   }
 };
 
+#ifdef ONNX_MLIR_ENABLE_MHLO
 void populateDecomposingONNXBeforeMhloPatterns(
     RewritePatternSet &patterns, MLIRContext *ctx) {
   patterns.add<SoftmaxPattern>(ctx);
 }
+#endif
 
 struct DecomposeONNXToONNXPass
     : public PassWrapper<DecomposeONNXToONNXPass, OperationPass<func::FuncOp>> {
@@ -252,10 +254,12 @@ void DecomposeONNXToONNXPass::runOnOperation() {
   populateWithGenerated(patterns);
   patterns.insert<onnx_mlir::DecomposeEinsumPattern>(&getContext());
 
+#ifdef ONNX_MLIR_ENABLE_MHLO
   if (this->target == "mhlo") {
     populateDecomposingONNXBeforeMhloPatterns(patterns, context);
     target.addIllegalOp<ONNXSoftmaxOp>();
   }
+#endif
 
   if (failed(applyPartialConversion(function, target, std::move(patterns))))
     signalPassFailure();

--- a/test/mlir/CMakeLists.txt
+++ b/test/mlir/CMakeLists.txt
@@ -14,6 +14,12 @@ else()
   message(STATUS "Accelerator lit tests    : NONE")
 endif()
 
+if (ONNX_MLIR_ENABLE_MHLO)
+  set(ONNX_MLIR_MHLO_ENABLED 1)
+else()
+  set(ONNX_MLIR_MHLO_ENABLED 0)
+endif()
+
 # Set LLVM_DEFAULT_EXTERNAL_LIT to an empty string to avoid warnings about the path
 # when using multi-config generators such as VS or Xcode
 set(LLVM_DEFAULT_EXTERNAL_LIT "")

--- a/test/mlir/conversion/onnx_to_mhlo/lit.local.cfg
+++ b/test/mlir/conversion/onnx_to_mhlo/lit.local.cfg
@@ -1,0 +1,2 @@
+if not config.enable_mhlo:
+  config.unsupported = True

--- a/test/mlir/lit.site.cfg.py.in
+++ b/test/mlir/lit.site.cfg.py.in
@@ -8,6 +8,7 @@ config.targets_to_build = "@TARGETS_TO_BUILD@"
 config.onnx_mlir_tools_dir = r"@ONNX_MLIR_TOOLS_DIR@"
 config.onnx_mlir_obj_root = r"@ONNX_MLIR_BIN_ROOT@"
 
+config.enable_mhlo = @ONNX_MLIR_MHLO_ENABLED@
 config.enable_nnpa= 0x0@NNPA_LIT_ENABLED@
 
 # Support substitution of the tools_dir with user parameters. This is


### PR DESCRIPTION
After this change, MHLO can be excluded by setting `ONNX_MLIR_ENABLE_MHLO` to `OFF`. The default remains set to `ON`, so MHLO will continue to be included.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>