### PR TITLE
Do not replace unstick/stick by LayoutTransform when layout is 1D or 2DS

### DIFF
--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.cpp
@@ -195,20 +195,19 @@ Value getConstantOfType(
   return create.onnx.constant(denseAttr);
 }
 
-bool oneIsOfNHWCLayout(Type t1, Type t2) {
+bool oneIsOfLayout(Type t1, Type t2,
+    onnx_mlir::zhigh::ZTensorEncodingAttr::DataLayout layout) {
   if (auto rtp1 = llvm::dyn_cast<RankedTensorType>(t1)) {
-    if (onnx_mlir::zhigh::getZTensorLayout(rtp1) ==
-        onnx_mlir::zhigh::ZTensorEncodingAttr::DataLayout::NHWC)
+    if (onnx_mlir::zhigh::getZTensorLayout(rtp1) == layout)
       return true;
-    // t1 is not of NHWC, check t2.
+    // t1 is not of `layout`, check t2.
     if (auto rtp2 = llvm::dyn_cast<RankedTensorType>(t2)) {
-      return (onnx_mlir::zhigh::getZTensorLayout(rtp2) ==
-              onnx_mlir::zhigh::ZTensorEncodingAttr::DataLayout::NHWC);
+      return (onnx_mlir::zhigh::getZTensorLayout(rtp2) == layout);
     }
     // t2 is unranked.
   }
   // t1 is unranked.
-  // Unranked type is potentially of NHWC.
+  // Unranked type is potentially of `layout`.
   return true;
 }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp
@@ -58,8 +58,9 @@ mlir::Value getMinusBcastConst(mlir::OpBuilder &builder, mlir::Location loc,
 mlir::Value getConstantOfType(
     mlir::OpBuilder &builder, mlir::Location loc, mlir::Type type, float val);
 
-/// True if at least one of the types is NHWC layout.
-bool oneIsOfNHWCLayout(mlir::Type t1, mlir::Type t2);
+/// True if at least one of the types is `layout`.
+bool oneIsOfLayout(
+    mlir::Type t1, mlir::Type t2, ZTensorEncodingAttr::DataLayout layout);
 
 /// Check if ONNXReshapeOp is reshaping 2D/3D to 4D by tiling each input
 /// dimension.

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td
@@ -45,8 +45,21 @@ def GetLayout : NativeCodeCall<
 >;
 
 def NoOneIsOfNHWCLayout: Constraint<
-  CPred<"!::onnx_mlir::zhigh::oneIsOfNHWCLayout($0.getType(), $1.getType())">,
+  CPred<"!::onnx_mlir::zhigh::oneIsOfLayout($0.getType(), $1.getType(), "
+        "::onnx_mlir::zhigh::ZTensorEncodingAttr::DataLayout::NHWC)">,
   "No tensor is of NHWC layout"
+>;
+
+def NoOneIsOf1DLayout: Constraint<
+  CPred<"!::onnx_mlir::zhigh::oneIsOfLayout($0.getType(), $1.getType(), "
+        "::onnx_mlir::zhigh::ZTensorEncodingAttr::DataLayout::_1D)">,
+  "No tensor is of 1D layout"
+>;
+
+def NoOneIsOf2DSLayout: Constraint<
+  CPred<"!::onnx_mlir::zhigh::oneIsOfLayout($0.getType(), $1.getType(), "
+        "::onnx_mlir::zhigh::ZTensorEncodingAttr::DataLayout::_2DS)">,
+  "No tensor is of 2DS layout"
 >;
 
 def GetEncodingAttr : NativeCodeCall<

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/ZHighStick.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/ZHighStick.td
@@ -53,7 +53,9 @@ def StickUnstickSameLayoutRemovalPattern : Pat<
 def StickUnstickDiffLayoutRemovalPattern : Pat<
   (ZHighStickOp:$stick (ZHighUnstickOp:$unstick $arg), $_),
   (ONNXLayoutTransformOp $arg, (GetEncodingAttr $stick)),
-  [(NotSameLayout $arg, $stick), (NoOneIsOfNHWCLayout $arg, $stick)]
+  [(NotSameLayout $arg, $stick), (NoOneIsOfNHWCLayout $arg, $stick),
+   // Do not support 1D and 2DS because of this issue: https://github.com/onnx/onnx-mlir/issues/1940
+   (NoOneIsOf1DLayout $arg, $stick), (NoOneIsOf2DSLayout $arg, $stick)]
 >;
 
 // The pattern

--- a/test/mlir/accelerators/nnpa/transform/zhigh-combine.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zhigh-combine.mlir
@@ -66,6 +66,27 @@ func.func @replace_stick_and_unstick_by_layout_transform(%arg0 : tensor<5x10x10x
 
 // -----
 
+// Donot replace unstick/stick by onnx.LayoutTransform because of 2ds layout.
+func.func @donot_replace_stick_and_unstick_by_layout_transform(%arg0 : tensor<5x10xf32>) -> tensor<5x10xf32> {
+  %0 = "zhigh.Stick"(%arg0) : (tensor<5x10xf32>) -> tensor<5x10xf32, #zhigh.layout<{dataLayout = "2D"}>>
+  %1 = "zhigh.Relu"(%0) : (tensor<5x10xf32, #zhigh.layout<{dataLayout = "2D"}>>) -> tensor<5x10xf32, #zhigh.layout<{dataLayout = "2D"}>>
+  %2 = "zhigh.Unstick"(%1) : (tensor<5x10xf32, #zhigh.layout<{dataLayout = "2D"}>>) -> tensor<5x10xf32>
+
+  %3 = "zhigh.Stick"(%2) {layout = "2DS"} : (tensor<5x10xf32>) -> tensor<5x10xf32, #zhigh.layout<{dataLayout = "2DS"}>>
+  %4 = "zhigh.Relu"(%3) : (tensor<5x10xf32, #zhigh.layout<{dataLayout = "2DS"}>>) -> tensor<5x10xf32, #zhigh.layout<{dataLayout = "2DS"}>>
+  %5 = "zhigh.Unstick"(%4) {layout = "2DS"} : (tensor<5x10xf32, #zhigh.layout<{dataLayout = "2DS"}>>) -> tensor<5x10xf32>
+  "func.return"(%5) : (tensor<5x10xf32>) -> ()
+
+  // CHECK-LABEL: donot_replace_stick_and_unstick_by_layout_transform
+  // CHECK: zhigh.Stick
+  // CHECK: zhigh.Relu
+  // CHECK: zhigh.Unstick
+  // CHECK: zhigh.Stick
+  // CHECK: zhigh.Relu
+  // CHECK: zhigh.Unstick
+}
+// -----
+
 // Remove Stick with NoneType input.
 func.func @remove_nonetype_stick() -> () {
   %cst = "onnx.NoValue"() {value} : () -> none 


### PR DESCRIPTION
Because of [an issue](https://github.com/onnx/onnx-mlir/issues/1940) about wrong index access for 1D and 2DS layout, this patch disables the replacement of unstic/stick by LayoutTransform in case of 1D and 2DS layout.

