### PR TITLE
Add Conversion for ConstOp ONNX to TOSA

### DIFF
--- a/src/Conversion/ONNXToTOSA/CMakeLists.txt
+++ b/src/Conversion/ONNXToTOSA/CMakeLists.txt
@@ -8,6 +8,7 @@ add_onnx_mlir_library(OMONNXToTOSA
   Math/Elementwise.cpp
   Math/Softmax.cpp
   NN/MaxPoolSingleOut.cpp
+  Tensor/Constant.cpp
 
   LINK_LIBS PUBLIC
   OMONNXOps

--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -29,6 +29,9 @@ void populateONNXToTOSAConversionPattern(ConversionTarget &target,
   // NN
   populateLoweringONNXMaxPoolSingleOutOpToTOSAPattern(
       target, patterns, typeConverter, ctx);
+  // Tensor
+  populateLoweringONNXConstOpToTOSAPattern(
+      target, patterns, typeConverter, ctx);
 }
 
 // Performs lowering to TOSA dialect

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -68,7 +68,7 @@ void populateLoweringONNXSoftmaxOpToTOSAPattern(mlir::ConversionTarget &,
 void populateLoweringONNXMaxPoolSingleOutOpToTOSAPattern(
     mlir::ConversionTarget &, mlir::RewritePatternSet &, mlir::TypeConverter &,
     mlir::MLIRContext *);
-// `NN` directory methods:
+// `Tensor` directory methods:
 void populateLoweringONNXConstOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -68,4 +68,7 @@ void populateLoweringONNXSoftmaxOpToTOSAPattern(mlir::ConversionTarget &,
 void populateLoweringONNXMaxPoolSingleOutOpToTOSAPattern(
     mlir::ConversionTarget &, mlir::RewritePatternSet &, mlir::TypeConverter &,
     mlir::MLIRContext *);
+// `NN` directory methods:
+void populateLoweringONNXConstOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Constant.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------------- Constant.cpp - Const Op -----------------------------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file lowers ONNX const operator to TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+namespace {
+
+class ONNXConstOpLoweringToTOSA : public OpConversionPattern<ONNXConstantOp> {
+public:
+  using OpConversionPattern<ONNXConstantOp>::OpConversionPattern;
+  using OpAdaptor = typename ONNXConstantOp::Adaptor;
+  LogicalResult matchAndRewrite(ONNXConstantOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto valueAttr = adaptor.value();
+    auto sparseAttr = adaptor.sparse_value();
+    // Only one of the attributes can/must be present. If
+    // sparse is there, value is not present. Currently sparse doesn't seem to
+    // be supported by TOSA.
+    if (sparseAttr.has_value()) {
+      return rewriter.notifyMatchFailure(
+          op, "tosa.const does not support sparse value");
+    }
+    ::mlir::Attribute currentAttr = valueAttr.value();
+    if (!currentAttr.isa<ElementsAttr>()) {
+      return rewriter.notifyMatchFailure(
+          op, "tosa.const does not support non-tensor types");
+    }
+    mlir::Type resultType =
+        getTypeConverter()->convertType(op.getResult().getType());
+    rewriter.replaceOpWithNewOp<mlir::tosa::ConstOp>(
+        op, resultType, currentAttr);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateLoweringONNXConstOpToTOSAPattern(ConversionTarget &target,
+    RewritePatternSet &patterns, TypeConverter &typeConverter,
+    MLIRContext *ctx) {
+  patterns.insert<ONNXConstOpLoweringToTOSA>(typeConverter, ctx);
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Constant.cpp
@@ -43,10 +43,8 @@ public:
       return rewriter.notifyMatchFailure(
           op, "tosa.const does not support non-tensor types");
     }
-    Type resultType =
-        getTypeConverter()->convertType(op.getResult().getType());
-    rewriter.replaceOpWithNewOp<tosa::ConstOp>(
-        op, resultType, currentAttr);
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+    rewriter.replaceOpWithNewOp<tosa::ConstOp>(op, resultType, currentAttr);
     return success();
   }
 };

--- a/src/Conversion/ONNXToTOSA/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Constant.cpp
@@ -29,8 +29,8 @@ public:
   using OpAdaptor = typename ONNXConstantOp::Adaptor;
   LogicalResult matchAndRewrite(ONNXConstantOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    auto valueAttr = adaptor.value();
-    auto sparseAttr = adaptor.sparse_value();
+    llvm::Optional<Attribute> valueAttr = adaptor.value();
+    llvm::Optional<Attribute> sparseAttr = adaptor.sparse_value();
     // Only one of the attributes can/must be present. If
     // sparse is there, value is not present. Currently sparse doesn't seem to
     // be supported by TOSA.
@@ -38,14 +38,14 @@ public:
       return rewriter.notifyMatchFailure(
           op, "tosa.const does not support sparse value");
     }
-    ::mlir::Attribute currentAttr = valueAttr.value();
+    Attribute currentAttr = valueAttr.value();
     if (!currentAttr.isa<ElementsAttr>()) {
       return rewriter.notifyMatchFailure(
           op, "tosa.const does not support non-tensor types");
     }
-    mlir::Type resultType =
+    Type resultType =
         getTypeConverter()->convertType(op.getResult().getType());
-    rewriter.replaceOpWithNewOp<mlir::tosa::ConstOp>(
+    rewriter.replaceOpWithNewOp<tosa::ConstOp>(
         op, resultType, currentAttr);
     return success();
   }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Constant.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Constant.mlir
@@ -1,0 +1,44 @@
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
+
+func.func @test_float_broadcast() -> tensor<3xf32> {
+  %0 = "onnx.Constant"() {value = dense<1.0> : tensor<3xf32>} : () -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+// CHECK-LABEL: @test_float_broadcast() ->  tensor<3xf32>
+// CHECK:       "tosa.const"() {value = dense<1.000000e+00> : tensor<3xf32>} : () -> tensor<3xf32>
+}
+
+// -----
+
+func.func @test_float_dense() -> tensor<3xf32> {
+  %0 = "onnx.Constant"() {value = dense<[0.0, 1.0, 2.0]> : tensor<3xf32>} : () -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+// CHECK-LABEL: @test_float_dense() -> tensor<3xf32>
+// CHECK:       "tosa.const"() {value = dense<[0.000000e+00, 1.000000e+00, 2.000000e+00]> : tensor<3xf32>} : () -> tensor<3xf32>
+}
+
+// -----
+
+func.func @test_int_single() -> tensor<1xi8> {
+  %0 = "onnx.Constant"() {value = dense<3> : tensor<1xi8>} : () -> tensor<1xi8>
+  return %0 : tensor<1xi8>
+// CHECK-LABEL: @test_int_single() -> tensor<1xi8>
+// CHECK:      "tosa.const"() {value = dense<3> : tensor<1xi8>} : () -> tensor<1xi8>
+}
+
+// -----
+
+func.func @test_int_broadcast() -> tensor<4xi32> {
+  %0 = "onnx.Constant"() {value = dense<3> : tensor<4xi32>} : () -> tensor<4xi32>
+  return %0 : tensor<4xi32>
+// CHECK-LABEL: @test_int_broadcast() -> tensor<4xi32>
+// CHECK:       "tosa.const"() {value = dense<3> : tensor<4xi32>} : () -> tensor<4xi32>
+}
+
+// -----
+
+func.func @test_int_dense() -> tensor<2xi8> {
+  %0 = "onnx.Constant"() {value = dense<[-1, -2]> : tensor<2xi8>} : () -> tensor<2xi8>
+  return %0 : tensor<2xi8>
+// CHECK-LABEL: @test_int_dense() -> tensor<2xi8>
+// CHECK:       "tosa.const"() {value = dense<[-1, -2]> : tensor<2xi8>} : () -> tensor<2xi8>
+}


### PR DESCRIPTION
This implements the conversion of the `ONNXConstantOp` to TOSA. 

Signed-off-by: Maximilian Bartel <maximilian.bartel@amd.com>