### PR TITLE
Suppress non-floating complex warning on newer MSVC versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # Disable warning for non-standard usages of std::complex template which was
   # introduced in MSVC 14.34.
   # More details at https://github.com/microsoft/STL/pull/2759.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING")
-
 endif()
 
 # Suppress warnings in third party code if requested.
@@ -137,7 +137,7 @@ if (ONNX_MLIR_SUPPRESS_THIRD_PARTY_WARNINGS)
   if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-  elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC") 
+  elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     # MSVC complains when overriding existing warning levels flags, so remove them.
     STRING(REGEX REPLACE "/W[0-4xX]" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
     STRING(REGEX REPLACE "/W[0-4xX]" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,26 @@ else()
   message(WARNING "Java Development component or JNI not found, JNI targets will not work")
 endif()
 
-# Use the new MSVC preprocessor to improve standard conformance.
-if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC") 
+if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  # Use the new MSVC preprocessor to improve standard conformance.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Zc:preprocessor")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:preprocessor")
+
+  # Starting from MSVC 14.34, the following warning was introduced:
+  #
+  # llvm/include/mlir/IR/BuiltinAttributes.h(353): error C2220: the following
+  # warning is treated as an error
+  #
+  # llvm/include/mlir/IR/BuiltinAttributes.h(353): warning C4996:
+  # 'std::complex<llvm::APFloat>::complex': warning STL4037: The effect of
+  # instantiating the template std::complex for any type other than float,
+  # double, or long double is unspecified.
+  # You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress
+  # this warning.
+  #
+  # Since the code is part of upstream mlir, suppress the warning for now.
+
+  add_definitions(-D_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING)
 endif()
 
 # Suppress warnings in third party code if requested.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,21 +122,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Zc:preprocessor")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:preprocessor")
 
-  # Starting from MSVC 14.34, the following warning was introduced:
-  #
-  # llvm/include/mlir/IR/BuiltinAttributes.h(353): error C2220: the following
-  # warning is treated as an error
-  #
-  # llvm/include/mlir/IR/BuiltinAttributes.h(353): warning C4996:
-  # 'std::complex<llvm::APFloat>::complex': warning STL4037: The effect of
-  # instantiating the template std::complex for any type other than float,
-  # double, or long double is unspecified.
-  # You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress
-  # this warning.
-  #
-  # Since the code is part of upstream mlir, suppress the warning for now.
+  # Disable warning for non-standard usages of std::complex template which was
+  # introduced in MSVC 14.34.
+  # More details at https://github.com/microsoft/STL/pull/2759.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING")
 
-  add_definitions(-D_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING)
 endif()
 
 # Suppress warnings in third party code if requested.


### PR DESCRIPTION
MSVC recently started issuing warnings when `std::complex` template is instantiated with types other than `float` and `double`, which caused failures in our builds. More details at https://github.com/microsoft/STL/pull/2759.

Unfortunately, the code that triggered the warning is part of upstream `mlir`, and accommodating this change isn't trivial. I propose that we suppress the warning for the time being.