### PR TITLE
Scrub upsample comment

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Tensor/Upsample.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Upsample.cpp
@@ -34,7 +34,7 @@ LogicalResult ONNXUpsampleOp::verify() {
   auto inputTy = X().getType().cast<RankedTensorType>();
   int32_t inputRank = inputTy.getShape().size();
 
-  // Sanity checks on scale argument
+  // Safety checks on scale argument
   auto scalesTy = scales().getType().cast<RankedTensorType>();
   if (scalesTy.getShape().size() != 1) {
     return emitError("Scales tensor must be rank-1");


### PR DESCRIPTION
I updated the comment from `sanity` to `safety`. Also I did a search in VSCode to see if there are any lingering references to `master` in the `onnx-mlir` repo. Seems like there are only 3 places where `master` is present. Two instances are `PyTorch` links which will break if we use the word `main` and another section that uses the following link: `https://raw.githubusercontent.com/caldwell/renderjson/master/` . This link is actually broken, I get back a 400- Invalid response so I wonder if we can just remove this from the `onnx-mlir/.buildbot/jenkins-check-model-zoo.py`.