### PR TITLE
use the same 'none' of NoneType everywhere

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -54,7 +54,7 @@ class VariadicSizeIsGT<int N> : Constraint<
 >;
 
 // Create a unit constant that will be used as none input.
-def CreateUnitConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
+def CreateNoneConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
 
 class getNth<int n, string x> : NativeCodeCall<x # "[" # n # "]">;
 
@@ -437,7 +437,7 @@ def GetMatMulBiasLayoutStringAttr : NativeCodeCall<
 //                          (ZHighMatMulOp
 //                              (ZHighStickOp %X),
 //                              (ZHighStickOp %Y),
-//                              CreateUnitConstant)
+//                              CreateNoneConstant)
 //===----------------------------------------------------------------------===//
 
 def replaceONNXMatMulPattern : Pat<
@@ -446,7 +446,7 @@ def replaceONNXMatMulPattern : Pat<
      (ZHighMatMulOp
         (ZHighStickOp $x, (GetMatMulLayoutStringAttr (GetRank $x))),
         (ZHighStickOp $y, (GetMatMulLayoutStringAttr (GetRank $y))),
-        (CreateUnitConstant)))
+        (CreateNoneConstant)))
 >;
 
 //===----------------------------------------------------------------------===//
@@ -567,7 +567,7 @@ def replaceONNXGemmBias2DPattern : Pat<
        (ZHighMatMulOp
           (ZHighStickOp $a, (_2DLayoutAttr)),
           (ZHighStickOp $b, (_2DLayoutAttr)),
-          (CreateUnitConstant)),
+          (CreateNoneConstant)),
        (returnType $res)),
     $c),
   [(HasRankOf<2> $c)],

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -54,7 +54,7 @@ class VariadicSizeIsGT<int N> : Constraint<
 >;
 
 // Create a unit constant that will be used as none input.
-def CreateNoneConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
+def CreateNoneValue : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
 
 class getNth<int n, string x> : NativeCodeCall<x # "[" # n # "]">;
 
@@ -437,7 +437,7 @@ def GetMatMulBiasLayoutStringAttr : NativeCodeCall<
 //                          (ZHighMatMulOp
 //                              (ZHighStickOp %X),
 //                              (ZHighStickOp %Y),
-//                              CreateNoneConstant)
+//                              CreateNoneValue)
 //===----------------------------------------------------------------------===//
 
 def replaceONNXMatMulPattern : Pat<
@@ -446,7 +446,7 @@ def replaceONNXMatMulPattern : Pat<
      (ZHighMatMulOp
         (ZHighStickOp $x, (GetMatMulLayoutStringAttr (GetRank $x))),
         (ZHighStickOp $y, (GetMatMulLayoutStringAttr (GetRank $y))),
-        (CreateNoneConstant)))
+        (CreateNoneValue)))
 >;
 
 //===----------------------------------------------------------------------===//
@@ -567,7 +567,7 @@ def replaceONNXGemmBias2DPattern : Pat<
        (ZHighMatMulOp
           (ZHighStickOp $a, (_2DLayoutAttr)),
           (ZHighStickOp $b, (_2DLayoutAttr)),
-          (CreateNoneConstant)),
+          (CreateNoneValue)),
        (returnType $res)),
     $c),
   [(HasRankOf<2> $c)],

--- a/src/Builder/FrontendDialectHelper.cpp
+++ b/src/Builder/FrontendDialectHelper.cpp
@@ -236,8 +236,7 @@ mlir::Value EmitInitializerForInputTensor(mlir::Location loc,
   llvm::ArrayRef<int64_t> tensorDims(
       initializer.dims().data(), initializer.dims().size());
   if (tensorDims.size() == 1 && tensorDims[0] == 0)
-    return builder.create<mlir::ONNXNoneOp>(
-        loc, builder.getNoneType(), builder.getUnitAttr());
+    return builder.create<mlir::ONNXNoneOp>(loc);
 
   mlir::ElementsAttr elmAttr =
       onnxTensorProtoToElmAttr(builder, externalDataDir, initializer);

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1065,9 +1065,7 @@ private:
       if (v.empty()) {
         // Missing (optional) parameter.
         operandOnnxTypes.push_back(unspecifiedType);
-        auto no_value = builder_.create<ONNXNoneOp>(UnknownLoc());
-
-        operands.push_back(no_value);
+        operands.push_back(none());
         operandTypes.push_back(builder_.getNoneType());
         continue;
       }

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -115,7 +115,9 @@ private:
     }
   }
 
-  Value none() { return builder_.create<ONNXNoneOp>(UnknownLoc()).getResult(); }
+  Value createNoneValue() {
+    return builder_.create<ONNXNoneOp>(UnknownLoc()).getResult();
+  }
 
   // onnx_type_map: a map from ONNX tensor name to ONNX TypeProto.
   SymbolToOnnxTypeMapping onnx_type_map;
@@ -546,7 +548,7 @@ private:
     // Trailing optional inputs.
     if (!variadicIn)
       for (int i = (int)inputs.size(); i < expectedNumOperands; i++) {
-        inputs.emplace_back(none());
+        inputs.emplace_back(createNoneValue());
       }
 
     std::vector<Type> outputTypes;
@@ -651,7 +653,7 @@ private:
   void getNodeInputs(const onnx::NodeProto &node, std::vector<Value> &inputs) {
     for (const auto &item : node.input()) {
       if (item.empty()) {
-        inputs.emplace_back(none());
+        inputs.emplace_back(createNoneValue());
       } else {
         if (const Value *valuePtr = frontend_symbols_.GetByOnnxName(item)) {
           inputs.push_back(*valuePtr);
@@ -748,7 +750,7 @@ private:
     for (const auto &item : node.input())
       if (item.empty()) {
         // Optional inputs using empty string will be imported as NoneType.
-        inputs.emplace_back(none());
+        inputs.emplace_back(createNoneValue());
       } else {
         if (const Value *valuePtr = frontend_symbols_.GetByOnnxName(item)) {
           inputs.push_back(*valuePtr);
@@ -927,8 +929,8 @@ private:
 
     assert(inVals[1] != nullptr && "Slice requires a starts attribute");
     assert(inVals[2] != nullptr && "Slice requires an ends attribute");
-    inVals[3] = inVals[3] == nullptr ? none() : inVals[3];
-    inVals[4] = inVals[4] == nullptr ? none() : inVals[4];
+    inVals[3] = inVals[3] == nullptr ? createNoneValue() : inVals[3];
+    inVals[4] = inVals[4] == nullptr ? createNoneValue() : inVals[4];
 
     int nIn = ONNXSliceOp::getNumberOfOperands();
     int nOut = ONNXSliceOp::getNumberOfResults();
@@ -1065,7 +1067,7 @@ private:
       if (v.empty()) {
         // Missing (optional) parameter.
         operandOnnxTypes.push_back(unspecifiedType);
-        operands.push_back(none());
+        operands.push_back(createNoneValue());
         operandTypes.push_back(builder_.getNoneType());
         continue;
       }

--- a/src/Dialect/ONNX/ONNX.td
+++ b/src/Dialect/ONNX/ONNX.td
@@ -219,12 +219,6 @@ class OptOf<Type type> :
 def ONNXConstantOpFromDenseAttr: NativeCodeCall<
   "onnx_mlir::OnnxBuilder($_builder, $_loc).constant($0)">;
 
-def createNoneIntegerConstant : NativeCodeCall<
-  "onnx_mlir::createNoneIntegerConstant($_builder, $0.getDefiningOp()->getLoc())">;
-
-def createNoneFloatConstant : NativeCodeCall<
-  "onnx_mlir::createNoneFloatConstant($_builder, $0.getDefiningOp()->getLoc())">;
-
 //===----------------------------------------------------------------------===//
 // ONNX Operations
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -301,41 +301,6 @@ ONNXConstantOp getONNXConstantOp(Value value) {
   return dyn_cast_or_null<ONNXConstantOp>(value.getDefiningOp());
 }
 
-// Use 0xi64 to represent a None for an optional integer input
-Value createNoneIntegerConstant(PatternRewriter &rewriter, Location loc) {
-  SmallVector<int64_t, 1> dims(1, 0);
-  SmallVector<int64_t> values;
-  auto tensorType = RankedTensorType::get(dims, rewriter.getIntegerType(64));
-  auto denseAttr = DenseElementsAttr::get(tensorType, llvm::ArrayRef(values));
-  return rewriter.create<ONNXConstantOp>(loc, Attribute(), denseAttr);
-}
-
-// Use 0xf32 to represent a None for an optional float input
-Value createNoneFloatConstant(PatternRewriter &rewriter, Location loc) {
-  SmallVector<int64_t, 1> dims(1, 0);
-  SmallVector<float> values;
-  auto tensorType = RankedTensorType::get(dims, rewriter.getF32Type());
-  auto denseAttr = DenseElementsAttr::get(tensorType, llvm::ArrayRef(values));
-  return rewriter.create<ONNXConstantOp>(loc, Attribute(), denseAttr);
-}
-
-// Returns true if the Value is defined by a unit constant.
-// The unit constant can  be 1. NoneType, or 2. 1D tensor with 0 length
-// For example, NoneType, tensor<0xf32>
-// Some onnx model uses 0 length tensor for unit constant.
-bool isNoneValue(Value v) {
-  if (v.getType().isa<NoneType>())
-    return true;
-
-  if (auto ty = v.getType().dyn_cast<ShapedType>()) {
-    auto shape = ty.getShape();
-    if (shape.size() == 1 && shape[0] == 0)
-      return true;
-  }
-
-  return false;
-}
-
 //===----------------------------------------------------------------------===//
 // Support for transpose patterns.
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -162,13 +162,13 @@ int64_t ArrayAttrIntVal(llvm::Optional<mlir::ArrayAttr> a, int i);
 mlir::ElementsAttr getElementAttributeFromONNXValue(mlir::Value value);
 
 mlir::ONNXConstantOp getONNXConstantOp(mlir::Value value);
-mlir::Value createNoneIntegerConstant(
-    mlir::PatternRewriter &rewriter, mlir::Location loc);
-mlir::Value createNoneFloatConstant(
-    mlir::PatternRewriter &rewriter, mlir::Location loc);
 
-// Test if the value is from a NoneType or tensor<0 x ELEMENTARY_TYPE>
-bool isNoneValue(mlir::Value value);
+// Test if the value is none. Since none is a unit value it never makes a
+// difference whether it's a constant (the result of ONNXNoneOp) or the
+// optional result of some other op (e.g. ONNXDropoutOp mask result).
+inline bool isNoneValue(mlir::Value value) {
+  return llvm::isa<mlir::NoneType>(value.getType());
+}
 
 //===----------------------------------------------------------------------===//
 // Support for transpose patterns.

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -166,6 +166,7 @@ mlir::ONNXConstantOp getONNXConstantOp(mlir::Value value);
 // Test if the value is none. Since none is a unit value it never makes a
 // difference whether it's a constant (the result of ONNXNoneOp) or the
 // optional result of some other op (e.g. ONNXDropoutOp mask result).
+// Note: It's ok to inline the isa<NoneType> test and not call this function.
 inline bool isNoneValue(mlir::Value value) {
   return llvm::isa<mlir::NoneType>(value.getType());
 }

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -133,7 +133,8 @@ class HaveSameDim<int dim>: Constraint<
         "$1.getType().cast<RankedTensorType>().getShape()[" # dim # "])">,
   "Two tensors have the same specified dimension">;
 
-def GetUnitAttr: NativeCodeCall<"$_builder.getUnitAttr()">;
+// Create a unit constant that will be used as none input.
+def CreateNoneConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
 
 def HasOneUse : Constraint<CPred<"$0.hasOneUse()">>;
 
@@ -387,11 +388,14 @@ def FuseMulConvNullBiasPattern: Pat<
 def IdentityEliminationPattern : Pat<(ONNXIdentityOp $arg),
                                      (replaceWithValue $arg)>;
 
-// y, mask = onnx.Dropout(x) -> y, mask = x, none
-def DropoutEliminationPattern : Pattern<(ONNXDropoutOp $arg, $arg1, $arg2, $ratio),
-  [(replaceWithValue $arg), (ONNXConstantOp (GetNullAttr), (GetUnitAttr), 
-   (GetNullAttr), (GetNullAttr), (GetNullAttr), (GetNullAttr), (GetNullAttr), 
-   (GetNullAttr))]>;
+//===----------------------------------------------------------------------===//
+// Canonicalization for ONNXDropoutOp
+//===----------------------------------------------------------------------===//
+
+// We assume that training_mode is not true so output, mask become data, none.
+// output, mask = onnx.Dropout(data) -> output, mask = data, none
+def DropoutEliminationPattern : Pattern<(ONNXDropoutOp $data, $ratio, $training_mode, $seed),
+  [(replaceWithValue $data), (CreateNoneConstant)]>;
 
 //===----------------------------------------------------------------------===//
 // Canonicalization for ONNXCastOp

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -134,7 +134,7 @@ class HaveSameDim<int dim>: Constraint<
   "Two tensors have the same specified dimension">;
 
 // Create a unit constant that will be used as none input.
-def CreateNoneConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
+def CreateNoneConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc).getResult()">;
 
 def HasOneUse : Constraint<CPred<"$0.hasOneUse()">>;
 

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -134,7 +134,7 @@ class HaveSameDim<int dim>: Constraint<
   "Two tensors have the same specified dimension">;
 
 // Create a unit constant that will be used as none input.
-def CreateNoneConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc).getResult()">;
+def CreateNoneValue : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc).getResult()">;
 
 def HasOneUse : Constraint<CPred<"$0.hasOneUse()">>;
 
@@ -395,7 +395,7 @@ def IdentityEliminationPattern : Pat<(ONNXIdentityOp $arg),
 // We assume that training_mode is not true so output, mask become data, none.
 // output, mask = onnx.Dropout(data) -> output, mask = data, none
 def DropoutEliminationPattern : Pattern<(ONNXDropoutOp $data, $ratio, $training_mode, $seed),
-  [(replaceWithValue $data), (CreateNoneConstant)]>;
+  [(replaceWithValue $data), (CreateNoneValue)]>;
 
 //===----------------------------------------------------------------------===//
 // Canonicalization for ONNXCastOp

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -94,10 +94,6 @@ DenseElementsAttr createScalarDenseAttr(
   llvm_unreachable("unexpected attribute type");
 }
 
-Value createUnitConstant(PatternRewriter &rewriter, Location loc) {
-  return rewriter.create<ONNXNoneOp>(loc);
-}
-
 // Create an DenseElementsAttr of ArrayAttr.
 // When ArrayAttr is Null, an empty Integer DenseElementAttr is returned
 DenseElementsAttr createDenseArrayAttrOrEmpty(

--- a/src/Transform/ONNX/Decompose.td
+++ b/src/Transform/ONNX/Decompose.td
@@ -52,8 +52,7 @@ def GetNullStringAttr : NativeCodeCall<"StringAttr()">;
 def GetNullArrayAttr :  NativeCodeCall<"ArrayAttr()">;
 
 // Create a unit constant that will be used as none input.
-def CreateUnitConstant
-    : NativeCodeCall<"::onnx_mlir::createUnitConstant($_builder, $_loc)">;
+def CreateNoneConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
 
 // Create a scalar DenseElementsAttr (rank 0) from a single attribute.
 // E.g return type is tensor<f32> instead of tensor<0xf32> or tensor<1xf32>
@@ -236,16 +235,16 @@ def LogSoftmaxPattern
 // Express Upsample using Resize.
 def UpsamplePattern : Pat<
   (ONNXUpsampleOp $x, $scales, $mode),
-  (ONNXResizeOp $x, (CreateUnitConstant), $scales, (CreateUnitConstant),
+  (ONNXResizeOp $x, (CreateNoneConstant), $scales, (CreateNoneConstant),
      (GetNullStringAttr), (GetNullFloatAttr), (GetNullIntegerAttr),
      (GetNullFloatAttr), $mode, (GetNullFloatAttr))
 >;
 
 def UpsampleV7Pattern : Pat<
   (ONNXUpsampleV7Op $x, $mode, $scales),
-  (ONNXResizeOp $x, (CreateUnitConstant),
+  (ONNXResizeOp $x, (CreateNoneConstant),
      (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scales)),
-     (CreateUnitConstant), (GetNullStringAttr), (GetNullFloatAttr),
+     (CreateNoneConstant), (GetNullStringAttr), (GetNullFloatAttr),
      (GetNullIntegerAttr), (GetNullFloatAttr), $mode, (GetNullFloatAttr))
 >;
 
@@ -265,12 +264,12 @@ def PadV11Pattern : Pat<
 
 def ResizeV10Pattern: Pat<
    (ONNXResizeV10Op:$res $x, $scales, $mode),
-   (ONNXResizeOp $x, (createNoneFloatConstant $res),
-        $scales, (createNoneIntegerConstant $res),
+   (ONNXResizeOp $x, (CreateNoneConstant),
+        $scales, (CreateNoneConstant),
        /*coordinate_transformation_mode*/(GetNullStringAttr),
        /*cubic_coeff_a*/(GetNullFloatAttr),
        /*exclude_outside*/(GetNullIntegerAttr),
-       /*exttrapolation_value*/(GetNullFloatAttr),
+       /*extrapolation_value*/(GetNullFloatAttr),
        /*mode*/$mode,
        /*nearest_mode*/(GetNullStringAttr))
 >;
@@ -278,11 +277,11 @@ def ResizeV10Pattern: Pat<
 def ResizeV11Pattern: Pat<
    (ONNXResizeV11Op:$res $x, $roi, $scales, $size,
                     $coordinate_transformation_node, $cubic_coeff_a,
-                    $exclude_outside, $exttrapolation_value, $mode,
+                    $exclude_outside, $extrapolation_value, $mode,
                     $nearest_mode),
    (ONNXResizeOp    $x, $roi, $scales, $size,
                     $coordinate_transformation_node, $cubic_coeff_a,
-                    $exclude_outside, $exttrapolation_value, $mode,
+                    $exclude_outside, $extrapolation_value, $mode,
                     $nearest_mode)
 >;
 
@@ -314,7 +313,7 @@ def ClipV12Pattern : Pat<
 
 def SplitV11PatternNoAttr : Pat<
   (ONNXSplitV11Op $x, $axis, $split),
-  (ONNXSplitOp $x, (CreateUnitConstant), $axis),
+  (ONNXSplitOp $x, (CreateNoneConstant), $axis),
   [(AttributeIsNull:$split)], (addBenefit 1)
 >;
 
@@ -326,7 +325,7 @@ def SplitV11Pattern : Pat<
 
 def SqueezeV11PatternNoAttr : Pat<
   (ONNXSqueezeV11Op $x, $axes),
-  (ONNXSqueezeOp $x, (CreateUnitConstant)),
+  (ONNXSqueezeOp $x, (CreateNoneConstant)),
   [(AttributeIsNull:$axes)], (addBenefit 1)
 >;
 
@@ -353,7 +352,7 @@ def ScatterPattern : Pat<
 def ReduceL1V13OpPattern1
     : Pat<(ONNXReduceL1V13Op $oprd, $axes, $keepdims),
           (ONNXReduceL1Op $oprd,
-              (CreateUnitConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceL1V13OpPattern2
@@ -369,7 +368,7 @@ def ReduceL1V13OpPattern2
 def ReduceL2V13OpPattern1
     : Pat<(ONNXReduceL2V13Op $oprd, $axes, $keepdims),
           (ONNXReduceL2Op $oprd,
-              (CreateUnitConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceL2V13OpPattern2
@@ -385,7 +384,7 @@ def ReduceL2V13OpPattern2
 def ReduceLogSumV13OpPattern1
     : Pat<(ONNXReduceLogSumV13Op $oprd, $axes, $keepdims),
           (ONNXReduceLogSumOp $oprd,
-              (CreateUnitConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceLogSumV13OpPattern2
@@ -401,7 +400,7 @@ def ReduceLogSumV13OpPattern2
 def ReduceLogSumExpV13OpPattern1
     : Pat<(ONNXReduceLogSumExpV13Op $oprd, $axes, $keepdims),
           (ONNXReduceLogSumExpOp $oprd,
-              (CreateUnitConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceLogSumExpV13OpPattern2
@@ -417,7 +416,7 @@ def ReduceLogSumExpV13OpPattern2
 def ReduceSumSquareV13OpPattern1
     : Pat<(ONNXReduceSumSquareV13Op $oprd, $axes, $keepdims),
           (ONNXReduceSumSquareOp $oprd,
-              (CreateUnitConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceSumSquareV13OpPattern2

--- a/src/Transform/ONNX/Decompose.td
+++ b/src/Transform/ONNX/Decompose.td
@@ -52,7 +52,7 @@ def GetNullStringAttr : NativeCodeCall<"StringAttr()">;
 def GetNullArrayAttr :  NativeCodeCall<"ArrayAttr()">;
 
 // Create a unit constant that will be used as none input.
-def CreateNoneConstant : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
+def CreateNoneValue : NativeCodeCall<"$_builder.create<ONNXNoneOp>($_loc)">;
 
 // Create a scalar DenseElementsAttr (rank 0) from a single attribute.
 // E.g return type is tensor<f32> instead of tensor<0xf32> or tensor<1xf32>
@@ -235,16 +235,16 @@ def LogSoftmaxPattern
 // Express Upsample using Resize.
 def UpsamplePattern : Pat<
   (ONNXUpsampleOp $x, $scales, $mode),
-  (ONNXResizeOp $x, (CreateNoneConstant), $scales, (CreateNoneConstant),
+  (ONNXResizeOp $x, (CreateNoneValue), $scales, (CreateNoneValue),
      (GetNullStringAttr), (GetNullFloatAttr), (GetNullIntegerAttr),
      (GetNullFloatAttr), $mode, (GetNullFloatAttr))
 >;
 
 def UpsampleV7Pattern : Pat<
   (ONNXUpsampleV7Op $x, $mode, $scales),
-  (ONNXResizeOp $x, (CreateNoneConstant),
+  (ONNXResizeOp $x, (CreateNoneValue),
      (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scales)),
-     (CreateNoneConstant), (GetNullStringAttr), (GetNullFloatAttr),
+     (CreateNoneValue), (GetNullStringAttr), (GetNullFloatAttr),
      (GetNullIntegerAttr), (GetNullFloatAttr), $mode, (GetNullFloatAttr))
 >;
 
@@ -264,8 +264,8 @@ def PadV11Pattern : Pat<
 
 def ResizeV10Pattern: Pat<
    (ONNXResizeV10Op:$res $x, $scales, $mode),
-   (ONNXResizeOp $x, (CreateNoneConstant),
-        $scales, (CreateNoneConstant),
+   (ONNXResizeOp $x, (CreateNoneValue),
+        $scales, (CreateNoneValue),
        /*coordinate_transformation_mode*/(GetNullStringAttr),
        /*cubic_coeff_a*/(GetNullFloatAttr),
        /*exclude_outside*/(GetNullIntegerAttr),
@@ -313,7 +313,7 @@ def ClipV12Pattern : Pat<
 
 def SplitV11PatternNoAttr : Pat<
   (ONNXSplitV11Op $x, $axis, $split),
-  (ONNXSplitOp $x, (CreateNoneConstant), $axis),
+  (ONNXSplitOp $x, (CreateNoneValue), $axis),
   [(AttributeIsNull:$split)], (addBenefit 1)
 >;
 
@@ -325,7 +325,7 @@ def SplitV11Pattern : Pat<
 
 def SqueezeV11PatternNoAttr : Pat<
   (ONNXSqueezeV11Op $x, $axes),
-  (ONNXSqueezeOp $x, (CreateNoneConstant)),
+  (ONNXSqueezeOp $x, (CreateNoneValue)),
   [(AttributeIsNull:$axes)], (addBenefit 1)
 >;
 
@@ -352,7 +352,7 @@ def ScatterPattern : Pat<
 def ReduceL1V13OpPattern1
     : Pat<(ONNXReduceL1V13Op $oprd, $axes, $keepdims),
           (ONNXReduceL1Op $oprd,
-              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceL1V13OpPattern2
@@ -368,7 +368,7 @@ def ReduceL1V13OpPattern2
 def ReduceL2V13OpPattern1
     : Pat<(ONNXReduceL2V13Op $oprd, $axes, $keepdims),
           (ONNXReduceL2Op $oprd,
-              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceL2V13OpPattern2
@@ -384,7 +384,7 @@ def ReduceL2V13OpPattern2
 def ReduceLogSumV13OpPattern1
     : Pat<(ONNXReduceLogSumV13Op $oprd, $axes, $keepdims),
           (ONNXReduceLogSumOp $oprd,
-              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceLogSumV13OpPattern2
@@ -400,7 +400,7 @@ def ReduceLogSumV13OpPattern2
 def ReduceLogSumExpV13OpPattern1
     : Pat<(ONNXReduceLogSumExpV13Op $oprd, $axes, $keepdims),
           (ONNXReduceLogSumExpOp $oprd,
-              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceLogSumExpV13OpPattern2
@@ -416,7 +416,7 @@ def ReduceLogSumExpV13OpPattern2
 def ReduceSumSquareV13OpPattern1
     : Pat<(ONNXReduceSumSquareV13Op $oprd, $axes, $keepdims),
           (ONNXReduceSumSquareOp $oprd,
-              (CreateNoneConstant), $keepdims, (noop_with_empty_axes)),
+              (CreateNoneValue), $keepdims, (noop_with_empty_axes)),
           [(AttributeIsNull:$axes)], (addBenefit 1)>;
 
 def ReduceSumSquareV13OpPattern2

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -47,6 +47,18 @@ func.func @test_identity_identity(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>
 
 // -----
 
+func.func @test_dropout(%arg: tensor<10x10xf32>) -> (tensor<10x10xf32>, none) {
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %1:2 = "onnx.Dropout"(%arg, %0, %0) : (tensor<10x10xf32>, none, none) -> (tensor<10x10xf32>, none)
+  "func.return"(%1#0, %1#1) : (tensor<10x10xf32>, none) -> ()
+  // CHECK-LABEL: test_dropout
+  // CHECK-NOT: "onnx.Dropout"
+  // CHECK-NEXT: [[NONE:%.+]] = "onnx.NoValue"
+  // CHECK-NEXT: return %arg0, [[NONE]] : tensor<10x10xf32>, none
+}
+
+// -----
+
 //CHECK-LABEL: @test_gemm_add_fusion(%{{.*}}: tensor<128x128xf32>, %{{.*}}: tensor<128x128xf32>, %{{.*}}: tensor<128xf32>) -> tensor<*xf32> {
 func.func @test_gemm_add_fusion(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -259,25 +259,23 @@ func.func @test_resizev10(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<4xf32>) -> t
   return %0 : tensor<*xf32>
   // CHECK-LABEL:  func @test_resizev10
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x3x4xf32>, [[PARAM_1_:%.+]]: tensor<4xf32>) -> tensor<*xf32> {
-  // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<> : tensor<0xf32>
-  // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<> : tensor<0xi64>
-  // CHECK:           [[VAR_2_:%.+]] = "onnx.Resize"([[PARAM_0_]], [[VAR_0_]], [[PARAM_1_]], [[VAR_1_]]) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x2x3x4xf32>, tensor<0xf32>, tensor<4xf32>, tensor<0xi64>) -> tensor<*xf32>
+  // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"
+  // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"
+  // CHECK:           [[VAR_2_:%.+]] = "onnx.Resize"([[PARAM_0_]], [[VAR_0_]], [[PARAM_1_]], [[VAR_1_]]) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x2x3x4xf32>, none, tensor<4xf32>, none) -> tensor<*xf32>
   // CHECK:           return [[VAR_2_]] : tensor<*xf32>
 }
 
 // -----
 
 func.func @test_resizev11(%arg0: tensor<*xf32>, %arg1: tensor<*xi64>) -> tensor<*xf32> {
-  %0 = onnx.Constant dense<> : tensor<0xf32>
-  %1 = onnx.Constant dense<> : tensor<0xf32>
-  %2 = "onnx.Resize"(%arg0, %0, %0, %arg1) {coordinate_transformation_mode = "half_pixel", mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize__697"} : (tensor<*xf32>, tensor<0xf32>, tensor<0xf32>, tensor<*xi64>) -> tensor<*xf32>
-  return %2 : tensor<*xf32>
+  %0 = "onnx.NoValue"() {value} : () -> none
+  %1 = "onnx.Resize"(%arg0, %0, %0, %arg1) {coordinate_transformation_mode = "half_pixel", mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize__697"} : (tensor<*xf32>, none, none, tensor<*xi64>) -> tensor<*xf32>
+  return %1 : tensor<*xf32>
   // CHECK-LABEL:  func @test_resizev11
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xi64>) -> tensor<*xf32> {
-  // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<> : tensor<0xf32>
-  // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<> : tensor<0xf32>
-  // CHECK:           [[VAR_2_:%.+]] = "onnx.Resize"([[PARAM_0_]], [[VAR_0_]], [[VAR_0_]], [[PARAM_1_]]) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize__697"} : (tensor<*xf32>, tensor<0xf32>, tensor<0xf32>, tensor<*xi64>) -> tensor<*xf32>
-  // CHECK:           return [[VAR_2_]] : tensor<*xf32>
+  // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"
+  // CHECK:           [[VAR_1_:%.+]] = "onnx.Resize"([[PARAM_0_]], [[VAR_0_]], [[VAR_0_]], [[PARAM_1_]]) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize__697"} : (tensor<*xf32>, none, none, tensor<*xi64>) -> tensor<*xf32>
+  // CHECK:           return [[VAR_1_]] : tensor<*xf32>
 }
 
 // -----


### PR DESCRIPTION
Replaced the use of empty tensors to represent 'none' in ONNXResizeOp decompositions and simplified isFromNone() to
```
// Test if the value is none. Since none is a unit value it never makes a
// difference whether it's a constant (the result of ONNXNoneOp) or the
// optional result of some other op (e.g. ONNXDropoutOp mask result).
// Note: It's ok to inline the isa<NoneType> test and not call this function.
inline bool isFromNone(mlir::Value value) {
  return llvm::isa<mlir::NoneType>(value.getType());
}
```

I inlined the implementation to emphasize that it's fine to inline the `isa<NoneType>` test like we already do in many places.