### PR TITLE
Update krnl.md

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -71,7 +71,7 @@ function(add_onnx_mlir_dialect_doc dialect dialect_tablegen_file)
   add_custom_target(${dialect}DocGen DEPENDS ${GEN_DOC_FILE})
   add_dependencies(onnx-mlir-docs ${dialect}DocGen)
 endfunction()
-add_custom_target(onnx-mlir-docs ALL)
+add_custom_target(onnx-mlir-docs)
 
 # Create the list of supported ops. Pass the input file to scan, and the target architecture.
 # Target will create a docs/SupportedONNXOps-<arch>.md file listed

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -64,14 +64,14 @@ function(add_onnx_mlir_dialect_doc dialect dialect_tablegen_file)
   set(GEN_DOC_FILE ${ONNX_MLIR_SRC_ROOT}/docs/Dialects/${dialect}.md)
   add_custom_command(
           OUTPUT ${GEN_DOC_FILE}
-          COMMAND ${CMAKE_COMMAND} -E copy
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
                   ${CMAKE_CURRENT_BINARY_DIR}/${dialect}.md
                   ${GEN_DOC_FILE}
           DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${dialect}.md)
   add_custom_target(${dialect}DocGen DEPENDS ${GEN_DOC_FILE})
   add_dependencies(onnx-mlir-docs ${dialect}DocGen)
 endfunction()
-add_custom_target(onnx-mlir-docs)
+add_custom_target(onnx-mlir-docs ALL)
 
 # Create the list of supported ops. Pass the input file to scan, and the target architecture.
 # Target will create a docs/SupportedONNXOps-<arch>.md file listed

--- a/docs/Dialects/krnl.md
+++ b/docs/Dialects/krnl.md
@@ -810,8 +810,12 @@ Interfaces: SpecializedKernelOpInterface
 
 Krnl memcpy operation
 
-In the KRNL dialect the reshape op
-doesn't generate a new memory entry and treats a reshape like a cast.
+Copy `num_elems` elements from `src` to `dest` MemRef.
+
+Starting positions for `src` and `dest` are defined by `src_offset` and
+`dest_offset`, respectively.
+
+It is the users' responsibility to make sure there is no out-of-bound read/write.
 
 Traits: MemRefsNormalizable
 
@@ -821,7 +825,9 @@ Traits: MemRefsNormalizable
 | :-----: | ----------- |
 | `dest` | memref of any type values
 | `src` | memref of any type values
-| `size` | integer
+| `num_elems` | 64-bit signless integer
+| `dest_offset` | index
+| `src_offset` | index
 
 ### `krnl.memset` (::mlir::KrnlMemsetOp)
 


### PR DESCRIPTION
At some point an update of krnl.md was missed - update the file and also change the target to only copy the `.md` files when they've changed.