### PR TITLE
Add a requirements.txt file for PyPi requirements in onnx-mlir

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -27,7 +27,7 @@ jobs:
       versionSpec: '3.9'
 
   - task: PowerShell@2
-    displayName: Setup ninja and lit
+    displayName: Setup ninja
     inputs:
       targetType: 'inline'
       script: |
@@ -37,15 +37,6 @@ jobs:
           echo "choco install ninja"
           choco install ninja
         }
-        echo "Check and set up lit"
-        if (-Not (Get-Command lit -errorAction SilentlyContinue))
-        {
-          python3 -m pip install --upgrade wheel
-          python3 -m pip install --upgrade lit
-        }
-        $litPath=(Get-Command lit).Path
-        echo "Setting LitPath to $litPath"
-        Write-Host "##vso[task.setvariable variable=LitPath;]$litPath"
 
   - script: |
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
@@ -54,12 +45,17 @@ jobs:
     workingDirectory: $(Agent.BuildDirectory)
 
   - task: PowerShell@2
-    displayName: Install protobuf python package
+    displayName: Install required python packages
     inputs:
       targetType: 'inline'
       script: |
-        echo "Install protobuf python package"
-        python3 -m pip install protobuf==3.20.3
+        echo "Install required python packages"
+        python3 -m pip install --upgrade wheel
+        python3 -m pip install -r onnx-mlir\requirements.txt
+        echo "Set up lit"
+        $litPath=(Get-Command lit).Path
+        echo "Setting LitPath to $litPath"
+        Write-Host "##vso[task.setvariable variable=LitPath;]$litPath"
 
   - powershell: |
       $mlir_match = Select-String -Path onnx-mlir\utils\clone-mlir.sh -Pattern "git checkout ([\da-f]+)"
@@ -128,7 +124,7 @@ jobs:
   - script: |
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
       cd onnx-mlir\third_party\onnx
-      python -m pip install .
+      python3 -m pip install .
     env:
       CMAKE_ARGS: -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)\protobuf_install" -DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_MSVC_STATIC_RUNTIME=OFF
     displayName: Install onnx

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -26,17 +26,15 @@ jobs:
     inputs:
       versionSpec: '3.9'
 
-  - task: PowerShell@2
+  - powershell: |
+      echo "Check and set up ninja"
+      if (-Not (Get-Command ninja -errorAction SilentlyContinue))
+      {
+        echo "choco install ninja"
+        choco install ninja
+      }
     displayName: Setup ninja
-    inputs:
-      targetType: 'inline'
-      script: |
-        echo "Check and set up ninja"
-        if (-Not (Get-Command ninja -errorAction SilentlyContinue))
-        {
-          echo "choco install ninja"
-          choco install ninja
-        }
+    workingDirectory: $(Agent.BuildDirectory)
 
   - script: |
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
@@ -44,18 +42,16 @@ jobs:
     displayName: Install protobuf
     workingDirectory: $(Agent.BuildDirectory)
 
-  - task: PowerShell@2
+  - powershell: |
+      echo "Install required python packages"
+      python3 -m pip install --upgrade wheel
+      python3 -m pip install -r onnx-mlir\requirements.txt
+      echo "Set up lit"
+      $litPath=(Get-Command lit).Path
+      echo "Setting LitPath to $litPath"
+      Write-Host "##vso[task.setvariable variable=LitPath;]$litPath"
     displayName: Install required python packages
-    inputs:
-      targetType: 'inline'
-      script: |
-        echo "Install required python packages"
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install -r onnx-mlir\requirements.txt
-        echo "Set up lit"
-        $litPath=(Get-Command lit).Path
-        echo "Setting LitPath to $litPath"
-        Write-Host "##vso[task.setvariable variable=LitPath;]$litPath"
+    workingDirectory: $(Agent.BuildDirectory)
 
   - powershell: |
       $mlir_match = Select-String -Path onnx-mlir\utils\clone-mlir.sh -Pattern "git checkout ([\da-f]+)"

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -39,8 +39,8 @@ jobs:
     - name: install python requirements
       run: |
         cd ~/work/onnx-mlir/onnx-mlir
-        pip3 install --upgrade wheel
-        pip3 install -r requirements.txt
+        python3 -m pip install --upgrade wheel
+        python3 -m pip install -r requirements.txt
     - name: install third_party/onnx
       run: |
         cd ~/work/onnx-mlir/onnx-mlir/third_party/onnx

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -36,11 +36,15 @@ jobs:
         cd ~/work/onnx-mlir
         sh ~/work/onnx-mlir/onnx-mlir/utils/clone-mlir.sh
         sh ~/work/onnx-mlir/onnx-mlir/utils/build-mlir.sh
+    - name: install python requirements
+      run: |
+        cd ~/work/onnx-mlir/onnx-mlir
+        pip3 install --upgrade wheel
+        pip3 install -r requirements.txt
     - name: install third_party/onnx
       run: |
         cd ~/work/onnx-mlir/onnx-mlir/third_party/onnx
         git fetch --prune --unshallow --tags
-        pip3 install numpy==1.23.5
         python3 -m pip install -v .
     - name: build onnx-mlir
       run: |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ make >= 4.2.1 or ninja >= 1.10.2
 java >= 1.11 (optional)
 ```
 
+All the `PyPi` package dependencies and their appropriate versions are captured in [requirements.txt](requirements.txt).
+
 Look [here](docs/Prerequisite.md) for help to set up the prerequisite software.
 
 At any point in time, ONNX-MLIR depends on a specific commit of the LLVM project that has been shown to work with the project.

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -40,7 +40,7 @@ Before running CMake for onnx-mlir, ensure that the bin directory to this protob
 set PATH=%root_dir%\protobuf_install\bin;%PATH%
 ```
 
-If you wish to be able to run all the ONNX-MLIR tests, you will also need to install the matchin version of protobuf through pip:
+If you wish to be able to run all the ONNX-MLIR tests, you will also need to install the matching version of protobuf through pip. Note that this is included in the requirements.txt file at the root of onnx-mlir, so if you plan on using it, you won't need to explicitly install protobuf.
 ```shell
 python3 -m pip install protobuf==3.20.3
 ```

--- a/docs/Prerequisite.md
+++ b/docs/Prerequisite.md
@@ -11,6 +11,7 @@ cmake >= 3.13.4
 make >= 4.2.1 or ninja >= 1.10.2
 java >= 1.11 (optional)
 ```
+
 Onnx-mlir is tested to work with python 3.8 and 3.9 but not yet fully tested with 3.10+. It may work with older 3.x python versions but not recommended since those either have already reached or are close to reach their EOL. To check the python version, run `python --version`.
 
 GCC can be installed with distro specific package manager on Linux such as yum on RHEL/Fedora, apt on Debian/Ubuntu, or brew on MacOS. If you prefer to compile gcc yourself, instructions can be found [here](https://gcc.gnu.org/install/). To check the gcc version, run `gcc --version`.
@@ -24,3 +25,5 @@ GNU make can be installed with distro specific package manager on Linux such as 
 Ninja can be installed with apt on Debian/Ubuntu Linux, or brew on MacOS. On RHEL/Fedora Linux, or if you want to compile ninja yourself, the instructions can be found [here](https://ninja-build.org/). To check the ninja version, run `ninja --version`.
 
 Java SDK can be installed with distro specific package manager on Linux such as yum on RHEL/Fedora, apt on Debian/Ubuntu, or brew on MacOS. Java SDK is only required if you plan to use the onnx-mlir `--EmitJNI` option to compile a model into a jar file for use in a Java environment. Note that the jar file contains native model runtime library called through JNI so it is not portable across different architectures. To check the java version, run `java --version`.
+
+All the `PyPi` package dependencies and their appropriate versions are captured in [requirements.txt](requirements.txt).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+lit==15.0.6
+# numpy 1.24 deprecates np.object, np.bool, np.float, np.complex, np.str,
+# and np.int which are used heavily in onnx-mlir.
+numpy>=1.19.5, <=1.23.5
+protobuf==3.20.3
+pytest>=4.6.9, <=7.2.0
+pytest-xdist>=1.31.0, <=2.5


### PR DESCRIPTION
This adds a `requirements.txt` file at the root of the repository with the current PyPi package requirements and pinned versions for them. This is the equivalent of the mlir change that pinned their package requirements (https://reviews.llvm.org/D142563). 

This change is pinning the requirements to a specific version (or a range) depending on the requirement. A couple of considerations:

* numpy 1.24 deprecates np.object, np.bool, np.float, np.complex, np.str, and np.int which are used heavily in onnx-mlir
* not all versions of each package are available on every platform - to the best of my knowledge, these ranges should work on Ubuntu, CentOS, macOS and Windows

Adding a minimum and maximum version, or pinning to a specific versions where possible, helps with two major goals - security and maintainability. It gives us an opportunity to make sure that the packages being used are not part of a security attack as well as guaranteeing that they support the features that onnx-mlir depends on (see note about numpy deprecation).

This also adds the requirements.txt file to the setup instructions and to the pipelines on Windows and macOS. I've not added it to the docker images but it can be used there as well with a little more effort.

Signed-off-by: Stella Stamenova <stilis@microsoft.com>