### PR TITLE
migrated ONNX dialect to new fold API

### DIFF
--- a/src/Dialect/ONNX/ONNX.td
+++ b/src/Dialect/ONNX/ONNX.td
@@ -38,7 +38,8 @@ def ONNX_Dialect : Dialect {
   let summary = "A high-level dialect for the ONNX specification";
   let cppNamespace = "::mlir";
   let useDefaultTypePrinterParser = 1;
-  let useDefaultAttributePrinterParser = 0;  
+  let useDefaultAttributePrinterParser = 0;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
   let dependentDialects = ["func::FuncDialect"];
   let extraClassDeclaration = [{
   private:

--- a/src/Dialect/ONNX/ONNXOps/Additional/None.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/None.cpp
@@ -22,6 +22,4 @@ using namespace onnx_mlir;
 // Helper functions
 //===----------------------------------------------------------------------===//
 
-OpFoldResult ONNXNoneOp::fold(FoldAdaptor adaptor) {
-  return getValueAttr();
-}
+OpFoldResult ONNXNoneOp::fold(FoldAdaptor adaptor) { return getValueAttr(); }

--- a/src/Dialect/ONNX/ONNXOps/Additional/None.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/None.cpp
@@ -22,6 +22,6 @@ using namespace onnx_mlir;
 // Helper functions
 //===----------------------------------------------------------------------===//
 
-OpFoldResult ONNXNoneOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ONNXNoneOp::fold(FoldAdaptor adaptor) {
   return getValueAttr();
 }


### PR DESCRIPTION
see https://discourse.llvm.org/t/psa-new-improved-fold-method-signature-has-landed-please-update-your-downstream-projects/67618

eliminated the warning:
```
src/Dialect/ONNX/ONNX.td:36:5: warning: Using deprecated def `kEmitRawAttributesFolder`
```

Signed-off-by: Soren Lassen <sorenlassen@gmail.com>