### PR TITLE
Adding utility to test and repair lit-tests

### DIFF
--- a/utils/fixLitTest.py
+++ b/utils/fixLitTest.py
@@ -1,0 +1,335 @@
+#!/usr/local/bin/python3
+
+# SPDX-License-Identifier: Apache-2.0
+
+##################### fixLitTest.py ########################################
+#
+# Copyright 2022 The IBM Research Authors.
+#
+################################################################################
+#
+# This file convert fixes an existing lit test
+#
+################################################################################
+
+import sys
+import os
+import getopt
+import fileinput
+import re
+import subprocess
+
+################################################################################
+# Usage.
+
+def dprint(msg):
+    sys.stderr.write(msg + "\n")
+
+def print_usage():
+    dprint("")
+    dprint('Fixes and tests lit-test file.')
+    dprint("")
+    dprint('fixLitTest [-dhprt] [-f <func-name> <lit-test-filename>')
+    dprint('  -t/--test   : Run FileCheck on each function individually.')
+    dprint('                When combined with \"--repair\", test repaired lit test.')
+    dprint('  -r/--repair : Repair lit test for each function individually.')    
+    dprint('  -f,--func <func-name>: Perform test/repair only on given function.')
+    dprint('  -p/--print  : Print original lit-test files for the individual.')
+    dprint('                functions that were not fixed. Useful only when used')
+    dprint('                in combination with \"-r -f <func-name>.')
+    dprint('  -h/--help   : Print help.')
+    dprint('  -d/--help   : Print debug info.')
+    dprint("")
+    dprint('File format for input list-test files:')
+    dprint(' * A single "// RUN:" comment')
+    dprint(' * A "// -----" comment')
+    dprint(' * Subsequent functions separated by a "// -----" comment')    
+    dprint("")
+    dprint("Workflow for debugging test.mlir:")
+    dprint(" * Test original file: \"fixLitTest -t test.mlir\".")
+    dprint(" * If errors, test a given func X: \"fixLitTest -t -f X test.mlir\".")
+    dprint(" * You may inspect the \"flt_*.mlir\" files in the current dir for more info.")
+    dprint(" * Spurious error, repair func X:  \"fixLitTest -t -r -f X test.mlir\".")
+    dprint(" * If good, save fix for X:  \"fixLitTest -r -f -p X test.mlir > test.mlir\".")
+    dprint("")
+    sys.exit()
+
+################################################################################
+# Globals.
+
+run_command = ""
+fix_fct_name = ""
+debug = 0
+test_error_num = 0
+
+# file names
+flt_orig_model_file_name = "flt_orig_model.mlir"
+flt_compiled_file_name = "flt_compiled.mlir"
+flt_new_model_file_name = "flt_new_model.mlir"
+
+# Segments are all of the text between "// -----"
+# Segment database for text, function name, mlir2FileCheck command.
+segment_text = []
+segment_fct_name = []
+segment_mlir2FileCheck_command = []
+
+################################################################################
+# Run commands.
+
+def run_onnx_mlir_opt(code_file_name, omo_command, output_file_name):
+    global debug
+
+    # Gen command from string.
+    command = omo_command.split()
+    command.append(code_file_name)
+    if debug:
+        print("//    onnx-mlir-opt command:", command)
+    res = subprocess.run(command, capture_output=True, text=True).stdout
+    # Write command output
+    with open(output_file_name, 'w') as f:
+        f.write(res)
+
+def run_mlir2FileCheck(model_file_name, compiled_file_name, 
+        m2fc_command, output_file_name):
+    global debug
+
+    if not m2fc_command:
+        m2fc_command = "mlir2FileCheck.py"
+    # Add the directory of this file to mlir2FileCheck.py
+    directory = os.path.dirname(sys.argv[0])
+    m2fc_command = directory + "/" + m2fc_command
+    # There are some issues with spaces inside the json map/arrays
+    m2fc_command = re.sub(r'\s*,\s*', r',', m2fc_command)
+    m2fc_command = re.sub(r'\s*:\s*', r':', m2fc_command)
+    # Gen command from string.
+    command = ["python"]
+    command.extend(m2fc_command.split())
+    command.extend(["-i", compiled_file_name])
+    command.extend(["-m", model_file_name])
+    if debug:
+        print("//    mlir2FileCheck command:", command)
+    res = subprocess.run(command, capture_output=True, text=True).stdout
+    # Write command output
+    with open(output_file_name, 'w') as f:
+        f.write(res)
+
+def run_FileCheck(test_name, compiled_file_name, model_file_name):
+    global debug, test_error_num
+    command = ['FileCheck', '--input-file='+compiled_file_name,
+        model_file_name]
+    if debug:
+        print("//    FileCheck command:", command)
+    res = subprocess.run(command, capture_output=True, text=True).stderr
+    if len(res) == 0:
+        dprint(">> Successful test of \"" + test_name + "\".")
+    else:
+        test_error_num += 1
+        dprint(">> Start failure report of test \"" + test_name + "\".")
+        dprint(res)
+        dprint(">> Stop failure report of test \"" + test_name + "\".")
+        dprint(">> run again with option \"-t -f " + test_name + 
+            "\" to focus on this test.")
+
+def print_file(file_name):
+    with open(file_name, 'r') as f:
+        print(f.read())
+
+
+################################################################################
+# Process segments.
+
+def gen_orig_model(i, output_file_name):
+    # Create the input file.
+    with open(output_file_name, 'w') as f:
+        for l in segment_text[i]:
+            f.write(l + '\n')
+
+def emit_unmodified_segment(i):
+    if i>0:
+        print("// -----")
+    for l in segment_text[i]:
+        print(l)
+
+def emit_modified_segment(i, has_test):
+    global run_command, debug
+    global flt_orig_model_file_name, flt_compiled_file_name
+    global flt_new_model_file_name
+    global segment_text, segment_fct_name, segment_mlir2FileCheck_command
+
+    # Print separator.
+    if i>0:
+        print("// -----\n")
+    # Print leading comments up to the function header line.
+    for l in segment_text[i]:
+        if re.match(r'\s*func', l) is not None:
+            # Has function, stop.
+            break;
+        if re.match(r'\s*//', l) is not None and re.match(r'\s*// CHECK', l) is None:
+            # Has comment, print.
+            print(l)
+    
+    gen_orig_model(i, flt_orig_model_file_name)
+    run_onnx_mlir_opt(flt_orig_model_file_name, run_command, flt_compiled_file_name)
+    run_mlir2FileCheck(flt_orig_model_file_name, flt_compiled_file_name, 
+        segment_mlir2FileCheck_command[i], flt_new_model_file_name)
+    print_file(flt_new_model_file_name)
+    if has_test:
+        run_FileCheck(segment_fct_name[i], flt_compiled_file_name, 
+          flt_new_model_file_name)
+
+
+def test_orig_model(i):
+    global run_command, debug, test_error_num
+    global flt_orig_model_file_name, flt_compiled_file_name
+
+    gen_orig_model(i, flt_orig_model_file_name)
+    run_onnx_mlir_opt(flt_orig_model_file_name, run_command, flt_compiled_file_name)
+    run_FileCheck(segment_fct_name[i], flt_compiled_file_name, 
+      flt_orig_model_file_name)
+
+
+################################################################################
+# Main.
+
+def main(argv):
+    global run_command, fix_fct_name, debug
+    global segment_text, segment_fct_name, segment_mlir2FileCheck_command
+    input_command = "fixLitTest.py"
+    has_fct = False
+    has_repair = False
+    has_test = False
+    has_print = False
+    try:
+        opts, args = getopt.getopt(
+            argv, "rtdf:hp", ["repair", "test", "debug", "func=", "help", "print"])
+    except getopt.GetoptError:
+        dprint("Error: unknown options")
+        print_usage()
+    for opt, arg in opts:
+        if opt in ('-r', "--repair"):
+            has_repair = True
+        elif opt in ('-t', "--test"):
+            has_test = 1
+        elif opt in ('-p', "--print"):
+            has_print = 1
+        elif opt in ('-d', "--debug"):
+            debug = 1
+        elif opt in ("-f", "--func"):
+            fix_fct_name = arg
+            has_fct = True
+        elif opt in ('-h', "--help"):
+            print_usage()
+
+    if not has_repair and not has_test:
+        dprint('Need "--repair" or "--test" option')
+        print_usage();
+
+    if len(args) != 1:
+        # All commands after the file name seems to be added here!!!
+        dprint("Need an single input file as last option: ", args, ".")
+        return
+    lit_test_filename = args[0]
+    if debug:
+        print('// Process lit test file "' + lit_test_filename + '".')
+
+    # Process the lit test file. 
+    # Segments are all of the text between "// -----".
+    # Ensure at most one function per segment.
+    # Current segment data.
+    curr_segment_text = []
+    curr_segment_fct_name = ""
+    curr_segment_mlir2FileCheck_command = ""
+    # Counters.
+    run_command_num = 0
+    fct_between_delimiters = 0
+    found_fct_to_fix = False
+    # Scan file and write info into segment database.
+    for line in open(lit_test_filename, 'r'):
+        # Handle segments.
+        if re.match(r'// -----', line) is not None:
+            # Has a new segment.
+            segment_text.append(curr_segment_text)
+            curr_segment_text = []
+            segment_fct_name.append(curr_segment_fct_name)
+            curr_segment_fct_name = ""
+            segment_mlir2FileCheck_command.append(curr_segment_mlir2FileCheck_command)
+            curr_segment_mlir2FileCheck_command = ""
+            fct_between_delimiters = 0
+        else:
+            # Not a new segment, append line to current segment.
+            l = line.rstrip()
+            curr_segment_text.append(l)
+        # Look for RUN command.
+        m = re.match(r'// RUN:\s*(.*)\|', line)
+        if m is not None:
+            if run_command_num > 0:
+                dprint('Got too many "// RUN:" command.')
+                print_usage()
+            run_command_num = 1
+            run_command = m.group(1)
+            # Strip the "%s" and "-split-input-file"
+            run_command = run_command.replace("%s", "")
+            run_command = run_command.replace("-split-input-file", "")
+            if debug:
+                print('//  Run command is "' + run_command + '".')
+            continue
+        # Handle function
+        m = re.match(r'\s*func.*@(\w+)\(', line)
+        if m is not None:
+            curr_segment_fct_name = m.group(1)
+            if fct_between_delimiters > 0:
+                dprint('Got too many function bodies between "// ----" command starting with', curr_segment_fct_name)
+                print_usage()
+            fct_between_delimiters = 1
+            if has_fct and curr_segment_fct_name == fix_fct_name:
+                found_fct_to_fix = True
+                if debug:
+                    print("//  Found function to fix:", curr_segment_fct_name)
+            continue
+         # Handle mlir2FileCheck command
+        m = re.match(r'\s*//\s*(mlir2FileCheck.py.*)$', line)
+        if m is not None:
+            curr_segment_mlir2FileCheck_command = m.group(1)
+    # Record the last segment.
+    segment_text.append(curr_segment_text)
+    segment_fct_name.append(curr_segment_fct_name)
+    segment_mlir2FileCheck_command.append(curr_segment_mlir2FileCheck_command)
+
+    # Make sure we got what we were waiting for.
+    if len(segment_text) < 2:
+        dprint('Expected at least 2 segments (text between "// ----"): one for RUN command and one for a function.')
+        print_usage()
+    if has_fct and not found_fct_to_fix:
+        dprint("Did not find function to fix: \'" + fix_fct_name + "\'.")
+        sys.exit()
+    if run_command_num == 0:
+        dprint('Expected "// RUN:" command.')
+        print_usage()
+    
+    # Process segments.
+    dprint(">> File runs \"" + run_command + "\" ")
+    if has_repair:
+        emit_unmodified_segment(0)
+    for i in range(1, len(segment_text)):
+        if not has_fct or segment_fct_name[i] == fix_fct_name:
+            # We have the selected function or we do them all
+            if has_repair:
+                sys.stderr.write("// > repair "+ segment_fct_name[i] + "\n")
+                emit_modified_segment(i, has_test)
+            elif has_test:
+                test_orig_model(i)
+        elif has_fct and segment_fct_name[i] != fix_fct_name:
+            # Specified a function, but does not have it.
+            # Print through if requested
+            if has_print:
+                sys.stderr.write("// > print "+ segment_fct_name[i] + "\n")
+                emit_unmodified_segment(i)
+
+    if has_test:
+        if test_error_num == 0:
+            dprint("\n>> Tested successfully without errors.")
+        else:
+            dprint("\n>> Tested with " + str(test_error_num) + " errors.")
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/utils/fixLitTest.py
+++ b/utils/fixLitTest.py
@@ -27,7 +27,8 @@ def dprint(msg):
 
 def print_usage():
     dprint("")
-    dprint('Fixes and tests lit-test file.')
+    dprint('Fixes and tests lit-test file. Repairs are done by \"utils/mlir2FileCHeck\"')
+    dprint("utility.")
     dprint("")
     dprint('fixLitTest [-dhprt] [-f <func-name> <lit-test-filename>')
     dprint('  -t/--test   : Run FileCheck on each function individually.')

--- a/utils/mlir2FileCheck.py
+++ b/utils/mlir2FileCheck.py
@@ -4,7 +4,7 @@
 
 ##################### mlir2FileCheck.py ########################################
 #
-# Copyright 2020 The IBM Research Authors.
+# Copyright 2020-2022 The IBM Research Authors.
 #
 ################################################################################
 #
@@ -12,6 +12,11 @@
 # performs renaming of variables for better readability. In debug mode, it
 # can be used to simply better read mlir files as variables have more
 # comprehensive names
+#
+# Known issues easy to fix in the original .mlir files
+# 1) function name cannot have "." in them
+# 2) last "}" of function must be on first row (no space before it)
+
 ################################################################################
 
 import sys
@@ -24,20 +29,18 @@ import subprocess
 ################################################################################
 # Usage.
 
-
 def print_usage():
-    print('Translate mlir format from stdin to a suitable FileCheck format.')
+    print('Translate mlir format from stdin/input file to a suitable FileCheck format.')
     print('mlir2FileCheck [-cdh] [-a <arg arrays>] [-d <dict>] [-m <model file>')
     print('  -a,--args <array>: Rename function arguments using a json array,')
-    print(
-        '                     such as \'["A", "B", "C"] for 1st, 2nd, & 3rd args.\'.')
+    print('                     such as \'["A", "B", "C"] for 1st, 2nd, & 3rd args.\'.')
     print('  -c,--check       : Run FileCheck on output, to verify that the output is good.')
     print('  -d,--debug       : Rename for easier debugging of code, disable FileCheck format.')
     print('  -h,--help        : Print help.')
-    print('  -m,--model <model name>: insert file-check text inside the model of a single function.')
+    print('  -i,--input <input file name>: read input from this file instead of stdin.')
+    print('  -m,--model <model file name>: insert file-check text inside the model of a single function.')
     print('  -n,--names <dict>: Rename variables using a json dictionary')
-    print(
-        '                     such as \'{"cst": "ZERO"}\' to rename cst to ZERO.')
+    print('                     such as \'{"cst": "ZERO"}\' to rename cst to ZERO.')
     sys.exit()
 
 
@@ -46,7 +49,6 @@ def print_usage():
 
 # Associate a color with each line; two lines with the same color are independent
 # and thus are eligible to use a CHECK-DAG.
-
 def process_def_use_chains(line):
     global def_set, line_color, curr_color
     def_qual_pat = re.compile(r'\s+%([a-zA-Z0-9][a-zA-Z0-9_\-]*)(:\d+)?\s+=')
@@ -80,14 +82,11 @@ def process_def_use_chains(line):
 ################################################################################
 # Handling of names: global dictionaries.
 
-
 prepare_name_dict = {}  # orig_name -> new_name (with ref count)
 name_dict = {}  # orig_name -> new_name (with ref count)
 refcount_dict = {}  # new_name (without ref count) -> definition count
 
 # Prepare name for def, for mapping given by the user.
-
-
 def prepare_name_def(orig_name, new_name):
     global prepare_name_dict
     if orig_name in prepare_name_dict.keys():
@@ -96,18 +95,14 @@ def prepare_name_def(orig_name, new_name):
     prepare_name_dict[orig_name] = new_name
 
 # Process name and make it a legit def for FileCheck.
-
-
-def def_string(name, num):
+def def_string(name, num, var_prefix = '%'):
     if debug:
         return name + "_" + num
-    return "[[" + name + "_:%.+]]" + num
+    return "[[" + name + "_:" + var_prefix + ".+]]" + num
 
 # Record an original name/number, with a suggested new name. Append_str is
 # added at the end (to match the string looked for and to be substituted).
-
-
-def record_name_def(orig_name, orig_num, new_name, append_str, num_for_zero, line):
+def record_name_def(orig_name, orig_num, new_name, append_str, num_for_zero, line, var_prefix = '%'):
     global name_dict, refcount_dict
     # original name: what we found in the text
     # new_name: if something was prepared for it, use the prepared name. But
@@ -132,18 +127,16 @@ def record_name_def(orig_name, orig_num, new_name, append_str, num_for_zero, lin
         curr_name = new_name + "_" + str(refcount)
         # Map the binding old -> current.
         name_dict[orig_name] = curr_name
-        return def_string(curr_name, orig_num) + append_str
+        return def_string(curr_name, orig_num, var_prefix) + append_str
     # Record the mapping of a first def.
     refcount_dict[new_name] = 1
     curr_name = new_name
     if num_for_zero:
         curr_name += "_0"
     name_dict[orig_name] = curr_name
-    return def_string(curr_name, orig_num) + append_str
+    return def_string(curr_name, orig_num, var_prefix) + append_str
 
 # Translate a FileCheck use of a pattern.
-
-
 def translate_use_name(orig_name, orig_num, append_str):
     global name_dict, refcount_dict
     if orig_name in name_dict.keys():
@@ -155,55 +148,66 @@ def translate_use_name(orig_name, orig_num, append_str):
 
 # Pattern that we are substituting from. To is either obtained by
 # record_name_def or translate_use_name
-
-
-def use_name(orig_name, orig_num, append_str):
-    return "%" + orig_name + orig_num + append_str
+def use_name(orig_name, orig_num, append_str, var_prefix='%'):
+    return var_prefix + orig_name + orig_num + append_str
 
 
 ################################################################################
 # process a line
 
 # Process the substitution for a whole line for the given pattern.
-
-
-def process_name(new_line, pattern, default_name, append_str, num_for_zero):
+def process_name(new_line, pattern, default_name, append_str, num_for_zero, var_prefix='%'):
     definitions = pattern.findall(new_line)
     for d in definitions:
         (name, num) = d
-        x = use_name(name, num, append_str)
+        x = use_name(name, num, append_str, var_prefix)
         y = record_name_def(name, num, default_name,
-                            append_str, num_for_zero, new_line)
+                            append_str, num_for_zero, new_line, var_prefix)
         new_line = new_line.replace(x, y)
     return new_line
-
 
 # Drive the processing of the current line.
 def process_line(i, line):
     global debug, check, squash_before_fct, prepare_name_dict, name_dict, refcount_dict
-    global line_color, curr_parallel_color
+    global line_color, curr_parallel_color, is_new_function_stuff
     def_arg_pat = re.compile(r'%([a-zA-Z0-9][a-zA-Z0-9_\-]*)():')
     def_qual_pat = re.compile(r'%([a-zA-Z0-9][a-zA-Z0-9_\-]*)(:\d+)?\s+=')
     def_pat = re.compile(r'%([a-zA-Z0-9][a-zA-Z0-9_\-]*)()\s+=')
+    def_map_pat = re.compile(r'#([a-zA-Z0-9][a-zA-Z0-9_\-]*)()\s+=')
     def_op_pat = re.compile(r'=\s+(?:\w+\.)?(\w+)')
     use_qual_pat = re.compile(r'%([a-zA-Z0-9][a-zA-Z0-9_\-]*)(:\d+)?')
-    # If we have an affine map, print it now unmodified.
-    if re.match(r'#\w+\s=\saffine_(map|set)<.*>', line) is not None:
-        if squash_before_fct != 1:
-            print("// CHECK-DAG:", line)
-        return
-    # Keep only function related text, which start by def with a space.
-    if re.match(r'\s+', line) is None:
-        return
+    use_map_qual_pat = re.compile(r'#([a-zA-Z0-9][a-zA-Z0-9_\-]*)()\(')
+    # Has a new function?
+    if re.match(r'#map', line) is not None or re.match(r'\s+(func\.)?func', line) is not None:
+        # have a function or a map on first char... Is is the first occurrence
+        if not is_new_function_stuff:
+            # Yes it is, reset dictionary and ref counts
+            name_dict = prepare_name_dict.copy()
+            refcount_dict.clear()
+            #print("/// reset dict with dic", name_dict, "refcount", refcount_dict)
+            is_new_function_stuff = True
+        # If not, we already have reset the map, no need to do it again.
+    else:
+        # We are processing something else: skip early stuff?
+        # all code does start with some space (ignoring modules)
+        if re.match(r'\s+', line) is None:
+            return
+        # Not skipping, disable processing stuff
+        is_new_function_stuff = False
+
     new_line = line
 
     # Process definition of variables.
+
+    # Special handling of map definition.
+    has_affine_map_def = False # Used for forcing CHECK-DAG as map def have no deps.
+    if re.match(r'#\w+\s=\saffine_(map|set)<.*>', line) is not None:
+        if squash_before_fct != 0:
+            return
+        new_line = process_name(new_line, def_map_pat, "MAP", " =", 1, '#')
+        has_affine_map_def = True
     # Special handling of function header.
-    if re.match(r'\s+(func\.)?func', line) is not None:
-        # Have a function: reset dictionary and ref counts
-        name_dict = prepare_name_dict.copy()
-        refcount_dict.clear()
-        #print("/// reset dict with dic", name_dict, "refcount", refcount_dict)
+    elif re.match(r'\s+(func\.)?func', line) is not None:
         new_line = process_name(new_line, def_arg_pat, "PARAM", ":", 1)
         squash_before_fct = 0 # After function, disable squashing
     # Special handling of loop iterations.
@@ -229,8 +233,8 @@ def process_line(i, line):
         new_line = process_name(new_line, def_qual_pat,
                                 "LOAD_"+mem+"_MEM", " =", 0)
     # Special handling for constant operations.
-    elif re.search(r'\sconstant\s(-?[0-9\.]+)', line) is not None:
-        res = re.search(r'\sconstant\s(-?[0-9\.]+)', line)
+    elif re.search(r'\sarith\.constant\s(-?[0-9\.]+)', line) is not None:
+        res = re.search(r'\sarith\.constant\s(-?[0-9\.]+)', line)
         num = res.group(1)
         num = res.group(1).replace("-", "minus_")
         num = num.replace(".", "_dot_")
@@ -248,11 +252,17 @@ def process_line(i, line):
             y = record_name_def(name, num, "VAR_"+name, " =", 0, new_line)
             new_line = new_line.replace(x, y)
 
-    # Process uses.
+    # Process uses and map use.
     uses = use_qual_pat.findall(new_line)
     for u in uses:
         (name, num) = u
         x = use_name(name, num, "")
+        y = translate_use_name(name, num, "")
+        new_line = new_line.replace(x, y)
+    uses = use_map_qual_pat.findall(new_line)
+    for u in uses:
+        (name, num) = u
+        x = use_name(name, num, "", "#")
         y = translate_use_name(name, num, "")
         new_line = new_line.replace(x, y)
 
@@ -280,7 +290,7 @@ def process_line(i, line):
             r'// CHECK-LABEL:\1\2\n// CHECK-SAME: \1\5', new_line)
         print(new_line)
     elif squash_before_fct != 1:
-        if line_color[i] == curr_parallel_color:
+        if line_color[i] == curr_parallel_color or has_affine_map_def:
             # This line is in an established parallel region
             print("// CHECK-DAG:  ", new_line)
         elif line_color[i] == line_color[i+1]:
@@ -302,17 +312,18 @@ def process_line(i, line):
 
 def main(argv):
     global debug, check, squash_before_fct
-    global def_set, line_color, curr_color, curr_parallel_color
+    global def_set, line_color, curr_color, curr_parallel_color, is_new_function_stuff
     debug = 0
     check = 0
     model = ""
     has_model = 0
     squash_before_fct = 0
     input_command = "mlir2FileCheck.py"
+    input_file_name = ""
     
     try:
         opts, args = getopt.getopt(
-            argv, "hdca:n:m:", ["help", "debug", "check", "args=", "names=", "model="])
+            argv, "hdca:n:m:i:", ["help", "debug", "check", "args=", "names=", "model=", "input="])
     except getopt.GetoptError:
         print_usage()
     for opt, arg in opts:
@@ -329,21 +340,25 @@ def main(argv):
                 return
             check = 1
         elif opt in ("-a", "--args"):
-            input_command += " -a\'" + arg + "\'"
+            # When the string has spurious \` instead of just `... remove it
+            arg = arg.replace('''\'''', "")
+            input_command += " -a \'" + arg + "\'"
             arg_names = json.loads(arg)
-            print("//  use arg names:", arg_names)
+            # print("//  use arg names:", arg_names)
             i = 0
             for new_name in arg_names:
                 prepare_name_def("arg" + str(i), new_name.upper())
                 i += 1
         elif opt in ("-n", "--names"):
+            arg = arg.replace('''\'''', "")
             input_command += " -n\'" + arg + "\'"
             user_dict = json.loads(arg)
-            print("//  use name dictionary:", user_dict)
+            # print("//  use name dictionary:", user_dict)
             for orig_name, new_name in user_dict.items():
                 prepare_name_def(orig_name, new_name.upper())
         elif opt in ("-m", "--model"):
-            squash_before_fct = 1
+            # We used to squash maps before the function, now keep them.
+            squash_before_fct = 0 
             has_model = 1
             model_file = open(arg, 'r')
             func_num = 0
@@ -351,16 +366,19 @@ def main(argv):
                 l = line.rstrip()
                 if re.match(r'\}', l) is not None: 
                     continue # Skip last bracket.
-                if re.match(r'//', l) is not None:
+                if re.match(r'\s*//', l) is not None:
                     continue # Skip old comments.
                 if re.match(r'$', l) is not None:
                     continue # Skip empty line.
-                if re.match(r'func', l) is not None:
+                if re.match(r'\s*func', l) is not None:
                     func_num = func_num + 1 # Count function to make sure only one.
                 model += l + "\n"
             if func_num != 1:
                 print("Error: the model option can only be used with one function, got", func_num)
                 return
+        elif opt in ("-i", "--input"):
+            # Do not add this option to the list of parameters recorded.
+            input_file_name = arg
 
     if len(args) > 0:
         print("command does not use arguments without options: ", args)
@@ -383,17 +401,28 @@ def main(argv):
     # Associate lines with a color; same color==same parallel set.
     line_color = []
     curr_color = 0  # Color identifying the current parallel set.
-    for line in sys.stdin:
-        l = line.rstrip()
-        process_def_use_chains(l)
-        if check:
-            print(l)
-        lines.append(l)
+    if input_file_name:
+        # Read from file
+        for line in open(input_file_name, 'r'):
+            l = line.rstrip()
+            process_def_use_chains(l)
+            if check:
+                print(l)
+            lines.append(l)
+    else:
+        # Read from stdin
+        for line in sys.stdin:
+            l = line.rstrip()
+            process_def_use_chains(l)
+            if check:
+                print(l)
+            lines.append(l)
     # Add one to avoid checking out of bound accesses.
     line_color.append(curr_color+1)
 
     # Process the input.
     curr_parallel_color = -1
+    is_new_function_stuff = False
     print("// " + input_command)
     for i, line in enumerate(lines):
         process_line(i, line)


### PR DESCRIPTION
Sometimes, we are making changes to the compiler which we know are correct, but results in different lit-tests patterns as currently used. Typically, we may "know" that a change works by running full backend tests, benchmarks, and exhaustive numerical tests.

At other times, we are discovering that a lit tests is broken because we broke the compiler, but using the normal FileCheck is painful as our lit-tests have sometimes upwards of 100 tests.

Here is a utility that may help.
```
Fixes and tests lit-test file. Repairs are done by "utils/mlir2FileCHeck"
utility.

fixLitTest [-dhprt] [-f <func-name> <lit-test-filename>
  -t/--test   : Run FileCheck on each function individually.
                When combined with "--repair", test repaired lit test.
  -r/--repair : Repair lit test for each function individually.
  -f,--func <func-name>: Perform test/repair only on given function.
  -p/--print  : Print original lit-test files for the individual.
                functions that were not fixed. Useful only when used
                in combination with "-r -f <func-name>.
  -h/--help   : Print help.
  -d/--help   : Print debug info.

File format for input list-test files:
 * A single "// RUN:" comment
 * A "// -----" comment
 * Subsequent functions separated by a "// -----" comment

Workflow for debugging test.mlir:
 * Test original file: "fixLitTest -t test.mlir".
 * If errors, test a given func X: "fixLitTest -t -f X test.mlir".
 * You may inspect the "flt_*.mlir" files in the current dir for more info.
 * Spurious error, repair func X:  "fixLitTest -t -r -f X test.mlir".
 * If good, save fix for X:  "fixLitTest -r -f -p X test.mlir > test.mlir".
 ```

For example, to discover what went wrong, we may run this
```
build# python ../utils/fixLitTest.py -t ../test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
>> File runs "onnx-mlir-opt -O3 --shape-inference --convert-onnx-to-krnl --canonicalize   " 
>> Successful test of "test_concat_5".
>> Successful test of "test_concat_4".
>> Successful test of "test_sequence_insert".
>> Successful test of "test_if_sign".
>> Successful test of "test_squeezev11_unknown_dimensions".
...
>> Start failure report of test "test_gather_elements_axis0neg".
flt_orig_model.mlir:22:42: error: undefined variable: PARAM_0
// CHECK: [[DATA_VAL:%.+]] = krnl.load [[PARAM_0]][[[SEL]], [[IV]]#1] : memref<3x2xf32>
                                         ^
flt_compiled.mlir:14:38: note: with "SEL" equal to "%7"
 %7 = arith.select %6, %5, %4 : index
                                     ^
flt_compiled.mlir:14:38: note: with "IV" equal to "%2"
 %7 = arith.select %6, %5, %4 : index
                                     ^
flt_compiled.mlir:15:5: note: possible intended match here
 %8 = krnl.load %arg0[%7, %2#1] : memref<3x2xf32>
...
>> Stop failure report of test "test_gather_elements_axis0neg".
>> run again with option "-t -f test_gather_elements_axis0neg" to focus on this test.
...
```

One can then run the command to isolate the failing function
```
build# python ../utils/fixLitTest.py -t -f test_gather_elements_axis0neg ../test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
...
>> Tested with 1 errors.
build# ls flt_*.mlir
flt_compiled.mlir  flt_new_model.mlir  flt_orig_model.mlir
```

Running a single command will leave `fly_*.mlir` files that can be used to better understand, run the command individually. Option `-d` prints all of the commands being used, if that helps.

Say the error is spurious, then we can repair the single erroneous function using this command (using the `-r` option)
```
build# python ../utils/fixLitTest.py -r -t -f test_gather_elements_axis0neg ../test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
```
which repair and tests with the repaired file check.

Let's say that we are satisfied, we can replace the error in place by printing all of the other functions unmodified using this command
```
build# python ../utils/fixLitTest.py -r -t -p -f test_gather_elements_axis0neg ../test/mlir/onnx/onnx_lowering_with_canonicalize.mlir > onnx_lowering_with_canonicalize.mlir
```
and eventually, we may move `onnx_lowering_with_canonicalize.mlir` into the original directory after diffing the files to make sure everything is ok.

