### PR TITLE
Change split(' ') to split() in RunONNXModel.py to avoid an error about command-line option

### DIFF
--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -321,7 +321,7 @@ def main():
             # Prepare compiler arguments.
             command_str = [ONNX_MLIR]
             if args.compile_args:
-                command_str += args.compile_args.split(' ')
+                command_str += args.compile_args.split()
             if args.compile_using_input_shape:
                 # Use shapes of the reference inputs to compile the model.
                 assert args.data_folder, "No data folder given"


### PR DESCRIPTION
Small update in RunONNXModel.py to avoid an error about command-line option.

I got an error when using "--compile-args -O3&nbsp;&nbsp;--mtriple=s390x-ibm-loz --mcpu=z14".  "--compile-args "-O3&nbsp;--mtriple=s390x-ibm-loz --mcpu=z14" works instead. Looks the same, but the first one has two space between `-O3` and `--mtriple`. 

--compile-args "-O3&nbsp;&nbsp;--mtriple=s390x-ibm-loz --mcpu=z14"  ==> Error
--compile-args "-O3&nbsp;--mtriple=s390x-ibm-loz --mcpu=z14"  ==> No error

To avoid this error, we can use default separator in split().

Signed-off-by: Haruki Imai <imaihal@jp.ibm.com>