### PR TITLE
fix two sprintf compiler warnings

### DIFF
--- a/src/Runtime/OMIndexLookup.inc
+++ b/src/Runtime/OMIndexLookup.inc
@@ -34,7 +34,7 @@ static inline uint32_t hash_string(uint32_t hval, const char *str) {
 // Adaptation of 32-bit FNV for int64_t values.
 static inline uint32_t hash_int64(uint32_t hval, int64_t val) {
   char str[20];
-  sprintf(str, "%lld", (long long)val);
+  snprintf(str, sizeof(str), "%lld", (long long)val);
   return hash_string(hval, str);
 }
 

--- a/src/Runtime/OMInstrument.inc
+++ b/src/Runtime/OMInstrument.inc
@@ -129,7 +129,7 @@ void ReportMemory() {
   char memOutput[200];
   FILE *memPipe;
   mypid = getpid();
-  sprintf(memCommand, "ps -o vsz='' -p %d", mypid);
+  snprintf(memCommand, sizeof(memCommand), "ps -o vsz='' -p %d", mypid);
   memPipe = popen(memCommand, "r");
   if (!memPipe) {
     if (psErrorCount > 20)


### PR DESCRIPTION
saw this warning with clang version 14.0.0 on mac:
```
.../src/Runtime/OMIndexLookup.inc:37:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  sprintf(str, "%lld", (long long)val);
```

Signed-off-by: Soren Lassen <sorenlassen@gmail.com>