### PR TITLE
Use 700 when loading .so for Java

### DIFF
--- a/src/Runtime/jni/src/com/ibm/onnxmlir/OMModel.java
+++ b/src/Runtime/jni/src/com/ibm/onnxmlir/OMModel.java
@@ -138,7 +138,7 @@ public class OMModel {
 
 			// z/OS USS requires "x" permission bit
 			Files.setPosixFilePermissions(lib,
-			      PosixFilePermissions.fromString("rwxr-xr-x"));
+			      PosixFilePermissions.fromString("rwx------"));
 
 			// Load the temporary .so copy
 			System.load(lib.toString());


### PR DESCRIPTION
AppScan on Cloud doesn't like other/world permissions set on files.

When running models on Java we extract the .so file from the .jar so we can load it. The file is exacted to a temp directory, loaded and then deleted. For z/OS cases, we have to set the permission to include the execute. However since the file is loaded and immediately deleted, we should be able to restrict the permissions to only the current user to make ASoC happy.