### PR TITLE
Removed the memory leaks directly in execution session

### DIFF
--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -284,8 +284,9 @@ OMTensor *omTensorCreateEmpty(
 void omTensorDestroy(OMTensor *tensor) {
   if (!tensor)
     return;
-  if (tensor->_owning)
+  if (tensor->_owning) {
     free(tensor->_allocatedPtr);
+  }
   free(tensor->_shape);
   free(tensor->_strides);
   free(tensor);

--- a/src/Runtime/OMTensorList.inc
+++ b/src/Runtime/OMTensorList.inc
@@ -103,8 +103,23 @@ void omTensorListDestroy(OMTensorList *list) {
     return;
   for (int64_t i = 0; i < list->_size; i++)
     omTensorDestroy(list->_omts[i]);
-  if (list->_owning)
+  if (list->_owning) {
     free(list->_omts);
+  }
+  free(list);
+}
+
+/* OMTensorList destroyer which does not destroy the tensors. Currently an
+ * unpublished call that is mainly used to handle the unique tensor scheme used
+ * in Execution Session.
+ */
+void omTensorListDestroyWithoutDestroyingTensors(OMTensorList *list) {
+  if (!list)
+    return;
+  // Omit destruction of the OMTensors.
+  if (list->_owning) {
+    free(list->_omts);
+  }
   free(list);
 }
 

--- a/test/numerical/TestLoop.cpp
+++ b/test/numerical/TestLoop.cpp
@@ -118,9 +118,9 @@ bool isOMLoopTheSameAsNaiveImplFor(std::string moduleIR,
   omTensorGetElem<bool>(condTensor.get(), {}) = true;
   inputs.emplace_back(move(condTensor));
 
-  auto *yInitShape = new int64_t[1]{1};
+  int64_t yInitShape = 1;
   auto yInitTensor = OMTensorUniquePtr(
-      omTensorCreateEmpty(&yInitShape[0], 1, OM_DATA_TYPE::ONNX_TYPE_INT64),
+      omTensorCreateEmpty(&yInitShape, 1, OM_DATA_TYPE::ONNX_TYPE_INT64),
       omTensorDestroy);
   omTensorGetElem<int64_t>(yInitTensor.get(), {0}) = yInit;
   inputs.emplace_back(move(yInitTensor));
@@ -135,9 +135,9 @@ bool isOMLoopTheSameAsNaiveImplFor(std::string moduleIR,
     return false;
   }
 
-  auto *yRefInitShape = new int64_t[1]{1};
+  int64_t yRefInitShape = 1;
   auto vFinalRef = OMTensorUniquePtr(
-      omTensorCreateEmpty(&yRefInitShape[0], 1, OM_DATA_TYPE::ONNX_TYPE_INT64),
+      omTensorCreateEmpty(&yRefInitShape, 1, OM_DATA_TYPE::ONNX_TYPE_INT64),
       omTensorDestroy);
 
   omTensorGetElem<int64_t>(vFinalRef.get(), {0}) = yInit;


### PR DESCRIPTION
There were some issues with respect to memory leaks in the ExecussionSession interfaces that use unique pointers.

These leaks were addressed in this issue. Namely, the following were removed.
```
==74700== 24 bytes in 1 blocks are definitely lost in loss record 21 of 119
==74700==    at 0x59E57F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==74700==    by 0x3612D07: omTensorListCreate (OMTensorList.inc:79)
==74700==    by 0x3605439: onnx_mlir::ExecutionSession::run(std::vector<std::unique_ptr<OMTensor, void (*)(OMTensor*)>, std::allocator<std::unique_ptr<OMTensor, void (*)(OMTensor*)> > >) (ExecutionSession.cpp:85)
==74700==    by 0x4244F0: onnx_mlir::test::isOMLoopTheSameAsNaiveImplFor(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long, long, long, long) (TestLoop.cpp:132)
==74700==    by 0x424D77: main (TestLoop.cpp:170)
```

Now there remain two types of remaining memory leaks. First there is some memory allocated in the compiled model that is not freed.
```
==67421== 24 bytes in 1 blocks are definitely lost in loss record 3 of 91
==67421==    at 0x59E57F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==67421==    by 0x5CCA559: ???
==67421==    by 0x3605437: onnx_mlir::ExecutionSession::run(std::vector<std::unique_ptr<OMTensor, void (*)(OMTensor*)>, std::allocator<std::unique_ptr<OMTensor, void (*)(OMTensor
*)> > >) (ExecutionSession.cpp:89)
==67421==    by 0x4244E0: onnx_mlir::test::isOMLoopTheSameAsNaiveImplFor(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long, long, long, long) 
(TestLoop.cpp:132)
==67421==    by 0x424DCC: main (TestLoop.cpp:171)
```

As I believed it is shown as `==67421==    by 0x5CCA559: ???`... namely a call site in the code that we generated from the model for which the loader has to direct location as it comes from ONNX.

The second leak is due to issues with the ONNX-MLIR compiler, as this model compiles and run the model. Up to now, the above leaks were related to running an inference. Now this is the compiler part of the program. While these should be eliminated, there are less of a concerns as we compile less often than perform inferences.

```
==67421== 1,988 (144 direct, 1,844 indirect) bytes in 1 blocks are definitely lost in loss record 78 of 91
==67421==    at 0x59E5E63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==67421==    by 0x6DD89B: __gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<RuntimeAPI::API const, RuntimeAPI> > >::allocate(unsigned long, void const*) (new_allocator.h:114)
==67421==    by 0x6DD5F0: std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<RuntimeAPI::API const, RuntimeAPI> > > >::allocate(std::allocator<std::_Rb_tree_node<s
td::pair<RuntimeAPI::API const, RuntimeAPI> > >&, unsigned long) (alloc_traits.h:444)
==67421==    by 0x6DD168: std::_Rb_tree<RuntimeAPI::API, std::pair<RuntimeAPI::API const, RuntimeAPI>, std::_Select1st<std::pair<RuntimeAPI::API const, RuntimeAPI> >, std::less<R
untimeAPI::API>, std::allocator<std::pair<RuntimeAPI::API const, RuntimeAPI> > >::_M_get_node() (stl_tree.h:580)
==67421==    by 0x6DC930: std::_Rb_tree_node<std::pair<RuntimeAPI::API const, RuntimeAPI> >* std::_Rb_tree<RuntimeAPI::API, std::pair<RuntimeAPI::API const, RuntimeAPI>, std::_Se
lect1st<std::pair<RuntimeAPI::API const, RuntimeAPI> >, std::less<RuntimeAPI::API>, std::allocator<std::pair<RuntimeAPI::API const, RuntimeAPI> > >::_M_create_node<RuntimeAPI::AP
I&, RuntimeAPI&>(RuntimeAPI::API&, RuntimeAPI&) (stl_tree.h:630)
==67421==    by 0x6DC2A3: std::pair<std::_Rb_tree_iterator<std::pair<RuntimeAPI::API const, RuntimeAPI> >, bool> std::_Rb_tree<RuntimeAPI::API, std::pair<RuntimeAPI::API const, R
untimeAPI>, std::_Select1st<std::pair<RuntimeAPI::API const, RuntimeAPI> >, std::less<RuntimeAPI::API>, std::allocator<std::pair<RuntimeAPI::API const, RuntimeAPI> > >::_M_emplac
e_unique<RuntimeAPI::API&, RuntimeAPI&>(RuntimeAPI::API&, RuntimeAPI&) (stl_tree.h:2408)
==67421==    by 0x6DBBD9: std::pair<std::_Rb_tree_iterator<std::pair<RuntimeAPI::API const, RuntimeAPI> >, bool> std::map<RuntimeAPI::API, RuntimeAPI, std::less<RuntimeAPI::API>,
 std::allocator<std::pair<RuntimeAPI::API const, RuntimeAPI> > >::emplace<RuntimeAPI::API&, RuntimeAPI&>(RuntimeAPI::API&, RuntimeAPI&) (stl_map.h:575)
==67421==    by 0x6DB0F5: RuntimeAPIRegistry::RuntimeAPIRegistry(mlir::ModuleOp&, mlir::OpBuilder&) (RuntimeAPI.cpp:108)
==67421==    by 0x6DA48F: RuntimeAPIRegistry::build(mlir::ModuleOp&, mlir::OpBuilder&) (RuntimeAPI.cpp:69)
==67421==    by 0x6B1BFB: onnx_mlir::krnl::KrnlEntryPointOpLowering::matchAndRewrite(mlir::KrnlEntryPointOp, mlir::PatternRewriter&) const (KrnlEntryPoint.cpp:71)
==67421==    by 0x6BBBF7: mlir::detail::OpOrInterfaceRewritePatternBase<mlir::KrnlEntryPointOp>::matchAndRewrite(mlir::Operation*, mlir::PatternRewriter&) const (PatternMatch.h:3
29)
==67421==    by 0x18C09FC: mlir::PatternApplicator::matchAndRewrite(mlir::Operation*, mlir::PatternRewriter&, llvm::function_ref<bool (mlir::Pattern const&)>, llvm::function_ref<
void (mlir::Pattern const&)>, llvm::function_ref<mlir::LogicalResult (mlir::Pattern const&)>) (in /workdir/onnx-mlir/build/Debug/bin/TestLoop)
```

some leaks might be related to the handling of loops, others may be just other generic compiler stuff.

In summary: before this PR:
```
==74700== LEAK SUMMARY:
==74700==    definitely lost: 9,792 bytes in 58 blocks
==74700==    indirectly lost: 75,690 bytes in 210 blocks
==74700==      possibly lost: 0 bytes in 0 blocks
==74700==    still reachable: 78,092 bytes in 133 blocks
==74700==         suppressed: 0 bytes in 0 blocks
```

With fixes of this PR
```
==67421== LEAK SUMMARY:
==67421==    definitely lost: 9,504 bytes in 34 blocks
==67421==    indirectly lost: 75,498 bytes in 204 blocks
==67421==      possibly lost: 0 bytes in 0 blocks
==67421==    still reachable: 78,092 bytes in 133 blocks
==67421==         suppressed: 0 bytes in 0 blocks
```

A step in the right direction, and important as it target losses during the inference time.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>