### PR TITLE
Rewrite softmax v11 to v13 when axis is the last dimension

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -6186,6 +6186,7 @@ def ONNXSoftmaxOp:ONNX_Op<"Softmax",
 
 def ONNXSoftmaxV11Op:ONNX_Op<"SoftmaxV11",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Softmax operation";
   let description = [{
   The operator computes the softmax (normalized exponential) values for each layer in the batch

--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -545,7 +545,16 @@ public:
 // =============================================================================
 /// Register optimization patterns as "canonicalization" patterns.
 /// Add op to OpsWithCanonicalizer in gen_onnx_mlir.py to activate.
+/// Please keep in alphabetical order.
 // =============================================================================
+
+/// on the ONNXBatchNormalizationInferenceModeOp.
+void ONNXBatchNormalizationInferenceModeOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<FuseBatchNormInferenceModeConvPattern>(context);
+  results.insert<RewriteBatchNormInferenceModeConvPattern1>(context);
+  results.insert<RewriteBatchNormInferenceModeConvPattern2>(context);
+}
 
 /// on the ONNXAddOp.
 void ONNXAddOp::getCanonicalizationPatterns(
@@ -557,10 +566,88 @@ void ONNXAddOp::getCanonicalizationPatterns(
   results.insert<FuseAddConvNullBiasPattern>(context);
 }
 
+/// on the ONNXCastOp.
+void ONNXCastOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<CastEliminationPattern>(context);
+  result.insert<FuseCastCastPattern>(context);
+}
+
+/// on the ONNXConstantOp.
+void ONNXConstantOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<ConstantOpNormalizationPattern1>(context);
+  results.insert<ConstantOpNormalizationPattern2>(context);
+  results.insert<ConstantOpNormalizationPattern3>(context);
+  results.insert<ConstantOpNormalizationPattern4>(context);
+  results.insert<ConstantOpNormalizationPattern5>(context);
+  results.insert<ConstantOpNormalizationPattern6>(context);
+}
+
+/// on the ONNXDepthToSpaceOp.
+void ONNXDepthToSpaceOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<RemoveDepthToSpaceSpaceToDepthPattern>(context);
+}
+
+/// on the ONNXDropoutOp.
+void ONNXDropoutOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<DropoutEliminationPattern>(context);
+}
+
 /// on the ONNXDimOp.
 void ONNXDimOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<DimOpToConstantPattern>(context);
+}
+
+/// on the ONNXGlobalAveragePoolOp.
+void ONNXGlobalAveragePoolOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<GlobalAveragePoolPattern>(context);
+}
+
+/// on the ONNXGlobalMaxPoolOp.
+void ONNXGlobalMaxPoolOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<GlobalMaxPoolPattern>(context);
+}
+
+/// on the ONNXGRUOp.
+void ONNXGRUOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<RNNOpRewriteLayoutPattern<ONNXGRUOp>>(context);
+}
+
+/// on the ONNXIdentityOp.
+void ONNXIdentityOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<IdentityEliminationPattern>(context);
+}
+
+/// on the ONNXLayoutTransformOp.
+void ONNXLayoutTransformOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<ONNXLayoutTransformEliminationPattern>(context);
+}
+
+/// on the ONNXLessOp.
+void ONNXLessOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<LessOpSameCastPattern>(context);
+}
+
+/// on the ONNXLoopOp.
+void ONNXLoopOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<LoopOpRewriteMaxTripCountPattern>(context);
+}
+
+/// on the ONNXLSTMOp.
+void ONNXLSTMOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<RNNOpRewriteLayoutPattern<ONNXLSTMOp>>(context);
 }
 
 /// on the ONNXMulOp.
@@ -570,23 +657,55 @@ void ONNXMulOp::getCanonicalizationPatterns(
   results.insert<FuseMulConvNullBiasPattern>(context);
 }
 
-/// on the ONNXIdentityOp.
-void ONNXIdentityOp::getCanonicalizationPatterns(
+/// on the ONNXReshapeOp.
+void ONNXReshapeOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<FuseReshapePattern>(context);
+  result.insert<RemoveIdentityReshapePattern>(context);
+  result.insert<SwapReshapeMatMulPattern>(context);
+}
+
+/// on the ONNXRNNOp.
+void ONNXRNNOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
-  results.insert<IdentityEliminationPattern>(context);
+  results.insert<RNNOpRewriteLayoutPattern<ONNXRNNOp>>(context);
 }
 
-/// on the ONNXCastOp.
-void ONNXCastOp::getCanonicalizationPatterns(
-    RewritePatternSet &result, MLIRContext *context) {
-  result.insert<CastEliminationPattern>(context);
-  result.insert<FuseCastCastPattern>(context);
+/// on the ONNXShapeOp.
+void ONNXShapeOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<ShapeToConstantPattern>(context);
 }
 
-/// on the ONNXLayoutTransformOp.
-void ONNXLayoutTransformOp::getCanonicalizationPatterns(
+/// on the ONNXSizeOp.
+void ONNXSizeOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<SizeToConstantPattern>(context);
+}
+
+/// on the ONNXSoftmaxV11Op.
+void ONNXSoftmaxV11Op::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<SoftmaxV11ToLatestPattern>(context);
+}
+
+/// on the ONNXSpaceToDepthOp.
+void ONNXSpaceToDepthOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<RemoveSpaceToDepthDepthToSpacePattern>(context);
+}
+
+/// on the ONNXSqueezeOp.
+void ONNXSqueezeOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
-  result.insert<ONNXLayoutTransformEliminationPattern>(context);
+  result.insert<RemoveSqueezeUnsqueezePattern>(context);
+  result.insert<RemoveSqueezeCastUnsqueezePattern>(context);
+}
+
+void ONNXSqueezeV11Op::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<RemoveSqueezeV11UnsqueezeV11Pattern>(context);
+  result.insert<RemoveSqueezeV11CastUnsqueezeV11Pattern>(context);
 }
 
 /// on the ONNXTransposeOp.
@@ -630,33 +749,6 @@ void ONNXTransposeOp::getCanonicalizationPatterns(
   result.insert<SwapTransposeConcatPattern>(context);
 }
 
-/// on the ONNXReshapeOp.
-void ONNXReshapeOp::getCanonicalizationPatterns(
-    RewritePatternSet &result, MLIRContext *context) {
-  result.insert<FuseReshapePattern>(context);
-  result.insert<RemoveIdentityReshapePattern>(context);
-  result.insert<SwapReshapeMatMulPattern>(context);
-}
-
-/// on the ONNXDropoutOp.
-void ONNXDropoutOp::getCanonicalizationPatterns(
-    RewritePatternSet &result, MLIRContext *context) {
-  result.insert<DropoutEliminationPattern>(context);
-}
-
-/// on the ONNXSqueezeOp.
-void ONNXSqueezeOp::getCanonicalizationPatterns(
-    RewritePatternSet &result, MLIRContext *context) {
-  result.insert<RemoveSqueezeUnsqueezePattern>(context);
-  result.insert<RemoveSqueezeCastUnsqueezePattern>(context);
-}
-
-void ONNXSqueezeV11Op::getCanonicalizationPatterns(
-    RewritePatternSet &result, MLIRContext *context) {
-  result.insert<RemoveSqueezeV11UnsqueezeV11Pattern>(context);
-  result.insert<RemoveSqueezeV11CastUnsqueezeV11Pattern>(context);
-}
-
 /// on the ONNXUnsqueezeOp.
 void ONNXUnsqueezeOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
@@ -668,89 +760,4 @@ void ONNXUnsqueezeV11Op::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<RemoveUnsqueezeV11SqueezeV11Pattern>(context);
   result.insert<RemoveUnsqueezeV11CastSqueezeV11Pattern>(context);
-}
-
-/// on the ONNXBatchNormalizationInferenceModeOp.
-void ONNXBatchNormalizationInferenceModeOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<FuseBatchNormInferenceModeConvPattern>(context);
-  results.insert<RewriteBatchNormInferenceModeConvPattern1>(context);
-  results.insert<RewriteBatchNormInferenceModeConvPattern2>(context);
-}
-
-/// on the ONNXShapeOp.
-void ONNXShapeOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<ShapeToConstantPattern>(context);
-}
-
-/// on the ONNXSizeOp.
-void ONNXSizeOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<SizeToConstantPattern>(context);
-}
-
-/// on the ONNXSpaceToDepthOp.
-void ONNXSpaceToDepthOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<RemoveSpaceToDepthDepthToSpacePattern>(context);
-}
-
-/// on the ONNXGlobalAveragePoolOp.
-void ONNXGlobalAveragePoolOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<GlobalAveragePoolPattern>(context);
-}
-
-/// on the ONNXGlobalMaxPoolOp.
-void ONNXGlobalMaxPoolOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<GlobalMaxPoolPattern>(context);
-}
-
-/// on the ONNXConstantOp.
-void ONNXConstantOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<ConstantOpNormalizationPattern1>(context);
-  results.insert<ConstantOpNormalizationPattern2>(context);
-  results.insert<ConstantOpNormalizationPattern3>(context);
-  results.insert<ConstantOpNormalizationPattern4>(context);
-  results.insert<ConstantOpNormalizationPattern5>(context);
-  results.insert<ConstantOpNormalizationPattern6>(context);
-}
-
-/// on the ONNXDepthToSpaceOp.
-void ONNXDepthToSpaceOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<RemoveDepthToSpaceSpaceToDepthPattern>(context);
-}
-
-/// on the ONNXLessOp.
-void ONNXLessOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<LessOpSameCastPattern>(context);
-}
-
-/// on the ONNXLoopOp.
-void ONNXLoopOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<LoopOpRewriteMaxTripCountPattern>(context);
-}
-
-/// on the ONNXGRUOp.
-void ONNXGRUOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<RNNOpRewriteLayoutPattern<ONNXGRUOp>>(context);
-}
-
-/// on the ONNXLSTMOp.
-void ONNXLSTMOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<RNNOpRewriteLayoutPattern<ONNXLSTMOp>>(context);
-}
-
-/// on the ONNXRNNOp.
-void ONNXRNNOp::getCanonicalizationPatterns(
-    RewritePatternSet &results, MLIRContext *context) {
-  results.insert<RNNOpRewriteLayoutPattern<ONNXRNNOp>>(context);
 }

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -227,6 +227,13 @@ def Equal: Constraint<CPred<"$0 == $1">, "are equal">;
 
 class EqualString<string s> : Constraint<CPred<"$0 == \"" # s # "\"">>;
 
+def AxisIsTheLastDim: Constraint<
+  CPred<"($1.getValue().getSExtValue() == -1) ||"
+        "(onnx_mlir::hasShapeAndRank($0) &&"
+        " ($0.getType().cast<ShapedType>().getRank() == $1.getValue().getSExtValue() + 1))">,
+  "Axis is the last dimension of the input"
+>;
+
 //===----------------------------------------------------------------------===//
 // Pattern-Match and Rewrite
 //===----------------------------------------------------------------------===//
@@ -931,6 +938,18 @@ def DimOpToConstantPattern: Pat<
       (GetNullArrayAttr), (GetNullStringAttr), (GetNullArrayAttr)
    ),
    [(DimAtIndexIsConstant $input, $axis)]
+>;
+
+//===----------------------------------------------------------------------===//
+// Canonicalization for ONNXSoftmaxV11 to the latest version
+//===----------------------------------------------------------------------===//
+
+// When axis is the last dimension of the input tensor, the semantics of V11 is
+// the same as that of V13 (the latest version).
+def SoftmaxV11ToLatestPattern: Pat<
+   (ONNXSoftmaxV11Op $input, $axisAttr),
+   (ONNXSoftmaxOp $input, $axisAttr),
+   [(AxisIsTheLastDim $input, $axisAttr)]
 >;
 
 #endif // ONNX_REWRITE

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -920,7 +920,6 @@ func.func @test_dim_to_constant(%arg0: tensor<?x256xi64>) -> (tensor<1xi64>) {
 
 // -----
 
-
 func.func @test_layout_transform(%arg0: tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>) -> tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>> {
     %0 = "onnx.LayoutTransform"(%arg0) {target_layout = #onnx.layout<{dataLayout = "NCHW4C"}>} : (tensor<5x3x32x32xf32,#onnx.layout<{dataLayout = "NCHW4C"}>>) -> tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>
     return %0 : tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>
@@ -928,4 +927,40 @@ func.func @test_layout_transform(%arg0: tensor<5x3x32x32xf32, #onnx.layout<{data
 // CHECK-LABEL: test_layout_transform 
 // CHECK-NOT: "onnx.LayoutTransform"
 // CHECK: return
+}
+
+// -----
+
+func.func @test_softmax_v11_ranked(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = 2 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+  return %0 : tensor<10x20x30xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_ranked
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = 2 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
+// CHECK:           return [[VAR_0_]] : tensor<10x20x30xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_softmax_v11_unranked_unchanged(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = 2 : si64} : (tensor<*xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_unranked_unchanged
+// CHECK: "onnx.SoftmaxV11"
+}
+
+// -----
+
+func.func @test_softmax_v11_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.SoftmaxV11"(%arg0) {axis = -1 : si64} : (tensor<*xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+// CHECK-LABEL:  func.func @test_softmax_v11_unranked
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = -1 : si64} : (tensor<*xf32>) -> tensor<*xf32>
+// CHECK:           return [[VAR_0_]] : tensor<*xf32>
+// CHECK:         }
 }

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -316,6 +316,7 @@ OpsWithCanonicalizer = [
     'RNN',
     'Shape',
     'Size',
+    'SoftmaxV11',
     'SpaceToDepth',
     'Squeeze',
     'SqueezeV11',


### PR DESCRIPTION
When `axis` in Softmax version 11 is the last dimension, Softmax version 11 is the same as Softmax version 13. This patch adds a rule for such a case.

This patch also re-organizes the list of canonicalization operations in the alphabetical orders without functional changes. 
Signed-off-by: Tung D. Le <tung@jp.ibm.com>