### PR TITLE
[cmake] Fix linkage of MLIRIR target at various locations

### DIFF
--- a/src/Accelerators/CMakeLists.txt
+++ b/src/Accelerators/CMakeLists.txt
@@ -44,12 +44,12 @@ add_onnx_mlir_library(OMInitAccelerators
   EXCLUDE_FROM_OM_LIBS
 
   DEPENDS 
-    AcceleratorsInc
-    MLIRIR
+    AcceleratorsInc    
 
   LINK_LIBS PUBLIC
     ${ACCEL_LINK_LIST}
     LLVMSupport
+    MLIRIR
   )
 
 add_onnx_mlir_library(OMAccelerator

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -56,9 +56,6 @@ add_onnx_mlir_library(OMCompilerPasses
 
   EXCLUDE_FROM_OM_LIBS
 
-  DEPENDS
-  MLIRIR
-
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}
 
@@ -69,6 +66,7 @@ add_onnx_mlir_library(OMCompilerPasses
   ${OMLibs}
   OMCompilerOptions
   MLIRAffineTransforms
+  MLIRIR
   MLIRLinalgTransforms
   MLIRLLVMToLLVMIRTranslation
   )
@@ -131,8 +129,7 @@ add_onnx_mlir_library(OMCompilerUtils
   EXCLUDE_FROM_OM_LIBS
 
   DEPENDS
-  ExternalUtil
-  MLIRIR
+  ExternalUtil  
   llc
   opt
 
@@ -148,6 +145,7 @@ add_onnx_mlir_library(OMCompilerUtils
   OMAccelerator
   OMInitAccelerators
   OMVersion
+  MLIRIR
 
   # Link LLVM libraries necessary to query which target architectures
   # are configured.


### PR DESCRIPTION
Moves MLIRIR from DEPENDS section of `add_onnx_mlir_library` to
`LINK_LIBS PUBLIC` section across CMakeLists files.

Other instances were corrected by 368d368a31410c6e2047e122df425184506d741d.

Fixes #1988.
