### PR TITLE
fix 2 compiler warnings

### DIFF
--- a/src/Conversion/ONNXToKrnl/PerfectHash.cpp
+++ b/src/Conversion/ONNXToKrnl/PerfectHash.cpp
@@ -43,10 +43,7 @@ public:
 
   // Adaptation of 32-bit FNV for int64_t values.
   static inline uint32_t hash(uint32_t hval, int64_t val) {
-    char str[20];
-    sprintf(str, "%lld", (long long)val);
-
-    return hash(hval, std::string(str));
+    return hash(hval, std::to_string(val));
   }
 
   // Extracts the keys of the given map.

--- a/src/Transform/ONNX/ConvOpt.cpp
+++ b/src/Transform/ONNX/ConvOpt.cpp
@@ -208,7 +208,9 @@ struct ConvOptONNXToONNXPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvOptONNXToONNXPass)
 
   ConvOptONNXToONNXPass() = default;
-  ConvOptONNXToONNXPass(const ConvOptONNXToONNXPass &pass) {}
+  ConvOptONNXToONNXPass(const ConvOptONNXToONNXPass &pass)
+      : mlir::PassWrapper<ConvOptONNXToONNXPass,
+            OperationPass<func::FuncOp>>() {}
 
   StringRef getArgument() const override { return "convopt-onnx"; }
 

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -204,7 +204,9 @@ struct DecomposeONNXToONNXPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DecomposeONNXToONNXPass)
 
   DecomposeONNXToONNXPass() = default;
-  DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass) {}
+  DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
+      : mlir::PassWrapper<DecomposeONNXToONNXPass,
+            OperationPass<func::FuncOp>>() {}
 
   StringRef getArgument() const override { return "decompose-onnx"; }
 


### PR DESCRIPTION
fixes `'sprintf' is deprecated` warning on Mac and `base class should be explicitly initialized in the copy constructor` warnings on Linux

the solution to the copy constructor warning was copied from `InstrumentONNXPass.cpp`

warning from Apple clang version 14.0.0 (clang-1400.0.29.201):
```
.../src/Conversion/ONNXToKrnl/PerfectHash.cpp:47:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    sprintf(str, "%lld", (long long)val);
/Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
```

compiler warning in Linux CI pipelines:
```
.../src/Transform/ONNX/ConvOpt.cpp: In copy constructor '{anonymous}::ConvOptONNXToONNXPass::ConvOptONNXToONNXPass(const {anonymous}::ConvOptONNXToONNXPass&)':
.../src/Transform/ONNX/ConvOpt.cpp:211:3: warning: base class 'class mlir::PassWrapper<{anonymous}::ConvOptONNXToONNXPass, mlir::OperationPass<mlir::func::FuncOp> >' should be explicitly initialized in the copy constructor [-Wextra]
   ConvOptONNXToONNXPass(const ConvOptONNXToONNXPass &pass) {}
```