### PR TITLE
parse DisposableElementsAttr

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.cpp
@@ -175,6 +175,7 @@ std::unique_ptr<llvm::MemoryBuffer> DisposableElementsAttr::parse(
         parser.getCurrentLocation(), "data size doesn't match type size");
     return nullptr;
   }
+  // TODO: Make big-endian platforms reorder bytes from little-endian.
   return llvm::MemoryBuffer::getMemBufferCopy(bytes);
 }
 
@@ -187,6 +188,7 @@ void DisposableElementsAttr::printWithoutType(AsmPrinter &printer) const {
   static OpPrintingFlags printerFlags{};
   printer << getMnemonic() << "<" << getImpl()->id << ":";
   if (isSplat() || !printerFlags.shouldElideElementsAttr(*this)) {
+    // TODO: Make big-endian platforms reorder bytes to little-endian.
     auto bytes = getRawBytes();
     auto u8array = castArrayRef<uint8_t>(bytes.get());
     printer << "\"0x" << llvm::toHex(u8array) << "\"";

--- a/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp
@@ -268,8 +268,11 @@ public:
 
   static constexpr StringLiteral getMnemonic() { return {"dense_disposable"}; }
 
+  // Returns the underlying data as a flat byte array in row-major order.
+  // If the element type is bool the data holds one byte (with value 0 or 1) per
+  // bool (contrary to how DenseElementsAttr::getRawData() bit packs bools).
   static std::unique_ptr<llvm::MemoryBuffer> parse(
-      AsmParser &parser, Type type);
+      AsmParser &parser, ShapedType type);
 
   void printWithoutType(AsmPrinter &printer) const;
 

--- a/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp
@@ -22,6 +22,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 #include <functional>
@@ -264,6 +265,11 @@ public:
 
   // Makes deep copy.
   DenseElementsAttr toDenseElementsAttr() const;
+
+  static constexpr StringLiteral getMnemonic() { return {"dense_disposable"}; }
+
+  static std::unique_ptr<llvm::MemoryBuffer> parse(
+      AsmParser &parser, Type type);
 
   void printWithoutType(AsmPrinter &printer) const;
 

--- a/src/Dialect/ONNX/ONNXAttributes.cpp
+++ b/src/Dialect/ONNX/ONNXAttributes.cpp
@@ -17,9 +17,9 @@
 #include "src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp"
 #include "src/Dialect/ONNX/ElementsAttr/DisposableElementsAttributeStorage.hpp"
 #include "src/Dialect/ONNX/ElementsAttr/DisposablePool.hpp"
-#include "src/Dialect/ONNX/OnnxElementsAttrBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+#include "src/Dialect/ONNX/OnnxElementsAttrBuilder.hpp"
 
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -125,8 +125,8 @@ Attribute ONNXDialect::parseAttribute(
     return attr;
   if (attrTag == DisposableElementsAttr::getMnemonic()) {
     if (auto membuf = DisposableElementsAttr::parse(parser, type))
-      return OnnxElementsAttrBuilder(type.getContext()).fromMemoryBuffer(
-          type, std::move(membuf));
+      return OnnxElementsAttrBuilder(type.getContext())
+          .fromMemoryBuffer(type, std::move(membuf));
     else
       return {};
   }

--- a/src/Dialect/ONNX/ONNXAttributes.cpp
+++ b/src/Dialect/ONNX/ONNXAttributes.cpp
@@ -17,6 +17,7 @@
 #include "src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp"
 #include "src/Dialect/ONNX/ElementsAttr/DisposableElementsAttributeStorage.hpp"
 #include "src/Dialect/ONNX/ElementsAttr/DisposablePool.hpp"
+#include "src/Dialect/ONNX/OnnxElementsAttrBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 
@@ -122,6 +123,13 @@ Attribute ONNXDialect::parseAttribute(
   if (Attribute attr;
       generatedAttributeParser(parser, &attrTag, type, attr).has_value())
     return attr;
+  if (attrTag == DisposableElementsAttr::getMnemonic()) {
+    if (auto membuf = DisposableElementsAttr::parse(parser, type))
+      return OnnxElementsAttrBuilder(type.getContext()).fromMemoryBuffer(
+          type, std::move(membuf));
+    else
+      return {};
+  }
   parser.emitError(parser.getCurrentLocation())
       << "unknown attribute `" << attrTag << "` in dialect `ONNX`";
   return {};


### PR DESCRIPTION
Solves #1975 

I changed the print format a little bit, removing the `#` before the "id", so it's now
```
#onnx.dense_disposable<1:"0x00010000">
```
instead of
```
#onnx.dense_disposable<1:"0x00010000">
```
I made the change because I couldn't figure out how to parse the `#`

I ran it on @tungld's example model bertsquad-12-int8.onnx and I no longer see the error `error: unknown attribute 'dense_disposable' in dialect 'ONNX'`