### PR TITLE
Fix run_man_graph leak after OMTensorList changes

### DIFF
--- a/docs/mnist_example/README.md
+++ b/docs/mnist_example/README.md
@@ -196,7 +196,7 @@ static float img_data[] = {...};
 int main() {
   // Create an input tensor list of 1 tensor.
   int inputNum = 1;
-  OMTensor **inputTensors = (OMTensor **)malloc(inputNum * sizeof(OMTensor *));
+  OMTensor *inputTensors[inputNum];
   // The first input is of tensor<1x1x28x28xf32>.
   int64_t rank = 4;
   int64_t shape[] = {1, 1, 28, 28};

--- a/docs/mnist_example/mnist.cpp
+++ b/docs/mnist_example/mnist.cpp
@@ -303,7 +303,7 @@ int main() {
   }
 
   // Free the output as it is no longer needed.
-  omTensorListDestroy(tensorListIn);
+  omTensorListDestroy(tensorListOut);
 
   printf("The digit is %d\n", digit);
   return 0;

--- a/docs/mnist_example/mnist.cpp
+++ b/docs/mnist_example/mnist.cpp
@@ -272,7 +272,7 @@ static float img_data[] = {-0.4242129623889923f, -0.4242129623889923f,
 int main() {
   // Create an input tensor list of 1 tensor.
   int inputNum = 1;
-  OMTensor **inputTensors = (OMTensor **)malloc(inputNum * sizeof(OMTensor *));
+  OMTensor *inputTensors[inputNum];
   // The first input is of tensor<1x1x28x28xf32>.
   int64_t rank = 4;
   int64_t shape[] = {1, 1, 28, 28};

--- a/docs/mnist_example/mnist.cpp
+++ b/docs/mnist_example/mnist.cpp
@@ -284,6 +284,9 @@ int main() {
   // Compute outputs.
   OMTensorList *tensorListOut = run_main_graph(tensorListIn);
 
+  // Free the input as it is no longer needed.
+  omTensorListDestroy(tensorListIn);
+
   // Extract the output. The model defines one output of type tensor<1x10xf32>.
   OMTensor *y = omTensorListGetOmtByIndex(tensorListOut, 0);
   float *prediction = (float *)omTensorGetDataPtr(y);
@@ -298,6 +301,9 @@ int main() {
       prob = prediction[i];
     }
   }
+
+  // Free the output as it is no longer needed.
+  omTensorListDestroy(tensorListIn);
 
   printf("The digit is %d\n", digit);
   return 0;

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -277,7 +277,7 @@ public:
 
     // Create wrapped output.
     Value wrappedOutput = RuntimeAPI::callApi(rewriter, loc, apiRegistry,
-        RuntimeAPI::API::CREATE_OMTENSOR_LIST, {outOmtPtrsArr, numOutput, one});
+        RuntimeAPI::API::CREATE_OMTENSOR_LIST, {outOmtPtrsArr, numOutput});
 
     // Return wrapped output.
     create.llvm._return(wrappedOutput);

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -4,7 +4,7 @@
 
 //===------ KrnlEntryPoint.cpp - Lower KrnlEntryPointOp -------------------===//
 //
-// Copyright 2019-2022 The IBM Research Authors.
+// Copyright 2019-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -236,16 +236,8 @@ public:
 
     Value numOutput =
         create.llvm.constant(int64Ty, (int64_t)outMemRefList.size());
-
-    auto mallocSym = getOrInsertMalloc(rewriter, module);
-    // TODO(tjingrant): get pointer size from data layout.
-    size_t kPtrSize = 8;
-    Value outputOmtPtrsArraySizeInByte = create.llvm.constant(
-        int64Ty, (int64_t)(outMemRefList.size() * kPtrSize));
-    Value outOmtPtrsArr = create.llvm.call(
-        LLVM::LLVMPointerType::get(IntegerType::get(module.getContext(), 8)),
-        mallocSym, ArrayRef<Value>(outputOmtPtrsArraySizeInByte));
-    outOmtPtrsArr = create.llvm.bitcastI8PtrPtr(outOmtPtrsArr);
+    Value outOmtPtrsArr = create.llvm._alloca(
+        LLVM::LLVMPointerType::get(opaquePtrTy), numOutput, /*alignment=*/0);
 
     for (unsigned int i = 0; i < outMemRefList.size(); i++) {
       // Get the i-th memref returned, convert to a dynamic memref and store it
@@ -349,19 +341,6 @@ private:
     }
 
     create.llvm.store(memRef, ptrToMemRef);
-  }
-
-  FlatSymbolRefAttr getOrInsertMalloc(
-      PatternRewriter &rewriter, ModuleOp module) const {
-    MultiDialectBuilder<LLVMBuilder> create(rewriter, module.getLoc());
-    // Insert the malloc/aligned_alloc declaration if it is not already present.
-    LLVMTypeConverter converter(rewriter.getContext());
-    SmallVector<Type, 2> callArgTypes = {converter.getIndexType()};
-    // aligned_alloc(size_t alignment, size_t size)
-    Type voidPtrType = LLVM::LLVMPointerType::get(
-        IntegerType::get(&converter.getContext(), 8));
-    return create.llvm.getOrInsertSymbolRef(
-        module, StringRef("malloc"), voidPtrType, callArgTypes);
   }
 
   FlatSymbolRefAttr getOrInsertOMInitAccel(

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -236,6 +236,7 @@ public:
 
     Value numOutput =
         create.llvm.constant(int64Ty, (int64_t)outMemRefList.size());
+    // Assume that OMTensor pointer size is 8
     Value outOmtPtrsArr = create.llvm._alloca(
         LLVM::LLVMPointerType::get(opaquePtrTy), numOutput, /*alignment=*/0);
 

--- a/src/Conversion/KrnlToLLVM/RuntimeAPI.cpp
+++ b/src/Conversion/KrnlToLLVM/RuntimeAPI.cpp
@@ -72,7 +72,7 @@ RuntimeAPIRegistry::RuntimeAPIRegistry(ModuleOp &module, OpBuilder &builder)
   // clang-format off
   using API = RuntimeAPI::API;
   std::vector<RuntimeAPI> RuntimeAPISpecs = {
-    RuntimeAPI(API::CREATE_OMTENSOR_LIST, "omTensorListCreate", opaquePtrTy, {opaquePtrPtrTy, int64Ty, int64Ty}),
+    RuntimeAPI(API::CREATE_OMTENSOR_LIST, "omTensorListCreate", opaquePtrTy, {opaquePtrPtrTy, int64Ty}),
     RuntimeAPI(API::CREATE_OMTENSOR, "omTensorCreateUntyped", opaquePtrTy, {int64Ty}),
     RuntimeAPI(API::GET_DATA, "omTensorGetDataPtr", opaquePtrTy, {opaquePtrTy}),
     RuntimeAPI(API::SET_DATA, "omTensorSetDataPtr", voidTy, {opaquePtrTy, int64Ty, opaquePtrTy, opaquePtrTy}),

--- a/test/modellib/CategoryMapperModel.cpp
+++ b/test/modellib/CategoryMapperModel.cpp
@@ -56,9 +56,6 @@ template <typename T1, typename T2>
 bool CategoryMapperLibBuilder<T1, T2>::prepareInputs() {
   constexpr int num = 1;
   OMTensor* list[num];
-  if (!list)
-    return false;
-
   int64_t shape[1] = {static_cast<int64_t>(input.size())};
   list[0] = createOMTensor<T1>(input, shape, 1,
       (std::is_same<T1, int64_t>::value) ? ONNX_TYPE_INT64 : ONNX_TYPE_STRING);

--- a/test/modellib/ConvModel.cpp
+++ b/test/modellib/ConvModel.cpp
@@ -124,8 +124,6 @@ bool Conv2DLibBuilder::build() {
 bool Conv2DLibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 2;
   OMTensor* list[num];
-  if (!list)
-    return false;
   list[0] = omTensorCreateWithRandomData<float>(
       {N, CIn, H, W}, dataRangeLB, dataRangeUB);
   list[1] = omTensorCreateWithRandomData<float>(

--- a/test/modellib/GRUModel.cpp
+++ b/test/modellib/GRUModel.cpp
@@ -121,8 +121,6 @@ bool GRULibBuilder::build() {
 bool GRULibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 2;
   OMTensor* list[num];
-  if (!list)
-    return false;
   list[0] = omTensorCreateWithRandomData<float>(
       llvm::ArrayRef(xShape), dataRangeLB, dataRangeUB);
   list[1] = omTensorCreateWithRandomData<float>(

--- a/test/modellib/GemmModel.cpp
+++ b/test/modellib/GemmModel.cpp
@@ -82,8 +82,6 @@ bool GemmLibBuilder::build() {
 bool GemmLibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 3;
   OMTensor* list[num];
-  if (!list)
-    return false;
   list[0] = omTensorCreateWithRandomData<float>(
       llvm::ArrayRef(aShape), dataRangeLB, dataRangeUB);
   list[1] = omTensorCreateWithRandomData<float>(

--- a/test/modellib/LSTMModel.cpp
+++ b/test/modellib/LSTMModel.cpp
@@ -137,8 +137,6 @@ bool LSTMLibBuilder::build() {
 bool LSTMLibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 3;
   OMTensor* list[num];
-  if (!list)
-    return false;
   float dataRangeHLL = (isNoneH) ? 0.0 : dataRangeLB;
   float dataRangeHUL = (isNoneH) ? 0.0 : dataRangeUB;
   float dataRangeCLL = (isNoneC) ? 0.0 : dataRangeLB;

--- a/test/modellib/LeakyReluModel.cpp
+++ b/test/modellib/LeakyReluModel.cpp
@@ -65,8 +65,6 @@ bool LeakyReluLibBuilder::build() {
 bool LeakyReluLibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 1;
   OMTensor* list[num];
-  if (!list)
-    return false;
   list[0] = omTensorCreateWithRandomData<float>({N}, dataRangeLB, dataRangeUB);
   inputs = omTensorListCreate(list, num);
   return inputs && list[0];

--- a/test/modellib/RNNModel.cpp
+++ b/test/modellib/RNNModel.cpp
@@ -117,8 +117,6 @@ bool RNNLibBuilder::build() {
 bool RNNLibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 2;
   OMTensor* list[num];
-  if (!list)
-    return false;
   list[0] = omTensorCreateWithRandomData<float>(
       llvm::ArrayRef(xShape), dataRangeLB, dataRangeUB);
   list[1] = omTensorCreateWithRandomData<float>(

--- a/test/modellib/ScanModel.cpp
+++ b/test/modellib/ScanModel.cpp
@@ -131,8 +131,6 @@ bool ScanLibBuilder::prepareInputs() {
 bool ScanLibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 2;
   OMTensor* list[num];
-  if (!list)
-    return false;
   list[0] = omTensorCreateWithRandomData<float>(
       llvm::ArrayRef(initialShape), dataRangeLB, dataRangeUB);
   list[1] = omTensorCreateWithRandomData<float>(

--- a/utils/RunONNXLib.cpp
+++ b/utils/RunONNXLib.cpp
@@ -325,10 +325,9 @@ OMTensorList *omTensorListCreateFromInputSignature(
   // Allocate array of inputs.
   int inputNum = JSONArray->size();
   assert(inputNum >= 0 && inputNum < 100 && "out of bound number of inputs");
-  OMTensor **inputTensors = nullptr;
-  if (inputNum > 0)
-    inputTensors = (OMTensor **)malloc(inputNum * sizeof(OMTensor *));
-  // Scan each input tensor
+
+  OMTensor *inputTensors[inputNum];
+
   int dimKnownAtRuntimeIndex = 0;
   for (int i = 0; i < inputNum; ++i) {
     auto JSONItem = (*JSONArray)[i].getAsObject();

--- a/utils/RunONNXLib.cpp
+++ b/utils/RunONNXLib.cpp
@@ -396,7 +396,7 @@ OMTensorList *omTensorListCreateFromInputSignature(
       cout << "and " << size << " elements" << endl;
     }
   }
-  return OM_TENSOR_LIST_CREATE(inputTensors, inputNum, true);
+  return OM_TENSOR_LIST_CREATE(inputTensors, inputNum);
 }
 
 // Data structures for timing info.


### PR DESCRIPTION
* The generated llvm code for run_main_graph was still using malloc to create a temporary list array. This changes that to a stack alloc instead.
* Fixed some warnings
* Fix some leaks in code examples
* Removed unused param from `CREATE_OMTENSOR_LIST`