### PR TITLE
simplify AreTheSameAxes logic and createArrayAttrFromConstantOp

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/IR/TypeUtilities.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include "src/Dialect/Mlir/IndexExpr.hpp"
@@ -391,37 +390,6 @@ bool HasSpecifiedConstantShape(Value value, Value shape) {
       return false;
   }
   return true;
-}
-
-/// Test if two axis arrays contain the same values or not.
-bool AreTheSameAxesArrayAttr(
-    int64_t rank, ArrayAttr lhsAttr, ArrayAttr rhsAttr) {
-  // false if one of the array attributes is null.
-  if (!(lhsAttr) || !(rhsAttr))
-    return false;
-
-  auto asSet = [rank](ArrayRef<Attribute> array) {
-    llvm::SmallSet<int64_t, 6> axes;
-    for (auto attr : array) {
-      int64_t axis = attr.cast<IntegerAttr>().getInt();
-      axes.insert(axis < 0 ? axis + rank : axis);
-    }
-    return axes;
-  };
-
-  // We don't check for duplicate axes. That invariant is checked elsewhere.
-  return asSet(lhsAttr.getValue()) == asSet(rhsAttr.getValue());
-}
-
-bool AreTheSameAxesConstant(int64_t rank, Value lhs, Value rhs) {
-  assert(cast<ShapedType>(lhs.getType()).getElementType().isInteger(64));
-  assert(cast<ShapedType>(rhs.getType()).getElementType().isInteger(64));
-  auto lhsConstOp = dyn_cast_or_null<ONNXConstantOp>(lhs.getDefiningOp());
-  auto rhsConstOp = dyn_cast_or_null<ONNXConstantOp>(rhs.getDefiningOp());
-  return lhsConstOp && rhsConstOp &&
-         AreTheSameAxesArrayAttr(rank,
-             createArrayAttrFromConstantOp(lhsConstOp),
-             createArrayAttrFromConstantOp(rhsConstOp));
 }
 
 /// Test if 'val' has shape and rank or not.

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -183,15 +183,14 @@ mlir::ArrayAttr CombinedTransposePattern(mlir::PatternRewriter &rewriter,
 bool IsIdentityPermuteVector(mlir::ArrayAttr permAttr);
 
 /// Test if two axis arrays contain the same values or not.
-bool AreTheSameAxisArray(
+bool AreTheSameAxesArrayAttr(
     int64_t rank, mlir::ArrayAttr lhsAttr, mlir::ArrayAttr rhsAttr);
 
 /// Test if the value has the specified constant shape
 bool HasSpecifiedConstantShape(mlir::Value value, mlir::Value shape);
 
-/// Test if two constant ops contain the same values or not.
-bool AreTheSameConstantOpDenseAttr(
-    mlir::Builder &builder, int64_t rank, mlir::Value lhsOp, mlir::Value rhsOp);
+/// Test if two values are constants with the same axis values.
+bool AreTheSameAxesConstant(int64_t rank, mlir::Value lhs, mlir::Value rhs);
 
 /// Test if 'val' has shape and rank or not.
 bool hasShapeAndRank(mlir::Value val);
@@ -219,8 +218,7 @@ mlir::DenseElementsAttr createDenseElementsAttrFromSize(
     mlir::PatternRewriter &rewriter, mlir::Value value);
 
 // Create an ArrayAttr from a dense ConstantOp
-mlir::ArrayAttr createArrayAttrFromConstantOp(
-    mlir::Builder &builder, mlir::Value constOp);
+mlir::ArrayAttr createArrayAttrFromConstantOp(mlir::ONNXConstantOp constOp);
 
 // Check whether a value is produced by a dense ONNXConstantOp.
 bool isDenseONNXConstant(mlir::Value result);

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -182,15 +182,8 @@ mlir::ArrayAttr CombinedTransposePattern(mlir::PatternRewriter &rewriter,
 /// Identity patterns are {0, 1, 2, ... , rank -1}.
 bool IsIdentityPermuteVector(mlir::ArrayAttr permAttr);
 
-/// Test if two axis arrays contain the same values or not.
-bool AreTheSameAxesArrayAttr(
-    int64_t rank, mlir::ArrayAttr lhsAttr, mlir::ArrayAttr rhsAttr);
-
 /// Test if the value has the specified constant shape
 bool HasSpecifiedConstantShape(mlir::Value value, mlir::Value shape);
-
-/// Test if two values are constants with the same axis values.
-bool AreTheSameAxesConstant(int64_t rank, mlir::Value lhs, mlir::Value rhs);
 
 /// Test if 'val' has shape and rank or not.
 bool hasShapeAndRank(mlir::Value val);

--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -153,6 +153,9 @@ bool AreTheSameAxesArrayAttr(
   return asSet(lhsAttr.getValue()) == asSet(rhsAttr.getValue());
 }
 
+// Same as AreTheSameAxesArrayAttr but takes (result value of)
+// ONNXConstantOp tensors as inputs.
+// Returns false if any of the input Values are not constant results.
 bool AreTheSameAxesConstant(int64_t rank, Value lhs, Value rhs) {
   assert(cast<ShapedType>(lhs.getType()).getElementType().isInteger(64));
   assert(cast<ShapedType>(rhs.getType()).getElementType().isInteger(64));

--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -134,10 +134,12 @@ DenseElementsAttr createDenseElementsAttrFromShapeOp(
 }
 
 /// Test if two axis arrays contain the same values or not.
+/// If rank != 0 then negative axes are adjusted by adding rank.
+/// No checking is done for invariants like out of range axes
+/// or duplicate axes.
 bool AreTheSameAxesArrayAttr(
     int64_t rank, ArrayAttr lhsAttr, ArrayAttr rhsAttr) {
-  // false if one of the array attributes is null.
-  if (!(lhsAttr) || !(rhsAttr))
+  if (!lhsAttr || !rhsAttr)
     return false;
 
   auto asSet = [rank](ArrayRef<Attribute> array) {
@@ -148,8 +150,6 @@ bool AreTheSameAxesArrayAttr(
     }
     return axes;
   };
-
-  // We don't check for duplicate axes. That invariant is checked elsewhere.
   return asSet(lhsAttr.getValue()) == asSet(rhsAttr.getValue());
 }
 

--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -17,6 +17,7 @@
 
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/SmallSet.h"
 
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
@@ -130,6 +131,37 @@ DenseElementsAttr createDenseElementsAttrFromShapeOp(
   ONNXShapeOpShapeHelper::getStartEndValues(shapeOp, start, end);
   return createDenseElementsAttrFromShape(
       rewriter, shapeOp.getData(), start, end);
+}
+
+/// Test if two axis arrays contain the same values or not.
+bool AreTheSameAxesArrayAttr(
+    int64_t rank, ArrayAttr lhsAttr, ArrayAttr rhsAttr) {
+  // false if one of the array attributes is null.
+  if (!(lhsAttr) || !(rhsAttr))
+    return false;
+
+  auto asSet = [rank](ArrayRef<Attribute> array) {
+    llvm::SmallSet<int64_t, 6> axes;
+    for (auto attr : array) {
+      int64_t axis = attr.cast<IntegerAttr>().getInt();
+      axes.insert(axis < 0 ? axis + rank : axis);
+    }
+    return axes;
+  };
+
+  // We don't check for duplicate axes. That invariant is checked elsewhere.
+  return asSet(lhsAttr.getValue()) == asSet(rhsAttr.getValue());
+}
+
+bool AreTheSameAxesConstant(int64_t rank, Value lhs, Value rhs) {
+  assert(cast<ShapedType>(lhs.getType()).getElementType().isInteger(64));
+  assert(cast<ShapedType>(rhs.getType()).getElementType().isInteger(64));
+  auto lhsConstOp = dyn_cast_or_null<ONNXConstantOp>(lhs.getDefiningOp());
+  auto rhsConstOp = dyn_cast_or_null<ONNXConstantOp>(rhs.getDefiningOp());
+  return lhsConstOp && rhsConstOp &&
+         AreTheSameAxesArrayAttr(rank,
+             createArrayAttrFromConstantOp(lhsConstOp),
+             createArrayAttrFromConstantOp(rhsConstOp));
 }
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -172,12 +172,6 @@ def IsStaticShapeTensor:
       "$_self.getType().cast<::mlir::ShapedType>().hasStaticShape()">,
     "hasStaticShape">;
 
-def AreTheSameAxisArray: Constraint<
-    CPred<"onnx_mlir::AreTheSameAxisArray("
-          "(onnx_mlir::hasShapeAndRank($0) ? $0.getType().cast<ShapedType>().getRank() : 0),"
-          "$1, $2)">,
-    "Two axis arrays are the same">;
-
 def HasSpecifiedConstantShape: Constraint<
     CPred<"onnx_mlir::HasSpecifiedConstantShape($0, $1)">,
           "Has the specified constant shape">;
@@ -195,11 +189,17 @@ def IsFromONNXConstantOpWithDenseElementsAttr: Constraint<
          CPred<" onnx_mlir::getONNXConstantOp($_self).getValueAttr().isa<DenseElementsAttr>() ">
         ]>, "Value is not a ONNXConstantOp with a DenseElementsAttr">;
 
-def AreTheSameConstantOpDenseAttr: Constraint<
-    CPred<"onnx_mlir::AreTheSameConstantOpDenseAttr($_builder,"
+def AreTheSameAxesConstant: Constraint<
+    CPred<"onnx_mlir::AreTheSameAxesConstant("
           "(onnx_mlir::hasShapeAndRank($0) ? $0.getType().cast<ShapedType>().getRank() : 0),"
           "$1, $2)">,
-    "Two ConstantOps have the same dense attribute values">;
+    "Two values are constants with the same axis values">;
+
+def AreTheSameAxesArrayAttr: Constraint<
+    CPred<"onnx_mlir::AreTheSameAxesArrayAttr("
+          "(onnx_mlir::hasShapeAndRank($0) ? $0.getType().cast<ShapedType>().getRank() : 0),"
+          "$1, $2)">,
+    "Two axis arrays are the same">;
 
 class AllDimsFromAxisToEndAre<int axis, int val>: Constraint<
     CPred<"llvm::all_of("
@@ -604,8 +604,7 @@ def RemoveSqueezeUnsqueezePattern:  Pat<
   // Remove both squeeze and unsqueeze.
   (replaceWithValue $val),
   // Check that both ops use the same `axes`.
-  [(AreTheSameConstantOpDenseAttr $val, $u_axes, $s_axes),
-   (IsFromONNXConstantOp $u_axes), (IsFromONNXConstantOp $s_axes)]>;
+  [(AreTheSameAxesConstant $val, $u_axes, $s_axes)]>;
 
 /// Combine squeeze and unsqueeze.
 /// Squeeze {axes = [a, b, c]} (Unsqueeze {axes = [a, b, c]} (%X)) = %X
@@ -615,7 +614,7 @@ def RemoveSqueezeV11UnsqueezeV11Pattern:  Pat<
   // Remove both squeeze and unsqueeze.
   (replaceWithValue $val),
   // Check that both ops use the same `axes`.
-  [(AreTheSameAxisArray $val, $u_axes, $s_axes)]>;
+  [(AreTheSameAxesArrayAttr $val, $u_axes, $s_axes)]>;
 
 /// Combine squeeze, cast and unsqueeze.
 /// Squeeze {axes = [a, b, c]} (Cast (Unsqueeze {axes = [a, b, c]} (%X))) = Cast %X
@@ -625,8 +624,7 @@ def RemoveSqueezeCastUnsqueezePattern:  Pat<
   // Remove both squeeze and unsqueeze.
   (ONNXCastOp $val, $castTo),
   // Check that both ops use the same `axes`.
-  [(AreTheSameConstantOpDenseAttr $val, $u_axes, $s_axes),
-   (IsFromONNXConstantOp $u_axes), (IsFromONNXConstantOp $s_axes)]>;
+  [(AreTheSameAxesConstant $val, $u_axes, $s_axes)]>;
 
 /// Combine squeeze, cast and unsqueeze.
 /// Squeeze {axes = [a, b, c]} (Cast (Unsqueeze {axes = [a, b, c]} (%X))) = Cast %X
@@ -636,7 +634,7 @@ def RemoveSqueezeV11CastUnsqueezeV11Pattern:  Pat<
   // Remove both squeeze and unsqueeze.
   (ONNXCastOp $val, $castTo),
   // Check that both ops use the same `axes`.
-  [(AreTheSameAxisArray $val, $u_axes, $s_axes)]>;
+  [(AreTheSameAxesArrayAttr $val, $u_axes, $s_axes)]>;
 
 //===----------------------------------------------------------------------===//
 // Canonicalization for ONNXUnsqueezeOp
@@ -650,8 +648,7 @@ def RemoveUnsqueezeSqueezePattern:  Pat<
   // Remove both squeeze and unsqueeze.
   (replaceWithValue $val),
   // Check that both ops use the same `axes`.
-  [(AreTheSameConstantOpDenseAttr $res, $u_axes, $s_axes),
-   (IsFromONNXConstantOp $u_axes), (IsFromONNXConstantOp $s_axes)]>;
+  [(AreTheSameAxesConstant $res, $u_axes, $s_axes)]>;
 
 /// Combine unsqueeze and squeeze.
 /// Unsqueeze {axes = [a, b, c]} (Squeeze {axes = [a, b, c]} (%X)) = %X
@@ -661,7 +658,7 @@ def RemoveUnsqueezeV11SqueezeV11Pattern:  Pat<
   // Remove both squeeze and unsqueeze.
   (replaceWithValue $val),
   // Check that both ops use the same `axes`.
-  [(AreTheSameAxisArray $res, $u_axes, $s_axes)]>;
+  [(AreTheSameAxesArrayAttr $res, $u_axes, $s_axes)]>;
 
 /// Combine unsqueeze, cast, and squeeze.
 /// Unsqueeze {axes = [a, b, c]} (Cast (Squeeze {axes = [a, b, c]} (%X))) = Cast %X
@@ -671,8 +668,7 @@ def RemoveUnsqueezeCastSqueezePattern:  Pat<
   // Remove both squeeze and unsqueeze.
   (ONNXCastOp $val, $castTo),
   // Check that both ops use the same `axes`.
-  [(AreTheSameConstantOpDenseAttr $res, $u_axes, $s_axes),
-   (IsFromONNXConstantOp $u_axes), (IsFromONNXConstantOp $s_axes)]>;
+  [(AreTheSameAxesConstant $res, $u_axes, $s_axes)]>;
 
 /// Combine unsqueeze, cast, and squeeze.
 /// Unsqueeze {axes = [a, b, c]} (Cast (Squeeze {axes = [a, b, c]} (%X))) = Cast %X
@@ -682,7 +678,7 @@ def RemoveUnsqueezeV11CastSqueezeV11Pattern:  Pat<
   // Remove both squeeze and unsqueeze.
   (ONNXCastOp $val, $castTo),
   // Check that both ops use the same `axes`.
-  [(AreTheSameAxisArray $res, $u_axes, $s_axes)]>;
+  [(AreTheSameAxesArrayAttr $res, $u_axes, $s_axes)]>;
 
 //===----------------------------------------------------------------------===//
 // Canonicalization for ONNXBatchNormOp

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -635,16 +635,12 @@ public:
 
   LogicalResult matchAndRewrite(
       ONNXSplitOp splitOp, PatternRewriter &rewriter) const override {
+    llvm::Optional<ArrayAttr> optionalAttr;
 
     auto split = splitOp.getSplit();
-    auto builder = mlir::Builder(splitOp.getContext());
-
-    llvm::Optional<ArrayAttr> optionalAttr;
     if (auto splitConstOp = getONNXConstantOp(split)) {
       // Checking value of split parameter.
-      auto splitAttribute =
-          createArrayAttrFromConstantOp(builder, splitConstOp);
-      optionalAttr.emplace(splitAttribute);
+      optionalAttr.emplace(createArrayAttrFromConstantOp(splitConstOp));
     } else if (!split.getType().isa<NoneType>()) {
       llvm_unreachable("dynamic split not yet supported");
     }

--- a/src/Transform/ONNX/Decompose.td
+++ b/src/Transform/ONNX/Decompose.td
@@ -81,10 +81,6 @@ def noop_with_empty_axes
 def IsDenseONNXConstant:
    Constraint<CPred<"::onnx_mlir::isDenseONNXConstant($_self)">, "not a dense constant">;
 
-// Create an ArrayAttr from a dense ConstantOp
-def createArrayAttrFromConstantOp : NativeCodeCall<
-  "::onnx_mlir::createArrayAttrFromConstantOp($_builder, $0)">;
-
 def createSequenceConstructOp : NativeCodeCall<
   "::onnx_mlir::createSequenceConstructOp($_builder, $0, $1)">;
 


### PR DESCRIPTION
I studied AreTheSameConstantOpDenseAttr() to see if it was a candidate for using the ElementsAttr equal() function in PR #2114. I discovered that it isn't. I found it a little bit confusing and this PR attempts to to simplify it and clarify how it's used.

In more detail: Renamed `AreTheSameAxisArray` and `AreTheSameConstantOpDenseAttr` to `AreTheSameAxesArrayAttr` and `AreTheSameAxesConstant` and cleaned up their comments, contracts, and implementation. Moved them from OpHelper to Rewrite.cpp because they are only used in Rewrite.td. Also simplified the implementation of `createArrayAttrFromConstantOp`.