### PR TITLE
constant propagation for ONNXWhereOp

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -52,8 +52,7 @@ bool testRawBytesValidityAndSplatness(
 }
 
 std::unique_ptr<llvm::MemoryBuffer> getMemoryBuffer(DenseElementsAttr dense) {
-  ShapedType type = dense.getType();
-  if (type.isInteger(1)) {
+  if (dense.getElementType().isInteger(1)) {
     // Don't use dense.rawData() which is bit packed, whereas
     // DisposableElementsAttr represents bools with one byte per bool value.
     if (dense.isSplat()) {
@@ -71,9 +70,9 @@ std::unique_ptr<llvm::MemoryBuffer> getMemoryBuffer(DenseElementsAttr dense) {
     ArrayRef<char> bytes = dense.getRawData();
     int64_t size = bytes.size();
     if (dense.isSplat())
-      assert(size == getEltSizeInBytes(type) && "size mismatch");
+      assert(size == getEltSizeInBytes(dense.getType()) && "size mismatch");
     else
-      assert(size == getSizeInBytes(type) && "size mismatch");
+      assert(size == getSizeInBytes(dense.getType()) && "size mismatch");
     return llvm::MemoryBuffer::getMemBuffer(asStringRef(bytes),
         /*BufferName=*/"", /*RequiresNullTerminator=*/false);
   }

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -147,6 +147,9 @@ private:
       llvm::ArrayRef<int64_t> expandedShape,
       llvm::SmallVectorImpl<int64_t> &expandedStrides) const;
 
+  mlir::ElementsAttr expandAndTransform(mlir::ElementsAttr elms,
+      mlir::ShapedType expandedTransformedType, Transformer transformer);
+
   mlir::ElementsAttr fromRawBytes(
       mlir::ShapedType type, BType bufferBType, llvm::ArrayRef<char> bytes);
 

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -95,6 +95,16 @@ public:
   mlir::ElementsAttr combine(mlir::ElementsAttr lhs, mlir::ElementsAttr rhs,
       mlir::ShapedType combinedType, WideNum (*combiner)(WideNum, WideNum));
 
+  // Returns an ElementsAttr that is the result of applying a the function
+  // (cond ? lhs : rhs) element-wise after broadcast to combinedType.
+  //
+  // Constructs new underlying data except in the cases where either cond is
+  // splat or lhs and rhs are both splat. In those case reuses the underlying
+  // data of one of the elements and just adds the necessary transformation
+  // and broadcast.
+  mlir::ElementsAttr where(mlir::ElementsAttr cond, mlir::ElementsAttr lhs,
+      mlir::ElementsAttr rhs, mlir::ShapedType combinedType);
+
   // Returns an ElementsAttr with the elements cast to the given newElementType.
   //
   // Reuses elms' underlying data without a data copy.

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -143,6 +143,10 @@ private:
 
   ElementsProperties getElementsProperties(mlir::ElementsAttr elements) const;
 
+  ArrayBuffer<WideNum> getWideNumsAndExpandedStrides(mlir::ElementsAttr elms,
+      llvm::ArrayRef<int64_t> expandedShape,
+      llvm::SmallVectorImpl<int64_t> &expandedStrides) const;
+
   mlir::ElementsAttr fromRawBytes(
       mlir::ShapedType type, BType bufferBType, llvm::ArrayRef<char> bytes);
 

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrHelper.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrHelper.cpp
@@ -59,6 +59,7 @@ void readElementsWideNums(ElementsAttr elms, MutableArrayRef<WideNum> dst) {
   if (auto disposable = elms.dyn_cast<DisposableElementsAttr>())
     return disposable.readWideNums(dst);
   // TODO: Implement the following in a more efficient way.
+  assert(dst.size() == static_cast<size_t>(elms.size()));
   BType btype = btypeOfMlirType(elms.getElementType());
   if (isFloatBType(btype)) {
     auto range = elms.getValues<APFloat>();

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrHelper.hpp.inc
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrHelper.hpp.inc
@@ -23,14 +23,14 @@ ArrayBuffer<X> getElementsArray(mlir::ElementsAttr elms) {
   return typename ArrayBuffer<X>::Vector(elms.getValues<X>());
 }
 
-// Copies out the elements in a flat array in row-major order.
-// Precondition: X must correspond to elms.getElementType().
 template <typename X>
 void readElementsArray(mlir::ElementsAttr elms, llvm::MutableArrayRef<X> dst) {
   if (auto disposable = elms.dyn_cast<mlir::DisposableElementsAttr>())
     return disposable.readArray<X>(dst);
-  if (elms.isSplat())
+  if (elms.isSplat()) {
+    assert(dst.size() == static_cast<size_t>(elms.size()));
     return std::fill(dst.begin(), dst.end(), elms.getSplatValue<X>());
+  }
   if (!elms.getElementType().isInteger(1)) {
     if (auto dense = elms.dyn_cast<mlir::DenseElementsAttr>()) {
       llvm::ArrayRef<X> data = castArrayRef<X>(dense.getRawData());

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -239,7 +239,7 @@ Value ConstPropWhere(PatternRewriter &rewriter, Value replacingValue,
   Type replacingType = replacingValue.getType().cast<ShapedType>();
 
   ElementsAttr cond = getConstValueElements(condValue);
-  assert(cond.getElementType.isInteger(1) &&
+  assert(cond.getElementType().isInteger(1) &&
          "ONNXWhereOp condition has bool element type");
   ElementsAttr lhs = getConstValueElements(lhsValue);
   ElementsAttr rhs = getConstValueElements(rhsValue);

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -235,7 +235,7 @@ Value ConstPropElementwiseUnary(
 
 Value ConstPropWhere(PatternRewriter &rewriter, Value replacingValue,
     Value condValue, Value lhsValue, Value rhsValue) {
-  ConstPropCounters::count("ElementwiseBinary", {lhsValue, rhsValue});
+  ConstPropCounters::count("Where", {condValue, lhsValue, rhsValue});
   Type replacingType = replacingValue.getType().cast<ShapedType>();
 
   ElementsAttr cond = getConstValueElements(condValue);
@@ -549,6 +549,7 @@ void ConstPropSliceImpl(ShapedType outputType,
 
 Value ConstPropSlice(
     PatternRewriter &rewriter, Value replacingValue, Value constValue) {
+  ConstPropCounters::count("Slice", {constValue});
   Operation *op = replacingValue.getDefiningOp();
   ONNXSliceOp sliceOp = cast<ONNXSliceOp>(op);
 

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -227,6 +227,33 @@ Value ConstPropElementwiseUnary(
 }
 
 //===----------------------------------------------------------------------===//
+// Code to perform constant propagation for ONNXWhereOp in presence of
+// broadcast.
+//
+/// Does element-wise ternary (cond ? lhs : rhs) with broadcast on all inputs.
+//===----------------------------------------------------------------------===//
+
+Value ConstPropWhere(PatternRewriter &rewriter, Value replacingValue,
+    Value condValue, Value lhsValue, Value rhsValue) {
+  ConstPropCounters::count("ElementwiseBinary", {lhsValue, rhsValue});
+  Type replacingType = replacingValue.getType().cast<ShapedType>();
+
+  ElementsAttr cond = getConstValueElements(condValue);
+  assert(cond.getElementType.isInteger(1) &&
+         "ONNXWhereOp condition has bool element type");
+  ElementsAttr lhs = getConstValueElements(lhsValue);
+  ElementsAttr rhs = getConstValueElements(rhsValue);
+  Type operandsElemType = lhs.getElementType();
+  assert(operandsElemType == rhs.getElementType() &&
+         "ONNXWhereOp branches have matching element types");
+  OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
+  ElementsAttr resultElements =
+      elementsBuilder.where(cond, lhs, rhs, replacingType);
+  return createReplacingConstantOp(rewriter, replacingValue, resultElements)
+      .getResult();
+}
+
+//===----------------------------------------------------------------------===//
 // Code to perform constant propagation for transpose.
 //===----------------------------------------------------------------------===//
 

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -106,6 +106,9 @@ def CreateMulOfTwoConst :
 def CreateDivOfTwoConst :
    NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXDivOp>($_builder, $0, $1, $2)">;
 
+def CreateWhereOfThreeConst :
+   NativeCodeCall<"ConstPropWhere($_builder, $0, $1, $2, $3)">;
+
 def CreateTransposeOfConst :
    NativeCodeCall<"ConstPropTranspose($_builder, $0, $1)">;
 
@@ -331,6 +334,23 @@ def DivConstProp : Pat<
     (CreateDivOfTwoConst $divOp, $lhs, $rhs),
     // Division constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+
+
+//===----------------------------------------------------------------------===//
+// Patterns for Where.
+//===----------------------------------------------------------------------===//
+
+// Constant Propagation for Where
+def WhereConstProp : Pat<
+    // From where(c0, c1, c2).
+    (ONNXWhereOp:$whereOp (ONNXConstantOp:$condition $_, $_, $_, $_, $_, $_, $_, $_),
+                      (ONNXConstantOp:$X $_, $_, $_, $_, $_, $_, $_, $_),
+                      (ONNXConstantOp:$Y $_, $_, $_, $_, $_, $_, $_, $_)),
+    // To c0?c1:c2
+    (CreateWhereOfThreeConst $whereOp, $condition, $X, $Y),
+    // Where constraints
+    [(IsFromDenseONNXConstantOp:$condition),
+     (IsFromDenseONNXConstantOp:$X), (IsFromDenseONNXConstantOp:$Y)]>;
 
 
 //===----------------------------------------------------------------------===//

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -348,6 +348,61 @@ func.func @test_relu() -> tensor<1x2xf32> {
 }
 
 //===----------------------------------------------------------------------===//
+/// Where tests
+
+// -----
+
+// CHECK-LABEL: @test_where() -> tensor<3x2xf32>
+func.func @test_where() -> tensor<3x2xf32> {
+  %0 = onnx.Constant dense<[true, false]> : tensor<2xi1>
+  %1 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
+  %2 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
+  %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
+  "func.return"(%3) : (tensor<3x2xf32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[2.000000e+00, 2.000000e+00], [6.000000e+00, 2.000000e+00], [1.000000e+01, 2.000000e+00]{{\]}}> : tensor<3x2xf32>
+  // CHECK-NOT: {{.*}} = "onnx.Div"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_where_true() -> tensor<3x2xf32>
+func.func @test_where_true() -> tensor<3x2xf32> {
+  %0 = onnx.Constant dense<true> : tensor<2xi1>
+  %1 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
+  %2 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
+  %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
+  "func.return"(%3) : (tensor<3x2xf32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[2.000000e+00, 4.000000e+00], [6.000000e+00, 8.000000e+00], [1.000000e+01, 1.200000e+01]{{\]}}> : tensor<3x2xf32>
+  // CHECK-NOT: {{.*}} = "onnx.Div"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_where_false() -> tensor<3x2xf32>
+func.func @test_where_false() -> tensor<3x2xf32> {
+  %0 = onnx.Constant dense<false> : tensor<2xi1>
+  %1 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
+  %2 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
+  %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
+  "func.return"(%3) : (tensor<3x2xf32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<2.000000e+00> : tensor<3x2xf32>
+  // CHECK-NOT: {{.*}} = "onnx.Div"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_where_splat_branches() -> tensor<3x2xf32>
+func.func @test_where_splat_branches() -> tensor<3x2xf32> {
+  %0 = onnx.Constant dense<[true, false]> : tensor<2xi1>
+  %1 = onnx.Constant dense<1.0> : tensor<3x2xf32>
+  %2 = onnx.Constant dense<2.0> : tensor<1x1xf32>
+  %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
+  "func.return"(%3) : (tensor<3x2xf32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[1.000000e+00, 2.000000e+00], [1.000000e+00, 2.000000e+00], [1.000000e+00, 2.000000e+00]{{\]}}> : tensor<3x2xf32>
+  // CHECK-NOT: {{.*}} = "onnx.Div"{{.*}}
+}
+
+//===----------------------------------------------------------------------===//
 /// Unsqueeze tests
 
 // -----

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -310,8 +310,8 @@ func.func @test_default_transpose_const_3() -> tensor<*xi32> {
 
 // -----
 
-// CHECK-LABEL: @test_div(%arg0: tensor<3x2xf32>) -> tensor<3x2xf32>
-func.func @test_div(%arg0: tensor<3x2xf32>) -> tensor<3x2xf32> {
+// CHECK-LABEL: @test_div() -> tensor<3x2xf32>
+func.func @test_div() -> tensor<3x2xf32> {
   %0 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
   %1 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
   %2 = "onnx.Div"(%0, %1) : (tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>


### PR DESCRIPTION
includes a bug fix in getMemoryBuffer() in ElementsAttrBuilder.cpp, which was exposed by the new const prop for Where

similarly, also added some checks in ElementsAttrHelper.hpp.inc in ElementsAttrHelper.cpp which would have caught some mistakes, and I threw in a refactor to remove code duplication between the get/readElementsWideNums() implementations, plus an optimization when the ElementsAttr is splat