### PR TITLE
clean up some old code

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -482,7 +482,7 @@ bool isSuitableForZDNN<ONNXGemmOp>(
   ArrayRef<int64_t> bShape = bType.getShape();
   ArrayRef<int64_t> cShape;
 
-  bool hasC = !isNoneType(C);
+  bool hasC = !isFromNone(C);
   if (hasC) {
     cType = C.getType().cast<ShapedType>();
     cShape = cType.getShape();
@@ -587,19 +587,19 @@ bool isSuitableForZDNN<ONNXLSTMOp>(
   if (hidden_size > MAXIMUM_NUM_HIDDEN_SIZE_LSTM)
     return false;
   // zDNN does not support sequence_lens.
-  if (!isNoneType(op.sequence_lens()))
+  if (!isFromNone(op.sequence_lens()))
     return false;
   // check if B, initial_h and initial_c have static dimensions if given.
-  if (!isNoneType(B) && !B.getType().cast<ShapedType>().hasStaticShape())
+  if (!isFromNone(B) && !B.getType().cast<ShapedType>().hasStaticShape())
     return false;
   // check if B's direction dim is 1 or 2.
-  if (!isNoneType(B)) {
+  if (!isFromNone(B)) {
     ArrayRef<int64_t> bShape = B.getType().cast<ShapedType>().getShape();
     if (bShape[0] != 1 && bShape[0] != 2)
       return false;
   }
   // zDNN does not support P(peepholes), activation_alpha and activation_beta.
-  if (!isNoneType(op.P()) || op.activation_alpha() || op.activation_beta())
+  if (!isFromNone(op.P()) || op.activation_alpha() || op.activation_beta())
     return false;
   // zDNN support the default activations (["Sigmoid", "Tanh", "Tanh"]) only.
   if ((activations && (activations.value().size() > 0) &&
@@ -659,13 +659,13 @@ bool isSuitableForZDNN<ONNXGRUOp>(
   if (hidden_size > MAXIMUM_NUM_HIDDEN_SIZE_GRU)
     return false;
   // zDNN does not support sequence_lens.
-  if (!isNoneType(op.sequence_lens()))
+  if (!isFromNone(op.sequence_lens()))
     return false;
   // check if B and initial_h have static dimensions if given.
-  if (!isNoneType(B) && !B.getType().cast<ShapedType>().hasStaticShape())
+  if (!isFromNone(B) && !B.getType().cast<ShapedType>().hasStaticShape())
     return false;
   // check if B's direction dim is 1 or 2.
-  if (!isNoneType(B)) {
+  if (!isFromNone(B)) {
     ArrayRef<int64_t> bShape = B.getType().cast<ShapedType>().getShape();
     if (bShape[0] != 1 && bShape[0] != 2)
       return false;

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp
@@ -94,7 +94,7 @@ Value getLSTMGRUZDNNWeightFromONNXWeight(
 Value getLSTMGRUGetY(
     Location loc, PatternRewriter &rewriter, Value val, Value resY) {
   Value noneValue;
-  if (isNoneType(resY)) {
+  if (isFromNone(resY)) {
     return noneValue;
   }
   return val;
@@ -103,7 +103,7 @@ Value getLSTMGRUGetY(
 Value getLSTMGRUGetYh(Location loc, PatternRewriter &rewriter, Value val,
     Value resY, Value resYh, Value X, StringAttr direction) {
   Value noneValue;
-  if (isNoneType(resYh) || isNoneType(val))
+  if (isFromNone(resYh) || isFromNone(val))
     return noneValue;
 
   ArrayRef<int64_t> shapeX = X.getType().cast<ShapedType>().getShape();
@@ -130,7 +130,7 @@ Value getLSTMGRUGetYh(Location loc, PatternRewriter &rewriter, Value val,
   StringRef directionStr = direction.getValue();
   ArrayRef<int64_t> resYhShape =
       resYh.getType().cast<RankedTensorType>().getShape();
-  int64_t T = isNoneType(resY) ? 1 : shapeX[0];
+  int64_t T = isFromNone(resY) ? 1 : shapeX[0];
   int64_t D = resYhShape[0];
   int64_t B = resYhShape[1];
   int64_t H = resYhShape[2];
@@ -173,7 +173,7 @@ Value getLSTMGRUGetYh(Location loc, PatternRewriter &rewriter, Value val,
 Value getLSTMGRUGetYc(
     Location loc, PatternRewriter &rewriter, Value val, Value resYc) {
   Value noneValue;
-  if (isNoneType(resYc))
+  if (isFromNone(resYc))
     return noneValue;
 
   zhigh::ZHighUnstickOp unstickOp =

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -588,7 +588,7 @@ class GetLSTMGRUZDNNWeightFromONNXWeight<string opName> : NativeCodeCall<
 
 def GetLSTMGRUReturnAllStepsAttr : NativeCodeCall<
   "$_builder.getIntegerAttr($_builder.getIntegerType(64, true),"
-  "(isNoneType($0) ? 1 : -1))">;
+  "(isFromNone($0) ? 1 : -1))">;
 
 def GetLSTMGRUGetY :
         NativeCodeCall<"getLSTMGRUGetY($_loc, $_builder, $0, $1)">;

--- a/src/Conversion/ONNXToKrnl/Math/Clip.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Clip.cpp
@@ -61,12 +61,12 @@ struct ONNXClipOpLowering : public ConversionPattern {
                              const ValueRange &indices) { // indices={i,j,k}
       Value loadedVal = create.krnl.load(input, indices); // load input[i,j,k]
       Value res = loadedVal;
-      if (!min.getType().isa<NoneType>()) {
+      if (!isFromNone(min)) {
         Value minVal = create.krnl.load(min);             // load min
         Value lessThanMin = create.math.slt(res, minVal); // (input[i,j,k]<min)
         res = create.math.select(lessThanMin, minVal, res);
       }
-      if (!max.getType().isa<NoneType>()) {
+      if (!isFromNone(max)) {
         Value maxVal = create.krnl.load(max);
         Value lessThanMax = create.math.slt(res, maxVal);
         res = create.math.select(lessThanMax, res, maxVal);

--- a/src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp
@@ -31,9 +31,6 @@ struct RNNActivation {
   llvm::Optional<mlir::FloatAttr> beta;
 };
 
-/// Check a mlir::Value's type is none or not.
-bool isNoneType(mlir::Value val);
-
 /// Get a dimension of the tensor's shape.
 int64_t dimAt(mlir::Value val, int index);
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -36,11 +36,7 @@ struct ONNXTransposeOpLowering : public ConversionPattern {
     Value data = operandAdaptor.data();
     auto permAttr = transposeOp.perm();
 
-    // Convert the input type to MemRefType.
-    Type inConvertedType = typeConverter->convertType(data.getType());
-    assert(inConvertedType && inConvertedType.isa<MemRefType>() &&
-           "Failed to convert type to MemRefType");
-    MemRefType inMemRefType = inConvertedType.cast<MemRefType>();
+    MemRefType inMemRefType = data.getType().cast<MemRefType>();
     uint64_t inRank = inMemRefType.getShape().size();
     // Convert the output type to MemRefType.
     Type outConvertedType =

--- a/src/Dialect/ONNX/ONNXOps/Math/Gemm.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/Gemm.cpp
@@ -35,7 +35,7 @@ LogicalResult ONNXGemmOpShapeHelper::computeShape() {
   Value A = operandAdaptor.A();
   Value B = operandAdaptor.B();
   Value C = operandAdaptor.C();
-  hasBias = !C.getType().isa<NoneType>();
+  hasBias = !isFromNone(C);
 
   // Test ranks.
   if (A.getType().cast<ShapedType>().getShape().size() != 2)
@@ -117,7 +117,7 @@ LogicalResult ONNXGemmOpShapeHelper::computeShape() {
 
 LogicalResult ONNXGemmOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  bool hasBias = !C().getType().isa<NoneType>();
+  bool hasBias = !isFromNone(C());
   // Cannot infer shape if no shape exists.
   if (!hasShapeAndRank(A()) || !hasShapeAndRank(B()) ||
       (hasBias && !hasShapeAndRank(C())))

--- a/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
@@ -360,7 +360,7 @@ LogicalResult ONNXConvOp::verify() {
   auto X = operandAdaptor.X();
   auto W = operandAdaptor.W();
   auto B = operandAdaptor.B();
-  bool hasBias = !B.getType().isa<NoneType>();
+  bool hasBias = !isFromNone(B);
   int64_t g = group();
   if (g < 1)
     return emitOpError("group must be strictly positive");
@@ -441,7 +441,7 @@ LogicalResult ONNXConvOp::inferShapes(
   // B: (M) Optional
 
   // Cannot infer shape if no shape exists.
-  bool hasBias = !B().getType().isa<NoneType>();
+  bool hasBias = !isFromNone(B());
   if (!hasShapeAndRank(X()) || !hasShapeAndRank(W()) ||
       (hasBias && !hasShapeAndRank(B())))
     return success();
@@ -542,7 +542,7 @@ LogicalResult ONNXConvTransposeOp::inferShapes(
   // W: (C x M/group x k1 x k2 x ... x kn)
   // B: (M) Optional
 
-  bool hasBias = !B().getType().isa<NoneType>();
+  bool hasBias = !isFromNone(B());
 
   // Cannot infer shape if no shape exists.
   if (!hasShapeAndRank(X()) || !hasShapeAndRank(W()) ||
@@ -683,7 +683,7 @@ LogicalResult ONNXQLinearConvOp::inferShapes(
   // B: (M) Optional
 
   // Cannot infer shape if no shape exists.
-  bool hasBias = !B().getType().isa<NoneType>();
+  bool hasBias = !isFromNone(B());
   if (!hasShapeAndRank(x()) || !hasShapeAndRank(w()) ||
       (hasBias && !hasShapeAndRank(B())))
     return success();
@@ -701,7 +701,7 @@ LogicalResult ONNXQLinearConvOp::inferShapes(
   // W: (M x C/group x k1 x k2 x ... x kn)
   // B: (M) Optional
 
-  bool hasBias = !B().getType().isa<NoneType>();
+  bool hasBias = !isFromNone(B());
 
   // Cannot infer shape if no shape exists.
   if (!x().getType().isa<RankedTensorType>() ||

--- a/src/Dialect/ONNX/ONNXOps/NN/Dropout.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Dropout.cpp
@@ -34,7 +34,7 @@ LogicalResult ONNXDropoutOpShapeHelper::computeShape() {
   createIE->getShapeAsDims(operandAdaptor.data(), outputDims);
   setOutputDims(outputDims, 0);
   // Optional Mask has also the same size as data. If none, size is empty.
-  if (dropout.mask().getType().isa<NoneType>())
+  if (isFromNone(dropout.mask()))
     outputDims.clear();
   setOutputDims(outputDims, 1);
   return success();

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -335,9 +335,9 @@ bool isFromNone(Value v) {
     return true;
 
   if (auto ty = v.getType().dyn_cast<ShapedType>()) {
-  auto shape = ty.getShape();
-  if (shape.size() == 1 && shape[0] == 0)
-    return true;
+    auto shape = ty.getShape();
+    if (shape.size() == 1 && shape[0] == 0)
+      return true;
   }
 
   return false;

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -327,18 +327,17 @@ Value createNoneFloatConstant(PatternRewriter &rewriter, Location loc) {
 }
 
 // Returns true if the Value is defined by a unit constant.
+// The unit constant can  be 1. NoneType, or 2. 1D tensor with 0 length
+// For example, NoneType, tensor<0xf32>
+// Some onnx model uses 0 length tensor for unit constant.
 bool isFromNone(Value v) {
-  if (auto op = v.getDefiningOp()) {
-    if (isa<ONNXNoneOp>(op))
-      return true;
+  if (v.getType().isa<NoneType>())
+    return true;
 
-    if (auto c = dyn_cast<ONNXConstantOp>(op))
-      if (c.value().has_value())
-        if (auto e = c.valueAttr().dyn_cast<ElementsAttr>()) {
-          auto shape = e.getType().getShape();
-          if (shape.size() == 1 && shape[0] == 0)
-            return true;
-        }
+  if (auto ty = v.getType().dyn_cast<ShapedType>()) {
+  auto shape = ty.getShape();
+  if (shape.size() == 1 && shape[0] == 0)
+    return true;
   }
 
   return false;

--- a/src/Dialect/ONNX/ONNXOps/RNN/RNN.cpp
+++ b/src/Dialect/ONNX/ONNXOps/RNN/RNN.cpp
@@ -100,8 +100,7 @@ LogicalResult ONNXGenericRNNShapeHelper<OP_TYPE>::customComputeShape(
   // Y :: [batch_size, seq_length, num_dir, hidden_size] if batchwiseLayout
   // Y :: [seq_length, num_dir, batch_size, hidden_size] otherwise
   DimsExpr yOutputDims;
-  Type yTy = op->getResult(0).getType();
-  if (!yTy.isa<NoneType>()) {
+  if (!isFromNone(op->getResult(0))) {
     if (batchwiseLayout) {
       yOutputDims = {batchSize, seqLength, numDir, hiddenSize};
     } else {
@@ -113,8 +112,7 @@ LogicalResult ONNXGenericRNNShapeHelper<OP_TYPE>::customComputeShape(
   // Y_h :: [batch_size, num_dir, hidden_size] if batchwiseLayout
   // Y_h :: [num_dir, batch_size, hidden_size] otherwise
   DimsExpr yHOutputDims;
-  Type yhTy = op->getResult(1).getType();
-  if (!yhTy.isa<NoneType>()) {
+  if (!isFromNone(op->getResult(1))) {
     if (batchwiseLayout) {
       yHOutputDims = {batchSize, numDir, hiddenSize};
     } else {
@@ -127,8 +125,7 @@ LogicalResult ONNXGenericRNNShapeHelper<OP_TYPE>::customComputeShape(
     // Y_c :: [batch_size, num_dir, hidden_size] if batchwiseLayout
     // Y_c :: [num_dir, batch_size, hidden_size] otherwise
     DimsExpr yCOutputDims;
-    Type ycTy = op->getResult(2).getType();
-    if (!ycTy.isa<NoneType>()) {
+    if (!isFromNone(op->getResult(2))) {
       if (batchwiseLayout) {
         yCOutputDims = {batchSize, numDir, hiddenSize};
       } else {

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Optional.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Optional.cpp
@@ -23,7 +23,7 @@ using namespace onnx_mlir;
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXOptionalOp::verify() {
-  if (type().has_value() != input().getType().isa<NoneType>())
+  if (type().has_value() != isFromNone(input()))
     return emitError(
         "Optional should have either type attribute or input value");
   return success();
@@ -36,8 +36,6 @@ LogicalResult ONNXOptionalOp::inferShapes(
     ty = typeAttr.value();
   } else {
     ty = input().getType();
-    // checked in verify()
-    assert(!ty.isa<NoneType>() && "type attribute or input value needed");
   }
   getResult().setType(OptType::get(ty));
   return success();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Pad.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Pad.cpp
@@ -77,7 +77,7 @@ LogicalResult ONNXPadOp::verify() {
   ShapedType dataTy = data().getType().cast<ShapedType>();
   Type constTy = constant_value().getType();
 
-  if (!constTy.isa<NoneType>()) {
+  if (!isFromNone(constant_value())) {
     // Check that the constant has the same element type as the input
     ShapedType shapedConstTy = constTy.cast<ShapedType>();
     if (dataTy.getElementType() != shapedConstTy.getElementType()) {

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -34,7 +34,7 @@ LogicalResult ONNXSliceOpShapeHelper::computeShape() {
   // Get each of the axes, and save the literal values in axesIntLit.
   SmallVector<int64_t, 4> axesIntLit;
   Value axes = operandAdaptor.axes();
-  if (axes.getType().isa<NoneType>()) {
+  if (isFromNone(axes)) {
     // If `axes` are omitted, they are set to `[0, ..., nDim-1]`."
     for (uint64_t i = 0; i < dataRank; ++i)
       axesIntLit.emplace_back(i);
@@ -165,7 +165,7 @@ LogicalResult ONNXSliceOp::inferShapes(
     const auto tensorType = RankedTensorType::get({startsDim}, elementType);
 
     // If axes is not specified, default to [0, ..., ndim-1]
-    if (this->getOperand(3).getType().isa<NoneType>()) {
+    if (isFromNone(this->getOperand(3))) {
       SmallVector<int64_t, 1> vals = {};
       for (size_t s = 0; s < (size_t)startsDim; ++s)
         vals.emplace_back(s);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Split.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Split.cpp
@@ -93,7 +93,7 @@ LogicalResult ONNXSplitOpShapeHelper::computeShape() {
   ONNXSplitOpAdaptor operandAdaptor(operands, op->getAttrDictionary());
   Value split = operandAdaptor.split();
   SmallVector<IndexExpr, 4> indexExprArray;
-  if (split.getType().template isa<NoneType>()) {
+  if (isFromNone(split)) {
     // None is fine, indexExprArray will be empty.
   } else {
     createIE->getIntFromArrayAsSymbols(split, indexExprArray);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Squeeze.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Squeeze.cpp
@@ -123,7 +123,7 @@ LogicalResult ONNXSqueezeOpShapeHelper::computeShape() {
   Value axes = operandAdaptor.axes();
   SmallVector<IndexExpr, 4> squeezedDims;
   bool squeezeFromShape = false;
-  if (axes.getType().template isa<NoneType>())
+  if (isFromNone(axes))
     squeezeFromShape = true;
   else
     createIE->getIntFromArrayAsSymbols(axes, squeezedDims);


### PR DESCRIPTION
Signed-off-by: chentong319 <chentong@us.ibm.com>
Two changes:
1. Detect optional input. The NoneType is originally used to represent the optional input when it is not presented. Later, some onnx model used 0 length tensor for that purpose. We have function isFromNone for both case.  This change replace the NoneType check for some old code with isFromNone. Also isFromNone is changed to check the type, not how the value (definition point) is defined because a Value may not have a definition point in constructing process.
2. Delete unnecessary use of TypeConverter. The TypeConverter should be called automatically on the input by Conversion process, according to the document. Old code did not use type converter and the explicit type conversion was replaced with type converter when type converter is added. Such code is not needed.