### PR TITLE
Remove KrnlRegion earlier

### DIFF
--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -144,6 +144,9 @@ void addKrnlToLLVMPasses(
   pm.addNestedPass<func::FuncOp>(mlir::createConvertVectorToSCFPass());
   pm.addPass(mlir::createLowerAffinePass());
 
+  // After affine is lowered, KrnlRegion for affine scope can be removed.
+  pm.addNestedPass<func::FuncOp>(krnl::createLowerKrnlRegionPass());
+
   // Hoist allocations out of loop nests to avoid stack overflow.
   pm.addPass(bufferization::createBufferLoopHoistingPass());
 
@@ -160,7 +163,6 @@ void addKrnlToLLVMPasses(
     pm.addNestedPass<func::FuncOp>(krnl::createKrnlOptimizeMemoryPoolsPass());
   }
 
-  pm.addNestedPass<func::FuncOp>(krnl::createLowerKrnlRegionPass());
   pm.addNestedPass<func::FuncOp>(krnl::createConvertSeqToMemrefPass());
   pm.addNestedPass<func::FuncOp>(mlir::createConvertSCFToCFPass());
 


### PR DESCRIPTION
Signed-off-by: chentong319 <chentong@us.ibm.com>
KrnlRegionOp is used to mark the boundary of affine scope. Previously, the KrnlRegion is removed after buffer deallocation. For the case of LoopOp, the KrnlRegion is inside the Then region of scf.if. The bufferization deallocation pass did not generate the deallocation for the last used buffer while deallocation is generated for other buffers.  The exact reason need further investigation.
This PR just moved the KrnlRegion lowering pass right after the affine is lowered and before the buffer deallocation pass.  This should be the right order in the first place.