### PR TITLE
OnnxBuilder now use create and infer shape

### DIFF
--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -34,7 +34,7 @@ Value OnnxBuilder::add(Value A, Value B) const {
   assert((A.getType().cast<ShapedType>().getElementType() ==
              B.getType().cast<ShapedType>().getElementType()) &&
          "A and B must have the same element type");
-  return b().create<ONNXAddOp>(loc(), toTensor(A), toTensor(B));
+  return createOpAndInferShapes<ONNXAddOp>(toTensor(A), toTensor(B));
 }
 
 Value OnnxBuilder::cast(Value input, TypeAttr to) const {
@@ -44,11 +44,11 @@ Value OnnxBuilder::cast(Value input, TypeAttr to) const {
         input.getType().cast<ShapedType>().getShape(), to.getValue());
   else
     resultType = UnrankedTensorType::get(to.getValue());
-  return b().create<ONNXCastOp>(loc(), resultType, input, to);
+  return createTypedOpAndInferShapes<ONNXCastOp>(resultType, input, to);
 }
 
 Value OnnxBuilder::ceil(Value input) const {
-  return b().create<ONNXCeilOp>(loc(), toTensor(input.getType()), input);
+  return createOpAndInferShapes<ONNXCeilOp>(toTensor(input.getType()), input);
 }
 
 Value OnnxBuilder::concat(
@@ -56,12 +56,12 @@ Value OnnxBuilder::concat(
   IntegerAttr concatAxisAttr =
       IntegerAttr::get(b().getIntegerType(64, /*isSigned=*/true),
           APInt(64, axis, /*isSigned=*/true));
-  return b().create<ONNXConcatOp>(
-      loc(), toTensor(outputType), inputs, concatAxisAttr);
+  return createTypedOpAndInferShapes<ONNXConcatOp>(
+      toTensor(outputType), inputs, concatAxisAttr);
 }
 
 Value OnnxBuilder::constant(Attribute denseAttr) const {
-  return b().create<ONNXConstantOp>(loc(), Attribute(), denseAttr);
+  return createOpAndInferShapes<ONNXConstantOp>(Attribute(), denseAttr);
 }
 
 Value OnnxBuilder::constantInt64(const ArrayRef<int64_t> intVals) const {
@@ -74,7 +74,7 @@ Value OnnxBuilder::dim(Value input, int axis) const {
   IntegerAttr axisAttr =
       IntegerAttr::get(b().getIntegerType(64, /*isSigned=*/true),
           APInt(64, axis, /*isSigned=*/true));
-  return b().create<ONNXDimOp>(loc(), resultType, input, axisAttr);
+  return createTypedOpAndInferShapes<ONNXDimOp>(resultType, input, axisAttr);
 }
 
 void OnnxBuilder::dimGroup(Value input, int axis, int groupID) const {
@@ -84,6 +84,7 @@ void OnnxBuilder::dimGroup(Value input, int axis, int groupID) const {
   IntegerAttr groupIDAttr =
       IntegerAttr::get(b().getIntegerType(64, /*isSigned=*/true),
           APInt(64, groupID, /*isSigned=*/true));
+  // No shape needed for this one I believe.
   b().create<ONNXDimGroupOp>(loc(), input, axisAttr, groupIDAttr);
 }
 
@@ -91,7 +92,7 @@ Value OnnxBuilder::div(Value A, Value B) const {
   assert((A.getType().cast<ShapedType>().getElementType() ==
              B.getType().cast<ShapedType>().getElementType()) &&
          "A and B must have the same element type");
-  return b().create<ONNXDivOp>(loc(), toTensor(A), toTensor(B));
+  return createOpAndInferShapes<ONNXDivOp>(toTensor(A), toTensor(B));
 }
 
 Value OnnxBuilder::matmul(Type Y, Value A, Value B, bool useGemm) const {
@@ -105,7 +106,7 @@ Value OnnxBuilder::matmul(Type Y, Value A, Value B, bool useGemm) const {
   auto aValue = toTensor(A);
   auto bValue = toTensor(B);
   if (canUseGemm)
-    return b().create<ONNXGemmOp>(loc(), Y, aValue, bValue,
+    return createOpAndInferShapes<ONNXGemmOp>(Y, aValue, bValue,
         b().createOrFold<ONNXNoneOp>(loc()),
         /*alpha=*/b().getF32FloatAttr(1.0), /*beta=*/b().getF32FloatAttr(1.0),
         /*transA=*/
@@ -114,7 +115,7 @@ Value OnnxBuilder::matmul(Type Y, Value A, Value B, bool useGemm) const {
         /*transB=*/
         IntegerAttr::get(b().getIntegerType(64, /*isSigned=*/true),
             APInt(64, 0, /*isSigned=*/true)));
-  return b().create<ONNXMatMulOp>(loc(), toTensor(Y), aValue, bValue);
+  return createOpAndInferShapes<ONNXMatMulOp>(toTensor(Y), aValue, bValue);
 }
 
 Value OnnxBuilder::min(ValueRange inputs) const {
@@ -127,44 +128,47 @@ Value OnnxBuilder::min(ValueRange inputs) const {
   for (uint64_t i = 1; i < inputs.size(); ++i)
     outputType = mlir::OpTrait::util::getBroadcastedType(
         toTensor(outputType), inputs[i].getType());
-  return b().create<ONNXMinOp>(loc(), toTensor(outputType), inputs);
+  return createTypedOpAndInferShapes<ONNXMinOp>(toTensor(outputType), inputs);
 }
 
 Value OnnxBuilder::mul(Value A, Value B) const {
   assert((A.getType().cast<ShapedType>().getElementType() ==
              B.getType().cast<ShapedType>().getElementType()) &&
          "A and B must have the same element type");
-  return b().create<ONNXMulOp>(loc(), toTensor(A), toTensor(B));
+  return createOpAndInferShapes<ONNXMulOp>(toTensor(A), toTensor(B));
 }
 
 Value OnnxBuilder::mul(Type resultType, Value A, Value B) const {
   assert((A.getType().cast<ShapedType>().getElementType() ==
              B.getType().cast<ShapedType>().getElementType()) &&
          "A and B must have the same element type");
-  return b().create<ONNXMulOp>(loc(), resultType, toTensor(A), toTensor(B));
+  return createTypedOpAndInferShapes<ONNXMulOp>(
+      resultType, toTensor(A), toTensor(B));
 }
 
 Value OnnxBuilder::reduceSum(Type outputType, Value data, Value axes,
     bool keepDims, bool noop_with_empty_axes) const {
   int64_t i_keepDims = keepDims; // 0 if false, 1 if true
   int64_t i_noop_with_empty_axes = noop_with_empty_axes; // ditto
-  return b().create<ONNXReduceSumOp>(loc(), toTensor(outputType),
+  return createTypedOpAndInferShapes<ONNXReduceSumOp>(toTensor(outputType),
       toTensor(data), toTensor(axes), i_keepDims, i_noop_with_empty_axes);
 }
 
 Value OnnxBuilder::reshape(Type outputType, Value input, Value shape) const {
-  return b().create<ONNXReshapeOp>(
-      loc(), toTensor(outputType), toTensor(input), toTensor(shape));
+  return createTypedOpAndInferShapes<ONNXReshapeOp>(
+      toTensor(outputType), toTensor(input), toTensor(shape));
 }
 
 Value OnnxBuilder::shape(Type outputType, Value input) const {
-  return b().create<ONNXShapeOp>(loc(), toTensor(outputType), toTensor(input));
+  return createTypedOpAndInferShapes<ONNXShapeOp>(
+      toTensor(outputType), toTensor(input));
 }
 
 Value OnnxBuilder::slice(Type outputType, Value input, Value starts, Value ends,
     Value axes, Value steps) const {
-  return b().create<ONNXSliceOp>(loc(), toTensor(outputType), toTensor(input),
-      toTensor(starts), toTensor(ends), toTensor(axes), toTensor(steps));
+  return createTypedOpAndInferShapes<ONNXSliceOp>(toTensor(outputType),
+      toTensor(input), toTensor(starts), toTensor(ends), toTensor(axes),
+      toTensor(steps));
 }
 
 // 1D slice: take ints instead of values, and axis is by default 0 since we deal
@@ -179,21 +183,21 @@ Value OnnxBuilder::slice(Type outputType, Value input, int64_t start,
 }
 
 Value OnnxBuilder::squeeze(Type outputType, Value data, Value axes) const {
-  return b().create<ONNXSqueezeOp>(
-      loc(), toTensor(outputType), toTensor(data), toTensor(axes));
+  return createTypedOpAndInferShapes<ONNXSqueezeOp>(
+      toTensor(outputType), toTensor(data), toTensor(axes));
 }
 
 Value OnnxBuilder::sub(Value A, Value B) const {
   assert((A.getType().cast<ShapedType>().getElementType() ==
              B.getType().cast<ShapedType>().getElementType()) &&
          "A and B must have the same element type");
-  return b().create<ONNXSubOp>(loc(), toTensor(A), toTensor(B));
+  return createOpAndInferShapes<ONNXSubOp>(toTensor(A), toTensor(B));
 }
 
 Value OnnxBuilder::transpose(
     Type outputType, Value input, ArrayAttr perm) const {
-  return b().create<ONNXTransposeOp>(
-      loc(), toTensor(outputType), toTensor(input), perm);
+  return createTypedOpAndInferShapes<ONNXTransposeOp>(
+      toTensor(outputType), toTensor(input), perm);
 }
 
 Value OnnxBuilder::toTensor(Value input) const {
@@ -202,6 +206,7 @@ Value OnnxBuilder::toTensor(Value input) const {
   assert(input.getType().isa<MemRefType>() &&
          "expect RankedMemref type when not a TensorType");
   auto aTensorTy = toTensor(input.getType());
+  // No shape inference for this op.
   return b()
       .create<UnrealizedConversionCastOp>(loc(), aTensorTy, input)
       .getResult(0);
@@ -227,20 +232,21 @@ Value OnnxBuilder::toMemref(Value input) const {
          "expect RankedMemref type when not a TensorType");
   auto aTy = input.getType().cast<ShapedType>();
   auto aTensorTy = MemRefType::get(aTy.getShape(), aTy.getElementType());
+  // No shape inference for this op.
   return b()
       .create<UnrealizedConversionCastOp>(loc(), aTensorTy, input)
       .getResult(0);
 }
 
 Value OnnxBuilder::unsqueeze(Type outputType, Value data, Value axes) const {
-  return b().create<ONNXUnsqueezeOp>(
-      loc(), toTensor(outputType), toTensor(data), toTensor(axes));
+  return createTypedOpAndInferShapes<ONNXUnsqueezeOp>(
+      toTensor(outputType), toTensor(data), toTensor(axes));
 }
 
 Value OnnxBuilder::where(
     Type outputType, Value condition, Value X, Value Y) const {
-  return b().create<ONNXWhereOp>(loc(), toTensor(outputType),
-      toTensor(condition), toTensor(X), toTensor(Y));
+  return createTypedOpAndInferShapes<ONNXWhereOp>(
+      toTensor(outputType), toTensor(condition), toTensor(X), toTensor(Y));
 }
 
 // =============================================================================

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -31,6 +31,15 @@ struct OnnxBuilder : DialectBuilder {
       : DialectBuilder(b, loc) {}
   OnnxBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
   virtual ~OnnxBuilder(){};
+
+  // Create operation and infer shape.
+  template <typename OnnxOpType, typename... Args>
+  OnnxOpType createOpAndInferShapes(Args &&... args) const;
+
+  template <typename OnnxOpType, typename... Args>
+  OnnxOpType createTypedOpAndInferShapes(
+      mlir::Type result_ty, Args &&... args) const;
+
   // ONNXAddOp
   mlir::Value add(mlir::Value A, mlir::Value B) const;
 
@@ -154,5 +163,8 @@ protected:
   mlir::Value getVal(mlir::Value intArrayVal, uint64_t i) final;
   mlir::Value getShapeVal(mlir::Value tensorOrMemrefValue, uint64_t i) final;
 };
+
+// Include inline code definitions.
+#include "DialectBuilder.hpp.inc"
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/DialectBuilder.hpp.inc
+++ b/src/Dialect/ONNX/DialectBuilder.hpp.inc
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----------- DialectBuilder.hpp.inc - Builder for ONNX dialects -------===//
+//
+// Copyright 2023 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains helper functions for lowering ONNX ops to Krnl Dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/Region.h"
+
+template <typename OnnxOpType, typename... Args>
+OnnxOpType OnnxBuilder::createOpAndInferShapes(Args &&... args) const {
+  OnnxOpType op = b().create<OnnxOpType>(loc(), args...);
+  if (!op)
+    llvm_unreachable("unexpected failure to create op");
+  if (failed(op.inferShapes([](mlir::Region &region) {})))
+    llvm_unreachable("unexpected inferShapes failure");
+  return op;
+}
+
+// There is technically no need for this function call as the one above could
+// also be used. However, this call ensure that a mlir::Type parameter is
+// given, so it provide a bit more typechecking than the more generic call
+// above.
+template <typename OnnxOpType, typename... Args>
+OnnxOpType OnnxBuilder::createTypedOpAndInferShapes(
+    mlir::Type result_ty, Args &&... args) const {
+  return createOpAndInferShapes<OnnxOpType>(result_ty, args...);
+}


### PR DESCRIPTION
Added infrastructure for a "create op and infer shapes" and used it in the OnnxBuilder.

This change allows the users of the builder not to have to manually infer the shapes. So potentially, code that invoke the builder could be simplified. I have not performed this simplification at this time. It is just that when adding new ops, this step is now automatically done by the shape inference interface.