### PR TITLE
Use DimAnalysis in rewrite-onnx-for-zhigh pass

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -30,6 +30,7 @@
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 #include "src/Support/TypeUtilities.hpp"
+#include "src/Transform/ONNX/ONNXDimAnalysis.hpp"
 
 using namespace mlir;
 
@@ -402,6 +403,11 @@ public:
 void RewriteONNXForZHighPass::runOnOperation() {
   ModuleOp module = getOperation();
 
+  // Run the unknown dimension analysis to help check equality of unknown
+  // dimensions at compile time.
+  onnx_mlir::DimAnalysis dimAnalysis(module);
+  dimAnalysis.analyze();
+
   // The first thing to define is the conversion target. This will define the
   // final target for this lowering.
   ConversionTarget target(getContext());
@@ -414,7 +420,7 @@ void RewriteONNXForZHighPass::runOnOperation() {
   // generating `ONNX.Add`, `ONNX.Sub`, `ONNX.Mul`, `ONNX.Div`,
   // and `ONNX.Sqrt` to calculate inputs(`a` and `b`)
   addDynamicallyLegalOpFor<ONNXBatchNormalizationInferenceModeOp>(
-      &target, nullptr, execNodesOnCpu);
+      &target, &dimAnalysis, execNodesOnCpu);
 
   // Illegalize BinaryOp if one of the two inputs is a constant and
   // unidirectional broadcastable to the other input. Rewrite patterns will be
@@ -448,11 +454,11 @@ void RewriteONNXForZHighPass::runOnOperation() {
   });
 
   // Illegalize MatMulOp if
-  // - both inputs are *the same* N-D, N > 3, or
+  // - both inputs are *the same* N-D, N > 3 and there is no broadcasting, or
   // - one input is N-D, N > 3 and the other is 2-D.
   // Rewrite patterns will be added to turn this MatMulOp into the one where N-D
   // will become 3-D.
-  target.addDynamicallyLegalOp<ONNXMatMulOp>([](ONNXMatMulOp op) {
+  target.addDynamicallyLegalOp<ONNXMatMulOp>([&dimAnalysis](ONNXMatMulOp op) {
     Type aType = op.A().getType();
     Type bType = op.B().getType();
     if (!isRankedShapedType(aType) || !isRankedShapedType(bType))
@@ -460,13 +466,27 @@ void RewriteONNXForZHighPass::runOnOperation() {
 
     int64_t aRank = getRank(aType);
     int64_t bRank = getRank(bType);
+
+    // - one input is N-D, N > 3 and the other is 2-D.
     if (aRank == 2 && bRank > 3)
       return false;
     if (bRank == 2 && aRank > 3)
       return false;
-    if (aRank > 3 && (aRank == bRank))
-      return false;
 
+    // - both inputs are *the same* N-D, N > 3 and there is no broadcasting
+    if (aRank > 3 && (aRank == bRank)) {
+      bool sameBatchDims = true;
+      ArrayRef<int64_t> aShape = getShape(aType);
+      ArrayRef<int64_t> bShape = getShape(bType);
+      for (int64_t i = 0; i < aRank - 2; ++i) {
+        sameBatchDims &= (aShape[i] == bShape[i]);
+        if (sameBatchDims && ShapedType::isDynamic(aShape[i]))
+          sameBatchDims = dimAnalysis.sameUnknownDim(op.A(), i, op.B(), i);
+      }
+      return !sameBatchDims;
+    }
+
+    // Make other cases legal.
     return true;
   });
 

--- a/src/Transform/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Transform/ONNX/ONNXDimAnalysis.cpp
@@ -178,6 +178,9 @@ void DimAnalysis::build(Value val) {
 
 bool DimAnalysis::sameUnknownDim(mlir::Value tensor1, uint64_t dimAxis1,
     mlir::Value tensor2, uint64_t dimAxis2) const {
+  if ((tensor1 == tensor2) && (dimAxis1 == dimAxis2))
+    return true;
+
   DimT dim1(tensor1, dimAxis1);
   DimT dim2(tensor2, dimAxis2);
   // Two dims are the same if they are in the same set.
@@ -521,7 +524,7 @@ void DimAnalysis::visitDim(
     if (axesAttr.has_value()) {
       // Do nothing if the target dim is the reduction dim.
       for (size_t i = 0; i < ArrayAttrSize(axesAttr); ++i) {
-        if (ArrayAttrIntVal(axesAttr, i) == dim.second)
+        if (ArrayAttrIntVal(axesAttr, i) == (int64_t)dim.second)
           return;
       }
       // The target dim is not the reduction dim, it would be the same as the


### PR DESCRIPTION
This patch applies DimAnalysis to the pass `rewrite-onnx-for-zhigh`.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>