### PR TITLE
fix einsum decomposition bug

### DIFF
--- a/src/Transform/ONNX/DecomposeEinsum.cpp
+++ b/src/Transform/ONNX/DecomposeEinsum.cpp
@@ -379,14 +379,19 @@ public:
     transpose(output1, subscripts1transposed);
     transpose(output2, subscripts2transposed);
 
+    // copy shapes, the ShapeRefs below will point into these copies,
+    // they cannot point into output1.shape and output2.shape because
+    // they are reshaped before we're done with the ShapeRefs
+    Shape shape1 = output1.shape;
+    Shape shape2 = output2.shape;
     // read off the shapes corresponding to the transposed subscripts
     ShapeRef sharedKeep1Shape, unshared1Shape, reducibleShape;
     std::tie(sharedKeep1Shape, unshared1Shape, reducibleShape) =
-        split3(makeArrayRef(output1.shape), sharedKeepSubscripts.size(),
+        split3(makeArrayRef(shape1), sharedKeepSubscripts.size(),
             subscripts1unshared.size(), reducibleSubscripts.size());
     ShapeRef sharedKeep2Shape, reducible2Shape, unshared2Shape;
     std::tie(sharedKeep2Shape, reducible2Shape, unshared2Shape) =
-        split3(makeArrayRef(output2.shape), sharedKeepSubscripts.size(),
+        split3(makeArrayRef(shape2), sharedKeepSubscripts.size(),
             reducibleSubscripts.size(), subscripts2unshared.size());
     // broadcast not needed because non-result 1-dim axes were squeezed at
     // outset

--- a/test/mlir/onnx/onnx_decompose_einsum.mlir
+++ b/test/mlir/onnx/onnx_decompose_einsum.mlir
@@ -101,3 +101,18 @@ func.func @test_einsum_trace(%arg0: tensor<3x3xf32>) -> tensor<f32> {
 // CHECK:           [[VAR_6_:%.+]] = "onnx.ReduceSum"([[VAR_4_]], [[VAR_5_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3xf32>, tensor<1xi64>) -> tensor<f32>
 // CHECK:           return [[VAR_6_]] : tensor<f32>
 }
+
+func.func @test_einsum_ibh_hnd(%arg0: tensor<128x1x1024xf16>, %arg1: tensor<1024x16x64xf16>) -> tensor<128x1x16x64xf16> {
+  %0 = "onnx.Einsum"(%arg0, %arg1) {equation = "ibh,hnd->ibnd"} : (tensor<128x1x1024xf16>, tensor<1024x16x64xf16>) -> tensor<128x1x16x64xf16>
+  return %0 : tensor<128x1x16x64xf16>
+// CHECK-LABEL:  func.func @test_einsum_ibh_hnd
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x1x1024xf16>, [[PARAM_1_:%.+]]: tensor<1024x16x64xf16>) -> tensor<128x1x16x64xf16> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Constant"() {value = dense<[128, 1024]> : tensor<2xi64>} : () -> tensor<2xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<128x1x1024xf16>, tensor<2xi64>) -> tensor<128x1024xf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Constant"() {value = dense<1024> : tensor<2xi64>} : () -> tensor<2xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<1024x16x64xf16>, tensor<2xi64>) -> tensor<1024x1024xf16>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_3_]]) : (tensor<128x1024xf16>, tensor<1024x1024xf16>) -> tensor<128x1024xf16>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Constant"() {value = dense<[128, 1, 16, 64]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:           [[VAR_6_:%.+]] = "onnx.Reshape"([[VAR_4_]], [[VAR_5_]]) {allowzero = 0 : si64} : (tensor<128x1024xf16>, tensor<4xi64>) -> tensor<128x1x16x64xf16>
+// CHECK:           return [[VAR_6_]] : tensor<128x1x16x64xf16>
+}


### PR DESCRIPTION
ArrayRef was used after the underlying array changed, fixed it by creating a copy of the underlying array and make the ArrayRef point to the copy

Signed-off-by: Soren Lassen <sorenlassen@gmail.com>