### PR TITLE
Another place in ScanOp::inferShapes needs refineShape=false

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -5111,7 +5111,8 @@ LogicalResult ONNXScanOp::inferShapes(
         scan_inputs().front().getType().cast<ShapedType>().getDimSize(0);
     unsqueezedShape.insert(unsqueezedShape.begin(), scanExtent);
     updateType(std::get<0>(vScanOutputValToTy), unsqueezedShape,
-        rankedScanTy.getElementType());
+        rankedScanTy.getElementType(), /*encoding=*/nullptr,
+        /*refineShape=*/false);
   }
 
   return success();


### PR DESCRIPTION
Complementary to #1767.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>