### PR TITLE
Create unique QuestionMarkIndexExpr by using a hash code of tensor and axis

### DIFF
--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -1165,11 +1165,12 @@ QuestionmarkIndexExpr::QuestionmarkIndexExpr() : IndexExpr() {
   indexExprObj->initAsQuestionmark();
 }
 
-QuestionmarkIndexExpr::QuestionmarkIndexExpr(Value val, int64_t axis)
+QuestionmarkIndexExpr::QuestionmarkIndexExpr(
+    Value tensorOrMemref, int64_t index)
     : IndexExpr() {
   indexExprObj = new IndexExprImpl();
   assert(indexExprObj && "failed to allocate IndexExpr implementation");
-  indexExprObj->initAsQuestionmark(val, axis);
+  indexExprObj->initAsQuestionmark(tensorOrMemref, index);
 }
 // Don't care about otherIndexExpr as question marks have no real data.
 

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -1165,6 +1165,12 @@ QuestionmarkIndexExpr::QuestionmarkIndexExpr() : IndexExpr() {
   indexExprObj->initAsQuestionmark();
 }
 
+QuestionmarkIndexExpr::QuestionmarkIndexExpr(Value val, int64_t axis)
+    : IndexExpr() {
+  indexExprObj = new IndexExprImpl();
+  assert(indexExprObj && "failed to allocate IndexExpr implementation");
+  indexExprObj->initAsQuestionmark(val, axis);
+}
 // Don't care about otherIndexExpr as question marks have no real data.
 
 QuestionmarkIndexExpr::QuestionmarkIndexExpr(IndexExpr const &o)
@@ -1666,7 +1672,8 @@ IndexExpr MemRefBoundsIndexCapture::get(uint64_t i) {
   IndexExprScope &scope = IndexExprScope::getCurrentScope();
   if (scope.isShapeInferencePass()) {
     // Not a constant; don't add code.
-    return QuestionmarkIndexExpr();
+    // Create a unique question mark for dimension i of tensorOrMemref.
+    return QuestionmarkIndexExpr(tensorOrMemref, i);
   }
 
   MemRefBuilder createMemRef(scope.getRewriter(), scope.getLoc());

--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -631,7 +631,11 @@ private:
 class QuestionmarkIndexExpr : public IndexExpr {
 public:
   QuestionmarkIndexExpr();
-  QuestionmarkIndexExpr(mlir::Value val, int64_t axis);
+  // Constuct a question mark for an unknown dimension in a Tensor/Memref.
+  // This constructor is needed for symbolic shape analysis where each
+  // question mark is assigned to a unique value hashed from the given
+  // tensorOrMemref and dimension index.
+  QuestionmarkIndexExpr(mlir::Value tensorOrMemref, int64_t index);
   QuestionmarkIndexExpr(IndexExpr const &o);
   QuestionmarkIndexExpr(UndefinedIndexExpr const &o);
   QuestionmarkIndexExpr(LiteralIndexExpr const &o);

--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -631,6 +631,7 @@ private:
 class QuestionmarkIndexExpr : public IndexExpr {
 public:
   QuestionmarkIndexExpr();
+  QuestionmarkIndexExpr(mlir::Value val, int64_t axis);
   QuestionmarkIndexExpr(IndexExpr const &o);
   QuestionmarkIndexExpr(UndefinedIndexExpr const &o);
   QuestionmarkIndexExpr(LiteralIndexExpr const &o);

--- a/src/Dialect/Mlir/IndexExprDetail.cpp
+++ b/src/Dialect/Mlir/IndexExprDetail.cpp
@@ -55,11 +55,14 @@ void IndexExprImpl::initAsQuestionmark() {
       AffineExpr(nullptr), Value(nullptr));
 }
 
-void IndexExprImpl::initAsQuestionmark(Value val, int64_t axis) {
+void IndexExprImpl::initAsQuestionmark(Value tensorOrMemref, int64_t index) {
   // Each question mark is assigned a unique integer that is obtained
-  // by hashing the tensor value and the target axis/dimension.
-  llvm::hash_code questionValue =
-      llvm::hash_combine(mlir::hash_value(val), llvm::hash_value(axis));
+  // by hashing the tensor/memref value and the target dimension index.
+  // According to `llvm/ADT/hashing.h`, a hash value is per execution of the
+  // program. Thus, it should not be trusted to be stable or predictable across
+  // processes or executions.
+  llvm::hash_code questionValue = llvm::hash_combine(
+      mlir::hash_value(tensorOrMemref), llvm::hash_value(index));
   init(/*isDefined*/ true, /*literal*/ false, IndexExprKind::Questionmark,
       questionValue, AffineExpr(nullptr), Value(nullptr));
 }

--- a/src/Dialect/Mlir/IndexExprDetail.hpp
+++ b/src/Dialect/Mlir/IndexExprDetail.hpp
@@ -18,8 +18,6 @@
 
 #include "src/Dialect/Mlir/IndexExpr.hpp"
 
-extern int64_t IndexExpr_gQuestionMarkCounter;
-
 namespace onnx_mlir {
 
 // Implementation of the IndexExpr. In nearly all cases, the value described by
@@ -36,6 +34,7 @@ public:
   // Basic initialization calls.
   void initAsUndefined();
   void initAsQuestionmark();
+  void initAsQuestionmark(mlir::Value val, int64_t axis);
   void initAsLiteral(int64_t const value, IndexExprKind const kind);
   void initAsKind(mlir::Value const value, IndexExprKind const kind);
   void initAsAffineExpr(mlir::AffineExpr const value);

--- a/src/Dialect/Mlir/IndexExprDetail.hpp
+++ b/src/Dialect/Mlir/IndexExprDetail.hpp
@@ -33,8 +33,13 @@ public:
 
   // Basic initialization calls.
   void initAsUndefined();
+  // Initialize a question mark with the default value of -1.
   void initAsQuestionmark();
-  void initAsQuestionmark(mlir::Value val, int64_t axis);
+  // Initialize a question mark for an unknown dimension in a Tensor/Memref.
+  // This initialization is needed for symbolic shape analysis where each
+  // question mark is assigned to a unique value hashed from the given
+  // tensorOrMemref and dimension index.
+  void initAsQuestionmark(mlir::Value tensorOrMemref, int64_t index);
   void initAsLiteral(int64_t const value, IndexExprKind const kind);
   void initAsKind(mlir::Value const value, IndexExprKind const kind);
   void initAsAffineExpr(mlir::AffineExpr const value);


### PR DESCRIPTION
Problem: given a tensor value, to do shape computation we call `MemRefBoundsIndexCapture(val)` e.g.
```c
Value data = operandAdaptor.data();
MemRefBoundsIndexCapture dataBounds(data);
```
Assume that axis 2 is an unknown dimension and now we get the QuestionMarkIndexExpr of it.
```c
QuestionMarkIndexExpr dim = dataBounds.getDim(2);
int64_t questionMarkValue = dim.getQuestionmark();
```
The problem is: everytime we call `dataBounds.getDim(2)`, a new QuestionMarkIndexExpr is created and its value is changed.

To keep the question mark value unchanged for a specific axis of a tensor, this patch uses a hash_code, that is a hash combination of the tensor value and axis, for the question mark value. 


Signed-off-by: Tung D. Le <tung@jp.ibm.com>