### PR TITLE
Fix an error in constant propagation for ConstantOfShape

### DIFF
--- a/src/Support/TypeUtilities.cpp
+++ b/src/Support/TypeUtilities.cpp
@@ -51,6 +51,7 @@ int64_t getRank(Type ty) {
 
 /// Get the number of elements.
 int64_t getNumberOfElements(Type ty) {
+  assert(ty.cast<ShapedType>().hasStaticShape() && "Has unknown dimensions");
   ArrayRef<int64_t> shape = getShape(ty);
   return ShapedType::getNumElements(shape);
 }

--- a/src/Support/TypeUtilities.cpp
+++ b/src/Support/TypeUtilities.cpp
@@ -50,8 +50,8 @@ int64_t getRank(Type ty) {
 }
 
 /// Get the number of elements.
-int64_t getNumberOfElements(Type ty) {
-  assert(ty.cast<ShapedType>().hasStaticShape() && "Has unknown dimensions");
+int64_t getNumberOfElements(ShapedType ty) {
+  assert(ty.hasStaticShape() && "Has unknown dimensions");
   ArrayRef<int64_t> shape = getShape(ty);
   return ShapedType::getNumElements(shape);
 }
@@ -71,9 +71,9 @@ int64_t getEltSizeInBytes(Type ty) {
 }
 
 /// Get the size of a tensor from its ranked type in bytes.
-int64_t getSizeInBytes(Type ty) {
+int64_t getSizeInBytes(ShapedType ty) {
   ArrayRef<int64_t> shape = getShape(ty);
-  assert(ty.cast<ShapedType>().hasStaticShape() && "Has unknown dimensions");
+  assert(ty.hasStaticShape() && "Has unknown dimensions");
   return ShapedType::getNumElements(shape) * getEltSizeInBytes(ty);
 }
 

--- a/src/Support/TypeUtilities.hpp
+++ b/src/Support/TypeUtilities.hpp
@@ -29,11 +29,11 @@ llvm::ArrayRef<int64_t> getShape(mlir::Type ty);
 /// Get rank.
 int64_t getRank(mlir::Type ty);
 /// Get the number of elements.
-int64_t getNumberOfElements(mlir::Type ty);
+int64_t getNumberOfElements(mlir::ShapedType ty);
 /// Get the element size in bytes.
 int64_t getEltSizeInBytes(mlir::Type ty);
 /// Get the size of a tensor from its ranked type in bytes.
-int64_t getSizeInBytes(mlir::Type ty);
+int64_t getSizeInBytes(mlir::ShapedType ty);
 /// Check if two RankedTensorTypes have the same encoding attribute or not.
 bool sameEncodingAttr(mlir::Type t1, mlir::Type t2);
 /// Get the byte width of an int or float type.

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -557,6 +557,7 @@ def ConstantOfShapeofConst :  Pat<
     (ONNXConstantOfShapeOp:$resOp (ONNXConstantOp:$shape $_, $_, $_, $_, $_, $_, $_, $_), $value),
     // To c where c is the expanded value.
     (CreateConstantOfShapeOfConst $resOp, $shape, $value),
-    [(IsFromDenseONNXConstantOp:$shape)]>;
+    [(IsFromDenseONNXConstantOp:$shape),
+     (HasStaticShape:$resOp)]>;
 
 #endif // ONNX_CONSTPROP

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1004,7 +1004,7 @@ func.func @test_reshape() -> tensor<*xf32> {
 
 func.func @test_constant_of_shape() -> tensor<3xi64> {
   %0 = onnx.Constant dense<3> : tensor<1xi64>
-  %1 = "onnx.ConstantOfShape"(%0) {onnx_node_name = "ConstantOfShape_177", value = dense<2> : tensor<1xi64>} : (tensor<1xi64>) -> tensor<3xi64>
+  %1 = "onnx.ConstantOfShape"(%0) {value = dense<2> : tensor<1xi64>} : (tensor<1xi64>) -> tensor<3xi64>
   "func.return"(%1) : (tensor<3xi64>) -> ()
 
 // CHECK-LABEL:  func.func @test_constant_of_shape
@@ -1018,7 +1018,7 @@ func.func @test_constant_of_shape() -> tensor<3xi64> {
 
 func.func @test_constant_of_shape_empty_tensor() -> tensor<f32> {
   %0 = onnx.Constant dense<> : tensor<0xi64>
-  %1 = "onnx.ConstantOfShape"(%0) {onnx_node_name = "ConstantOfShape_177", value = dense<2.0> : tensor<1xf32>} : (tensor<0xi64>) -> tensor<f32>
+  %1 = "onnx.ConstantOfShape"(%0) {value = dense<2.0> : tensor<1xf32>} : (tensor<0xi64>) -> tensor<f32>
   "func.return"(%1) : (tensor<f32>) -> ()
 
 // CHECK-LABEL:  func.func @test_constant_of_shape_empty_tensor


### PR DESCRIPTION
This patch adds an additional condition for ConstantOfShape's constant propagation that is to check whether the output type is static or not. Constant propagation should happen when the output type is static (for example by shape inference).