### PR TITLE
constant propagate ReduceSum/Prod/Min/Max/Mean

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -408,6 +408,8 @@ ElementsAttr ElementsAttrBuilder::reduce(ElementsAttr elms,
     }
   }
 
+  // TODO: Explain the unusual "sparse" strided arrays and traverseStrides
+  //       invocations below.
   StridedArrayRef<WideNum> axesStrided(srcNums.get(), axesStrides);
   StridedArrayRef<WideNum> reducedStrided(srcNums.get(), reducedStrides);
   ShapedType reducedType = keepdims ? type : type.clone(reducedShape);

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -216,7 +216,7 @@ struct Caster {
 template <typename SrcT, typename DstT>
 using WideCaster = WideNumWrappedFunction<Caster<SrcT, DstT>>;
 
-auto wideCaster(BType src, BType dst) {
+auto wideCaster(BType src, BType dst) -> WideNum (*)(WideNum) {
   constexpr BType DBL = BType::DOUBLE, I64 = BType::INT64, U64 = BType::UINT64;
   // clang-format off
   if (src == DBL && dst == I64) return WideCaster<double, int64_t>::eval;

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -389,7 +389,6 @@ ElementsAttr ElementsAttrBuilder::reduce(ElementsAttr elms,
   ShapedType type = elms.getType();
   auto shape = type.getShape();
 
-  ElementsProperties props = getElementsProperties(elms);
   SmallVector<int64_t, 4> strides;
   ArrayBuffer<WideNum> srcNums = getWideNumsAndStrides(elms, strides);
   SmallVector<int64_t, 4> axesShape;
@@ -400,7 +399,7 @@ ElementsAttr ElementsAttrBuilder::reduce(ElementsAttr elms,
   for (unsigned axis = 0; axis < shape.size(); ++axis) {
     if (it != sortedAxes.end() && *it == axis) {
       axesShape.push_back(shape[axis]);
-      axesStrides.push_back(props.strides[axis]);
+      axesStrides.push_back(strides[axis]);
       if (keepdims) {
         reducedShape.push_back(1);
         reducedStrides.push_back(0);
@@ -408,7 +407,7 @@ ElementsAttr ElementsAttrBuilder::reduce(ElementsAttr elms,
       ++it;
     } else {
       reducedShape.push_back(shape[axis]);
-      reducedStrides.push_back(props.strides[axis]);
+      reducedStrides.push_back(strides[axis]);
     }
   }
 

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -465,6 +465,9 @@ ArrayBuffer<WideNum> ElementsAttrBuilder::getWideNumsAndExpandedStrides(
   if (auto disposable = elms.dyn_cast<DisposableElementsAttr>()) {
     expandedStrides = expandStrides(disposable.getStrides(), expandedShape);
     return disposable.getBufferAsWideNums();
+  } else if (elms.isSplat()) {
+    expandedStrides = getSplatStrides(expandedShape);
+    return ArrayBuffer<WideNum>::Vector(1, getElementsSplatWideNum(elms));
   } else {
     auto strides = getDefaultStrides(elms.getType().getShape());
     expandedStrides = expandStrides(strides, expandedShape);

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -446,7 +446,7 @@ auto ElementsAttrBuilder::getElementsProperties(ElementsAttr elements) const
     ShapedType type = dense.getType();
     SmallVector<int64_t, 4> strides;
     if (dense.isSplat()) {
-      strides.assign(type.getRank(), 0);
+      strides = getSplatStrides(type.getShape());
     } else {
       strides = getDefaultStrides(type.getShape());
     }

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -188,7 +188,9 @@ ElementsAttr ElementsAttrBuilder::where(ElementsAttr cond, ElementsAttr lhs,
 
     WideNum *end = traverseStrides<WideNum *, WideNum, WideNum>(combinedShape,
         dstNums.begin(), stridedLhs, stridedRhs,
-        [](WideNum *res, WideNum x, WideNum y) { *res = res->u64 ? x : y; });
+        [](WideNum *res, const WideNum *x, const WideNum *y) {
+          *res = res->u64 ? *x : *y;
+        });
     assert(end == dstNums.end() && "traverses every dstNums element");
   });
 }

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -401,6 +401,10 @@ ElementsAttr ElementsAttrBuilder::reduce(ElementsAttr elms,
     if (it != sortedAxes.end() && *it == axis) {
       axesShape.push_back(shape[axis]);
       axesStrides.push_back(props.strides[axis]);
+      if (keepdims) {
+        reducedShape.push_back(1);
+        reducedStrides.push_back(0);
+      }
       ++it;
     } else {
       reducedShape.push_back(shape[axis]);
@@ -412,7 +416,7 @@ ElementsAttr ElementsAttrBuilder::reduce(ElementsAttr elms,
   //       invocations below.
   StridedArrayRef<WideNum> axesStrided(srcNums.get(), axesStrides);
   StridedArrayRef<WideNum> reducedStrided(srcNums.get(), reducedStrides);
-  ShapedType reducedType = keepdims ? type : type.clone(reducedShape);
+  ShapedType reducedType = type.clone(reducedShape);
   return fromWideNums(reducedType, [&](MutableArrayRef<WideNum> dstNums) {
     int64_t count = traverseStrides<int64_t, WideNum>(
         axesShape, 0, axesStrided, [&](int64_t counter, const WideNum *iter) {

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -69,19 +69,16 @@ public:
         });
   }
 
-  // A transformer mutates elements.
-  using Transformer = std::function<void(llvm::MutableArrayRef<WideNum>)>;
-
-  // Constructs a transformer that changes every element to the result of
-  // applying the given function to the element.
-  static Transformer functionTransformer(WideNum (*fun)(WideNum));
-
   // Returns an ElementsAttr where each element is transformed
   // by running the given transformer on all the elements.
   //
   // Reuses elms' underlying data without a data copy.
+  template <typename Function = WideNum (*)(WideNum)>
   mlir::ElementsAttr transform(mlir::ElementsAttr elms,
-      mlir::Type transformedElementType, Transformer transformer);
+      mlir::Type transformedElementType, Function fun) {
+    return doTransform(
+        elms, transformedElementType, functionTransformer(std::move(fun)));
+  }
 
   // Returns an ElementsAttr that is the result of applying a binary function
   // pairwise on the elements lhs and rhs after broadcast to combinedType.
@@ -138,6 +135,11 @@ public:
   std::vector<mlir::ElementsAttr> split(
       mlir::ElementsAttr elms, unsigned axis, llvm::ArrayRef<int64_t> sizes);
 
+  // Assumption: reducer is associative and commutative.
+  mlir::ElementsAttr reduce(mlir::ElementsAttr elms,
+      llvm::ArrayRef<unsigned> axes, bool keepdims,
+      WideNum (*reducer)(WideNum, WideNum));
+
 private:
   struct ElementsProperties;
 
@@ -146,6 +148,22 @@ private:
   ArrayBuffer<WideNum> getWideNumsAndExpandedStrides(mlir::ElementsAttr elms,
       llvm::ArrayRef<int64_t> expandedShape,
       llvm::SmallVectorImpl<int64_t> &expandedStrides) const;
+
+  // A transformer mutates elements.
+  using Transformer = std::function<void(llvm::MutableArrayRef<WideNum>)>;
+
+  // Constructs a transformer that changes every element to the result of
+  // applying the given function to the element.
+  template <typename Function = WideNum (*)(WideNum)>
+  static inline Transformer functionTransformer(Function fun) {
+    return [fun = std::move(fun)](llvm::MutableArrayRef<WideNum> data) -> void {
+      for (WideNum &n : data)
+        n = fun(n);
+    };
+  }
+
+  mlir::ElementsAttr doTransform(mlir::ElementsAttr elms,
+      mlir::Type transformedElementType, Transformer transformer);
 
   mlir::ElementsAttr expandAndTransform(mlir::ElementsAttr elms,
       mlir::ShapedType expandedTransformedType, Transformer transformer);

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -145,6 +145,12 @@ private:
 
   ElementsProperties getElementsProperties(mlir::ElementsAttr elements) const;
 
+  ArrayBuffer<WideNum> getWideNumsAndStrides(
+      mlir::ElementsAttr elms, llvm::SmallVectorImpl<int64_t> &strides) const {
+    return getWideNumsAndExpandedStrides(
+        elms, elms.getType().getShape(), strides);
+  }
+
   ArrayBuffer<WideNum> getWideNumsAndExpandedStrides(mlir::ElementsAttr elms,
       llvm::ArrayRef<int64_t> expandedShape,
       llvm::SmallVectorImpl<int64_t> &expandedStrides) const;

--- a/src/Dialect/ONNX/ElementsAttr/Strides.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/Strides.cpp
@@ -53,6 +53,10 @@ SmallVector<int64_t, 4> getDefaultStrides(ArrayRef<int64_t> shape) {
   return strides;
 }
 
+SmallVector<int64_t, 4> getSplatStrides(ArrayRef<int64_t> shape) {
+  return SmallVector<int64_t, 4>(shape.size(), 0);
+}
+
 Optional<SmallVector<int64_t, 4>> reshapeStrides(ArrayRef<int64_t> shape,
     ArrayRef<int64_t> strides, ArrayRef<int64_t> reshapedShape) {
   assert(shape.size() == strides.size());

--- a/src/Dialect/ONNX/ElementsAttr/Strides.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/Strides.hpp
@@ -64,6 +64,9 @@ bool areStridesContiguous(
 // Returns row-major order strides for the given shape.
 llvm::SmallVector<int64_t, 4> getDefaultStrides(llvm::ArrayRef<int64_t> shape);
 
+// Returns all-zeros strides.
+llvm::SmallVector<int64_t, 4> getSplatStrides(llvm::ArrayRef<int64_t> shape);
+
 // Returns the strides that can map the underlying data to reshapedShape
 // equivalently to restriding it, if such strides exist, otherwise returns None.
 llvm::Optional<llvm::SmallVector<int64_t, 4>> reshapeStrides(

--- a/src/Dialect/ONNX/ElementsAttr/Strides.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/Strides.hpp
@@ -117,7 +117,7 @@ struct StridedArrayRef : public llvm::ArrayRef<T> {
 };
 
 template <typename Iterator, typename... Args,
-    typename Action = llvm::function_ref<void(Iterator, Args...)>>
+    typename Action = llvm::function_ref<void(Iterator, const Args *...)>>
 Iterator traverseStrides(llvm::ArrayRef<int64_t> shape, Iterator begin,
     StridedArrayRef<Args>... src, Action &&act);
 

--- a/src/Dialect/ONNX/ElementsAttr/Strides.hpp.inc
+++ b/src/Dialect/ONNX/ElementsAttr/Strides.hpp.inc
@@ -16,7 +16,7 @@ Iterator traverseStrides(llvm::ArrayRef<int64_t> shape, Iterator begin,
   auto traverse = [=](const auto &recurse, unsigned axis, Iterator it,
                       const Arg0 *elm0) -> Iterator {
     if (axis == shape.size()) {
-      act(it, *elm0);
+      act(it, elm0);
       it++;
     } else {
       for (int64_t i = 0; i < shape[axis]; ++i) {
@@ -35,7 +35,7 @@ Iterator traverseStrides(llvm::ArrayRef<int64_t> shape, Iterator begin,
   auto traverse = [=](const auto &recurse, unsigned axis, Iterator it,
                       const Arg0 *elm0, const Arg1 *elm1) -> Iterator {
     if (axis == shape.size()) {
-      act(it, *elm0, *elm1);
+      act(it, elm0, elm1);
       it++;
     } else {
       for (int64_t i = 0; i < shape[axis]; ++i) {
@@ -53,7 +53,7 @@ template <typename Res, typename Arg0, typename Action>
 void mapStrides(llvm::ArrayRef<int64_t> shape, llvm::MutableArrayRef<Res> dst,
     StridedArrayRef<Arg0> src0, Action &&act) {
   Res *end = traverseStrides<Res *, Arg0>(shape, dst.begin(), src0,
-      [&act](Res *res, Arg0 arg0) { *res = act(arg0); });
+      [&act](Res *res, const Arg0 *arg0) { *res = act(*arg0); });
   assert(end == dst.end() && "traverses every dst element");
 }
 
@@ -61,7 +61,9 @@ template <typename Res, typename Arg0, typename Arg1, typename Action>
 void mapStrides(llvm::ArrayRef<int64_t> shape, llvm::MutableArrayRef<Res> dst,
     StridedArrayRef<Arg0> src0, StridedArrayRef<Arg1> src1, Action &&act) {
   Res *end = traverseStrides<Res *, Arg0, Arg1>(shape, dst.begin(), src0, src1,
-      [&act](Res *res, Arg0 arg0, Arg1 arg1) { *res = act(arg0, arg1); });
+      [&act](Res *res, const Arg0 *arg0, const Arg1 *arg1) {
+        *res = act(*arg0, *arg1);
+      });
   assert(end == dst.end() && "traverses every dst element");
 }
 

--- a/src/Dialect/ONNX/ElementsAttr/Strides.hpp.inc
+++ b/src/Dialect/ONNX/ElementsAttr/Strides.hpp.inc
@@ -73,7 +73,7 @@ Iterator traverseStrides(llvm::ArrayRef<int64_t> shape, Iterator begin,
   auto traverse = [=](const auto &recurse, unsigned axis, Iterator it,
                       const Args *... elms) -> Iterator {
     if (axis == shape.size()) {
-      act(it, *elms...);
+      act(it, elms...);
       it++;
     } else {
       for (int64_t i = 0; i < shape[axis]; ++i) {
@@ -90,7 +90,7 @@ template <typename Res, typename... Args, typename Action>
 void mapStrides(llvm::ArrayRef<int64_t> shape, llvm::MutableArrayRef<Res> dst,
     StridedArrayRef<Args>... src, Action &&act) {
   Res *end = traverseStrides<Res *, Args...>(shape, dst.begin(), src...,
-      [&act](Res *res, Args... args) { *res = act(args...); });
+      [&act](Res *res, const Args *... args) { *res = act(*args...); });
   assert(end == dst.end() && "traverses every dst element");
 }
 

--- a/src/Dialect/ONNX/ElementsAttr/WideNum.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/WideNum.hpp
@@ -176,11 +176,28 @@ using WideNumWrappedFunction =
 template <template <class OP, typename... T> class TemplateFunction, class OP>
 auto getWideNumWrappedTemplateFunction(mlir::Type type);
 
-// TODO: Document.
+// Returns a wrapped function with WideNum argument and return type.
+// It unpacks the argument to the arument type Arg, calls the lambda, and
+// takes the result of type Res and returns it packed as a WideNum.
+// Types Res and Arg must be double, int64_t, uint64_t, or bool.
 template <typename Res, typename Arg>
 std::function<WideNum(WideNum)> widenumWrapped(std::function<Res(Arg)> lambda);
 
-// TODO: Document.
+// Calls act with a zero of the C++ type corresponding to the given mlir type
+// (promotes to the nearest among the 4 types double, int64_t, uint64_t, bool).
+// The zero argument is a token which can be used to find the C++ type.
+// Use it similarly to dispatchByBType: call it with a generic lambda which
+// can read the C++ type of the argument with decltype. For instance, given
+// a signed integer factor and a WideNum packed according to an mlir type
+// you can multiply the WideNum with:
+//
+//   WideNum multiplyBy(int factor, WideNum n, Type type) {
+//     return wideZeroDispatch(type, [factor, n](auto wideZero) {
+//       using TAG = toBType(decltype(wideZero));
+//       return widen<TAG>(factor * narrow<TAG>(n));
+//     });
+//   }
+//
 template <typename Action>
 auto wideZeroDispatch(mlir::Type type, Action &&act) {
   if (type.isa<mlir::FloatType>())

--- a/src/Dialect/ONNX/ElementsAttr/WideNum.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/WideNum.hpp
@@ -199,16 +199,25 @@ std::function<WideNum(WideNum)> widenumWrapped(std::function<Res(Arg)> lambda);
 //   }
 //
 template <typename Action>
-auto wideZeroDispatch(mlir::Type type, Action &&act) {
+auto wideZeroDispatch(mlir::Type type, Action &&act);
+
+template <typename Action>
+auto wideZeroDispatchNonBool(mlir::Type type, Action &&act) {
   if (type.isa<mlir::FloatType>())
     return act(static_cast<double>(0));
   auto itype = type.cast<mlir::IntegerType>();
-  if (itype.getWidth() == 1)
-    return act(static_cast<bool>(0));
-  else if (itype.isUnsigned())
+  if (itype.isUnsigned())
     return act(static_cast<uint64_t>(0));
   else
     return act(static_cast<int64_t>(0));
+}
+
+template <typename Action>
+inline auto wideZeroDispatch(mlir::Type type, Action &&act) {
+  if (type.isInteger(1))
+    return act(static_cast<bool>(0));
+  else
+    return wideZeroDispatchNonBool(type, act);
 }
 
 // Include template implementations.

--- a/src/Dialect/ONNX/ElementsAttr/WideNum.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/WideNum.hpp
@@ -37,28 +37,6 @@ union WideNum {
   int64_t i64;  // Signed ints up to bitwidth 64.
   uint64_t u64; // Unsigned ints up to bitwidth 64, including bool.
 
-  template <typename T>
-  T to(mlir::Type ttag) const {
-    BType tag = btypeOfMlirType(ttag);
-    if constexpr (std::is_same_v<T, llvm::APFloat>)
-      return toAPFloat(tag);
-    else if constexpr (std::is_same_v<T, llvm::APInt>)
-      return toAPInt(tag);
-    else
-      return to<T>(tag);
-  }
-
-  template <typename T>
-  static WideNum from(mlir::Type ttag, T x) {
-    BType tag = btypeOfMlirType(ttag);
-    if constexpr (std::is_same_v<T, llvm::APFloat>)
-      return fromAPFloat(tag, x);
-    else if constexpr (std::is_same_v<T, llvm::APInt>)
-      return fromAPInt(tag, x);
-    else
-      return from<T>(tag, x);
-  }
-
   llvm::APFloat toAPFloat(BType tag) const;
 
   static WideNum fromAPFloat(BType tag, llvm::APFloat x);

--- a/src/Dialect/ONNX/ElementsAttr/WideNum.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/WideNum.hpp
@@ -176,6 +176,24 @@ using WideNumWrappedFunction =
 template <template <class OP, typename... T> class TemplateFunction, class OP>
 auto getWideNumWrappedTemplateFunction(mlir::Type type);
 
+// TODO: Document.
+template <typename Res, typename Arg>
+std::function<WideNum(WideNum)> widenumWrapped(std::function<Res(Arg)> lambda);
+
+// TODO: Document.
+template <typename Action>
+auto wideZeroDispatch(mlir::Type type, Action &&act) {
+  if (type.isa<mlir::FloatType>())
+    return act(static_cast<double>(0));
+  auto itype = type.cast<mlir::IntegerType>();
+  if (itype.getWidth() == 1)
+    return act(static_cast<bool>(0));
+  else if (itype.isUnsigned())
+    return act(static_cast<uint64_t>(0));
+  else
+    return act(static_cast<int64_t>(0));
+}
+
 // Include template implementations.
 #include "WideNum.hpp.inc"
 

--- a/src/Dialect/ONNX/ElementsAttr/WideNum.hpp.inc
+++ b/src/Dialect/ONNX/ElementsAttr/WideNum.hpp.inc
@@ -7,20 +7,20 @@
 namespace detail {
 
 template <typename X>
-inline constexpr bool isPackable =
-    llvm::is_one_of<X, double, int64_t, uint64_t, bool>::value;
+inline constexpr bool isWideCppType =
+    llvm::is_one_of<std::decay_t<X>, double, int64_t, uint64_t, bool>::value;
 
 // unpack<X>(n) is like reinterpret_cast<X>(n).
 template <typename X>
 constexpr X unpack(WideNum n) {
-  assert(isPackable<X>);
+  static_assert(isWideCppType<X>);
   return n.narrow<toBType<X>>(); // == n.to<X>(toBType<X>);
 }
 
 // pack<X>(x) is like reinterpret_cast<WideNum>(x).
 template <typename X>
 constexpr WideNum pack(X x) {
-  assert(isPackable<X>);
+  static_assert(isWideCppType<X>);
   return WideNum::widen<toBType<X>>(x); // == from<X>(toBType<X>, x);
 }
 
@@ -37,18 +37,18 @@ struct FunctionWrapper<Res(Args...), Function> {
 
 } // namespace detail
 
-template <template <class OP, typename... T> class FunctionTemplate, class OP>
-inline constexpr auto getWideNumWrappedTemplateFunction(mlir::Type type) {
+template <template <class OP, typename... T> class TemplateFunction, class OP>
+inline auto getWideNumWrappedTemplateFunction(mlir::Type type) {
   if (auto itype = type.dyn_cast<mlir::IntegerType>()) {
     if (itype.getWidth() == 1) {
-      return WideNumWrappedFunction<FunctionTemplate<OP, bool>>::eval;
+      return WideNumWrappedFunction<TemplateFunction<OP, bool>>::eval;
     } else if (itype.isUnsigned()) {
-      return WideNumWrappedFunction<FunctionTemplate<OP, uint64_t>>::eval;
+      return WideNumWrappedFunction<TemplateFunction<OP, uint64_t>>::eval;
     } else {
-      return WideNumWrappedFunction<FunctionTemplate<OP, int64_t>>::eval;
+      return WideNumWrappedFunction<TemplateFunction<OP, int64_t>>::eval;
     }
   } else {
     assert(type.isa<mlir::FloatType>());
-    return WideNumWrappedFunction<FunctionTemplate<OP, double>>::eval;
+    return WideNumWrappedFunction<TemplateFunction<OP, double>>::eval;
   }
 }

--- a/src/Dialect/ONNX/ElementsAttr/WideNum.hpp.inc
+++ b/src/Dialect/ONNX/ElementsAttr/WideNum.hpp.inc
@@ -39,16 +39,16 @@ struct FunctionWrapper<Res(Args...), Function> {
 
 template <template <class OP, typename... T> class TemplateFunction, class OP>
 inline auto getWideNumWrappedTemplateFunction(mlir::Type type) {
-  if (auto itype = type.dyn_cast<mlir::IntegerType>()) {
-    if (itype.getWidth() == 1) {
-      return WideNumWrappedFunction<TemplateFunction<OP, bool>>::eval;
-    } else if (itype.isUnsigned()) {
-      return WideNumWrappedFunction<TemplateFunction<OP, uint64_t>>::eval;
-    } else {
-      return WideNumWrappedFunction<TemplateFunction<OP, int64_t>>::eval;
-    }
-  } else {
-    assert(type.isa<mlir::FloatType>());
-    return WideNumWrappedFunction<TemplateFunction<OP, double>>::eval;
-  }
+  return wideZeroDispatch(type, [](auto wideZero) {
+    using WideCppType = decltype(wideZero);
+    return WideNumWrappedFunction<TemplateFunction<OP, WideCppType>>::eval;
+  });
+}
+
+template <typename Res, typename Arg>
+inline std::function<WideNum(WideNum)> widenumWrapped(
+    std::function<Res(Arg)> lambda) {
+  return [lambda = std::move(lambda)](detail::Packed<Arg> arg) -> WideNum {
+    return detail::pack<Res>(lambda(detail::unpack<Arg>(arg)));
+  };
 }

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -301,7 +301,7 @@ std::function<WideNum(WideNum)> divideBy(Type type, int64_t denominator) {
 }
 
 template <typename ReduceOp, typename AxesRange = std::initializer_list<APInt>>
-Value ConstPropReduceAxes(PatternRewriter &rewriter, Value replacingValue,
+Value ConstPropReduceAxesRange(PatternRewriter &rewriter, Value replacingValue,
     Value dataValue, AxesRange axesRange) {
   ConstPropCounters::count("Reduce", {dataValue});
   Operation *op = replacingValue.getDefiningOp();
@@ -365,10 +365,10 @@ Value ConstPropReduce(PatternRewriter &rewriter, Value replacingValue,
   if (axesValue && !axesValue.getType().isa<NoneType>()) {
     ElementsAttr axes = getConstValueElements(axesValue);
     auto axesRange = axes.getValues<APInt>();
-    return ConstPropReduceAxes<ReduceOp>(
+    return ConstPropReduceAxesRange<ReduceOp>(
         rewriter, replacingValue, dataValue, axesRange);
   } else {
-    return ConstPropReduceAxes<ReduceOp>(
+    return ConstPropReduceAxesRange<ReduceOp>(
         rewriter, replacingValue, dataValue, {});
   }
 }
@@ -378,10 +378,10 @@ Value ConstPropReduce(PatternRewriter &rewriter, Value replacingValue,
     Value dataValue, ArrayAttr axesArray) {
   if (axesArray) {
     auto axesRange = axesArray.getAsValueRange<IntegerAttr>();
-    return ConstPropReduceAxes<ReduceOp>(
+    return ConstPropReduceAxesRange<ReduceOp>(
         rewriter, replacingValue, dataValue, axesRange);
   } else {
-    return ConstPropReduceAxes<ReduceOp>(
+    return ConstPropReduceAxesRange<ReduceOp>(
         rewriter, replacingValue, dataValue, {});
   }
 }

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -293,7 +293,7 @@ Attribute getIdentity(Builder &builder, Type type) {
 }
 
 std::function<WideNum(WideNum)> divideBy(Type type, int64_t denominator) {
-  return wideZeroDispatch(type, [denominator](auto wideZero) {
+  return wideZeroDispatchNonBool(type, [denominator](auto wideZero) {
     using WideCppType = decltype(wideZero);
     return widenumWrapped<WideCppType, WideCppType>(
         [denominator](auto x) { return x / denominator; });

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -272,7 +272,7 @@ Value ConstPropWhere(PatternRewriter &rewriter, Value replacingValue,
 // ReduceSum followed by element-wise division to calculate the mean.
 //===----------------------------------------------------------------------===//
 
-int64_t intAttr(Operation *op, StringRef attrName, int64_t deflt) {
+int64_t getSIntAttr(Operation *op, StringRef attrName, int64_t deflt) {
   IntegerAttr iattr = op->getAttrOfType<IntegerAttr>(attrName);
   return iattr ? iattr.getSInt() : deflt;
 }
@@ -323,7 +323,7 @@ Value ConstPropReduceAxesRange(PatternRewriter &rewriter, Value replacingValue,
 
   // If axes are empty and !noop_with_empty_axes, reduce over all dimensions.
   if (absoluteAxes.empty() &&
-      intAttr(op, "noop_with_empty_axes", /*default=*/0) == 0) {
+      getSIntAttr(op, "noop_with_empty_axes", /*default=*/0) == 0) {
     for (int64_t axis = 0; axis < rank; ++axis)
       absoluteAxes.push_back(axis);
   }
@@ -337,7 +337,7 @@ Value ConstPropReduceAxesRange(PatternRewriter &rewriter, Value replacingValue,
     Attribute identity = getIdentity<ReduceOp>(rewriter, elemType);
     reduced = DenseElementsAttr::get(replacingValue.getType(), {identity});
   } else {
-    bool keepdims = intAttr(op, "keepdims", /*default=*/1) != 0;
+    bool keepdims = getSIntAttr(op, "keepdims", /*default=*/1) != 0;
     OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
     if constexpr (std::is_same_v<ReduceOp, ONNXReduceMeanOp>) {
       // sum = ReduceSum(data)

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -362,14 +362,14 @@ Value ConstPropReduceAxesRange(PatternRewriter &rewriter, Value replacingValue,
 template <typename ReduceOp>
 Value ConstPropReduce(PatternRewriter &rewriter, Value replacingValue,
     Value dataValue, Value axesValue) {
-  if (axesValue && !axesValue.getType().isa<NoneType>()) {
+  if (isFromNone(axesValue)) {
+    return ConstPropReduceAxesRange<ReduceOp>(
+        rewriter, replacingValue, dataValue, {});
+  } else {
     ElementsAttr axes = getConstValueElements(axesValue);
     auto axesRange = axes.getValues<APInt>();
     return ConstPropReduceAxesRange<ReduceOp>(
         rewriter, replacingValue, dataValue, axesRange);
-  } else {
-    return ConstPropReduceAxesRange<ReduceOp>(
-        rewriter, replacingValue, dataValue, {});
   }
 }
 

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -321,10 +321,9 @@ Value ConstPropReduceAxesRange(PatternRewriter &rewriter, Value replacingValue,
     absoluteAxes.push_back(axis);
   }
 
-  // Comply with noop_with_empty_axes attribute.
+  // If axes are empty and !noop_with_empty_axes, reduce over all dimensions.
   if (absoluteAxes.empty() &&
       intAttr(op, "noop_with_empty_axes", /*default=*/0) == 0) {
-    // Reduce over all the dimensions:
     for (int64_t axis = 0; axis < rank; ++axis)
       absoluteAxes.push_back(axis);
   }

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -109,6 +109,21 @@ def CreateDivOfTwoConst :
 def CreateWhereOfThreeConst :
    NativeCodeCall<"ConstPropWhere($_builder, $0, $1, $2, $3)">;
 
+def CreateReduceSumConst :
+    NativeCodeCall<"ConstPropReduce<mlir::ONNXAddOp>($_builder, $0, $1, $2)">;
+
+def CreateReduceProdConst :
+    NativeCodeCall<"ConstPropReduce<mlir::ONNXMulOp>($_builder, $0, $1, $2)">;
+
+def CreateReduceMinConst :
+    NativeCodeCall<"ConstPropReduce<mlir::ONNXMinOp>($_builder, $0, $1, $2)">;
+
+def CreateReduceMaxConst :
+    NativeCodeCall<"ConstPropReduce<mlir::ONNXMaxOp>($_builder, $0, $1, $2)">;
+
+def CreateReduceMeanConst :
+    NativeCodeCall<"ConstPropReduce<mlir::ONNXReduceMeanOp>($_builder, $0, $1, $2)">;
+
 def CreateTransposeOfConst :
    NativeCodeCall<"ConstPropTranspose($_builder, $0, $1)">;
 
@@ -352,6 +367,59 @@ def WhereConstProp : Pat<
     [(IsFromDenseONNXConstantOp:$condition),
      (IsFromDenseONNXConstantOp:$X), (IsFromDenseONNXConstantOp:$Y)]>;
 
+//===----------------------------------------------------------------------===//
+// Patterns for Reduce ops.
+//===----------------------------------------------------------------------===//
+
+def ReduceSumConstProp: Pat<
+      (ONNXReduceSumOp:$reduceSumOp
+        (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
+        $axes,
+        $_,
+        $_),
+    (CreateReduceSumConst $reduceSumOp, $data, $axes),
+    [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
+    >;
+
+// TODO: Check (IsFromDenseONNXConstantOpOrNone:$axes) in opset 18 when axes is input.
+def ReduceProdConstProp: Pat<
+      (ONNXReduceProdOp:$reduceProdOp
+        (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
+        $axes,
+        $_),
+    (CreateReduceProdConst $reduceProdOp, $data, $axes),
+    [(IsFromDenseONNXConstantOp:$data)]
+    >;
+
+// TODO: Check (IsFromDenseONNXConstantOpOrNone:$axes) in opset 18 when axes is input.
+def ReduceMinConstProp: Pat<
+      (ONNXReduceMinOp:$reduceMinOp
+        (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
+        $axes,
+        $_),
+    (CreateReduceMinConst $reduceMinOp, $data, $axes),
+    [(IsFromDenseONNXConstantOp:$data)]
+    >;
+
+// TODO: Check (IsFromDenseONNXConstantOpOrNone:$axes) in opset 18 when axes is input.
+def ReduceMaxConstProp: Pat<
+      (ONNXReduceMaxOp:$reduceMaxOp
+        (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
+        $axes,
+        $_),
+    (CreateReduceMaxConst $reduceMaxOp, $data, $axes),
+    [(IsFromDenseONNXConstantOp:$data)]
+    >;
+
+// TODO: Check (IsFromDenseONNXConstantOpOrNone:$axes) in opset 18 when axes is input.
+def ReduceMeanConstProp: Pat<
+      (ONNXReduceMeanOp:$reduceMeanOp
+        (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
+        $axes,
+        $_),
+    (CreateReduceMeanConst $reduceMeanOp, $data, $axes),
+    [(IsFromDenseONNXConstantOp:$data)]
+    >;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Transpose operations.

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -471,6 +471,17 @@ func.func @test_reduce_sum_noop_with_empty_axes_true() -> tensor<2x2xi32> {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1, 2], [3, 4]{{.}}> : tensor<2x2xi32>
 }
 
+// -----
+
+// CHECK-LABEL: @test_reduce_sum_empty() -> tensor<1x1xi32>
+func.func @test_reduce_sum_empty() -> tensor<1x1xi32> {
+  %0 = "onnx.Constant"() {value = dense<> : tensor<0x2xi32>} : () -> tensor<0x2xi32>
+  %1 = "onnx.NoValue"() {value} : () -> none
+  %2 = "onnx.ReduceSum"(%0, %1) : (tensor<0x2xi32>, none) -> tensor<1x1xi32>
+  "func.return"(%2) : (tensor<1x1xi32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<0> : tensor<1x1xi32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Unsqueeze tests
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -482,6 +482,17 @@ func.func @test_reduce_sum_empty() -> tensor<1x1xi32> {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<0> : tensor<1x1xi32>
 }
 
+// -----
+
+// CHECK-LABEL: @test_reduce_sum_scalar() -> tensor<i32>
+func.func @test_reduce_sum_scalar() -> tensor<i32> {
+  %0 = "onnx.Constant"() {value = dense<42> : tensor<i32>} : () -> tensor<i32>
+  %1 = "onnx.NoValue"() {value} : () -> none
+  %2 = "onnx.ReduceSum"(%0, %1) : (tensor<i32>, none) -> tensor<i32>
+  "func.return"(%2) : (tensor<i32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<42> : tensor<i32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Unsqueeze tests
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -503,6 +503,16 @@ func.func @test_reduce_prod_positive_axis() -> tensor<2x1xi32> {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[2], [12]{{.}}> : tensor<2x1xi32>
 }
 
+// -----
+
+// CHECK-LABEL: @test_reduce_prod_empty() -> tensor<1x1xi32>
+func.func @test_reduce_prod_empty() -> tensor<1x1xi32> {
+  %0 = "onnx.Constant"() {value = dense<> : tensor<0x2xi32>} : () -> tensor<0x2xi32>
+  %1 = "onnx.ReduceProd"(%0) : (tensor<0x2xi32>) -> tensor<1x1xi32>
+  "func.return"(%1) : (tensor<1x1xi32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<1> : tensor<1x1xi32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Unsqueeze tests
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -535,12 +535,22 @@ func.func @test_reduce_max_positive_axis() -> tensor<2x1xi32> {
 
 // -----
 
-// CHECK-LABEL: @test_reduce_mean_positive_axis() -> tensor<2x1xi32>
-func.func @test_reduce_mean_positive_axis() -> tensor<2x1xi32> {
+// CHECK-LABEL: @test_reduce_mean_i32() -> tensor<2x1xi32>
+func.func @test_reduce_mean_i32() -> tensor<2x1xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [4, 6]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.ReduceMean"(%0) {axes = [1]} : (tensor<2x2xi32>) -> tensor<2x1xi32>
   "func.return"(%1) : (tensor<2x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1], [5]{{.}}> : tensor<2x1xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_reduce_mean_f32() -> tensor<2x1xf32>
+func.func @test_reduce_mean_f32() -> tensor<2x1xf32> {
+  %0 = "onnx.Constant"() {value = dense<[[1.0, 2.0], [4.0, 6.0]]> : tensor<2x2xf32>} : () -> tensor<2x2xf32>
+  %1 = "onnx.ReduceMean"(%0) {axes = [1]} : (tensor<2x2xf32>) -> tensor<2x1xf32>
+  "func.return"(%1) : (tensor<2x1xf32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1.500000e+00], [5.000000e+00]{{.}}> : tensor<2x1xf32>
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -493,6 +493,16 @@ func.func @test_reduce_sum_scalar() -> tensor<i32> {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<42> : tensor<i32>
 }
 
+// -----
+
+// CHECK-LABEL: @test_reduce_prod_positive_axis() -> tensor<2x1xi32>
+func.func @test_reduce_prod_positive_axis() -> tensor<2x1xi32> {
+  %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %1 = "onnx.ReduceProd"(%0) {axes = [1]} : (tensor<2x2xi32>) -> tensor<2x1xi32>
+  "func.return"(%1) : (tensor<2x1xi32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[2], [12]{{.}}> : tensor<2x1xi32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Unsqueeze tests
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -513,6 +513,26 @@ func.func @test_reduce_prod_empty() -> tensor<1x1xf32> {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<1x1xf32>
 }
 
+// -----
+
+// CHECK-LABEL: @test_reduce_min_positive_axis() -> tensor<2x1xi32>
+func.func @test_reduce_min_positive_axis() -> tensor<2x1xi32> {
+  %0 = "onnx.Constant"() {value = dense<[[1, 2], [4, 3]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %1 = "onnx.ReduceMin"(%0) {axes = [1]} : (tensor<2x2xi32>) -> tensor<2x1xi32>
+  "func.return"(%1) : (tensor<2x1xi32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1], [3]{{.}}> : tensor<2x1xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_reduce_max_positive_axis() -> tensor<2x1xi32>
+func.func @test_reduce_max_positive_axis() -> tensor<2x1xi32> {
+  %0 = "onnx.Constant"() {value = dense<[[1, 2], [4, 3]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %1 = "onnx.ReduceMax"(%0) {axes = [1]} : (tensor<2x2xi32>) -> tensor<2x1xi32>
+  "func.return"(%1) : (tensor<2x1xi32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[2], [4]{{.}}> : tensor<2x1xi32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Unsqueeze tests
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -505,12 +505,12 @@ func.func @test_reduce_prod_positive_axis() -> tensor<2x1xi32> {
 
 // -----
 
-// CHECK-LABEL: @test_reduce_prod_empty() -> tensor<1x1xi32>
-func.func @test_reduce_prod_empty() -> tensor<1x1xi32> {
-  %0 = "onnx.Constant"() {value = dense<> : tensor<0x2xi32>} : () -> tensor<0x2xi32>
-  %1 = "onnx.ReduceProd"(%0) : (tensor<0x2xi32>) -> tensor<1x1xi32>
-  "func.return"(%1) : (tensor<1x1xi32>) -> ()
-  // CHECK: [[CONST:%.+]] = onnx.Constant dense<1> : tensor<1x1xi32>
+// CHECK-LABEL: @test_reduce_prod_empty() -> tensor<1x1xf32>
+func.func @test_reduce_prod_empty() -> tensor<1x1xf32> {
+  %0 = "onnx.Constant"() {value = dense<> : tensor<0x2xf32>} : () -> tensor<0x2xf32>
+  %1 = "onnx.ReduceProd"(%0) : (tensor<0x2xf32>) -> tensor<1x1xf32>
+  "func.return"(%1) : (tensor<1x1xf32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<1x1xf32>
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -533,6 +533,16 @@ func.func @test_reduce_max_positive_axis() -> tensor<2x1xi32> {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[2], [4]{{.}}> : tensor<2x1xi32>
 }
 
+// -----
+
+// CHECK-LABEL: @test_reduce_mean_positive_axis() -> tensor<2x1xi32>
+func.func @test_reduce_mean_positive_axis() -> tensor<2x1xi32> {
+  %0 = "onnx.Constant"() {value = dense<[[1, 2], [4, 6]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+  %1 = "onnx.ReduceMean"(%0) {axes = [1]} : (tensor<2x2xi32>) -> tensor<2x1xi32>
+  "func.return"(%1) : (tensor<2x1xi32>) -> ()
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1], [5]{{.}}> : tensor<2x1xi32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Unsqueeze tests
 


### PR DESCRIPTION
constant propagates ReduceSum/Prod/Min/Max/Mean when data and axes are constant

implemented with a new ElementsAttrBuilder::reduce() method, which uses traverseStrides() in an unusual nested way: the outermost loop runs through all the elements to reduce into each output element and the inner loop reduces the next element into the output element (and all of this is done in a way that supports traversing the input with arbitrary strides)

the above logic needs to read the next input element to reduce with an offset and therefore traverseStrides() is refactored to pass arguments as const pointers to the lambda argument

ReduceMean is implemented with ReduceSum followed by dividing the result with the number of elements summed into each output element:
```
    if constexpr (std::is_same_v<ReduceOp, ONNXReduceMeanOp>) {
      // sum = ReduceSum(data)
      ElementsAttr sum = elementsBuilder.reduce(data, absoluteAxes, keepdims,
          elementwiseBinaryOpCombiner<ONNXAddOp>(elemType));
      assert(data.size() % sum.size() == 0 &&
             "ReduceSum reduces tensor size by integer factor");
      int64_t denominator = data.size() / sum.size();
      // reduced = sum / denominator
      reduced = elementsBuilder.transform(
          sum, elemType, divideBy(elemType, denominator));
```
where `divideBy()` is defined as: 
```
std::function<WideNum(WideNum)> divideBy(Type type, int64_t denominator) {
  return wideZeroDispatchNonBool(type, [denominator](auto wideZero) {
    using WideCppType = decltype(wideZero);
    return widenumWrapped<WideCppType, WideCppType>(
        [denominator](auto x) { return x / denominator; });
  });
}
```
In order to express `divideBy` in this way `wideZeroDispatchNonBool` was introduced through a refactor of `getWideNumWrappedTemplateFunction`

some small refactors in ElementsAttrBuilder facilitated code reuse in the implementation of ElementsAttrBuilder::reduce() and, moreover, functionTransformer() and the Transformer type were made private as it became evident that evident that it suffices for transform() and reduce() to operate on simple function from WideNums to WideNum