### PR TITLE
ONNXHybridTransformPass

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -208,6 +208,11 @@ llvm::cl::opt<bool> enableSimdDataLayout("simd-data-layout",
                    "Set to 'true' if you want to enable SIMD optimizations."),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
 
+llvm::cl::opt<bool> enableONNXHybridPass("onnx-hybrid-pass",
+    llvm::cl::desc("Enable ONNX hybrid pass (default=false)\n"
+                   "Set to 'true' if you want to enable ONNX hybrid pass."),
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
+
 llvm::cl::opt<bool> verifyInputTensors("verifyInputTensors",
     llvm::cl::desc(
         "Verify input tensors whenever the entry point function is called.\n"

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -74,6 +74,7 @@ extern llvm::cl::opt<bool> onnxConstPropReport;
 extern llvm::cl::opt<bool> enableParallel;
 extern llvm::cl::opt<bool> disableSimdOption;
 extern llvm::cl::opt<bool> enableSimdDataLayout;
+extern llvm::cl::opt<bool> enableONNXHybridPass;
 
 // The customEnvFlags must be scanned before the normal options.
 bool parseCustomEnvFlagsCommandLineOption(int argc, const char *const *argv,

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -57,9 +57,15 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU) {
       std::make_unique<DisposableGarbageCollector>(pm.getContext()));
 
   pm.addNestedPass<func::FuncOp>(onnx_mlir::createDecomposeONNXToONNXPass());
-  pm.addPass(onnx_mlir::createShapeInferencePass());
-  pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(onnx_mlir::createShapeInferencePass());
+  if (enableONNXHybridPass) {
+    // For starters only illustrating the new hybrid pass by replacing 3 passes
+    // here. The plan is to replace most of the passes in addONNXToMLIRPasses.
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass());
+  } else {
+    pm.addPass(onnx_mlir::createShapeInferencePass());
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(onnx_mlir::createShapeInferencePass());
+  }
   // Convolution Optimization for CPU: enable when there are no accelerators.
   if (targetCPU) {
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(

--- a/src/InitOMPasses.hpp
+++ b/src/InitOMPasses.hpp
@@ -38,7 +38,17 @@ void initOMPasses(int optLevel) {
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
-    return createShapeInferencePass();
+    return createONNXHybridTransformPass();
+  });
+
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    if (enableONNXHybridPass) {
+      // Replaces shape inference in onnx-mlir-opt which is used in all the
+      // lit tests, except the parse lit tests.
+      return createONNXShapeInferenceTransformPass();
+    } else {
+      return createShapeInferencePass();
+    }
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -61,6 +61,13 @@ std::unique_ptr<mlir::Pass> createInstrumentONNXSignaturePass();
 std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass(
     bool report = false);
 
+/// Pass that combines multiple ONNX dialect transformations,
+/// including shape inference.
+std::unique_ptr<mlir::Pass> createONNXHybridTransformPass();
+
+/// Shape inference only variant of ONNXHybridTransform.
+std::unique_ptr<mlir::Pass> createONNXShapeInferenceTransformPass();
+
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();
 

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -56,6 +56,16 @@ add_onnx_mlir_library(OMOpTransform
   MLIRTransforms
   )
 
+add_onnx_mlir_library(OMHybridTransform
+  ONNXHybridTransformPass.cpp
+
+  LINK_LIBS PUBLIC
+  OMONNXOps
+  OMShapeInferenceOpInterface
+  MLIRPass
+  MLIRTransforms
+  )
+
 add_onnx_mlir_library(OMONNXPreKrnlVerifyONNX
   ONNXPreKrnlVerifyPass.cpp
 

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------------------ ONNXHybridTransformPass.cpp -----------------------===//
+//
+// Hybrid ONNX transformation pass that combines conversion patterns for
+// shape inference and canonicalization.
+//
+// TODO: add constant propagation and decomposition
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Interface/ShapeInferenceOpInterface.hpp"
+#include "src/Pass/Passes.hpp"
+
+using namespace mlir;
+
+namespace {
+
+struct InferShapesPattern : public OpInterfaceRewritePattern<ShapeInference> {
+  using OpInterfaceRewritePattern<ShapeInference>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ShapeInference shapeOp, PatternRewriter &rewriter) const override {
+    // TODO: check if it's necessary to skip ops that satisfy
+    // !returnsDynamicOrUnknownShape (see ShapeInferencePass.cpp)
+
+    // Verify the operation before attempting to infer the shape of the
+    // produced output(s).
+    Optional<RegisteredOperationName> registeredInfo =
+        shapeOp->getName().getRegisteredInfo();
+    if (registeredInfo && failed(registeredInfo->verifyInvariants(&*shapeOp)))
+      return shapeOp.emitOpError("verification failed");
+
+    // Infer the results shapes.
+    if (failed(shapeOp.inferShapes([](Region &region) {})))
+      return shapeOp.emitOpError("shape inference failed");
+
+    return success();
+  }
+};
+
+struct ReturnShapesPattern : public OpRewritePattern<ONNXReturnOp> {
+  using OpRewritePattern<ONNXReturnOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      ONNXReturnOp returnOp, PatternRewriter &rewriter) const override {
+    Operation *parent = returnOp->getParentOp();
+    (void)parent;
+    assert(parent && "every onnx.Return op has a parent");
+    if (auto shapeOp = llvm::dyn_cast<ShapeInference>(parent)) {
+      if (failed(shapeOp.inferShapes([](Region &region) {})))
+        return shapeOp.emitOpError("shape inference failed");
+    } else {
+      llvm_unreachable("onnx.Return always has if/loop/scan parent");
+    }
+    return success();
+  }
+};
+
+// The pass combines patterns for shape inference and other ONNX-to-ONNX
+// transforms, controlled by the shapeInferenceOnly constructor argument.
+//
+// Shape inference is done with two patterns. One pattern is for regular ONNX
+// ops from the ONNX specification, which all implement the ShapeInference
+// interface. The other pattern is for ONNXReturnOp which terminates
+// if/loop/scan subgraphs. The pass executes patterns top down so shape
+// inference cascades through the ops from the graph's inputs to outputs, and
+// recursively into subgraphs. Ops with subgraphs, namely if/loop/scan, are
+// matched by the first pattern before the pass recurses into the subgraph. The
+// recursive subgraph pass ends with the ONNXReturnOp whose pattern reruns shape
+// inference for the parent if/loop/scan op. The effect is that the two runs of
+// the parent if/loop/scan op each accomplishes one half of shape propagation to
+// and from the subgraph: The first run propagates input shapes from the parent
+// op to the subgraph and the second run propagates result shapes from the
+// subgraph to the parent op.
+struct ONNXHybridTransformPass
+    : public PassWrapper<ONNXHybridTransformPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ONNXHybridTransformPass)
+
+  ONNXHybridTransformPass(bool shapeInferenceOnly)
+      : shapeInferenceOnly(shapeInferenceOnly) {}
+
+  StringRef getArgument() const override {
+    return shapeInferenceOnly ? "shape-inference" : "onnx-hybrid-transform";
+  }
+
+  LogicalResult initialize(MLIRContext *context) override {
+    RewritePatternSet cumulativePatterns(context);
+    cumulativePatterns.insert<InferShapesPattern>(context);
+    cumulativePatterns.insert<ReturnShapesPattern>(context);
+
+    if (!shapeInferenceOnly) {
+      // canonicalization (copied from mlir/lib/Transforms/Canonicalizer.cpp)
+      for (auto *dialect : context->getLoadedDialects())
+        dialect->getCanonicalizationPatterns(cumulativePatterns);
+      for (RegisteredOperationName op : context->getRegisteredOperations())
+        op.getCanonicalizationPatterns(cumulativePatterns, context);
+
+      // TODO: constant propagation, decomposition
+    }
+
+    patterns = FrozenRewritePatternSet(std::move(cumulativePatterns));
+    return success();
+  }
+
+  void runOnOperation() override {
+    // TODO: check if it's necessary to skip functions with names not
+    // ending in "main_graph" (see ShapeInferencePass.cpp)
+    func::FuncOp f = getOperation();
+    Region &body = f.getBody();
+
+    GreedyRewriteConfig config;
+    config.useTopDownTraversal = true;
+    (void)applyPatternsAndFoldGreedily(body, patterns, config);
+
+    Operation *returnOp = f.getBody().back().getTerminator();
+    assert(returnOp && "function must return");
+    FunctionType fty = f.getFunctionType();
+    assert(f.getNumResults() == returnOp->getNumOperands() &&
+           "returned results count much match function type");
+    f.setType(fty.clone(fty.getInputs(), returnOp->getOperandTypes()));
+  }
+
+  const bool shapeInferenceOnly;
+  FrozenRewritePatternSet patterns;
+};
+
+} // namespace
+
+namespace onnx_mlir {
+
+std::unique_ptr<mlir::Pass> createONNXHybridTransformPass() {
+  return std::make_unique<ONNXHybridTransformPass>(
+      /*shapeInferenceOnly=*/false);
+}
+
+std::unique_ptr<mlir::Pass> createONNXShapeInferenceTransformPass() {
+  return std::make_unique<ONNXHybridTransformPass>(/*shapeInferenceOnly=*/true);
+}
+
+} // namespace onnx_mlir

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -93,9 +93,13 @@ struct ONNXHybridTransformPass
   }
 
   LogicalResult initialize(MLIRContext *context) override {
+    // Bump up the pattern benefit of the shape inference patterns to run them
+    // before the canonicalization patterns, because some canonicalization
+    // patterns work best after shapes are inferred.
+    PatternBenefit highPriority(10000);
     RewritePatternSet cumulativePatterns(context);
-    cumulativePatterns.insert<InferShapesPattern>(context);
-    cumulativePatterns.insert<ReturnShapesPattern>(context);
+    cumulativePatterns.insert<InferShapesPattern>(context, highPriority);
+    cumulativePatterns.insert<ReturnShapesPattern>(context, highPriority);
 
     if (!shapeInferenceOnly) {
       // canonicalization (copied from mlir/lib/Transforms/Canonicalizer.cpp)

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -52,7 +52,6 @@ struct ReturnShapesPattern : public OpRewritePattern<ONNXReturnOp> {
   LogicalResult matchAndRewrite(
       ONNXReturnOp returnOp, PatternRewriter &rewriter) const override {
     Operation *parent = returnOp->getParentOp();
-    (void)parent;
     assert(parent && "every onnx.Return op has a parent");
     if (auto shapeInfOp = llvm::dyn_cast<ShapeInference>(parent)) {
       if (failed(shapeInfOp.inferShapes([](Region &region) {})))
@@ -75,11 +74,11 @@ struct ReturnShapesPattern : public OpRewritePattern<ONNXReturnOp> {
 // recursively into subgraphs. Ops with subgraphs, namely if/loop/scan, are
 // matched by the first pattern before the pass recurses into the subgraph. The
 // recursive subgraph pass ends with the ONNXReturnOp whose pattern reruns shape
-// inference for the parent if/loop/scan op. The effect is that the two runs of
-// the parent if/loop/scan op each accomplishes one half of shape propagation to
-// and from the subgraph: The first run propagates input shapes from the parent
-// op to the subgraph and the second run propagates result shapes from the
-// subgraph to the parent op.
+// inference for the parent if/loop/scan op. The effect is that the 2 or 3 runs
+// of the parent if/loop/scan op accomplish two phases of shape propagation to
+// and from the subgraph(s): The first run propagates input shapes from the
+// parent op to the subgraph(s) and the last run(s) propagate(s) result shapes
+// from the subgraph(s) to the parent op.
 struct ONNXHybridTransformPass
     : public PassWrapper<ONNXHybridTransformPass, OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ONNXHybridTransformPass)

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -83,6 +83,8 @@ struct ONNXHybridTransformPass
     : public PassWrapper<ONNXHybridTransformPass, OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ONNXHybridTransformPass)
 
+  // TODO: Change bool argument to a general control of which transformation
+  // patterns, not just shape inference only, will be added in the hybrid pass.
   ONNXHybridTransformPass(bool shapeInferenceOnly)
       : shapeInferenceOnly(shapeInferenceOnly) {}
 


### PR DESCRIPTION
Includes a new pattern-based shape inference implementation.

So far only combines shape inference and canonicalization but the plan is to include constant propagation and decomposition so that a single pass with all the patterns can cascade shape inference and all the transforms in a single pass.

I encountered a model with a long dependency chain between shape inference, canonicalization, and constant propagation which requires an incredible number of repetitive passes with the current pass infrastructure.

See PR #1770 for an earlier version of this PR.