### PR TITLE
Add value info fix

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -333,7 +333,7 @@ private:
     // Import the input tensor types that are not constant and not initialized.
     int inputIndex = 0;
     for (const auto &input : graph.input()) {
-      AddValueInfo(input);
+      AddValueInfo(input, true);
       if (initializerNames.count(input.name()) == 0) {
         inputNames.push_back(input.name());
         Type argTy = ImportType(input.type());


### PR DESCRIPTION
2 data points for why this is helpful

--------

ONNX Extractor is an open source python library for chopping an onnx model. There are two outstanding issues with its generated onnx file.

1. There is an extra `value_info` field for each input and output which is technically redundant and can be deleted.
1. Sometimes there are more than one `value_info` for each constant. Base on my observation they are all redundant and has the same value.

New `onnx-mlir` is unnecessarily harsh about redundancy between `value_info`s. We should emit a warning if there is a redundant (but the same) value info and move on, instead of giving up.

---------

we were able to compile 9 models using our ML Agility framework. When using the latest version of the compiler (pulled from head April 4th at night) only 2 models are compiling. All of those 7 models that used to work are showing the same exact error message:
groq-compiler: ../src/Builder/SymbolTable.hpp:129: void onnx_mlir::SymbolMapping<T>::AddMapping(const string&, T) [with T = onnx::TypeProto; std::string = std::__cxx11::basic_string<char>]: Assertion !scopes.back().contain(name) && "Tensor already exists."' failed.