### PR TITLE
Handle scalar tensor tensor<type> in SimplifyShapeRelatesOps pass

### DIFF
--- a/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
+++ b/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
@@ -45,6 +45,26 @@ func.func @test_shape_to_dim_negative_axis(%arg0: tensor<?x256x?xi64>) -> (tenso
 
 // -----
 
+func.func @test_pass_dims_scalar(%arg0: tensor<?x?x200xf32>) -> tensor<i64> {
+  %0 = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+  %1 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<?x?x200xf32>) -> tensor<1xi64>
+  %2 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?x200xf32>) -> tensor<1xi64>
+  %3 = "onnx.Constant"() {value = dense<200> : tensor<1xi64>} : () -> tensor<1xi64>
+  %4 = "onnx.Concat"(%1, %2, %3) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
+  %5 = "onnx.Gather"(%4, %0) {axis = 0 : si64} : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+  return %5 : tensor<i64>
+
+// CHECK-LABEL:  func.func @test_pass_dims_scalar
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x200xf32>) -> tensor<i64> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x?x200xf32>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Constant"() {value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Squeeze"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xi64>, tensor<1xi64>) -> tensor<i64>
+// CHECK:           return [[VAR_2_]] : tensor<i64>
+// CHECK:         }
+}
+
+// -----
+
 func.func @test_pass_dims_through_cast(%arg0: tensor<?x256xi64>) -> (tensor<2xf32>) {
   %0 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
   %1 = "onnx.Constant"() {value = dense<256> : tensor<1xi64>} : () -> tensor<1xi64>


### PR DESCRIPTION
Some ops to process shape return a scalar tensor `tensor<i64>` instead of `tensor<1xi64>`, while our SimplifyShapeRelatesOps pass always use `tensor<1xi64>`. So we need to convert `tensor<1xi64>` to `tensor<i64>` by a squeeze op.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>