### PR TITLE
fix compiler warnings

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
@@ -126,8 +126,6 @@ Value insertAllocAndDeallocZMemRef(ZMemRefType zType, ArrayRef<IndexExpr> dims,
 static Value insertAllocAndDeallocWorkAreaForRNNOps(
     IndexExprBuilderForKrnl &createIE, PatternRewriter &rewriter, Location loc,
     Value rnnInput, Value rnnHiddenWeight, unsigned numOfGates, bool isDouble) {
-  Value alloc;
-
   SmallVector<IndexExpr, 4> inputDims, hiddenWeightDims;
   createIE.getShapeAsDims(rnnInput, inputDims);
   createIE.getShapeAsDims(rnnHiddenWeight, hiddenWeightDims);

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowRewrite.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowRewrite.cpp
@@ -247,7 +247,7 @@ public:
     // All consumers of zlow.unstick must be affine.load.
     SmallVector<AffineLoadOp, 4> loadOps;
     if (!matchAndCollectAffineLoad(unstickOp, cpuMemRef, loadOps))
-      rewriter.notifyMatchFailure(op, [&](::mlir::Diagnostic &diag) {
+      return rewriter.notifyMatchFailure(op, [&](::mlir::Diagnostic &diag) {
         diag << "Failed to match AffineLoadOp";
       });
 

--- a/src/Dialect/ONNX/ONNXOps/Additional/ShapeTransform.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/ShapeTransform.cpp
@@ -31,7 +31,7 @@ LogicalResult ONNXShapeTransformOpShapeHelper::computeShape() {
   auto inputType = input.getType().cast<ShapedType>();
   Type elementType = inputType.getElementType();
   ArrayRef<int64_t> inputDims = inputType.getShape();
-  uint64_t outputRank = indexMap.getNumResults();
+  int64_t outputRank = indexMap.getNumResults();
 
   // Use the given affine_map to compute output's shape.
   // IndexExpr does not support construction with an existing affine_map, so
@@ -52,7 +52,7 @@ LogicalResult ONNXShapeTransformOpShapeHelper::computeShape() {
   assert((flatMemRefType.getRank() == outputRank) && "Normalization failed");
 
   DimsExpr outputIEs(outputRank);
-  for (uint64_t i = 0; i < outputRank; ++i) {
+  for (int64_t i = 0; i < outputRank; ++i) {
     LiteralIndexExpr dim(flatMemRefType.getShape()[i]);
     outputIEs[i] = dim;
   }

--- a/test/modellib/MatMulModel.cpp
+++ b/test/modellib/MatMulModel.cpp
@@ -64,8 +64,6 @@ bool MatMul2DLibBuilder::build() {
 bool MatMul2DLibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 2;
   OMTensor *list[num];
-  if (!list)
-    return false;
   list[0] =
       omTensorCreateWithRandomData<float>({I, K}, dataRangeLB, dataRangeUB);
   list[1] =
@@ -172,8 +170,6 @@ bool MatMulSingleBroadcastLibBuilder::build() {
 bool MatMulSingleBroadcastLibBuilder::prepareInputs() {
   constexpr int num = 2;
   OMTensor *list[num];
-  if (!list)
-    return false;
   list[0] = omTensorCreateWithRandomData<float>(aShape);
   list[1] = omTensorCreateWithRandomData<float>(bShape);
   inputs = omTensorListCreate(list, num);


### PR DESCRIPTION
Fixed 4 compiler warnings reported by Apple clang version 14.0.0.

Please see the 4 commits for details.

AFAICT they were introduced by:
@hamptonm1 in #2046
@tungld in #2011 and #2022
@AlexandreEichenberger in #2042