### PR TITLE
namespace cleanup

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.hpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.hpp
@@ -21,13 +21,14 @@ void addDynamicallyLegalOpFor(mlir::ConversionTarget *target,
     mlir::ArrayRef<std::string> execNodesOnCpu) {
   target->addDynamicallyLegalOp<OP_TYPE>([execNodesOnCpu](OP_TYPE op) {
     // Check operations to be forced to run on CPU.
-    Operation *genericOp = op.getOperation();
-    StringAttr nodeName =
-        genericOp->getAttrOfType<::mlir::StringAttr>("onnx_node_name");
+    mlir::Operation *genericOp = op.getOperation();
+    mlir::StringAttr nodeName =
+        genericOp->getAttrOfType<mlir::StringAttr>("onnx_node_name");
     if (nodeName) {
-      bool exists = llvm::any_of(execNodesOnCpu, [nodeName](StringRef val) {
-        return nodeName.getValue().equals_insensitive(val);
-      });
+      bool exists =
+          llvm::any_of(execNodesOnCpu, [nodeName](llvm::StringRef val) {
+            return nodeName.getValue().equals_insensitive(val);
+          });
       if (exists)
         return true;
     }
@@ -35,10 +36,10 @@ void addDynamicallyLegalOpFor(mlir::ConversionTarget *target,
     // Check zDNN limitations
     // TODO: Check tensor size NNPA_MAXIMUM_TENSOR_SIZE of another limitation
     bool exceedLimit =
-        llvm::any_of(genericOp->getOperands(), [](Value operand) {
-          if (auto valueType = operand.getType().dyn_cast<ShapedType>()) {
+        llvm::any_of(genericOp->getOperands(), [](mlir::Value operand) {
+          if (auto valueType = operand.getType().dyn_cast<mlir::ShapedType>()) {
             // Check if static dimension size exceeds zDNN limitations
-            ArrayRef<int64_t> valueShape = valueType.getShape();
+            llvm::ArrayRef<int64_t> valueShape = valueType.getShape();
             if (llvm::any_of(valueShape, [](int64_t dim) {
                   return (dim != -1) &&
                          (dim > NNPA_MAXIMUM_DIMENSION_INDEX_SIZE);

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -20,6 +20,8 @@
 
 bool ONNXToKrnl_gEmitDealloc = false;
 
+using namespace mlir;
+
 namespace onnx_mlir {
 
 Value OnnxToKrnlBuilder::reshape(

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -54,18 +54,20 @@ extern bool ONNXToKrnl_gEmitDealloc;
 namespace onnx_mlir {
 
 struct OnnxToKrnlBuilder : public OnnxBuilder {
-  OnnxToKrnlBuilder(OpBuilder &b, Location loc) : OnnxBuilder(b, loc) {}
+  OnnxToKrnlBuilder(mlir::OpBuilder &b, mlir::Location loc)
+      : OnnxBuilder(b, loc) {}
   OnnxToKrnlBuilder(DialectBuilder &db) : OnnxBuilder(db) {}
 
   // Generate an 'onnx.reshape' operation on the 'input' tensor, the new shape
   // is provided by 'shapeDims'.
-  Value reshape(
-      const Value input, const ArrayRef<DimIndexExpr> shapeDims) const;
+  mlir::Value reshape(const mlir::Value input,
+      const llvm::ArrayRef<DimIndexExpr> shapeDims) const;
 
   // Generate a 'onnx.Transpose' operation on the 'input' tensor given the
   // permutation array 'perm' and the operator output dimensions 'outputDims'.
-  Value transpose(const Value input, const ArrayRef<int64_t> perm,
-      const ArrayRef<DimIndexExpr> outputDims) const;
+  mlir::Value transpose(const mlir::Value input,
+      const llvm::ArrayRef<int64_t> perm,
+      const llvm::ArrayRef<DimIndexExpr> outputDims) const;
 };
 
 //===----------------------------------------------------------------------===//
@@ -73,92 +75,101 @@ struct OnnxToKrnlBuilder : public OnnxBuilder {
 //===----------------------------------------------------------------------===//
 
 /// Check if all operands are scalar values at compile time.
-bool hasAllScalarValues(ArrayRef<Value> values);
+bool hasAllScalarValues(llvm::ArrayRef<mlir::Value> values);
 
 /// Check if the value is a KrnlGlobalOp with a dense attribute of non-negative
 /// integer constants.
-bool indicesAreNonNegativeConstants(Value indices);
+bool indicesAreNonNegativeConstants(mlir::Value indices);
 
 /// Insert an allocation and deallocation for the given MemRefType.
-Value insertAllocAndDealloc(MemRefType type, Location loc,
-    PatternRewriter &rewriter, bool insertDealloc, Value operand = nullptr,
-    int64_t alignment = -1);
+mlir::Value insertAllocAndDealloc(mlir::MemRefType type, mlir::Location loc,
+    mlir::PatternRewriter &rewriter, bool insertDealloc,
+    mlir::Value operand = nullptr, int64_t alignment = -1);
 
 // Insert an allocation and deallocation for the given MemRefType, handling
 // compile time relying on the above function, and extracting the runtime
 // definitions from the index expressions otherwise.
-Value insertAllocAndDeallocSimple(PatternRewriter &rewriter, Operation *op,
-    MemRefType type, Location loc, const SmallVectorImpl<IndexExpr> &outputDims,
-    int64_t alignment = -1);
+mlir::Value insertAllocAndDeallocSimple(mlir::PatternRewriter &rewriter,
+    mlir::Operation *op, mlir::MemRefType type, mlir::Location loc,
+    const llvm::SmallVectorImpl<IndexExpr> &outputDims, int64_t alignment = -1);
 // Same where boolean to assert if dealloc is to be gen or not is specified
-Value insertAllocAndDeallocSimple(PatternRewriter &rewriter, Operation *op,
-    MemRefType type, Location loc, const SmallVectorImpl<IndexExpr> &outputDims,
-    bool insertDealloc, int64_t alignment = -1);
+mlir::Value insertAllocAndDeallocSimple(mlir::PatternRewriter &rewriter,
+    mlir::Operation *op, mlir::MemRefType type, mlir::Location loc,
+    const llvm::SmallVectorImpl<IndexExpr> &outputDims, bool insertDealloc,
+    int64_t alignment = -1);
 
 // Determine if current function returns the result value of the
 // current op being lowered. If it does then dealloc should not be
 // inserted.
-bool checkInsertDealloc(Operation *currentOp, int resultIndex = 0);
+bool checkInsertDealloc(mlir::Operation *currentOp, int resultIndex = 0);
 
 // Create a mapping from result type's dimensions to input type's dimensions,
 // given that the result type is the result of a reduction op over the input
 // type.
 std::map<int64_t, int64_t> getReductionMapping(
-    MemRefType inputTy, ArrayRef<int64_t> axes, bool keepdims);
+    mlir::MemRefType inputTy, llvm::ArrayRef<int64_t> axes, bool keepdims);
 
 // Add bounds associated with the op operand to the KRNL iteration pack.
 // Dynamic dimensions are supported.
-void addDimensionToPack(ConversionPatternRewriter &rewriter, Location loc,
-    krnl::KrnlIterateOperandPack &pack, Value operand, int index);
+void addDimensionToPack(mlir::ConversionPatternRewriter &rewriter,
+    mlir::Location loc, krnl::KrnlIterateOperandPack &pack, mlir::Value operand,
+    int index);
 
 // Function that emits the define_loop operation to define `numLoops`
 // number of krnl loops, and fill `loop` with the newly defined loops.
-void defineLoops(ConversionPatternRewriter &rewriter, Location loc,
-    std::vector<Value> &loops, int64_t numLoops);
+void defineLoops(mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
+    std::vector<mlir::Value> &loops, int64_t numLoops);
 
 /// Get a dimension value from a memref. Emit a constant if the dimension is
 /// constant. Otherwise, emit a dim op.
 /// If the return type is different from IndexType, emit a cast op to cast the
 /// output of the dim op.
-Value getDimOrConstant(ConversionPatternRewriter &rewriter, Location loc,
-    Value operand, int64_t axis, Type type);
+mlir::Value getDimOrConstant(mlir::ConversionPatternRewriter &rewriter,
+    mlir::Location loc, mlir::Value operand, int64_t axis, mlir::Type type);
 
 /// Emit an ONNXSqueezeOp. If the input is constant, do const propagation, and
 /// return a constant.
-Value foldOrEmitONNXSqueezeV11Op(ConversionPatternRewriter &rewriter,
-    Location loc, Type resultType, Value input, int64_t axis);
+mlir::Value foldOrEmitONNXSqueezeV11Op(
+    mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
+    mlir::Type resultType, mlir::Value input, int64_t axis);
 
 /// Emit an ONNXUnsqueezeOp. If the input is constant, do const propagation, and
 /// return a constant.
-Value foldOrEmitONNXUnsqueezeV11Op(ConversionPatternRewriter &rewriter,
-    Location loc, Type resultType, Value input, int64_t axis);
+mlir::Value foldOrEmitONNXUnsqueezeV11Op(
+    mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
+    mlir::Type resultType, mlir::Value input, int64_t axis);
 
 /// Emit an ONNXSplitOp. If the input is constant, do const propagation, and
 /// return constants.
 /// Only support evenly splitting.
-std::vector<Value> foldOrEmitONNXSplitOp(ConversionPatternRewriter &rewriter,
-    Location loc, ArrayRef<Type> resultTypes, Value input, int64_t axis);
+std::vector<mlir::Value> foldOrEmitONNXSplitOp(
+    mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
+    llvm::ArrayRef<mlir::Type> resultTypes, mlir::Value input, int64_t axis);
 
 /// Emit an ONNXTransposeOp. If the input is constant, do const propagation, and
 /// return a constant.
-Value foldOrEmitONNXTransposeOp(ConversionPatternRewriter &rewriter,
-    Location loc, Type resultType, Value input, ArrayAttr permAttr);
+mlir::Value foldOrEmitONNXTransposeOp(mlir::ConversionPatternRewriter &rewriter,
+    mlir::Location loc, mlir::Type resultType, mlir::Value input,
+    mlir::ArrayAttr permAttr);
 
 /// Emit MemRef ReinterpretCastOp to create a new view for 'data'.
 /// The new view is created using the given 'outputDims'.
-Value emitMemRefReinterpretCastOp(ConversionPatternRewriter &rewriter,
-    Location loc, Value data, SmallVectorImpl<IndexExpr> &outputDims,
-    Type outputType);
+mlir::Value emitMemRefReinterpretCastOp(
+    mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
+    mlir::Value data, llvm::SmallVectorImpl<IndexExpr> &outputDims,
+    mlir::Type outputType);
 
 /// Emit krnl iterate to compute argsort of a given MemRef along a given axis.
 /// Output MemRef has the same shape as the input MemRef but is of IndexType.
-Value emitArgSort(ConversionPatternRewriter &rewriter, Location loc,
-    Value input, int64_t axis, bool ascending = false);
+mlir::Value emitArgSort(mlir::ConversionPatternRewriter &rewriter,
+    mlir::Location loc, mlir::Value input, int64_t axis,
+    bool ascending = false);
 
 /// Return a DenseElementAttr of a KrnlGlobalOp or ONNXConstantOp.
 /// This function satisfies the ArrayValueIndexCapture::DenseElementsAttr
 /// lambda type, using ONNX and Krnl operations.
-DenseElementsAttr getDenseElementAttributeFromConstantValue(Value value);
+mlir::DenseElementsAttr getDenseElementAttributeFromConstantValue(
+    mlir::Value value);
 
 //===----------------------------------------------------------------------===//
 // This is to get a scalar operation of a given type for a specific operation.
@@ -178,8 +189,8 @@ using ScalarIOp = typename ScalarOp<IOp>::IOp;
 // Return NULL if the function does not have identity.
 // Specialize this for a new Op.
 template <typename Op>
-Value getIdentityValue(
-    ConversionPatternRewriter &rewriter, Location loc, Type type) {
+mlir::Value getIdentityValue(mlir::ConversionPatternRewriter &rewriter,
+    mlir::Location loc, mlir::Type type) {
   return nullptr;
 }
 
@@ -189,12 +200,13 @@ Value getIdentityValue(
 // Use template specialization for each of different ONNX operations.
 //===----------------------------------------------------------------------===//
 template <typename Op>
-Value emitScalarOpFor(ConversionPatternRewriter &rewriter, Location loc,
-    Operation *op, Type elementType, ArrayRef<Value> scalarOperands) {
-  if (elementType.isa<IntegerType>()) {
+mlir::Value emitScalarOpFor(mlir::ConversionPatternRewriter &rewriter,
+    mlir::Location loc, mlir::Operation *op, mlir::Type elementType,
+    llvm::ArrayRef<mlir::Value> scalarOperands) {
+  if (elementType.isa<mlir::IntegerType>()) {
     return rewriter.create<ScalarIOp<Op>>(
         loc, elementType, scalarOperands, mlir::None);
-  } else if (elementType.isa<FloatType>()) {
+  } else if (elementType.isa<mlir::FloatType>()) {
     return rewriter.create<ScalarFOp<Op>>(
         loc, elementType, scalarOperands, mlir::None);
   } else {
@@ -208,25 +220,23 @@ Value emitScalarOpFor(ConversionPatternRewriter &rewriter, Location loc,
 //   - from onnx.StringType to krnl.StringType
 //===----------------------------------------------------------------------===//
 
-class KrnlTypeConverter : public TypeConverter {
+class KrnlTypeConverter : public mlir::TypeConverter {
 public:
-  using TypeConverter::TypeConverter;
-
   KrnlTypeConverter();
 
   /// Return true if the inputs and outputs of the given function type are
   /// legal. [Taken from MLIR and adapted to only check the legality of the
   /// inputs. Once unranked results can be handled gracefully this
   /// override needs to be removed in favour of the original MLIR one.]
-  bool isSignatureLegal(FunctionType funcType) {
-    return llvm::all_of(
-        llvm::concat<const Type>(funcType.getInputs(), funcType.getResults()),
-        [this](Type type) { return isLegal(type); });
+  bool isSignatureLegal(mlir::FunctionType funcType) {
+    return llvm::all_of(llvm::concat<const mlir::Type>(
+                            funcType.getInputs(), funcType.getResults()),
+        [this](mlir::Type type) { return isLegal(type); });
   }
 
   /// Return true if the operands/results of call have a legal type.
   bool isSignatureLegal(mlir::func::CallOp call) {
-    auto f = [this](Type type) { return isLegal(type); };
+    auto f = [this](mlir::Type type) { return isLegal(type); };
     return llvm::all_of(call.getOperandTypes(), f) &&
            llvm::all_of(call.getResultTypes(), f);
   }
@@ -237,154 +247,154 @@ public:
 //===----------------------------------------------------------------------===//
 
 // For all ONNX operations.
-void populateONNXToKrnlConversionPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *, bool enableTiling);
+void populateONNXToKrnlConversionPattern(mlir::RewritePatternSet &,
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling);
 
 // `ControlFlow` directory methods:
 void populateLoweringONNXIfOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXLoopOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXScanOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
 // `Math` directory methods:
 void populateLoweringONNXClipOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXCumSumOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXElementwiseOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
-void populateLoweringONNXGemmOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *, bool enableTiling);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXGemmOpPattern(mlir::RewritePatternSet &,
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling);
 void populateLoweringONNXHardmaxOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXLRNOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
-void populateLoweringONNXMatMulOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *, bool enableTiling);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXMatMulOpPattern(mlir::RewritePatternSet &,
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling);
 void populateLoweringONNXRandomNormalOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXRandomNormalLikeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXReductionOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSoftmaxOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXTopKOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
 // `ML` directory methods:
 void populateLoweringONNXCategoryMapperOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
 // `NN` directory methods:
-void populateLoweringONNXConvOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *, bool enableTiling);
+void populateLoweringONNXConvOpPattern(mlir::RewritePatternSet &,
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling);
 void populateLoweringONNXNormalizationOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXPoolingOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
 // `ObjectDetection` directory methods:
 void populateLoweringONNXNonMaxSuppressionOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
 // `RNN` directory methods:
 void populateLoweringONNXGRUOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXLSTMOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXRNNOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
 // `Sequence` directory methods:
 void populateLoweringONNXSequenceAtOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSequenceEmptyOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSequenceEraseOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSequenceInsertOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSequenceLengthOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
 // `Tensor` directory methods:
 void populateLoweringONNXArgMinMaxOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXDimOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXUnsqueezeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXUnsqueezeV11OpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXTransposeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXGatherOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXGatherElementsOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXGatherNDOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXPadConstantValuePadOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXPadOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXRangeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXReshapeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXIdentityOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXConstantOfShapeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXConstantOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXConcatOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXDepthToSpaceOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSpaceToDepthOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXScatterElementsOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXScatterNDOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXShapeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSliceOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSqueezeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSqueezeV11OpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSplitOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSplitV11OpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXSizeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXTileOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXFlattenOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXResizeOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXNonZeroOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXReverseSequenceOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXExpandOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXOneHotOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXCompressOpPattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXPrintSignaturePattern(
-    RewritePatternSet &, TypeConverter &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
-bool checkOpResultIsUsedByGetRef(memref::AllocOp *allocOp);
+bool checkOpResultIsUsedByGetRef(mlir::memref::AllocOp *allocOp);
 
 /// This function returns the index in the list of alloc arguments of the
 /// dynamic dimension corresponding to `index` in the MemRef shape.
@@ -395,7 +405,7 @@ bool checkOpResultIsUsedByGetRef(memref::AllocOp *allocOp);
 /// In the above alloc the list of alloc arguments is being represented by
 /// %d0, %d1 and %d2. Their indices 0, 1, 2 correspond to `index` values
 /// 1, 2 and 4 in the MemRef shape respectively
-int64_t getAllocArgIndex(memref::AllocOp allocOp, int64_t index);
+int64_t getAllocArgIndex(mlir::memref::AllocOp allocOp, int64_t index);
 
 /// This function returns a location with the corresponding ONNX operator name
 /// inside. This is useful when tracing what expanded MLIR instructions
@@ -403,16 +413,17 @@ int64_t getAllocArgIndex(memref::AllocOp allocOp, int64_t index);
 ///
 ///
 template <typename OP_TYPE>
-Location ONNXLoc(Operation *op) {
-  return NameLoc::get(
-      StringAttr::get(op->getContext(), OP_TYPE::getOperationName()),
+mlir::Location ONNXLoc(mlir::Operation *op) {
+  return mlir::NameLoc::get(
+      mlir::StringAttr::get(op->getContext(), OP_TYPE::getOperationName()),
       op->getLoc());
 }
 
 /// This function returns a scalar of type 'dtype' from an optional value.
 /// Optional value must be: NoneType, memref<1xdtype> or memref<dtype>.
 /// Default value is used in case of NoneType.
-Value getOptionalScalarValue(ConversionPatternRewriter &rewriter, Location loc,
-    Value optionalScalar, Type elementType, double defaultValue);
+mlir::Value getOptionalScalarValue(mlir::ConversionPatternRewriter &rewriter,
+    mlir::Location loc, mlir::Value optionalScalar, mlir::Type elementType,
+    double defaultValue);
 
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToMhlo/ONNXToMhloCommon.cpp
+++ b/src/Conversion/ONNXToMhlo/ONNXToMhloCommon.cpp
@@ -15,6 +15,8 @@
 
 #include "src/Conversion/ONNXToMhlo/ONNXToMhloCommon.hpp"
 
+using namespace mlir;
+
 namespace onnx_mlir {
 
 Value getShapedZero(Location loc, ConversionPatternRewriter &rewriter,

--- a/src/Conversion/ONNXToMhlo/ONNXToMhloCommon.hpp
+++ b/src/Conversion/ONNXToMhlo/ONNXToMhloCommon.hpp
@@ -54,28 +54,29 @@ using MhloOp = typename MhloDialectOp<ONNXOp>::Op;
 // Common functions used when lowering the ONNX frontend dialect to MHLO.
 //===----------------------------------------------------------------------===//
 
-// Get shaped constant zero for the given input Type. If the input type doesn't
-// have static shape, then add dynamic broadcast.
-Value getShapedZero(Location loc, ConversionPatternRewriter &rewriter,
-    const ShapedType &inpType, Value &inp, const Type &resultType);
+// Get shaped constant zero for the given input mlir::Type. If the input type
+// doesn't have static shape, then add dynamic broadcast.
+mlir::Value getShapedZero(mlir::Location loc,
+    mlir::ConversionPatternRewriter &rewriter, const mlir::ShapedType &inpType,
+    mlir::Value &inp, const mlir::Type &resultType);
 
-// Get shaped constant for the given input Type and float value. If the input
-// type doesn't have static shape, then add dynamic broadcast.
+// Get shaped constant for the given input mlir::Type and float value. If the
+// input type doesn't have static shape, then add dynamic broadcast.
 template <typename T>
-Value getShapedFloat(Location loc, ConversionPatternRewriter &rewriter,
-    const ShapedType &inpType, const T &value, Value &inp,
-    const Type &resultType) {
-  Value broadcastedValue;
+mlir::Value getShapedFloat(mlir::Location loc,
+    mlir::ConversionPatternRewriter &rewriter, const mlir::ShapedType &inpType,
+    const T &value, mlir::Value &inp, const mlir::Type &resultType) {
+  mlir::Value broadcastedValue;
   if (inpType.hasStaticShape())
-    broadcastedValue = rewriter.create<mhlo::ConstantOp>(
-        loc, DenseElementsAttr::get(inpType,
+    broadcastedValue = rewriter.create<mlir::mhlo::ConstantOp>(
+        loc, mlir::DenseElementsAttr::get(inpType,
                  rewriter.getFloatAttr(inpType.getElementType(), value)));
   else {
-    Type elemType = inpType.getElementType();
-    Value floatValue = rewriter.create<mhlo::ConstantOp>(
+    mlir::Type elemType = inpType.getElementType();
+    mlir::Value floatValue = rewriter.create<mlir::mhlo::ConstantOp>(
         loc, rewriter.getFloatAttr(elemType, value));
-    Value shape = rewriter.create<shape::ShapeOfOp>(loc, inp);
-    broadcastedValue = rewriter.create<mhlo::DynamicBroadcastInDimOp>(
+    mlir::Value shape = rewriter.create<mlir::shape::ShapeOfOp>(loc, inp);
+    broadcastedValue = rewriter.create<mlir::mhlo::DynamicBroadcastInDimOp>(
         loc, resultType, floatValue, shape, rewriter.getI64TensorAttr({}));
   }
   return broadcastedValue;
@@ -83,21 +84,21 @@ Value getShapedFloat(Location loc, ConversionPatternRewriter &rewriter,
 
 // `Math` directory methods:
 void populateLoweringONNXElementwiseOpToMhloPattern(
-    RewritePatternSet &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::MLIRContext *);
 void populateLoweringONNXGemmOpToMhloPattern(
-    RewritePatternSet &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::MLIRContext *);
 void populateLoweringONNXReductionOpToMhloPattern(
-    RewritePatternSet &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::MLIRContext *);
 // `NN` directory methods:
 void populateLoweringONNXNormalizationOpToMhloPattern(
-    RewritePatternSet &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::MLIRContext *);
 void populateLoweringONNXPoolingOpToMhloPattern(
-    RewritePatternSet &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::MLIRContext *);
 // `Tensor` directory methods:
 void populateLoweringONNXConcatOpToMhloPattern(
-    RewritePatternSet &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::MLIRContext *);
 void populateLoweringONNXConstantOpToMhloPattern(
-    RewritePatternSet &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::MLIRContext *);
 void populateLoweringONNXReshapeOpToMhloPattern(
-    RewritePatternSet &, MLIRContext *);
+    mlir::RewritePatternSet &, mlir::MLIRContext *);
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -36,15 +36,15 @@ namespace onnx_mlir {
 // Check for valid TOSA types.
 //===----------------------------------------------------------------------===//
 
-inline bool isTOSASignedInt(Type type) {
-  IntegerType intType = type.dyn_cast<IntegerType>();
+inline bool isTOSASignedInt(mlir::Type type) {
+  mlir::IntegerType intType = type.dyn_cast<mlir::IntegerType>();
   std::set<unsigned> intWidth{8, 16, 32, 48, 64};
   return intType && intType.isSigned() &&
          (intWidth.find(intType.getWidth()) != intWidth.end());
 }
 
-inline bool isTOSAFloat(Type type) {
-  return type.isa<BFloat16Type, Float16Type, Float32Type>();
+inline bool isTOSAFloat(mlir::Type type) {
+  return type.isa<mlir::BFloat16Type, mlir::Float16Type, mlir::Float32Type>();
 }
 
 //===----------------------------------------------------------------------===//
@@ -59,6 +59,6 @@ template <typename Op>
 using TOSAOp = typename TOSADialectOp<Op>::Op;
 
 // `Math` directory methods:
-void populateLoweringONNXElementwiseOpToTOSAPattern(
-    ConversionTarget &, RewritePatternSet &, TypeConverter &, MLIRContext *);
+void populateLoweringONNXElementwiseOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 } // namespace onnx_mlir

--- a/src/Transform/ONNX/ConstPropHelper.cpp
+++ b/src/Transform/ONNX/ConstPropHelper.cpp
@@ -22,7 +22,8 @@
 #include "src/Support/TypeUtilities.hpp"
 
 using namespace mlir;
-using namespace onnx_mlir;
+
+namespace onnx_mlir {
 
 /// Get the size of a tensor from its ranked type in bytes, using the largest
 /// precision.
@@ -299,3 +300,5 @@ template void copyAndCastArr<int64_t, float>(
     char *srcRawArr, char *destRawArr, int64_t size);
 template void copyAndCastArr<int64_t, double>(
     char *srcRawArr, char *destRawArr, int64_t size);
+
+} // namespace onnx_mlir

--- a/src/Transform/ONNX/ConstPropHelper.hpp
+++ b/src/Transform/ONNX/ConstPropHelper.hpp
@@ -26,7 +26,7 @@
 
 #include <math.h>
 
-using namespace mlir;
+namespace onnx_mlir {
 
 /// Get the size of a tensor from its ranked type in bytes, using the largest
 /// precision.
@@ -61,15 +61,17 @@ void copyAndCastArr(char *srcRawArr, char *destRawArr, int64_t size);
 /// element type is the one of 'outType' (smaller precision). It does not
 /// support converting from floating point to integer and vise versa.
 void convertDoubleInt64ToExactType(
-    Type destType, char *srcRawArr, char *destRawArr);
+    mlir::Type destType, char *srcRawArr, char *destRawArr);
 
 /// Constant propagation for split.
-void ConstPropSplitImpl(Type elementType, char *constArray,
+void ConstPropSplitImpl(mlir::Type elementType, char *constArray,
     llvm::ArrayRef<int64_t> constShape, uint64_t splitAxis,
     llvm::ArrayRef<int64_t> splitOffsets,
     llvm::ArrayRef<mlir::Type> replacingTypes, std::vector<char *> &resBuffers);
 
 /// Constant propagation for transpose.
-void ConstPropTransposeImpl(Type elementType, char *constArray,
+void ConstPropTransposeImpl(mlir::Type elementType, char *constArray,
     llvm::ArrayRef<int64_t> constShape, llvm::ArrayRef<uint64_t> perm,
     llvm::ArrayRef<int64_t> resShape, char *resArray);
+
+} // namespace onnx_mlir


### PR DESCRIPTION
removed `using namespace mlir` from ConstPropHelper.hpp and added requisite `mlir::` and `llvm::` in header files to get everything to compile again

also put ConstPropHelper definitions in namespace onnx_mlir

Signed-off-by: Soren Lassen <sorenlassen@gmail.com>