### PR TITLE
update the how to join for slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Current levels of support for the code generation of ONNX operations are listed 
 ## Interacting with the community.
 
 For ongoing discussions, we use an [`#onnx-mlir-discussion`](https://lfaifoundation.slack.com/archives/C01J4NAL4A2) slack channel established under the Linux Foundation AI and Data Workspace.
+Join this workspace using this [link](https://join.slack.com/t/lfaifoundation/shared_invite/zt-o65errpw-gMTbwNr7FnNbVXNVFkmyNA).
+
 We use GitHub Issues for request for comments, questions, or bug reports.
 Security-related issues are reported using the channels listed in the [SECURITY](SECURITY.md) page.
 

--- a/docs/ONNXAI.md
+++ b/docs/ONNXAI.md
@@ -8,4 +8,7 @@ Intermediate Representation (MLIR) compiler infrastructure.
 
 # Slack channel
 
-We have a slack channel established under the Linux Foundation AI and Data Workspace, named `#onnx-mlir-discussion`. This channel can be used for asking quick questions related to this project. A direct link is [here](https://lfaifoundation.slack.com/archives/C01J4NAL4A2).
+We have a slack channel established under the Linux Foundation AI and Data Workspace, named `#onnx-mlir-discussion`.
+This channel can be used for asking quick questions related to this project.
+A direct link is [here](https://lfaifoundation.slack.com/archives/C01J4NAL4A2).
+Join this workspace using this [link](https://join.slack.com/t/lfaifoundation/shared_invite/zt-o65errpw-gMTbwNr7FnNbVXNVFkmyNA).


### PR DESCRIPTION
Previous link did not let folks join in without being invited by someone. The new link, borrowed from onnx site, worked for me.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>