### PR TITLE
Use IndexExpr to compute shape for unary element-wise ops

### DIFF
--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -847,15 +847,16 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
            "Failed to convert type to MemRefType");
     MemRefType memRefType = convertedType.cast<MemRefType>();
 
-    // Insert an allocation and deallocation for the result of this operation.
-    Value alloc;
-    bool insertDealloc = checkInsertDealloc(op);
+    // Shape helper.
+    ONNXGenericOpUnaryElementwiseShapeHelper shapeHelper(op, &rewriter,
+        krnl::getDenseElementAttributeFromKrnlValue,
+        krnl::loadDenseElementArrayValueAtIndex, /*in scope*/ nullptr);
+    auto shapecomputed = shapeHelper.computeShape(X);
+    assert(succeeded(shapecomputed) && "Could not compute output shape");
 
-    if (hasAllConstantDimensions(memRefType))
-      alloc = insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc);
-    else
-      alloc =
-          insertAllocAndDealloc(memRefType, loc, rewriter, insertDealloc, X);
+    // Insert an allocation and deallocation for the result of this operation.
+    Value alloc = insertAllocAndDeallocSimple(
+        rewriter, op, memRefType, loc, shapeHelper.dimsForOutput());
 
     KrnlBuilder createKrnl(rewriter, loc);
     // Only create krnl.iterate if one of the operands is not scalar tensor.

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -854,7 +854,7 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
     auto shapecomputed = shapeHelper.computeShape(X);
     assert(succeeded(shapecomputed) && "Could not compute output shape");
 
-    // Insert an allocation and deallocation for the result of this operation.
+    // Insert an allocation for the result of this operation.
     Value alloc = insertAllocAndDeallocSimple(
         rewriter, op, memRefType, loc, shapeHelper.dimsForOutput());
 

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
@@ -151,7 +151,7 @@ LogicalResult ONNXGenericOpUnaryElementwiseShapeHelper::computeShape(
   // Output and input have the same shape. Just pass the input shape to the
   // output.
   MemRefBoundsIndexCapture bounds(operand);
-  for (int64_t i = 0; i < bounds.getRank(); ++i)
+  for (uint64_t i = 0; i < bounds.getRank(); ++i)
     outputDims.emplace_back(bounds.getDim(i));
 
   setOutputDims(outputDims);

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.cpp
@@ -129,6 +129,36 @@ void ONNXOpShapeHelper<OP>::setOutputDims(DimsExpr inferredDims, int n) {
 }
 
 //===----------------------------------------------------------------------===//
+// ONNX Op Shape Helper for Generic Unary Elementwise Operations
+//===----------------------------------------------------------------------===//
+
+ONNXGenericOpUnaryElementwiseShapeHelper::
+    ONNXGenericOpUnaryElementwiseShapeHelper(
+        Operation *newOp, IndexExprScope *inScope)
+    : ONNXOpShapeHelper<Operation>(newOp, 1, inScope) {}
+
+ONNXGenericOpUnaryElementwiseShapeHelper::
+    ONNXGenericOpUnaryElementwiseShapeHelper(Operation *newOp,
+        mlir::OpBuilder *rewriter,
+        ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+        ArrayValueIndexCapture::LoadVal fLoadVal, IndexExprScope *inScope)
+    : ONNXOpShapeHelper<Operation>(
+          newOp, 1, rewriter, fGetDenseVal, fLoadVal, inScope) {}
+
+LogicalResult ONNXGenericOpUnaryElementwiseShapeHelper::computeShape(
+    Value operand) {
+  DimsExpr outputDims;
+  // Output and input have the same shape. Just pass the input shape to the
+  // output.
+  MemRefBoundsIndexCapture bounds(operand);
+  for (int64_t i = 0; i < bounds.getRank(); ++i)
+    outputDims.emplace_back(bounds.getDim(i));
+
+  setOutputDims(outputDims);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ONNX Op Shape Helper for Broadcasting
 //===----------------------------------------------------------------------===//
 
@@ -471,10 +501,16 @@ LogicalResult inferShapeForUnaryElementwiseOps(Operation *op) {
   if (!hasShapeAndRank(input))
     return success();
 
+  ONNXGenericOpUnaryElementwiseShapeHelper shapeHelper(op);
+  if (failed(shapeHelper.computeShape(input)))
+    return op->emitError("Failed to scan parameters successfully");
+  SmallVector<int64_t, 4> outputDims;
+  IndexExpr::getShape(shapeHelper.dimsForOutput(), outputDims);
+
   // Inferred shape is getting from the input's shape.
   RankedTensorType inputType = input.getType().dyn_cast<RankedTensorType>();
-  updateType(output, inputType.getShape(), inputType.getElementType(),
-      inputType.getEncoding());
+  updateType(
+      output, outputDims, inputType.getElementType(), inputType.getEncoding());
   return success();
 }
 

--- a/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp
+++ b/src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp
@@ -114,6 +114,25 @@ private:
   bool ownScope;
 };
 
+/// Compute an output shape for a unary element-wise operation. The output and
+/// input of an unary element-wise operation have the same shape.
+struct ONNXGenericOpUnaryElementwiseShapeHelper
+    : public ONNXOpShapeHelper<mlir::Operation> {
+  ONNXGenericOpUnaryElementwiseShapeHelper(
+      mlir::Operation *newOp, IndexExprScope *inScope = nullptr);
+
+  ONNXGenericOpUnaryElementwiseShapeHelper(mlir::Operation *newOp,
+      mlir::OpBuilder *rewriter,
+      ArrayValueIndexCapture::GetDenseVal fGetDenseVal,
+      ArrayValueIndexCapture::LoadVal fLoadVal,
+      IndexExprScope *inScope = nullptr);
+
+  // Compute a vector of IndexExprs to represent the output shape. Results
+  // are stored in 'outputDims'. Used in shape inference and memory allocation
+  // for the output.
+  mlir::LogicalResult computeShape(mlir::Value operand);
+};
+
 /// Compute a broadcasted shape from the shapes of given operands. Operands must
 /// be ranked in advance.
 template <class OP>


### PR DESCRIPTION
Though it is quite simple to infer shape for unary element-wise operations, this patch uses IndexExpr for the shape inference to help analyze unknown dimensions in a systematic way in the future.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>