### PR TITLE
Replace "sanity" references with "safety"

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/Strides.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/Strides.cpp
@@ -182,7 +182,7 @@ template <typename T>
 void restrideArrayImpl(unsigned elementBytewidth, ArrayRef<int64_t> shape,
     ArrayRef<int64_t> srcStrides, ArrayRef<char> src,
     MutableArrayRef<char> dst) {
-  assert(sizeof(T) == elementBytewidth && "dispatch sanity check");
+  assert(sizeof(T) == elementBytewidth && "dispatch safety check");
   StridedArrayRef<T> stridedSrcT(castArrayRef<T>(src), srcStrides);
   MutableArrayRef<T> dstT = castMutableArrayRef<T>(dst);
   mapStrides<T, T>(shape, dstT, stridedSrcT, [&](T elem) { return elem; });

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Upsample.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Upsample.cpp
@@ -74,7 +74,7 @@ LogicalResult ONNXUpsampleOp::verify() {
   auto inputTy = getX().getType().cast<RankedTensorType>();
   int32_t inputRank = inputTy.getShape().size();
 
-  // Sanity checks on scale argument
+  // Safety checks on scale argument
   auto scalesTy = getScales().getType().cast<RankedTensorType>();
   if (scalesTy.getShape().size() != 1) {
     return emitError("Scales tensor must be rank 1");


### PR DESCRIPTION
Replace "sanity" references with "safety"

Signed-off-by: Charles Volzka <cjvolzka@us.ibm.com>