### PR TITLE
build(Passes.hpp): add missing includes for StringRef, string

### DIFF
--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include "llvm/ADT/StringRef.h"
+
 #include <memory>
+#include <string>
 
 namespace mlir {
 class MLIRContext;


### PR DESCRIPTION
Depending on the include order of Passes.hpp, it was possible to trigger a build error because llvm::StringRef and std::string were unknown. Add includes for both string and StringRef to make Passes.hpp useable without depending on outside includes.

Signed-off-by: Dominik Montada <dominik.montada@amd.com>