### PR TITLE
Perf noinline

### DIFF
--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -99,7 +99,7 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
    -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir ^
-   -DONNX_MLIR_BUILD_TESTS=OFF
+   -DONNX_MLIR_BUILD_TESTS=ON
 
 call cmake --build . --config Release --target onnx-mlir
 ```

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -46,7 +46,7 @@ endfunction()
 
 # The CompilerUtils ExecutionSession are also included in ModelLib,
 # but it did not compile when I removed these two. TODO, figure out why.
-set(TEST_LINK_LIBS PerfLib ModelLib CompilerUtils benchmark)
+set(TEST_LINK_LIBS benchmark CompilerUtils ModelLib PerfLib)
 
 add_perf_unittest(PerfGemm
   PerfGemm.cpp

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -7,6 +7,9 @@ add_onnx_mlir_library(PerfLib
   INCLUDE_DIRS PRIVATE
   ${ONNX_MLIR_SRC_ROOT}/third_party/benchmark/include
   ${ONNX_MLIR_BIN_ROOT}/third_party/benchmark/include
+
+  LINK_LIBS PRIVATE
+  benchmark
   )
 
 add_custom_target(perf)

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -1,5 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
+add_onnx_mlir_library(PerfLib
+  PerfHelper.cpp
+  EXCLUDE_FROM_OM_LIBS
+
+  INCLUDE_DIRS PRIVATE
+  ${ONNX_MLIR_SRC_ROOT}/third_party/benchmark/include
+  ${ONNX_MLIR_BIN_ROOT}/third_party/benchmark/include
+  )
+
 add_custom_target(perf)
 set_target_properties(perf PROPERTIES FOLDER "Perf")
 
@@ -37,7 +46,7 @@ endfunction()
 
 # The CompilerUtils ExecutionSession are also included in ModelLib,
 # but it did not compile when I removed these two. TODO, figure out why.
-set(TEST_LINK_LIBS ModelLib CompilerUtils benchmark)
+set(TEST_LINK_LIBS PerfLib ModelLib CompilerUtils benchmark)
 
 add_perf_unittest(PerfGemm
   PerfGemm.cpp

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -8,8 +8,9 @@ add_onnx_mlir_library(PerfLib
   ${ONNX_MLIR_SRC_ROOT}/third_party/benchmark/include
   ${ONNX_MLIR_BIN_ROOT}/third_party/benchmark/include
 
-  LINK_LIBS PRIVATE
-  benchmark CompilerUtils
+  LINK_LIBS PUBLIC
+  benchmark 
+  CompilerUtils
   )
 
 add_custom_target(perf)
@@ -49,7 +50,7 @@ endfunction()
 
 # The CompilerUtils ExecutionSession are also included in ModelLib,
 # but it did not compile when I removed these two. TODO, figure out why.
-set(TEST_LINK_LIBS benchmark CompilerUtils ModelLib PerfLib)
+set(TEST_LINK_LIBS ModelLib PerfLib)
 
 add_perf_unittest(PerfGemm
   PerfGemm.cpp

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -9,7 +9,7 @@ add_onnx_mlir_library(PerfLib
   ${ONNX_MLIR_BIN_ROOT}/third_party/benchmark/include
 
   LINK_LIBS PRIVATE
-  benchmark
+  benchmark CompilerUtils
   )
 
 add_custom_target(perf)

--- a/test/perf/PerfConv.cpp
+++ b/test/perf/PerfConv.cpp
@@ -42,7 +42,7 @@ static void BM_Conv2D_C16_K1(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   // FLOPS assume D=1, S=1.
-  PERF_RECORD_FLOPS(2.0 * N * C * C * H * W * K * K);
+  PERF_RECORD_FLOPS(state, 2.0 * N * C * C * H * W * K * K);
 }
 BENCHMARK(BM_Conv2D_C16_K1)
     ->ArgsProduct({{1, 16, 64}, {16, 64, 256}})
@@ -64,7 +64,7 @@ static void BM_Conv2D_C16_K3(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   // FLOPS assume D=1, S=1.
-  PERF_RECORD_FLOPS(2.0 * N * C * C * H * W * K * K);
+  PERF_RECORD_FLOPS(state, 2.0 * N * C * C * H * W * K * K);
 }
 BENCHMARK(BM_Conv2D_C16_K3)
     ->ArgsProduct({{1, 16, 64}, {16, 64, 256}})

--- a/test/perf/PerfConv.cpp
+++ b/test/perf/PerfConv.cpp
@@ -42,7 +42,7 @@ static void BM_Conv2D_C16_K1(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   // FLOPS assume D=1, S=1.
-  PERF_RECORD_FLOPS(state, 2.0 * N * C * C * H * W * K * K);
+  perf_recordFlops(state, 2.0 * N * C * C * H * W * K * K);
 }
 BENCHMARK(BM_Conv2D_C16_K1)
     ->ArgsProduct({{1, 16, 64}, {16, 64, 256}})
@@ -64,7 +64,7 @@ static void BM_Conv2D_C16_K3(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   // FLOPS assume D=1, S=1.
-  PERF_RECORD_FLOPS(state, 2.0 * N * C * C * H * W * K * K);
+  perf_recordFlops(state, 2.0 * N * C * C * H * W * K * K);
 }
 BENCHMARK(BM_Conv2D_C16_K3)
     ->ArgsProduct({{1, 16, 64}, {16, 64, 256}})

--- a/test/perf/PerfGemm.cpp
+++ b/test/perf/PerfGemm.cpp
@@ -34,7 +34,7 @@ static void BM_MatrixVectorProduct(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   state.SetComplexityN(I);
-  PERF_RECORD_FLOPS(state, 2.0 * I * J * K);
+  perf_recordFlops(state, 2.0 * I * J * K);
 }
 BENCHMARK(BM_MatrixVectorProduct)
     ->RangeMultiplier(2)
@@ -52,7 +52,7 @@ static void BM_MatmulSquare(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   state.SetComplexityN(I);
-  PERF_RECORD_FLOPS(state, 2.0 * I * J * K);
+  perf_recordFlops(state, 2.0 * I * J * K);
 }
 BENCHMARK(BM_MatmulSquare)
     ->RangeMultiplier(2)
@@ -72,7 +72,7 @@ static void BM_MatmulSquareBroadcastB4x(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   state.SetComplexityN(I);
-  PERF_RECORD_FLOPS(state, /*broadcast 4x*/ 4.0 /*matmul*/ * 2.0 * I * J * K);
+  perf_recordFlops(state, /*broadcast 4x*/ 4.0 /*matmul*/ * 2.0 * I * J * K);
 }
 BENCHMARK(BM_MatmulSquareBroadcastB4x)
     ->RangeMultiplier(2)
@@ -92,7 +92,7 @@ static void BM_MatMulWithGemmSquare(benchmark::State &state) {
     model.run();
   state.SetComplexityN(I);
   // Because alpha is 1, its not counted; beta is zero, sum of B is ignored.
-  PERF_RECORD_FLOPS(state, 1.0 * I * J * (2.0 * K - 1.0));
+  perf_recordFlops(state, 1.0 * I * J * (2.0 * K - 1.0));
 }
 BENCHMARK(BM_MatMulWithGemmSquare)
     ->RangeMultiplier(2)
@@ -112,7 +112,7 @@ static void BM_GemmSquare(benchmark::State &state) {
     model.run();
   state.SetComplexityN(I);
   // Because alpha is 1, its not counted; beta is 1, sum of B is counted.
-  PERF_RECORD_FLOPS(state, 1.0 * I * J * (2.0 * K - 1.0) + I * K);
+  perf_recordFlops(state, 1.0 * I * J * (2.0 * K - 1.0) + I * K);
 }
 BENCHMARK(BM_GemmSquare)
     ->RangeMultiplier(2)

--- a/test/perf/PerfGemm.cpp
+++ b/test/perf/PerfGemm.cpp
@@ -34,7 +34,7 @@ static void BM_MatrixVectorProduct(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   state.SetComplexityN(I);
-  PERF_RECORD_FLOPS(2.0 * I * J * K);
+  PERF_RECORD_FLOPS(state, 2.0 * I * J * K);
 }
 BENCHMARK(BM_MatrixVectorProduct)
     ->RangeMultiplier(2)
@@ -52,7 +52,7 @@ static void BM_MatmulSquare(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   state.SetComplexityN(I);
-  PERF_RECORD_FLOPS(2.0 * I * J * K);
+  PERF_RECORD_FLOPS(state, 2.0 * I * J * K);
 }
 BENCHMARK(BM_MatmulSquare)
     ->RangeMultiplier(2)
@@ -72,7 +72,7 @@ static void BM_MatmulSquareBroadcastB4x(benchmark::State &state) {
   for (auto _ : state)
     model.run();
   state.SetComplexityN(I);
-  PERF_RECORD_FLOPS(/*broadcast 4x*/ 4.0 /*matmul*/ * 2.0 * I * J * K);
+  PERF_RECORD_FLOPS(state, /*broadcast 4x*/ 4.0 /*matmul*/ * 2.0 * I * J * K);
 }
 BENCHMARK(BM_MatmulSquareBroadcastB4x)
     ->RangeMultiplier(2)
@@ -92,7 +92,7 @@ static void BM_MatMulWithGemmSquare(benchmark::State &state) {
     model.run();
   state.SetComplexityN(I);
   // Because alpha is 1, its not counted; beta is zero, sum of B is ignored.
-  PERF_RECORD_FLOPS(1.0 * I * J * (2.0 * K - 1.0));
+  PERF_RECORD_FLOPS(state, 1.0 * I * J * (2.0 * K - 1.0));
 }
 BENCHMARK(BM_MatMulWithGemmSquare)
     ->RangeMultiplier(2)
@@ -112,7 +112,7 @@ static void BM_GemmSquare(benchmark::State &state) {
     model.run();
   state.SetComplexityN(I);
   // Because alpha is 1, its not counted; beta is 1, sum of B is counted.
-  PERF_RECORD_FLOPS(1.0 * I * J * (2.0 * K - 1.0) + I * K);
+  PERF_RECORD_FLOPS(state, 1.0 * I * J * (2.0 * K - 1.0) + I * K);
 }
 BENCHMARK(BM_GemmSquare)
     ->RangeMultiplier(2)

--- a/test/perf/PerfHelper.cpp
+++ b/test/perf/PerfHelper.cpp
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===================-- PerfHelper.cpp - Helper for perf tests -=============//
+//
+// Copyright 2022 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains helper macro and functions for repetitive Benchmark
+// actions.
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/CommandLine.h"
+
+#include "test/perf/PerfHelper.hpp"
+
+// Pass f as a (double) number of FLOP in the measurement and report it as the
+// actual number (FLOP) and as a rate per seconds (FLOPS).
+void perf_recordFlops(benchmark::State &state, float f) {
+  state.counters["FLOPS"] = benchmark::Counter(f,
+      benchmark::Counter::kIsRate | benchmark::Counter::kIsIterationInvariant,
+      benchmark::Counter::OneK::kIs1000);
+  state.counters["FLOP"] = benchmark::Counter(
+      f, benchmark::Counter::kDefaults, benchmark::Counter::OneK::kIs1000);
+}
+
+// Define performance main, with default opt level of 3, and scan PERF_ARGS to
+// override default onnx-mlir compiler options.
+int perf_main(int argc, char **argv) {
+  ::benchmark::Initialize(&argc, argv);
+  const int onnxMlirArgc = 2;
+  const char *onnxMlirArgv[onnxMlirArgc];
+  onnxMlirArgv[0] = argv[0];
+  onnxMlirArgv[1] = "-O3";
+  if (!llvm::cl::ParseCommandLineOptions(onnxMlirArgc, onnxMlirArgv,
+          "set options for perf-algo", nullptr, /*env var*/ "PERF_ARGS"))
+    return 2;
+  if (::benchmark::ReportUnrecognizedArguments(argc, argv))
+    return 1;
+  ::benchmark::RunSpecifiedBenchmarks();
+  ::benchmark::Shutdown();
+  return 0;
+}

--- a/test/perf/PerfHelper.hpp
+++ b/test/perf/PerfHelper.hpp
@@ -14,14 +14,13 @@
 
 #include <benchmark/benchmark.h>
 
-void perf_recordFlops(benchmark::State &state, float f);
-int perf_main(int argc, char **argv);
-
 // Pass f as a (double) number of FLOP in the measurement and report it as the
 // actual number (FLOP) and as a rate per seconds (FLOPS).
-#define PERF_RECORD_FLOPS(_s, _f) perf_recordFlops(_s, _f)
+void perf_recordFlops(benchmark::State &state, float f);
 
 // Define performance main, with default opt level of 3, and scan PERF_ARGS to
 // override default onnx-mlir compiler options.
+int perf_main(int argc, char **argv);
+
 #define PERF_MAIN()                                                            \
   int main(int argc, char **argv) { return perf_main(argc, argv); }

--- a/test/perf/PerfHelper.hpp
+++ b/test/perf/PerfHelper.hpp
@@ -12,33 +12,16 @@
 // actions.
 //===----------------------------------------------------------------------===//
 
+#include <benchmark/benchmark.h>
+
+void perf_recordFlops(benchmark::State &state, float f);
+int perf_main(int argc, char **argv);
+
 // Pass f as a (double) number of FLOP in the measurement and report it as the
 // actual number (FLOP) and as a rate per seconds (FLOPS).
-#define PERF_RECORD_FLOPS(_f)                                                  \
-  {                                                                            \
-    state.counters["FLOPS"] = benchmark::Counter((_f),                         \
-        benchmark::Counter::kIsRate |                                          \
-            benchmark::Counter::kIsIterationInvariant,                         \
-        benchmark::Counter::OneK::kIs1000);                                    \
-    state.counters["FLOP"] = benchmark::Counter((_f),                          \
-        benchmark::Counter::kDefaults, benchmark::Counter::OneK::kIs1000);     \
-  }
+#define PERF_RECORD_FLOPS(_s, _f) perf_recordFlops(_s, _f)
 
 // Define performance main, with default opt level of 3, and scan PERF_ARGS to
 // override default onnx-mlir compiler options.
 #define PERF_MAIN()                                                            \
-  int main(int argc, char **argv) {                                            \
-    ::benchmark::Initialize(&argc, argv);                                      \
-    int onnxMlirArgc = 2;                                                      \
-    const char *onnxMlirArgv[onnxMlirArgc];                                    \
-    onnxMlirArgv[0] = argv[0];                                                 \
-    onnxMlirArgv[1] = "-O3";                                                   \
-    if (!llvm::cl::ParseCommandLineOptions(onnxMlirArgc, onnxMlirArgv,         \
-            "set options for perf-algo", nullptr, /*env var*/ "PERF_ARGS"))    \
-      return 2;                                                                \
-    if (::benchmark::ReportUnrecognizedArguments(argc, argv))                  \
-      return 1;                                                                \
-    ::benchmark::RunSpecifiedBenchmarks();                                     \
-    ::benchmark::Shutdown();                                                   \
-    return 0;                                                                  \
-  }
+  int main(int argc, char **argv) { return perf_main(argc, argv); }

--- a/test/perf/PerfRNN.cpp
+++ b/test/perf/PerfRNN.cpp
@@ -72,7 +72,7 @@ static void BM_LSTM(benchmark::State &state) {
   // FLOPS for LSTM: ignore activations, assume static S and B.
   // Eight matrix-matrix multiplications are combined into two
   // matrix-matrix multiplications: [B,I]x[I,4*H] and [B,H]x[H,4*H].
-  PERF_RECORD_FLOPS(state, 
+  perf_recordFlops(state,
       D * S * (4.0 * B * H * (2.0 * I - 1.0) + 4.0 * B * H * (2.0 * H - 1.0)));
 }
 BENCHMARK(BM_LSTM)->Apply(CommonArgs)->Unit(benchmark::kMillisecond);
@@ -94,7 +94,7 @@ static void BM_GRU_LINEAR_BEFORE_RESET(benchmark::State &state) {
   // FLOPS for GRU: ignore activations, assume static S and B.
   // Six matrix-matrix multiplications are combined into two
   // matrix-matrix multiplications: [B,I]x[I,3*H] and [B,H]x[H,3*H].
-  PERF_RECORD_FLOPS(state, 
+  perf_recordFlops(state,
       D * S * (3.0 * B * H * (2.0 * I - 1.0) + 3.0 * B * H * (2.0 * H - 1.0)));
 }
 BENCHMARK(BM_GRU_LINEAR_BEFORE_RESET)
@@ -118,7 +118,7 @@ static void BM_GRU_LINEAR_AFTER_RESET(benchmark::State &state) {
   // FLOPS for GRU: ignore activations, assume static S and B.
   // Six matrix-matrix multiplications are combined into two
   // matrix-matrix multiplications: [B,I]x[I,3*H] and [B,H]x[H,3*H].
-  PERF_RECORD_FLOPS(state, 
+  perf_recordFlops(state,
       D * S * (3.0 * B * H * (2.0 * I - 1.0) + 3.0 * B * H * (2.0 * H - 1.0)));
 }
 BENCHMARK(BM_GRU_LINEAR_AFTER_RESET)
@@ -141,8 +141,8 @@ static void BM_RNN(benchmark::State &state) {
     rnn.run();
   // FLOPS for RNN: ignore activations, assume static S and B.
   // Two matrix-matrix multiplications: [B,I]x[I,H] and [B,H]x[H,H].
-  PERF_RECORD_FLOPS(state, 
-      D * S * (B * H * (2.0 * I - 1.0) + B * H * (2.0 * H - 1.0)));
+  perf_recordFlops(
+      state, D * S * (B * H * (2.0 * I - 1.0) + B * H * (2.0 * H - 1.0)));
 }
 BENCHMARK(BM_RNN)->Apply(CommonArgs)->Unit(benchmark::kMillisecond);
 

--- a/test/perf/PerfRNN.cpp
+++ b/test/perf/PerfRNN.cpp
@@ -72,7 +72,7 @@ static void BM_LSTM(benchmark::State &state) {
   // FLOPS for LSTM: ignore activations, assume static S and B.
   // Eight matrix-matrix multiplications are combined into two
   // matrix-matrix multiplications: [B,I]x[I,4*H] and [B,H]x[H,4*H].
-  PERF_RECORD_FLOPS(
+  PERF_RECORD_FLOPS(state, 
       D * S * (4.0 * B * H * (2.0 * I - 1.0) + 4.0 * B * H * (2.0 * H - 1.0)));
 }
 BENCHMARK(BM_LSTM)->Apply(CommonArgs)->Unit(benchmark::kMillisecond);
@@ -94,7 +94,7 @@ static void BM_GRU_LINEAR_BEFORE_RESET(benchmark::State &state) {
   // FLOPS for GRU: ignore activations, assume static S and B.
   // Six matrix-matrix multiplications are combined into two
   // matrix-matrix multiplications: [B,I]x[I,3*H] and [B,H]x[H,3*H].
-  PERF_RECORD_FLOPS(
+  PERF_RECORD_FLOPS(state, 
       D * S * (3.0 * B * H * (2.0 * I - 1.0) + 3.0 * B * H * (2.0 * H - 1.0)));
 }
 BENCHMARK(BM_GRU_LINEAR_BEFORE_RESET)
@@ -118,7 +118,7 @@ static void BM_GRU_LINEAR_AFTER_RESET(benchmark::State &state) {
   // FLOPS for GRU: ignore activations, assume static S and B.
   // Six matrix-matrix multiplications are combined into two
   // matrix-matrix multiplications: [B,I]x[I,3*H] and [B,H]x[H,3*H].
-  PERF_RECORD_FLOPS(
+  PERF_RECORD_FLOPS(state, 
       D * S * (3.0 * B * H * (2.0 * I - 1.0) + 3.0 * B * H * (2.0 * H - 1.0)));
 }
 BENCHMARK(BM_GRU_LINEAR_AFTER_RESET)
@@ -141,7 +141,7 @@ static void BM_RNN(benchmark::State &state) {
     rnn.run();
   // FLOPS for RNN: ignore activations, assume static S and B.
   // Two matrix-matrix multiplications: [B,I]x[I,H] and [B,H]x[H,H].
-  PERF_RECORD_FLOPS(
+  PERF_RECORD_FLOPS(state, 
       D * S * (B * H * (2.0 * I - 1.0) + B * H * (2.0 * H - 1.0)));
 }
 BENCHMARK(BM_RNN)->Apply(CommonArgs)->Unit(benchmark::kMillisecond);

--- a/utils/build-onnx-mlir.cmd
+++ b/utils/build-onnx-mlir.cmd
@@ -8,6 +8,6 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
    -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir ^
-   -DONNX_MLIR_BUILD_TESTS=OFF
+   -DONNX_MLIR_BUILD_TESTS=ON
 
 call cmake --build . --config Release --target onnx-mlir


### PR DESCRIPTION
In the test/perf, there were functions that were inlined by #def macros.This may contribute to compile issue on Windows.

This PR transformed the inline macros into functions integrated in a new `PerfLib`, so hopefully this will help Windows... and it is a nicer code anyway.