### PR TITLE
ingest BFLOAT16

### DIFF
--- a/src/Builder/FrontendDialectHelper.cpp
+++ b/src/Builder/FrontendDialectHelper.cpp
@@ -20,6 +20,7 @@
 
 #include "src/Builder/FrontendDialectHelper.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+#include "src/Support/FloatingPoint16.hpp"
 
 namespace {
 
@@ -67,7 +68,8 @@ template <typename T>
 struct TransformValueToONNXData {
   static const google::protobuf::RepeatedField<int32_t> &data(
       const onnx::TensorProto &tp) {
-    // int32_data is used for int32, uint8, int8, uint16, int16, bool
+    // int32_data is used for:
+    // int32, uint8, int8, uint16, int16, bool, float_16, bfloat_16
     return tp.int32_data();
   }
 };
@@ -124,7 +126,20 @@ template <typename T>
 using DenseElementsAttrBuilder =
     llvm::function_ref<mlir::DenseElementsAttr(llvm::ArrayRef<T>)>;
 
-// When the protobuf repeated field has a type of the same size as T,
+// Converts to the cpp type 'To' that correspond's to the tensor element type
+// (bool, int8, float_16, uint32, etc) from the the proto data field type
+// which may be a wider type (int32, uint64). In most cases the conversion is
+// just standard C implicit conversion. The exception is float_16 and bfloat_16
+// which must be bit-wise converted from uint16_t.
+template <typename To, typename From>
+To deserializeDatum(From from) {
+  if constexpr (onnx_mlir::isFP16Type<To>)
+    return To::bitcastFromU16(from);
+  else
+    return from;
+}
+
+// When the protobuf repeated field has type T,
 // access the data directly via ArrayRef.
 template <typename T, typename U>
 std::enable_if_t<std::is_same_v<T, U>, mlir::DenseElementsAttr>
@@ -133,15 +148,35 @@ createDenseElmAttrFromProtoData(const google::protobuf::RepeatedField<U> &data,
   return denseBuilder(llvm::makeArrayRef(data.data(), data.size()));
 }
 
-// When the protobuf repeated field has a type larger than T,
+// When the protobuf repeated field has a type different from T,
 // copy the data into correctly typed SmallVector because
 // DenseElementsAttr needs argument type of the correct bitwidth.
 template <typename T, typename U>
 std::enable_if_t<!std::is_same_v<T, U>, mlir::DenseElementsAttr>
 createDenseElmAttrFromProtoData(const google::protobuf::RepeatedField<U> &data,
     DenseElementsAttrBuilder<T> denseBuilder) {
-  llvm::SmallVector<T> copy(data.begin(), data.end());
+  llvm::SmallVector<T> copy;
+  copy.resize_for_overwrite(data.size());
+  std::transform(data.begin(), data.end(), copy.data(), deserializeDatum<T, U>);
   return denseBuilder(llvm::makeArrayRef(copy));
+}
+
+// Perform byte swap if system endianness is BE.
+// ONNX tensor content raw data is always in LE.
+// Don't byte swap single byte types, because that's unnecessary
+// and llvm::sys::getSwappedBytes(bool) also happens to be broken.
+template <typename T>
+constexpr bool shouldSwapLEBytes =
+    sizeof(T) > 1 && llvm::support::endian::system_endianness() !=
+                         llvm::support::endianness::little;
+
+// Extension of llvm::sys::getSwappedBytes to also handle float_16, bfloat_16.
+template <typename T>
+T swappedBytes(T x) {
+  if constexpr (onnx_mlir::isFP16Type<T>)
+    return T::bitcastFromU16(llvm::sys::getSwappedBytes(x.bitcastToU16()));
+  else
+    return llvm::sys::getSwappedBytes(x);
 }
 
 // Returns DenseElementsAttr with tp's data.
@@ -157,36 +192,20 @@ mlir::DenseElementsAttr createDenseElmAttr(const std::string &externalDataDir,
     llvm::StringRef buffer = externalData ? externalData->getBuffer()
                                           : llvm::StringRef(tp.raw_data());
     size_t size = buffer.size() / sizeof(T);
-    llvm::ArrayRef<T> arrayRef(
-        reinterpret_cast<T const *>(buffer.data()), size);
-    // Perform byte swap if system endianness is BE.
-    // ONNX tensor content raw data is always in LE.
-    if (sizeof(T) > 1 && llvm::support::endian::system_endianness() !=
-                             llvm::support::endianness::little) {
-      llvm::SmallVector<T> vector;
-      vector.reserve(size);
-      for (T x : arrayRef) {
-        vector.push_back(llvm::sys::getSwappedBytes(x));
-      }
-      return denseBuilder(llvm::makeArrayRef(vector));
+    llvm::ArrayRef<T> array(reinterpret_cast<T const *>(buffer.data()), size);
+    if (shouldSwapLEBytes<T>) {
+      llvm::SmallVector<T> copy;
+      copy.resize_for_overwrite(size);
+      std::transform(array.begin(), array.end(), copy.data(), swappedBytes<T>);
+      return denseBuilder(llvm::makeArrayRef(copy));
     } else {
-      // No need to take care of endianness.
-      return denseBuilder(arrayRef);
+      return denseBuilder(array);
     }
   } else {
     // Not raw, no need to take care of endianness.
     const auto &data = TransformValueToONNXData<T>::data(tp);
     return createDenseElmAttrFromProtoData(data, denseBuilder);
   }
-}
-
-llvm::SmallVector<llvm::APFloat> U16ToF16Array(
-    llvm::ArrayRef<uint16_t> u16arrayRef) {
-  llvm::SmallVector<llvm::APFloat> f16Array;
-  f16Array.reserve(u16arrayRef.size());
-  for (uint16_t u : u16arrayRef)
-    f16Array.emplace_back(llvm::APFloat::IEEEhalf(), llvm::APInt(16, u));
-  return f16Array;
 }
 
 } // namespace
@@ -219,15 +238,10 @@ mlir::DenseElementsAttr onnxTensorProtoToDenseElmAttr(mlir::OpBuilder &builder,
     return mlir::DenseElementsAttr::get(tensorType, arrayRef);
   };
   switch (tp.data_type()) {
-  case (onnx::TensorProto::FLOAT16): {
-    // F16s are converted bit-wise to U16s when written to protobufs.
-    // So we read U16 from the protobuf and then convert to F16.
-    auto denseBuilderU16ToF16 = [denseBuilder](auto arrayRef) {
-      return denseBuilder(llvm::makeArrayRef(U16ToF16Array(arrayRef)));
-    };
-    return createDenseElmAttr<uint16_t>(
-        externalDataDir, tp, denseBuilderU16ToF16);
-  }
+  case (onnx::TensorProto::FLOAT16):
+    return createDenseElmAttr<float_16>(externalDataDir, tp, denseBuilder);
+  case (onnx::TensorProto::BFLOAT16):
+    return createDenseElmAttr<bfloat_16>(externalDataDir, tp, denseBuilder);
   case (onnx::TensorProto::FLOAT):
     return createDenseElmAttr<float>(externalDataDir, tp, denseBuilder);
   case (onnx::TensorProto::DOUBLE):

--- a/src/Support/CMakeLists.txt
+++ b/src/Support/CMakeLists.txt
@@ -21,6 +21,7 @@ add_onnx_mlir_library(OMSupport
   )
 
 add_onnx_mlir_library(OMMlirUtilities
+  FloatingPoint16.cpp
   TypeUtilities.cpp
   # Expect to have other utilities for Attribute and Value in the future.
   # AttributeUtilities.cpp

--- a/src/Support/FloatingPoint16.cpp
+++ b/src/Support/FloatingPoint16.cpp
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----------------------- FloatingPoint16.cpp --------------------------===//
+//
+// 16 bit floating point types.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Support/FloatingPoint16.hpp"
+
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
+
+using llvm::APFloat;
+using llvm::APInt;
+
+namespace onnx_mlir {
+
+namespace {
+uint64_t bitcastAPFloat(APFloat f, const llvm::fltSemantics &semantics) {
+  bool ignored;
+  f.convert(semantics, APFloat::rmNearestTiesToEven, &ignored);
+  APInt i = f.bitcastToAPInt();
+  return i.getZExtValue();
+}
+} // namespace
+
+namespace detail {
+
+template <typename FP16>
+APFloat FP16Base<FP16>::toAPFloat() const {
+  return APFloat(FP16::semantics(), APInt(16, u16));
+}
+
+/*static*/
+template <typename FP16>
+FP16 FP16Base<FP16>::fromAPFloat(APFloat a) {
+  bitcasttype u16 = bitcastAPFloat(a, FP16::semantics());
+  return bitcastFromU16(u16);
+}
+
+// Explicit instantiation for all the classes derived from FP16Base.
+template class FP16Base<float_16>;
+template class FP16Base<bfloat_16>;
+
+} // namespace detail
+
+} // namespace onnx_mlir

--- a/src/Support/FloatingPoint16.hpp
+++ b/src/Support/FloatingPoint16.hpp
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----------------------- FloatingPoint16.hpp --------------------------===//
+//
+// 16 bit floating point types.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/ADT/APFloat.h"
+
+namespace onnx_mlir {
+
+class float_16;
+class bfloat_16;
+
+namespace detail {
+
+// Base class for float_16, bfloat_16.
+template <typename FP16> // FP16 is the derived class, float_16 or bfloat_16.
+class FP16Base {
+public:
+  using bitcasttype = uint16_t;
+
+  constexpr FP16Base() : u16() {}
+  constexpr explicit FP16Base(const FP16 &f16) : u16(f16.u16) {}
+  // Support static_cast<FP16>(X) for any x that is convertible to float.
+  template <typename T, typename = std::enable_if_t<!std::is_same_v<T, FP16>>>
+  explicit FP16Base(const T &x)
+      : u16(fromAPFloat(llvm::APFloat(static_cast<float>(x))).u16) {}
+
+  // Support static_cast<T>(*this) for any T that float converts to.
+  template <typename T, typename = std::enable_if_t<!std::is_same_v<T, FP16>>>
+  explicit operator T() const {
+    return static_cast<float>(toFloat());
+  }
+
+  llvm::APFloat toAPFloat() const;
+
+  // Same as static_cast<float>(*this).
+  float toFloat() const { return toAPFloat().convertToFloat(); }
+
+  // Substitute for reinterpret_cast<uint16_t>(*this), which C++ doesn't allow.
+  constexpr bitcasttype bitcastToU16() const { return u16; }
+
+  static FP16 fromAPFloat(llvm::APFloat a);
+
+  // Substitute for reinterpret_cast<FP16>(f), which C++ doesn't allow.
+  static FP16 fromFloat(float f) { return fromAPFloat(llvm::APFloat(f)); }
+
+  // Substitute for reinterpret_cast<FP16>(u), which C++ doesn't allow.
+  static constexpr FP16 bitcastFromU16(bitcasttype u) {
+    FP16 f16;
+    f16.u16 = u;
+    return f16;
+  }
+
+private:
+  bitcasttype u16;
+};
+
+extern template class FP16Base<float_16>;
+extern template class FP16Base<bfloat_16>;
+
+} // namespace detail
+
+template <class T>
+inline constexpr bool isFP16Type = std::is_base_of_v<detail::FP16Base<T>, T>;
+
+// Represents a FLOAT16 value with the correct bitwidth and in a form that
+// is unambiguous when used as a template parameter alongside the other basic
+// Cpp data types uint16_t, float, etc.
+class float_16 : public detail::FP16Base<float_16> {
+  using Base = detail::FP16Base<float_16>;
+
+public:
+  using Base::Base;
+  static const llvm::fltSemantics &semantics() {
+    return llvm::APFloat::IEEEhalf();
+  }
+};
+static_assert(sizeof(float_16) * CHAR_BIT == 16, "float_16 is 16 bits wide");
+
+// Represents a BFLOAT16 value with the correct bitwidth and in a form that
+// is unambiguous when used as a template parameter alongside the other basic
+// Cpp data types uint16_t, float, etc.
+class bfloat_16 : public detail::FP16Base<bfloat_16> {
+  using Base = detail::FP16Base<bfloat_16>;
+
+public:
+  using Base::Base;
+  static const llvm::fltSemantics &semantics() {
+    return llvm::APFloat::BFloat();
+  }
+};
+static_assert(sizeof(bfloat_16) * CHAR_BIT == 16, "bfloat_16 is 16 bits wide");
+
+// When doing arithmetic on a template type T that may be a (b)float_16 or a
+// native arithmetic type, convert arguments to toArithmetic<T> and back, e.g.:
+//
+//   template <typename T> T Sqrt(T lhs, T rhs) {
+//     return static_cast<T>(sqrtf(static_cast<toArithmetic<T>>(x)));
+//   }
+//
+template <typename T>
+using toArithmetic = std::conditional_t<isFP16Type<T>, float, T>;
+
+} // namespace onnx_mlir
+
+// Enable DenseElementsAttr to operate on float_16, bfloat_16 data types.
+template <>
+struct mlir::DenseElementsAttr::is_valid_cpp_fp_type<onnx_mlir::float_16> {
+  static constexpr bool value = true;
+};
+template <>
+struct mlir::DenseElementsAttr::is_valid_cpp_fp_type<onnx_mlir::bfloat_16> {
+  static constexpr bool value = true;
+};

--- a/test/mlir/onnx/parse/fp16_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp16_nonraw_data.json
@@ -1,0 +1,103 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+// fp16_nonraw_data.json is an onnx model that outputs 2 constant tensors
+// with float16 and bfloat16 data types
+
+// json is generated with utils/testing/floatingpoint16_data.py nonraw
+{
+  "irVersion": "8",
+  "graph": {
+    "node": [
+      {
+        "output": [
+          "output_f16"
+        ],
+        "opType": "Constant",
+        "attribute": [
+          {
+            "name": "value",
+            "t": {
+              "dims": [
+                "2"
+              ],
+              "dataType": 10,
+              "int32Data": [
+                48128,
+                28896
+              ],
+              "name": "tensor_f16"
+            },
+            "type": "TENSOR"
+          }
+        ]
+      },
+      {
+        "output": [
+          "output_bf16"
+        ],
+        "opType": "Constant",
+        "attribute": [
+          {
+            "name": "value",
+            "t": {
+              "dims": [
+                "2"
+              ],
+              "dataType": 16,
+              "int32Data": [
+                49024,
+                17948
+              ],
+              "name": "tensor_bf16"
+            },
+            "type": "TENSOR"
+          }
+        ]
+      }
+    ],
+    "name": "fp16_nonraw_data",
+    "output": [
+      {
+        "name": "output_f16",
+        "type": {
+          "tensorType": {
+            "elemType": 10,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "2"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "output_bf16",
+        "type": {
+          "tensorType": {
+            "elemType": 16,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "2"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "opsetImport": [
+    {
+      "version": "16"
+    }
+  ]
+}
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_names = [], output_names = ["output_f16", "output_bf16"]} {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xbf16>
+// CHECK:           return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
+// CHECK:         }

--- a/test/mlir/onnx/parse/fp16_raw_data.json
+++ b/test/mlir/onnx/parse/fp16_raw_data.json
@@ -1,0 +1,98 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+// fp16_naw_data.json is an onnx model that outputs 2 constant tensors
+// with float16 and bfloat16 data types
+// and with the data represented as raw_data byte arrays
+
+// json is generated with utils/testing/floatingpoint16_data.py raw
+{
+  "irVersion": "8",
+  "graph": {
+    "node": [
+      {
+        "output": [
+          "output_f16"
+        ],
+        "opType": "Constant",
+        "attribute": [
+          {
+            "name": "value",
+            "t": {
+              "dims": [
+                "2"
+              ],
+              "dataType": 10,
+              "name": "tensor_f16",
+              "rawData": "ALzgcA=="
+            },
+            "type": "TENSOR"
+          }
+        ]
+      },
+      {
+        "output": [
+          "output_bf16"
+        ],
+        "opType": "Constant",
+        "attribute": [
+          {
+            "name": "value",
+            "t": {
+              "dims": [
+                "2"
+              ],
+              "dataType": 16,
+              "name": "tensor_bf16",
+              "rawData": "gL8cRg=="
+            },
+            "type": "TENSOR"
+          }
+        ]
+      }
+    ],
+    "name": "fp16_raw_data",
+    "output": [
+      {
+        "name": "output_f16",
+        "type": {
+          "tensorType": {
+            "elemType": 10,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "2"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "output_bf16",
+        "type": {
+          "tensorType": {
+            "elemType": 16,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "2"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "opsetImport": [
+    {
+      "version": "16"
+    }
+  ]
+}
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_names = [], output_names = ["output_f16", "output_bf16"]} {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xbf16>
+// CHECK:           return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
+// CHECK:         }

--- a/utils/testing/floatingpoint16_data.py
+++ b/utils/testing/floatingpoint16_data.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+######################### floatingpoint16_data.py ##############################
+#
+# Generates raw/nonraw_data (b)float16 models in test/mlir/onnx/parse/
+#
+# The model outputs 2 constant tensors with float16 and bfloat16 data types.
+# The data_format command line argument controls whether the tensor data
+# is represented "nonraw" (normally) or "raw" (as raw_data byte arrays).
+#
+################################################################################
+
+from typing import Any, Sequence
+import argparse
+import onnx
+from onnx import helper
+from google.protobuf.json_format import MessageToJson
+import numpy as np
+
+parser = argparse.ArgumentParser()
+parser.add_argument('data_format', choices=['raw', 'nonraw'],
+    help="Tensor data representation")
+parser.add_argument('--save_dot_onnx', action='store_true',
+    help="Save model as .onnx")
+args = parser.parse_args()
+
+# formats nptensor for make_tensor vals arg: bytes if raw else np.ndarray
+def tensor_vals(nptensor, raw):
+    if raw:
+        # onnx proto spec for raw_data requires "fixed-width, little-endian order"
+        return nptensor.astype(np.dtype('uint16').newbyteorder('<')).tobytes()
+    else:
+        return nptensor
+
+# Variant of onnx.helper.make_tensor that works for both float16 and bfloat16
+# with uint16 np.ndarray vals when raw == False.
+def make_fp16_tensor(
+    name: str, data_type: int, dims: Sequence[int], vals: Any, raw: bool = False
+) -> onnx.TensorProto:
+    tensor = onnx.TensorProto()
+    tensor.data_type = data_type
+    tensor.name = name
+    if raw:
+        tensor.raw_data = vals
+    else:
+        tensor.int32_data.extend(vals.flatten().tolist())
+    tensor.dims.extend(dims)
+    return tensor
+
+def main():
+    raw = args.data_format == 'raw'
+
+    f16_minus_one = 48128  # FLOAT16    -1 is represented by UINT16 48128
+    f16_9984 = 28896       # FLOAT16  9984 is represented by UINT16 28896
+    bf16_minus_one = 49024 # BFLOAT16   -1 is represented by UINT16 49024
+    bf16_9984 = 17948      # BFLOAT16 9984 is represented by UINT16 17948
+    dtype = np.dtype('uint16')
+
+    f16_nptensor = np.array([f16_minus_one, f16_9984]).astype(dtype)
+    bf16_nptensor = np.array([bf16_minus_one, bf16_9984]).astype(dtype)
+
+    nodes = [
+        helper.make_node(
+            "Constant",
+            inputs=[],
+            outputs=["output_f16"],
+            value=make_fp16_tensor(
+                f"tensor_f16",
+                data_type=onnx.TensorProto.FLOAT16,
+                dims=f16_nptensor.shape,
+                vals=tensor_vals(f16_nptensor, raw),
+                raw=raw,
+            ),
+        ),
+        helper.make_node(
+            "Constant",
+            inputs=[],
+            outputs=["output_bf16"],
+            value=make_fp16_tensor(
+                f"tensor_bf16",
+                data_type=onnx.TensorProto.BFLOAT16,
+                dims=bf16_nptensor.shape,
+                vals=tensor_vals(bf16_nptensor, raw),
+                raw=raw,
+            ),
+        )
+    ]
+    outputs = [
+        helper.make_tensor_value_info("output_f16", onnx.TensorProto.FLOAT16, f16_nptensor.shape),
+        helper.make_tensor_value_info("output_bf16", onnx.TensorProto.BFLOAT16, bf16_nptensor.shape)
+    ]
+    inputs = []
+    name = f"fp16_{args.data_format}_data"
+    graph = helper.make_graph(nodes, name, inputs, outputs)
+    model = helper.make_model(graph)
+    onnx.checker.check_model(model)
+    if args.save_dot_onnx:
+        onnx.save_model(model, f"{name}.onnx")
+    print(MessageToJson(model))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
introduces float_16 and bfloat_16 data types to represent both FLOAT16 and BFLOAT16 as c++ data types, which makes it possible to treat them like the other scalar types in many ways

this will also make it possible to do constant propagation, see PR #1874

this PR has been factored out from PR #1874