### PR TITLE
Fix a memory leak about targetMachine that is not destroyed

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -819,8 +819,9 @@ static std::string getDataLayout(const Location &loc) {
   const std::string targetCpu = getTargetCpu();
   const llvm::Target &LLVMTarget = *getLLVMTarget(targetTriple, loc);
   llvm::TargetOptions ops;
-  llvm::TargetMachine *targetMachine = LLVMTarget.createTargetMachine(
-      targetTriple, targetCpu, "" /*features*/, ops, None);
+  auto targetMachine =
+      std::unique_ptr<llvm::TargetMachine>{LLVMTarget.createTargetMachine(
+          targetTriple, targetCpu, "" /*features*/, ops, None)};
   if (!targetMachine) {
     emitError(loc, "failed to create target machine");
     return nullptr;


### PR DESCRIPTION
`targetMachine` is created and not destroyed which causes this error reported by valgrind:
```
==3261261== 48 bytes in 1 blocks are indirectly lost in loss record 31 of 90
==3261261==    at 0x4831334: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-s390x-linux.so)
==3261261==    by 0x67A5F4D: createSystemZMCInstrInfo() (in /home/tungld/dl/llvm-project.om/build/lib/libLLVMSystemZDesc.so.16git)
==3261261==    by 0x8BD72CF: llvm::LLVMTargetMachine::initAsmInfo() (in /home/tungld/dl/llvm-project.om/build/lib/libLLVMCodeGen.so.16git)
==3261261==    by 0x66E3B83: llvm::SystemZTargetMachine::SystemZTargetMachine(llvm::Target const&, llvm::Triple const&, llvm::StringRef, llvm::StringRef, llvm::TargetOptions const&, llvm::Optional<llvm::Reloc::Model>, llvm::Optional<llvm::CodeModel::Model>, llvm::CodeGenOpt::Level, bool) (in /home/tungld/dl/llvm-project.om/build/lib/libLLVMSystemZCodeGen.so.16git)

(ignored the middle part)

==3261261== LEAK SUMMARY:
==3261261==    definitely lost: 1,472 bytes in 2 blocks
==3261261==    indirectly lost: 4,215 bytes in 29 blocks
==3261261==      possibly lost: 0 bytes in 0 blocks
==3261261==    still reachable: 154,358 bytes in 1,150 blocks
==3261261==         suppressed: 0 bytes in 0 blocks
==3261261==
==3261261== For counts of detected and suppressed errors, rerun with: -v
==3261261== ERROR SUMMARY: 146 errors from 5 contexts (suppressed: 0 from 0)
```

This patch is to fix that issue by using `std::unique_ptr`. The issue is disappeared and the total number of errors becomes (reduced by 1):
```
==3262752== LEAK SUMMARY:
==3262752==    definitely lost: 48 bytes in 1 blocks
==3262752==    indirectly lost: 1,940 bytes in 22 blocks
==3262752==      possibly lost: 0 bytes in 0 blocks
==3262752==    still reachable: 154,358 bytes in 1,150 blocks
==3262752==         suppressed: 0 bytes in 0 blocks
==3262752==
==3262752== For counts of detected and suppressed errors, rerun with: -v
==3262752== ERROR SUMMARY: 145 errors from 4 contexts (suppressed: 0 from 0)
```

Signed-off-by: Tung D. Le <tung@jp.ibm.com>