### PR TITLE
Lower ONNXDequantizeLinear to krnl

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -57,7 +57,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 18. Limitatio
 | **CumSum** |14 | | |
 | **DFT** | |unsupported | |
 | **DepthToSpace** |13 | | |
-| **DequantizeLinear** | |unsupported | |
+| **DequantizeLinear** |13 |Only support for per-tensor or layer dequantization. Not support for per-axis dequantization. | |
 | **Det** | |unsupported | |
 | **DictVectorizer** | |unsupported | |
 | **Div** |14 |No support for short integers. | |

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -971,10 +971,10 @@ Value emitScalarOpFor<ONNXDequantizeLinearOp>(
   Type xzeroPointTy = XZeroPoint.getType();
 
   // Only support scalar scale and zero_point.
-  if (!(isRankedShapedType(xscaleTy) && getRank(xscaleTy) == 0))
-    llvm_unreachable("[ONNXDequantizeLinearOp] Only per-tensor dequantization");
-  if (!(isRankedShapedType(xzeroPointTy) && getRank(xzeroPointTy) == 0))
-    llvm_unreachable("[ONNXDequantizeLinearOp] Only per-tensor dequantization");
+  assert((isRankedShapedType(xscaleTy) && getRank(xscaleTy) == 0) &&
+         "[ONNXDequantizeLinearOp] Only support per-tensor dequantization");
+  assert((isRankedShapedType(xzeroPointTy) && getRank(xzeroPointTy) == 0) &&
+         "[ONNXDequantizeLinearOp] Only support per-tensor dequantization");
 
   Value scaleFloat = create.krnl.load(XScale);
   Value zeroPointInt = create.krnl.load(XZeroPoint);

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -946,6 +946,46 @@ Value emitScalarOpFor<ONNXRoundOp>(ConversionPatternRewriter &rewriter,
 }
 
 //===----------------------------------------------------------------------===//
+// Scalar unary ops for lowering ONNXDequantizeLinearOp
+//===----------------------------------------------------------------------===//
+template <>
+struct ScalarOp<ONNXDequantizeLinearOp> {
+  using FOp = NotSuportedScalarOp;
+  using IOp = CustomScalarOp;
+  using SimdEnabled = NoSimdScalarOp;
+};
+
+template <>
+Value emitScalarOpFor<ONNXDequantizeLinearOp>(
+    ConversionPatternRewriter &rewriter, Location loc, Operation *op,
+    Type elementType, ArrayRef<Value> scalarOperands) {
+  MultiDialectBuilder<MathBuilder, KrnlBuilder> create(rewriter, loc);
+  // Dequantization formulas: y = (x - x_zero_point) * x_scale
+  // x and x_zero_point can be of type i8, ui8, int32.
+  // y is of type f32.
+  Value XInt = scalarOperands[0];
+  Value XScale = scalarOperands[1];
+  Value XZeroPoint = scalarOperands[2];
+
+  Type xscaleTy = XScale.getType();
+  Type xzeroPointTy = XZeroPoint.getType();
+
+  // Only support scalar scale and zero_point.
+  if (!(isRankedShapedType(xscaleTy) && getRank(xscaleTy) == 0))
+    llvm_unreachable("[ONNXDequantizeLinearOp] Only per-tensor dequantization");
+  if (!(isRankedShapedType(xzeroPointTy) && getRank(xzeroPointTy) == 0))
+    llvm_unreachable("[ONNXDequantizeLinearOp] Only per-tensor dequantization");
+
+  Value scaleFloat = create.krnl.load(XScale);
+  Value zeroPointInt = create.krnl.load(XZeroPoint);
+  Value zeroPointFloat = create.math.cast(elementType, zeroPointInt);
+  Value xFloat = create.math.cast(elementType, XInt);
+  Value sub = create.math.sub(xFloat, zeroPointFloat);
+  Value res = create.math.mul(sub, scaleFloat);
+  return res;
+}
+
+//===----------------------------------------------------------------------===//
 // SIMD code gen for kernels where data can be fully flattened.
 //===----------------------------------------------------------------------===//
 
@@ -1160,15 +1200,23 @@ struct ONNXElementwiseUnaryOpLowering
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
             Value loadedVal = createKrnl.load(X, loopInd);
+            SmallVector<Value> args;
+            args.emplace_back(loadedVal);
+            for (uint64_t i = 1; i < operands.size(); i++)
+              args.emplace_back(operands[i]);
             auto loweredOpResult = emitScalarOpFor<ElementwiseUnaryOp>(
-                rewriter, loc, op, elementType, {loadedVal});
+                rewriter, loc, op, elementType, args);
             // Store result in the resulting array.
             createKrnl.store(loweredOpResult, alloc, loopInd);
           });
     } else {
       Value loadedVal = create.krnl.load(X);
+      SmallVector<Value> args;
+      args.emplace_back(loadedVal);
+      for (uint64_t i = 1; i < operands.size(); i++)
+        args.emplace_back(operands[i]);
       auto loweredOpResult = emitScalarOpFor<ElementwiseUnaryOp>(
-          rewriter, loc, op, elementType, {loadedVal});
+          rewriter, loc, op, elementType, args);
       // Store result in the resulting array.
       create.krnl.store(loweredOpResult, alloc);
     }
@@ -1515,6 +1563,7 @@ void populateLoweringONNXElementwiseOpPattern(RewritePatternSet &patterns,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXCeilOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXCosOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXCoshOp>,
+      ONNXElementwiseUnaryOpLowering<mlir::ONNXDequantizeLinearOp>,
       ONNXElementwiseVariadicOpLowering<mlir::ONNXDivOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXEluOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXErfOp>,

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -273,7 +273,10 @@ def get_test_models():
         "test_depthtospace_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         "test_depthtospace_crd_mode_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
 
-        # DequatizeLinear
+        # ==OP== DequantizeLinear
+        # ==LIM== Only support for per-tensor or layer dequantization. Not support for per-axis dequantization.
+        #"test_dequantizelinear_axis_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
+        "test_dequantizelinear_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
 
         # Det
 
@@ -715,7 +718,7 @@ def get_test_models():
         "test_reduce_l2_negative_axes_keep_dims_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         "test_reduce_l2_negative_axes_keep_dims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
 
-        # ==OP== #ReduceMax
+        # ==OP== ReduceMax
         ## ==LIM== do_not_keep_dim not supported.
         #"test_reduce_max_default_axes_keepdim_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         #"test_reduce_max_default_axes_keepdims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -3894,3 +3894,82 @@ module {
 // CHECK:         }
   }
 }
+
+// -----
+
+func.func @test_dequantizelinear_i8(%arg0: tensor<4xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<4xf32> {
+  %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<4xi8>, tensor<f32>, tensor<i8>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+
+// CHECK-LABEL:  func.func @test_dequantizelinear_i8
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<4xi8>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<i8>) -> memref<4xf32> {
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<4xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 4){
+// CHECK:             [[VAR_1_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]{{.}} : memref<4xi8>
+// CHECK-DAG:         [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]][] : memref<i8>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.sitofp [[LOAD_PARAM_2_MEM_]] : i8 to f32
+// CHECK-DAG:         [[VAR_6_:%.+]] = arith.sitofp [[LOAD_PARAM_0_MEM_]] : i8 to f32
+// CHECK:             [[VAR_7_:%.+]] = arith.subf [[VAR_6_]], [[VAR_5_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = arith.mulf [[VAR_7_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_8_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<4xf32>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<4xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_dequantizelinear_ui8(%arg0: tensor<4xui8>, %arg1: tensor<f32>, %arg2: tensor<ui8>) -> tensor<4xf32> {
+  %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<4xui8>, tensor<f32>, tensor<ui8>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+
+// CHECK-LABEL:  func.func @test_dequantizelinear_ui8
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<4xui8>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<ui8>) -> memref<4xf32> {
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<4xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 4){
+// CHECK:             [[VAR_1_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]{{.}} : memref<4xui8>
+// CHECK-DAG:         [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]][] : memref<ui8>
+// CHECK:             [[VAR_5_:%.+]] = builtin.unrealized_conversion_cast [[LOAD_PARAM_2_MEM_]] : ui8 to i8
+// CHECK-DAG:         [[VAR_6_:%.+]] = arith.uitofp [[VAR_5_]] : i8 to f32
+// CHECK-DAG:         [[VAR_7_:%.+]] = builtin.unrealized_conversion_cast [[LOAD_PARAM_0_MEM_]] : ui8 to i8
+// CHECK:             [[VAR_8_:%.+]] = arith.uitofp [[VAR_7_]] : i8 to f32
+// CHECK:             [[VAR_9_:%.+]] = arith.subf [[VAR_8_]], [[VAR_6_]] : f32
+// CHECK:             [[VAR_10_:%.+]] = arith.mulf [[VAR_9_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_10_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<4xf32>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<4xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_dequantizelinear_i32(%arg0: tensor<4xi32>, %arg1: tensor<f32>, %arg2: tensor<i32>) -> tensor<4xf32> {
+  %0 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<4xi32>, tensor<f32>, tensor<i32>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+
+// CHECK-LABEL:  func.func @test_dequantizelinear_i32
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<4xi32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<i32>) -> memref<4xf32> {
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<4xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 4){
+// CHECK:             [[VAR_1_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]{{.}} : memref<4xi32>
+// CHECK-DAG:         [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]][] : memref<i32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.sitofp [[LOAD_PARAM_2_MEM_]] : i32 to f32
+// CHECK-DAG:         [[VAR_6_:%.+]] = arith.sitofp [[LOAD_PARAM_0_MEM_]] : i32 to f32
+// CHECK:             [[VAR_7_:%.+]] = arith.subf [[VAR_6_]], [[VAR_5_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = arith.mulf [[VAR_7_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_8_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<4xf32>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<4xf32>
+// CHECK:         }
+}

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -155,6 +155,7 @@ MLIR_TYPE_TO_NP_TYPE = {
     'i32': np.dtype("int32"),
     'i16': np.dtype("int16"),
     'i8': np.dtype("int8"),
+    'ui8': np.dtype("uint8"),
     'i1': np.dtype("bool"),
 }
 
@@ -296,15 +297,17 @@ def generate_random_input(input_signature, input_shapes):
         if (np.issubdtype(np_elem_type, np.floating)):
             lb = -1.0
             ub = 1.0
-
-        elif (np.issubdtype(np_elem_type, np.integer)):
-            lb = -10
+        elif (np.issubdtype(np_elem_type, np.uint8)):
+            lb = 0
             ub = 10
         elif (np.issubdtype(np_elem_type, np.dtype(bool).type)):
             # For some reason, random.uniform with lb/ub to 0/1 resulted in 1 only.
             lb = -10
             ub = 9
             random_element_type = np.dtype("int32")
+        elif (np.issubdtype(np_elem_type, np.integer)):
+            lb = -10
+            ub = 10
         else:
             raise AssertionError("Unsuported element type")
         rinput = np.random.uniform(lb, ub, explicit_shape).astype(random_element_type)

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -115,6 +115,19 @@ data_group.add_argument('--shape-info',
                         help="Shape for each dynamic input of the model, e.g. 0:1x10x20,1:7x5x3. "
                         "Used to generate random inputs for the model if --load-ref is not set")
 
+parser.add_argument('--lower-bound',
+                    type=str,
+                    help="Lower bound values for each data type. Used inputs."
+                    " E.g. --lower-bound=int64:-10,float32:-0.2,uint8:1."
+                    " Supported types are bool, uint8, int8, uint16, int16, uint32, int32,"
+                    " uint64, int64,float16, float32, float64")
+parser.add_argument('--upper-bound',
+                    type=str,
+                    help="Upper bound values for each data type. Used to generate random inputs."
+                    " E.g. --upper-bound=int64:10,float32:0.2,uint8:9."
+                    " Supported types are bool, uint8, int8, uint16, int16, uint32, int32,"
+                    " uint64, int64, float16, float32, float64")
+
 args = parser.parse_args()
 
 if (not os.environ.get('ONNX_MLIR_HOME', None)):
@@ -155,10 +168,46 @@ MLIR_TYPE_TO_NP_TYPE = {
     'i32': np.dtype("int32"),
     'i16': np.dtype("int16"),
     'i8': np.dtype("int8"),
+    'ui64': np.dtype("uint64"),
+    'ui32': np.dtype("uint32"),
+    'ui16': np.dtype("uint16"),
     'ui8': np.dtype("uint8"),
     'i1': np.dtype("bool"),
 }
 
+# Default lower bound for generating random inputs.
+DEFAULT_LB = {
+    'float64': -0.1,
+    'float32': -0.1,
+    'float16': -0.1,
+    'int64': -0.1,
+    'int32': -0.1,
+    'int16': -0.1,
+    'int8': -0.1,
+    'uint64': 0,
+    'uint32': 0,
+    'uint16': 0,
+    'uint8': 0,
+    # For some reason, random.uniform with lb/ub to 0/1 resulted in 1 only.
+    'bool': -10, # treated as int32
+}
+
+# Default upper bound for generating random inputs.
+DEFAULT_UB = {
+    'float64': 0.1,
+    'float32': 0.1,
+    'float16': 0.1,
+    'int64': 0.1,
+    'int32': 0.1,
+    'int16': 0.1,
+    'int8': 0.1,
+    'uint64': 10,
+    'uint32': 10,
+    'uint16': 10,
+    'uint8': 10,
+    # For some reason, random.uniform with lb/ub to 0/1 resulted in 1 only.
+    'bool': 9, # treated as int32
+}
 
 def ordinal(n):
     suffix = ['th', 'st', 'nd', 'rd', 'th'][min(n % 10, 4)]
@@ -291,23 +340,64 @@ def generate_random_input(input_signature, input_shapes):
         # Get element type.
         elem_type = sig['type']
         np_elem_type = MLIR_TYPE_TO_NP_TYPE[elem_type]
+
         # Set a range for random values.
+        custom_lb = {}
+        custom_ub = {}
+        # Get user's range if any.
+        if args.lower_bound:
+            for type_lbs in args.lower_bound.strip().split(","):
+                type_lb = type_lbs.split(":")
+                assert not (type_lb[0] in custom_lb), "Duplicate types"
+                custom_lb[type_lb[0]] = type_lb[1]
+        if args.upper_bound:
+            for type_ubs in args.upper_bound.strip().split(","):
+                type_ub = type_ubs.split(":")
+                assert not (type_ub[0] in custom_ub), "Duplicate types"
+                custom_ub[type_ub[0]] = type_ub[1]
+        DEFAULT_LB.update(custom_lb)
+        DEFAULT_UB.update(custom_ub)
+
         lb = ub = 0
         random_element_type = np_elem_type
-        if (np.issubdtype(np_elem_type, np.floating)):
-            lb = -1.0
-            ub = 1.0
-        elif (np.issubdtype(np_elem_type, np.uint8)):
-            lb = 0
-            ub = 10
-        elif (np.issubdtype(np_elem_type, np.dtype(bool).type)):
+        if (np.issubdtype(np_elem_type, np.dtype(bool).type)):
             # For some reason, random.uniform with lb/ub to 0/1 resulted in 1 only.
-            lb = -10
-            ub = 9
+            lb = int(DEFAULT_LB["bool"])
+            ub = int(DEFAULT_UB["bool"])
             random_element_type = np.dtype("int32")
-        elif (np.issubdtype(np_elem_type, np.integer)):
-            lb = -10
-            ub = 10
+        elif (np.issubdtype(np_elem_type, np.uint8)):
+            lb = int(DEFAULT_LB["uint8"])
+            ub = int(DEFAULT_UB["uint8"])
+        elif (np.issubdtype(np_elem_type, np.uint16)):
+            lb = int(DEFAULT_LB["uint16"])
+            ub = int(DEFAULT_UB["uint16"])
+        elif (np.issubdtype(np_elem_type, np.uint32)):
+            lb = int(DEFAULT_LB["uint32"])
+            ub = int(DEFAULT_UB["uint32"])
+        elif (np.issubdtype(np_elem_type, np.uint64)):
+            lb = int(DEFAULT_LB["uint64"])
+            ub = int(DEFAULT_UB["uint64"])
+        elif (np.issubdtype(np_elem_type, np.int8)):
+            lb = int(DEFAULT_LB["int8"])
+            ub = int(DEFAULT_UB["int8"])
+        elif (np.issubdtype(np_elem_type, np.int16)):
+            lb = int(DEFAULT_LB["int16"])
+            ub = int(DEFAULT_UB["int16"])
+        elif (np.issubdtype(np_elem_type, np.int32)):
+            lb = int(DEFAULT_LB["int32"])
+            ub = int(DEFAULT_UB["int32"])
+        elif (np.issubdtype(np_elem_type, np.int64)):
+            lb = int(DEFAULT_LB["int64"])
+            ub = int(DEFAULT_UB["int64"])
+        elif (np.issubdtype(np_elem_type, np.float64)):
+            lb = float(DEFAULT_LB["float64"])
+            ub = float(DEFAULT_UB["float64"])
+        elif (np.issubdtype(np_elem_type, np.float32)):
+            lb = float(DEFAULT_LB["float32"])
+            ub = float(DEFAULT_UB["float32"])
+        elif (np.issubdtype(np_elem_type, np.float16)):
+            lb = float(DEFAULT_LB["float16"])
+            ub = float(DEFAULT_UB["float16"])
         else:
             raise AssertionError("Unsuported element type")
         rinput = np.random.uniform(lb, ub, explicit_shape).astype(random_element_type)
@@ -328,7 +418,7 @@ def warning(msg):
 
 
 def main():
-    if not(args.model or args.load_so):
+    if not (args.model or args.load_so):
         print("error: no input model, use argument --model and/or --load-so.")
         print(parser.format_usage())
         exit(1)
@@ -482,14 +572,12 @@ def main():
                 os.mkdir(load_ref)
             for i in range(len(inputs)):
                 tensor = numpy_helper.from_array(inputs[i])
-                tensor_path = os.path.join(load_ref,
-                                           'input_{}.pb'.format(i))
+                tensor_path = os.path.join(load_ref, 'input_{}.pb'.format(i))
                 with open(tensor_path, 'wb') as f:
                     f.write(tensor.SerializeToString())
             for i in range(len(outs)):
                 tensor = numpy_helper.from_array(outs[i])
-                tensor_path = os.path.join(load_ref,
-                                           'output_{}.pb'.format(i))
+                tensor_path = os.path.join(load_ref, 'output_{}.pb'.format(i))
                 with open(tensor_path, 'wb') as f:
                     f.write(tensor.SerializeToString())
 


### PR DESCRIPTION
This patch supports ONNXDequantizeLinear, where:
- ONNXDequantizeLinear is lowered to Krnl dialect
- Backend and LIT tests for ONNXDequantizeLinear are enables.
- Only support for per-tensor or layer dequantization. Not support for per-axis dequantization at this moment.

Besides, this patch edits `RunONNXModel.py` script to support `ui8` input.

The lowering of ONNXDequantizeLinear borrows `ONNXElementwiseUnaryOpLowering`, so this patch contains some code from #2056. It's better to land #2056 before this patch.