### PR TITLE
made ~NewONNXOpShapeHelper() virtual to fix warning

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/NewShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/NewShapeHelper.hpp
@@ -39,7 +39,7 @@ struct NewONNXOpShapeHelper {
   // Constructor for shape inference.
   NewONNXOpShapeHelper(OP *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder, IndexExprScope *scope);
-  ~NewONNXOpShapeHelper() {
+  virtual ~NewONNXOpShapeHelper() {
     if (ownScope)
       delete scope;
   }


### PR DESCRIPTION
warning was:
```
'onnx_mlir::NewONNXOpShapeHelper<mlir::Operation>' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
```

Signed-off-by: Soren Lassen <sorenlassen@gmail.com>