### PR TITLE
Update logic so that the decompose pass is successful 

### DIFF
--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -109,19 +109,20 @@ DenseElementsAttr createDenseArrayAttrOrEmpty(
         RankedTensorType::get(wrapper.size(), elementType),
         llvm::makeArrayRef(wrapper));
   }
+}
 
-  Value createSequenceConstructOp(
-      PatternRewriter & rewriter, mlir::Value seq, mlir::OperandRange inputs) {
-    Type resType = seq.getType();
-    Location loc = seq.getLoc();
-    Value position = rewriter.create<ONNXNoneOp>(loc);
+Value createSequenceConstructOp(
+    PatternRewriter &rewriter, mlir::Value seq, mlir::OperandRange inputs) {
+  Type resType = seq.getType();
+  Location loc = seq.getLoc();
+  Value position = rewriter.create<ONNXNoneOp>(loc);
 
-    for (auto input : inputs)
-      seq = rewriter.create<ONNXSequenceInsertOp>(
-          loc, resType, seq, input, position);
+  for (auto input : inputs)
+    seq = rewriter.create<ONNXSequenceInsertOp>(
+        loc, resType, seq, input, position);
 
-    return seq;
-  }
+  return seq;
+}
 
 } // namespace onnx_mlir
 


### PR DESCRIPTION
It seems like a small syntax change in the `decompose.cpp` file is causing an error when running the following command:

root@5d0487c69ecc:~/onnx-mlir/build# onnx-mlir --O3 --EmitLib --maccel=NNPA roberta-base-11.onnx --onnx-op-stats TXT --shapeInformation 0:1x1 -v
Operations encountered:
-----------------------
   func.func            , 1
   func.return          , 1
   onnx.Add             , 70
   onnx.Cast            , 2
   onnx.Concat          , 80
   onnx.Constant        , 272
   onnx.ConstantOfShape , 2
   onnx.CumSum          , 1
   onnx.Dim             , 116
   onnx.Div             , 41
   onnx.Equal           , 1
   onnx.Erf             , 12
   onnx.Gather          , 4
   onnx.LayoutTransform , 56
   onnx.Mul             , 32
   onnx.NoValue         , 1
   onnx.Not             , 1
   onnx.ReduceMean      , 50
   onnx.Reshape         , 139
   onnx.Sqrt            , 25
   onnx.Sub             , 25
   onnx.Transpose       , 48
   onnx.Unsqueeze       , 2
  zhigh.Add             , 74
  zhigh.Div             , 8
  zhigh.MatMul          , 97
  zhigh.Mul             , 44
  zhigh.Softmax         , 12
  zhigh.Stick           , 321
  zhigh.Sub             , 1
  zhigh.Tanh            , 1
  zhigh.Unstick         , 150
root@5d0487c69ecc:~/onnx-mlir/build# echo $?
13