### PR TITLE
NFC: remove redundant or unnecessary semicolons

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/BType.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/BType.hpp
@@ -115,7 +115,7 @@ struct CppTypeTrait : public detail::BTypeTraitBase<BType::UNDEFINED, CPPTY> {};
   template <>                                                                  \
   struct BTypeTrait<BTYPE> : public detail::BTypeTraitBase<BTYPE, CPPTY> {};   \
   template <>                                                                  \
-  struct CppTypeTrait<CPPTY> : public BTypeTrait<BTYPE> {};
+  struct CppTypeTrait<CPPTY> : public BTypeTrait<BTYPE> {}
 
 DEFINE_BTypeCppTypeTraits(BType::BOOL, bool);
 DEFINE_BTypeCppTypeTraits(BType::INT8, int8_t);

--- a/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp
@@ -30,7 +30,7 @@
 namespace onnx_mlir {
 class DisposablePool;
 class ElementsAttrBuilder;
-}; // namespace onnx_mlir
+} // namespace onnx_mlir
 
 namespace mlir {
 


### PR DESCRIPTION
This fixes warnings that are present when building with clang-15.