### PR TITLE
Support SliceOp and SplitOp in DimAnalysis

### DIFF
--- a/src/Transform/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Transform/ONNX/ONNXDimAnalysis.cpp
@@ -534,6 +534,20 @@ void DimAnalysis::visitDim(
     return;
   }
 
+  // SliceOp
+  if (auto sliceOp = dyn_cast<ONNXSliceOp>(op)) {
+    exploreSameInputDims<ONNXSliceOp, ONNXSliceOpShapeHelper>(
+        dim, sliceOp, sameDims);
+    return;
+  }
+
+  // SplitOp
+  if (auto splitOp = dyn_cast<ONNXSplitOp>(op)) {
+    exploreSameInputDims<ONNXSplitOp, ONNXSplitOpShapeHelper>(
+        dim, splitOp, sameDims);
+    return;
+  }
+
   // SqueezeOp
   if (auto squeezeOp = dyn_cast<ONNXSqueezeOp>(op)) {
     exploreSameInputDims<ONNXSqueezeOp, ONNXSqueezeOpShapeHelper>(


### PR DESCRIPTION
SliceOp and SplitOp are found in the GPT2 model. So add them to DimAnalysis.