### PR TITLE
Fix -o in onnx-mlir-opt

### DIFF
--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -189,8 +189,12 @@ int main(int argc, char **argv) {
   }
 
   // TODO(imaihal): Change preloadDialectsInContext to false.
-  return failed(mlir::MlirOptMain(output->os(), std::move(file), passPipeline,
-      registry, split_input_file, verify_diagnostics, verify_passes,
-      allowUnregisteredDialects, /*preloadDialectsInContext*/ true,
-      /*emitBytecode*/ false, /*implicitModule*/ true));
+  if (failed(mlir::MlirOptMain(output->os(), std::move(file), passPipeline,
+          registry, split_input_file, verify_diagnostics, verify_passes,
+          allowUnregisteredDialects, /*preloadDialectsInContext*/ true,
+          /*emitBytecode*/ false, /*implicitModule*/ true)))
+    return mlir::asMainReturnCode(failure());
+
+  output->keep();
+  return mlir::asMainReturnCode(success());
 }

--- a/test/mlir/driver/outputfile.mlir
+++ b/test/mlir/driver/outputfile.mlir
@@ -1,0 +1,2 @@
+// RUN: onnx-mlir-opt %s -o %t
+// RUN: test -f %t


### PR DESCRIPTION
If `onnx-mlir-opt` was used with `-o` to create an outputfile, the file was always deleted after the run. This fixes it and also adds a test to make sure a file is created.

The implementation and test are adapted from [upstream MLIR](https://github.com/llvm/llvm-project/blob/05ff7606c9d47135ecf5b69e25b1327634f6fa27/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp#L306-L315).


Signed-off-by: Maximilian Bartel <maximilian.bartel@amd.com>