### PR TITLE
Suppress parameter list mismatch warning on newer msvc versions

### DIFF
--- a/src/Runtime/OMSort.inc
+++ b/src/Runtime/OMSort.inc
@@ -221,7 +221,10 @@ void omTensorSort(OMTensor *orderTensor, const OMTensor *inputTensor,
   sortFunctionType *sortFunc = qsort_r;
 #elif defined(_MSC_VER)
 #pragma warning(push, 3)
+// Newer MSVC warns 4113 instead of 4028 for function signature mismatch.
+// Disable both here.
 #pragma warning(disable : 4028)
+#pragma warning(disable : 4113)
   // Windows supports qsort_s
   sortFunctionType *sortFunc = qsort_s;
 #pragma warning(pop)


### PR DESCRIPTION
On newer msvc versions (starting with Visual Studio 17.1), warning 4113 is issued in place of 4028. To preserve the same behaviour, also disable 4113 before using `qsort_s`.

Please see https://learn.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170#c4028-is-now-c4133-for-function-to-pointer-operations for more details.