### PR TITLE
normalize value_float/int/string to rank zero scalars

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -496,10 +496,8 @@ ArrayAttr createArrayAttrFromConstantOp(Builder &builder, Value constOp) {
 // Create a DenseElementsAttr from a float attribute.
 DenseElementsAttr createDenseElementsAttrFromFloatAttr(
     PatternRewriter &rewriter, Type elementType, FloatAttr attr) {
-  SmallVector<int64_t, 1> dims(1, 1);
-  SmallVector<float, 1> values(1, attr.getValue().convertToFloat());
-  auto tensorType = RankedTensorType::get(dims, elementType);
-  return DenseElementsAttr::get(tensorType, makeArrayRef(values));
+  auto tensorType = RankedTensorType::get({1}, elementType);
+  return DenseElementsAttr::get(tensorType, {attr.getValue()});
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -204,7 +204,7 @@ bool hasShapeAndRank(mlir::Value val);
 // Support for Rewrite.
 //===----------------------------------------------------------------------===//
 
-// Create a DenseElementsAttr from a float attribute.
+// Create a (rank 1) DenseElementsAttr from a float attribute.
 mlir::DenseElementsAttr createDenseElementsAttrFromFloatAttr(
     mlir::PatternRewriter &rewriter, mlir::Type elementType,
     mlir::FloatAttr attr);

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -209,30 +209,6 @@ mlir::DenseElementsAttr createDenseElementsAttrFromFloatAttr(
     mlir::PatternRewriter &rewriter, mlir::Type elementType,
     mlir::FloatAttr attr);
 
-mlir::DenseElementsAttr createDenseElementsAttrFromFloatAttrs(
-    mlir::PatternRewriter &rewriter, mlir::Type elementType,
-    llvm::SmallVector<mlir::Attribute> attrs);
-
-// Create a DenseElementsAttr from a integer attribute.
-// The attribute is assumed to be SingedInteger.
-mlir::DenseElementsAttr createDenseElementsAttrFromIntegerAttr(
-    mlir::PatternRewriter &rewriter, mlir::Type elementType,
-    mlir::IntegerAttr attr);
-
-mlir::DenseElementsAttr createDenseElementsAttrFromFloatAttrs(
-    mlir::PatternRewriter &rewriter, mlir::Type elementType,
-    llvm::SmallVector<mlir::Attribute> attrs);
-
-// Integer attribute is assumed to be Signedless
-mlir::DenseElementsAttr createDenseElementsAttrFromIntegerAttrs(
-    mlir::PatternRewriter &rewriter, mlir::Type elementType,
-    llvm::SmallVector<mlir::Attribute> attrs);
-
-// Create a DenseElementsAttr from a String attribute.
-mlir::DenseElementsAttr createDenseElementsAttrFromStringAttrs(
-    mlir::PatternRewriter &rewriter, mlir::Type elementType,
-    llvm::SmallVector<mlir::Attribute> attrs);
-
 /// Create a DenseElementsAttr from a raw buffer.
 mlir::DenseElementsAttr createDenseElementsAttrFromRawBuffer(
     mlir::Type resType, char *buf);

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -610,7 +610,7 @@ func.func @test_constant_1() -> tensor<i64> {
   %0 = "onnx.Constant"() {value_int = 1 : si64} : () -> tensor<i64>
   return %0 : tensor<i64>
 // CHECK-LABEL:       func @test_constant_1
-// CHECK:           [[VAR_0:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<i64>
+// CHECK:           [[VAR_0:%.+]] = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
 // CHECK:           return [[VAR_0]] : tensor<i64>
 }
 
@@ -621,7 +621,7 @@ func.func @test_constant_2() -> tensor<f32> {
   %0 = "onnx.Constant"() {value_float = 2.0 : f32 } : () -> tensor<f32>
   return %0 : tensor<f32>
 // CHECK-LABEL:     func @test_constant_2 
-// CHECK: [[VAR_0:%.+]] = "onnx.Constant"() {value = dense<2.000000e+00> : tensor<1xf32>} : () -> tensor<f32>
+// CHECK: [[VAR_0:%.+]] = "onnx.Constant"() {value = dense<2.000000e+00> : tensor<f32>} : () -> tensor<f32>
 // CHECK: return [[VAR_0]] : tensor<f32>
 }
 


### PR DESCRIPTION
The normalization of value_float and value_int onnx constant ops to "rank 1 scalars" (with shape {1}) is causing problems for constant folding (see PR #1799 and PR #1874). I think it was wrong and we should make these rank 0 scalars (with empty shape {}), as implemented in this PR.