### PR TITLE
Handle -1 in --shapeInformation option and model signature

### DIFF
--- a/src/Builder/ModelInputShaper.cpp
+++ b/src/Builder/ModelInputShaper.cpp
@@ -40,12 +40,13 @@ ModelInputShaper::ModelInputShaper() : force_dim_dynamic_enabled_(false) {
       }
       // Default to the all dimensions if dims are not specified.
       if (dims.empty())
-        dims.emplace_back(-1);
+        dims.emplace_back(ModelInputShaper::kUserDynamic);
       forced_inputs_dims_.emplace(std::stoi(inputString), dims);
     }
     // Default to the all inputs and dimensions.
     if (forced_inputs_dims_.empty())
-      forced_inputs_dims_.emplace(-1, std::vector<int>(1, -1));
+      forced_inputs_dims_.emplace(ModelInputShaper::kUserDynamic,
+          std::vector<int>(1, ModelInputShaper::kUserDynamic));
   }
 }
 
@@ -67,7 +68,10 @@ void ModelInputShaper::setShapeInformation(
       std::vector<int64_t> dims;
       while (std::getline(dimSizes, dimStr, 'x')) {
         int64_t dimSize = std::stoi(dimStr);
-        assert((dimSize == -1 || dimSize > 0) && "dim must be -1 or > 0");
+        assert((dimSize == ModelInputShaper::kUserDynamic || dimSize > 0) &&
+               "dim must be -1 or > 0");
+        if (dimSize == ModelInputShaper::kUserDynamic)
+          dimSize = ShapedType::kDynamic;
         dims.emplace_back(dimSize);
       }
       inputs_shape_information_.insert(std::make_pair(inputID, dims));
@@ -81,7 +85,7 @@ RankedTensorType forceShape(
   auto shape = tensorTy.getShape();
   llvm::SmallVector<int64_t, 4> newDims;
   for (unsigned int i = 0; i < shape.size(); i++) {
-    if (llvm::is_contained(forcedDims, -1) ||
+    if (llvm::is_contained(forcedDims, ModelInputShaper::kUserDynamic) ||
         llvm::is_contained(forcedDims, i)) {
       newDims.push_back(ShapedType::kDynamic);
     } else {
@@ -97,7 +101,7 @@ Type ModelInputShaper::reshape(int inputIndex, Type inputType) const {
     // Update the input dimensions based on internal information.
     if (force_dim_dynamic_enabled_ && tensorTy.hasRank()) {
       auto rankedTensorTy = tensorTy.cast<RankedTensorType>();
-      auto it = forced_inputs_dims_.find(-1);
+      auto it = forced_inputs_dims_.find(kUserDynamic);
       if (it != forced_inputs_dims_.end())
         return forceShape(rankedTensorTy, it->second);
       it = forced_inputs_dims_.find(inputIndex);

--- a/src/Builder/ModelInputShaper.hpp
+++ b/src/Builder/ModelInputShaper.hpp
@@ -56,6 +56,9 @@ namespace onnx_mlir {
 //    dimensions
 class ModelInputShaper {
 public:
+  // To users of onnx-mlir, -1 is used for dynamic/unknown dimension.
+  static constexpr int64_t kUserDynamic = -1;
+
   ModelInputShaper();
 
   // shapeInformation specifies custom shapes for the inputs of the ONNX model,

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -18,6 +18,7 @@
 #include "src/Compiler/CompilerOptions.hpp"
 
 #include "src/Accelerators/Accelerator.hpp"
+#include "src/Builder/ModelInputShaper.hpp"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 
 using namespace mlir;
@@ -84,7 +85,10 @@ private:
           if (tensorTy.hasRank()) {
             int64_t rank = tensorTy.getRank();
             for (int j = 0; j < rank; j++) {
-              dstream << comma << tensorTy.getDimSize(j);
+              int64_t dimSize = tensorTy.getDimSize(j);
+              if (dimSize == ShapedType::kDynamic)
+                dimSize = ModelInputShaper::kUserDynamic;
+              dstream << comma << dimSize;
               comma = std::string(" , ");
             }
           } else {

--- a/test/mlir/onnx/onnx_lowering_entry_point.mlir
+++ b/test/mlir/onnx/onnx_lowering_entry_point.mlir
@@ -1,0 +1,96 @@
+// RUN: onnx-mlir-opt --convert-onnx-to-krnl %s -split-input-file | FileCheck %s
+
+
+// -----
+
+// type: i1/bool
+module {
+  func.func @main_graph(%arg0: tensor<?x3xi1>, %arg1: tensor<?x3xi1>) -> (tensor<?x3xi1>, tensor<?x3xi1>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+    return %arg0, %arg1 : tensor<?x3xi1>, tensor<?x3xi1>
+  }
+// CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// -----
+
+// type: i8
+module {
+  func.func @main_graph(%arg0: tensor<?x3xi8>, %arg1: tensor<?x3xi8>) -> (tensor<?x3xi8>, tensor<?x3xi8>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+    return %arg0, %arg1 : tensor<?x3xi8>, tensor<?x3xi8>
+  }
+// CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// -----
+
+// type: i16
+module {
+  func.func @main_graph(%arg0: tensor<?x3xi16>, %arg1: tensor<?x3xi16>) -> (tensor<?x3xi16>, tensor<?x3xi16>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+    return %arg0, %arg1 : tensor<?x3xi16>, tensor<?x3xi16>
+  }
+
+// CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i16\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i16\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i16\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i16\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// -----
+
+// type: i32
+module {
+  func.func @main_graph(%arg0: tensor<?x3xi32>, %arg1: tensor<?x3xi32>) -> (tensor<?x3xi32>, tensor<?x3xi32>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+    return %arg0, %arg1 : tensor<?x3xi32>, tensor<?x3xi32>
+  }
+
+// CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i32\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i32\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i32\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i32\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// -----
+
+// type: i64
+module {
+  func.func @main_graph(%arg0: tensor<?x3xi64>, %arg1: tensor<?x3xi64>) -> (tensor<?x3xi64>, tensor<?x3xi64>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+    return %arg0, %arg1 : tensor<?x3xi64>, tensor<?x3xi64>
+  }
+
+// CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i64\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i64\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i64\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i64\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// -----
+
+// type: f16
+module {
+  func.func @main_graph(%arg0: tensor<?x3xf16>, %arg1: tensor<?x3xf16>) -> (tensor<?x3xf16>, tensor<?x3xf16>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+    return %arg0, %arg1 : tensor<?x3xf16>, tensor<?x3xf16>
+  }
+
+// CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : f16 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : f16 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : f16 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : f16 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// -----
+
+// type: f32
+module {
+  func.func @main_graph(%arg0: tensor<?x3xf32>, %arg1: tensor<?x3xf32>) -> (tensor<?x3xf32>, tensor<?x3xf32>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+    return %arg0, %arg1 : tensor<?x3xf32>, tensor<?x3xf32>
+  }
+
+// CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22f32\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22f32\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22f32\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22f32\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// -----
+
+// type: f64
+module {
+  func.func @main_graph(%arg0: tensor<?x3xf64>, %arg1: tensor<?x3xf64>) -> (tensor<?x3xf64>, tensor<?x3xf64>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+    return %arg0, %arg1 : tensor<?x3xf64>, tensor<?x3xf64>
+  }
+
+// CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22f64\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22f64\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22f64\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22f64\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}


### PR DESCRIPTION
After updating LLVM, we internally use `ShapedType::kDynamic`(that is `std::numeric_limits<int64_t>::min()`) because that is the way MLIR handles dynamic dimension.

But, for onnx-mlir's users, it is convenient to use `-1` to denote a dynamic dimension, e.g. in the model signatures or `--shapeInformation` option, which is easy to remember.

This patch fixes #1995 #1996 issues and add a LIT test for lowering `onnx.EntryPoint` to `krnl.entry_point`.

Signed-off-by: Tung D. Le <tung@jp.ibm.com>