### PR TITLE
[NNPA] Optimize onnx.pow(input,exponent) with "exponentiation by squaring" method

### DIFF
--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -441,15 +441,16 @@ func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tenso
 
 // COM: Expand Pow into multiple Mul if exponent is an integer and <= 64.
 func.func @expand_pow_into_mul(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
-    %cst = "onnx.Constant"() {value = dense<3.0> : tensor<f32>} : () -> tensor<f32>
+    %cst = "onnx.Constant"() {value = dense<5.0> : tensor<f32>} : () -> tensor<f32>
     %0 = "onnx.Pow"(%arg0, %cst) : (tensor<3x4x5xf32>, tensor<f32>) -> tensor<3x4x5xf32>
     return %0 : tensor<3x4x5xf32>
 
 // CHECK-LABEL:  func.func @expand_pow_into_mul
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[PARAM_0_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_1_]], [[PARAM_0_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-// CHECK:           return [[VAR_2_]] : tensor<3x4x5xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_1_]], [[VAR_1_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
+// CHECK:           return [[VAR_3_]] : tensor<3x4x5xf32>
 // CHECK:        }
 }
 


### PR DESCRIPTION
Minimize the number of onnx.Mul for onnx.Pow(input, exponent) with "exponentiation by squaring" method.
This PR reduces the calculation order from O(exponent) to O(log exponent).

Signed-off-by: Yasushi Negishi <negishi@jp.ibm.com>