### PR TITLE
Set const for array passed or returned from C/C++ API

### DIFF
--- a/include/onnx-mlir/Runtime/OMTensor.h
+++ b/include/onnx-mlir/Runtime/OMTensor.h
@@ -4,7 +4,7 @@
 
 //===-------------- OMTensor.h - OMTensor Declaration header --------------===//
 //
-// Copyright 2019-2020 The IBM Research Authors.
+// Copyright 2019-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -90,7 +90,7 @@ extern "C" {
  *
  */
 OM_EXTERNAL_VISIBILITY OMTensor *omTensorCreate(
-    void *data_ptr, int64_t *shape, int64_t rank, OM_DATA_TYPE dtype);
+    void *data_ptr, const int64_t *shape, int64_t rank, OM_DATA_TYPE dtype);
 
 /**
  * \brief Create an OMTensor with specified data pointer, shape, rank and
@@ -121,7 +121,7 @@ OM_EXTERNAL_VISIBILITY OMTensor *omTensorCreate(
  *
  */
 OM_EXTERNAL_VISIBILITY OMTensor *omTensorCreateWithOwnership(void *data_ptr,
-    int64_t *shape, int64_t rank, OM_DATA_TYPE dtype, int64_t owning);
+    const int64_t *shape, int64_t rank, OM_DATA_TYPE dtype, int64_t owning);
 
 /**
  * Create an OMTensor with the specified shape, rank and element type,
@@ -141,7 +141,7 @@ OM_EXTERNAL_VISIBILITY OMTensor *omTensorCreateWithOwnership(void *data_ptr,
  *
  */
 OM_EXTERNAL_VISIBILITY OMTensor *omTensorCreateEmpty(
-    int64_t *shape, int64_t rank, OM_DATA_TYPE dtype);
+    const int64_t *shape, int64_t rank, OM_DATA_TYPE dtype);
 
 /**
  * \brief Destroy the OMTensor struct.
@@ -179,7 +179,7 @@ OM_EXTERNAL_VISIBILITY void *omTensorGetDataPtr(const OMTensor *tensor);
  * @param tensor pointer to the OMTensor
  * @return pointer to the data shape array.
  */
-OM_EXTERNAL_VISIBILITY int64_t *omTensorGetShape(const OMTensor *tensor);
+OM_EXTERNAL_VISIBILITY const int64_t *omTensorGetShape(const OMTensor *tensor);
 
 /**
  * \brief OMTensor data shape setter.
@@ -195,7 +195,7 @@ OM_EXTERNAL_VISIBILITY int64_t *omTensorGetShape(const OMTensor *tensor);
  *
  * Set the data shape array of the OMTensor to the values in the input array.
  */
-OM_EXTERNAL_VISIBILITY void omTensorSetShape(OMTensor *tensor, int64_t *shape);
+OM_EXTERNAL_VISIBILITY void omTensorSetShape(OMTensor *tensor, const int64_t *shape);
 
 /**
  * \brief OMTensor data strides getter
@@ -209,7 +209,7 @@ OM_EXTERNAL_VISIBILITY void omTensorSetShape(OMTensor *tensor, int64_t *shape);
  * @param tensor pointer to the OMTensor
  * @return pointer to the data strides array.
  */
-OM_EXTERNAL_VISIBILITY int64_t *omTensorGetStrides(const OMTensor *tensor);
+OM_EXTERNAL_VISIBILITY const int64_t *omTensorGetStrides(const OMTensor *tensor);
 
 /**
  * \brief OMTensor data strides setter
@@ -226,7 +226,7 @@ OM_EXTERNAL_VISIBILITY int64_t *omTensorGetStrides(const OMTensor *tensor);
  * Set the data strides array of the OMTensor to the values in the input array.
  */
 OM_EXTERNAL_VISIBILITY void omTensorSetStrides(
-    OMTensor *tensor, int64_t *stride);
+    OMTensor *tensor, const int64_t *stride);
 
 /**
  * \brief OMTensor data strides setter with stride values from PyArray strides
@@ -247,7 +247,7 @@ OM_EXTERNAL_VISIBILITY void omTensorSetStrides(
  * Set the data strides array of the OMTensor to the values in the input array.
  */
 OM_EXTERNAL_VISIBILITY void omTensorSetStridesWithPyArrayStrides(
-    OMTensor *tensor, int64_t *stridesInBytes);
+    OMTensor *tensor, const int64_t *stridesInBytes);
 
 /**
  * \brief OMTensor data type getter

--- a/include/onnx-mlir/Runtime/OMTensorList.h
+++ b/include/onnx-mlir/Runtime/OMTensorList.h
@@ -77,7 +77,7 @@ OM_EXTERNAL_VISIBILITY void omTensorListDestroyShallow(OMTensorList *list);
  * @param list pointer to the OMTensorList
  * @return pointer to the array of OMTensor pointers.
  */
-OM_EXTERNAL_VISIBILITY OMTensor **omTensorListGetOmtArray(OMTensorList *list);
+OM_EXTERNAL_VISIBILITY OMTensor **omTensorListGetOmtArray(const OMTensorList *list);
 
 /**
  * \brief OMTensorList size getter
@@ -86,7 +86,7 @@ OM_EXTERNAL_VISIBILITY OMTensor **omTensorListGetOmtArray(OMTensorList *list);
  * @param list pointer to the OMTensorList
  * @return number of elements in the OMTensor array.
  */
-OM_EXTERNAL_VISIBILITY int64_t omTensorListGetSize(OMTensorList *list);
+OM_EXTERNAL_VISIBILITY int64_t omTensorListGetSize(const OMTensorList *list);
 
 /**
  * \brief OMTensorList OMTensor getter by index
@@ -96,7 +96,7 @@ OM_EXTERNAL_VISIBILITY int64_t omTensorListGetSize(OMTensorList *list);
  * @return pointer to the OMTensor, NULL if not found.
  */
 OM_EXTERNAL_VISIBILITY OMTensor *omTensorListGetOmtByIndex(
-    OMTensorList *list, int64_t index);
+    const OMTensorList *list, int64_t index);
 
 #ifdef __cplusplus
 }

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -4,7 +4,7 @@
 
 //===------- ExecutionSession.cpp - ExecutionSession Implementation -------===//
 //
-// Copyright 2019-2020 The IBM Research Authors.
+// Copyright 2019-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -83,7 +83,7 @@ std::vector<OMTensorUniquePtr> ExecutionSession::run(
   std::vector<OMTensor *> omts;
   for (const auto &inOmt : ins)
     omts.emplace_back(inOmt.get());
-  auto *wrappedInput = omTensorListCreate(&omts[0], (int64_t)omts.size());
+  auto *wrappedInput = omTensorListCreate(omts.data(), (int64_t)omts.size());
 
   auto *wrappedOutput = _entryPointFunc(wrappedInput);
 

--- a/src/Runtime/OMResize.inc
+++ b/src/Runtime/OMResize.inc
@@ -1,3 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------- OMTensorList.cpp - OMTensor C/C++ Implementation ----------===//
+//
+// Copyright 2022-2023 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains C/C++ neutral implementation of OMTensorList data
+// structures and helper functions.
+//
+//===----------------------------------------------------------------------===//
 #ifdef __cplusplus
 #include <cassert>
 #else
@@ -230,7 +244,7 @@ static void interpolate_nd_OMTensor(OMTensor *output_OMT, OMTensor *data,
          "Resize runtime: only float type is supported currently");
 
   int64_t rank = omTensorGetRank(data);
-  int64_t *inputShape = omTensorGetShape(data);
+  const int64_t *inputShape = omTensorGetShape(data);
   float *scale_factor = NULL;
   int64_t *output_size = NULL;
   if (scale_factor_OMT != NULL)

--- a/src/Runtime/OMResize.inc
+++ b/src/Runtime/OMResize.inc
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===---------- OMTensorList.cpp - OMTensor C/C++ Implementation ----------===//
+//===---------- OMResize.cpp - OMTensor C/C++ Implementation ----------===//
 //
 // Copyright 2022-2023 The IBM Research Authors.
 //

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -4,7 +4,7 @@
 
 //===--------- OMTensor.inc - C/C++ Neutral OMTensor Implementation--------===//
 //
-// Copyright 2019-2022 The IBM Research Authors.
+// Copyright 2019-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -191,7 +191,7 @@ static inline int64_t computeElemOffset(
 
 // Create a OMTensor.
 OMTensor *omTensorCreate(
-    void *data_ptr, int64_t *shape, int64_t rank, OM_DATA_TYPE dtype) {
+    void *data_ptr, const int64_t *shape, int64_t rank, OM_DATA_TYPE dtype) {
   OMTensor *tensor = (OMTensor *)malloc(sizeof(OMTensor));
   if (!tensor)
     return NULL;
@@ -221,7 +221,7 @@ OMTensor *omTensorCreate(
 }
 
 // Create a OMTensor with specified ownership.
-OMTensor *omTensorCreateWithOwnership(void *data_ptr, int64_t *shape,
+OMTensor *omTensorCreateWithOwnership(void *data_ptr, const int64_t *shape,
     int64_t rank, OM_DATA_TYPE dtype, int64_t owning) {
   OMTensor *tensor = omTensorCreate(data_ptr, shape, rank, dtype);
   // If ctor fails, return NULL.
@@ -267,7 +267,7 @@ OMTensor *omTensorCreateUntyped(int64_t rank) {
 }
 
 OMTensor *omTensorCreateEmpty(
-    int64_t *shape, int64_t rank, OM_DATA_TYPE dtype) {
+    const int64_t *shape, int64_t rank, OM_DATA_TYPE dtype) {
   OMTensor *tensor;
   void *dataPtr;
   if (((dataPtr = malloc(getNumElems(shape, rank) * getDataTypeSize(dtype))) ==
@@ -323,26 +323,26 @@ void omTensorSetDataPtr(
 }
 
 /* OMTensor data shape getter */
-int64_t *omTensorGetShape(const OMTensor *tensor) { return tensor->_shape; }
+const int64_t *omTensorGetShape(const OMTensor *tensor) { return tensor->_shape; }
 
 /* OMTensor data shape setter */
-void omTensorSetShape(OMTensor *tensor, int64_t *shape) {
+void omTensorSetShape(OMTensor *tensor, const int64_t *shape) {
   for (int64_t i = 0; i < tensor->_rank; i++)
     tensor->_shape[i] = shape[i];
 }
 
 /* OMTensor data strides getter */
-int64_t *omTensorGetStrides(const OMTensor *tensor) { return tensor->_strides; }
+const int64_t *omTensorGetStrides(const OMTensor *tensor) { return tensor->_strides; }
 
 /* OMTensor data strides setter */
-void omTensorSetStrides(OMTensor *tensor, int64_t *strides) {
+void omTensorSetStrides(OMTensor *tensor, const int64_t *strides) {
   for (int64_t i = 0; i < tensor->_rank; i++)
     tensor->_strides[i] = strides[i];
 }
 
 /* OMTensor data strides setter with PyArray stride values */
 void omTensorSetStridesWithPyArrayStrides(
-    OMTensor *tensor, int64_t *stridesInBytes) {
+    OMTensor *tensor, const int64_t *stridesInBytes) {
   for (int64_t i = 0; i < tensor->_rank; i++)
     tensor->_strides[i] =
         stridesInBytes[i] / getDataTypeSize(tensor->_dataType);

--- a/src/Runtime/OMTensorList.inc
+++ b/src/Runtime/OMTensorList.inc
@@ -109,13 +109,13 @@ void omTensorListDestroyShallow(OMTensorList *list) {
 }
 
 /* OMTensorList OMTensor array getter */
-OMTensor **omTensorListGetOmtArray(OMTensorList *list) { return list->_omts; }
+OMTensor **omTensorListGetOmtArray(const OMTensorList *list) { return list->_omts; }
 
 /* OMTensorList number of OMTensor getter */
-int64_t omTensorListGetSize(OMTensorList *list) { return list->_size; }
+int64_t omTensorListGetSize(const OMTensorList *list) { return list->_size; }
 
 /* Return OMTensor at specified index in the OMTensorList */
-OMTensor *omTensorListGetOmtByIndex(OMTensorList *rlist, int64_t index) {
+OMTensor *omTensorListGetOmtByIndex(const OMTensorList *rlist, int64_t index) {
   assert(index >= 0);
   assert(index < rlist->_size);
   return rlist->_omts[index];

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -562,12 +562,12 @@ jobject omtl_native_to_java(
 
     LIB_TYPE_VAR_CALL(void *, jni_data, omTensorGetDataPtr(jni_omts[i]),
         jni_data != NULL, env, japi->jecpt_cls, "omt[%d]:data=%p", i, jni_data);
-    LIB_TYPE_VAR_CALL(int64_t *, jni_shape, omTensorGetShape(jni_omts[i]),
+    LIB_TYPE_VAR_CALL(const int64_t *, jni_shape, omTensorGetShape(jni_omts[i]),
         jni_shape != NULL, env, japi->jecpt_cls, "omt[%d]:shape=%p", i,
         jni_shape);
-    LIB_TYPE_VAR_CALL(int64_t *, jni_strides, omTensorGetStrides(jni_omts[i]),
-        jni_strides != NULL, env, japi->jecpt_cls, "omt[%d]:strides=%p", i,
-        jni_strides);
+    LIB_TYPE_VAR_CALL(const int64_t *, jni_strides,
+        omTensorGetStrides(jni_omts[i]), jni_strides != NULL, env,
+        japi->jecpt_cls, "omt[%d]:strides=%p", i, jni_strides);
     LIB_TYPE_VAR_CALL(OM_DATA_TYPE, jni_dataType,
         omTensorGetDataType(jni_omts[i]), jni_dataType != ONNX_TYPE_UNDEFINED,
         env, japi->jecpt_cls, "omt[%d]:dataType=%d", i, jni_dataType);

--- a/test/modellib/ModelLib.cpp
+++ b/test/modellib/ModelLib.cpp
@@ -4,7 +4,7 @@
 
 //===========-- ModelLib.cpp - Helper function for building models -==========//
 //
-// Copyright 2022 The IBM Research Authors.
+// Copyright 2022-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -208,7 +208,7 @@ void ModelLibBuilder::printIndices(
 void ModelLibBuilder::printTensor(
     const OMTensor *t, std::vector<int64_t> &indices, bool isLast) const {
   int64_t rank = omTensorGetRank(t);
-  int64_t *shape = omTensorGetShape(t);
+  const int64_t *shape = omTensorGetShape(t);
   int64_t currSize = indices.size();
   // Utility to print tabs.
   auto printTab = [](int currSize) {
@@ -253,7 +253,7 @@ void ModelLibBuilder::printTensor(
 void ModelLibBuilder::printTensor(
     const std::string varName, const OMTensor *t, bool asNumpy) const {
   int64_t rank = omTensorGetRank(t);
-  int64_t *shape = omTensorGetShape(t);
+  const int64_t *shape = omTensorGetShape(t);
   std::vector<int64_t> shapeVect(shape, shape + rank);
   // Print message as comment and add rank and shape.
   printf("# ");

--- a/test/numerical/TestGemm.cpp
+++ b/test/numerical/TestGemm.cpp
@@ -4,7 +4,7 @@
 
 //====-- TestGemm.cpp - test GEMM code -======================================//
 //
-// Copyright 2022 The IBM Research Authors.
+// Copyright 2022-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -29,7 +29,7 @@ void *omTensorGetAllocatedPtr(OMTensor *tensor);
 template <typename TYPE>
 void omPrintAsPython(OMTensor *tensor, std::string name) {
   int rank = omTensorGetRank(tensor);
-  int64_t *shape = omTensorGetShape(tensor);
+  const int64_t *shape = omTensorGetShape(tensor);
   if (false) {
     printf("# tensor 0x%llx, allocated addr 0x%llx, data addr 0x%llx\n",
         (long long)tensor, (long long)omTensorGetAllocatedPtr(tensor),

--- a/test/numerical/TestScan.cpp
+++ b/test/numerical/TestScan.cpp
@@ -4,7 +4,7 @@
 
 //====-- TestScan.cpp - test Scan code -======================================//
 //
-// Copyright 2022 The IBM Research Authors.
+// Copyright 2022-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -29,7 +29,7 @@ void *omTensorGetAllocatedPtr(OMTensor *tensor);
 template <typename TYPE>
 void omPrintAsPython(OMTensor *tensor, std::string name) {
   int rank = omTensorGetRank(tensor);
-  int64_t *shape = omTensorGetShape(tensor);
+  const int64_t *shape = omTensorGetShape(tensor);
   if (false) {
     printf("# tensor 0x%llx, allocated addr 0x%llx, data addr 0x%llx\n",
         (long long)tensor, (long long)omTensorGetAllocatedPtr(tensor),

--- a/test/unit/Runtime/OMTensorTest.c
+++ b/test/unit/Runtime/OMTensorTest.c
@@ -5,7 +5,7 @@
 //===----------------- OMTensorTest.h - OMTensor Unit Test
 //-----------------===//
 //
-// Copyright 2019-2020 The IBM Research Authors.
+// Copyright 2019-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -24,12 +24,12 @@ void testOMTensorCtor() {
   OMTensor *tensor = omTensorCreate(data, shape, 2, ONNX_TYPE_FLOAT);
   assert(tensor);
 
-  int64_t *shape_ptr = omTensorGetShape(tensor);
+  const int64_t *shape_ptr = omTensorGetShape(tensor);
   assert(shape_ptr);
   assert(shape_ptr[0] == 2);
   assert(shape_ptr[1] == 2);
 
-  int64_t *strides_ptr = omTensorGetStrides(tensor);
+  const int64_t *strides_ptr = omTensorGetStrides(tensor);
   assert(strides_ptr);
   assert(strides_ptr[0] == 2);
   assert(strides_ptr[1] == 1);


### PR DESCRIPTION
* Set parameters returns of arrays like `shape`, `strides` and some TensorList pointers as `const`
* Implements https://github.com/onnx/onnx-mlir/issues/2075