### PR TITLE
Support .mlir file as input to RunONNXModel.py

### DIFF
--- a/docs/DebuggingNumericalError.md
+++ b/docs/DebuggingNumericalError.md
@@ -32,50 +32,36 @@ reference inputs and outputs in protobuf.
 
 ```bash
 $ python ../utils/RunONNXModel.py  --help
-usage: RunONNXModel.py [-h] [--print-input] [--print-output]
-                       [--save-onnx PATH] [--save-so PATH | --load-so PATH]
-                       [--save-data PATH]
+usage: RunONNXModel.py [-h] [--model MODEL] [--compile-args COMPILE_ARGS] [--compile-only] [--compile-using-input-shape]
+                       [--print-input] [--print-output] [--save-onnx PATH] [--save-data PATH] [--verify {onnxruntime,ref}]
+                       [--verify-all-ops] [--rtol RTOL] [--atol ATOL] [--save-so PATH | --load-so PATH]
                        [--data-folder DATA_FOLDER | --shape-info SHAPE_INFO]
-                       [--compile-args COMPILE_ARGS]
-                       [--verify {onnxruntime,ref}] [--verify-all-ops]
-                       [--compile-using-input-shape] [--rtol RTOL]
-                       [--atol ATOL]
-                       model_path
-
-positional arguments:
-  model_path            Path to the ONNX model
 
 optional arguments:
   -h, --help            show this help message and exit
+  --model MODEL         Path to an ONNX model (.onnx or .mlir)
+  --compile-args COMPILE_ARGS
+                        Arguments passed directly to onnx-mlir command. See bin/onnx-mlir --help
+  --compile-only        Only compile the input model
+  --compile-using-input-shape
+                        Compile the model by using the shape info getting from the inputs in data folder. Must set --data-folder
   --print-input         Print out inputs
   --print-output        Print out inference outputs produced by onnx-mlir
-  --save-onnx PATH      File path to save the onnx model
-  --save-so PATH        File path to save the generated shared library of the
-                        model
-  --load-so PATH        File path to load a generated shared library for
-                        inference, and the ONNX model will not be re-compiled
-  --save-data PATH      Path to a folder to save the inputs and outputs in
-                        protobuf
-  --data-folder DATA_FOLDER
-                        Path to a folder containing inputs and outputs stored
-                        in protobuf. If --verify=ref, inputs and outputs are
-                        reference data for verification
-  --shape-info SHAPE_INFO
-                        Shape for each dynamic input of the model, e.g.
-                        0:1x10x20,1:7x5x3. Used to generate random inputs for
-                        the model if --data-folder is not set
-  --compile-args COMPILE_ARGS
-                        Arguments passed directly to onnx-mlir command. See
-                        bin/onnx-mlir --help
+  --save-onnx PATH      File path to save the onnx model. Only effective if --verify=onnxruntime
+  --save-data PATH      Path to a folder to save the inputs and outputs in protobuf
   --verify {onnxruntime,ref}
-                        Verify the output by using onnxruntime or reference
-                        inputs/outputs. By default, no verification
+                        Verify the output by using onnxruntime or reference inputs/outputs. By default, no verification
   --verify-all-ops      Verify all operation outputs when using onnxruntime.
-  --compile-using-input-shape
-                        Compile the model by using the shape info getting from
-                        the inputs in data folder. Must set --data-folder
   --rtol RTOL           Relative tolerance for verification
   --atol ATOL           Absolute tolerance for verification
+  --save-so PATH        File path to save the generated shared library of the model
+  --load-so PATH        File path to load a generated shared library for inference, and the ONNX model will not be re-compiled
+  --data-folder DATA_FOLDER
+                        Path to a folder containing inputs and outputs stored in protobuf. If --verify=ref, inputs and outputs are
+                        reference data for verification
+  --shape-info SHAPE_INFO
+                        Shape for each dynamic input of the model, e.g. 0:1x10x20,1:7x5x3. Used to generate random inputs for the
+                        model if --data-folder is not set
 ```
 
 ## Debugging the Code Generated for an Operator.

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -308,6 +308,11 @@ def warning(msg):
 
 
 def main():
+    if not(args.model or args.load_so):
+        print("error: no input model, use argument --model and/or --load-so.")
+        print(parser.format_usage())
+        exit(1)
+
     # Get shape information if given.
     # args.shape_info in the form of 'input_index:d1xd2, input_index:d1xd2'
     input_shapes = {}

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -207,11 +207,8 @@ def get_names_in_signature(signature):
     names = []
     # Load the input signature.
     signature_dict = json.loads(signature)
-    for i, sig in enumerate(signature_dict):
-        name = 'input_{}'.format(i)
-        if sig['name']:
-            name = sig['name']
-        names.append(name)
+    for sig in signature_dict:
+        names.append(sig['name'])
     return names
 
 

--- a/utils/RunONNXModelZoo.py
+++ b/utils/RunONNXModelZoo.py
@@ -328,7 +328,8 @@ def check_model(model_path, model_name, compile_args, report_dir):
             options += RunONNXModel_additional_options[model_name]
         if (args.compile_only):
             options += ['--compile-only']
-        ok, msg = execute_commands(RUN_ONNX_MODEL_CMD + [onnx_file] + options)
+        options += ['--model={}'.format(onnx_file)]
+        ok, msg = execute_commands(RUN_ONNX_MODEL_CMD + options)
         state = TEST_PASSED if ok else TEST_FAILED
         logger.debug("[{}] {}".format(model_name, msg))
 


### PR DESCRIPTION
This patch updates the python script `RunONNXModel.py` to allow compiling and running a `.mlir` file. This is very useful for debugging and profiling an MLIR program instead of an ONNX model.

For example, we have a `matmul.mIir` program as follows
```llvm
module attributes {llvm.data_layout = "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64", llvm.target_triple = "s390x-ibm-linux"} {
  func.func @main_graph(%arg0: tensor<?x4xf32>, %arg1: tensor<4x3xf32>) -> tensor<?x3xf32> attributes {input_names = ["a", "b"], output_names = ["c"]} {
    %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<?x4xf32>, tensor<4x3xf32>) -> tensor<?x3xf32>
    return %0 : tensor<?x3xf32>
  }
  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
}
```
We can use RunONNXModel.py to compile and run it. Input data are automatically generated by using the signature:
```shell
$ ONNX_MLIR_HOME=~/dl/onnx-mlir/build/Debug python ..//utils/RunONNXModel.py --model=./matmul.mlir --shape-info=0:5x4
Temporary directory has been created at /tmp/tmp4hxg01st
Compiling the model ...
['/home/tungld/dl/onnx-mlir/build/Debug/bin/onnx-mlir', './matmul.mlir', '-o', '/tmp/tmp4hxg01st/model']
  took  0.22306624427437782  seconds.

Loading the compiled model ...
  took  0.0003013238310813904  seconds.

Generating random inputs ...
  - 1st input's shape (5, 4), element type float32. Value ranges [-1.0, 1.0]
  - 2nd input's shape (4, 3), element type float32. Value ranges [-1.0, 1.0]
  done.

Running inference ...
  took  7.39172101020813e-05  seconds.
```

I reorganized the python script a bit to make it easy to maintain.