### PR TITLE
Analyze unknown dimensions for ExpandOp when shape is from concatenation of dims

### DIFF
--- a/src/Transform/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Transform/ONNX/ONNXDimAnalysis.cpp
@@ -391,6 +391,17 @@ void DimAnalysis::visitDim(
     return;
   }
 
+  // ExpandOp when shape is from Concat of dims.
+  if (auto expandOp = dyn_cast<ONNXExpandOp>(op)) {
+    if (areDimsFromConcat(expandOp.getShape())) {
+      SmallVector<Value, 4> shapes;
+      getDims(expandOp.getShape(), shapes);
+      DimT newSameDim(shapes[dimIndex], dimIndex);
+      sameDims.insert(newSameDim);
+      return;
+    }
+  }
+
   // MatMulOp
   if (auto matmulOp = dyn_cast<ONNXMatMulOp>(op)) {
     bool success = exploreSameInputDims(dim, op, sameDims);

--- a/test/mlir/onnx/onnx_dim_analysis.mlir
+++ b/test/mlir/onnx/onnx_dim_analysis.mlir
@@ -125,3 +125,25 @@ func.func @test_binary_elementwise(%arg0 : tensor<?x3x?xf32>) -> tensor<?x3x?xf3
 // CHECK:           return [[VAR_1_]] : tensor<?x3x?xf32>
 // CHECK:         }
 }
+
+// -----
+
+func.func @test_expand_from_concat_dims(%arg0: tensor<1x256xi64>, %arg1: tensor<?x256xi64>) -> tensor<?x256xi64> {
+  %0 = onnx.Constant dense<256> : tensor<1xi64>
+  %1 = "onnx.Dim"(%arg1) {axis = 0 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
+  %2 = "onnx.Concat"(%1, %0) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+  %3 = "onnx.Expand"(%arg0, %2) {onnx_node_name = "Expand_30"} : (tensor<1x256xi64>, tensor<2xi64>) -> tensor<?x256xi64>
+  return %3: tensor<?x256xi64>
+
+// CHECK-LABEL:  func.func @test_expand_from_concat_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x256xi64>, [[PARAM_1_:%.+]]: tensor<?x256xi64>) -> tensor<?x256xi64> {
+// CHECK:           "onnx.DimGroup"([[PARAM_1_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x256xi64>) -> ()
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Dim"([[PARAM_1_]]) {axis = 0 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
+// CHECK:           "onnx.DimGroup"([[PARAM_1_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x256xi64>) -> ()
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]], [[VAR_0_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Expand"([[PARAM_0_]], [[VAR_2_]]) {onnx_node_name = "Expand_30"} : (tensor<1x256xi64>, tensor<2xi64>) -> tensor<?x256xi64>
+// CHECK:           "onnx.DimGroup"([[VAR_3_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x256xi64>) -> ()
+// CHECK:           return [[VAR_3_]] : tensor<?x256xi64>
+// CHECK:         }
+}


### PR DESCRIPTION
This adds a case in DimAnalysis for ExpandOp when its shape is concatenation of unknown dimensions.

It seems this situation will happen with other operations, so we need a systematic way to handle it. However, this patch is for ExpandOp to make DimAnalysis work with the roBERTa model.