### PR TITLE
Fix IndexExprScope in TransposesOp lowering

### DIFF
--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -197,6 +197,7 @@ private:
     create->krnl.iterateIE(loopDef, loopDef, lbs, inUBs,
         [&](KrnlBuilder &createKrnl, ValueRange indices) {
           MultiDialectBuilder<MathBuilder, KrnlBuilder> create(createKrnl);
+          IndexExprScope loopScope(createKrnl);
           // Compute destination and source offsets for memcpy.
           IndexExpr destOffsetIE = LiteralIndexExpr(0);
           IndexExpr srcOffsetIE = LiteralIndexExpr(0);

--- a/utils/RunONNXLib.cpp
+++ b/utils/RunONNXLib.cpp
@@ -113,7 +113,7 @@ extern "C" OMTensorList *run_main_graph(OMTensorList *);
 extern "C" const char *omInputSignature(const char *);
 extern "C" const char *omOutputSignature(const char *);
 extern "C" OMTensor *omTensorCreateWithOwnership(
-    void *, int64_t *, int64_t, OM_DATA_TYPE, int64_t);
+    void *, const int64_t *, int64_t, OM_DATA_TYPE, int64_t);
 extern "C" OMTensorList *TensorListCreate(OMTensor **, int);
 extern "C" void omTensorListDestroy(OMTensorList *list);
 // DLL definitions


### PR DESCRIPTION
This patch fixes an issue about IndexExprScope in TransposesOp lowering and a function signature in RunONNXLib.cpp