### PR TITLE
Cleanup of is<RankedTensorType> in shape inference

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Additional/ConcatShapeTranspose.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/ConcatShapeTranspose.cpp
@@ -151,13 +151,9 @@ LogicalResult ONNXConcatShapeTransposeOpShapeHelper::computeShape() {
 
 LogicalResult ONNXConcatShapeTransposeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-
   // If any input is not ranked tensor, do nothing.
-  int inputNum = getNumOperands();
-  for (int i = 0; i < inputNum; ++i) {
-    if (!getOperand(i).getType().isa<RankedTensorType>())
-      return success();
-  }
+  if (!hasShapeAndRank(getOperation()))
+    return success();
   auto commonType = getOperand(0).getType().cast<RankedTensorType>();
   Type intType = IntegerType::get(getContext(), 64).cast<Type>();
   SmallVector<Type> elementTypes = {intType, commonType.getElementType()};

--- a/src/Dialect/ONNX/ONNXOps/ML/CategoryMapper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ML/CategoryMapper.cpp
@@ -74,7 +74,7 @@ LogicalResult ONNXCategoryMapperOp::verify() {
 LogicalResult ONNXCategoryMapperOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!X().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(X()))
     return success();
 
   Type inputElementType = X().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Math/Clip.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/Clip.cpp
@@ -44,14 +44,14 @@ LogicalResult ONNXClipOpShapeHelper::computeShape() {
 LogicalResult ONNXClipOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Look at input.
-  if (!input().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(input()))
     return success();
   RankedTensorType inputTy = input().getType().cast<RankedTensorType>();
   Type elementType = inputTy.getElementType();
   // Look at optional min.
   if (!min().getType().isa<NoneType>()) {
     // Has a min, make sure its of the right type.
-    if (!min().getType().isa<RankedTensorType>())
+    if (!hasShapeAndRank(min()))
       return success();
     // And size.
     RankedTensorType minTy = min().getType().cast<RankedTensorType>();
@@ -63,7 +63,7 @@ LogicalResult ONNXClipOp::inferShapes(
   // Look at optional max
   if (!max().getType().isa<NoneType>()) {
     // Has a max, make sure its of the right type.
-    if (!max().getType().isa<RankedTensorType>())
+    if (!hasShapeAndRank(max()))
       return success();
     // And size.
     RankedTensorType maxTy = max().getType().cast<RankedTensorType>();

--- a/src/Dialect/ONNX/ONNXOps/Math/ElementwiseBroadcast.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/ElementwiseBroadcast.cpp
@@ -353,9 +353,7 @@ LogicalResult ONNXPReluOp::verify() {
 
 LogicalResult ONNXPReluOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  ONNXPReluOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
+  if (!hasShapeAndRank(getOperation()))
     return success();
 
   Type elementType = X().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Math/Gemm.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/Gemm.cpp
@@ -119,13 +119,11 @@ LogicalResult ONNXGemmOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   bool hasBias = !C().getType().isa<NoneType>();
   // Cannot infer shape if no shape exists.
-  if (!A().getType().isa<RankedTensorType>() ||
-      !B().getType().isa<RankedTensorType>() ||
-      (hasBias && !C().getType().isa<RankedTensorType>()))
+  if (!hasShapeAndRank(A()) || !hasShapeAndRank(B()) ||
+      (hasBias && !hasShapeAndRank(C())))
     return success();
 
   Type elementType = A().getType().cast<ShapedType>().getElementType();
-
   ONNXGemmOpShapeHelper shapeHelper(getOperation(), {});
   return shapeHelper.computeShapeAndUpdateType(elementType);
 }

--- a/src/Dialect/ONNX/ONNXOps/Math/MatMul.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/MatMul.cpp
@@ -166,8 +166,7 @@ LogicalResult ONNXGenericMatMulOpShapeHelper<OP_TYPE>::computeShape() {
 LogicalResult ONNXMatMulOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!A().getType().isa<RankedTensorType>() ||
-      !B().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(A()) || !hasShapeAndRank(B()))
     return success();
 
   Type elementType = A().getType().cast<ShapedType>().getElementType();
@@ -182,8 +181,7 @@ LogicalResult ONNXMatMulOp::inferShapes(
 LogicalResult ONNXMatMulIntegerOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!A().getType().isa<RankedTensorType>() ||
-      !B().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(A()) || !hasShapeAndRank(B()))
     return success();
 
   Type elementType = getResult().getType().cast<ShapedType>().getElementType();
@@ -197,8 +195,7 @@ LogicalResult ONNXMatMulIntegerOp::inferShapes(
 
 LogicalResult ONNXQLinearMatMulOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!a().getType().isa<RankedTensorType>() ||
-      !b().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(a()) || !hasShapeAndRank(b()))
     return success();
 
   Type elementType = getResult().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Math/RandomNormalLike.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/RandomNormalLike.cpp
@@ -61,7 +61,7 @@ LogicalResult ONNXRandomNormalLikeOp::verify() {
 
 LogicalResult ONNXRandomNormalLikeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!input().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(input()))
     return success();
   auto inputType = input().getType().cast<RankedTensorType>();
   auto elementTypeIDDType = dtype();

--- a/src/Dialect/ONNX/ONNXOps/Math/Scatter.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/Scatter.cpp
@@ -33,9 +33,8 @@ LogicalResult ONNXScatterOp::inferShapes(
 
 LogicalResult ONNXScatterElementsOp::verify() {
   ONNXScatterElementsOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   // Get operands and attributes.
   Value data = operandAdaptor.data();
@@ -104,9 +103,8 @@ LogicalResult ONNXScatterElementsOp::inferShapes(
 
 LogicalResult ONNXScatterNDOp::verify() {
   ONNXScatterNDOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   // Get operands and attributes.
   Value data = operandAdaptor.data();

--- a/src/Dialect/ONNX/ONNXOps/Math/TopK.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/TopK.cpp
@@ -102,8 +102,7 @@ LogicalResult ONNXTopKOp::verify() {
 LogicalResult ONNXTopKOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer the output shape if the operands shape isn't known yet.
-  if (llvm::any_of(this->getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
+  if (!hasShapeAndRank(getOperation()))
     return success();
 
   Builder b(getContext());

--- a/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
@@ -442,9 +442,8 @@ LogicalResult ONNXConvOp::inferShapes(
 
   // Cannot infer shape if no shape exists.
   bool hasBias = !B().getType().isa<NoneType>();
-  if (!X().getType().isa<RankedTensorType>() ||
-      !W().getType().isa<RankedTensorType>() ||
-      (hasBias && !B().getType().isa<RankedTensorType>()))
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(W()) ||
+      (hasBias && !hasShapeAndRank(B())))
     return success();
 
   Type elementType = X().getType().cast<ShapedType>().getElementType();
@@ -546,9 +545,8 @@ LogicalResult ONNXConvTransposeOp::inferShapes(
   bool hasBias = !B().getType().isa<NoneType>();
 
   // Cannot infer shape if no shape exists.
-  if (!X().getType().isa<RankedTensorType>() ||
-      !W().getType().isa<RankedTensorType>() ||
-      (hasBias && !B().getType().isa<RankedTensorType>())) {
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(W()) ||
+      (hasBias && !hasShapeAndRank(B()))) {
     return success();
   }
 
@@ -686,9 +684,8 @@ LogicalResult ONNXQLinearConvOp::inferShapes(
 
   // Cannot infer shape if no shape exists.
   bool hasBias = !B().getType().isa<NoneType>();
-  if (!x().getType().isa<RankedTensorType>() ||
-      !w().getType().isa<RankedTensorType>() ||
-      (hasBias && !B().getType().isa<RankedTensorType>()))
+  if (!hasShapeAndRank(x()) || !hasShapeAndRank(w()) ||
+      (hasBias && !hasShapeAndRank(B())))
     return success();
 
   Type elementType = x().getType().cast<ShapedType>().getElementType();
@@ -807,8 +804,7 @@ LogicalResult ONNXConvIntegerOp::inferShapes(
   // B: (M) Optional
 
   // Cannot infer shape if no shape exists.
-  if (!x().getType().isa<RankedTensorType>() ||
-      !w().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(x()) || !hasShapeAndRank(w()))
     return success();
 
   Type outputElementType = IntegerType::get(getContext(), 32);

--- a/src/Dialect/ONNX/ONNXOps/NN/Dropout.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Dropout.cpp
@@ -52,7 +52,7 @@ LogicalResult ONNXDropoutOpShapeHelper::computeShape() {
 
 LogicalResult ONNXDropoutOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!data().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(data()))
     return success();
 
   Type outputElementType =

--- a/src/Dialect/ONNX/ONNXOps/NN/Normalization.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Normalization.cpp
@@ -36,11 +36,9 @@ LogicalResult ONNXBatchNormalizationInferenceModeOpShapeHelper::computeShape() {
 LogicalResult ONNXBatchNormalizationInferenceModeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!X().getType().isa<RankedTensorType>() ||
-      !scale().getType().isa<RankedTensorType>() ||
-      !B().getType().isa<RankedTensorType>() ||
-      !mean().getType().isa<RankedTensorType>() ||
-      !var().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(scale()) ||
+      !hasShapeAndRank(B()) || !hasShapeAndRank(mean()) ||
+      !hasShapeAndRank(var()))
     return success();
 
   // Verifier code.

--- a/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
@@ -124,7 +124,7 @@ LogicalResult ONNXAveragePoolOp::verify() {
 LogicalResult ONNXAveragePoolOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!X().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(X()))
     return success();
 
   Type elementType = X().getType().cast<ShapedType>().getElementType();
@@ -222,7 +222,7 @@ LogicalResult ONNXMaxPoolSingleOutOp::verify() {
 LogicalResult ONNXMaxPoolSingleOutOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!X().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(X()))
     return success();
 
   // Verify parameters: mandatory for kernel shape.
@@ -241,9 +241,7 @@ LogicalResult ONNXMaxPoolSingleOutOp::inferShapes(
 
 LogicalResult ONNXMaxRoiPoolOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!X().getType().isa<RankedTensorType>())
-    return success();
-  if (!rois().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(rois()))
     return success();
 
   Type elementType = X().getType().cast<RankedTensorType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/NN/RoiAlign.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/RoiAlign.cpp
@@ -82,8 +82,7 @@ LogicalResult ONNXRoiAlignOp::verify() {
 LogicalResult ONNXRoiAlignOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!X().getType().isa<RankedTensorType>() ||
-      !batch_indices().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(batch_indices()))
     return success();
 
   Type elementType = X().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/RNN/RNN.cpp
+++ b/src/Dialect/ONNX/ONNXOps/RNN/RNN.cpp
@@ -167,9 +167,7 @@ mlir::LogicalResult ONNXRNNOpShapeHelper::computeShape() {
 
 LogicalResult ONNXGRUOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!X().getType().isa<RankedTensorType>() ||
-      !W().getType().isa<RankedTensorType>() ||
-      !R().getType().isa<RankedTensorType>()) {
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(W()) || !hasShapeAndRank(R())) {
     return success();
   }
   Type elementType = X().getType().cast<RankedTensorType>().getElementType();
@@ -183,9 +181,7 @@ LogicalResult ONNXGRUOp::inferShapes(
 
 LogicalResult ONNXLSTMOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!X().getType().isa<RankedTensorType>() ||
-      !W().getType().isa<RankedTensorType>() ||
-      !R().getType().isa<RankedTensorType>()) {
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(W()) || !hasShapeAndRank(R())) {
     return success();
   }
   Type elementType = X().getType().cast<RankedTensorType>().getElementType();
@@ -199,9 +195,7 @@ LogicalResult ONNXLSTMOp::inferShapes(
 
 LogicalResult ONNXRNNOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!X().getType().isa<RankedTensorType>() ||
-      !W().getType().isa<RankedTensorType>() ||
-      !R().getType().isa<RankedTensorType>()) {
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(W()) || !hasShapeAndRank(R())) {
     return success();
   }
   Type elementType = X().getType().cast<RankedTensorType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ArgMinMax.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ArgMinMax.cpp
@@ -74,9 +74,8 @@ LogicalResult ONNXArgMinMaxOpShapeHelper<OP_TYPE>::computeShape() {
 
 LogicalResult ONNXArgMaxOp::verify() {
   ONNXArgMaxOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   int64_t rank = data().getType().cast<ShapedType>().getRank();
   int64_t axisIndex = axis();
@@ -107,9 +106,8 @@ LogicalResult ONNXArgMaxOp::inferShapes(
 
 LogicalResult ONNXArgMinOp::verify() {
   ONNXArgMinOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   int64_t rank = data().getType().cast<ShapedType>().getRank();
   int64_t axisIndex = axis();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Compress.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Compress.cpp
@@ -83,9 +83,8 @@ LogicalResult ONNXCompressOpShapeHelper::computeShape() {
 LogicalResult ONNXCompressOp::verify() {
   // Cannot check constraints if the shape of the inputs is not yet knwon.
   ONNXCompressOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   int64_t inputRank = input().getType().cast<ShapedType>().getRank();
   Optional<int64_t> optionalAxis = axis();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Concat.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Concat.cpp
@@ -140,7 +140,7 @@ LogicalResult ONNXConcatOp::inferShapes(
   // The check of constraints is kept
   // However, current check handles dynamic dim only for the concat dim
   if (!hasShapeAndRank(getOperation()))
-      return success();
+    return success();
   // Checking value of axis parameter.
   auto commonType = getOperand(0).getType().cast<RankedTensorType>();
   auto commonShape = commonType.getShape();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Concat.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Concat.cpp
@@ -139,11 +139,8 @@ LogicalResult ONNXConcatOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // The check of constraints is kept
   // However, current check handles dynamic dim only for the concat dim
-  int inputNum = getNumOperands();
-  for (int i = 0; i < inputNum; ++i) {
-    if (!getOperand(i).getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(getOperation()))
       return success();
-  }
   // Checking value of axis parameter.
   auto commonType = getOperand(0).getType().cast<RankedTensorType>();
   auto commonShape = commonType.getShape();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Concat.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Concat.cpp
@@ -86,9 +86,8 @@ LogicalResult ONNXConcatOpShapeHelper::computeShape() {
 LogicalResult ONNXConcatOp::verify() {
   // Cannot verify semantics if the operands do not have a known shape yet.
   ONNXConcatOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   auto commonType =
       operandAdaptor.getOperands().front().getType().cast<ShapedType>();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/DepthToSpace.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/DepthToSpace.cpp
@@ -101,7 +101,7 @@ LogicalResult ONNXDepthToSpaceOp::verify() {
 LogicalResult ONNXDepthToSpaceOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no input shape exists.
-  if (!input().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(input()))
     return success();
 
   Type elementType = input().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
@@ -101,9 +101,7 @@ LogicalResult ONNXExpandOp::verify() {
 
 LogicalResult ONNXExpandOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!input().getType().isa<RankedTensorType>())
-    return success();
-  if (!shape().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(input()) || !hasShapeAndRank(shape()))
     return success();
 
   Type elementType = input().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Gather.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Gather.cpp
@@ -64,9 +64,8 @@ LogicalResult ONNXGatherOpShapeHelper::computeShape() {
 
 LogicalResult ONNXGatherOp::verify() {
   ONNXGatherOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   auto dataType = operandAdaptor.data().getType().cast<RankedTensorType>();
   ArrayRef<int64_t> dataShape = dataType.getShape();
@@ -88,8 +87,7 @@ LogicalResult ONNXGatherOp::verify() {
 
 LogicalResult ONNXGatherOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (llvm::any_of(this->getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
+  if (!hasShapeAndRank(getOperation()))
     return success();
 
   Type elementType = data().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/GatherElements.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/GatherElements.cpp
@@ -38,9 +38,8 @@ LogicalResult ONNXGatherElementsOpShapeHelper::computeShape() {
 
 LogicalResult ONNXGatherElementsOp::verify() {
   ONNXGatherElementsOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   // Get operands and attributes.
   Value data = operandAdaptor.data();
@@ -95,8 +94,7 @@ LogicalResult ONNXGatherElementsOp::verify() {
 LogicalResult ONNXGatherElementsOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer the output shape if the operands shape is not yet known.
-  if (llvm::any_of(this->getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
+  if (!hasShapeAndRank(getOperation()))
     return success();
 
   Type elementType = data().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/GatherND.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/GatherND.cpp
@@ -86,9 +86,8 @@ LogicalResult ONNXGatherNDOpShapeHelper::computeShape() {
 
 LogicalResult ONNXGatherNDOp::verify() {
   ONNXGatherNDOpAdaptor operandAdaptor(*this);
-  if (llvm::any_of(operandAdaptor.getOperands(),
-          [](const Value &op) { return !hasShapeAndRank(op); }))
-    return success(); // Won't be able to do any checking at this stage.
+  if (!hasShapeAndRank(getOperation()))
+    return success();
 
   // Get operands and attributes.
   Value data = operandAdaptor.data();
@@ -170,8 +169,7 @@ LogicalResult ONNXGatherNDOp::verify() {
 LogicalResult ONNXGatherNDOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer the shape of the output if the inputs shape is not yet known.
-  if (llvm::any_of(
-          this->getOperands(), [](Value op) { return !hasShapeAndRank(op); }))
+  if (!hasShapeAndRank(getOperation()))
     return success();
 
   // The output rank is given by:

--- a/src/Dialect/ONNX/ONNXOps/Tensor/OneHot.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/OneHot.cpp
@@ -115,7 +115,7 @@ LogicalResult ONNXOneHotOp::verify() {
 LogicalResult ONNXOneHotOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!indices().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(indices()))
     return success();
 
   Type elementType = values().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Pad.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Pad.cpp
@@ -95,8 +95,7 @@ LogicalResult ONNXPadOp::verify() {
 LogicalResult ONNXPadOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!data().getType().isa<RankedTensorType>() ||
-      !pads().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(data()) || !hasShapeAndRank(pads()))
     return success();
 
   Type elementType = data().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Range.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Range.cpp
@@ -50,11 +50,8 @@ LogicalResult ONNXRangeOpShapeHelper::computeShape() {
 
 LogicalResult ONNXRangeOp::verify() {
   // All inputs must be valid ranked tensors.
-  if (!start().getType().isa<RankedTensorType>())
-    return success();
-  if (!limit().getType().isa<RankedTensorType>())
-    return success();
-  if (!delta().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(start()) || !hasShapeAndRank(limit()) ||
+      !hasShapeAndRank(delta()))
     return success();
 
   auto startTensorTy = start().getType().cast<RankedTensorType>();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Reshape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Reshape.cpp
@@ -100,10 +100,7 @@ LogicalResult ONNXReshapeOpShapeHelper::computeShape() {
 LogicalResult ONNXReshapeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape tensor is specified.
-  if (!data().getType().isa<RankedTensorType>())
-    return success();
-
-  if (!shape().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(data()) || !hasShapeAndRank(shape()))
     return success();
 
   // Only rank 1 shape tensors are supported.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
@@ -73,7 +73,7 @@ LogicalResult ONNXResizeOp::verify() {
 
 LogicalResult ONNXResizeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!hasShapeAndRank(X())) 
+  if (!hasShapeAndRank(X()))
     return success();
 
   // TODO : Remove this if branch once floating point scales are handled in

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
@@ -52,7 +52,7 @@ LogicalResult ONNXResizeOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXResizeOp::verify() {
-  if (!X().getType().isa<RankedTensorType>()) {
+  if (!hasShapeAndRank(X())) {
     return success();
   }
 
@@ -73,9 +73,8 @@ LogicalResult ONNXResizeOp::verify() {
 
 LogicalResult ONNXResizeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!X().getType().isa<RankedTensorType>()) {
+  if (!hasShapeAndRank(X())) 
     return success();
-  }
 
   // TODO : Remove this if branch once floating point scales are handled in
   // ONNXResizeOpShapeHelper Issue number : #1958

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ReverseSequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ReverseSequence.cpp
@@ -77,7 +77,7 @@ LogicalResult ONNXReverseSequenceOp::verify() {
 
 LogicalResult ONNXReverseSequenceOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!input().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(input()))
     return success();
 
   Type elementType = input().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Shape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Shape.cpp
@@ -101,7 +101,7 @@ void ONNXShapeOpShapeHelper::computeSelectedDataShape(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXShapeOp::verify() {
-  if (!data().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(data()))
     return success();
   int64_t start, end;
   ONNXShapeOpShapeHelper::getStartEndValues(*this, start, end);
@@ -117,7 +117,7 @@ LogicalResult ONNXShapeOp::verify() {
 LogicalResult ONNXShapeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!data().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(data()))
     return success();
 
   // Output is an 1D int64 tensor containing the shape of the input tensor.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -152,7 +152,7 @@ LogicalResult ONNXSliceOpShapeHelper::computeShape() {
 LogicalResult ONNXSliceOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!data().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(data()))
     return success();
 
   const auto startsType =

--- a/src/Dialect/ONNX/ONNXOps/Tensor/SpaceToDepth.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/SpaceToDepth.cpp
@@ -103,7 +103,7 @@ LogicalResult ONNXSpaceToDepthOp::verify() {
 LogicalResult ONNXSpaceToDepthOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no input shape exists.
-  if (!input().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(input()))
     return success();
 
   Type elementType = input().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Tile.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Tile.cpp
@@ -56,11 +56,7 @@ LogicalResult ONNXTileOpShapeHelper::computeShape() {
 LogicalResult ONNXTileOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!input().getType().isa<RankedTensorType>())
-    return success();
-
-  // Read 'repeats' value.
-  if (!repeats().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(input()) || !hasShapeAndRank(repeats()))
     return success();
 
   // 'repeats' tensor is an 1D tensor.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Transpose.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Transpose.cpp
@@ -71,7 +71,7 @@ LogicalResult ONNXTransposeOpShapeHelper::computeShape() {
 LogicalResult ONNXTransposeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer shape if no shape exists.
-  if (!data().getType().isa<RankedTensorType>())
+  if (!hasShapeAndRank(data()))
     return success();
 
   Type elementType = data().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Upsample.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Upsample.cpp
@@ -67,12 +67,8 @@ LogicalResult ONNXUpsampleOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXUpsampleOp::verify() {
-  if (!X().getType().isa<RankedTensorType>()) {
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(scales()))
     return success();
-  }
-  if (!scales().getType().isa<RankedTensorType>()) {
-    return success();
-  }
 
   auto inputTy = X().getType().cast<RankedTensorType>();
   int32_t inputRank = inputTy.getShape().size();
@@ -116,12 +112,8 @@ LogicalResult ONNXUpsampleOp::verify() {
 
 LogicalResult ONNXUpsampleOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  if (!X().getType().isa<RankedTensorType>()) {
+  if (!hasShapeAndRank(X()) || !hasShapeAndRank(scales()))
     return success();
-  }
-  if (!scales().getType().isa<RankedTensorType>()) {
-    return success();
-  }
 
   Type elementType = X().getType().cast<RankedTensorType>().getElementType();
   ONNXUpsampleOpShapeHelper shapeHelper(getOperation(), {});


### PR DESCRIPTION
Non functional changes

The function `hasShapeAndRank` is more precise an cover more cases than the simple `is<RankedTensorType>()` in shape inference. Replaced all the cases where it made sense.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>