### PR TITLE
LLVM update: Highlight issues with opaque pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ llvm_update_compile_flags(rapidcheck)
 
 if (ONNX_MLIR_ENABLE_MHLO)
   llvm_update_compile_flags(stablehlo-opt)
-  llvm_update_compile_flags(stablehlo-interpreter)
+  llvm_update_compile_flags(stablehlo-translate)
   llvm_update_compile_flags(mlir-hlo-opt)
 endif()
 

--- a/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVM.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVM.cpp
@@ -90,6 +90,8 @@ public:
     Location loc = op->getLoc();
 
     ZLowStickOpAdaptor operandAdaptor(operands);
+
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getX()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -148,6 +150,8 @@ public:
     Location loc = op->getLoc();
 
     ZLowStickForLSTMOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getFGate()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -237,6 +241,8 @@ public:
     Location loc = op->getLoc();
 
     ZLowStickForGRUOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getZGate()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -325,6 +331,8 @@ public:
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowLSTMOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getInput()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -524,6 +532,8 @@ public:
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowGRUOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getInput()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -681,6 +691,8 @@ public:
     Location loc = op->getLoc();
 
     ZLowUnstickOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getOut()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -744,6 +756,8 @@ public:
     Value input = operands[0];
     Value shape = operands[1];
     Value output = operands[2];
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = input.getType()
                              .dyn_cast<LLVM::LLVMStructType>()
                              .getBody()[0]
@@ -824,6 +838,8 @@ public:
     Value input2 = operands[1];
     Value shape = operands[2];
     Value output = operands[3];
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = input1.getType()
                              .dyn_cast<LLVM::LLVMStructType>()
                              .getBody()[0]
@@ -901,6 +917,8 @@ public:
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowSoftmaxOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getX()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -987,6 +1005,8 @@ public:
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowMatMulOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getX()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -1128,6 +1148,8 @@ public:
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowConv2DOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getInput()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -1281,6 +1303,8 @@ public:
     Value input = operands[0];
     Value shape = operands[1];
     Value output = operands[2];
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = input.getType()
                              .dyn_cast<LLVM::LLVMStructType>()
                              .getBody()[0]
@@ -1384,6 +1408,8 @@ public:
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowMeanReduce2DOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getInput()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()
@@ -1455,6 +1481,8 @@ public:
     Location loc = op->getLoc();
 
     ZLowBatchNormOpAdaptor operandAdaptor(operands);
+    
+    // TODO: how to get this type now that pointers are opaque?
     Type llvmElementTy = operandAdaptor.getInput()
                              .getType()
                              .dyn_cast<LLVM::LLVMStructType>()

--- a/src/Conversion/KrnlToLLVM/KrnlCall.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlCall.cpp
@@ -106,8 +106,7 @@ private:
 
       krnl::fillOMTensorWithMemRef(parameter, omTensor, false /*outOwning*/,
           rewriter, loc, apiRegistry, module);
-      auto int8Ty = IntegerType::get(context, 8);
-      auto opaquePtrTy = LLVM::LLVMPointerType::get(int8Ty);
+      auto opaquePtrTy = LLVM::LLVMPointerType::get(context);
       parameterTypeList.emplace_back(opaquePtrTy);
       parameterList.emplace_back(omTensor);
       omTensors.emplace_back(omTensor);
@@ -133,8 +132,7 @@ private:
               krnl::getOrCreateGlobalString(attrValue, loc, rewriter, module,
                   static_cast<LLVMTypeConverter *>(typeConverter));
           Value strPtr = krnl::getPtrToGlobalString(globalStr, loc, rewriter);
-          auto int8Ty = IntegerType::get(context, 8);
-          auto opaquePtrTy = LLVM::LLVMPointerType::get(int8Ty);
+          auto opaquePtrTy = LLVM::LLVMPointerType::get(context);
           parameterTypeList.emplace_back(opaquePtrTy);
           parameterList.emplace_back(strPtr);
         })
@@ -182,8 +180,7 @@ private:
 
           krnl::fillOMTensorWithMemRef(convertedConstantGlobal, omTensor,
               false /*outOwning*/, rewriter, loc, apiRegistry, module);
-          auto int8Ty = IntegerType::get(context, 8);
-          auto opaquePtrTy = LLVM::LLVMPointerType::get(int8Ty);
+          auto opaquePtrTy = LLVM::LLVMPointerType::get(context);
           parameterTypeList.emplace_back(opaquePtrTy);
           parameterList.emplace_back(omTensor);
         })

--- a/src/Conversion/KrnlToLLVM/KrnlGetRef.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlGetRef.cpp
@@ -71,18 +71,11 @@ public:
     auto outputMemPoolTypePtrAlloc =
         create.llvm.getElemPtr(llvmMemPoolType, alignedMemPoolBase, {offset});
 
-    // Bitcast to output MemRef type i.e. from i8* to the element type
-    // of the output MemRef.
-    auto llvmOutputElementType = outputElementType.cast<Type>();
-    Value outputTypedPtrAlloc =
-        create.llvm.bitcast(LLVM::LLVMPointerType::get(llvmOutputElementType),
-            outputMemPoolTypePtrAlloc);
-
     // Handle the static case.
     if (hasAllConstantDimensions(memRefTy)) {
       // Create llvm MemRef from original MemRef and fill the data pointers.
       auto llvmMemRef = MemRefDescriptor::fromStaticShape(
-          rewriter, loc, *getTypeConverter(), memRefTy, outputTypedPtrAlloc);
+          rewriter, loc, *getTypeConverter(), memRefTy, outputMemPoolTypePtrAlloc);
 
       rewriter.replaceOp(op, {llvmMemRef});
       return success();

--- a/src/Conversion/KrnlToLLVM/KrnlGlobal.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlGlobal.cpp
@@ -197,13 +197,13 @@ private:
   // Store the given address into a MemRefDescriptor (a struct).
   MemRefDescriptor createMemRefDescriptor(Value address, MemRefType memRefType,
       Location loc, OpBuilder &builder) const {
+    // TODO: Is this the struct type that I'm looking for in KrnlEntryPoint?
     Type elementType = memRefType.getElementType();
     LLVMTypeConverter &typeConverter = *getTypeConverter();
-    Type llvmElemType = typeConverter.convertType(elementType);
     MultiDialectBuilder<LLVMBuilder> create(builder, loc);
 
     // Prepare data to be inserted into a MemRefDescriptor (a struct).
-    auto ptrType = LLVM::LLVMPointerType::get(llvmElemType);
+    auto ptrType = LLVM::LLVMPointerType::get(getContext());
     // Bitcast the address to the MemRefType's element type.
     Value bitCastOp = create.llvm.bitcast(ptrType, address);
     // Create llvm MemRef from original MemRef and fill the data pointers.
@@ -225,8 +225,7 @@ private:
     DenseElementsAttr denseAttr =
         krnlGlobalOp.getValue().value().cast<DenseElementsAttr>();
 
-    Type i8Type = IntegerType::get(builder.getContext(), 8);
-    Type i8PtrType = LLVM::LLVMPointerType::get(i8Type);
+    Type i8PtrType = LLVM::LLVMPointerType::get(builder.getContext());
 
     // Generate LLVM GlobalOps for each string in the KrnlGlobalOp dense
     // attribute.

--- a/src/Conversion/KrnlToLLVM/KrnlInstrument.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlInstrument.cpp
@@ -82,8 +82,7 @@ private:
     MultiDialectBuilder<LLVMBuilder> create(rewriter, module.getLoc());
     Type llvmVoidTy = LLVM::LLVMVoidType::get(context);
     Type llvmI64Ty = IntegerType::get(context, 64);
-    Type llvmI8Ty = IntegerType::get(context, 8);
-    Type opaquePtrTy = LLVM::LLVMPointerType::get(llvmI8Ty);
+    Type opaquePtrTy = LLVM::LLVMPointerType::get(rewriter.getContext());
     return create.llvm.getOrInsertSymbolRef(module,
         StringRef("OMInstrumentPoint"), llvmVoidTy,
         {opaquePtrTy, llvmI64Ty, opaquePtrTy});

--- a/src/Conversion/KrnlToLLVM/KrnlMemcpy.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlMemcpy.cpp
@@ -110,7 +110,7 @@ private:
     // Create a function declaration for memcpy, the signature is:
     //   * `void (i8*, i8* , i64, i1)`
     Type llvmVoidTy = LLVM::LLVMVoidType::get(context);
-    Type llvmI8PtrTy = LLVM::LLVMPointerType::get(IntegerType::get(context, 8));
+    Type llvmI8PtrTy = LLVM::LLVMPointerType::get(context);
     Type llvmI64Ty = IntegerType::get(context, 64);
     Type llvmI1Ty = IntegerType::get(context, 1);
     return create.llvm.getOrInsertSymbolRef(module,

--- a/src/Conversion/KrnlToLLVM/KrnlPrint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlPrint.cpp
@@ -67,8 +67,7 @@ private:
     MultiDialectBuilder<LLVMBuilder> create(rewriter, module.getLoc());
     MLIRContext *ctx = rewriter.getContext();
     Type voidType = LLVM::LLVMVoidType::get(ctx);
-    Type i8Type = IntegerType::get(ctx, 8);
-    Type i8PtrType = LLVM::LLVMPointerType::get(i8Type);
+    Type i8PtrType = LLVM::LLVMPointerType::get(ctx);
     return create.llvm.getOrInsertSymbolRef(module, StringRef("printf"),
         voidType, {i8PtrType},
         /*isVarArg=*/true);

--- a/src/Conversion/KrnlToLLVM/KrnlRandomNormal.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlRandomNormal.cpp
@@ -81,10 +81,9 @@ private:
     //  (memref<3x4x5xf64>, index, f64, f64, f64)
     Type llvmVoidTy = LLVM::LLVMVoidType::get(context);
     Type llvmOptionsTy = FloatType::getF32(context);
-    Type llvmOutputTy = LLVM::LLVMPointerType::get(llvmOptionsTy);
+    Type llvmOutputTy = LLVM::LLVMPointerType::get(context);
     if (inType.isF64()) {
       llvmOptionsTy = FloatType::getF64(context);
-      llvmOutputTy = LLVM::LLVMPointerType::get(llvmOptionsTy);
     }
     Type llvmI64Ty = IntegerType::get(context, 64);
     return create.llvm.getOrInsertSymbolRef(module, functionName, llvmVoidTy,

--- a/src/Conversion/KrnlToLLVM/KrnlStrlen.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlStrlen.cpp
@@ -49,8 +49,7 @@ public:
 
     // Operand.
     MLIRContext *ctx = module.getContext();
-    Type i8Type = IntegerType::get(ctx, 8);
-    Type i8PtrType = LLVM::LLVMPointerType::get(i8Type);
+    Type i8PtrType = LLVM::LLVMPointerType::get(ctx);
     Value strPtr = rewriter.create<LLVM::IntToPtrOp>(
         loc, i8PtrType, operandAdaptor.getStr());
 
@@ -73,8 +72,7 @@ private:
     // Create 'strlen' function signature: `size_t (i8*)`
     // TODO: need to create size_t not i64.
     MLIRContext *ctx = module.getContext();
-    Type i8Type = IntegerType::get(ctx, 8);
-    Type i8PtrType = LLVM::LLVMPointerType::get(i8Type);
+    Type i8PtrType = LLVM::LLVMPointerType::get(ctx);
     return create.llvm.getOrInsertSymbolRef(
         module, StringRef("strlen"), rewriter.getI64Type(), {i8PtrType});
   }

--- a/src/Conversion/KrnlToLLVM/KrnlStrncmp.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlStrncmp.cpp
@@ -48,8 +48,7 @@ public:
 
     // Operands.
     MLIRContext *ctx = module.getContext();
-    Type i8Type = IntegerType::get(ctx, 8);
-    Type i8PtrType = LLVM::LLVMPointerType::get(i8Type);
+    Type i8PtrType = LLVM::LLVMPointerType::get(ctx);
     Value str1Ptr = rewriter.create<LLVM::IntToPtrOp>(
         loc, i8PtrType, operandAdaptor.getStr1());
     Value str2Ptr = rewriter.create<LLVM::IntToPtrOp>(

--- a/src/Conversion/KrnlToLLVM/RuntimeAPI.cpp
+++ b/src/Conversion/KrnlToLLVM/RuntimeAPI.cpp
@@ -61,30 +61,27 @@ RuntimeAPIRegistry::RuntimeAPIRegistry(ModuleOp &module, OpBuilder &builder)
     : registry() {
   MLIRContext *context = module.getContext();
   auto voidTy = LLVM::LLVMVoidType::get(context);
-  auto int8Ty = IntegerType::get(context, 8);
-  auto opaquePtrTy = LLVM::LLVMPointerType::get(int8Ty);
-  auto opaquePtrPtrTy = LLVM::LLVMPointerType::get(opaquePtrTy);
+  auto ptrTy = LLVM::LLVMPointerType::get(context);
   auto int64Ty = IntegerType::get(context, 64);
-  auto int64PtrTy = LLVM::LLVMPointerType::get(int64Ty);
 
   // Declare API type as an enum value, its string name and an LLVM Type
   // specifying its signature.
   // clang-format off
   using API = RuntimeAPI::API;
   std::vector<RuntimeAPI> RuntimeAPISpecs = {
-    RuntimeAPI(API::CREATE_OMTENSOR_LIST, "omTensorListCreate", opaquePtrTy, {opaquePtrPtrTy, int64Ty}),
-    RuntimeAPI(API::CREATE_OMTENSOR, "omTensorCreateUntyped", opaquePtrTy, {int64Ty}),
-    RuntimeAPI(API::DESTROY_OMTENSOR, "omTensorDestroy", voidTy, {opaquePtrTy}),
-    RuntimeAPI(API::GET_DATA, "omTensorGetDataPtr", opaquePtrTy, {opaquePtrTy}),
-    RuntimeAPI(API::SET_DATA, "omTensorSetDataPtr", voidTy, {opaquePtrTy, int64Ty, opaquePtrTy, opaquePtrTy}),
-    RuntimeAPI(API::GET_DATA_RANK, "omTensorGetRank", int64Ty, {opaquePtrTy}),
-    RuntimeAPI(API::GET_DATA_SHAPE, "omTensorGetShape", int64PtrTy, {opaquePtrTy}),
-    RuntimeAPI(API::GET_DATA_STRIDES, "omTensorGetStrides", int64PtrTy, {opaquePtrTy}),
-    RuntimeAPI(API::GET_DATA_TYPE, "omTensorGetDataType", int64Ty, {opaquePtrTy}),
-    RuntimeAPI(API::SET_DATA_TYPE, "omTensorSetDataType", voidTy, {opaquePtrTy, int64Ty}),
-    RuntimeAPI(API::GET_OMT_ARRAY, "omTensorListGetOmtArray", opaquePtrPtrTy, {opaquePtrTy}),
-    RuntimeAPI(API::PRINT_OMTENSOR, "omTensorPrint", voidTy, {opaquePtrTy, opaquePtrTy}),
-    RuntimeAPI(API::GET_OMTENSOR_LIST_SIZE, "omTensorListGetSize", int64Ty, {opaquePtrTy}),
+    RuntimeAPI(API::CREATE_OMTENSOR_LIST, "omTensorListCreate", ptrTy, {ptrTy, int64Ty}),
+    RuntimeAPI(API::CREATE_OMTENSOR, "omTensorCreateUntyped", ptrTy, {int64Ty}),
+    RuntimeAPI(API::DESTROY_OMTENSOR, "omTensorDestroy", voidTy, {ptrTy}),
+    RuntimeAPI(API::GET_DATA, "omTensorGetDataPtr", ptrTy, {ptrTy}),
+    RuntimeAPI(API::SET_DATA, "omTensorSetDataPtr", voidTy, {ptrTy, int64Ty, ptrTy, ptrTy}),
+    RuntimeAPI(API::GET_DATA_RANK, "omTensorGetRank", int64Ty, {ptrTy}),
+    RuntimeAPI(API::GET_DATA_SHAPE, "omTensorGetShape", ptrTy, {ptrTy}),
+    RuntimeAPI(API::GET_DATA_STRIDES, "omTensorGetStrides", ptrTy, {ptrTy}),
+    RuntimeAPI(API::GET_DATA_TYPE, "omTensorGetDataType", int64Ty, {ptrTy}),
+    RuntimeAPI(API::SET_DATA_TYPE, "omTensorSetDataType", voidTy, {ptrTy, int64Ty}),
+    RuntimeAPI(API::GET_OMT_ARRAY, "omTensorListGetOmtArray", ptrTy, {ptrTy}),
+    RuntimeAPI(API::PRINT_OMTENSOR, "omTensorPrint", voidTy, {ptrTy, ptrTy}),
+    RuntimeAPI(API::GET_OMTENSOR_LIST_SIZE, "omTensorListGetSize", int64Ty, {ptrTy}),
   };
   // clang-format on
 

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1401,8 +1401,9 @@ Value LLVMBuilder::addressOf(LLVM::GlobalOp op) const {
 }
 
 Value LLVMBuilder::_alloca(
-    Type resultType, Value size, int64_t alignment) const {
-  return b().create<LLVM::AllocaOp>(loc(), resultType, size, alignment);
+    Type resultType, Type elementType, Value size, int64_t alignment) const {
+  return b().create<LLVM::AllocaOp>(
+      loc(), resultType, elementType, size, alignment);
 }
 
 Value LLVMBuilder::bitcast(Type type, Value val) const {
@@ -1411,12 +1412,12 @@ Value LLVMBuilder::bitcast(Type type, Value val) const {
 
 Value LLVMBuilder::bitcastI8Ptr(Value val) const {
   return b().create<LLVM::BitcastOp>(
-      loc(), LLVM::LLVMPointerType::get(b().getI8Type()), val);
+      loc(), LLVM::LLVMPointerType::get(b().getContext()), val);
 }
 
 Value LLVMBuilder::bitcastI8PtrPtr(Value val) const {
   return b().create<LLVM::BitcastOp>(loc(),
-      LLVM::LLVMPointerType::get(LLVM::LLVMPointerType::get(b().getI8Type())),
+      LLVM::LLVMPointerType::get(LLVM::LLVMPointerType::get(b().getContext())),
       val);
 }
 
@@ -1537,8 +1538,8 @@ Value LLVMBuilder::inttoptr(Type type, Value val) const {
   return b().create<LLVM::IntToPtrOp>(loc(), type, val);
 }
 
-Value LLVMBuilder::load(Value addr) const {
-  return b().create<LLVM::LoadOp>(loc(), addr);
+Value LLVMBuilder::load(Type type, Value addr) const {
+  return b().create<LLVM::LoadOp>(loc(), type, addr);
 }
 
 Value LLVMBuilder::mul(Value lhs, Value rhs) const {
@@ -1550,7 +1551,7 @@ Value LLVMBuilder::null(Type type) const {
 }
 
 Value LLVMBuilder::nullI8Ptr() const {
-  Type I8PtrTy = LLVM::LLVMPointerType::get(b().getI8Type());
+  Type I8PtrTy = LLVM::LLVMPointerType::get(b().getContext());
   return b().create<LLVM::NullOp>(loc(), I8PtrTy);
 }
 

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -472,7 +472,7 @@ struct LLVMBuilder final : DialectBuilder {
 
   // AllocaOp
   mlir::Value _alloca(
-      mlir::Type resultType, mlir::Value size, int64_t alignment) const;
+      mlir::Type resultType, mlir::Type elementType, mlir::Value size, int64_t alignment) const;
 
   // BitcastOp
   mlir::Value bitcast(mlir::Type type, mlir::Value val) const;
@@ -527,7 +527,7 @@ struct LLVMBuilder final : DialectBuilder {
   mlir::Value inttoptr(mlir::Type type, mlir::Value val) const;
 
   // LoadOp
-  mlir::Value load(mlir::Value addr) const;
+  mlir::Value load(mlir::Type type, mlir::Value addr) const;
 
   // MulOp
   mlir::Value mul(mlir::Value lhs, mlir::Value rhs) const;

--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -282,6 +282,7 @@ TypeRange OnnxBuilder::toTensors(TypeRange inputs) const {
     }
     resultTypes.emplace_back(RankedTensorType::get(aTy.getShape(), elementTy));
   }
+  llvm::errs() << __FILE__ << "::" << __LINE__ << "\n";
   return TypeRange(resultTypes);
 }
 

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -329,6 +329,7 @@ ValueRange emitSplitAxisOutputLength1(
   }
   Type splitType = RankedTensorType::get(splitShape, elementType);
   SmallVector<Type, 4> splitTypes(inputShape[axis], splitType);
+  llvm::errs() << __FILE__ << "::" << __LINE__ << "\n";
   ValueRange results =
       create.onnx.split(ArrayRef(splitTypes), input, split, axis);
   return results;


### PR DESCRIPTION
Hey there,

As mentioned briefly in the meeting yesterday, the LLVM dialect in MLIR has switched to opaque pointers per default. This is causing a lot of issues in the Kernel dialect. Unfortunately I cannot refactor the code to use opaque pointers as part of the bump.

With this PR, I wanted to highlight some places that I found where code will need to change once opaque pointers become not only the default, but the only type of pointer there is. The idea is that the people, that understand the needs of the Kernel dialect and are familiar with the affected parts of the code, can start migrating the code use opaque pointers, such that at some point in the future, we can enable opaque pointers in the LLVM dialect again.

For the actual bump, I will disable opaque pointers and open a new PR without these changes here.