### PR TITLE
Switch to use OpConversionPattern instead of ConversionPattern - part 1 - ONNXToKrnl

### DIFF
--- a/src/Conversion/ONNXToKrnl/ControlFlow/If.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/If.cpp
@@ -18,19 +18,17 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXIfOpLowering : public ConversionPattern {
+struct ONNXIfOpLowering : public OpConversionPattern<ONNXIfOp> {
   explicit ONNXIfOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXIfOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXIfOp ifOp, ONNXIfOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
+    Operation *op = ifOp.getOperation();
     Location loc = ONNXLoc<ONNXIfOp>(op);
-    auto ifOp = dyn_cast<ONNXIfOp>(op);
-    ONNXIfOpAdaptor ifOpAdaptor(operands, op->getAttrDictionary());
 
     KrnlBuilder createKrnl(rewriter, loc);
-    Value cond = createKrnl.load(ifOpAdaptor.getCond());
+    Value cond = createKrnl.load(adaptor.getCond());
 
     auto resultTypes = ifOp.getResultTypes();
     SmallVector<Type> convertedResultTypes;

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -707,16 +707,21 @@ Value emitScalarOpFor<ONNXRoundOp>(ConversionPatternRewriter &rewriter,
 // Element-wise unary ops lowering to Krnl dialect.
 //===----------------------------------------------------------------------===//
 template <typename ElementwiseUnaryOp>
-struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
+struct ONNXElementwiseUnaryOpLowering
+    : public OpConversionPattern<ElementwiseUnaryOp> {
+  using OpAdaptor = typename ElementwiseUnaryOp::Adaptor;
   bool enableSIMD = false;
+
   ONNXElementwiseUnaryOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableSIMD)
-      : ConversionPattern(
-            typeConverter, ElementwiseUnaryOp::getOperationName(), 1, ctx),
+      : OpConversionPattern<ElementwiseUnaryOp>(typeConverter, ctx),
         enableSIMD(enableSIMD) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ElementwiseUnaryOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
+    Operation *op = elmsOp.getOperation();
+    ValueRange operands = adaptor.getOperands();
+
     Location loc = ONNXLoc<ElementwiseUnaryOp>(op);
     Value X = operands[0];
 
@@ -731,8 +736,8 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
     }
 
     // Convert the output type to MemRefType.
-    Type outputTensorType = *op->result_type_begin();
-    Type convertedType = typeConverter->convertType(outputTensorType);
+    Type outputTensorType = elmsOp.getResult().getType();
+    Type convertedType = this->typeConverter->convertType(outputTensorType);
     int64_t alignment =
         KrnlTypeConverter::getDefaultAllocAlignment(outputTensorType);
     assert(convertedType && convertedType.isa<MemRefType>() &&
@@ -783,25 +788,26 @@ struct ONNXElementwiseUnaryOpLowering : public ConversionPattern {
 // different from the input type.
 //===----------------------------------------------------------------------===//
 template <typename ElementwiseBinaryOp>
-struct ONNXElementwiseBinaryOpLowering : public ConversionPattern {
+struct ONNXElementwiseBinaryOpLowering
+    : public OpConversionPattern<ElementwiseBinaryOp> {
+  using OpAdaptor = typename ElementwiseBinaryOp::Adaptor;
   bool enableSIMD = false;
   bool isUniBroadcasting = false;
 
   ONNXElementwiseBinaryOpLowering(TypeConverter &typeConverter,
       MLIRContext *ctx, bool enableSIMD, bool isUniBroadcasting = false)
-      : ConversionPattern(
-            typeConverter, ElementwiseBinaryOp::getOperationName(), 1, ctx),
+      : OpConversionPattern<ElementwiseBinaryOp>(typeConverter, ctx),
         enableSIMD(enableSIMD), isUniBroadcasting(isUniBroadcasting) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ElementwiseBinaryOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = NameLoc::get(StringAttr::get(op->getContext(),
-                                    ElementwiseBinaryOp::getOperationName()),
-        op->getLoc());
+    Operation *op = elmsOp.getOperation();
+    ValueRange operands = adaptor.getOperands();
+    Location loc = ONNXLoc<ElementwiseBinaryOp>(op);
 
     // Convert the output type to MemRefType.
-    Type outputTensorType = *op->result_type_begin();
-    Type convertedType = typeConverter->convertType(outputTensorType);
+    Type outputTensorType = elmsOp.getResult().getType();
+    Type convertedType = this->typeConverter->convertType(outputTensorType);
     int64_t alignment =
         KrnlTypeConverter::getDefaultAllocAlignment(outputTensorType);
     assert(convertedType && convertedType.isa<MemRefType>() &&
@@ -875,25 +881,26 @@ struct ONNXElementwiseBinaryOpLowering : public ConversionPattern {
 // Element-wise variadic ops lowering to Krnl dialect.
 //===----------------------------------------------------------------------===//
 template <typename ElementwiseVariadicOp>
-struct ONNXElementwiseVariadicOpLowering : public ConversionPattern {
+struct ONNXElementwiseVariadicOpLowering
+    : public OpConversionPattern<ElementwiseVariadicOp> {
+  using OpAdaptor = typename ElementwiseVariadicOp::Adaptor;
   bool enableSIMD = false;
 
   ONNXElementwiseVariadicOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableSIMD)
-      : ConversionPattern(
-            typeConverter, ElementwiseVariadicOp::getOperationName(), 1, ctx),
+      : OpConversionPattern<ElementwiseVariadicOp>(typeConverter, ctx),
         enableSIMD(enableSIMD) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ElementwiseVariadicOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = NameLoc::get(StringAttr::get(op->getContext(),
-                                    ElementwiseVariadicOp::getOperationName()),
-        op->getLoc());
-    unsigned numArgs = op->getNumOperands();
+    Operation *op = elmsOp.getOperation();
+    Location loc = ONNXLoc<ElementwiseVariadicOp>(op);
+    ValueRange operands = adaptor.getOperands();
+    unsigned numArgs = elmsOp.getNumOperands();
 
     // Convert the output type to MemRefType.
-    Type outputTensorType = *op->result_type_begin();
-    Type convertedType = typeConverter->convertType(outputTensorType);
+    Type outputTensorType = elmsOp.getResult().getType();
+    Type convertedType = this->typeConverter->convertType(outputTensorType);
     int64_t alignment =
         KrnlTypeConverter::getDefaultAllocAlignment(outputTensorType);
     assert(convertedType && convertedType.isa<MemRefType>() &&

--- a/src/Conversion/ONNXToKrnl/Math/Hardmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Hardmax.cpp
@@ -77,20 +77,21 @@ static Value emitArgmax(ConversionPatternRewriter &rewriter, Location loc,
   return resMemRef;
 }
 
-struct ONNXHardmaxOpLowering : public ConversionPattern {
+struct ONNXHardmaxOpLowering : public OpConversionPattern<ONNXHardmaxOp> {
   ONNXHardmaxOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXHardmaxOp::getOperationName(), 1, ctx) {}
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      : OpConversionPattern(typeConverter, ctx) {}
+  LogicalResult matchAndRewrite(ONNXHardmaxOp hardmaxOp,
+      ONNXHardmaxOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = op->getLoc();
+    Operation *op = hardmaxOp.getOperation();
+    Location loc = ONNXLoc<ONNXHardmaxOp>(op);
+    ValueRange operands = adaptor.getOperands();
+    Value input = adaptor.getInput();
+
     MultiDialectBuilder<MathBuilder, KrnlBuilder, IndexExprBuilderForKrnl,
         MemRefBuilder>
         create(rewriter, loc);
     IndexExprScope scope(create.krnl);
-
-    ONNXHardmaxOpAdaptor operandAdaptor(operands);
-    Value input = operandAdaptor.getInput();
 
     // Convert the output type to MemRefType.
     Type convertedType = typeConverter->convertType(*op->result_type_begin());

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -28,18 +28,15 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXMatMulOpLowering : public ConversionPattern {
+struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
   ONNXMatMulOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableTiling)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXMatMulOp::getOperationName(), 1, ctx),
-        enableTiling(enableTiling) {}
+      : OpConversionPattern(typeConverter, ctx), enableTiling(enableTiling) {}
   bool enableTiling;
   // Handle the generic cases, including when there are broadcasts.
-  void replaceGenericMatmul(ONNXMatMulOp &matMulOp,
-      ONNXMatMulOpAdaptor &operandAdaptor, Type elementType,
-      ONNXMatMulOpShapeHelper &shapeHelper, Value alloc, Value fZero,
-      ConversionPatternRewriter &rewriter, Location loc) const {
+  void replaceGenericMatmul(ONNXMatMulOpAdaptor &operandAdaptor,
+      Type elementType, ONNXMatMulOpShapeHelper &shapeHelper, Value alloc,
+      Value fZero, ConversionPatternRewriter &rewriter, Location loc) const {
 
     // Define loops and bounds.
     MultiDialectBuilder<KrnlBuilder, MemRefBuilder> create(rewriter, loc);
@@ -229,8 +226,7 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
   // Handle the cases with 2x2 matrices both for A, B, and C without
   // broadcast. Implementation here uses the efficient 1d tiling plus kernel
   // substitution.
-  void replace2x2Matmul2d(ONNXMatMulOp &matMulOp,
-      ONNXMatMulOpAdaptor &operandAdaptor, Type elementType,
+  void replace2x2Matmul2d(ONNXMatMulOpAdaptor &operandAdaptor, Type elementType,
       ONNXMatMulOpShapeHelper &shapeHelper, Value alloc, Value zeroVal,
       ConversionPatternRewriter &rewriter, Location loc) const {
     // Prepare: loop bounds and zero
@@ -288,10 +284,9 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
   // broadcasting ranks. In such case, sameStaticBroadcast is true, and the
   // value of broadcastingB does not matter as they treated as both
   // broadcasting.
-  void replace2x2Matmul2dBroadcasting(ONNXMatMulOp &matMulOp,
-      ONNXMatMulOpAdaptor &operandAdaptor, Type elementType,
-      ONNXMatMulOpShapeHelper &shapeHelper, bool broadcastingB,
-      bool sameStaticBroadcast, Value alloc, Value zeroVal,
+  void replace2x2Matmul2dBroadcasting(ONNXMatMulOpAdaptor &operandAdaptor,
+      Type elementType, ONNXMatMulOpShapeHelper &shapeHelper,
+      bool broadcastingB, bool sameStaticBroadcast, Value alloc, Value zeroVal,
       ConversionPatternRewriter &rewriter, Location loc) const {
     // Prepare: loop bounds and zero
     Value A(operandAdaptor.getA()), B(operandAdaptor.getB()), C(alloc);
@@ -389,11 +384,11 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
   // broadcast, broadcast of A to rank 2 B,  broadcast of B to rank 2 A, or
   // static, identical shaped broadcasting size A & B.
   // Implementation here uses the efficient 2d tiling plus kernel substitution.
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXMatMulOp matMulOp,
+      ONNXMatMulOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    // Get shape.
-    ONNXMatMulOpAdaptor operandAdaptor(operands);
-    ONNXMatMulOp matMulOp = llvm::cast<ONNXMatMulOp>(op);
+    Operation *op = matMulOp.getOperation();
+    ValueRange operands = adaptor.getOperands();
     Location loc = ONNXLoc<ONNXMatMulOp>(op);
     MultiDialectBuilder<IndexExprBuilderForKrnl, MathBuilder, MemRefBuilder>
         create(rewriter, loc);
@@ -416,26 +411,26 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
     // Get the constants: zero.
     Value zero = create.math.constant(elementType, 0);
 
-    Value A(operandAdaptor.getA()), B(operandAdaptor.getB());
+    Value A(adaptor.getA()), B(adaptor.getB());
     int aRank = A.getType().cast<MemRefType>().getShape().size();
     int bRank = B.getType().cast<MemRefType>().getShape().size();
     int cRank = alloc.getType().cast<MemRefType>().getShape().size();
     if (enableTiling && aRank == 2 && bRank == 2) {
       // Optimized Matmul only when 2D and allowed to tile and unroll.
       assert(cRank == 2 && "expected IxK * KxJ = IxJ 2D result");
-      replace2x2Matmul2d(matMulOp, operandAdaptor, elementType, shapeHelper,
-          alloc, zero, rewriter, loc);
+      replace2x2Matmul2d(
+          adaptor, elementType, shapeHelper, alloc, zero, rewriter, loc);
     } else if (enableTiling && aRank == 2 && bRank > 2) {
       // Broadcasting B.
       assert(cRank == bRank && "expected IxK * *xKxJ = *xIxJ result");
-      replace2x2Matmul2dBroadcasting(matMulOp, operandAdaptor, elementType,
-          shapeHelper, /*broadcasting B*/ true,
+      replace2x2Matmul2dBroadcasting(adaptor, elementType, shapeHelper,
+          /*broadcasting B*/ true,
           /*same static broadcast*/ false, alloc, zero, rewriter, loc);
     } else if (enableTiling && aRank > 2 && bRank == 2) {
       // Broadcasting A.
       assert(cRank == aRank && "expected IxK * *xKxJ = *xIxJ result");
-      replace2x2Matmul2dBroadcasting(matMulOp, operandAdaptor, elementType,
-          shapeHelper, /*broadcasting B*/ false,
+      replace2x2Matmul2dBroadcasting(adaptor, elementType, shapeHelper,
+          /*broadcasting B*/ false,
           /*same static broadcast*/ false, alloc, zero, rewriter, loc);
     } else {
       // Test if have A and B have identical static broadcast shapes.
@@ -453,12 +448,12 @@ struct ONNXMatMulOpLowering : public ConversionPattern {
       // same logic as in replace2x2Matmul2dBroadcasting. So reuse that code.
       if (sameStaticBroadcast) {
         assert(cRank == aRank && "expected IxK * *xKxJ = *xIxJ result");
-        replace2x2Matmul2dBroadcasting(matMulOp, operandAdaptor, elementType,
-            shapeHelper, /*broadcasting B*/ true,
+        replace2x2Matmul2dBroadcasting(adaptor, elementType, shapeHelper,
+            /*broadcasting B*/ true,
             /*same static broadcast*/ true, alloc, zero, rewriter, loc);
       } else {
-        replaceGenericMatmul(matMulOp, operandAdaptor, elementType, shapeHelper,
-            alloc, zero, rewriter, loc);
+        replaceGenericMatmul(
+            adaptor, elementType, shapeHelper, alloc, zero, rewriter, loc);
       }
     }
     // Done.

--- a/src/Conversion/ONNXToKrnl/Math/RandomNormalLike.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/RandomNormalLike.cpp
@@ -24,17 +24,17 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXRandomNormalLikeOpLowering : public ConversionPattern {
+struct ONNXRandomNormalLikeOpLowering
+    : public OpConversionPattern<ONNXRandomNormalLikeOp> {
   ONNXRandomNormalLikeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXRandomNormalLikeOp::getOperationName(), 1, ctx) {}
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      : OpConversionPattern(typeConverter, ctx) {}
+  LogicalResult matchAndRewrite(ONNXRandomNormalLikeOp randOp,
+      ONNXRandomNormalLikeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = op->getLoc();
-
-    // Get the input memref:
-    ONNXRandomNormalLikeOpAdaptor operandAdaptor(operands);
-    Value input = operandAdaptor.getInput();
+    Operation *op = randOp.getOperation();
+    ValueRange operands = adaptor.getOperands();
+    Location loc = ONNXLoc<ONNXRandomNormalLikeOp>(op);
+    Value input = adaptor.getInput();
 
     // Convert the output type to MemRefType.
     Type convertedType = typeConverter->convertType(*op->result_type_begin());
@@ -67,13 +67,11 @@ struct ONNXRandomNormalLikeOpLowering : public ConversionPattern {
     }
 
     // Create the Krnl Random Normal operation:
-    ONNXRandomNormalLikeOp randomNormalLikeOp =
-        cast<ONNXRandomNormalLikeOp>(op);
-    double mean = randomNormalLikeOp.getMean().convertToDouble();
+    double mean = adaptor.getMean().convertToDouble();
     Value meanValue = create.math.constant(elementType, mean);
-    double scale = randomNormalLikeOp.getScale().convertToDouble();
+    double scale = adaptor.getScale().convertToDouble();
     Value scaleValue = create.math.constant(elementType, scale);
-    auto seed = randomNormalLikeOp.getSeed();
+    auto seed = adaptor.getSeed();
     srand(time(NULL));
     double doubleSeed = rand() % 100;
     if (seed)

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -424,8 +424,7 @@ struct ONNXReduceSumOpLowering : public OpConversionPattern<ONNXReduceSumOp> {
       // Unless noop_with_empty_axesDim is false and axesDim is
       // ShapedType::kDynamic.
       Value initVal;
-      if (axesDim == ShapedType::kDynamic &&
-          !adaptor.getNoopWithEmptyAxes()) {
+      if (axesDim == ShapedType::kDynamic && !adaptor.getNoopWithEmptyAxes()) {
         IndexExprScope axesLoopContex(&rewriter, loc);
         Value zeroIndex = create.math.constantIndex(0);
         IndexExpr axesBound0 = create.krnlIE.getShapeAsDim(axesVal, 0);

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -118,17 +118,17 @@ Value emitScalarOpFor<ONNXReduceMinOp>(ConversionPatternRewriter &rewriter,
 }
 
 template <typename ONNXReductionOp>
-struct ONNXReductionOpLowering : public ConversionPattern {
+struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
+  using OpAdaptor = typename ONNXReductionOp::Adaptor;
   bool computeMean = false;
 
   ONNXReductionOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool computeMean = false)
-      : ConversionPattern(
-            typeConverter, ONNXReductionOp::getOperationName(), 1, ctx) {
+      : OpConversionPattern<ONNXReductionOp>(typeConverter, ctx) {
     this->computeMean = computeMean;
   }
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXReductionOp reduceOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     /*
      * Condition: reduction function must be associative and commutative.
@@ -150,11 +150,14 @@ struct ONNXReductionOpLowering : public ConversionPattern {
      * }
      *
      */
-    Location loc = op->getLoc();
+    Operation *op = reduceOp.getOperation();
+    ValueRange operands = adaptor.getOperands();
+    Location loc = ONNXLoc<ONNXReductionOp>(op);
     Value input = operands[0];
     MemRefType memRefInType = input.getType().cast<MemRefType>();
     // Convert the output type to MemRefType.
-    Type convertedType = typeConverter->convertType(*op->result_type_begin());
+    Type convertedType =
+        this->typeConverter->convertType(*op->result_type_begin());
     assert(convertedType && convertedType.isa<MemRefType>() &&
            "Failed to convert type to MemRefType");
     MemRefType memRefOutType = convertedType.cast<MemRefType>();
@@ -168,7 +171,7 @@ struct ONNXReductionOpLowering : public ConversionPattern {
     // Get axes value defined by op
     // Leave empty is not defined
     std::vector<int64_t> definedAxes;
-    ArrayAttr axisAttrs = llvm::dyn_cast<ONNXReductionOp>(op).getAxesAttr();
+    ArrayAttr axisAttrs = adaptor.getAxesAttr();
     if (axisAttrs) {
       for (auto axisAttr : axisAttrs.getValue()) {
         int64_t axis = axisAttr.cast<IntegerAttr>().getInt();
@@ -190,7 +193,7 @@ struct ONNXReductionOpLowering : public ConversionPattern {
         axes.push_back(i);
 
     // KeepDims
-    auto keepdims = llvm::dyn_cast<ONNXReductionOp>(op).getKeepdims();
+    auto keepdims = adaptor.getKeepdims();
     bool isKeepdims = (keepdims == 1) ? true : false;
 
     // Get type information
@@ -326,16 +329,15 @@ struct ONNXReductionOpLowering : public ConversionPattern {
 
 // This duplicated code can be eliminated with if constexpr in c++ 17
 // Or onnx uses input for axes for all ops
-struct ONNXReduceSumOpLowering : public ConversionPattern {
+struct ONNXReduceSumOpLowering : public OpConversionPattern<ONNXReduceSumOp> {
   bool computeMean = false;
 
   ONNXReduceSumOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool computeMean = false)
-      : ConversionPattern(
-            typeConverter, ONNXReduceSumOp::getOperationName(), 1, ctx),
-        computeMean(computeMean) {}
+      : OpConversionPattern(typeConverter, ctx), computeMean(computeMean) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXReduceSumOp reduceSumOp,
+      ONNXReduceSumOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     /*
      * Condition: reduction function must be associative and commutative.
@@ -357,11 +359,11 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
      * }
      *
      */
-    Location loc = op->getLoc();
-    ONNXReduceSumOpAdaptor operandAdaptor(operands);
-    ONNXReduceSumOp reduceSumOp = cast<ONNXReduceSumOp>(op);
-    auto input = operands[0];
-    auto axesVal = operands[1];
+    Operation *op = reduceSumOp.getOperation();
+    ValueRange operands = adaptor.getOperands();
+    Location loc = ONNXLoc<ONNXReduceSumOp>(op);
+    Value input = operands[0];
+    Value axesVal = operands[1];
     auto memRefInType = input.getType().cast<MemRefType>();
     // Convert the output type to MemRefType.
     Type convertedType = typeConverter->convertType(*op->result_type_begin());
@@ -375,7 +377,7 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
         create(rewriter, loc);
 
     // KeepDims
-    int64_t keepdims = reduceSumOp.getKeepdims();
+    int64_t keepdims = adaptor.getKeepdims();
     bool isKeepdims = (keepdims == 1);
 
     // Get axes dims
@@ -394,6 +396,7 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
     Value valueOne = nullptr;
     std::map<int64_t, int64_t> outInDimMap;
 
+    // Axes is an optional input, do not use adaptor to get it.
     Value axesValue = reduceSumOp.getAxes();
     // Dynamic axes
     if (!isFromNone(axesValue) && !getONNXConstantOp(axesValue)) {
@@ -422,7 +425,7 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
       // ShapedType::kDynamic.
       Value initVal;
       if (axesDim == ShapedType::kDynamic &&
-          !reduceSumOp.getNoopWithEmptyAxes()) {
+          !adaptor.getNoopWithEmptyAxes()) {
         IndexExprScope axesLoopContex(&rewriter, loc);
         Value zeroIndex = create.math.constantIndex(0);
         IndexExpr axesBound0 = create.krnlIE.getShapeAsDim(axesVal, 0);
@@ -496,7 +499,7 @@ struct ONNXReduceSumOpLowering : public ConversionPattern {
           if (std::find(axes.begin(), axes.end(), newAxis) == axes.end())
             axes.push_back(newAxis);
         }
-      } else if (!reduceSumOp.getNoopWithEmptyAxes()) {
+      } else if (!adaptor.getNoopWithEmptyAxes()) {
         for (decltype(inRank) i = 0; i < inRank; ++i) {
           axes.push_back(i);
         }

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -19,19 +19,20 @@ using namespace mlir;
 namespace onnx_mlir {
 
 struct ONNXBatchNormalizationInferenceModeOpLowering
-    : public ConversionPattern {
+    : public OpConversionPattern<ONNXBatchNormalizationInferenceModeOp> {
   ONNXBatchNormalizationInferenceModeOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXBatchNormalizationInferenceModeOp::getOperationName(), 1,
-            ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(
+      ONNXBatchNormalizationInferenceModeOp batchnormOp,
+      ONNXBatchNormalizationInferenceModeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     // batchnorm{epsilon}(x, scale, bias, mean, variance) =
     //      scale * (x - mean) / sqrt(variance + epsilon) + bias
-    ONNXBatchNormalizationInferenceModeOpAdaptor operandAdaptor(operands);
-    Location loc = op->getLoc();
+    Operation *op = batchnormOp.getOperation();
+    Location loc = ONNXLoc<ONNXBatchNormalizationInferenceModeOp>(op);
+    ValueRange operands = adaptor.getOperands();
 
     MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder> create(
         rewriter, loc);
@@ -42,15 +43,13 @@ struct ONNXBatchNormalizationInferenceModeOpLowering
            "Failed to convert type to MemRefType");
     MemRefType memRefType = convertedType.cast<MemRefType>();
 
-    Value epsilon = create.math.constant(memRefType.getElementType(),
-        cast<ONNXBatchNormalizationInferenceModeOp>(op)
-            .getEpsilon()
-            .convertToDouble());
-    Value operand = operandAdaptor.getX();
-    Value scale = operandAdaptor.getScale();
-    Value bias = operandAdaptor.getB();
-    Value mean = operandAdaptor.getMean();
-    Value variance = operandAdaptor.getVar();
+    Value epsilon = create.math.constant(
+        memRefType.getElementType(), adaptor.getEpsilon().convertToDouble());
+    Value operand = adaptor.getX();
+    Value scale = adaptor.getScale();
+    Value bias = adaptor.getB();
+    Value mean = adaptor.getMean();
+    Value variance = adaptor.getVar();
 
     // Insert an allocation and deallocation for the result of this operation.
     Value alloc = create.mem.alignedAlloc(operand, memRefType);
@@ -137,18 +136,21 @@ struct ONNXBatchNormalizationInferenceModeOpLowering
   }
 };
 
-struct ONNXInstanceNormalizationOpLowering : public ConversionPattern {
+struct ONNXInstanceNormalizationOpLowering
+    : public OpConversionPattern<ONNXInstanceNormalizationOp> {
   ONNXInstanceNormalizationOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXInstanceNormalizationOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXInstanceNormalizationOp instanceOp,
+      ONNXInstanceNormalizationOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     // instance_normalization{epsilon}(x, scale, bias) =
     //      scale * (x - mean) / sqrt(variance + epsilon) + bias
-    ONNXInstanceNormalizationOpAdaptor operandAdaptor(operands);
-    Location loc = op->getLoc();
+    Operation *op = instanceOp.getOperation();
+    Location loc = ONNXLoc<ONNXInstanceNormalizationOp>(op);
+    ValueRange operands = adaptor.getOperands();
+
     MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MemRefBuilder,
         MathBuilder>
         create(rewriter, loc);
@@ -159,12 +161,11 @@ struct ONNXInstanceNormalizationOpLowering : public ConversionPattern {
            "Failed to convert type to MemRefType");
     MemRefType memRefType = convertedType.cast<MemRefType>();
     Type elementType = memRefType.getElementType();
-    Value epsilon = create.math.constant(elementType,
-        cast<ONNXInstanceNormalizationOp>(op).getEpsilon().convertToDouble());
-
-    Value inputMemRef = operandAdaptor.getInput();
-    Value scaleMemRef = operandAdaptor.getScale();
-    Value biasMemRef = operandAdaptor.getB();
+    Value epsilon = create.math.constant(
+        elementType, adaptor.getEpsilon().convertToDouble());
+    Value inputMemRef = adaptor.getInput();
+    Value scaleMemRef = adaptor.getScale();
+    Value biasMemRef = adaptor.getB();
 
     // Insert an allocation and deallocation for the result of this operation.
     Value resMemRef = create.mem.alignedAlloc(inputMemRef, memRefType);

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -107,7 +107,7 @@ Value OnnxToKrnlBuilder::transpose(const Value input,
 }
 
 /// Check if all operands are scalar values at compile time.
-bool hasAllScalarValues(ArrayRef<Value> values) {
+bool hasAllScalarValues(ValueRange values) {
   for (Value value : values) {
     if (value.getType().cast<ShapedType>().getRank() != 0)
       return false;

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -84,7 +84,7 @@ struct MultiDialectBuilder<OnnxToKrnlBuilder, Ts...>
 //===----------------------------------------------------------------------===//
 
 /// Check if all operands are scalar values at compile time.
-bool hasAllScalarValues(llvm::ArrayRef<mlir::Value> values);
+bool hasAllScalarValues(mlir::ValueRange values);
 
 /// Check if the value is a KrnlGlobalOp with a dense attribute of non-negative
 /// integer constants.

--- a/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
+++ b/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
@@ -203,19 +203,20 @@ static Value tryToUnflip(
   return resMemRef;
 }
 
-struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
+struct ONNXNonMaxSuppressionOpLowering
+    : public OpConversionPattern<ONNXNonMaxSuppressionOp> {
   ONNXNonMaxSuppressionOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            ONNXNonMaxSuppressionOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
   /// To understand how code is generated for NonMaxSuppression, look at the
   /// python implementation at the end of this file.
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXNonMaxSuppressionOp nmsOp,
+      ONNXNonMaxSuppressionOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    ONNXNonMaxSuppressionOp nmsOp = llvm::cast<ONNXNonMaxSuppressionOp>(op);
-    ONNXNonMaxSuppressionOpAdaptor operandAdaptor(operands);
-    Location loc = op->getLoc();
+    Operation *op = nmsOp.getOperation();
+    Location loc = ONNXLoc<ONNXNonMaxSuppressionOp>(op);
+    ValueRange operands = adaptor.getOperands();
 
     // Builder helper.
     IndexExprScope mainScope(&rewriter, loc);
@@ -237,19 +238,19 @@ struct ONNXNonMaxSuppressionOpLowering : public ConversionPattern {
 
     // Operation's operands.
     // Bounding boxes.
-    Value boxes = operandAdaptor.getBoxes();
+    Value boxes = adaptor.getBoxes();
     // Scores.
-    Value scores = operandAdaptor.getScores();
+    Value scores = adaptor.getScores();
     // Maximum number of output boxes per class.
     Value maxOutputBoxPerClass = getOptionalScalarValue(
-        rewriter, loc, operandAdaptor.getMaxOutputBoxesPerClass(), i64Type, 0);
+        rewriter, loc, adaptor.getMaxOutputBoxesPerClass(), i64Type, 0);
     // Score threshold.
     Type scoreType = scores.getType().cast<MemRefType>().getElementType();
     Value scoreTH = getOptionalScalarValue(
-        rewriter, loc, operandAdaptor.getScoreThreshold(), scoreType, 0);
+        rewriter, loc, adaptor.getScoreThreshold(), scoreType, 0);
     // IOU threshold.
     Value iouTH = getOptionalScalarValue(
-        rewriter, loc, operandAdaptor.getIouThreshold(), scoreType, 0);
+        rewriter, loc, adaptor.getIouThreshold(), scoreType, 0);
     // Mode: diagonal corners or center point.
     int64_t centerPointBox = nmsOp.getCenterPointBox();
 

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceAt.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceAt.cpp
@@ -19,25 +19,28 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXSequenceAtOpLowering : public ConversionPattern {
+struct ONNXSequenceAtOpLowering : public OpConversionPattern<ONNXSequenceAtOp> {
   ONNXSequenceAtOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXSequenceAtOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXSequenceAtOp seqOp,
+      ONNXSequenceAtOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = op->getLoc();
-    ONNXSequenceAtOpAdaptor operandAdaptor(operands);
+    Operation *op = seqOp.getOperation();
+    Location loc = ONNXLoc<ONNXSequenceAtOp>(op);
+    ValueRange operands = adaptor.getOperands();
+    Value input_sequence = adaptor.getInputSequence();
+
     MultiDialectBuilder<KrnlBuilder, MemRefBuilder> create(rewriter, loc);
     IndexExprScope IEScope(&rewriter, loc);
 
-    Value input_sequence = operandAdaptor.getInputSequence();
     Type outputMemRefType =
         input_sequence.getType().cast<MemRefType>().getElementType();
+
     auto dimSize = create.mem.dim(input_sequence, 0);
     SymbolIndexExpr boundIE(dimSize);
     IndexExpr positionIE =
-        SymbolIndexExpr(create.krnl.load(operandAdaptor.getPosition()));
+        SymbolIndexExpr(create.krnl.load(adaptor.getPosition()));
     // Handle the negative position
     IndexExpr condIE = positionIE < 0;
     IndexExpr fixedPosition = positionIE + boundIE;

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceEmpty.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceEmpty.cpp
@@ -19,14 +19,16 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXSequenceEmptyOpLowering : public ConversionPattern {
+struct ONNXSequenceEmptyOpLowering
+    : public OpConversionPattern<ONNXSequenceEmptyOp> {
   ONNXSequenceEmptyOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXSequenceEmptyOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXSequenceEmptyOp seqOp,
+      ONNXSequenceEmptyOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = op->getLoc();
+    Operation *op = seqOp.getOperation();
+    Location loc = ONNXLoc<ONNXSequenceEmptyOp>(op);
 
     // Convert the output type to MemRefType.
     Type convertedType = typeConverter->convertType(*op->result_type_begin());

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceErase.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceErase.cpp
@@ -19,33 +19,32 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXSequenceEraseOpLowering : public ConversionPattern {
+struct ONNXSequenceEraseOpLowering
+    : public OpConversionPattern<ONNXSequenceEraseOp> {
   ONNXSequenceEraseOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXSequenceEraseOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXSequenceEraseOp seqOp,
+      ONNXSequenceEraseOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
+    Operation *op = seqOp.getOperation();
+    Location loc = ONNXLoc<ONNXSequenceEraseOp>(op);
 
     // This Op creates a new sequence from the input sequence
     // with the element at the specified position erased.
-    Location loc = op->getLoc();
-    ONNXSequenceEraseOpAdaptor operandAdaptor(operands);
-    ONNXSequenceEraseOp thisOp = dyn_cast<ONNXSequenceEraseOp>(op);
     MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder> create(
         rewriter, loc);
     IndexExprScope IEScope(&rewriter, loc);
 
-    auto input_sequence = operandAdaptor.getInputSequence();
-    auto dimSize = create.mem.dim(input_sequence, 0);
+    Value input_sequence = adaptor.getInputSequence();
+    Value dimSize = create.mem.dim(input_sequence, 0);
     SymbolIndexExpr boundIE(dimSize);
 
     MemRefType outputMemRefType =
-        typeConverter->convertType(thisOp.getResult().getType())
+        typeConverter->convertType(seqOp.getResult().getType())
             .cast<MemRefType>();
-    ;
 
-    auto outputBound = boundIE - 1;
+    SymbolIndexExpr outputBound = boundIE - 1;
     Value outputBoundVal = outputBound.getValue();
     Value alloc =
         rewriter.create<KrnlSeqAllocOp>(loc, outputMemRefType, outputBoundVal);
@@ -53,15 +52,14 @@ struct ONNXSequenceEraseOpLowering : public ConversionPattern {
     // Fill the output sequence
 
     IndexExpr positionIE;
-    if (isFromNone(operandAdaptor.getPosition())) {
+    if (isFromNone(adaptor.getPosition())) {
       // Erase the end of the sequence
       positionIE = boundIE - 1;
     } else {
-      positionIE =
-          SymbolIndexExpr(create.krnl.load(operandAdaptor.getPosition()));
+      positionIE = SymbolIndexExpr(create.krnl.load(adaptor.getPosition()));
       // Handle the negative position
-      auto correctionIE = positionIE + boundIE;
-      auto conditionIE = positionIE < 0;
+      IndexExpr correctionIE = positionIE + boundIE;
+      IndexExpr conditionIE = positionIE < 0;
       positionIE = IndexExpr::select(conditionIE, correctionIE, positionIE);
     }
 
@@ -74,8 +72,8 @@ struct ONNXSequenceEraseOpLowering : public ConversionPattern {
     ValueRange firstLoopDef = createKrnl.defineLoops(1);
     createKrnl.iterateIE(firstLoopDef, firstLoopDef, lbs, ubs,
         [&](KrnlBuilder createKrnl, ValueRange indicesLoopInd) {
-          auto element = createKrnl.load(
-              operandAdaptor.getInputSequence(), indicesLoopInd[0]);
+          Value element =
+              createKrnl.load(adaptor.getInputSequence(), indicesLoopInd[0]);
           createKrnl.seqstore(element, alloc, positionIE);
           // createKrnl.store(element, alloc, indicesLoopInd[0]);
         });
@@ -88,10 +86,10 @@ struct ONNXSequenceEraseOpLowering : public ConversionPattern {
     ValueRange secondLoopDef = createKrnl.defineLoops(1);
     createKrnl.iterateIE(secondLoopDef, secondLoopDef, lbs1, ubs1,
         [&](KrnlBuilder createKrnl, ValueRange indicesLoopInd) {
-          auto element = createKrnl.load(
-              operandAdaptor.getInputSequence(), indicesLoopInd[0]);
-          auto oneIndex = create.math.constantIndex(1);
-          auto outputIndex = create.math.sub(indicesLoopInd[0], oneIndex);
+          Value element =
+              createKrnl.load(adaptor.getInputSequence(), indicesLoopInd[0]);
+          Value oneIndex = create.math.constantIndex(1);
+          Value outputIndex = create.math.sub(indicesLoopInd[0], oneIndex);
           createKrnl.seqstore(element, alloc, outputIndex);
         });
 

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceLength.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceLength.cpp
@@ -19,20 +19,22 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXSequenceLengthOpLowering : public ConversionPattern {
+struct ONNXSequenceLengthOpLowering
+    : public OpConversionPattern<ONNXSequenceLengthOp> {
   ONNXSequenceLengthOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXSequenceLengthOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXSequenceLengthOp seqOp,
+      ONNXSequenceLengthOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = op->getLoc();
-    ONNXSequenceLengthOpAdaptor operandAdaptor(operands);
+    Operation *op = seqOp.getOperation();
+    Location loc = ONNXLoc<ONNXSequenceLengthOp>(op);
+
     MultiDialectBuilder<MemRefBuilder> create(rewriter, loc);
     IndexExprScope IEScope(&rewriter, loc);
 
-    auto input = operandAdaptor.getInputSequence();
-    auto outputVal = create.mem.dim(input, 0);
+    Value input = adaptor.getInputSequence();
+    Value outputVal = create.mem.dim(input, 0);
 
     rewriter.replaceOp(op, outputVal);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
@@ -21,17 +21,19 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXConcatShapeTransposeOpLowering : public ConversionPattern {
+struct ONNXConcatShapeTransposeOpLowering
+    : public OpConversionPattern<ONNXConcatShapeTransposeOp> {
   ONNXConcatShapeTransposeOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXConcatShapeTransposeOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXConcatShapeTransposeOp concatOp,
+      ONNXConcatShapeTransposeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = op->getLoc();
-    ONNXConcatShapeTransposeOpAdaptor operandAdaptor(
-        operands, op->getAttrDictionary());
+    Operation *op = concatOp.getOperation();
+    Location loc = ONNXLoc<ONNXConcatShapeTransposeOp>(op);
+    ValueRange operands = adaptor.getOperands();
+
     MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MathBuilder,
         MemRefBuilder>
         create(rewriter, loc);
@@ -43,12 +45,12 @@ struct ONNXConcatShapeTransposeOpLowering : public ConversionPattern {
 
     // Compute concat output shape.
     unsigned numInputs = op->getNumOperands();
-    Value firstInput = operandAdaptor.getInputs().front();
+    Value firstInput = adaptor.getInputs().front();
     ArrayRef<int64_t> commonShape =
         firstInput.getType().cast<ShapedType>().getShape();
     // firstInput.getType().cast<ShapedType>().getElementType();
     uint64_t rank = commonShape.size();
-    int64_t axis = operandAdaptor.getAxis();
+    int64_t axis = adaptor.getAxis();
 
     // Negative axis means values are counted from the opposite side.
     // TODO should be in normalization pass
@@ -65,7 +67,7 @@ struct ONNXConcatShapeTransposeOpLowering : public ConversionPattern {
 
     // Handle the rest of input
     for (unsigned i = 1; i < numInputs; ++i) {
-      Value currInput = operandAdaptor.getInputs()[i];
+      Value currInput = adaptor.getInputs()[i];
       for (unsigned dim = 0; dim < rank; dim++) {
         if (dim == axis) {
           IndexExpr currentSize = create.krnlIE.getShapeAsDim(currInput, axis);
@@ -83,10 +85,10 @@ struct ONNXConcatShapeTransposeOpLowering : public ConversionPattern {
     outputConcatDims[axis] = cumulativeAxisSize;
 
     // Shape for Shape
-    int64_t start = operandAdaptor.getStart();
+    int64_t start = adaptor.getStart();
     int64_t end = rank;
-    if (operandAdaptor.getEnd().has_value()) {
-      end = operandAdaptor.getEnd().value();
+    if (adaptor.getEnd().has_value()) {
+      end = adaptor.getEnd().value();
     }
     // Handle negative
     if (start < 0)
@@ -110,7 +112,7 @@ struct ONNXConcatShapeTransposeOpLowering : public ConversionPattern {
 
     // Convert the output type to MemRefType.
     DimsExpr outputTransposeDims = shapeHelper.getOutputDims(1);
-    ArrayAttr permAttr = operandAdaptor.getPermAttr();
+    ArrayAttr permAttr = adaptor.getPermAttr();
     Type t = op->getResultTypes()[1];
     auto outputTransposeType = typeConverter->convertType(t).cast<MemRefType>();
     Value alloc =

--- a/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Constant.cpp
@@ -18,15 +18,15 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXConstantOpLowering : public ConversionPattern {
+struct ONNXConstantOpLowering : public OpConversionPattern<ONNXConstantOp> {
   ONNXConstantOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXConstantOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXConstantOp constantOp,
+      ONNXConstantOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
+    Operation *op = constantOp.getOperation();
     Location loc = ONNXLoc<ONNXConstantOp>(op);
-    auto constantOp = cast<ONNXConstantOp>(op);
 
     if (constantOp.getSparseValue().has_value())
       return emitError(loc, "Only support dense values at this time");

--- a/src/Conversion/ONNXToKrnl/Tensor/DepthToSpace.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/DepthToSpace.cpp
@@ -23,18 +23,19 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXDepthToSpaceOpLowering : public ConversionPattern {
+struct ONNXDepthToSpaceOpLowering
+    : public OpConversionPattern<ONNXDepthToSpaceOp> {
   ONNXDepthToSpaceOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXDepthToSpaceOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXDepthToSpaceOp depthToSpaceOp,
+      ONNXDepthToSpaceOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    auto spaceToDepthOp = llvm::cast<ONNXDepthToSpaceOp>(op);
-    // assert(spaceToDepthOp && "Expecting op to have type ONNXDepthToSpaceOp");
-    ONNXDepthToSpaceOpAdaptor operandAdaptor(operands);
-    Value input = operandAdaptor.getInput();
-    Location loc = op->getLoc();
+    Operation *op = depthToSpaceOp.getOperation();
+    Location loc = ONNXLoc<ONNXDepthToSpaceOp>(op);
+    ValueRange operands = adaptor.getOperands();
+    Value input = adaptor.getInput();
+
     MultiDialectBuilder<IndexExprBuilderForKrnl, OnnxToKrnlBuilder> create(
         rewriter, loc);
 
@@ -42,8 +43,8 @@ struct ONNXDepthToSpaceOpLowering : public ConversionPattern {
     ONNXDepthToSpaceOpShapeHelper shapeHelper(op, operands, &create.krnlIE);
     shapeHelper.computeShapeAndAssertOnFailure();
 
-    int64_t bs = spaceToDepthOp.getBlocksize();
-    StringRef mode = spaceToDepthOp.getMode();
+    int64_t bs = depthToSpaceOp.getBlocksize();
+    StringRef mode = depthToSpaceOp.getMode();
     assert(create.krnlIE.getShapedTypeRank(input) == 4 &&
            "Input tensor should have rank equal to 4");
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Dim.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Dim.cpp
@@ -18,19 +18,18 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXDimOpLowering : public ConversionPattern {
+struct ONNXDimOpLowering : public OpConversionPattern<ONNXDimOp> {
   ONNXDimOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXDimOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXDimOp dimOp, ONNXDimOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     // Get basic info.
-    Location loc = op->getLoc();
-    auto dimOp = llvm::dyn_cast<ONNXDimOp>(op);
-    ONNXDimOpAdaptor operandAdaptor(operands);
-    Value data = operandAdaptor.getData();
-    int64_t axis = dimOp.getAxis();
+    Operation *op = dimOp.getOperation();
+    Location loc = ONNXLoc<ONNXDimOp>(op);
+    Value data = adaptor.getData();
+    int64_t axis = adaptor.getAxis();
+
     MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MathBuilder,
         MemRefBuilder>
         create(rewriter, loc);

--- a/src/Conversion/ONNXToKrnl/Tensor/Flatten.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Flatten.cpp
@@ -49,20 +49,20 @@ Value insertAllocForFlatten(MemRefType memRefType, Location loc,
   return create.mem.alignedAlloc(memRefType, allocOperands);
 }
 
-struct ONNXFlattenOpLowering : public ConversionPattern {
+struct ONNXFlattenOpLowering : public OpConversionPattern<ONNXFlattenOp> {
   ONNXFlattenOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXFlattenOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXFlattenOp flattenOp,
+      ONNXFlattenOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
 
     // Gather info.
-    Location loc = op->getLoc();
-    ONNXFlattenOp flattenOp = llvm::dyn_cast<ONNXFlattenOp>(op);
+    Operation *op = flattenOp.getOperation();
+    Location loc = ONNXLoc<ONNXFlattenOp>(op);
+    ValueRange operands = adaptor.getOperands();
 
-    ONNXFlattenOpAdaptor operandAdaptor(operands);
-    Value input = operandAdaptor.getInput();
+    Value input = adaptor.getInput();
     auto inputTy = input.getType().cast<MemRefType>();
     auto inputShape = inputTy.getShape();
     size_t inputRank = inputShape.size();

--- a/src/Conversion/ONNXToKrnl/Tensor/Identity.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Identity.cpp
@@ -18,15 +18,14 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXIdentityOpLowering : public ConversionPattern {
+struct ONNXIdentityOpLowering : public OpConversionPattern<ONNXIdentityOp> {
   ONNXIdentityOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXIdentityOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXIdentityOp identityOp,
+      ONNXIdentityOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    ONNXIdentityOpAdaptor operandAdaptor(operands);
-    rewriter.replaceOp(op, operandAdaptor.getInput());
+    rewriter.replaceOp(identityOp, adaptor.getInput());
     return success();
   }
 };

--- a/src/Conversion/ONNXToKrnl/Tensor/LayoutTransform.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/LayoutTransform.cpp
@@ -20,18 +20,19 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXLayoutTransformOpLowering : public ConversionPattern {
+struct ONNXLayoutTransformOpLowering
+    : public OpConversionPattern<ONNXLayoutTransformOp> {
   ONNXLayoutTransformOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXLayoutTransformOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXLayoutTransformOp layoutOp,
+      ONNXLayoutTransformOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    ONNXLayoutTransformOpAdaptor operandAdaptor(operands);
-    Location loc = op->getLoc();
+    Operation *op = layoutOp.getOperation();
+    Location loc = ONNXLoc<ONNXLayoutTransformOp>(op);
 
     // Operands and attributes.
-    Value data = operandAdaptor.getData();
+    Value data = adaptor.getData();
 
     // Convert the input type to MemRefType.
     Type inConvertedType = typeConverter->convertType(data.getType());

--- a/src/Conversion/ONNXToKrnl/Tensor/OneHot.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/OneHot.cpp
@@ -19,17 +19,19 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXOneHotOpLowering : public ConversionPattern {
+struct ONNXOneHotOpLowering : public OpConversionPattern<ONNXOneHotOp> {
   ONNXOneHotOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXOneHotOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXOneHotOp onehotOp,
+      ONNXOneHotOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    ONNXOneHotOpAdaptor operandAdaptor(operands);
-    Location loc = op->getLoc();
-    Value indices = operandAdaptor.getIndices();
-    Value values = operandAdaptor.getValues();
+    Operation *op = onehotOp.getOperation();
+    Location loc = ONNXLoc<ONNXOneHotOp>(op);
+    ValueRange operands = adaptor.getOperands();
+    Value indices = adaptor.getIndices();
+    Value values = adaptor.getValues();
+
     MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MemRefBuilder>
         create(rewriter, loc);
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
@@ -19,20 +19,19 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXPadOpLowering : public ConversionPattern {
+struct ONNXPadOpLowering : public OpConversionPattern<ONNXPadOp> {
   ONNXPadOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXPadOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXPadOp padOp, ONNXPadOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     // Gather info.
-    Location loc = op->getLoc();
-    ONNXPadOp padOp = llvm::dyn_cast<ONNXPadOp>(op);
-    ONNXPadOpAdaptor operandAdaptor(operands);
-    Value data = operandAdaptor.getData();
-    Value constantValue = operandAdaptor.getConstantValue();
-    StringRef padMode = padOp.getMode();
+    Operation *op = padOp.getOperation();
+    Location loc = ONNXLoc<ONNXPadOp>(op);
+    ValueRange operands = adaptor.getOperands();
+    Value data = adaptor.getData();
+    Value constantValue = adaptor.getConstantValue();
+    StringRef padMode = adaptor.getMode();
 
     // Builder helper.
     MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MathBuilder,

--- a/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
@@ -19,15 +19,14 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXRangeOpLowering : public ConversionPattern {
+struct ONNXRangeOpLowering : public OpConversionPattern<ONNXRangeOp> {
   ONNXRangeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXRangeOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXRangeOp rangeOp, ONNXRangeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    ONNXRangeOpAdaptor operandAdaptor(operands);
-    Location loc = op->getLoc();
+    Operation *op = rangeOp.getOperation();
+    Location loc = ONNXLoc<ONNXRangeOp>(op);
 
     // Create an index expression scope.
     // Scope for krnl ops
@@ -36,9 +35,9 @@ struct ONNXRangeOpLowering : public ConversionPattern {
         create(rewriter, loc);
     IndexExprScope ieScope(create.krnl);
 
-    Value start = operandAdaptor.getStart();
-    Value limit = operandAdaptor.getLimit();
-    Value delta = operandAdaptor.getDelta();
+    Value start = adaptor.getStart();
+    Value limit = adaptor.getLimit();
+    Value delta = adaptor.getDelta();
 
     auto startShape = start.getType().cast<MemRefType>().getShape();
     auto limitShape = limit.getType().cast<MemRefType>().getShape();

--- a/src/Conversion/ONNXToKrnl/Tensor/Reshape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Reshape.cpp
@@ -22,16 +22,17 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXReshapeOpLowering : public ConversionPattern {
+struct ONNXReshapeOpLowering : public OpConversionPattern<ONNXReshapeOp> {
   ONNXReshapeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXReshapeOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXReshapeOp reshapeOp,
+      ONNXReshapeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    ONNXReshapeOpAdaptor operandAdaptor(operands);
-    Location loc = op->getLoc();
-    Value data = operandAdaptor.getData();
+    Operation *op = reshapeOp.getOperation();
+    Location loc = ONNXLoc<ONNXReshapeOp>(op);
+    ValueRange operands = adaptor.getOperands();
+    Value data = adaptor.getData();
 
     // Convert the output type to MemRefType.
     Type convertedType = typeConverter->convertType(*op->result_type_begin());

--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -19,18 +19,18 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXResizeOpLowering : public ConversionPattern {
+struct ONNXResizeOpLowering : public OpConversionPattern<ONNXResizeOp> {
   ONNXResizeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXResizeOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXResizeOp resizeOp,
+      ONNXResizeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     // Gather info.
-    Location loc = op->getLoc();
-    ONNXResizeOp resizeOp = llvm::cast<ONNXResizeOp>(op);
-    ONNXResizeOpAdaptor operandAdaptor(operands);
-    Value data = operandAdaptor.getX();
+    Operation *op = resizeOp.getOperation();
+    Location loc = ONNXLoc<ONNXResizeOp>(op);
+    ValueRange operands = adaptor.getOperands();
+    Value data = adaptor.getX();
 
     // Convert the output type to MemRefType.
     Type convertedType = typeConverter->convertType(*op->result_type_begin());

--- a/src/Conversion/ONNXToKrnl/Tensor/ScatterND.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ScatterND.cpp
@@ -19,20 +19,20 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXScatterNDOpLowering : public ConversionPattern {
+struct ONNXScatterNDOpLowering : public OpConversionPattern<ONNXScatterNDOp> {
   ONNXScatterNDOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, ONNXScatterNDOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXScatterNDOp scatterNDOp,
+      ONNXScatterNDOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    ONNXScatterNDOpAdaptor operandAdaptor(operands);
-    Location loc = op->getLoc();
+    Operation *op = scatterNDOp.getOperation();
+    Location loc = ONNXLoc<ONNXScatterNDOp>(op);
 
     // Operands and attributes.
-    Value data = operandAdaptor.getData();
-    Value updates = operandAdaptor.getUpdates();
-    Value indices = operandAdaptor.getIndices();
+    Value data = adaptor.getData();
+    Value updates = adaptor.getUpdates();
+    Value indices = adaptor.getIndices();
     auto dataType = data.getType().cast<ShapedType>();
     auto indicesType = indices.getType().cast<ShapedType>();
     auto updatesType = updates.getType().cast<ShapedType>();

--- a/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
@@ -20,14 +20,16 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXShapeOpLowering : public ConversionPattern {
+struct ONNXShapeOpLowering : public OpConversionPattern<ONNXShapeOp> {
   ONNXShapeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXShapeOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXShapeOp shapeOp, ONNXShapeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    Location loc = op->getLoc();
+    Operation *op = shapeOp.getOperation();
+    Location loc = ONNXLoc<ONNXShapeOp>(op);
+    ValueRange operands = adaptor.getOperands();
+
     MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MathBuilder,
         MemRefBuilder>
         create(rewriter, loc);

--- a/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
@@ -18,21 +18,21 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXSizeOpLowering : public ConversionPattern {
+struct ONNXSizeOpLowering : public OpConversionPattern<ONNXSizeOp> {
   ONNXSizeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXSizeOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXSizeOp sizeOp, ONNXSizeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
     // Gather info.
-    Location loc = op->getLoc();
-    ONNXSizeOp sizeOp = cast<ONNXSizeOp>(op);
+    Operation *op = sizeOp.getOperation();
+    Location loc = ONNXLoc<ONNXSizeOp>(op);
+    ValueRange operands = adaptor.getOperands();
+
     MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder> create(
         rewriter, loc);
 
-    ONNXSizeOpAdaptor operandAdaptor(operands);
-    Value data = operandAdaptor.getData();
+    Value data = adaptor.getData();
     ArrayRef<int64_t> dataShape = data.getType().cast<MemRefType>().getShape();
     Value resultOperand = sizeOp.getSize();
 

--- a/src/Conversion/ONNXToKrnl/Tensor/SpaceToDepth.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/SpaceToDepth.cpp
@@ -23,17 +23,17 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-struct ONNXSpaceToDepthOpLowering : public ConversionPattern {
+struct ONNXSpaceToDepthOpLowering
+    : public OpConversionPattern<ONNXSpaceToDepthOp> {
   ONNXSpaceToDepthOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, ONNXSpaceToDepthOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXSpaceToDepthOp spaceToDepthOp,
+      ONNXSpaceToDepthOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    auto spaceToDepthOp = dyn_cast_or_null<ONNXSpaceToDepthOp>(op);
-    assert(spaceToDepthOp && "Expecting op to have type ONNXSpaceToDepthOp");
-    ONNXSpaceToDepthOpAdaptor operandAdaptor(operands, op->getAttrDictionary());
-    Location loc = spaceToDepthOp.getLoc();
+    Operation *op = spaceToDepthOp.getOperation();
+    Location loc = ONNXLoc<ONNXSpaceToDepthOp>(op);
+    ValueRange operands = adaptor.getOperands();
 
     MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, OnnxToKrnlBuilder,
         MathBuilder>
@@ -43,8 +43,8 @@ struct ONNXSpaceToDepthOpLowering : public ConversionPattern {
     ONNXSpaceToDepthOpShapeHelper shapeHelper(op, operands, &create.krnlIE);
     shapeHelper.computeShapeAndAssertOnFailure();
 
-    Value input = operandAdaptor.getInput();
-    int64_t bs = operandAdaptor.getBlocksize();
+    Value input = adaptor.getInput();
+    int64_t bs = adaptor.getBlocksize();
 
     // Compute the new dimensions.
     assert(create.krnlIE.getShapedTypeRank(input) == 4 &&

--- a/src/Conversion/ONNXToKrnl/Tensor/Squeeze.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Squeeze.cpp
@@ -19,15 +19,15 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-template <typename OP_TYPE>
-LogicalResult ONNXSqueezeOpLoweringCommon(Operation *op,
-    ArrayRef<Value> operands, ConversionPatternRewriter &rewriter,
-    TypeConverter *typeConverter) {
-  typename OP_TYPE::Adaptor operandAdaptor(operands);
+template <typename OP_TYPE, typename OP_ADAPTOR>
+LogicalResult ONNXSqueezeOpLoweringCommon(OP_TYPE squeezeOp, OP_ADAPTOR adaptor,
+    ConversionPatternRewriter &rewriter, TypeConverter *typeConverter) {
+  Operation *op = squeezeOp.getOperation();
+  Location loc = ONNXLoc<OP_TYPE>(op);
+  ValueRange operands = adaptor.getOperands();
 
-  Location loc = op->getLoc();
   IndexExprBuilderForKrnl createIE(rewriter, loc);
-  Value data = operandAdaptor.getData();
+  Value data = adaptor.getData();
 
   // Convert the output type to MemRefType.
   Type convertedType = typeConverter->convertType(*op->result_type_begin());
@@ -45,27 +45,27 @@ LogicalResult ONNXSqueezeOpLoweringCommon(Operation *op,
   return success();
 }
 
-struct ONNXSqueezeOpLowering : public ConversionPattern {
+struct ONNXSqueezeOpLowering : public OpConversionPattern<ONNXSqueezeOp> {
   ONNXSqueezeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXSqueezeOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXSqueezeOp squeezeOp,
+      ONNXSqueezeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    return ONNXSqueezeOpLoweringCommon<ONNXSqueezeOp>(
-        op, operands, rewriter, typeConverter);
+    return ONNXSqueezeOpLoweringCommon<ONNXSqueezeOp, ONNXSqueezeOpAdaptor>(
+        squeezeOp, adaptor, rewriter, typeConverter);
   }
 };
 
-struct ONNXSqueezeV11OpLowering : public ConversionPattern {
+struct ONNXSqueezeV11OpLowering : public OpConversionPattern<ONNXSqueezeV11Op> {
   ONNXSqueezeV11OpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXSqueezeV11Op::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXSqueezeV11Op squeezeOp,
+      ONNXSqueezeV11OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    return ONNXSqueezeOpLoweringCommon<ONNXSqueezeV11Op>(
-        op, operands, rewriter, typeConverter);
+    return ONNXSqueezeOpLoweringCommon<ONNXSqueezeV11Op,
+        ONNXSqueezeV11OpAdaptor>(squeezeOp, adaptor, rewriter, typeConverter);
   }
 };
 

--- a/src/Conversion/ONNXToKrnl/Tensor/Unsqueeze.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Unsqueeze.cpp
@@ -19,16 +19,16 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
-template <typename OP_TYPE>
-LogicalResult ONNXUnsqueezeOpLoweringCommon(Operation *op,
-    ArrayRef<Value> operands, ConversionPatternRewriter &rewriter,
+template <typename OP_TYPE, typename OP_ADAPTOR>
+LogicalResult ONNXUnsqueezeOpLoweringCommon(OP_TYPE unsqueezeOp,
+    OP_ADAPTOR adaptor, ConversionPatternRewriter &rewriter,
     TypeConverter *typeConverter) {
-  typename OP_TYPE::Adaptor operandAdaptor(operands);
-  // Op unsqueezeOp = dyn_cast_or_null<Op>(op);
+  Operation *op = unsqueezeOp.getOperation();
+  Location loc = ONNXLoc<OP_TYPE>(op);
+  ValueRange operands = adaptor.getOperands();
 
-  Location loc = op->getLoc();
   IndexExprBuilderForKrnl createIE(rewriter, loc);
-  Value data = operandAdaptor.getData();
+  Value data = adaptor.getData();
 
   // Convert the output type to MemRefType.
   Type convertedType = typeConverter->convertType(*op->result_type_begin());
@@ -47,27 +47,29 @@ LogicalResult ONNXUnsqueezeOpLoweringCommon(Operation *op,
   return success();
 }
 
-struct ONNXUnsqueezeOpLowering : public ConversionPattern {
+struct ONNXUnsqueezeOpLowering : public OpConversionPattern<ONNXUnsqueezeOp> {
   ONNXUnsqueezeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(
-            typeConverter, mlir::ONNXUnsqueezeOp::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXUnsqueezeOp unsqueezeOp,
+      ONNXUnsqueezeOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    return ONNXUnsqueezeOpLoweringCommon<ONNXUnsqueezeOp>(
-        op, operands, rewriter, typeConverter);
+    return ONNXUnsqueezeOpLoweringCommon<ONNXUnsqueezeOp,
+        ONNXUnsqueezeOpAdaptor>(unsqueezeOp, adaptor, rewriter, typeConverter);
   }
 };
 
-struct ONNXUnsqueezeV11OpLowering : public ConversionPattern {
+struct ONNXUnsqueezeV11OpLowering
+    : public OpConversionPattern<ONNXUnsqueezeV11Op> {
   ONNXUnsqueezeV11OpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter,
-            mlir::ONNXUnsqueezeV11Op::getOperationName(), 1, ctx) {}
+      : OpConversionPattern(typeConverter, ctx) {}
 
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+  LogicalResult matchAndRewrite(ONNXUnsqueezeV11Op unsqueezeOp,
+      ONNXUnsqueezeV11OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    return ONNXUnsqueezeOpLoweringCommon<ONNXUnsqueezeV11Op>(
-        op, operands, rewriter, typeConverter);
+    return ONNXUnsqueezeOpLoweringCommon<ONNXUnsqueezeV11Op,
+        ONNXUnsqueezeV11OpAdaptor>(
+        unsqueezeOp, adaptor, rewriter, typeConverter);
   }
 };
 

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -92,7 +92,7 @@ static void refineDims(DimsExpr &inferredDims, Value output) {
 //===----------------------------------------------------------------------===//
 
 ONNXOpShapeHelper::ONNXOpShapeHelper(Operation *inputOp,
-    ArrayRef<Value> inputOperands, IndexExprBuilder *inputIeBuilder,
+    ValueRange inputOperands, IndexExprBuilder *inputIeBuilder,
     IndexExprScope *inputScope)
     : op(inputOp), operands(inputOperands), createIE(inputIeBuilder),
       scope(inputScope), privateOutputsDims(), ownScope(inputScope == nullptr),
@@ -114,7 +114,7 @@ ONNXOpShapeHelper::ONNXOpShapeHelper(Operation *inputOp,
     // could not find one at this time.
     privateOperandsCache = llvm::SmallVector<Value, 4>(
         op->getOperands().begin(), op->getOperands().end());
-    operands = ArrayRef<Value>(privateOperandsCache);
+    operands = ValueRange(privateOperandsCache);
   }
 }
 
@@ -227,7 +227,7 @@ LogicalResult ONNXOpShapeHelper::computeShapeAndUpdateTypes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXBroadcastOpShapeHelper::customComputeShape(
-    ArrayRef<Value> initialOperands, DimsExpr *additionalOperand) {
+    ValueRange initialOperands, DimsExpr *additionalOperand) {
   // if additionalOperand is not used, we expect a zero-sized vector.
   // A temporary IndexExpr vector for the output.
   DimsExpr dimsExpr;

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
@@ -69,8 +69,7 @@ void resetTypesShapeToQuestionmarks(mlir::Operation *op);
 //===----------------------------------------------------------------------===//
 
 struct ONNXUnimplementedOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXUnimplementedOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXUnimplementedOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXUnimplementedOpShapeHelper() {}
@@ -111,8 +110,7 @@ using ONNXSplitToSequenceOpShapeHelper = ONNXUnimplementedOpShapeHelper; // Reas
 /// Compute an output shape for a unary element-wise operation. The output and
 /// input of an unary element-wise operation have the same shape.
 struct ONNXUnaryOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXUnaryOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXUnaryOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXUnaryOpShapeHelper() {}
@@ -200,8 +198,7 @@ using ONNXTriluOpShapeHelper = ONNXUnaryOpShapeHelper;
 // Compute a broadcasted shape from the shapes of given operands. Operands must
 // be ranked in advance.
 struct ONNXBroadcastOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXBroadcastOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXBroadcastOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr,
       bool hasUniBroadcasting = false, bool hasNoBroadcasting = false)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope), inputsDims(),
@@ -211,7 +208,7 @@ struct ONNXBroadcastOpShapeHelper : public ONNXOpShapeHelper {
 
   // Custom shape compute which takes additional parameters.
   mlir::LogicalResult customComputeShape(
-      mlir::ArrayRef<mlir::Value> initialOperands, DimsExpr *additionalOperand);
+      mlir::ValueRange initialOperands, DimsExpr *additionalOperand);
 
   // Default shape compute (every operands of the operation and no additional
   // parameters).
@@ -276,8 +273,7 @@ using ONNXXorOpShapeHelper = ONNXBroadcastOpShapeHelper;
 
 // Helper for ExpandOp
 struct ONNXExpandOpShapeHelper : public ONNXBroadcastOpShapeHelper {
-  ONNXExpandOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXExpandOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXBroadcastOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXExpandOpShapeHelper() {}
@@ -286,8 +282,7 @@ struct ONNXExpandOpShapeHelper : public ONNXBroadcastOpShapeHelper {
 
 // Helper for ONNXPReluOp
 struct ONNXPReluOpShapeHelper : public ONNXBroadcastOpShapeHelper {
-  ONNXPReluOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXPReluOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXBroadcastOpShapeHelper(op, operands, ieBuilder, scope,
             /*hasUniBroadcasting*/ true) {}
@@ -302,8 +297,7 @@ struct ONNXPReluOpShapeHelper : public ONNXBroadcastOpShapeHelper {
 //===----------------------------------------------------------------------===//
 
 struct ONNXShapeOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXShapeOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXShapeOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope), start(-1), end(-1) {}
   virtual ~ONNXShapeOpShapeHelper() {}
@@ -325,8 +319,7 @@ struct ONNXShapeOpShapeHelper : public ONNXOpShapeHelper {
 // Generic pool shape helper.
 template <typename OP_TYPE>
 struct ONNXGenericPoolOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXGenericPoolOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXGenericPoolOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXGenericPoolOpShapeHelper() {}
@@ -362,8 +355,7 @@ using ONNXMaxPoolSingleOutOpShapeHelper = ONNXGenericPoolOpShapeHelper<mlir::ONN
 //===----------------------------------------------------------------------===//
 
 struct ONNXConvTransposeOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXConvTransposeOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXConvTransposeOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope), kernelShape(),
         pads(), strides(), dilations(), outputPadding(), dimsNoOutputPadding() {
@@ -386,8 +378,8 @@ struct ONNXConvTransposeOpShapeHelper : public ONNXOpShapeHelper {
 template <typename OP_TYPE>
 struct ONNXGenericGlobalPoolOpShapeHelper : public ONNXOpShapeHelper {
   ONNXGenericGlobalPoolOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
-      IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
+      mlir::ValueRange operands, IndexExprBuilder *ieBuilder = nullptr,
+      IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXGenericGlobalPoolOpShapeHelper() {}
   mlir::LogicalResult computeShape() final;
@@ -404,8 +396,7 @@ using ONNXGlobalMaxPoolOpShapeHelper = ONNXGenericGlobalPoolOpShapeHelper<mlir::
 //===----------------------------------------------------------------------===//
 
 struct ONNXSliceOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXSliceOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXSliceOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope){};
   virtual ~ONNXSliceOpShapeHelper() {}
@@ -419,8 +410,7 @@ struct ONNXSliceOpShapeHelper : public ONNXOpShapeHelper {
 //===----------------------------------------------------------------------===//
 
 struct ONNXGemmOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXGemmOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXGemmOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope), aDims(), bDims(),
         cDims(), hasBias(/*dummy value*/ false), cRank(-1) {}
@@ -440,8 +430,7 @@ struct ONNXGemmOpShapeHelper : public ONNXOpShapeHelper {
 
 template <typename OP_TYPE>
 struct ONNXGenericMatMulOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXGenericMatMulOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXGenericMatMulOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope), aDims(), bDims(),
         aPadDims(), bPadDims() {}
@@ -465,8 +454,7 @@ using ONNXQLinearMatMulOpShapeHelper = ONNXGenericMatMulOpShapeHelper<mlir::ONNX
 //===----------------------------------------------------------------------===//
 
 struct ONNXPadOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXPadOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXPadOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope), pads() {}
   virtual ~ONNXPadOpShapeHelper() {}
@@ -480,8 +468,7 @@ struct ONNXPadOpShapeHelper : public ONNXOpShapeHelper {
 //===----------------------------------------------------------------------===//
 
 struct ONNXOneHotOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXOneHotOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXOneHotOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope), axis(-1), depth() {}
   virtual ~ONNXOneHotOpShapeHelper() {}
@@ -496,8 +483,7 @@ struct ONNXOneHotOpShapeHelper : public ONNXOpShapeHelper {
 //===----------------------------------------------------------------------===//
 
 struct ONNXRoiAlignOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXRoiAlignOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXRoiAlignOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope), xDims(),
         batchIndicesDims() {}
@@ -516,8 +502,7 @@ struct ONNXRoiAlignOpShapeHelper : public ONNXOpShapeHelper {
 // respective identical operand adaptor, so specialize with templated code.
 template <typename OP_TYPE>
 struct ONNXArgMinMaxOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXArgMinMaxOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXArgMinMaxOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXArgMinMaxOpShapeHelper() {}
@@ -537,8 +522,7 @@ using ONNXArgMinOpShapeHelper = ONNXArgMinMaxOpShapeHelper<mlir::ONNXArgMinOp>;
 // templated code.
 template <typename OP_TYPE>
 struct ONNXCommonSplitOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXCommonSplitOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXCommonSplitOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXCommonSplitOpShapeHelper() {}
@@ -561,8 +545,7 @@ using ONNXSplitV11OpShapeHelper = ONNXCommonSplitOpShapeHelper<mlir::ONNXSplitV1
 // templated code.
 template <typename OP_TYPE>
 struct ONNXCommonSqueezeOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXCommonSqueezeOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXCommonSqueezeOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXCommonSqueezeOpShapeHelper() {}
@@ -591,8 +574,8 @@ using ONNXSqueezeV11OpShapeHelper = ONNXCommonSqueezeOpShapeHelper<mlir::ONNXSqu
 template <typename OP_TYPE>
 struct ONNXCommonUnsqueezeOpShapeHelper : public ONNXOpShapeHelper {
   ONNXCommonUnsqueezeOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
-      IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
+      mlir::ValueRange operands, IndexExprBuilder *ieBuilder = nullptr,
+      IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXCommonUnsqueezeOpShapeHelper() {}
   mlir::LogicalResult computeShape() final;
@@ -618,8 +601,8 @@ using ONNXUnsqueezeV11OpShapeHelper = ONNXCommonUnsqueezeOpShapeHelper<mlir::ONN
 template <typename OP_TYPE>
 struct ONNXGenericReductionOpShapeHelper : public ONNXOpShapeHelper {
   ONNXGenericReductionOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
-      IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
+      mlir::ValueRange operands, IndexExprBuilder *ieBuilder = nullptr,
+      IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXGenericReductionOpShapeHelper() {}
   mlir::LogicalResult computeShape() final;
@@ -651,8 +634,7 @@ using ONNXReduceSumSquareOpShapeHelper = ONNXGenericReductionOpShapeHelper<mlir:
 // Generic Reduction shape helper.
 template <typename OP_TYPE>
 struct ONNXGenericRNNShapeHelper : public ONNXOpShapeHelper {
-  ONNXGenericRNNShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXGenericRNNShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXGenericRNNShapeHelper() {}
@@ -675,8 +657,7 @@ using ONNXRNNOpShapeHelper = ONNXGenericRNNShapeHelper<mlir::ONNXRNNOp>;
 //===----------------------------------------------------------------------===//
 
 struct ONNXResizeOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXResizeOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXResizeOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXResizeOpShapeHelper() {}
@@ -705,8 +686,7 @@ struct ONNXResizeOpShapeHelper : public ONNXOpShapeHelper {
 
 template <typename OP_TYPE>
 struct ONNXNonSpecificOpShapeHelper : public ONNXOpShapeHelper {
-  ONNXNonSpecificOpShapeHelper(mlir::Operation *op,
-      mlir::ArrayRef<mlir::Value> operands,
+  ONNXNonSpecificOpShapeHelper(mlir::Operation *op, mlir::ValueRange operands,
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr)
       : ONNXOpShapeHelper(op, operands, ieBuilder, scope) {}
   virtual ~ONNXNonSpecificOpShapeHelper() {}

--- a/src/Interface/ShapeHelperOpInterface.hpp
+++ b/src/Interface/ShapeHelperOpInterface.hpp
@@ -79,8 +79,8 @@ struct ONNXOpShapeHelper {
    directly enclosing scope vanishes).
    */
 
-  ONNXOpShapeHelper(mlir::Operation *op,    /* Op to be analyzed. */
-      mlir::ArrayRef<mlir::Value> operands, /* If empty, use operands from op.*/
+  ONNXOpShapeHelper(mlir::Operation *op, /* Op to be analyzed. */
+      mlir::ValueRange operands,         /* If empty, use operands from op.*/
       IndexExprBuilder *ieBuilder, /* Use IndexExprBuilderForAnalysis if null.*/
       IndexExprScope *scope);      /* Install local scope if null. */
   virtual ~ONNXOpShapeHelper();
@@ -137,7 +137,7 @@ protected:
   // Data that must be present for every ShapeHelper operation. Op and scope
   // are initialized in the constructor.
   mlir::Operation *op;
-  mlir::ArrayRef<mlir::Value> operands;
+  mlir::ValueRange operands;
   IndexExprBuilder *createIE;
   IndexExprScope *scope;
 


### PR DESCRIPTION
This patch replaces ConversionPattern by OpConversionPattern used in ONNXToKrnl, which is more convenient because OpAdaptor is available to use without explicitly construction.

ONNXLoc is used to annotate more bug information (e.g. operation name) into Location, instead of using the bare location via `op->getLoc`. Now all lowerings from ONNX to Krnl are using ONNXLoc.

Replacement for other lowerings for Krnl, ZHigh, ZLow will come next.