### PR TITLE
fixes for mac

### DIFF
--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -58,7 +58,7 @@ struct OnnxToKrnlBuilder : public OnnxBuilder {
   OnnxToKrnlBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : OnnxBuilder(b, loc) {}
   OnnxToKrnlBuilder(DialectBuilder &db) : OnnxBuilder(db) {}
-  ~OnnxToKrnlBuilder() {}
+  virtual ~OnnxToKrnlBuilder() {}
 
   // Generate an 'onnx.reshape' operation on the 'input' tensor, the new shape
   // is provided by 'shapeDims'.

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -107,7 +107,9 @@ Value KrnlBuilder::vectorTypeCast(Value sourceMemref, int64_t vectorLen) const {
 }
 
 ValueRange KrnlBuilder::defineLoops(int64_t originalLoopNum) const {
-  return b().create<KrnlDefineLoopsOp>(loc(), originalLoopNum).getResults();
+  return b()
+      .template create<KrnlDefineLoopsOp>(loc(), originalLoopNum)
+      .getResults();
 }
 
 ValueRange KrnlBuilder::block(Value loop, int64_t blockSize) const {
@@ -119,7 +121,9 @@ void KrnlBuilder::permute(ValueRange loops, ArrayRef<int64_t> map) const {
 }
 
 ValueRange KrnlBuilder::getInductionVarValue(ValueRange loops) const {
-  return b().create<KrnlGetInductionVariableValueOp>(loc(), loops).getResults();
+  return b()
+      .template create<KrnlGetInductionVariableValueOp>(loc(), loops)
+      .getResults();
 }
 
 void KrnlBuilder::iterate(ValueRange originalLoops, ValueRange optimizedLoops,

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -27,7 +27,7 @@ struct KrnlBuilder : public DialectBuilder {
   KrnlBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   KrnlBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~KrnlBuilder() {}
+  virtual ~KrnlBuilder() {}
 
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
   // When ranks of offsets<indices, add offsets to the least significant dims.
@@ -176,7 +176,7 @@ struct IndexExprBuilderForKrnl : IndexExprBuilder {
   IndexExprBuilderForKrnl(mlir::OpBuilder &b, mlir::Location loc)
       : IndexExprBuilder(b, loc) {}
   IndexExprBuilderForKrnl(const DialectBuilder &db) : IndexExprBuilder(db) {}
-  ~IndexExprBuilderForKrnl() {}
+  virtual ~IndexExprBuilderForKrnl() {}
 
 protected:
   mlir::DenseElementsAttr getConst(mlir::Value value) final;

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -31,7 +31,7 @@ struct DialectBuilder {
       : builder(&b), location(loc) {}
   DialectBuilder(const DialectBuilder &db)
       : builder(db.builder), location(db.location) {}
-  ~DialectBuilder() {}
+  virtual ~DialectBuilder() {}
   DialectBuilder(DialectBuilder &&) = delete;
   DialectBuilder &operator=(const DialectBuilder &) = delete;
   DialectBuilder &&operator=(const DialectBuilder &&) = delete;
@@ -77,7 +77,7 @@ struct MathBuilder final : DialectBuilder {
   MathBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   MathBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~MathBuilder() {}
+  virtual ~MathBuilder() {}
 
   mlir::Value abs(mlir::Value val) const;
 
@@ -150,7 +150,7 @@ struct MemRefBuilder final : DialectBuilder {
   MemRefBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   MemRefBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~MemRefBuilder() {}
+  virtual ~MemRefBuilder() {}
 
   mlir::memref::AllocOp alloc(mlir::MemRefType type) const;
   mlir::memref::AllocOp alloc(
@@ -191,7 +191,7 @@ struct SCFBuilder final : DialectBuilder {
   SCFBuilder(mlir::Location loc) : DialectBuilder(loc) {}
   SCFBuilder(mlir::OpBuilder &b, mlir::Location loc) : DialectBuilder(b, loc) {}
   SCFBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~SCFBuilder() {}
+  virtual ~SCFBuilder() {}
 
   /// Create an if then with optional else. Construct does not generate a result
   /// (unlike some scf::if) and introduces the yields automatically.
@@ -215,7 +215,7 @@ struct VectorBuilder final : DialectBuilder {
   VectorBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   VectorBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~VectorBuilder() {}
+  virtual ~VectorBuilder() {}
 
   // Get the machine SIMD vector length for the given elementary type.
   // This can help guide certain optimizations.
@@ -264,7 +264,7 @@ struct GenericAffineBuilder final : DialectBuilder {
   GenericAffineBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   GenericAffineBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~GenericAffineBuilder() {}
+  virtual ~GenericAffineBuilder() {}
 
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
   // When ranks of offsets<indices, add offsets to the least significant dims.
@@ -332,7 +332,7 @@ struct LLVMBuilder final : DialectBuilder {
   LLVMBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   LLVMBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~LLVMBuilder() {}
+  virtual ~LLVMBuilder() {}
 
   // AddressOfOp
   mlir::Value addressOf(mlir::LLVM::GlobalOp op) const;

--- a/src/Dialect/Mlir/DialectBuilder.hpp.inc
+++ b/src/Dialect/Mlir/DialectBuilder.hpp.inc
@@ -1,10 +1,15 @@
 //===---- DialectBuilder.hpp.inc - Helper functions for MLIR dialects -----===//
 //
-// Copyright 2019-2021 The IBM Research Authors.
+// Copyright 2019-2022 The IBM Research Authors.
 //
 // =============================================================================
 //
 // This file contains helper functions for building MLIR operations.
+//
+// Note on usage of template keyword. Since the GenericAffineBuilder is
+// templated, and we use templated functions (such as create<OP>), we must add
+// the "template" keyword before the "create" function to indicate what is being
+// templated.
 //
 //===----------------------------------------------------------------------===//
 
@@ -12,7 +17,7 @@
 template <class LOAD_OP, class STORE_OP>
 mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::load(
     mlir::Value memref, mlir::ValueRange indices) const {
-  return b().create<LOAD_OP>(loc(), memref, indices);
+  return b().template create<LOAD_OP>(loc(), memref, indices);
 }
 
 template <class LOAD_OP, class STORE_OP>
@@ -36,7 +41,7 @@ mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::loadIE(mlir::Value memref,
 template <class LOAD_OP, class STORE_OP>
 inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::store(
     mlir::Value val, mlir::Value memref, mlir::ValueRange indices) const {
-  b().create<STORE_OP>(loc(), val, memref, indices);
+  b().template create<STORE_OP>(loc(), val, memref, indices);
 }
 
 template <class LOAD_OP, class STORE_OP>
@@ -70,8 +75,8 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forIE(IndexExpr lb,
   lb.getAffineMapAndOperands(lbMap, lbOperands);
   ub.getAffineMapAndOperands(ubMap, ubOperands);
   // Create affine for.
-  b().create<mlir::AffineForOp>(loc(), lbOperands, lbMap, ubOperands, ubMap,
-      step, mlir::ValueRange{},
+  b().template create<mlir::AffineForOp>(loc(), lbOperands, lbMap, ubOperands,
+      ubMap, step, mlir::ValueRange{},
       [&](mlir::OpBuilder &b, mlir::Location loc, mlir::Value index,
           mlir::ValueRange args) {
         GenericAffineBuilder createAffine(b, loc);
@@ -120,8 +125,8 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::ifThenElse(
       scope.getNumDims(), scope.getNumSymbols(), affineCond, isEq);
   llvm::SmallVector<mlir::Value, 8> dimAndSymbolList;
   scope.getDimAndSymbolList(dimAndSymbolList);
-  auto ifOp =
-      b().create<mlir::AffineIfOp>(loc(), inset, dimAndSymbolList, true);
+  auto ifOp = b().template create<mlir::AffineIfOp>(
+      loc(), inset, dimAndSymbolList, true);
   mlir::Block *thenBlock = ifOp.getThenBlock();
   mlir::Block *elseBlock = ifOp.getElseBlock();
   if (!allFalse) {
@@ -140,7 +145,7 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::ifThenElse(
 
 template <class LOAD_OP, class STORE_OP>
 inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::yield() const {
-  b().create<mlir::AffineYieldOp>(loc());
+  b().template create<mlir::AffineYieldOp>(loc());
 }
 
 // Support for multiple forIE loops.

--- a/src/Dialect/Mlir/IndexExprBuilder.hpp
+++ b/src/Dialect/Mlir/IndexExprBuilder.hpp
@@ -65,7 +65,7 @@ struct IndexExprBuilder : DialectBuilder {
   IndexExprBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   IndexExprBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~IndexExprBuilder() {}
+  virtual ~IndexExprBuilder() {}
 
   using IndexExprList = llvm::SmallVectorImpl<IndexExpr>;
 

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -30,7 +30,7 @@ struct OnnxBuilder : onnx_mlir::DialectBuilder {
   OnnxBuilder(mlir::OpBuilder &b, mlir::Location loc)
       : DialectBuilder(b, loc) {}
   OnnxBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
-  ~OnnxBuilder(){};
+  virtual ~OnnxBuilder(){};
   // ONNXAddOp
   mlir::Value add(mlir::Value A, mlir::Value B) const;
 
@@ -145,7 +145,7 @@ struct IndexExprBuilderForAnalysis : IndexExprBuilder {
       : IndexExprBuilder(b, loc) {}
   IndexExprBuilderForAnalysis(const DialectBuilder &db)
       : IndexExprBuilder(db) {}
-  ~IndexExprBuilderForAnalysis() {}
+  virtual ~IndexExprBuilderForAnalysis() {}
 
 protected:
   mlir::DenseElementsAttr getConst(mlir::Value value) final;

--- a/test/modellib/ModelLib.hpp
+++ b/test/modellib/ModelLib.hpp
@@ -393,7 +393,7 @@ public:
       const bool isDynamicB, const bool isNoneH = false,
       const bool isNoneC = false, const bool isNoneP = false,
       const int layout = 0);
-  ~LSTMLibBuilder();
+  virtual ~LSTMLibBuilder();
   bool build() final;
   bool prepareInputs() final;
   bool prepareInputs(float dataRangeLB, float dataRangeUB);
@@ -415,7 +415,7 @@ public:
   GRULibBuilder(const std::string &modelName, const int direction, const int S,
       const int B, const int I, const int H, const int linearBeforeReset,
       const bool isDynamicS, const bool isDynamicB, const int layout = 0);
-  ~GRULibBuilder();
+  virtual ~GRULibBuilder();
   bool build() final;
   bool prepareInputs() final;
   bool prepareInputs(float dataRangeLB, float dataRangeUB);
@@ -436,7 +436,7 @@ public:
   RNNLibBuilder(const std::string &modelName, const int direction, const int S,
       const int B, const int I, const int H, const bool isDynamicS,
       const bool isDynamicB, const int layout = 0);
-  ~RNNLibBuilder();
+  virtual ~RNNLibBuilder();
   bool build() final;
   bool prepareInputs() final;
   bool prepareInputs(float dataRangeLB, float dataRangeUB);


### PR DESCRIPTION
Fixes for mac build, originally introduced by #1859
* Warning for non virtual destructors of classes with virtual functions
* `template` keyword where the compiler may be confused as templates are used for the class and a function call within the class. See https://www.aerialmantis.co.uk/blog/2017/03/17/template-keywords/ for explanation on the second point. Added a warning comment in the file that needed this fix so that we may better remember the cause of this extra `template` keyword.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>