### PR TITLE
Fix duplicated symbol errors in KrnlToLLVM conversion.

### DIFF
--- a/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.cpp
@@ -182,7 +182,8 @@ LLVM::GlobalOp getOrCreateGlobalString(StringRef str, Location loc,
     OpBuilder &builder, ModuleOp module, LLVMTypeConverter *typeConverter) {
   MultiDialectBuilder<LLVMBuilder> create(builder, loc);
   assert(typeConverter && "Expecting a valid LLVM type converter");
-  LLVM::GlobalOp global = module.lookupSymbol<LLVM::GlobalOp>(str);
+  LLVM::GlobalOp global =
+      module.lookupSymbol<LLVM::GlobalOp>("om_" + str.str());
   if (!global) {
     // Create the global at the entry of the module.
     OpBuilder::InsertionGuard insertGuard(builder);
@@ -191,7 +192,7 @@ LLVM::GlobalOp getOrCreateGlobalString(StringRef str, Location loc,
     Type i8Type = IntegerType::get(builder.getContext(), 8);
     Type type = LLVM::LLVMArrayType::get(i8Type, str.size());
     global = create.llvm.globalOp(type, /*isConstant=*/true,
-        LLVM::Linkage::Internal, str, builder.getStringAttr(str));
+        LLVM::Linkage::Internal, "om_" + str.str(), builder.getStringAttr(str));
 
     krnl::setAlignment(global, nullptr, module, builder, *typeConverter);
   }

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -51,7 +51,7 @@ static void refineDims(DimsExpr &inferredDims, Value output) {
 
   // Try to update inferredDim if existingDim is static.
   for (unsigned i = 0; i < existingDims.size(); ++i) {
-    // Sanity checks for old convention of using -1 for dynamic.
+    // Safety checks for old convention of using -1 for dynamic.
     assert(existingDims[i] != -1 && "dynamic use kDynamic now");
     if (inferredDims[i].isLiteral()) {
       // Index expressions should not use the ShapedType::kDynamic ever to
@@ -75,7 +75,7 @@ static void refineDims(DimsExpr &inferredDims, Value output) {
       continue;
     }
     // inferredDim is different from existingDim. Believe in existingDim.
-    assert(inferredDims[i].isLiteral() && "sanity");
+    assert(inferredDims[i].isLiteral() && "isLiteral failed");
     if (existingDims[i] != inferredDims[i].getLiteral()) {
       // Warning for users.
       llvm::outs() << "Warning: [Shape inference, dim " << i

--- a/test/mlir/krnl/input_verification.mlir
+++ b/test/mlir/krnl/input_verification.mlir
@@ -20,7 +20,7 @@ module {
 // CHECK:           %[[VAL_3:.*]] = llvm.icmp "ne" %[[CONST_2]], %[[VAL_2]] : i64
 // CHECK:           llvm.cond_br %[[VAL_3]], ^bb1, ^bb2
 // CHECK:         ^bb1:
-// CHECK:           %[[VAL_4:.*]] = llvm.mlir.addressof @"Wrong number of input tensors: expect 2, but got {{\%}}lld\0A" : !llvm.ptr<array<54 x i8>>
+// CHECK:           %[[VAL_4:.*]] = llvm.mlir.addressof @"om_Wrong number of input tensors: expect 2, but got {{\%}}lld\0A" : !llvm.ptr<array<54 x i8>>
 // CHECK:           %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]][0, 0] : (!llvm.ptr<array<54 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_6]], %[[VAL_2]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_7:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -35,7 +35,7 @@ module {
 // CHECK:           %[[VAL_14:.*]] = llvm.icmp "ne" %[[CONST_1]], %[[VAL_13]] : i64
 // CHECK:           llvm.cond_br %[[VAL_14]], ^bb3, ^bb4
 // CHECK:         ^bb3:
-// CHECK-DAG:       %[[VAL_15:.*]] = llvm.mlir.addressof @"Wrong data type for the input 0: expect f32\0A" : !llvm.ptr<array<44 x i8>>
+// CHECK-DAG:       %[[VAL_15:.*]] = llvm.mlir.addressof @"om_Wrong data type for the input 0: expect f32\0A" : !llvm.ptr<array<44 x i8>>
 // CHECK-DAG:       %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_15]][0, 0] : (!llvm.ptr<array<44 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_17]]) : (!llvm.ptr<i8>) -> ()
 // CHECK-DAG:       %[[VAL_18:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -48,7 +48,7 @@ module {
 // CHECK:           %[[VAL_23:.*]] = llvm.icmp "ne" %[[CONST_3]], %[[VAL_22]] : i64
 // CHECK:           llvm.cond_br %[[VAL_23]], ^bb5, ^bb6
 // CHECK:         ^bb5:
-// CHECK-DAG:       %[[VAL_24:.*]] = llvm.mlir.addressof @"Wrong rank for the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
+// CHECK-DAG:       %[[VAL_24:.*]] = llvm.mlir.addressof @"om_Wrong rank for the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
 // CHECK-DAG:       %[[VAL_26:.*]] = llvm.getelementptr %[[VAL_24]][0, 0] : (!llvm.ptr<array<51 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_26]], %[[VAL_22]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_27:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -62,7 +62,7 @@ module {
 // CHECK-DAG:       %[[VAL_33:.*]] = llvm.icmp "ne" %[[CONST_3]], %[[VAL_31]] : i64
 // CHECK:           llvm.cond_br %[[VAL_33]], ^bb7, ^bb8
 // CHECK:         ^bb7:
-// CHECK-DAG:       %[[VAL_34:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 0 of the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
+// CHECK-DAG:       %[[VAL_34:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 0 of the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_36:.*]] = llvm.getelementptr %[[VAL_34]][0, 0] : (!llvm.ptr<array<70 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_36]], %[[VAL_31]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_37:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -76,7 +76,7 @@ module {
 // CHECK-DAG:       %[[VAL_44:.*]] = llvm.icmp "ne" %[[CONST_4]], %[[VAL_42]] : i64
 // CHECK:           llvm.cond_br %[[VAL_44]], ^bb9, ^bb10
 // CHECK:         ^bb9:
-// CHECK-DAG:       %[[VAL_45:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 1 of the input 0: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
+// CHECK-DAG:       %[[VAL_45:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 1 of the input 0: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_47:.*]] = llvm.getelementptr %[[VAL_45]][0, 0] : (!llvm.ptr<array<70 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_47]], %[[VAL_42]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_48:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -90,7 +90,7 @@ module {
 // CHECK-DAG:       %[[VAL_55:.*]] = llvm.icmp "ne" %[[CONST_5]], %[[VAL_53]] : i64
 // CHECK:           llvm.cond_br %[[VAL_55]], ^bb11, ^bb12
 // CHECK:         ^bb11:
-// CHECK-DAG:       %[[VAL_56:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 2 of the input 0: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
+// CHECK-DAG:       %[[VAL_56:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 2 of the input 0: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_58:.*]] = llvm.getelementptr %[[VAL_56]][0, 0] : (!llvm.ptr<array<70 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_58]], %[[VAL_53]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_59:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -105,7 +105,7 @@ module {
 // CHECK:           %[[VAL_67:.*]] = llvm.icmp "ne" %[[CONST_1]], %[[VAL_66]] : i64
 // CHECK:           llvm.cond_br %[[VAL_67]], ^bb13, ^bb14
 // CHECK:         ^bb13:
-// CHECK-DAG:       %[[VAL_68:.*]] = llvm.mlir.addressof @"Wrong data type for the input 1: expect f32\0A" : !llvm.ptr<array<44 x i8>>
+// CHECK-DAG:       %[[VAL_68:.*]] = llvm.mlir.addressof @"om_Wrong data type for the input 1: expect f32\0A" : !llvm.ptr<array<44 x i8>>
 // CHECK-DAG:       %[[VAL_70:.*]] = llvm.getelementptr %[[VAL_68]][0, 0] : (!llvm.ptr<array<44 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_70]]) : (!llvm.ptr<i8>) -> ()
 // CHECK-DAG:       %[[VAL_71:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -118,7 +118,7 @@ module {
 // CHECK-DAG:       %[[VAL_76:.*]] = llvm.icmp "ne" %[[CONST_3]], %[[VAL_75]] : i64
 // CHECK:           llvm.cond_br %[[VAL_76]], ^bb15, ^bb16
 // CHECK:         ^bb15:
-// CHECK-DAG:       %[[VAL_77:.*]] = llvm.mlir.addressof @"Wrong rank for the input 1: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
+// CHECK-DAG:       %[[VAL_77:.*]] = llvm.mlir.addressof @"om_Wrong rank for the input 1: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
 // CHECK-DAG:       %[[VAL_79:.*]] = llvm.getelementptr %[[VAL_77]][0, 0] : (!llvm.ptr<array<51 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_79]], %[[VAL_75]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_80:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -132,7 +132,7 @@ module {
 // CHECK-DAG:       %[[VAL_86:.*]] = llvm.icmp "slt" %[[VAL_84]], %[[CONST_0]] : i64
 // CHECK:           llvm.cond_br %[[VAL_86]], ^bb17, ^bb18
 // CHECK:         ^bb17:
-// CHECK-DAG:       %[[VAL_87:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 0 of the input 1: expect a non-negative value\0A" : !llvm.ptr<array<75 x i8>>
+// CHECK-DAG:       %[[VAL_87:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 0 of the input 1: expect a non-negative value\0A" : !llvm.ptr<array<75 x i8>>
 // CHECK-DAG:       %[[VAL_89:.*]] = llvm.getelementptr %[[VAL_87]][0, 0] : (!llvm.ptr<array<75 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_89]]) : (!llvm.ptr<i8>) -> ()
 // CHECK-DAG:       %[[VAL_90:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -146,7 +146,7 @@ module {
 // CHECK-DAG:       %[[VAL_97:.*]] = llvm.icmp "ne" %[[CONST_4]], %[[VAL_95]] : i64
 // CHECK:           llvm.cond_br %[[VAL_97]], ^bb19, ^bb20
 // CHECK:         ^bb19:
-// CHECK-DAG:       %[[VAL_98:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 1 of the input 1: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
+// CHECK-DAG:       %[[VAL_98:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 1 of the input 1: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_100:.*]] = llvm.getelementptr %[[VAL_98]][0, 0] : (!llvm.ptr<array<70 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_100]], %[[VAL_95]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_101:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
@@ -160,7 +160,7 @@ module {
 // CHECK-DAG:      %[[VAL_108:.*]] = llvm.icmp "ne" %[[CONST_5]], %[[VAL_106]] : i64
 // CHECK:           llvm.cond_br %[[VAL_108]], ^bb21, ^bb22
 // CHECK:         ^bb21:
-// CHECK-DAG:       %[[VAL_109:.*]] = llvm.mlir.addressof @"Wrong size for the dimension 2 of the input 1: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
+// CHECK-DAG:       %[[VAL_109:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 2 of the input 1: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_111:.*]] = llvm.getelementptr %[[VAL_109]][0, 0] : (!llvm.ptr<array<70 x i8>>) -> !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_111]], %[[VAL_106]]) : (!llvm.ptr<i8>, i64) -> ()
 // CHECK-DAG:       %[[VAL_112:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>

--- a/test/mlir/krnl/krnl_category_mapper.mlir
+++ b/test/mlir/krnl/krnl_category_mapper.mlir
@@ -78,20 +78,20 @@ func.func private @test_category_mapper_string_to_int64(%arg0: memref<2x2x!krnl.
   // CHECK-DAG: llvm.func @strncmp(!llvm.ptr<i8>, !llvm.ptr<i8>, i64) -> i32
   // CHECK-DAG: llvm.func @strlen(!llvm.ptr<i8>) -> i64
   // CHECK-DAG: llvm.func @find_index_str(!llvm.ptr<i8>, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i64
-  // CHECK-DAG: llvm.mlir.global internal constant @cat("cat")
-  // CHECK-DAG: llvm.mlir.global internal constant @dog("dog")
-  // CHECK-DAG: llvm.mlir.global internal constant @cow("cow")    
+  // CHECK-DAG: llvm.mlir.global internal constant @om_cat("cat")
+  // CHECK-DAG: llvm.mlir.global internal constant @om_dog("dog")
+  // CHECK-DAG: llvm.mlir.global internal constant @om_cow("cow")
   // CHECK:     llvm.mlir.global internal constant @cats_strings{{.*}}() {addr_space = 0 : i32, alignment = 16 : i64} : !llvm.array<3 x ptr<i8>> { 
   // CHECK:       [[ARRAY:%.+]] = llvm.mlir.undef : !llvm.array<3 x ptr<i8>>
-  // CHECK:       [[CAT_ADDR:%.+]] = llvm.mlir.addressof @cat : !llvm.ptr<array<3 x i8>>
+  // CHECK:       [[CAT_ADDR:%.+]] = llvm.mlir.addressof @om_cat : !llvm.ptr<array<3 x i8>>
   // CHECK:       [[ZERO:%.+]] = llvm.mlir.constant(0 : i64) : i64
   // CHECK:       [[CAT_GEP:%.+]] = llvm.getelementptr [[CAT_ADDR]]{{.*}}[[ZERO]], [[ZERO]]{{.*}} : (!llvm.ptr<array<3 x i8>>, i64, i64) -> !llvm.ptr<i8>
   // CHECK:       [[CAT_INS_VAL:%.+]] = llvm.insertvalue [[CAT_GEP]], [[ARRAY]][0] : !llvm.array<3 x ptr<i8>>
-  // CHECK:       [[DOG_ADDR:%.+]] = llvm.mlir.addressof @dog : !llvm.ptr<array<3 x i8>>
+  // CHECK:       [[DOG_ADDR:%.+]] = llvm.mlir.addressof @om_dog : !llvm.ptr<array<3 x i8>>
   // CHECK:       [[ZERO:%.+]] = llvm.mlir.constant(0 : i64) : i64  
   // CHECK:       [[DOG_GEP:%.+]] = llvm.getelementptr [[DOG_ADDR]]{{.*}}[[ZERO]], [[ZERO]]{{.*}} : (!llvm.ptr<array<3 x i8>>, i64, i64) -> !llvm.ptr<i8>
   // CHECK:       [[DOG_INS_VAL:%.+]] = llvm.insertvalue [[DOG_GEP]], [[CAT_INS_VAL]][1] : !llvm.array<3 x ptr<i8>>
-  // CHECK:       [[COW_ADDR:%.+]] = llvm.mlir.addressof @cow : !llvm.ptr<array<3 x i8>>
+  // CHECK:       [[COW_ADDR:%.+]] = llvm.mlir.addressof @om_cow : !llvm.ptr<array<3 x i8>>
   // CHECK:       [[ZERO:%.+]] = llvm.mlir.constant(0 : i64) : i64    
   // CHECK:       [[COW_GEP:%.+]] = llvm.getelementptr [[COW_ADDR]]{{.*}}[[ZERO]], [[ZERO]]{{.*}} : (!llvm.ptr<array<3 x i8>>, i64, i64) -> !llvm.ptr<i8>
   // CHECK:       [[COW_INS_VAL:%.+]] = llvm.insertvalue [[COW_GEP]], [[DOG_INS_VAL]][2] : !llvm.array<3 x ptr<i8>>
@@ -162,21 +162,21 @@ func.func private @test_category_mapper_int64_to_string(%arg0: memref<2x2xi64>) 
   return %0 : memref<2x2x!krnl.string>
 
   // CHECK-DAG:  llvm.func @find_index_i64(i64, !llvm.ptr<i32>, !llvm.ptr<i32>, i32) -> i64
-  // CHECK-DAG:  llvm.mlir.global internal constant @none("none")
-  // CHECK-DAG:  llvm.mlir.global internal constant @cat("cat")
-  // CHECK-DAG:  llvm.mlir.global internal constant @dog("dog")
-  // CHECK-DAG:  llvm.mlir.global internal constant @cow("cow")    
+  // CHECK-DAG:  llvm.mlir.global internal constant @om_none("none")
+  // CHECK-DAG:  llvm.mlir.global internal constant @om_cat("cat")
+  // CHECK-DAG:  llvm.mlir.global internal constant @om_dog("dog")
+  // CHECK-DAG:  llvm.mlir.global internal constant @om_cow("cow")    
   // CHECK:      llvm.mlir.global internal constant @cats_strings{{.*}}() {addr_space = 0 : i32, alignment = 16 : i64} : !llvm.array<3 x ptr<i8>> { 
   // CHECK:        [[ARRAY:%.+]] = llvm.mlir.undef : !llvm.array<3 x ptr<i8>>
-  // CHECK:        [[CAT_ADDR:%.+]] = llvm.mlir.addressof @cat : !llvm.ptr<array<3 x i8>>
+  // CHECK:        [[CAT_ADDR:%.+]] = llvm.mlir.addressof @om_cat : !llvm.ptr<array<3 x i8>>
   // CHECK:        [[ZERO:%.+]] = llvm.mlir.constant(0 : i64) : i64
   // CHECK:        [[CAT_GEP:%.+]] = llvm.getelementptr [[CAT_ADDR]]{{.*}}[[ZERO]], [[ZERO]]{{.*}} : (!llvm.ptr<array<3 x i8>>, i64, i64) -> !llvm.ptr<i8>
   // CHECK:        [[CAT_INS_VAL:%.+]] = llvm.insertvalue [[CAT_GEP]], [[ARRAY]][0] : !llvm.array<3 x ptr<i8>>
-  // CHECK:        [[DOG_ADDR:%.+]] = llvm.mlir.addressof @dog : !llvm.ptr<array<3 x i8>>
+  // CHECK:        [[DOG_ADDR:%.+]] = llvm.mlir.addressof @om_dog : !llvm.ptr<array<3 x i8>>
   // CHECK:        [[ZERO:%.+]] = llvm.mlir.constant(0 : i64) : i64  
   // CHECK:        [[DOG_GEP:%.+]] = llvm.getelementptr [[DOG_ADDR]]{{.*}}[[ZERO]], [[ZERO]]{{.*}} : (!llvm.ptr<array<3 x i8>>, i64, i64) -> !llvm.ptr<i8>
   // CHECK:        [[DOG_INS_VAL:%.+]] = llvm.insertvalue [[DOG_GEP]], [[CAT_INS_VAL]][1] : !llvm.array<3 x ptr<i8>>
-  // CHECK:        [[COW_ADDR:%.+]] = llvm.mlir.addressof @cow : !llvm.ptr<array<3 x i8>>
+  // CHECK:        [[COW_ADDR:%.+]] = llvm.mlir.addressof @om_cow : !llvm.ptr<array<3 x i8>>
   // CHECK:        [[ZERO:%.+]] = llvm.mlir.constant(0 : i64) : i64    
   // CHECK:        [[COW_GEP:%.+]] = llvm.getelementptr [[COW_ADDR]]{{.*}}[[ZERO]], [[ZERO]]{{.*}} : (!llvm.ptr<array<3 x i8>>, i64, i64) -> !llvm.ptr<i8>
   // CHECK:        [[COW_INS_VAL:%.+]] = llvm.insertvalue [[COW_GEP]], [[DOG_INS_VAL]][2] : !llvm.array<3 x ptr<i8>>


### PR DESCRIPTION
An error occurs with “Redefinition of symbol named free” in KrnlToLLVM conversion pass, because the current onnx-mlir generate each symbol with its corresponding string used in the onnx model. 

This PR prepends “om_”  to symbol names for string constants to avoid the symbol conflict with C function names and symbol names for the string constants.