### PR TITLE
LLVM Update to green commit for the week of 2/6/2023

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -14,7 +14,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 9acc2f37bdfce08ca0c2faec03392db10d1bb7a9 && cd ..
+cd llvm-project && git checkout ba8b8a73fcb6b830e63cd8e20c6e13b2a14d69bf && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 9acc2f37bdfce08ca0c2faec03392db10d1bb7a9 && cd ..
+cd llvm-project && git checkout ba8b8a73fcb6b830e63cd8e20c6e13b2a14d69bf && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -901,7 +901,8 @@ int compileModule(mlir::OwningOpRef<ModuleOp> &module,
   if (rc != CompilerSuccess)
     return rc;
 
-  mlir::PassManager pm(&context, mlir::OpPassManager::Nesting::Implicit);
+  mlir::PassManager pm(
+      module.get()->getName(), mlir::OpPassManager::Nesting::Implicit);
   // TODO(tung): Revise adding passes. The current mechanism does not work if
   // there are multiple accelerators enabled at the same time. It's because
   // each `accel->addPasses` is independent and controls the whole compilation

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -171,7 +171,7 @@ void populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
   arith::populateArithExpandOpsPatterns(patterns);
   populateMathToLLVMConversionPatterns(typeConverter, patterns);
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);
-  populateMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
   arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
 

--- a/src/Dialect/ONNX/ONNXOps/Sequence/Sequence.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Sequence/Sequence.cpp
@@ -203,7 +203,7 @@ LogicalResult ONNXSequenceLengthOp::inferShapes(
     SmallVector<int64_t, 1> dims;
     auto builder = Builder(getContext());
     Type scalarTy = RankedTensorType::get(dims, builder.getIntegerType(64));
-    getResult().setType(scalarTy);
+    getResult().setType(cast<TensorType>(scalarTy));
   }
   // ElementType of I64 will be checked by verifier
   return success();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Optional.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Optional.cpp
@@ -72,6 +72,6 @@ LogicalResult ONNXOptionalHasElementOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   Builder builder(getContext());
   Type scalarBoolType = RankedTensorType::get({}, builder.getI1Type());
-  getResult().setType(scalarBoolType);
+  getResult().setType(cast<TensorType>(scalarBoolType));
   return success();
 }

--- a/test/modellib/LSTMModel.cpp
+++ b/test/modellib/LSTMModel.cpp
@@ -80,7 +80,7 @@ bool LSTMLibBuilder::build() {
   func::FuncOp funcOp = createEmptyTestFunction(inputsType, outputsType);
   Block &entryBlock = funcOp.getBody().front();
 
-  auto noneVal = builder.create<ONNXNoneOp>(loc).getResult();
+  Value noneVal = builder.create<ONNXNoneOp>(loc).getResult();
   auto xVal = entryBlock.getArgument(0);
   auto hVal = (isNoneH) ? noneVal : entryBlock.getArgument(1);
   auto cVal = (isNoneC) ? noneVal : entryBlock.getArgument(2);

--- a/test/onnx2mlir/CustomFnTest.cpp
+++ b/test/onnx2mlir/CustomFnTest.cpp
@@ -87,7 +87,8 @@ int check(ModelProto &model) {
   options.useOnnxModelTypes = true;
   onnx_mlir::ImportFrontendModel(model, context, module, options);
 
-  mlir::PassManager pm(&context, mlir::OpPassManager::Nesting::Implicit);
+  mlir::PassManager pm(
+      module.get()->getName(), mlir::OpPassManager::Nesting::Implicit);
   pm.addPass(onnx_mlir::createShapeInferencePass(true));
   mlir::applyPassManagerCLOptions(pm);
   if (mlir::failed(pm.run(*module))) {

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 9acc2f37bdfce08ca0c2faec03392db10d1bb7a9 && cd ..
+cd llvm-project && git checkout ba8b8a73fcb6b830e63cd8e20c6e13b2a14d69bf && cd ..


### PR DESCRIPTION
This is using the green commits that match torch-mlir and that are published here (https://github.com/onnx/onnx-mlir/issues/1971#issuecomment-1419182049).

Green LLVM commit: `ba8b8a73fcb6b830e63cd8e20c6e13b2a14d69bf`
Green MHLO commit: `d5a2c51fd78cca9dd91611137cc3d3e89ddf6aa9` (branch: `greencommit/2023-02-06-ba8b8a73`)

The major changes that impact the update are:

https://reviews.llvm.org/D142855
https://reviews.llvm.org/D142463
https://reviews.llvm.org/D137731

Overall, this is a pretty easy update.