### PR TITLE
Fix Resize implementation

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
@@ -76,9 +76,60 @@ LogicalResult ONNXResizeOp::inferShapes(
   if (!X().getType().isa<RankedTensorType>()) {
     return success();
   }
-  Type elementType = X().getType().cast<RankedTensorType>().getElementType();
-  ONNXResizeOpShapeHelper shapeHelper(getOperation(), {});
-  return shapeHelper.computeShapeAndUpdateType(elementType);
+  // TODO : Return to this implementation once floating point scales are handled
+  //
+  // Type elementType = X().getType().cast<RankedTensorType>().getElementType();
+  // ONNXResizeOpShapeHelper shapeHelper(getOperation(), {});
+  // return shapeHelper.computeShapeAndUpdateType(elementType);
+
+  auto inputTy = X().getType().cast<RankedTensorType>();
+
+  // Output should at least has the same rank as X input
+  if (!getResult().getType().isa<RankedTensorType>()) {
+    SmallVector<int64_t, 4> dims(inputTy.getRank(), -1);
+    getResult().setType(RankedTensorType::get(dims, inputTy.getElementType()));
+  }
+
+  assert(isFromNone(scales()) != isFromNone(sizes()) &&
+         "Exactly one of scales and sizes can be defined");
+
+  // Current implementation handles constant scales only
+  if (!isFromNone(scales())) {
+    ElementsAttr scalesAttrs = getElementAttributeFromONNXValue(scales());
+    if (!scalesAttrs) {
+      return success();
+    }
+
+    SmallVector<float, 4> scalesConstant;
+    for (auto scaleAttr : scalesAttrs.getValues<FloatAttr>()) {
+      scalesConstant.emplace_back(scaleAttr.getValueAsDouble());
+    }
+
+    SmallVector<int64_t, 4> dims;
+    for (int i = 0; i < inputTy.getRank(); i++) {
+      int newDim;
+      if (ShapedType::isDynamic(inputTy.getShape()[i]))
+        newDim = -1;
+      else
+        newDim = inputTy.getShape()[i] * scalesConstant[i];
+      dims.emplace_back(newDim);
+    }
+
+    updateType(getResult(), dims, inputTy.getElementType());
+  } else {
+    ElementsAttr sizesAttrs = getElementAttributeFromONNXValue(sizes());
+    if (!sizesAttrs) {
+      return success();
+    }
+
+    SmallVector<int64_t, 4> sizesConstant;
+    for (auto sizeAttr : sizesAttrs.getValues<IntegerAttr>()) {
+      sizesConstant.emplace_back(sizeAttr.getInt());
+    }
+
+    updateType(getResult(), sizesConstant, inputTy.getElementType());
+  }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2615,6 +2615,23 @@ func.func @test_resize1(%arg0 : tensor<3x4x5x6xf32>) -> tensor<*xf32> {
 
 // -----
 
+func.func @test_resize_scales_floor(%arg0 : tensor<3x4x5x6xf32>) -> tensor<*xf32> {
+  %cst = "onnx.NoValue"() {value} : () -> none
+  %0 = onnx.Constant dense<[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<8xf32>
+  %1 = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 1.510000e+00]> : tensor<4xf32>
+  %2 = "onnx.Resize"(%arg0, %0, %1, %cst) {coordinate_transformation_mode = "asymmetric", mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize1"} : (tensor<3x4x5x6xf32>, tensor<8xf32>, tensor<4xf32>, none) -> tensor<*xf32>
+  "func.return"(%2) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: @test_resize_scales_floor
+  // CHECK-SAME: ([[ARG:%.+]]: tensor<3x4x5x6xf32>) -> tensor<3x4x10x9xf32> {
+  // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
+  // CHECK: [[R0:%.+]] = onnx.Constant dense<[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<8xf32>
+  // CHECK: [[R1:%.+]] = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 1.510000e+00]> : tensor<4xf32>
+  // CHECK: [[R2:%.+]] = "onnx.Resize"([[ARG]], [[R0]], [[R1]], [[CST]]) {coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize1"} : (tensor<3x4x5x6xf32>, tensor<8xf32>, tensor<4xf32>, none) -> tensor<3x4x10x9xf32>
+}
+
+// -----
+
   func.func @test_reversesequence_1(%arg0: tensor<10x30xf32>, %arg1: tensor<30xi64>) -> tensor<*xf32> {
     %0 = "onnx.ReverseSequence"(%arg0, %arg1) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<10x30xf32>, tensor<30xi64>) -> tensor<*xf32>
     return %0 : tensor<*xf32>


### PR DESCRIPTION
This PR reverts the resize implementation of `shapeInference`. The issue is the new implementation casts `scales[i]` to an integer. This is not the correct behavior. 
 
It is hard to implement Resize with `indexExprs` because of the lack of support for the float type. Since Resize shape inference has a bug for `scales` I've elected to go to the old implementation that way we have it working correctly on `main`. 

I have filed an associated issue https://github.com/onnx/onnx-mlir/issues/1958.

@AlexandreEichenberger this only meant as a temporary roll back until we figure out a proper way to support floating point numbers in the `IndexExpr` framework. 