### PR TITLE
MatMulInteger const prop

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -510,6 +510,7 @@ ElementsAttr ElementsAttrBuilder::matMul(ElementsAttr lhs, ElementsAttr rhs) {
   Type elementType = lhsType.getElementType();
   assert(elementType == rhsType.getElementType() &&
          "matMul() requires identical element types");
+  assert(!elementType.isInteger(1) && "matMul() elements must be numbers");
 
   ArrayRef<int64_t> lhsShape = lhsType.getShape();
   unsigned lhsRank = lhsShape.size();

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -513,10 +513,10 @@ ElementsAttr ElementsAttrBuilder::matMul(ElementsAttr lhs, ElementsAttr rhs) {
   assert(!elementType.isInteger(1) && "matMul() elements must be numbers");
 
   ArrayRef<int64_t> lhsShape = lhsType.getShape();
-  unsigned lhsRank = lhsShape.size();
+  size_t lhsRank = lhsShape.size();
 
   ArrayRef<int64_t> rhsShape = rhsType.getShape();
-  unsigned rhsRank = rhsShape.size();
+  size_t rhsRank = rhsShape.size();
 
   assert(lhsRank >= 1);
   assert(rhsRank >= 1);
@@ -553,7 +553,7 @@ ElementsAttr ElementsAttrBuilder::matMul(ElementsAttr lhs, ElementsAttr rhs) {
   SmallVector<int64_t> matMulShape = combinedBatchShape;
   matMulShape.push_back(M);
   matMulShape.push_back(N);
-  unsigned matMulRank = matMulShape.size();
+  size_t matMulRank = matMulShape.size();
 
   SmallVector<int64_t> xpLhsShape = combinedBatchShape;
   if (lhsRank != 1)

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -154,6 +154,8 @@ public:
       llvm::ArrayRef<unsigned> axes, bool keepdims,
       WideNum (*reducer)(WideNum, WideNum));
 
+  mlir::ElementsAttr matMul(mlir::ElementsAttr lhs, mlir::ElementsAttr rhs);
+
 private:
   struct ElementsProperties;
 

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -154,6 +154,7 @@ public:
       llvm::ArrayRef<unsigned> axes, bool keepdims,
       WideNum (*reducer)(WideNum, WideNum));
 
+  // Returns the matrix product like numpy.matmul.
   mlir::ElementsAttr matMul(mlir::ElementsAttr lhs, mlir::ElementsAttr rhs);
 
 private:

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -94,7 +94,7 @@ bool isVariadicOperandFromDenseONNXConstantOp(ValueRange operands) {
   return llvm::all_of(operands, [](Value v) { return isDenseONNXConstant(v); });
 }
 
-ONNXConstantOp createZeroTensor(
+Value ConstZeroTensor(
     PatternRewriter &rewriter, Location loc, ShapedType type) {
   return createONNXConstantOpWithDenseAttr(rewriter, loc,
       DenseElementsAttr::get(

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -88,6 +88,19 @@ struct ConstPropCounters {
 
 std::unordered_map<std::string, ConstPropCounters> ConstPropCounters::map;
 
+/// A helper function to check whether a variadic value is produced by dense
+/// ONNXConstantOps.
+bool isVariadicOperandFromDenseONNXConstantOp(ValueRange operands) {
+  return llvm::all_of(operands, [](Value v) { return isDenseONNXConstant(v); });
+}
+
+ONNXConstantOp createZeroTensor(
+    PatternRewriter &rewriter, Location loc, ShapedType type) {
+  return createONNXConstantOpWithDenseAttr(rewriter, loc,
+      DenseElementsAttr::get(
+          type, rewriter.getZeroAttr(type.getElementType())));
+}
+
 ElementsAttr getConstValueElements(Value constValue) {
   ONNXConstantOp constOp = cast<ONNXConstantOp>(constValue.getDefiningOp());
   return constOp.getValueAttr().cast<ElementsAttr>();

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -427,12 +427,9 @@ Value ConstPropReduce(PatternRewriter &rewriter, Value replacingValue,
 // returns the zero point reshaped so it broadcasts to the matrix shape.
 ElementsAttr reshapeMatMulIntegerLhsZero(
     ArrayRef<int64_t> matrixShape, ElementsAttr zeroPoint) {
-  // The following conditional checks whether zeroPoint is well-formed and
-  // broadcasts to matrix's shape, and reshapes zeroPoint if necessary.
-  if (zeroPoint.isSplat() || zeroPoint.getType().getRank() == 0) {
-    // Splat case is easy: zeroPoint trivially broadcasts to matrix's shape.
+  if (zeroPoint.getType().getRank() == 0) {
+    // Scalar case is easy: zeroPoint trivially broadcasts to matrix's shape.
   } else {
-    auto matrixRank = matrixShape.size();
     ShapedType zeroPointType = zeroPoint.getType();
     auto zeroPointShape = zeroPointType.getShape();
     auto zeroPointRank = zeroPointShape.size();
@@ -449,6 +446,7 @@ ElementsAttr reshapeMatMulIntegerLhsZero(
       assert(rows != 1 && "non-splat zero_point cannot be singleton");
       // Per-row zero point is a proper vector we need to broadcast, unless
       // matrix is also a vector so the broadcasts cancel out.
+      auto matrixRank = matrixShape.size();
       if (matrixRank == 1) {
         // Broadcast of matrix and zero point vectors cancel out.
         assert(matrixShape == zeroPointShape &&

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -430,8 +430,9 @@ ElementsAttr reshapeMatMulIntegerLhsZero(
   ShapedType zeroPointType = zeroPoint.getType();
   auto zeroPointShape = zeroPointType.getShape();
   auto zeroPointRank = zeroPointShape.size();
-  if (zeroPointRank == 0) {
+  if (zeroPointRank == 0 || (zeroPointRank == 1 && zeroPointShape[0] == 1)) {
     // Scalar case is easy: zeroPoint trivially broadcasts to matrix's shape.
+    // Scalars can be represented as singleton tensors with rank 0 or 1.
   } else if (zeroPointRank == 1) {
     // Vector with zero point scalar per row. Same shape as a matrix column.
     assert(zeroPointRank == 1);

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -88,19 +88,6 @@ struct ConstPropCounters {
 
 std::unordered_map<std::string, ConstPropCounters> ConstPropCounters::map;
 
-/// A helper function to check whether a variadic value is produced by dense
-/// ONNXConstantOps.
-bool isVariadicOperandFromDenseONNXConstantOp(ValueRange operands) {
-  return llvm::all_of(operands, [](Value v) { return isDenseONNXConstant(v); });
-}
-
-Value ConstZeroTensor(
-    PatternRewriter &rewriter, Location loc, ShapedType type) {
-  return createONNXConstantOpWithDenseAttr(rewriter, loc,
-      DenseElementsAttr::get(
-          type, rewriter.getZeroAttr(type.getElementType())));
-}
-
 ElementsAttr getConstValueElements(Value constValue) {
   ONNXConstantOp constOp = cast<ONNXConstantOp>(constValue.getDefiningOp());
   return constOp.getValueAttr().cast<ElementsAttr>();
@@ -121,6 +108,13 @@ using EnableNotBool = std::enable_if_t<!std::is_same_v<T, bool>>;
 /// Checks whether a variadic value is produced by dense ONNXConstantOps.
 bool isVariadicOperandFromDenseONNXConstantOp(ValueRange operands) {
   return llvm::all_of(operands, [](Value v) { return isDenseONNXConstant(v); });
+}
+
+Value ConstZeroTensor(
+    PatternRewriter &rewriter, Location loc, ShapedType type) {
+  return createONNXConstantOpWithDenseAttr(rewriter, loc,
+      DenseElementsAttr::get(
+          type, rewriter.getZeroAttr(type.getElementType())));
 }
 
 /// Checks whether a constant tensor's elements are all equal to a given scalar.

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -463,6 +463,13 @@ ElementsAttr reshapeMatMulIntegerLhsZero(
   return zeroPoint;
 }
 
+// Rhs zero point scalar / vector / tensor always broadcasts to
+// matrix's shape.
+ElementsAttr reshapeMatMulIntegerRhsZero(
+    ArrayRef<int64_t> matrixShape, ElementsAttr zeroPoint) {
+  return zeroPoint;
+}
+
 bool isMatMulIntegerMatrixZero(Value matrixValue, Value zeroPointValue,
     function_ref<ElementsAttr(ArrayRef<int64_t>, ElementsAttr)> reshapeZero) {
   ElementsAttr matrix = getConstValueElements(matrixValue);
@@ -498,10 +505,8 @@ bool isMatMulIntegerLhsZero(Value matrixValue, Value zeroPointValue) {
 }
 
 bool isMatMulIntegerRhsZero(Value matrixValue, Value zeroPointValue) {
-  auto noReshape = [](ArrayRef<int64_t> matrixShape, ElementsAttr zeroPoint) {
-    return zeroPoint;
-  };
-  return isMatMulIntegerMatrixZero(matrixValue, zeroPointValue, noReshape);
+  return isMatMulIntegerMatrixZero(
+      matrixValue, zeroPointValue, reshapeMatMulIntegerRhsZero);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -530,15 +530,16 @@ ElementsAttr getMatMulIntegerMatrixElements(
 }
 
 Value ConstPropMatMulInteger(PatternRewriter &rewriter, Value replacingValue,
-    Value lhsMatrixValue, Value lhsZeroPointValue, Value rhsMatrixValue,
+    Value lhsMatrixValue, Value rhsMatrixValue, Value lhsZeroPointValue,
     Value rhsZeroPointValue) {
   OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
   ElementsAttr lhs = getMatMulIntegerMatrixElements(elementsBuilder,
       lhsMatrixValue, lhsZeroPointValue, reshapeMatMulIntegerLhsZero);
   ElementsAttr rhs = getMatMulIntegerMatrixElements(elementsBuilder,
       rhsMatrixValue, rhsZeroPointValue, reshapeMatMulIntegerRhsZero);
-  // TODO: do the matrix multiply
-  return nullptr;
+  ElementsAttr matMulElements = elementsBuilder.matMul(lhs, rhs);
+  return createReplacingConstantOp(rewriter, replacingValue, matMulElements)
+      .getResult();
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -429,9 +429,7 @@ ElementsAttr reshapeMatMulIntegerLhsZero(
     // Scalars can be represented as singleton tensors with rank 0 or 1.
   } else if (zeroPointRank == 1) {
     // Vector with zero point scalar per row. Same shape as a matrix column.
-    assert(zeroPointRank == 1);
     int64_t rows = zeroPointShape[0];
-    assert(rows != 1 && "non-splat zero_point cannot be singleton");
     // Per-row zero point is a proper vector we need to broadcast, unless
     // matrix is also a vector so the broadcasts cancel out.
     auto matrixRank = matrixShape.size();

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -78,12 +78,12 @@ def ValuesHaveSameType : Constraint<
   CPred<"$0.getType() == $1.getType()">,
   "Values have same type">;
 
-def IsZeroLhsOfMatMulInteger: Constraint<
-    CPred<"isZeroLhsOfMatMulInteger($0, $1)">,
+def IsMatMulIntegerLhsZero: Constraint<
+    CPred<"isMatMulIntegerLhsZero($0, $1)">,
     "MatMulInteger lhs matrix is zero for given zero point">;
 
-def IsZeroRhsOfMatMulInteger: Constraint<
-    CPred<"isZeroRhsOfMatMulInteger($0, $1)">,
+def IsMatMulIntegerRhsZero: Constraint<
+    CPred<"isMatMulIntegerRhsZero($0, $1)">,
     "MatMulInteger rhs matrix is zero for given zero point">;
 
 // Creation helpers:
@@ -514,7 +514,7 @@ def MatMulIntegerConstZeroLhs : Pat<
     ),
     (CreateZeroTensorOfType $resOp),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOpOrNone:$a_zero_point),
-     (IsZeroLhsOfMatMulInteger $A, $a_zero_point)]>;
+     (IsMatMulIntegerLhsZero $A, $a_zero_point)]>;
 
 def MatMulIntegerConstZeroRhs : Pat<
     (ONNXMatMulIntegerOp:$resOp
@@ -524,7 +524,7 @@ def MatMulIntegerConstZeroRhs : Pat<
     ),
     (CreateZeroTensorOfType $resOp),
     [(IsFromDenseONNXConstantOp:$B), (IsFromDenseONNXConstantOpOrNone:$b_zero_point),
-     (IsZeroRhsOfMatMulInteger $B, $b_zero_point)]>;
+     (IsMatMulIntegerRhsZero $B, $b_zero_point)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Transpose operations.

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -66,8 +66,6 @@ def HasStaticShape: Constraint<CPred<
   "A value has static shape"
 >;
 
-// Creation helpers:
-
 def IsConstOfZeros : Constraint<
   CPred<"isConstOf($_self, 0.0)">,
   "Value is an all-zeros constant tensor">;
@@ -88,8 +86,10 @@ def IsZeroRhsOfMatMulInteger: Constraint<
     CPred<"isZeroRhsOfMatMulInteger($0, $1)">,
     "MatMulInteger rhs matrix is zero for given zero point">;
 
+// Creation helpers:
+
 def CreateZeroTensorOfType: NativeCodeCall<
-  "createZeroTensor($_builder, $_loc, $0.getType())"
+  "ConstZeroTensor($_builder, $_loc, $0.getType())"
 >;
 
 def CreateAddOfTwoConst :

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -88,10 +88,8 @@ def IsZeroRhsOfMatMulInteger: Constraint<
     CPred<"isZeroRhsOfMatMulInteger($0, $1)">,
     "MatMulInteger rhs matrix is zero for given zero point">;
 
-def CreateZeroOfType: NativeCodeCall<
-  "createONNXConstantOpWithDenseAttr($_builder, $_loc,"
-  " mlir::DenseElementsAttr::get($0.getType(),"
-  "  $_builder.getZeroAttr(mlir::getElementTypeOrSelf($0))))"
+def CreateZeroTensorOfType: NativeCodeCall<
+  "createZeroTensor($_builder, $_loc, $0.getType())"
 >;
 
 def CreateAddOfTwoConst :
@@ -514,7 +512,7 @@ def MatMulIntegerConstZeroLhs : Pat<
       $B,
       $a_zero_point, $b_zero_point
     ),
-    (CreateZeroOfType $resOp),
+    (CreateZeroTensorOfType $resOp),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOpOrNone:$a_zero_point),
      (IsZeroLhsOfMatMulInteger $A, $a_zero_point)]>;
 
@@ -524,7 +522,7 @@ def MatMulIntegerConstZeroRhs : Pat<
       (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_),
       $a_zero_point, $b_zero_point
     ),
-    (CreateZeroOfType $resOp),
+    (CreateZeroTensorOfType $resOp),
     [(IsFromDenseONNXConstantOp:$B), (IsFromDenseONNXConstantOpOrNone:$b_zero_point),
      (IsZeroRhsOfMatMulInteger $B, $b_zero_point)]>;
 

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -137,6 +137,9 @@ def CreateReduceMaxConst :
 def CreateReduceMeanConst :
     NativeCodeCall<"ConstPropReduce<mlir::ONNXReduceMeanOp>($_builder, $0, $1, $2)">;
 
+def CreateMatMulIntegerOfConsts :
+    NativeCodeCall<"ConstPropMatMulInteger($_builder, $0, $1, $2, $3, $4)">;
+
 def CreateTransposeOfConst :
    NativeCodeCall<"ConstPropTranspose($_builder, $0, $1)">;
 
@@ -514,7 +517,8 @@ def MatMulIntegerConstZeroLhs : Pat<
     ),
     (CreateZeroTensorOfType $resOp),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOpOrNone:$a_zero_point),
-     (IsMatMulIntegerLhsZero $A, $a_zero_point)]>;
+     (IsMatMulIntegerLhsZero $A, $a_zero_point)]
+    >;
 
 def MatMulIntegerConstZeroRhs : Pat<
     (ONNXMatMulIntegerOp:$resOp
@@ -524,7 +528,19 @@ def MatMulIntegerConstZeroRhs : Pat<
     ),
     (CreateZeroTensorOfType $resOp),
     [(IsFromDenseONNXConstantOp:$B), (IsFromDenseONNXConstantOpOrNone:$b_zero_point),
-     (IsMatMulIntegerRhsZero $B, $b_zero_point)]>;
+     (IsMatMulIntegerRhsZero $B, $b_zero_point)]
+    >;
+
+def MatMulIntegerOfConsts : Pat<
+    (ONNXMatMulIntegerOp:$resOp
+      (ONNXConstantOp:$A $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_),
+      $a_zero_point, $b_zero_point
+    ),
+    (CreateMatMulIntegerOfConsts $resOp, $A, $B, $a_zero_point, $b_zero_point),
+    [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOpOrNone:$a_zero_point),
+     (IsFromDenseONNXConstantOp:$B), (IsFromDenseONNXConstantOpOrNone:$b_zero_point)]
+    >;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Transpose operations.

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -80,6 +80,20 @@ def ValuesHaveSameType : Constraint<
   CPred<"$0.getType() == $1.getType()">,
   "Values have same type">;
 
+def IsZeroLhsOfMatMulInteger: Constraint<
+    CPred<"isZeroLhsOfMatMulInteger($0, $1)">,
+    "MatMulInteger lhs matrix is zero for given zero point">;
+
+def IsZeroRhsOfMatMulInteger: Constraint<
+    CPred<"isZeroRhsOfMatMulInteger($0, $1)">,
+    "MatMulInteger rhs matrix is zero for given zero point">;
+
+def CreateZeroOfType: NativeCodeCall<
+  "createONNXConstantOpWithDenseAttr($_builder, $_loc,"
+  " mlir::DenseElementsAttr::get($0.getType(),"
+  "  $_builder.getZeroAttr(mlir::getElementTypeOrSelf($0))))"
+>;
+
 def CreateAddOfTwoConst :
    NativeCodeCall<"ConstPropElementwiseBinary<mlir::ONNXAddOp>($_builder, $0, $1, $2)">;
 
@@ -489,6 +503,30 @@ def ReduceMeanConstProp: Pat<
     (CreateReduceMeanConst $reduceMeanOp, $data, $axes),
     [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
+
+//===----------------------------------------------------------------------===//
+// Patterns for MatMul.
+//===----------------------------------------------------------------------===//
+
+def MatMulIntegerConstZeroLhs : Pat<
+    (ONNXMatMulIntegerOp:$resOp
+      (ONNXConstantOp:$A $_, $_, $_, $_, $_, $_, $_, $_),
+      $B,
+      $a_zero_point, $b_zero_point
+    ),
+    (CreateZeroOfType $resOp),
+    [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOpOrNone:$a_zero_point),
+     (IsZeroLhsOfMatMulInteger $A, $a_zero_point)]>;
+
+def MatMulIntegerConstZeroRhs : Pat<
+    (ONNXMatMulIntegerOp:$resOp
+      $A,
+      (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_),
+      $a_zero_point, $b_zero_point
+    ),
+    (CreateZeroOfType $resOp),
+    [(IsFromDenseONNXConstantOp:$B), (IsFromDenseONNXConstantOpOrNone:$b_zero_point),
+     (IsZeroRhsOfMatMulInteger $B, $b_zero_point)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Transpose operations.

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -562,6 +562,18 @@ func.func @test_matmulinteger_rhs_zero_tensor(%arg0: tensor<1x4x3xi8>) -> tensor
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
 
+// -----
+
+func.func @test_matmulinteger_2d() -> (tensor<2x1xi32>) {
+  %0 = "onnx.Constant"() {value = dense<1> : tensor<2x3xi8>} : () -> tensor<2x3xi8>
+  %1 = "onnx.Constant"() {value = dense<1> : tensor<3x1xi8>} : () -> tensor<3x1xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<2x3xi8>, tensor<3x1xi8>, none, none) -> tensor<2x1xi32>
+  return %3 : tensor<2x1xi32>
+  // CHECK-LABEL: test_matmulinteger_2d
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<3> : tensor<2x1xi32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Reduce tests
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -656,14 +656,25 @@ func.func @test_matmulinteger_two_vectors() -> (tensor<i32>) {
 }
 
 // This example is taken from the onnx MatMulInteger operation specification.
-func.func @test_matmulinteger_with_zeros() -> (tensor<4x2xi32>) {
+func.func @test_matmulinteger_with_1Dzeros() -> (tensor<4x2xi32>) {
+  %0 = "onnx.Constant"() {value = dense<[[11, 7, 3], [10, 6, 2], [9, 5, 1], [8, 4, 0]]> : tensor<4x3xui8>} : () -> tensor<4x3xui8>
+  %1 = "onnx.Constant"() {value = dense<[[1, 4], [2, 5], [3, 6]]> : tensor<3x2xui8>} : () -> tensor<3x2xui8>
+  %2 = "onnx.Constant"() {value = dense<[12]> : tensor<1xui8>} : () -> tensor<1xui8>
+  %3 = "onnx.Constant"() {value = dense<[0]> : tensor<1xui8>} : () -> tensor<1xui8>
+  %4 = "onnx.MatMulInteger"(%0, %1, %2, %3) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<1xui8>, tensor<1xui8>) -> tensor<4x2xi32>
+  return %4 : tensor<4x2xi32>
+  // CHECK-LABEL: test_matmulinteger_with_1Dzeros
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{\[}}[-38, -83], [-44, -98], [-50, -113], [-56, -128]{{\]}}> : tensor<4x2xi32>
+}
+
+func.func @test_matmulinteger_with_0dzeros() -> (tensor<4x2xi32>) {
   %0 = "onnx.Constant"() {value = dense<[[11, 7, 3], [10, 6, 2], [9, 5, 1], [8, 4, 0]]> : tensor<4x3xui8>} : () -> tensor<4x3xui8>
   %1 = "onnx.Constant"() {value = dense<[[1, 4], [2, 5], [3, 6]]> : tensor<3x2xui8>} : () -> tensor<3x2xui8>
   %2 = "onnx.Constant"() {value = dense<12> : tensor<ui8>} : () -> tensor<ui8>
   %3 = "onnx.Constant"() {value = dense<0> : tensor<ui8>} : () -> tensor<ui8>
   %4 = "onnx.MatMulInteger"(%0, %1, %2, %3) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<ui8>, tensor<ui8>) -> tensor<4x2xi32>
   return %4 : tensor<4x2xi32>
-  // CHECK-LABEL: test_matmulinteger_with_zeros
+  // CHECK-LABEL: test_matmulinteger_with_0dzeros
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{\[}}[-38, -83], [-44, -98], [-50, -113], [-56, -128]{{\]}}> : tensor<4x2xi32>
 }
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -574,6 +574,37 @@ func.func @test_matmulinteger_2d() -> (tensor<2x1xi32>) {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3> : tensor<2x1xi32>
 }
 
+func.func @test_matmulinteger_lhs_vector() -> (tensor<3xi32>) {
+  %0 = "onnx.Constant"() {value = dense<[100, 200]> : tensor<2xui8>} : () -> tensor<2xui8>
+  %1 = "onnx.Constant"() {value = dense<10> : tensor<2x3xi8>} : () -> tensor<2x3xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<2xui8>, tensor<2x3xi8>, none, none) -> tensor<3xi32>
+  return %3 : tensor<3xi32>
+  // CHECK-LABEL: test_matmulinteger_lhs_vector
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<3000> : tensor<3xi32>
+}
+
+func.func @test_matmulinteger_rhs_vector() -> (tensor<2xi32>) {
+  %0 = "onnx.Constant"() {value = dense<100> : tensor<2x3xui8>} : () -> tensor<2x3xui8>
+  %1 = "onnx.Constant"() {value = dense<[10, 20, 30]> : tensor<3xi8>} : () -> tensor<3xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<2x3xui8>, tensor<3xi8>, none, none) -> tensor<2xi32>
+  return %3 : tensor<2xi32>
+  // CHECK-LABEL: test_matmulinteger_rhs_vector
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<6000> : tensor<2xi32>
+}
+
+// 1486 == 200 * 7 + 40 * 2 + 2 * 3
+func.func @test_matmulinteger_two_vectors() -> (tensor<i32>) {
+  %0 = "onnx.Constant"() {value = dense<[200, 40, 2]> : tensor<3xui8>} : () -> tensor<3xui8>
+  %1 = "onnx.Constant"() {value = dense<[7, 2, 3]> : tensor<3xi8>} : () -> tensor<3xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<3xui8>, tensor<3xi8>, none, none) -> tensor<i32>
+  return %3 : tensor<i32>
+  // CHECK-LABEL: test_matmulinteger_two_vectors
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<1486> : tensor<i32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Reduce tests
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -458,6 +458,33 @@ func.func @test_where_splat_branches() -> tensor<3x2xf32> {
 }
 
 //===----------------------------------------------------------------------===//
+/// MatMulInteger tests
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_zero_lhs(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32>
+func.func @test_matmulinteger_zero_lhs(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32> {
+  %0 = onnx.Constant dense<0> : tensor<4x3xi8>
+  %1 = "onnx.NoValue"() {value} : () -> none
+  %2 = "onnx.MatMulInteger"(%0, %arg0, %1, %1) : (tensor<4x3xi8>, tensor<3x2xui8>, none, none) -> tensor<4x2xi32>
+  "func.return"(%2) : (tensor<4x2xi32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
+  // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_zero_rhs(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32>
+func.func @test_matmulinteger_zero_rhs(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32> {
+  %0 = onnx.Constant dense<0> : tensor<3x2xui8>
+  %1 = "onnx.NoValue"() {value} : () -> none
+  %2 = "onnx.MatMulInteger"(%arg0, %0, %1, %1) : (tensor<4x3xi8>, tensor<3x2xui8>, none, none) -> tensor<4x2xi32>
+  "func.return"(%2) : (tensor<4x2xi32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
+  // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
+}
+
+//===----------------------------------------------------------------------===//
 /// Reduce tests
 
 // -----

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -655,6 +655,18 @@ func.func @test_matmulinteger_two_vectors() -> (tensor<i32>) {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<1486> : tensor<i32>
 }
 
+// This example is taken from the onnx MatMulInteger operation specification.
+func.func @test_matmulinteger_with_zeros() -> (tensor<4x2xi32>) {
+  %0 = "onnx.Constant"() {value = dense<[[11, 7, 3], [10, 6, 2], [9, 5, 1], [8, 4, 0]]> : tensor<4x3xui8>} : () -> tensor<4x3xui8>
+  %1 = "onnx.Constant"() {value = dense<[[1, 4], [2, 5], [3, 6]]> : tensor<3x2xui8>} : () -> tensor<3x2xui8>
+  %2 = "onnx.Constant"() {value = dense<12> : tensor<ui8>} : () -> tensor<ui8>
+  %3 = "onnx.Constant"() {value = dense<0> : tensor<ui8>} : () -> tensor<ui8>
+  %4 = "onnx.MatMulInteger"(%0, %1, %2, %3) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<ui8>, tensor<ui8>) -> tensor<4x2xi32>
+  return %4 : tensor<4x2xi32>
+  // CHECK-LABEL: test_matmulinteger_with_zeros
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{\[}}[-38, -83], [-44, -98], [-50, -113], [-56, -128]{{\]}}> : tensor<4x2xi32>
+}
+
 //===----------------------------------------------------------------------===//
 /// Reduce tests
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -574,6 +574,36 @@ func.func @test_matmulinteger_2d() -> (tensor<2x1xi32>) {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3> : tensor<2x1xi32>
 }
 
+func.func @test_matmulinteger_2d_batch() -> (tensor<4x2x1xi32>) {
+  %0 = "onnx.Constant"() {value = dense<100> : tensor<4x2x3xi8>} : () -> tensor<4x2x3xi8>
+  %1 = "onnx.Constant"() {value = dense<100> : tensor<4x3x1xi8>} : () -> tensor<4x3x1xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<4x2x3xi8>, tensor<4x3x1xi8>, none, none) -> tensor<4x2x1xi32>
+  return %3 : tensor<4x2x1xi32>
+  // CHECK-LABEL: test_matmulinteger_2d_batch
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<30000> : tensor<4x2x1xi32>
+}
+
+func.func @test_matmulinteger_2d_batch_lhs() -> (tensor<4x2x1xi32>) {
+  %0 = "onnx.Constant"() {value = dense<1> : tensor<4x2x3xi8>} : () -> tensor<4x2x3xi8>
+  %1 = "onnx.Constant"() {value = dense<3> : tensor<3x1xi8>} : () -> tensor<3x1xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<4x2x3xi8>, tensor<3x1xi8>, none, none) -> tensor<4x2x1xi32>
+  return %3 : tensor<4x2x1xi32>
+  // CHECK-LABEL: test_matmulinteger_2d_batch_lhs
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<9> : tensor<4x2x1xi32>
+}
+
+func.func @test_matmulinteger_2d_batch_broadcast() -> (tensor<5x4x2x1xi32>) {
+  %0 = "onnx.Constant"() {value = dense<1> : tensor<4x2x3xi8>} : () -> tensor<4x2x3xi8>
+  %1 = "onnx.Constant"() {value = dense<-1> : tensor<5x1x3x1xi8>} : () -> tensor<5x1x3x1xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<4x2x3xi8>, tensor<5x1x3x1xi8>, none, none) -> tensor<5x4x2x1xi32>
+  return %3 : tensor<5x4x2x1xi32>
+  // CHECK-LABEL: test_matmulinteger_2d_batch_broadcast
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<-3> : tensor<5x4x2x1xi32>
+}
+
 func.func @test_matmulinteger_lhs_vector() -> (tensor<3xi32>) {
   %0 = "onnx.Constant"() {value = dense<[100, 200]> : tensor<2xui8>} : () -> tensor<2xui8>
   %1 = "onnx.Constant"() {value = dense<10> : tensor<2x3xi8>} : () -> tensor<2x3xi8>
@@ -584,6 +614,16 @@ func.func @test_matmulinteger_lhs_vector() -> (tensor<3xi32>) {
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3000> : tensor<3xi32>
 }
 
+func.func @test_matmulinteger_lhs_vector_batch() -> (tensor<4x3xi32>) {
+  %0 = "onnx.Constant"() {value = dense<[100, 200]> : tensor<2xui8>} : () -> tensor<2xui8>
+  %1 = "onnx.Constant"() {value = dense<10> : tensor<4x2x3xi8>} : () -> tensor<4x2x3xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<2xui8>, tensor<4x2x3xi8>, none, none) -> tensor<4x3xi32>
+  return %3 : tensor<4x3xi32>
+  // CHECK-LABEL: test_matmulinteger_lhs_vector_batch
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<3000> : tensor<4x3xi32>
+}
+
 func.func @test_matmulinteger_rhs_vector() -> (tensor<2xi32>) {
   %0 = "onnx.Constant"() {value = dense<100> : tensor<2x3xui8>} : () -> tensor<2x3xui8>
   %1 = "onnx.Constant"() {value = dense<[10, 20, 30]> : tensor<3xi8>} : () -> tensor<3xi8>
@@ -592,6 +632,16 @@ func.func @test_matmulinteger_rhs_vector() -> (tensor<2xi32>) {
   return %3 : tensor<2xi32>
   // CHECK-LABEL: test_matmulinteger_rhs_vector
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<6000> : tensor<2xi32>
+}
+
+func.func @test_matmulinteger_rhs_vector_batch() -> (tensor<4x2xi32>) {
+  %0 = "onnx.Constant"() {value = dense<100> : tensor<4x2x3xui8>} : () -> tensor<4x2x3xui8>
+  %1 = "onnx.Constant"() {value = dense<[10, 20, 30]> : tensor<3xi8>} : () -> tensor<3xi8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<4x2x3xui8>, tensor<3xi8>, none, none) -> tensor<4x2xi32>
+  return %3 : tensor<4x2xi32>
+  // CHECK-LABEL: test_matmulinteger_rhs_vector_batch
+  // CHECK: [[CONST:%.+]] = onnx.Constant dense<6000> : tensor<4x2xi32>
 }
 
 // 1486 == 200 * 7 + 40 * 2 + 2 * 3

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -462,8 +462,8 @@ func.func @test_where_splat_branches() -> tensor<3x2xf32> {
 
 // -----
 
-// CHECK-LABEL: @test_matmulinteger_zero_lhs(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32>
-func.func @test_matmulinteger_zero_lhs(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32> {
+// CHECK-LABEL: @test_matmulinteger_lhs_zero(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32>
+func.func @test_matmulinteger_lhs_zero(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32> {
   %0 = onnx.Constant dense<0> : tensor<4x3xi8>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.MatMulInteger"(%0, %arg0, %1, %1) : (tensor<4x3xi8>, tensor<3x2xui8>, none, none) -> tensor<4x2xi32>
@@ -474,13 +474,91 @@ func.func @test_matmulinteger_zero_lhs(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32
 
 // -----
 
-// CHECK-LABEL: @test_matmulinteger_zero_rhs(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32>
-func.func @test_matmulinteger_zero_rhs(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32> {
+// CHECK-LABEL: @test_matmulinteger_lhs_scalar(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32>
+func.func @test_matmulinteger_lhs_scalar(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32> {
+  %0 = onnx.Constant dense<7> : tensor<4x3xui8>
+  %1 = onnx.Constant dense<7> : tensor<ui8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %arg0, %1, %2) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<ui8>, none) -> tensor<4x2xi32>
+  "func.return"(%3) : (tensor<4x2xi32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
+  // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_lhs_vector(%arg0: tensor<3x4xui8>) -> tensor<2x4xi32>
+func.func @test_matmulinteger_lhs_vector(%arg0: tensor<3x4xui8>) -> tensor<2x4xi32> {
+  %0 = onnx.Constant dense<[[7, 7, 7], [9, 9, 9]]> : tensor<2x3xui8>
+  %1 = onnx.Constant dense<[7, 9]> : tensor<2xui8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %arg0, %1, %2) : (tensor<2x3xui8>, tensor<3x4xui8>, tensor<2xui8>, none) -> tensor<2x4xi32>
+  "func.return"(%3) : (tensor<2x4xi32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<2x4xi32>
+  // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_lhs_matrix(%arg0: tensor<3x4xui8>) -> tensor<2x4xi32>
+func.func @test_matmulinteger_lhs_matrix(%arg0: tensor<3x4xui8>) -> tensor<2x4xi32> {
+  %0 = onnx.Constant dense<[[7, 7, 7], [9, 9, 9]]> : tensor<2x3xui8>
+  %1 = onnx.Constant dense<[[7], [9]]> : tensor<2x1xui8>
+  %2 = "onnx.NoValue"() {value} : () -> none
+  %3 = "onnx.MatMulInteger"(%0, %arg0, %1, %2) : (tensor<2x3xui8>, tensor<3x4xui8>, tensor<2x1xui8>, none) -> tensor<2x4xi32>
+  "func.return"(%3) : (tensor<2x4xi32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<2x4xi32>
+  // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_rhs_zero_none(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32>
+func.func @test_matmulinteger_rhs_zero_none(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32> {
   %0 = onnx.Constant dense<0> : tensor<3x2xui8>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.MatMulInteger"(%arg0, %0, %1, %1) : (tensor<4x3xi8>, tensor<3x2xui8>, none, none) -> tensor<4x2xi32>
   "func.return"(%2) : (tensor<4x2xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
+  // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_rhs_zero_scalar(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32>
+func.func @test_matmulinteger_rhs_zero_scalar(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32> {
+  %0 = onnx.Constant dense<42> : tensor<3x2xui8>
+  %1 = "onnx.NoValue"() {value} : () -> none
+  %2 = onnx.Constant dense<42> : tensor<ui8>
+  %3 = "onnx.MatMulInteger"(%arg0, %0, %1, %2) : (tensor<4x3xi8>, tensor<3x2xui8>, none, tensor<ui8>) -> tensor<4x2xi32>
+  "func.return"(%3) : (tensor<4x2xi32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
+  // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_rhs_zero_vector(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32>
+func.func @test_matmulinteger_rhs_zero_vector(%arg0: tensor<4x3xi8>) -> tensor<4x2xi32> {
+  %0 = onnx.Constant dense<[[1, 2], [1, 2], [1, 2]]> : tensor<3x2xui8>
+  %1 = "onnx.NoValue"() {value} : () -> none
+  %2 = onnx.Constant dense<[1, 2]> : tensor<2xui8>
+  %3 = "onnx.MatMulInteger"(%arg0, %0, %1, %2) : (tensor<4x3xi8>, tensor<3x2xui8>, none, tensor<2xui8>) -> tensor<4x2xi32>
+  "func.return"(%3) : (tensor<4x2xi32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
+  // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_rhs_zero_tensor(%arg0: tensor<1x4x3xi8>) -> tensor<1x4x2xi32>
+func.func @test_matmulinteger_rhs_zero_tensor(%arg0: tensor<1x4x3xi8>) -> tensor<1x4x2xi32> {
+  %0 = onnx.Constant dense<[[[1, 2], [1, 2], [1, 2]]]> : tensor<1x3x2xui8>
+  %1 = "onnx.NoValue"() {value} : () -> none
+  %2 = onnx.Constant dense<[[[1, 2]]]> : tensor<1x1x2xui8>
+  %3 = "onnx.MatMulInteger"(%arg0, %0, %1, %2) : (tensor<1x4x3xi8>, tensor<1x3x2xui8>, none, tensor<1x1x2xui8>) -> tensor<1x4x2xi32>
+  "func.return"(%3) : (tensor<1x4x2xi32>) -> ()
+  // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<1x4x2xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
 


### PR DESCRIPTION
Note that it is implemented with a reusable helper method ElementsAttrBuilder::matMul() which is designed to also work for the MatMul op, so it will be easy to add const prop for MatMul afterwards.