### PR TITLE
Preinstall numpy 1.23.5 since 1.24 appears to break onnx

### DIFF
--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -40,6 +40,7 @@ jobs:
       run: |
         cd ~/work/onnx-mlir/onnx-mlir/third_party/onnx
         git fetch --prune --unshallow --tags
+        pip3 install numpy==1.23.5
         python3 -m pip install -v .
     - name: build onnx-mlir
       run: |


### PR DESCRIPTION
Signed-off-by: Gong Su <gong_su@hotmail.com>