### PR TITLE
Fix Modelzoo Check

### DIFF
--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -40,6 +40,11 @@ def valid_onnx_input(fname):
 
 # Command arguments.
 parser = argparse.ArgumentParser()
+parser.add_argument('--log-to-file',
+                    action='store', nargs='?',
+                    const="compilation.log",
+                    default=None,
+                    help="Output compilation messages to file, default compilation.log")
 parser.add_argument('--model',
                     type=lambda s: valid_onnx_input(s),
                     help="Path to an ONNX model (.onnx or .mlir)")
@@ -404,12 +409,12 @@ def main():
             start = time.perf_counter()
             ok, msg = execute_commands(command_str)
             # Dump the compilation log into a file.
-            print("  Compilation log is dumped into compilation.log")
-            original_stdout = sys.stdout
-            with open('compilation.log', 'w') as f:
-                sys.stdout = f
-                print(msg)
-                sys.stdout = original_stdout
+            if args.log_to_file:
+                log_file = (args.log_to_file if args.log_to_file.startswith('/') else
+                            os.path.join(os.getcwd(), args.log_to_file))
+                print("  Compilation log is dumped into {}".format(log_file))
+                with open(log_file, 'w') as f:
+                    f.write(msg)
             if not ok:
                 print(msg)
                 exit(1)

--- a/utils/RunONNXModelZoo.py
+++ b/utils/RunONNXModelZoo.py
@@ -146,16 +146,24 @@ args = get_args()
 logger = get_logger()
 
 
-def execute_commands(cmds, cwd=None):
+def execute_commands(cmds, cwd=None, tmout=None):
     logger.debug('cmd={} cwd={}'.format(' '.join(cmds), cwd))
     out = subprocess.Popen(cmds, cwd=cwd,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE)
-    stdout, stderr = out.communicate()
+    try:
+        stdout, stderr = out.communicate(timeout=tmout)
+    except subprocess.TimeoutExpired:
+        # Kill the child process and finish communication
+        out.kill()
+        stdout, stderr = out.communicate()
+        return (False, (stderr.decode("utf-8") + stdout.decode("utf-8") +
+                        "Timeout after {} seconds".format(tmout)))
+    msg = stderr.decode("utf-8") + stdout.decode("utf-8")
     if out.returncode == -signal.SIGSEGV:
-        return (False, "Segfault")
+        return (False, msg + "Segfault")
     if out.returncode != 0:
-        return (False, stderr.decode("utf-8") + stdout.decode("utf-8"))
+        return (False, msg + "Return code {}".format(out.returncode))
     return (True, stdout.decode("utf-8"))
 
 
@@ -329,8 +337,10 @@ def check_model(model_path, model_name, compile_args, report_dir):
         if (args.compile_only):
             options += ['--compile-only']
         options += ['--model={}'.format(onnx_file)]
-        ok, msg = execute_commands(RUN_ONNX_MODEL_CMD + options)
+        # Wait up to 30 minutes for compilation and inference to finish
+        ok, msg = execute_commands(RUN_ONNX_MODEL_CMD + options, tmout=1800)
         state = TEST_PASSED if ok else TEST_FAILED
+        logger.info("[{}] check {}".format(model_name, "passed" if ok else "failed"))
         logger.debug("[{}] {}".format(model_name, msg))
 
         if args.Html:


### PR DESCRIPTION
- add --log-to-file to optionally log output to a file
- allow max 30 minutes for compilation+inference for a model check