### PR TITLE
Streamline pointer logic inside of FrontendDialectTransformer's Infer…

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1125,8 +1125,6 @@ private:
 
   void InferTypes(const onnx::FunctionProto *func,
       std::vector<onnx::TypeProto> &inputTypes) {
-    // types: Used for temporary copies of Types, freed at end of function.
-    std::vector<std::unique_ptr<onnx::TypeProto>> types;
     std::unordered_map<std::string, onnx::TypeProto *> typeMap;
     // Initialize types and values (if available) of function inputs:
     const auto num_inputs =
@@ -1148,10 +1146,7 @@ private:
 
       // Update types:
       for (int i = 0; i < n.output_size(); ++i) {
-        std::unique_ptr<onnx::TypeProto> p =
-            std::make_unique<onnx::TypeProto>(*node_ctx.getOutputType(i));
-        typeMap[n.output(i)] = p.get();
-        types.push_back(std::move(p));
+        typeMap[n.output(i)] = node_ctx.getOutputType(i);
       }
     }
 


### PR DESCRIPTION
…Types.

This PR introduces logic to streamline pointer logic found towards the end of FrontendDialectTransformer's InferTypes. I was seeing issues with use of out of scope local variables, so I collapsed this down to the smallest possible case that passes our unit tests as well as quiesces other issues I was seeing.

Signed-off-by: Brad Messer <messerb5467@gmail.com>