### PR TITLE
Fix shape inference warning related to ReduceMean

### DIFF
--- a/src/Transform/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Transform/ONNX/ONNXDimAnalysis.cpp
@@ -509,7 +509,7 @@ void DimAnalysis::visitDim(
     // IndexExpr for its shape inferece.
     // ```c
     // exploreSameInputDims<ONNXReduceMeanOp, ONNXReduceMeanOpShapeHelper>(
-    //    dim, squeezeOp, sameDims);
+    //    dim, reduceMeanOp, sameDims);
     // ```
 
     // Only support keepdims at this moment.


### PR DESCRIPTION
Resolves #1843 

DimAnalysis borrows ShapeHelper of unary elementwise ops for analysing unknown dimensions of ReduceMean. That's because there is no ShapeHelper using IndexExpr for ReduceMean currenlty. 
But this emits a warning related to mismatch in static dimensions.

For the purpose of unknown dimension analysis, we simply pass the input unknown dimension to the output unknown dimension. This patch does it manually. 

However, a long-term solution should be writing IndexExpr-based ShapeHelper for ReduceMean.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>