### PR TITLE
heap reporting

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -125,6 +125,7 @@ set_property(SOURCE CompilerUtils.cpp APPEND PROPERTY COMPILE_DEFINITIONS ${DEFI
 
 add_onnx_mlir_library(OMCompilerUtils
   CompilerUtils.cpp
+  HeapReporter.cpp
 
   EXCLUDE_FROM_OM_LIBS
 

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -210,6 +210,18 @@ llvm::cl::opt<bool> allowSorting("allowSorting",
     llvm::cl::desc("Perform topological sort on onnx graph"),
     llvm::cl::init(true), llvm::cl::cat(OnnxMlirOptions));
 
+llvm::cl::opt<std::string> reportHeapBefore("report-heap-before",
+    llvm::cl::desc("Comma separated list of names of passes.\n"
+                   "Before each heap statistics are dumped to "
+                   "<output-files-base-path>.heap.log"),
+    llvm::cl::init(""), llvm::cl::cat(OnnxMlirOptions));
+
+llvm::cl::opt<std::string> reportHeapAfter("report-heap-after",
+    llvm::cl::desc("Comma separated list of names of passes.\n"
+                   "After each heap statistics are dumped to "
+                   "<output-files-base-path>.heap.log"),
+    llvm::cl::init(""), llvm::cl::cat(OnnxMlirOptions));
+
 // Configuration states associated with certain options.
 // For example, when maccel is specified, NNPA can register
 // dependent libdnn.

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -60,7 +60,8 @@ extern llvm::cl::list<std::string> Xllc;
 extern llvm::cl::opt<std::string> mllvm;
 extern llvm::cl::opt<bool> verifyInputTensors;
 extern llvm::cl::opt<bool> allowSorting;
-
+extern llvm::cl::opt<std::string> reportHeapBefore;
+extern llvm::cl::opt<std::string> reportHeapAfter;
 extern llvm::cl::opt<InstrumentStages> instrumentStage;
 extern llvm::cl::opt<std::string> instrumentOps;
 extern llvm::cl::bits<InstrumentActions> instrumentControlBits;

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -32,6 +32,7 @@
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerPasses.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
+#include "src/Compiler/HeapReporter.hpp"
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 #include "src/Version/Version.hpp"
 
@@ -911,7 +912,11 @@ int compileModule(mlir::OwningOpRef<ModuleOp> &module,
   }
   if (!hasAccel)
     addPasses(module, pm, emissionTarget);
-  // TODO: Add HeapReporter PassInstrumentation.
+  if (!reportHeapBefore.empty() || !reportHeapAfter.empty()) {
+    std::string heapLogFileame = outputNameNoExt + ".heap.log";
+    pm.addInstrumentation(std::make_unique<HeapReporter>(
+        heapLogFileame, reportHeapBefore, reportHeapAfter));
+  }
   mlir::applyPassManagerCLOptions(pm);
   mlir::applyDefaultTimingPassManagerCLOptions(pm);
 

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -911,6 +911,7 @@ int compileModule(mlir::OwningOpRef<ModuleOp> &module,
   }
   if (!hasAccel)
     addPasses(module, pm, emissionTarget);
+  // TODO: Add HeapReporter PassInstrumentation.
   mlir::applyPassManagerCLOptions(pm);
   mlir::applyDefaultTimingPassManagerCLOptions(pm);
 

--- a/src/Compiler/HeapReporter.cpp
+++ b/src/Compiler/HeapReporter.cpp
@@ -10,10 +10,95 @@
 
 #include "src/Compiler/HeapReporter.hpp"
 
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+#include <unistd.h>
+
 using namespace mlir;
 
 namespace onnx_mlir {
 
+namespace {
+void splitToSet(StringRef commaSeparated, llvm::StringSet<> &set) {
+  SmallVector<StringRef> splits;
+  commaSeparated.split(splits, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  for (StringRef s : splits)
+    set.insert(s.trim());
+}
+
+void logMessage(StringRef logFilename, StringRef msg,
+    llvm::sys::fs::OpenFlags extraFlags = llvm::sys::fs::OF_None) {
+  std::error_code EC;
+  llvm::raw_fd_ostream os(logFilename, EC, llvm::sys::fs::OF_Text | extraFlags);
+  if (EC) {
+    llvm::errs() << "Error: '" << EC.message() << "' opening heap report file '"
+                 << logFilename << "'\n";
+    exit(1);
+  }
+  os << msg;
+}
+} // namespace
+
+HeapReporter::HeapReporter(
+    std::string logFilename, StringRef beforePasses, StringRef afterPasses)
+    : logFilename(logFilename) {
+  splitToSet(beforePasses, this->beforePassesSet);
+  splitToSet(afterPasses, this->afterPassesSet);
+  reportBegin("onnx-mlir heap report"
+              "\n--report-heap-before='" +
+              beforePasses.str() + "'\n--report-heap-after='" +
+              afterPasses.str() + "'");
+}
+
 HeapReporter::~HeapReporter() {}
+
+void HeapReporter::runBeforePass(mlir::Pass *pass, mlir::Operation *op) {
+  StringRef name = pass->getArgument();
+  if (beforePassesSet.contains(name))
+    reportHeap("BEFORE PASS " + name.str());
+}
+
+void HeapReporter::runAfterPass(mlir::Pass *pass, mlir::Operation *op) {
+  StringRef name = pass->getArgument();
+  if (afterPassesSet.contains(name))
+    reportHeap("AFTER PASS " + name.str());
+}
+
+#if defined(__APPLE__)
+void HeapReporter::reportBegin(const std::string &heading) {
+  if (!getenv("MallocStackLogging")) {
+    llvm::errs() << "Error: Environment variable MallocStackLogging must be "
+                    "set to report heap usage.\n"
+                    "See utils/onnx-mlir-report-heap.sh\n";
+    exit(1);
+  }
+  // Capture the first 40 lines of heap output, which include the top level
+  // numbers and a handful of the largest allocation classes.
+  command =
+      "heap -s " + std::to_string(getpid()) + " | head -n40 >> " + logFilename;
+  logMessage(logFilename,
+      heading + "\nusing heap report command: '" + command + "'\n");
+}
+
+void HeapReporter::reportHeap(const std::string &heading) {
+  logMessage(logFilename, "\n" + heading + ":\n", llvm::sys::fs::OF_Append);
+  std::system(command.c_str());
+}
+#else
+// TODO: Support heap reporting on more operating systems.
+
+void HeapReporter::reportBegin(const std::string &heading) {
+  llvm_unreachable("report-heap is not supported for this OS currently");
+}
+
+void HeapReporter::reportHeap(const std::string &heading) {
+  llvm_unreachable("report-heap is not supported for this OS currently");
+}
+#endif
 
 } // namespace onnx_mlir

--- a/src/Compiler/HeapReporter.cpp
+++ b/src/Compiler/HeapReporter.cpp
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------------------------- HeapReporter.cpp --------------------------===//
+//
+// Reports heap usage before and after compiler passes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Compiler/HeapReporter.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+HeapReporter::~HeapReporter() {}
+
+} // namespace onnx_mlir

--- a/src/Compiler/HeapReporter.cpp
+++ b/src/Compiler/HeapReporter.cpp
@@ -17,7 +17,9 @@
 
 #include <string>
 
-#include <unistd.h>
+#if defined(__APPLE__)
+#include <unistd.h> // Unsupported on MSVC.
+#endif
 
 using namespace mlir;
 

--- a/src/Compiler/HeapReporter.hpp
+++ b/src/Compiler/HeapReporter.hpp
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------------------------- HeapReporter.hpp --------------------------===//
+//
+// Reports heap usage before and after compiler passes.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Pass/PassInstrumentation.h"
+#include "llvm/ADT/StringSet.h"
+
+namespace onnx_mlir {
+
+struct HeapReporter : public mlir::PassInstrumentation {
+  HeapReporter(std::string logFilename, std::string beforePasses, std::string afterPasses);
+  ~HeapReporter() override;
+
+  void runBeforePass(mlir::Pass *pass, mlir::Operation *op) override;
+  void runAfterPass(mlir::Pass *pass, mlir::Operation *op) override;
+
+private:
+  std::string logFilename;
+  llvm::StringSet beforePasses;
+  llvm::StringSet afterPasses;
+};
+
+} // namespace onnx_mlir

--- a/src/Compiler/HeapReporter.hpp
+++ b/src/Compiler/HeapReporter.hpp
@@ -16,16 +16,21 @@
 namespace onnx_mlir {
 
 struct HeapReporter : public mlir::PassInstrumentation {
-  HeapReporter(std::string logFilename, std::string beforePasses, std::string afterPasses);
+  HeapReporter(std::string logFilename, llvm::StringRef beforePasses,
+      llvm::StringRef afterPasses);
   ~HeapReporter() override;
 
   void runBeforePass(mlir::Pass *pass, mlir::Operation *op) override;
   void runAfterPass(mlir::Pass *pass, mlir::Operation *op) override;
 
 private:
+  void reportBegin(const std::string &heading);
+  void reportHeap(const std::string &heading);
+
   std::string logFilename;
-  llvm::StringSet beforePasses;
-  llvm::StringSet afterPasses;
+  llvm::StringSet<> beforePassesSet;
+  llvm::StringSet<> afterPassesSet;
+  std::string command;
 };
 
 } // namespace onnx_mlir

--- a/src/Compiler/HeapReporter.hpp
+++ b/src/Compiler/HeapReporter.hpp
@@ -6,10 +6,7 @@
 //
 // Reports heap usage before and after compiler passes.
 //
-// The heap usage is written to the specified logFilename.
-// It is unclear what will happen if applied to parallel compiler passes,
-// so it is recommended to use this only on module level compiler passes
-// or with multithreading disabled.
+// See the explanation about how to run it in utils/onnx-mlir-report-heap.sh
 //
 //===----------------------------------------------------------------------===//
 

--- a/src/Compiler/HeapReporter.hpp
+++ b/src/Compiler/HeapReporter.hpp
@@ -6,6 +6,11 @@
 //
 // Reports heap usage before and after compiler passes.
 //
+// The heap usage is written to the specified logFilename.
+// It is unclear what will happen if applied to parallel compiler passes,
+// so it is recommended to use this only on module level compiler passes
+// or with multithreading disabled.
+//
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/utils/onnx-mlir-report-heap.sh
+++ b/utils/onnx-mlir-report-heap.sh
@@ -1,0 +1,30 @@
+# This script behaves like onnx-mlir (same arguments and behavior) but
+# with the necessary setup and execution environment to report heap usage.
+#
+# Assumptions:
+# 1) script is run in the onnx-mlir/build subdir
+# 2) onnx-mlir executable is built with the CMAKE_BUILD_TYPE (Debug, Release,
+#    RelWithDebInfo) in onnx-mlir/build/CMakeCache.txt
+# 3) arguments include --report-heap-before and/or --report-heap-after
+
+# ask git for the onnx-mlir top level dir
+ONNX_MLIR=$(git rev-parse --show-toplevel)
+if [ $(pwd) != $ONNX_MLIR/build ]; then
+  echo "Error: this script must be run from the build dir $ONNX_MLIR/build"
+  exit 1
+fi
+CMAKE_BUILD_TYPE=$(fgrep CMAKE_BUILD_TYPE:STRING= CMakeCache.txt | cut -d= -f2)
+ONNX_MLIR_BIN=$CMAKE_BUILD_TYPE/bin
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # On MacOS onnx-mlir executes the heap command to report heap usage.
+  # The heap command requires the MallocStackLogging and DYLD_INSERT_LIBRARIES
+  # environment variables to be set, and onnx-mlir must be run in the debugger.
+  export MallocStackLogging=1 DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib
+  lldb -o run -o quit -- $ONNX_MLIR_BIN/onnx-mlir "$@"
+  unset MallocStackLogging DYLD_INSERT_LIBRARIES
+else
+  # TODO: Support heap reporting on more operating systems.
+  echo "report-heap is not supported for this OS currently" 1>&2
+  exit 1
+fi

--- a/utils/onnx-mlir-report-heap.sh
+++ b/utils/onnx-mlir-report-heap.sh
@@ -1,5 +1,15 @@
 # This script behaves like onnx-mlir (same arguments and behavior) but
 # with the necessary setup and execution environment to report heap usage.
+# Use only on module level compiler passes or with multithreading disabled
+# to avoid parallel writing to the log file.
+#
+# Example which writes heap usage to /tmp/resnet50.heap.log:
+#
+#  cd build
+#  bash  ../utils/onnx-mlir-report-heap.sh \
+#    test/backend/Debug/models/resnet50/model.onnx -o=/tmp/resnet50 \
+#    --mlir-elide-elementsattrs-if-larger=1 \
+#    --report-heap-before=constprop-onnx --report-heap-after=constprop-onnx
 #
 # Assumptions:
 # 1) script is run in the onnx-mlir/build subdir


### PR DESCRIPTION
Added HeapReporter PassInstrumentation which dumps a heap log before/after the passes specified in the command line arguments ---report-heap-before and --report-heap-after.

Added script utils/onnx-mlir-report-heap.sh to run onnx-mlir with the necessary setup and execution environment, which means running it in the debugger on MacOS.

Only implemented for MacOS for now. Hopefully, someone will implement it on other OSs in the future.

Was used to measure the memory effects in PR #1874.