### PR TITLE
Make the doc example test work with Ninja on Ubuntu

### DIFF
--- a/docs/doc_example/CMakeLists.txt
+++ b/docs/doc_example/CMakeLists.txt
@@ -93,7 +93,7 @@ add_onnx_mlir_executable(OMRuntimeCppTest
 
 set_output_directory(OMRuntimeCppTest BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-add_test(NAME OMRuntimeTest COMMAND OMRuntimeTest WORKING_DIRECTORY ${ONNX_MLIR_BIN_ROOT})
+add_test(NAME OMRuntimeTest COMMAND OMRuntimeTest WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_property(TARGET OMRuntimeTest PROPERTY FOLDER "Docs")
 set_tests_properties(OMRuntimeTest PROPERTIES LABELS doc-example)
 add_dependencies(doc-example OMRuntimeTest)

--- a/docs/doc_example/CMakeLists.txt
+++ b/docs/doc_example/CMakeLists.txt
@@ -25,16 +25,18 @@ configure_file(
   )
 
 if (WIN32)
-  set(OMRuntimeTestModelLibraryFiles ${CMAKE_CURRENT_BINARY_DIR}/add${CMAKE_SHARED_LIBRARY_SUFFIX})
-  list(APPEND OMRuntimeTestModelLibraryFiles ${CMAKE_CURRENT_BINARY_DIR}/add${CMAKE_LINK_LIBRARY_SUFFIX})
-else() 
-  set(OMRuntimeTestModelLibraryFiles ${CMAKE_CURRENT_BINARY_DIR}/add${CMAKE_SHARED_MODULE_SUFFIX})
+  set(OMRuntimeTestModelLibraryName add)
+  set(OMRuntimeTestModelLibraryFiles ${CMAKE_CURRENT_BINARY_DIR}/${OMRuntimeTestModelLibraryName}${CMAKE_SHARED_LIBRARY_SUFFIX})
+  list(APPEND OMRuntimeTestModelLibraryFiles ${CMAKE_CURRENT_BINARY_DIR}/${OMRuntimeTestModelLibraryName}${CMAKE_LINK_LIBRARY_SUFFIX})
+else()
+  set(OMRuntimeTestModelLibraryName libadd)
+  set(OMRuntimeTestModelLibraryFiles ${CMAKE_CURRENT_BINARY_DIR}/${OMRuntimeTestModelLibraryName}${CMAKE_SHARED_MODULE_SUFFIX})
 endif()
 
 add_custom_command(
   OUTPUT ${OMRuntimeTestModelLibraryFiles}
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/gen_add_onnx.py
-  COMMAND onnx-mlir add.onnx
+  COMMAND onnx-mlir add.onnx -o ${OMRuntimeTestModelLibraryName}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS onnx-mlir
   )
@@ -47,14 +49,17 @@ add_library(OMRuntimeTestModelLibrary SHARED IMPORTED)
 add_dependencies(OMRuntimeTestModelLibrary OMRuntimeTestModel)
 if (WIN32)
   set_target_properties(OMRuntimeTestModelLibrary PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/add${CMAKE_SHARED_LIBRARY_SUFFIX}
+    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${OMRuntimeTestModelLibraryName}${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
   set_target_properties(OMRuntimeTestModelLibrary PROPERTIES
-    IMPORTED_IMPLIB ${CMAKE_CURRENT_BINARY_DIR}/add${CMAKE_LINK_LIBRARY_SUFFIX}
+    IMPORTED_IMPLIB ${CMAKE_CURRENT_BINARY_DIR}/${OMRuntimeTestModelLibraryName}${CMAKE_LINK_LIBRARY_SUFFIX}
     )
 else()
   set_target_properties(OMRuntimeTestModelLibrary PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/add${CMAKE_SHARED_MODULE_SUFFIX}
+    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${OMRuntimeTestModelLibraryName}${CMAKE_SHARED_MODULE_SUFFIX}
+    )
+  set_target_properties(OMRuntimeTestModelLibrary PROPERTIES
+    IMPORTED_NO_SONAME TRUE
     )
 endif()
 
@@ -71,7 +76,9 @@ add_onnx_mlir_executable(OMRuntimeTest
   cruntime
   )
 
-  add_onnx_mlir_executable(OMRuntimeCppTest
+set_output_directory(OMRuntimeTest BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+add_onnx_mlir_executable(OMRuntimeCppTest
   main.cpp
 
   NO_INSTALL
@@ -84,14 +91,13 @@ add_onnx_mlir_executable(OMRuntimeTest
   OMExecutionSession
   )
 
+set_output_directory(OMRuntimeCppTest BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-set_output_directory(OMRuntimeTest BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME OMRuntimeTest COMMAND OMRuntimeTest WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME OMRuntimeTest COMMAND OMRuntimeTest WORKING_DIRECTORY ${ONNX_MLIR_BIN_ROOT})
 set_property(TARGET OMRuntimeTest PROPERTY FOLDER "Docs")
 set_tests_properties(OMRuntimeTest PROPERTIES LABELS doc-example)
 add_dependencies(doc-example OMRuntimeTest)
 
-set_output_directory(OMRuntimeCppTest BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME OMRuntimeCppTest COMMAND OMRuntimeCppTest WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_property(TARGET OMRuntimeCppTest PROPERTY FOLDER "Docs")
 set_tests_properties(OMRuntimeCppTest PROPERTIES LABELS doc-example)


### PR DESCRIPTION
This should, in theory, work on all platforms now.

Before this change, the test worked correctly with `Makefiles` on any platform because `Makefiles` always use the full path to the library. It also worked correctly on Windows regardless of generator because by default an executable will look for any `dlls` in the same directory first. However, it did not work correctly with `ninja` on non-Windows because `ninja` was converting the full path to a path relative to the root of the binary tree for the build step and then failing at execution. More specifically, the library would be linked as `docs/doc_example/add.so`, then at execution time of the test, the test would run from `docs/doc_example`, so it would look for the library in `docs/doc_example/docs/doc_example`. The behavior could not be altered by setting `rpath` or by explicitly passing the full path (without using the `imported` library).

To make the test work everywhere, I've changed the output library to be `add` on Windows and `libadd` on non-Windows. This allows us to set the `IMPORTED_NO_SONAME` target property which will then link the library via `-ladd` instead of by relative path.