### PR TITLE
Uses IndexExpr for MHLO conversion

### DIFF
--- a/src/Conversion/ONNXToMhlo/CMakeLists.txt
+++ b/src/Conversion/ONNXToMhlo/CMakeLists.txt
@@ -70,7 +70,3 @@ target_link_libraries(MhloDialect PUBLIC
 target_link_libraries(StablehloTypeInference PUBLIC
   StablehloBase
   )
-
-target_link_libraries(StablehloTypeInference PUBLIC
-  StablehloBase
-  )

--- a/src/Conversion/ONNXToMhlo/ConvertONNXToMhlo.cpp
+++ b/src/Conversion/ONNXToMhlo/ConvertONNXToMhlo.cpp
@@ -83,7 +83,7 @@ void FrontendToMhloLoweringPass::runOnOperation() {
   // We define the specific operations, or dialects, that are legal targets for
   // this lowering.
   target.addLegalDialect<mhlo::MhloDialect, func::FuncDialect,
-      arith::ArithDialect, shape::ShapeDialect>();
+      arith::ArithDialect, shape::ShapeDialect, mlir::AffineDialect>();
   // Needed to support unsigned int computations. To be removed if we use a
   // scheme that does not rely on the UnrealizedConversionCastOp.
   target.addLegalOp<::mlir::UnrealizedConversionCastOp>();

--- a/src/Conversion/ONNXToMhlo/ONNXToMhloCommon.hpp
+++ b/src/Conversion/ONNXToMhlo/ONNXToMhloCommon.hpp
@@ -114,6 +114,16 @@ llvm::SmallVector<Value, 4> getBroadcastedOperands(
     llvm::SmallVector<Value, 4> &operands, Type outputType,
     ConversionPatternRewriter &rewriter, Location loc, int64_t outputRank);
 
+// This function satisfies the ArrayValueIndexCapture::DenseElementsAttr lambda
+// type, using MHLO and ONNX operations.
+mlir::DenseElementsAttr getDenseElementAttributeFromMhloValue(
+    mlir::Value value);
+
+// This function satisfies the ArrayValueIndexCapture::LoadVal lambda
+// type, using MHLO operations.
+mlir::Value loadValuefromArrayAtIndexWithMhlo(mlir::OpBuilder &rewriter,
+    mlir::Location loc, mlir::Value array, int64_t index);
+
 // `Math` directory methods:
 void populateLoweringONNXElementwiseOpToMhloPattern(
     RewritePatternSet &, MLIRContext *);

--- a/src/Conversion/ONNXToMhlo/Tensor/Flatten.cpp
+++ b/src/Conversion/ONNXToMhlo/Tensor/Flatten.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/Conversion/ONNXToMhlo/ONNXToMhloCommon.hpp"
+#include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
 using namespace mlir;
@@ -33,28 +34,16 @@ struct ONNXFlattenOpLoweringToMhlo : public ConversionPattern {
     ONNXFlattenOpAdaptor operandAdaptor(operands);
     ONNXFlattenOp flattenOp = llvm::cast<ONNXFlattenOp>(op);
 
-    Value input = operandAdaptor.input();
-    assert(isRankedShapedType(input.getType()) && "Expected Ranked ShapedType");
-    ShapedType inputType = input.getType().cast<ShapedType>();
-    int64_t rank = inputType.getRank();
-    int64_t axis = flattenOp.axis();
-    assert(axis >= -rank && axis <= rank - 1);
-    axis = axis >= 0 ? axis : rank + axis;
+    // shape helper
+    IndexExprScope scope(&rewriter, loc);
+    ONNXFlattenOpShapeHelper shapeHelper(&flattenOp, &scope);
+    LogicalResult shapecomputed = shapeHelper.computeShape(operandAdaptor);
+    assert(!failed(shapecomputed) && "shape helper failed");
 
-    Value flattenDimFirst = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value inputShape = rewriter.create<shape::ShapeOfOp>(loc, input);
-    for (int64_t i = 0; i < axis; i++) {
-      Value dim = rewriter.create<shape::GetExtentOp>(loc, inputShape, i);
-      flattenDimFirst =
-          rewriter.create<shape::MulOp>(loc, flattenDimFirst, dim);
-    }
-    Value flattenDimSecond = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    for (int64_t i = axis; i < rank; i++) {
-      Value dim = rewriter.create<shape::GetExtentOp>(loc, inputShape, i);
-      flattenDimSecond =
-          rewriter.create<shape::MulOp>(loc, flattenDimSecond, dim);
-    }
-    SmallVector<Value> dims{flattenDimFirst, flattenDimSecond};
+    Value input = operandAdaptor.input();
+
+    SmallVector<Value> dims;
+    IndexExpr::getValues(shapeHelper.dimsForOutput(), dims);
     Type outputShapeType = RankedTensorType::get({2}, rewriter.getIndexType());
     Value outputShape = rewriter.create<shape::FromExtentsOp>(loc, dims);
     outputShape = rewriter.create<shape::ToExtentTensorOp>(

--- a/src/Conversion/ONNXToMhlo/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToMhlo/Tensor/Slice.cpp
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/Conversion/ONNXToMhlo/ONNXToMhloCommon.hpp"
-#include "src/Dialect/Krnl/KrnlHelper.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
@@ -31,171 +30,107 @@ struct ONNXSliceOpLoweringToMhlo : public ConversionPattern {
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
-    ONNXSliceOpAdaptor operandAdaptor(operands);
+    ONNXSliceOpAdaptor operandAdaptor(operands, op->getAttrDictionary());
     ONNXSliceOp sliceOp = llvm::cast<ONNXSliceOp>(op);
     Location loc = op->getLoc();
 
+    // shape helper
+    IndexExprScope scope(&rewriter, loc);
+    ONNXSliceOpShapeHelper shapeHelper(&sliceOp, &rewriter,
+        getDenseElementAttributeFromMhloValue,
+        loadValuefromArrayAtIndexWithMhlo, &scope);
+    LogicalResult shapecomputed = shapeHelper.computeShape(operandAdaptor);
+    assert(!failed(shapecomputed) && "shape helper failed");
+
     Value data = sliceOp.data();
-    Value starts = sliceOp.starts();
-    Value axes = sliceOp.axes();
-    Value ends = sliceOp.ends();
-    Value steps = sliceOp.steps();
 
     assert(isRankedShapedType(data.getType()) &&
            "data must be ranked Shaped Type");
     ShapedType dataType = data.getType().cast<ShapedType>();
     int64_t rank = dataType.getRank();
-    Type indiceElementType = rewriter.getI64Type();
-    Value zero = rewriter.create<mhlo::ConstantOp>(loc,
-        DenseIntElementsAttr::get(RankedTensorType::get({1}, indiceElementType),
-            ArrayRef<int64_t>{0}));
-    Value one = rewriter.create<mhlo::ConstantOp>(loc,
-        DenseIntElementsAttr::get(RankedTensorType::get({1}, indiceElementType),
-            ArrayRef<int64_t>{1}));
-    SmallVector<Value, 4> stepValues;
-    SmallVector<Value, 4> beginValues;
-    SmallVector<Value, 4> endValues;
-    SmallVector<int64_t, 2> axesIntLitToIdx(rank, -1);
-    SmallVector<Value, 4> indices;
-
-    if (axes.getType().isa<NoneType>()) {
-      // If `axes` are omitted, they are set to `[0, ..., nDim-1]`."
-      for (int64_t i = 0; i < rank; ++i)
-        axesIntLitToIdx[i] = i;
-    } else if (auto valueAttribute =
-                   getDenseElementAttributeFromONNXValue(axes)) {
-      // If `axes` are constants, read them."
-      int64_t idx = 0;
-      for (IntegerAttr value : valueAttribute.getValues<IntegerAttr>()) {
-        int64_t axis = value.cast<IntegerAttr>().getInt();
-        if (axis < 0)
-          axis += rank;
-        assert((axis >= 0 && axis < (int64_t)rank) &&
-               "Axes contains an out-of-bound index");
-        axesIntLitToIdx[axis] = idx++;
-      }
-    } else {
-      assert(false && "Axes must be known at compile time");
-    }
-
     Value inputShape = rewriter.create<shape::ShapeOfOp>(loc, data);
+    Value zero = rewriter.create<mhlo::ConstantOp>(
+        loc, DenseIntElementsAttr::get(
+                 RankedTensorType::get({1}, rewriter.getI64Type()),
+                 ArrayRef<int64_t>{0}));
+    SmallVector<IndexExpr, 4> startIEs;
+    SmallVector<IndexExpr, 4> endIEs;
+    SmallVector<IndexExpr, 4> stepIEs;
 
+    MemRefBoundsIndexCapture dataBounds(data);
     for (int64_t i = 0; i < rank; ++i) {
-      Value dimValue;
-      if (dataType.getShape()[i] != ShapedType::kDynamicSize)
-        dimValue = rewriter.create<mhlo::ConstantOp>(
-            loc, DenseIntElementsAttr::get(
-                     RankedTensorType::get({1}, indiceElementType),
-                     ArrayRef<int64_t>{dataType.getShape()[i]}));
-      else {
-        Value dimIndexValue =
-            rewriter.create<shape::GetExtentOp>(loc, inputShape, i);
-        dimValue = rewriter.create<shape::FromExtentsOp>(loc, dimIndexValue);
-        dimValue = rewriter.create<shape::ToExtentTensorOp>(
-            loc, RankedTensorType::get({1}, rewriter.getIndexType()), dimValue);
-        dimValue = rewriter.create<arith::IndexCastOp>(
-            loc, RankedTensorType::get({1}, indiceElementType), dimValue);
-      }
-      if (axesIntLitToIdx[i] == -1) {
-        beginValues.push_back(zero);
-        stepValues.push_back(one);
-        endValues.push_back(dimValue);
+      DimIndexExpr dimInput(dataBounds.getDim(i));
+      IndexExpr start = shapeHelper.starts[i];
+      IndexExpr end = shapeHelper.ends[i];
+      IndexExpr step = shapeHelper.steps[i];
+
+      IndexExpr isNonNegativeIE = step >= 0;
+      IndexExpr startFinal =
+          IndexExpr::select(isNonNegativeIE, start, dimInput - 1 - start);
+      IndexExpr endFinal =
+          IndexExpr::select(isNonNegativeIE, end, dimInput - 1 - end);
+      IndexExpr stepFinal =
+          IndexExpr::select(isNonNegativeIE, step, LiteralIndexExpr(0) - step);
+      startIEs.push_back(startFinal);
+      endIEs.push_back(endFinal);
+      stepIEs.push_back(stepFinal);
+
+      Value reversedData = rewriter.create<mhlo::ReverseOp>(loc, data,
+          DenseIntElementsAttr::get(
+              RankedTensorType::get({1}, rewriter.getI64Type()),
+              ArrayRef<int64_t>{i}));
+      if (step.isLiteral()) {
+        if (step.getLiteral() < 0)
+          data = reversedData;
       } else {
-        Value beginValue = rewriter.create<mhlo::SliceOp>(loc,
-            RankedTensorType::get({1}, indiceElementType), starts,
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{axesIntLitToIdx[i]}),
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{axesIntLitToIdx[i] + 1}),
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{1}));
-        Value stepValue = rewriter.create<mhlo::SliceOp>(loc,
-            RankedTensorType::get({1}, indiceElementType), steps,
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{axesIntLitToIdx[i]}),
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{axesIntLitToIdx[i] + 1}),
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{1}));
-        Value endValue = rewriter.create<mhlo::SliceOp>(loc,
-            RankedTensorType::get({1}, indiceElementType), ends,
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{axesIntLitToIdx[i]}),
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{axesIntLitToIdx[i] + 1}),
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{1}));
-        Value isNegativeStepValue = rewriter.create<mhlo::CompareOp>(
-            loc, stepValue, zero, mhlo::ComparisonDirection::LT);
-        Value broadcastedIsNegativeValue =
+        Value stepValue = rewriter.create<shape::FromExtentsOp>(
+            loc, ArrayRef<Value>{step.getValue()});
+        stepValue = rewriter.create<shape::ToExtentTensorOp>(loc,
+            RankedTensorType::get({1}, rewriter.getIndexType()), stepValue);
+        stepValue = rewriter.create<arith::IndexCastOp>(
+            loc, RankedTensorType::get({1}, rewriter.getI64Type()), stepValue);
+        Value isNonNegative = rewriter.create<mhlo::CompareOp>(
+            loc, stepValue, zero, mhlo::ComparisonDirection::GE);
+        Value broadcastedIsNonNegative =
             rewriter.create<mhlo::DynamicBroadcastInDimOp>(loc,
                 RankedTensorType::get(
                     dataType.getShape(), rewriter.getI1Type()),
-                isNegativeStepValue, inputShape,
-                rewriter.getI64TensorAttr({0}));
-        Value negatedStepValue = rewriter.create<mhlo::NegOp>(loc, stepValue);
-        Value negatedStartValue =
-            rewriter.create<mhlo::AddOp>(loc, endValue, one);
-        Value negatedEndValue =
-            rewriter.create<mhlo::AddOp>(loc, beginValue, one);
-        Value reversedData = rewriter.create<mhlo::ReverseOp>(loc, data,
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({1}, indiceElementType),
-                ArrayRef<int64_t>{i}));
-        beginValue = rewriter.create<mhlo::SelectOp>(
-            loc, isNegativeStepValue, negatedStartValue, beginValue);
-        endValue = rewriter.create<mhlo::SelectOp>(
-            loc, isNegativeStepValue, negatedEndValue, endValue);
-        stepValue = rewriter.create<mhlo::SelectOp>(
-            loc, isNegativeStepValue, negatedStepValue, stepValue);
+                isNonNegative, inputShape, rewriter.getI64TensorAttr({0}));
         data = rewriter.create<mhlo::SelectOp>(
-            loc, broadcastedIsNegativeValue, reversedData, data);
-        Value exceedDimValue = rewriter.create<mhlo::CompareOp>(
-            loc, endValue, dimValue, mhlo::ComparisonDirection::GT);
-        Value clampedEndValue = rewriter.create<mhlo::SelectOp>(
-            loc, exceedDimValue, dimValue, endValue);
-        Value negDimValue = rewriter.create<mhlo::CompareOp>(
-            loc, clampedEndValue, zero, mhlo::ComparisonDirection::LT);
-        Value posDimValue =
-            rewriter.create<mhlo::AddOp>(loc, clampedEndValue, dimValue);
-        Value resultEndValue = rewriter.create<mhlo::SelectOp>(
-            loc, negDimValue, posDimValue, clampedEndValue);
-        Value negStartValue = rewriter.create<mhlo::CompareOp>(
-            loc, beginValue, zero, mhlo::ComparisonDirection::LT);
-        Value posStartValue =
-            rewriter.create<mhlo::AddOp>(loc, beginValue, dimValue);
-        Value resultBeginValue = rewriter.create<mhlo::SelectOp>(
-            loc, negStartValue, posStartValue, beginValue);
-        beginValues.push_back(resultBeginValue);
-        stepValues.push_back(stepValue);
-        endValues.push_back(resultEndValue);
+            loc, broadcastedIsNonNegative, data, reversedData);
       }
     }
 
+    auto createIndicesValue = [&](SmallVector<IndexExpr, 4> &IEs,
+                                  Value &indicesValue) {
+      Type indexTensorType =
+          RankedTensorType::get({rank}, rewriter.getIndexType());
+      Type I64TensorType = RankedTensorType::get({rank}, rewriter.getI64Type());
+      if (IndexExpr::isLiteral(IEs)) {
+        SmallVector<int64_t, 4> values;
+        for (int i = 0; i < rank; i++) {
+          values.push_back(IEs[i].getLiteral());
+        }
+        indicesValue = rewriter.create<mhlo::ConstantOp>(
+            loc, DenseIntElementsAttr::get(I64TensorType, values));
+      } else {
+        SmallVector<Value, 4> values;
+        IndexExpr::getValues(IEs, values);
+        indicesValue = rewriter.create<shape::FromExtentsOp>(loc, values);
+        indicesValue = rewriter.create<shape::ToExtentTensorOp>(
+            loc, indexTensorType, indicesValue);
+        indicesValue = rewriter.create<arith::IndexCastOp>(
+            loc, I64TensorType, indicesValue);
+      }
+    };
+    Value startIndices, endIndices, stepIndices;
+    createIndicesValue(startIEs, startIndices);
+    createIndicesValue(endIEs, endIndices);
+    createIndicesValue(stepIEs, stepIndices);
+
     Type outputType = *op->result_type_begin();
-    auto start_indices = rewriter.create<mhlo::ConcatenateOp>(loc,
-        RankedTensorType::get(
-            {static_cast<int64_t>(beginValues.size())}, indiceElementType),
-        beginValues, IntegerAttr::get(rewriter.getIntegerType(64), 0));
-    auto end_indices = rewriter.create<mhlo::ConcatenateOp>(loc,
-        RankedTensorType::get(
-            {static_cast<int64_t>(endValues.size())}, indiceElementType),
-        endValues, IntegerAttr::get(rewriter.getIntegerType(64), 0));
-    auto step_indices = rewriter.create<mhlo::ConcatenateOp>(loc,
-        RankedTensorType::get(
-            {static_cast<int64_t>(stepValues.size())}, indiceElementType),
-        stepValues, IntegerAttr::get(rewriter.getIntegerType(64), 0));
     Value sliceValue = rewriter.create<mhlo::RealDynamicSliceOp>(
-        loc, outputType, data, start_indices, end_indices, step_indices);
+        loc, outputType, data, startIndices, endIndices, stepIndices);
     rewriter.replaceOp(op, sliceValue);
     return success();
   }

--- a/src/Conversion/ONNXToMhlo/Tensor/Unsqueeze.cpp
+++ b/src/Conversion/ONNXToMhlo/Tensor/Unsqueeze.cpp
@@ -33,47 +33,18 @@ struct ONNXUnsqueezeOpLoweringToMhlo : public ConversionPattern {
     ONNXUnsqueezeOp unsqueezeOp = llvm::cast<ONNXUnsqueezeOp>(op);
     Location loc = op->getLoc();
     Value data = unsqueezeOp.data();
-    Value axes = unsqueezeOp.axes();
-    assert(isRankedShapedType(data.getType()) &&
-           "data must be ranked Shaped Type");
-    ShapedType dataType = data.getType().cast<ShapedType>();
-    int64_t rank = dataType.getRank();
 
-    ONNXUnsqueezeOpShapeHelper shapeHelper(&unsqueezeOp);
+    IndexExprScope scope(&rewriter, loc);
+    ONNXUnsqueezeOpShapeHelper shapeHelper(&unsqueezeOp, &scope);
     LogicalResult shapecomputed = shapeHelper.computeShape(operandAdaptor);
     assert(succeeded(shapecomputed) && "Could not compute output shape");
 
-    SmallVector<int64_t, 4> axesList;
-    if (DenseElementsAttr axesAttr =
-            getDenseElementAttributeFromONNXValue(axes)) {
-      for (IntegerAttr value : axesAttr.getValues<IntegerAttr>()) {
-        int64_t axis = value.cast<IntegerAttr>().getInt();
-        if (axis < 0)
-          axis += rank;
-        axesList.push_back(axis);
-      }
-    }
+    SmallVector<Value, 4> dims;
+    IndexExpr::getValues(shapeHelper.dimsForOutput(), dims);
 
-    int64_t newRank = rank + axesList.size();
-    SmallVector<Value, 4> newShape;
-    SmallVector<bool, 4> isUnsqueezeDim(newRank, false);
-    Value dataShape = rewriter.create<shape::ShapeOfOp>(loc, data);
-    for (int64_t axis : axesList) {
-      isUnsqueezeDim[axis] = true;
-    }
-    for (int64_t i = 0, j = 0; i < newRank; i++) {
-      if (isUnsqueezeDim[i]) {
-        Value indexValue = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-        newShape.push_back(indexValue);
-      } else {
-        Value dim = rewriter.create<shape::GetExtentOp>(loc, dataShape, j);
-        newShape.push_back(dim);
-        j++;
-      }
-    }
     Type outputShapeType =
-        RankedTensorType::get({newRank}, rewriter.getIndexType());
-    Value newShapeValue = rewriter.create<shape::FromExtentsOp>(loc, newShape);
+        RankedTensorType::get({(int64_t)dims.size()}, rewriter.getIndexType());
+    Value newShapeValue = rewriter.create<shape::FromExtentsOp>(loc, dims);
     newShapeValue = rewriter.create<shape::ToExtentTensorOp>(
         loc, outputShapeType, newShapeValue);
     Type outputType = *op->result_type_begin();

--- a/src/Dialect/Mlir/CMakeLists.txt
+++ b/src/Dialect/Mlir/CMakeLists.txt
@@ -14,6 +14,7 @@ add_onnx_mlir_library(OMMlirDialects
   MLIRMathDialect
   MLIRAffineDialect
   MLIRSCFDialect
+  MLIRShapeDialect
   MLIRVectorDialect
   MLIRLLVMIRTransforms
   )

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -625,6 +626,19 @@ Value MemRefBuilder::dim(Value val, Value index) const {
          "memref::DimOp expects input operand to have MemRefType or "
          "UnrankedMemRefType");
   return b().createOrFold<memref::DimOp>(loc(), val, index);
+}
+
+//===----------------------------------------------------------------------===//
+// Shape Dialect Builder
+//===----------------------------------------------------------------------===//
+
+Value ShapeBuilder::dim(Value val, int64_t index) const {
+  assert(val.getType().isa<ShapedType>() &&
+         "ShapeBuilder expects an input operand of ShapedType for "
+         "shape::ShapeOfOp");
+  assert(index >= 0 && "Expecting a valid index");
+  Value shapeValue = b().create<shape::ShapeOfOp>(loc(), val);
+  return b().create<shape::GetExtentOp>(loc(), shapeValue, index);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -184,6 +184,18 @@ struct MemRefBuilder final : DialectBuilder {
 static constexpr int64_t gDefaultAllocAlign = 16;
 
 //===----------------------------------------------------------------------===//
+// Shape Dialect Builder
+//===----------------------------------------------------------------------===//
+
+struct ShapeBuilder final : DialectBuilder {
+  ShapeBuilder(mlir::OpBuilder &b, mlir::Location loc)
+      : DialectBuilder(b, loc) {}
+  ShapeBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
+
+  mlir::Value dim(mlir::Value val, int64_t index) const;
+};
+
+//===----------------------------------------------------------------------===//
 // Structured Control Flow (SCF) Builder
 //===----------------------------------------------------------------------===//
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -123,8 +123,8 @@ LogicalResult ONNXSliceOpShapeHelper::computeShape(
         IndexExpr::select(endInput < 0, endInput + dimInput, endInput);
     endPos = endPos.selectOrSelf(endInput <= negInf, -1);
     endPos = endPos.selectOrSelf(endInput >= posInf, dimInput);
-    // End: step<0: clamp(-1, end, dim); step>0 clamp(0, end, dim)
-    neg = endPos.clamp(-1, dimInput);
+    // End: step<0: clamp(-1, end, dim -1); step>0 clamp(0, end, dim)
+    neg = endPos.clamp(-1, dimInput - 1);
     pos = endPos.clamp(0, dimInput);
     IndexExpr endFinal = IndexExpr::select(stepInput < 0, neg, pos);
 

--- a/test/mlir/conversion/onnx_to_mhlo/Tensor/ArgMax.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Tensor/ArgMax.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo %s --canonicalize -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --lower-affine %s --canonicalize -split-input-file | FileCheck %s
 
 func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64> {
   %1 = "onnx.ArgMax"(%arg0) { axis = -1 : si64} : (tensor<5x5x1x32xf32>)  -> tensor<*xi64>
@@ -19,19 +19,18 @@ func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64>
 // CHECK-DAG:       mhlo.return %[[V7]], %[[V11]] : tensor<f32>, tensor<i64>
 // CHECK-DAG:     }
 // CHECK-DAG:     %[[V5:.*]] = mhlo.reshape %[[V4]]#1 : (tensor<5x5x1xi64>) -> tensor<5x5x1x1xi64>
-// CHECK-DAG:     return %[[V5]] : tensor<5x5x1x1xi64>
-  
+// CHECK-DAG:     return %[[V5]] : tensor<5x5x1x1xi64>  
 }
 
 func.func @test_argmax_verifier_2(%arg0 : tensor<5x?x1x32xf32>) -> tensor<*xi64> {
   %1 = "onnx.ArgMax"(%arg0) { axis = 3 : si64} : (tensor<5x?x1x32xf32>)  -> tensor<*xi64>
   "func.return"(%1) : (tensor<*xi64>) -> ()
 // CHECK-LABEL: func.func @test_argmax_verifier_2(%arg0: tensor<5x?x1x32xf32>) -> tensor<5x?x1x1xi64> {
-// CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : index
 // CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
-// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C5:.*]] = arith.constant 5 : index
 // CHECK-DAG:     %[[V0:.*]] = mhlo.constant dense<0> : tensor<i64>
 // CHECK-DAG:     %[[V1:.*]] = mhlo.constant dense<0xFF800000> : tensor<f32>
+// CHECK-DAG:     %[[V6:.*]] = shape.shape_of %arg0 : tensor<5x?x1x32xf32> -> tensor<4xindex>
 // CHECK-DAG:     %[[V2:.*]] = shape.shape_of %arg0 : tensor<5x?x1x32xf32> -> tensor<4xindex>
 // CHECK-DAG:     %[[V3:.*]] = "mhlo.iota"() {iota_dimension = 0 : i64} : () -> tensor<32xi64>
 // CHECK-DAG:     %[[V4:.*]] = "mhlo.dynamic_broadcast_in_dim"(%[[V3]], %[[V2]]) {broadcast_dimensions = dense<3> : tensor<1xi64>} : (tensor<32xi64>, tensor<4xindex>) -> tensor<5x?x1x32xi64>
@@ -45,11 +44,9 @@ func.func @test_argmax_verifier_2(%arg0 : tensor<5x?x1x32xf32>) -> tensor<*xi64>
 // CHECK-DAG:       %[[V17:.*]] = mhlo.select %[[V14]], %[[V15]], %[[V16]] : tensor<i1>, tensor<i64>
 // CHECK-DAG:       mhlo.return %[[V13]], %[[V17]] : tensor<f32>, tensor<i64>
 // CHECK-DAG:     }
-// CHECK-DAG:     %[[V6:.*]] = shape.get_extent %[[V2]], %[[C0]] : tensor<4xindex>, index -> index
-// CHECK-DAG:     %[[V7:.*]] = shape.get_extent %[[V2]], %[[C1]] : tensor<4xindex>, index -> index
-// CHECK-DAG:     %[[V8:.*]] = shape.get_extent %[[V2]], %[[C2]] : tensor<4xindex>, index -> index
-// CHECK-DAG:     %[[V9:.*]] = shape.from_extents %[[V6]], %[[V7]], %[[V8]], %[[C1]] : index, index, index, index
-// CHECK-DAG:     %[[V10:.*]] = shape.to_extent_tensor %[[V9]] : !shape.shape -> tensor<4xindex>
-// CHECK-DAG:     %[[V11:.*]] = mhlo.dynamic_reshape %[[V5]]#1, %[[V10]] : (tensor<5x?x1xi64>, tensor<4xindex>) -> tensor<5x?x1x1xi64>
-// CHECK-DAG:     return %[[V11]] : tensor<5x?x1x1xi64>
+// CHECK-DAG:     %[[V7:.*]] = shape.get_extent %[[V6]], %[[C1]] : tensor<4xindex>, index -> index
+// CHECK-DAG:     %[[V8:.*]] = shape.from_extents %[[C5]], %[[V7]], %[[C1]], %[[C1]] : index, index, index, index
+// CHECK-DAG:     %[[V9:.*]] = shape.to_extent_tensor %[[V8]] : !shape.shape -> tensor<4xindex>
+// CHECK-DAG:     %[[V10:.*]] = mhlo.dynamic_reshape %[[V5]]#1, %[[V9]] : (tensor<5x?x1xi64>, tensor<4xindex>) -> tensor<5x?x1x1xi64>
+// CHECK-DAG:     return %[[V10]] : tensor<5x?x1x1xi64>
 }

--- a/test/mlir/conversion/onnx_to_mhlo/Tensor/Flatten.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Tensor/Flatten.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo %s --canonicalize -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --lower-affine %s --canonicalize -split-input-file | FileCheck %s
 
 // Test normal case
 func.func @test_flatten(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
@@ -35,17 +35,13 @@ func.func @test_flatten1(%arg0 : tensor<2x?x4xf32>) -> tensor<*xf32> {
   "func.return"(%1) : (tensor<*xf32>) -> ()
 // CHECK-LABEL: func @test_flatten1
 // CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<2x?x4xf32>) -> tensor<?x4xf32> {
-// CHECK-DAG:    [[C2:%.+]] = arith.constant 2 : index
-// CHECK-DAG:    [[C0:%.+]] = arith.constant 0 : index
+// CHECK-DAG:    [[C4:%.+]] = arith.constant 4 : index
 // CHECK-DAG:    [[C1:%.+]] = arith.constant 1 : index
-// CHECK-NEXT:    %0 = shape.shape_of %arg0 : tensor<2x?x4xf32> -> tensor<3xindex>
-// CHECK-NEXT:    %1 = shape.get_extent %0, [[C0]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:    %2 = shape.mul %1, [[C1]] : index, index -> index
-// CHECK-NEXT:    %3 = shape.get_extent %0, [[C1]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:    %4 = shape.mul %2, %3 : index, index -> index
-// CHECK-NEXT:    %5 = shape.get_extent %0, [[C2]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:    %6 = shape.mul %5, [[C1]] : index, index -> index
-// CHECK-NEXT:    %7 = shape.from_extents %4, %6 : index, index
-// CHECK-NEXT:    %8 = shape.to_extent_tensor %7 : !shape.shape -> tensor<2xindex>
-// CHECK-NEXT:    %9 = mhlo.dynamic_reshape %arg0, %8 : (tensor<2x?x4xf32>, tensor<2xindex>) -> tensor<?x4xf32>
+// CHECK-DAG:    [[C2:%.+]] = arith.constant 2 : index
+// CHECK-NEXT:    %0 = shape.shape_of [[PARAM_0_]] : tensor<2x?x4xf32> -> tensor<3xindex>
+// CHECK-NEXT:    %1 = shape.get_extent %0, [[C1]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:    %2 = arith.muli %1, [[C2]] : index
+// CHECK-NEXT:    %3 = shape.from_extents %2, [[C4]] : index, index
+// CHECK-NEXT:    %4 = shape.to_extent_tensor %3 : !shape.shape -> tensor<2xindex>
+// CHECK-NEXT:    %5 = mhlo.dynamic_reshape [[PARAM_0_]], %4 : (tensor<2x?x4xf32>, tensor<2xindex>) -> tensor<?x4xf32>
 }

--- a/test/mlir/conversion/onnx_to_mhlo/Tensor/Slice.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Tensor/Slice.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --canonicalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --lower-affine --canonicalize %s -split-input-file | FileCheck %s
 
 func.func @test_slice_constant_default_axes(%arg0 : tensor<2x4xf32>) -> tensor<*xf32> {
   %axes = "onnx.NoValue"() {value} : () -> none
@@ -74,7 +74,7 @@ func.func @test_slice_all_constant_negative_steps(%arg0 : tensor<2x4xf32>) -> te
   "func.return"(%1) : (tensor<*xf32>) -> ()
 // CHECK-LABEL: func @test_slice_all_constant_negative_steps
 // CHECK: %0 = "mhlo.reverse"(%arg0) {dimensions = dense<1> : tensor<1xi64>} : (tensor<2x4xf32>) -> tensor<2x4xf32>
-// CHECK: %1 = "mhlo.slice"(%0) {limit_indices = dense<[2, 4]> : tensor<2xi64>, start_indices = dense<1> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<2x4xf32>) -> tensor<1x2xf32>
+// CHECK: %1 = "mhlo.slice"(%0) {limit_indices = dense<[2, 3]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<2x4xf32>) -> tensor<1x2xf32>
 }
 
 // -----
@@ -89,28 +89,19 @@ func.func @dyntest_slice_constant_dynshape_not_spliced(%arg0 : tensor<?x4x5xf32>
   "func.return"(%res) : (tensor<*xf32>) -> ()
 // CHECK-LABEL: func @dyntest_slice_constant_dynshape_not_spliced
 // CHECK-SAME: ([[PARAM_0_:%.+]]: tensor<?x4x5xf32>) -> tensor<?x2x3xf32> {
-// CHECK-DAG:    [[VAR_0_:%.+]] = mhlo.constant dense<1> : tensor<3xi64>
-// CHECK-DAG:    [[VAR_1_:%.+]] = mhlo.constant dense<[0, 1, 1]> : tensor<3xi64>
-// CHECK-DAG:    [[VAR_2_:%.+]] = mhlo.constant dense<false> : tensor<1xi1>
-// CHECK-DAG:    [[VAR_3_:%.+]] = mhlo.constant dense<4> : tensor<1xi64>
-// CHECK-DAG:    [[VAR_4_:%.+]] = mhlo.constant dense<3> : tensor<1xi64>
+// CHECK-DAG:    [[VAR_STEP_:%.+]] = mhlo.constant dense<1> : tensor<3xi64>
+// CHECK-DAG:    [[VAR_START_:%.+]] = mhlo.constant dense<[0, 1, 1]> : tensor<3xi64>
 // CHECK-DAG:    [[C0:%.+]] = arith.constant 0 : index
-// CHECK-DAG:    [[VAR_5_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<?x4x5xf32> -> tensor<3xindex>
-// CHECK-DAG:    [[VAR_6_:%.+]] = shape.get_extent [[VAR_5_]], [[C0]] : tensor<3xindex>, index -> index
-// CHECK-DAG:    [[VAR_7_:%.+]] = shape.from_extents [[VAR_6_]] : index
-// CHECK-DAG:    [[VAR_17_:%.+]] = shape.to_extent_tensor [[VAR_7_]] : !shape.shape -> tensor<1xindex>
-// CHECK-DAG:    [[VAR_8_:%.+]] = arith.index_cast [[VAR_17_]] : tensor<1xindex> to tensor<1xi64>
-// CHECK-DAG:    [[VAR_9_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_2_]], [[VAR_5_]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xi1>, tensor<3xindex>) -> tensor<?x4x5xi1>
-// CHECK-DAG:    [[VAR_10_:%.+]] = "mhlo.reverse"([[PARAM_0_]]) {dimensions = dense<1> : tensor<1xi64>} : (tensor<?x4x5xf32>) -> tensor<?x4x5xf32>
-// CHECK-DAG:    [[VAR_11_:%.+]] = mhlo.select [[VAR_9_]], [[VAR_10_]], [[PARAM_0_]] : tensor<?x4x5xi1>, tensor<?x4x5xf32>
-// CHECK-DAG:    [[VAR_12_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_2_]], [[VAR_5_]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xi1>, tensor<3xindex>) -> tensor<?x4x5xi1>
-// CHECK-DAG:    [[VAR_13_:%.+]] = "mhlo.reverse"([[VAR_11_]]) {dimensions = dense<2> : tensor<1xi64>} : (tensor<?x4x5xf32>) -> tensor<?x4x5xf32>
-// CHECK-DAG:    [[VAR_14_:%.+]] = mhlo.select [[VAR_12_]], [[VAR_13_]], [[VAR_11_]] : tensor<?x4x5xi1>, tensor<?x4x5xf32>
-// CHECK-DAG:    [[VAR_15_:%.+]] = "mhlo.concatenate"([[VAR_8_]], [[VAR_4_]], [[VAR_3_]]) {dimension = 0 : i64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
-// CHECK-DAG:    [[VAR_16_:%.+]] = mhlo.real_dynamic_slice [[VAR_14_]], [[VAR_1_]], [[VAR_15_]], [[VAR_0_]] : (tensor<?x4x5xf32>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<?x2x3xf32>
-// CHECK-DAG:    return [[VAR_16_]] : tensor<?x2x3xf32>
+// CHECK-DAG:    [[C4:%.+]] = arith.constant 4 : index
+// CHECK-DAG:    [[C3:%.+]] = arith.constant 3 : index
+// CHECK-DAG:    [[VAR_2_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<?x4x5xf32> -> tensor<3xindex>
+// CHECK-DAG:    [[VAR_3_:%.+]] = shape.get_extent [[VAR_2_]], [[C0]] : tensor<3xindex>, index -> index
+// CHECK-DAG:    [[VAR_4_:%.+]] = shape.from_extents [[VAR_3_]], [[C3]], [[C4]] : index, index, index
+// CHECK-DAG:    [[VAR_5_:%.+]] = shape.to_extent_tensor [[VAR_4_]] : !shape.shape -> tensor<3xindex>
+// CHECK-DAG:    [[VAR_END_:%.+]] = arith.index_cast [[VAR_5_]] : tensor<3xindex> to tensor<3xi64>
+// CHECK-DAG:    [[VAR_7_:%.+]] = mhlo.real_dynamic_slice [[PARAM_0_]], [[VAR_START_]], [[VAR_END_]], [[VAR_STEP_]] : (tensor<?x4x5xf32>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<?x2x3xf32>
+// CHECK-DAG:    return [[VAR_7_]] : tensor<?x2x3xf32>
 }
-
 
 // -----
 
@@ -120,57 +111,132 @@ func.func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %
   %res = "onnx.Slice"(%data, %arg0, %arg1, %axes, %arg2) : (tensor<3x4x5xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<*xi64>
   "func.return"(%res) : (tensor<*xi64>) -> ()
 // CHECK-LABEL: func @compute_slice_all_dyn
-// CHECK-DAG:     %[[V0:.*]] = mhlo.constant {{.*}}30, 31, 32, 33, 34{{.*}} tensor<3x4x5xi64>
-// CHECK-DAG:     %[[V1:.*]] = mhlo.constant dense<5> : tensor<1xi64>
-// CHECK-DAG:     %[[V2:.*]] = mhlo.constant dense<4> : tensor<1xi64>
-// CHECK-DAG:     %[[V3:.*]] = mhlo.constant dense<3> : tensor<1xi64>
-// CHECK-DAG:     %[[V4:.*]] = mhlo.constant {{.*}}0, 1, 2, 3, 4{{.*}} tensor<3x4x5xi64>
-// CHECK-DAG:     %[[V5:.*]] = mhlo.constant dense<0> : tensor<1xi64>
-// CHECK-DAG:     %[[V6:.*]] = mhlo.constant dense<1> : tensor<1xi64>
-// CHECK-DAG:     %[[V7:.*]] = "mhlo.slice"(%arg0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK-DAG:     %[[V8:.*]] = "mhlo.slice"(%arg2) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK-DAG:     %[[V9:.*]] = "mhlo.slice"(%arg1) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK-DAG:     %[[V10:.*]] = mhlo.compare  LT, %[[V8]], %[[V5]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-// CHECK-DAG:     %[[V11:.*]] = "mhlo.broadcast_in_dim"(%[[V10]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xi1>) -> tensor<3x4x5xi1>
-// CHECK-DAG:     %[[V12:.*]] = mhlo.negate %[[V8]] : tensor<1xi64>
-// CHECK-DAG:     %[[V13:.*]] = mhlo.add %[[V9]], %[[V6]] : tensor<1xi64>
-// CHECK-DAG:     %[[V14:.*]] = mhlo.add %[[V7]], %[[V6]] : tensor<1xi64>
-// CHECK-DAG:     %[[V15:.*]] = mhlo.select %[[V10]], %[[V13]], %[[V7]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V16:.*]] = mhlo.select %[[V10]], %[[V14]], %[[V9]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V17:.*]] = mhlo.select %[[V10]], %[[V12]], %[[V8]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V18:.*]] = mhlo.select %[[V11]], %[[V0]], %[[V4]] : tensor<3x4x5xi1>, tensor<3x4x5xi64>
-// CHECK-DAG:     %[[V19:.*]] = mhlo.compare  GT, %[[V16]], %[[V2]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-// CHECK-DAG:     %[[V20:.*]] = mhlo.select %[[V19]], %[[V2]], %[[V16]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V21:.*]] = mhlo.compare  LT, %[[V20]], %[[V5]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-// CHECK-DAG:     %[[V22:.*]] = mhlo.add %[[V20]], %[[V2]] : tensor<1xi64>
-// CHECK-DAG:     %[[V23:.*]] = mhlo.select %[[V21]], %[[V22]], %[[V20]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V24:.*]] = mhlo.compare  LT, %[[V15]], %[[V5]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-// CHECK-DAG:     %[[V25:.*]] = mhlo.add %[[V15]], %[[V2]] : tensor<1xi64>
-// CHECK-DAG:     %[[V26:.*]] = mhlo.select %[[V24]], %[[V25]], %[[V15]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V27:.*]] = "mhlo.slice"(%arg0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK-DAG:     %[[V28:.*]] = "mhlo.slice"(%arg2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK-DAG:     %[[V29:.*]] = "mhlo.slice"(%arg1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi64>) -> tensor<1xi64>
-// CHECK-DAG:     %[[V30:.*]] = mhlo.compare  LT, %[[V28]], %[[V5]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-// CHECK-DAG:     %[[V31:.*]] = "mhlo.broadcast_in_dim"(%[[V30]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xi1>) -> tensor<3x4x5xi1>
-// CHECK-DAG:     %[[V32:.*]] = mhlo.negate %[[V28]] : tensor<1xi64>
-// CHECK-DAG:     %[[V33:.*]] = mhlo.add %[[V29]], %[[V6]] : tensor<1xi64>
-// CHECK-DAG:     %[[V34:.*]] = mhlo.add %[[V27]], %[[V6]] : tensor<1xi64>
-// CHECK-DAG:     %[[V35:.*]] = "mhlo.reverse"(%[[V18]]) {dimensions = dense<2> : tensor<1xi64>} : (tensor<3x4x5xi64>) -> tensor<3x4x5xi64>
-// CHECK-DAG:     %[[V36:.*]] = mhlo.select %[[V30]], %[[V33]], %[[V27]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V37:.*]] = mhlo.select %[[V30]], %[[V34]], %[[V29]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V38:.*]] = mhlo.select %[[V30]], %[[V32]], %[[V28]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V39:.*]] = mhlo.select %[[V31]], %[[V35]], %[[V18]] : tensor<3x4x5xi1>, tensor<3x4x5xi64>
-// CHECK-DAG:     %[[V40:.*]] = mhlo.compare  GT, %[[V37]], %[[V1]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-// CHECK-DAG:     %[[V41:.*]] = mhlo.select %[[V40]], %[[V1]], %[[V37]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V42:.*]] = mhlo.compare  LT, %[[V41]], %[[V5]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-// CHECK-DAG:     %[[V43:.*]] = mhlo.add %[[V41]], %[[V1]] : tensor<1xi64>
-// CHECK-DAG:     %[[V44:.*]] = mhlo.select %[[V42]], %[[V43]], %[[V41]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V45:.*]] = mhlo.compare  LT, %[[V36]], %[[V5]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-// CHECK-DAG:     %[[V46:.*]] = mhlo.add %[[V36]], %[[V1]] : tensor<1xi64>
-// CHECK-DAG:     %[[V47:.*]] = mhlo.select %[[V45]], %[[V46]], %[[V36]] : tensor<1xi1>, tensor<1xi64>
-// CHECK-DAG:     %[[V48:.*]] = "mhlo.concatenate"(%[[V5]], %[[V26]], %[[V47]]) {dimension = 0 : i64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
-// CHECK-DAG:     %[[V49:.*]] = "mhlo.concatenate"(%[[V3]], %[[V23]], %[[V44]]) {dimension = 0 : i64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
-// CHECK-DAG:     %[[V50:.*]] = "mhlo.concatenate"(%[[V6]], %[[V17]], %[[V38]]) {dimension = 0 : i64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
-// CHECK-DAG:     %[[V51:.*]] = mhlo.real_dynamic_slice %[[V39]], %[[V48]], %[[V49]], %[[V50]] : (tensor<3x4x5xi64>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<3x?x?xi64>
-// CHECK-DAG:     return %[[V51]] : tensor<3x?x?xi64>
+// CHECK-SAME: ([[PARAM_START_:%.+]]: tensor<2xi64>, [[PARAM_END_:%.+]]: tensor<2xi64>, [[PARAM_STEP_:%.+]]: tensor<2xi64>) -> tensor<3x?x?xi64> {
+// CHECK-DAG:    [[DATA_:%.+]] = mhlo.constant
+// CHECK-SAME{LITERAL}: dense<[[[30, 31, 32, 33, 34], [20, 21, 22, 23, 24], [10, 11, 12, 13, 14], [0, 1, 2, 3, 4]], [[130, 131, 132, 133, 134], [120, 121, 122, 123, 124], [110, 111, 112, 113, 114], [100, 101, 102, 103, 104]], [[230, 231, 232, 233, 234], [220, 221, 222, 223, 224], [210, 211, 212, 213, 214], [200, 201, 202, 203, 204]]]> : tensor<3x4x5xi64>
+// CHECK-DAG:    [[VAR_1_:%.+]] = mhlo.constant dense<0> : tensor<1xi64>
+// CHECK-DAG:    %c3 = arith.constant 3 : index
+// CHECK-DAG:    %c2147483647 = arith.constant 2147483647 : index
+// CHECK-DAG:    %c-1 = arith.constant -1 : index
+// CHECK-DAG:    %c-2147483648 = arith.constant -2147483648 : index
+// CHECK-DAG:    %c4 = arith.constant 4 : index
+// CHECK-DAG:    %c1 = arith.constant 1 : index
+// CHECK-DAG:    %c5 = arith.constant 5 : index
+// CHECK-DAG:    %c0 = arith.constant 0 : index
+// CHECK-DAG:    [[REVERSED_1_:%.+]] = mhlo.constant
+// CHECK-SAME{LITERAL}: dense<[[[0, 1, 2, 3, 4], [10, 11, 12, 13, 14], [20, 21, 22, 23, 24], [30, 31, 32, 33, 34]], [[100, 101, 102, 103, 104], [110, 111, 112, 113, 114], [120, 121, 122, 123, 124], [130, 131, 132, 133, 134]], [[200, 201, 202, 203, 204], [210, 211, 212, 213, 214], [220, 221, 222, 223, 224], [230, 231, 232, 233, 234]]]> : tensor<3x4x5xi64>
+
+// The following content is added by ONNXSliceOpShapeHelper::computeShape()
+// CHECK-DAG:    [[VAR_3_:%.+]] = arith.index_cast [[PARAM_START_]] : tensor<2xi64> to tensor<2xindex>
+// CHECK-DAG:    [[VAR_4_:%.+]] = shape.get_extent [[VAR_3_]], %c0 : tensor<2xindex>, index -> index
+// CHECK-DAG:    [[VAR_5_:%.+]] = arith.index_cast [[PARAM_END_]] : tensor<2xi64> to tensor<2xindex>
+// CHECK-DAG:    [[VAR_6_:%.+]] = shape.get_extent [[VAR_5_]], %c0 : tensor<2xindex>, index -> index
+// CHECK-DAG:    [[VAR_7_:%.+]] = arith.index_cast [[PARAM_STEP_]] : tensor<2xi64> to tensor<2xindex>
+// CHECK-DAG:    [[STEP_2_:%.+]] = shape.get_extent [[VAR_7_]], %c0 : tensor<2xindex>, index -> index
+// CHECK-DAG:    [[VAR_9_:%.+]] = arith.addi [[VAR_4_]], %c5 : index
+// CHECK-DAG:    [[VAR_10_:%.+]] = arith.cmpi slt, [[VAR_4_]], %c0 : index
+// CHECK-DAG:    [[VAR_11_:%.+]] = arith.select [[VAR_10_]], [[VAR_9_]], [[VAR_4_]] : index
+// CHECK-DAG:    [[VAR_12_:%.+]] = arith.cmpi slt, [[VAR_11_]], %c0 : index
+// CHECK-DAG:    [[VAR_13_:%.+]] = arith.select [[VAR_12_]], %c0, [[VAR_11_]] : index
+// CHECK-DAG:    [[VAR_14_:%.+]] = arith.cmpi sgt, [[VAR_13_]], %c4 : index
+// CHECK-DAG:    [[VAR_15_:%.+]] = arith.select [[VAR_14_]], %c4, [[VAR_13_]] : index
+// CHECK-DAG:    [[VAR_16_:%.+]] = arith.cmpi slt, [[VAR_11_]], %c0 : index
+// CHECK-DAG:    [[VAR_17_:%.+]] = arith.select [[VAR_16_]], %c0, [[VAR_11_]] : index
+// CHECK-DAG:    [[VAR_18_:%.+]] = arith.cmpi sgt, [[VAR_17_]], %c5 : index
+// CHECK-DAG:    [[VAR_19_:%.+]] = arith.select [[VAR_18_]], %c5, [[VAR_17_]] : index
+// CHECK-DAG:    [[VAR_20_:%.+]] = arith.cmpi slt, [[STEP_2_]], %c0 : index
+// CHECK-DAG:    [[VAR_21_:%.+]] = arith.select [[VAR_20_]], [[VAR_15_]], [[VAR_19_]] : index
+// CHECK-DAG:    [[VAR_22_:%.+]] = arith.addi [[VAR_6_]], %c5 : index
+// CHECK-DAG:    [[VAR_23_:%.+]] = arith.cmpi slt, [[VAR_6_]], %c0 : index
+// CHECK-DAG:    [[VAR_24_:%.+]] = arith.select [[VAR_23_]], [[VAR_22_]], [[VAR_6_]] : index
+// CHECK-DAG:    [[VAR_25_:%.+]] = arith.cmpi sle, [[VAR_6_]], %c-2147483648 : index
+// CHECK-DAG:    [[VAR_26_:%.+]] = arith.select [[VAR_25_]], %c-1, [[VAR_24_]] : index
+// CHECK-DAG:    [[VAR_27_:%.+]] = arith.cmpi sge, [[VAR_6_]], %c2147483647 : index
+// CHECK-DAG:    [[VAR_28_:%.+]] = arith.select [[VAR_27_]], %c5, [[VAR_26_]] : index
+// CHECK-DAG:    [[VAR_29_:%.+]] = arith.cmpi slt, [[VAR_28_]], %c-1 : index
+// CHECK-DAG:    [[VAR_30_:%.+]] = arith.select [[VAR_29_]], %c-1, [[VAR_28_]] : index
+// CHECK-DAG:    [[VAR_31_:%.+]] = arith.cmpi sgt, [[VAR_30_]], %c4 : index
+// CHECK-DAG:    [[VAR_32_:%.+]] = arith.select [[VAR_31_]], %c4, [[VAR_30_]] : index
+// CHECK-DAG:    [[VAR_33_:%.+]] = arith.cmpi slt, [[VAR_28_]], %c0 : index
+// CHECK-DAG:    [[VAR_34_:%.+]] = arith.select [[VAR_33_]], %c0, [[VAR_28_]] : index
+// CHECK-DAG:    [[VAR_35_:%.+]] = arith.cmpi sgt, [[VAR_34_]], %c5 : index
+// CHECK-DAG:    [[VAR_36_:%.+]] = arith.select [[VAR_35_]], %c5, [[VAR_34_]] : index
+// CHECK-DAG:    [[VAR_37_:%.+]] = arith.cmpi slt, [[STEP_2_]], %c0 : index
+// CHECK-DAG:    [[VAR_38_:%.+]] = arith.select [[VAR_37_]], [[VAR_32_]], [[VAR_36_]] : index
+// CHECK-DAG:    [[VAR_39_:%.+]] = arith.index_cast [[PARAM_START_]] : tensor<2xi64> to tensor<2xindex>
+// CHECK-DAG:    [[VAR_40_:%.+]] = shape.get_extent [[VAR_39_]], %c1 : tensor<2xindex>, index -> index
+// CHECK-DAG:    [[VAR_41_:%.+]] = arith.index_cast [[PARAM_END_]] : tensor<2xi64> to tensor<2xindex>
+// CHECK-DAG:    [[VAR_42_:%.+]] = shape.get_extent [[VAR_41_]], %c1 : tensor<2xindex>, index -> index
+// CHECK-DAG:    [[VAR_43_:%.+]] = arith.index_cast [[PARAM_STEP_]] : tensor<2xi64> to tensor<2xindex>
+// CHECK-DAG:    [[STEP_1_:%.+]] = shape.get_extent [[VAR_43_]], %c1 : tensor<2xindex>, index -> index
+// CHECK-DAG:    [[VAR_45_:%.+]] = arith.addi [[VAR_40_]], %c4 : index
+// CHECK-DAG:    [[VAR_46_:%.+]] = arith.cmpi slt, [[VAR_40_]], %c0 : index
+// CHECK-DAG:    [[VAR_47_:%.+]] = arith.select [[VAR_46_]], [[VAR_45_]], [[VAR_40_]] : index
+// CHECK-DAG:    [[VAR_48_:%.+]] = arith.cmpi slt, [[VAR_47_]], %c0 : index
+// CHECK-DAG:    [[VAR_49_:%.+]] = arith.select [[VAR_48_]], %c0, [[VAR_47_]] : index
+// CHECK-DAG:    [[VAR_50_:%.+]] = arith.cmpi sgt, [[VAR_49_]], %c3 : index
+// CHECK-DAG:    [[VAR_51_:%.+]] = arith.select [[VAR_50_]], %c3, [[VAR_49_]] : index
+// CHECK-DAG:    [[VAR_52_:%.+]] = arith.cmpi slt, [[VAR_47_]], %c0 : index
+// CHECK-DAG:    [[VAR_53_:%.+]] = arith.select [[VAR_52_]], %c0, [[VAR_47_]] : index
+// CHECK-DAG:    [[VAR_54_:%.+]] = arith.cmpi sgt, [[VAR_53_]], %c4 : index
+// CHECK-DAG:    [[VAR_55_:%.+]] = arith.select [[VAR_54_]], %c4, [[VAR_53_]] : index
+// CHECK-DAG:    [[VAR_56_:%.+]] = arith.cmpi slt, [[STEP_1_]], %c0 : index
+// CHECK-DAG:    [[VAR_57_:%.+]] = arith.select [[VAR_56_]], [[VAR_51_]], [[VAR_55_]] : index
+// CHECK-DAG:    [[VAR_58_:%.+]] = arith.addi [[VAR_42_]], %c4 : index
+// CHECK-DAG:    [[VAR_59_:%.+]] = arith.cmpi slt, [[VAR_42_]], %c0 : index
+// CHECK-DAG:    [[VAR_60_:%.+]] = arith.select [[VAR_59_]], [[VAR_58_]], [[VAR_42_]] : index
+// CHECK-DAG:    [[VAR_61_:%.+]] = arith.cmpi sle, [[VAR_42_]], %c-2147483648 : index
+// CHECK-DAG:    [[VAR_62_:%.+]] = arith.select [[VAR_61_]], %c-1, [[VAR_60_]] : index
+// CHECK-DAG:    [[VAR_63_:%.+]] = arith.cmpi sge, [[VAR_42_]], %c2147483647 : index
+// CHECK-DAG:    [[VAR_64_:%.+]] = arith.select [[VAR_63_]], %c4, [[VAR_62_]] : index
+// CHECK-DAG:    [[VAR_65_:%.+]] = arith.cmpi slt, [[VAR_64_]], %c-1 : index
+// CHECK-DAG:    [[VAR_66_:%.+]] = arith.select [[VAR_65_]], %c-1, [[VAR_64_]] : index
+// CHECK-DAG:    [[VAR_67_:%.+]] = arith.cmpi sgt, [[VAR_66_]], %c3 : index
+// CHECK-DAG:    [[VAR_68_:%.+]] = arith.select [[VAR_67_]], %c3, [[VAR_66_]] : index
+// CHECK-DAG:    [[VAR_69_:%.+]] = arith.cmpi slt, [[VAR_64_]], %c0 : index
+// CHECK-DAG:    [[VAR_70_:%.+]] = arith.select [[VAR_69_]], %c0, [[VAR_64_]] : index
+// CHECK-DAG:    [[VAR_71_:%.+]] = arith.cmpi sgt, [[VAR_70_]], %c4 : index
+// CHECK-DAG:    [[VAR_72_:%.+]] = arith.select [[VAR_71_]], %c4, [[VAR_70_]] : index
+// CHECK-DAG:    [[VAR_73_:%.+]] = arith.cmpi slt, [[STEP_1_]], %c0 : index
+// CHECK-DAG:    [[VAR_74_:%.+]] = arith.select [[VAR_73_]], [[VAR_68_]], [[VAR_72_]] : index
+
+// The following content is **not** added by ONNXSliceOpShapeHelper::computeShape()
+// CHECK-DAG:    [[IS_NON_NEG_STEP_1_:%.+]] = arith.cmpi sge, [[STEP_1_]], %c0 : index
+// CHECK-DAG:    [[VAR_76_:%.+]] = arith.subi %c3, [[VAR_57_]] : index
+// CHECK-DAG:    [[SELECTED_START_1_:%.+]] = arith.select [[IS_NON_NEG_STEP_1_]], [[VAR_57_]], [[VAR_76_]] : index
+// CHECK-DAG:    [[VAR_78_:%.+]] = arith.subi %c3, [[VAR_74_]] : index
+// CHECK-DAG:    [[SELECTED_END_1_:%.+]] = arith.select [[IS_NON_NEG_STEP_1_]], [[VAR_74_]], [[VAR_78_]] : index
+// CHECK-DAG:    [[VAR_80_:%.+]] = arith.muli [[STEP_1_]], %c-1 : index
+// CHECK-DAG:    [[SELECTED_STEP_1_:%.+]] = arith.select [[IS_NON_NEG_STEP_1_]], [[STEP_1_]], [[VAR_80_]] : index
+// CHECK-DAG:    [[VAR_82_:%.+]] = shape.from_extents [[STEP_1_]] : index
+// CHECK-DAG:    [[VAR_83_:%.+]] = shape.to_extent_tensor [[VAR_82_]] : !shape.shape -> tensor<1xindex>
+// CHECK-DAG:    [[VAR_84_:%.+]] = arith.index_cast [[VAR_83_]] : tensor<1xindex> to tensor<1xi64>
+// CHECK-DAG:    [[NON_NEG_1_:%.+]] = mhlo.compare  GE, [[VAR_84_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:    [[VAR_86_:%.+]] = "mhlo.broadcast_in_dim"([[NON_NEG_1_]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xi1>) -> tensor<3x4x5xi1>
+// CHECK-DAG:    [[SELECTED_DATA_1_:%.+]] = mhlo.select [[VAR_86_]], [[REVERSED_1_]], [[DATA_]] : tensor<3x4x5xi1>, tensor<3x4x5xi64>
+// CHECK-DAG:    [[IS_NON_NEG_STEP_2_:%.+]] = arith.cmpi sge, [[STEP_2_]], %c0 : index
+// CHECK-DAG:    [[VAR_89_:%.+]] = arith.subi %c4, [[VAR_21_]] : index
+// CHECK-DAG:    [[SELECTED_START_2_:%.+]] = arith.select [[IS_NON_NEG_STEP_2_]], [[VAR_21_]], [[VAR_89_]] : index
+// CHECK-DAG:    [[VAR_91_:%.+]] = arith.subi %c4, [[VAR_38_]] : index
+// CHECK-DAG:    [[SELECTED_END_2_:%.+]] = arith.select [[IS_NON_NEG_STEP_2_]], [[VAR_38_]], [[VAR_91_]] : index
+// CHECK-DAG:    [[VAR_93_:%.+]] = arith.muli [[STEP_2_]], %c-1 : index
+// CHECK-DAG:    [[SELECTED_STEP_2_:%.+]] = arith.select [[IS_NON_NEG_STEP_2_]], [[STEP_2_]], [[VAR_93_]] : index
+// CHECK-DAG:    [[REVERSED_2_:%.+]] = "mhlo.reverse"([[SELECTED_DATA_1_]]) {dimensions = dense<2> : tensor<1xi64>} : (tensor<3x4x5xi64>) -> tensor<3x4x5xi64>
+// CHECK-DAG:    [[VAR_96_:%.+]] = shape.from_extents [[STEP_2_]] : index
+// CHECK-DAG:    [[VAR_97_:%.+]] = shape.to_extent_tensor [[VAR_96_]] : !shape.shape -> tensor<1xindex>
+// CHECK-DAG:    [[VAR_98_:%.+]] = arith.index_cast [[VAR_97_]] : tensor<1xindex> to tensor<1xi64>
+// CHECK-DAG:    [[NON_NEG_2_:%.+]] = mhlo.compare  GE, [[VAR_98_]], [[VAR_1_]],  NOTYPE : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
+// CHECK-DAG:    [[VAR_100_:%.+]] = "mhlo.broadcast_in_dim"([[NON_NEG_2_]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<1xi1>) -> tensor<3x4x5xi1>
+// CHECK-DAG:    [[SELECTED_DATA_2_:%.+]] = mhlo.select [[VAR_100_]], [[SELECTED_DATA_1_]], [[REVERSED_2_]] : tensor<3x4x5xi1>, tensor<3x4x5xi64>
+// CHECK-DAG:    [[VAR_102_:%.+]] = shape.from_extents %c0, [[SELECTED_START_1_]], [[SELECTED_START_2_]] : index, index, index
+// CHECK-DAG:    [[VAR_103_:%.+]] = shape.to_extent_tensor [[VAR_102_]] : !shape.shape -> tensor<3xindex>
+// CHECK-DAG:    [[VAR_104_:%.+]] = arith.index_cast [[VAR_103_]] : tensor<3xindex> to tensor<3xi64>
+// CHECK-DAG:    [[VAR_105_:%.+]] = shape.from_extents %c3, [[SELECTED_END_1_]], [[SELECTED_END_2_]] : index, index, index
+// CHECK-DAG:    [[VAR_106_:%.+]] = shape.to_extent_tensor [[VAR_105_]] : !shape.shape -> tensor<3xindex>
+// CHECK-DAG:    [[VAR_107_:%.+]] = arith.index_cast [[VAR_106_]] : tensor<3xindex> to tensor<3xi64>
+// CHECK-DAG:    [[VAR_108_:%.+]] = shape.from_extents %c1, [[SELECTED_STEP_1_]], [[SELECTED_STEP_2_]] : index, index, index
+// CHECK-DAG:    [[VAR_109_:%.+]] = shape.to_extent_tensor [[VAR_108_]] : !shape.shape -> tensor<3xindex>
+// CHECK-DAG:    [[VAR_110_:%.+]] = arith.index_cast [[VAR_109_]] : tensor<3xindex> to tensor<3xi64>
+// CHECK-DAG:    [[VAR_111_:%.+]] = mhlo.real_dynamic_slice [[SELECTED_DATA_2_]], [[VAR_104_]], [[VAR_107_]], [[VAR_110_]] : (tensor<3x4x5xi64>, tensor<3xi64>, tensor<3xi64>, tensor<3xi64>) -> tensor<3x?x?xi64>
+// CHECK-DAG:    return [[VAR_111_]] : tensor<3x?x?xi64>
 }

--- a/test/mlir/conversion/onnx_to_mhlo/Tensor/Squeeze.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Tensor/Squeeze.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --canonicalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --lower-affine --canonicalize %s -split-input-file | FileCheck %s
 
 func.func @test_squeeze(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.Constant"() {value = dense<[1, -2]> : tensor<2xi64>} : () -> tensor<2xi64>
@@ -13,14 +13,12 @@ func.func @test_squeeze_unknown_dimensions(%arg0 : tensor<?x1x32x?x64xf32>) -> t
   %1 = "onnx.Squeeze"(%arg0, %0) : (tensor<?x1x32x?x64xf32>, tensor<2xi64>) -> (tensor<*xf32>)
   "func.return"(%1) : (tensor<*xf32>) -> ()
 // CHECK-LABEL: func @test_squeeze_unknown_dimensions
-// CHECK-DAG:    [[C4:%.+]] = arith.constant 4 : index
-// CHECK-DAG:    [[C2:%.+]] = arith.constant 2 : index
+// CHECK-DAG:    [[C64:%.+]] = arith.constant 64 : index
+// CHECK-DAG:    [[C32:%.+]] = arith.constant 32 : index
 // CHECK-DAG:    [[C0:%.+]] = arith.constant 0 : index
 // CHECK-DAG:    [[VAR_0_:%.+]] = shape.shape_of %arg0 : tensor<?x1x32x?x64xf32> -> tensor<5xindex>
 // CHECK-DAG:    [[VAR_1_:%.+]] = shape.get_extent %0, [[C0]] : tensor<5xindex>, index -> index
-// CHECK-DAG:    [[VAR_2_:%.+]] = shape.get_extent %0, [[C2]] : tensor<5xindex>, index -> index
-// CHECK-DAG:    [[VAR_3_:%.+]] = shape.get_extent %0, [[C4]] : tensor<5xindex>, index -> index
-// CHECK-DAG:   [[VAR_4_:%.+]] = shape.from_extents [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : index, index, index
-// CHECK-DAG:   [[VAR_5_:%.+]] = shape.to_extent_tensor [[VAR_4_]] : !shape.shape -> tensor<3xindex>
-// CHECK-DAG:   [[VAR_6_:%.+]] = mhlo.dynamic_reshape %arg0, [[VAR_5_]] : (tensor<?x1x32x?x64xf32>, tensor<3xindex>) -> tensor<?x32x64xf32>
+// CHECK-DAG:    [[VAR_2_:%.+]] = shape.from_extents [[VAR_1_]], [[C32]], [[C64]] : index, index, index
+// CHECK-DAG:    [[VAR_3_:%.+]] = shape.to_extent_tensor [[VAR_2_]] : !shape.shape -> tensor<3xindex>
+// CHECK-DAG:    [[VAR_4_:%.+]] = mhlo.dynamic_reshape %arg0, [[VAR_3_]] : (tensor<?x1x32x?x64xf32>, tensor<3xindex>) -> tensor<?x32x64xf32>
 }

--- a/test/mlir/conversion/onnx_to_mhlo/Tensor/Unsqueeze.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Tensor/Unsqueeze.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --canonicalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --lower-affine --canonicalize %s -split-input-file | FileCheck %s
 
 func.func @test_unsqueeze(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Constant"() {value = dense<[0, 3]> : tensor<2xi64>} : () -> tensor<2xi64>
@@ -25,4 +25,21 @@ func.func @test_unsqueeze_mix(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
 // CHECK-LABEL: func @test_unsqueeze_mix
 // CHECK-NEXT:         %0 = mhlo.reshape %arg0 : (tensor<16x32x64xf32>) -> tensor<16x1x32x1x64xf32>
 // CHECK-NEXT:         return %0 : tensor<16x1x32x1x64xf32>
+}
+
+func.func @test_unsqueeze_unknown_dimensions(%arg0 : tensor<?x?xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Constant"() {value = dense<[0, 2]> : tensor<2xi64>} : () -> tensor<2xi64>
+  %1 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<?x?xf32>, tensor<2xi64>) -> (tensor<*xf32>)
+  "func.return"(%1) : (tensor<*xf32>) -> ()
+// CHECK-LABEL: func @test_unsqueeze_unknown_dimensions
+// CHECK-DAG:      [[C0:%.+]] = arith.constant 0 : index
+// CHECK-DAG:      [[C1:%.+]] = arith.constant 1 : index
+// CHECK-DAG:      [[VAR_0_:%.+]] = shape.shape_of %arg0 : tensor<?x?xf32> -> tensor<2xindex>
+// CHECK-DAG:      [[VAR_1_:%.+]] = shape.get_extent [[VAR_0_]], [[C0]] : tensor<2xindex>, index -> index
+// CHECK-DAG:      [[VAR_2_:%.+]] = shape.shape_of %arg0 : tensor<?x?xf32> -> tensor<2xindex>
+// CHECK-DAG:      [[VAR_3_:%.+]] = shape.get_extent [[VAR_2_]], [[C1]] : tensor<2xindex>, index -> index
+// CHECK-DAG:      [[VAR_4_:%.+]] = shape.from_extents [[C1]], [[VAR_1_]], [[C1]], [[VAR_3_]] : index, index, index, index
+// CHECK-DAG:      [[VAR_5_:%.+]] = shape.to_extent_tensor [[VAR_4_]] : !shape.shape -> tensor<4xindex>
+// CHECK-DAG:      [[VAR_6_:%.+]] = mhlo.dynamic_reshape %arg0, [[VAR_5_]] : (tensor<?x?xf32>, tensor<4xindex>) -> tensor<1x?x1x?xf32>
+// CHECK-DAG:      return [[VAR_6_]] : tensor<1x?x1x?xf32>
 }

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -477,8 +477,8 @@ func.func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %
 // CHECK:           [[VAR_27_:%.+]] = arith.select [[VAR_26_]], [[CST_5_]], [[VAR_25_]] : index
 // CHECK:           [[VAR_28_:%.+]] = arith.cmpi slt, [[VAR_27_]], [[CST_minus_1_]] : index
 // CHECK:           [[VAR_29_:%.+]] = arith.select [[VAR_28_]], [[CST_minus_1_]], [[VAR_27_]] : index
-// CHECK:           [[VAR_30_:%.+]] = arith.cmpi sgt, [[VAR_29_]], [[CST_5_]] : index
-// CHECK-DAG:       [[VAR_31_:%.+]] = arith.select [[VAR_30_]], [[CST_5_]], [[VAR_29_]] : index
+// CHECK:           [[VAR_30_:%.+]] = arith.cmpi sgt, [[VAR_29_]], [[CST_4_]] : index
+// CHECK-DAG:       [[VAR_31_:%.+]] = arith.select [[VAR_30_]], [[CST_4_]], [[VAR_29_]] : index
 // CHECK-DAG:       [[VAR_32_:%.+]] = arith.cmpi slt, [[VAR_27_]], [[CST_0_]] : index
 // CHECK:           [[VAR_33_:%.+]] = arith.select [[VAR_32_]], [[CST_0_]], [[VAR_27_]] : index
 // CHECK:           [[VAR_34_:%.+]] = arith.cmpi sgt, [[VAR_33_]], [[CST_5_]] : index
@@ -523,8 +523,8 @@ func.func @compute_slice_all_dyn(%arg0 : tensor<2xi64>, %arg1 : tensor<2xi64>, %
 // CHECK:           [[VAR_67_:%.+]] = arith.select [[VAR_66_]], [[CST_4_]], [[VAR_65_]] : index
 // CHECK:           [[VAR_68_:%.+]] = arith.cmpi slt, [[VAR_67_]], [[CST_minus_1_]] : index
 // CHECK:           [[VAR_69_:%.+]] = arith.select [[VAR_68_]], [[CST_minus_1_]], [[VAR_67_]] : index
-// CHECK:           [[VAR_70_:%.+]] = arith.cmpi sgt, [[VAR_69_]], [[CST_4_]] : index
-// CHECK-DAG:       [[VAR_71_:%.+]] = arith.select [[VAR_70_]], [[CST_4_]], [[VAR_69_]] : index
+// CHECK:           [[VAR_70_:%.+]] = arith.cmpi sgt, [[VAR_69_]], [[CST_3_]] : index
+// CHECK-DAG:       [[VAR_71_:%.+]] = arith.select [[VAR_70_]], [[CST_3_]], [[VAR_69_]] : index
 // CHECK-DAG:       [[VAR_72_:%.+]] = arith.cmpi slt, [[VAR_67_]], [[CST_0_]] : index
 // CHECK:           [[VAR_73_:%.+]] = arith.select [[VAR_72_]], [[CST_0_]], [[VAR_67_]] : index
 // CHECK:           [[VAR_74_:%.+]] = arith.cmpi sgt, [[VAR_73_]], [[CST_4_]] : index


### PR DESCRIPTION
This pull request:

Refactors ONNX -> MHLO conversion to use IndexExpr:
- `Argmax`, `Flatten`, `Squeeze`, `Unsqueeze`, `Slice`