### PR TITLE
Add sameDynShape and broadcastLastDim in DimAnalysis and re-word unknown to dynamic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ A comprehensive list of documents is found [here](docs/DocumentList.md).
 * To test new code, see [here](docs/Testing.md) for instructions.
 * A guide on how to do constant propagation for ONNX operations is found
   [here](docs/ConstPropagationPass.md).
-* A guide on how to analyze unknown dimensions and query their equality at compile time is found [here](docs/UnknownDimensionAnalysis).
+* A guide on how to analyze dynamic dimensions and query their equality at compile time is found [here](docs/DynamicDimensionAnalysis).
 * To build and test for specialized accelerator, see [here](docs/AccelNNPAHowToUseAndTest.md)
 
 ## ONNX-MLIR specific dialects

--- a/docs/DocumentList.md
+++ b/docs/DocumentList.md
@@ -26,7 +26,7 @@ at the ONNX operand level.
 * All the passes may be controlled with [options](Options.md).
 * How to handle errors can be found [here](ErrorHandling.md).
 * How to support a new accelerator can be found [here](AddCustomAccelerators.md).
-* How to analyze unknown dimensions and query their equality at compile time can be found [here](UnknownDimensionAnalysis.md).
+* How to analyze unknown dimensions and query their equality at compile time can be found [here](DynamicDimensionAnalysis.md).
 * A Jenkins monitor job was setup to help with updating LLVM commit. It locates the next commit we can update to without breaking ONNX-MLIR, as well as the commit that will break ONNX-MLIR. You can see the commit(s) here: [s390x](https://www.onnxmlir.xyz/jenkins/job/LLVM-Watch-Docker-Build/LLVM_20Watch_20Report/), [ppc64le](https://www.onnxmlir.xyz/jenkinp/job/LLVM-Watch-Docker-Build/LLVM_20Watch_20Report/), [amd64](https://www.onnxmlir.xyz/jenkinx/job/LLVM-Watch-Docker-Build/LLVM_20Watch_20Report/).
 
 [#](#) Execution

--- a/docs/DynamicDimensionAnalysis.md
+++ b/docs/DynamicDimensionAnalysis.md
@@ -1,4 +1,4 @@
-It is often the case where we want to know two unknown dimensions are equal or not at compile time. This helps with decision on how to lowering an ONNX operator. For example, given an ONNXAddOp as follows:
+It is often the case where we want to know two dynamic dimensions are equal or not at compile time. This helps with decision on how to lowering an ONNX operator. For example, given an ONNXAddOp as follows:
 
 ```mlir
 %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x3x5xf32>, tensor<?x3x5xf32>) -> tensor<?x3x5xf32>
@@ -7,12 +7,12 @@ If we know at compile time that the first dimensions of `%arg0` and `%arg1` are 
 
 This also helps generate code for accelerators. If an accelerator does not support broadcasting, we can check at compile to decide whether the ONNXAddOp will be offloaded to the accelerator or not.
 
-We provide a helper class [DimAnalysis](../src/Transform/ONNX/ONNXDimAnalysis.hpp) to analyze unknown dimensions and to check whether two unknown dimensions are the same or not. Below is an example of using DimAnalysis:
+We provide a helper class [DimAnalysis](../src/Transform/ONNX/ONNXDimAnalysis.hpp) to analyze dynamic dimensions and to check whether two dynamic dimensions are the same or not. Below is an example of using DimAnalysis:
 
 ```C
 #include "src/Dialect/ONNX/ONNXDimAnalysis.hpp"
 
-// Run the unknown dimension analysis to help check equality of unknown
+// Run the dynamic dimension analysis to help check equality of dynamic
 // dimensions at compile time.
 ModuleOp moduleOp = getOperation();
 onnx_mlir::DimAnalysis dimAnalysis(moduleOp);
@@ -21,10 +21,10 @@ dimAnalysis.analyze();
 
 DimAnalysis is constructed for a ModuleOp so that all operations in the ModuleOp will be analyzed.
 Then, actual analysis is done via calling `analyze()` function.
-After that, we can query if two unknown dimensions are the same or not via calling
+After that, we can query if two dynamic dimensions are the same or not via calling
 ```C
-bool sameDim = dimAnalysis.sameUnknownDim(tensor1, dimAxis1, tensor2, dimAxis2);
+bool sameDim = dimAnalysis.sameDynDim(tensor1, dimAxis1, tensor2, dimAxis2);
 ```
-where the first unknown dimension is identified by its tensor `tensor1` and its axis `dimAxis1`, and the second unknown dimension by `tensor2` and `dimAxis2`.
+where the first dynamic dimension is identified by its tensor `tensor1` and its axis `dimAxis1`, and the second dynamic dimension by `tensor2` and `dimAxis2`.
 
 DimAnalysis has been using for NNPA, please see [ONNXToZHigh](../src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp) for more information.

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -480,8 +480,7 @@ void RewriteONNXForZHighPass::runOnOperation() {
       for (int64_t i = 0; i < aRank - 2; ++i) {
         sameBatchDims &= (aShape[i] == bShape[i]);
         if (sameBatchDims && ShapedType::isDynamic(aShape[i]))
-          sameBatchDims =
-              dimAnalysis.sameUnknownDim(op.getA(), i, op.getB(), i);
+          sameBatchDims = dimAnalysis.sameDynDim(op.getA(), i, op.getB(), i);
       }
       return !sameBatchDims;
     }

--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -8,7 +8,7 @@
 //
 // =============================================================================
 //
-// This file implements an analysis on unknown dimensions in ONNX ops.
+// This file implements an analysis on dynamic dimensions in ONNX ops.
 //
 //===----------------------------------------------------------------------===//
 
@@ -58,8 +58,8 @@ bool areOverlapping(const onnx_mlir::DimAnalysis::DimSetT &lhs,
   return false;
 }
 
-/// Given a QuestionMarkIndexExpr representing an unknown dimension, find the
-/// same unknown dimensions in the inputs.
+/// Given a QuestionMarkIndexExpr representing a dynamic dimension, find the
+/// same dynamic dimensions in the inputs.
 static void findAndAddSameDim(const onnx_mlir::QuestionmarkIndexExpr &qmOuputIE,
     mlir::Operation *op, mlir::ValueRange operands,
     onnx_mlir::DimAnalysis::DimSetT &sameDims) {
@@ -69,7 +69,7 @@ static void findAndAddSameDim(const onnx_mlir::QuestionmarkIndexExpr &qmOuputIE,
   // Cannot process if the question mark is not a specific one.
   if (!qmOuputIE.specificQuestionmark())
     return;
-  // Find the same unknown dimension in the inputs.
+  // Find the same dynamic dimension in the inputs.
   for (Value v : operands) {
     if (onnx_mlir::isNoneValue(v))
       continue;
@@ -83,8 +83,8 @@ static void findAndAddSameDim(const onnx_mlir::QuestionmarkIndexExpr &qmOuputIE,
   }
 }
 
-/// Given an unknown dimension, find the same unknown dimensions in the inputs.
-/// This function uses ShapeHelper to explore the same unknown dimensions.
+/// Given a dynamic dimension, find the same dynamic dimensions in the inputs.
+/// This function uses ShapeHelper to explore the same dynamic dimensions.
 /// Use this function for operations that use adaptor to compute shape.
 bool exploreSameInputDims(const onnx_mlir::DimAnalysis::DimT &dim,
     mlir::Operation *op, onnx_mlir::DimAnalysis::DimSetT &sameDims) {
@@ -116,7 +116,7 @@ bool exploreSameInputDims(const onnx_mlir::DimAnalysis::DimT &dim,
     }
   }
 
-  // Find the unknown input dimensions that were transferred to the unknown
+  // Find the dynamic input dimensions that were transferred to the dynamic
   // output dimension.
   uint64_t dimIndex = dim.second;
   onnx_mlir::QuestionmarkIndexExpr qmOuputIE =
@@ -135,8 +135,8 @@ DimAnalysis::DimAnalysis(ArrayRef<Value> vals) {
     if (!isNoneValue(val))
       build(val);
 
-  LLVM_DEBUG(llvm::dbgs() << "The number of unknown dims in the IR: "
-                          << numOfUnknownDims << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "The number of dynamic dims in the IR: "
+                          << numOfDynamicDims << "\n");
 }
 
 DimAnalysis::DimAnalysis(ModuleOp moduleOp) {
@@ -144,27 +144,50 @@ DimAnalysis::DimAnalysis(ModuleOp moduleOp) {
     for (Value output : op->getResults())
       build(output);
   });
-  LLVM_DEBUG(llvm::dbgs() << "The number of unknown dims in the IR: "
-                          << numOfUnknownDims << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "The number of dynamic dims in the IR: "
+                          << numOfDynamicDims << "\n");
 }
 
 void DimAnalysis::build(Value val) {
   if (auto tensorType = val.getType().dyn_cast<RankedTensorType>()) {
     for (unsigned i = 0; i < tensorType.getRank(); ++i) {
-      // Only care about unknown dimensions.
+      // Only care about dynamic dimensions.
       if (tensorType.isDynamicDim(i)) {
         DimT ti(val, i);
         DimSetT dimSet;
         dimSet.insert(ti);
         dimSetMap[setCounter++] = dimSet;
-        numOfUnknownDims++;
+        numOfDynamicDims++;
       }
     }
   }
 }
 
-bool DimAnalysis::sameUnknownDim(mlir::Value tensor1, uint64_t dimAxis1,
-    mlir::Value tensor2, uint64_t dimAxis2) const {
+bool DimAnalysis::sameDim(
+    Value tensor1, uint64_t dimAxis1, Value tensor2, uint64_t dimAxis2) const {
+  // Same tensor, same axis.
+  if ((tensor1 == tensor2) && (dimAxis1 == dimAxis2))
+    return true;
+
+  ShapedType tensor1Type = tensor1.getType().cast<ShapedType>();
+  ShapedType tensor2Type = tensor2.getType().cast<ShapedType>();
+  if (!tensor1Type.hasRank() || !tensor2Type.hasRank())
+    return false;
+  int64_t dim1 = tensor1Type.getShape()[dimAxis1];
+  int64_t dim2 = tensor2Type.getShape()[dimAxis2];
+  // Both dims are static.
+  if (!ShapedType::isDynamic(dim1) && !ShapedType::isDynamic(dim2))
+    return (dim1 == dim2);
+  // One is static, other is dynamic.
+  if (dim1 != dim2)
+    return false;
+  // Both are dynamic.
+  return sameDynDim(tensor1, dimAxis1, tensor2, dimAxis2);
+}
+
+bool DimAnalysis::sameDynDim(
+    Value tensor1, uint64_t dimAxis1, Value tensor2, uint64_t dimAxis2) const {
+  // Same tensor, same axis.
   if ((tensor1 == tensor2) && (dimAxis1 == dimAxis2))
     return true;
 
@@ -180,35 +203,57 @@ bool DimAnalysis::sameUnknownDim(mlir::Value tensor1, uint64_t dimAxis1,
 }
 
 bool DimAnalysis::sameShape(Value tensor1, Value tensor2) const {
-  ShapedType tensor1Type = tensor1.getType().cast<ShapedType>();
-  ShapedType tensor2Type = tensor2.getType().cast<ShapedType>();
-  if (!tensor1Type.hasRank() || !tensor2Type.hasRank())
+  if (!sameRank(tensor1, tensor2))
     return false;
-  // Different rank, return false.
-  if (tensor1Type.getRank() != tensor2Type.getRank())
-    return false;
-  // Both tensors have static dimensions.
-  if (tensor1Type.hasStaticShape() && tensor2Type.hasStaticShape())
-    return (tensor1Type.getShape() == tensor2Type.getShape());
-  // There are unknown dimensions, use DimAnalysis to check equality.
-  for (unsigned i = 0; i < tensor1Type.getRank(); ++i) {
-    int64_t dim1 = tensor1Type.getShape()[i];
-    int64_t dim2 = tensor2Type.getShape()[i];
-    if (dim1 != dim2)
+  unsigned rank = tensor1.getType().cast<ShapedType>().getRank();
+  // Check each dimension.
+  for (unsigned i = 0; i < rank; ++i) {
+    if (!sameDim(tensor1, i, tensor2, i))
       return false;
-    // Same dimensions but can be unknown (ShapedType::kDynamic).
-    if (ShapedType::isDynamic(dim1)) {
-      // Two unknown dimensions are NOT the same at compile time.
-      if (!sameUnknownDim(tensor1, i, tensor2, i))
-        return false;
-    }
+  }
+  return true;
+}
+
+bool DimAnalysis::sameDynShape(Value tensor1, Value tensor2) const {
+  if (!sameRank(tensor1, tensor2))
+    return false;
+  ArrayRef<int64_t> shape1 = tensor1.getType().cast<ShapedType>().getShape();
+  ArrayRef<int64_t> shape2 = tensor2.getType().cast<ShapedType>().getShape();
+  // Check each dimension.
+  for (unsigned i = 0; i < shape1.size(); ++i) {
+    int64_t dim1 = shape1[i];
+    int64_t dim2 = shape2[i];
+    // Both dims are static, ignore this case. Only care about dynamic dims.
+    if (!ShapedType::isDynamic(dim1) && !ShapedType::isDynamic(dim2))
+      continue;
+    // At least one is dynamic.
+    if (!sameDim(tensor1, i, tensor2, i))
+      return false;
+  }
+  return true;
+}
+
+bool DimAnalysis::broadcastLastDim(Value tensor1, Value tensor2) const {
+  if (!sameRank(tensor1, tensor2))
+    return false;
+  ArrayRef<int64_t> shape1 = tensor1.getType().cast<ShapedType>().getShape();
+  ArrayRef<int64_t> shape2 = tensor2.getType().cast<ShapedType>().getShape();
+  unsigned rank = shape1.size();
+  // The last dimension of tensor1 must be 1, so that tensor1 is broadcasting
+  // to tensor2.
+  if (shape1[rank - 1] != 1)
+    return false;
+  // Other dimensions except the last one must be the same.
+  for (unsigned i = 0; i < rank - 1; ++i) {
+    if (!sameDim(tensor1, i, tensor2, i))
+      return false;
   }
   return true;
 }
 
 void DimAnalysis::dump() const {
-  llvm::outs() << numOfUnknownDims
-               << " unknown dimensions (not including block arguments) are "
+  llvm::outs() << numOfDynamicDims
+               << " dynamic dimensions (not including block arguments) are "
                   "classified into "
                << dimSetMap.size() << " sets.\n";
   for (auto &entry : dimSetMap) {
@@ -221,11 +266,11 @@ void DimAnalysis::dump() const {
 }
 
 void DimAnalysis::analyze() {
-  // Build sets of the same unknown dimensions and merge them until a fixed
+  // Build sets of the same dynamic dimensions and merge them until a fixed
   // point where there is no update on each set.
   bool continued = true;
   while (continued) {
-    // Local search and update each set of unknown dimensions.
+    // Local search and update each set of dynamic dimensions.
     continued = updateDimSets();
 
     // Merge sets if there is update.
@@ -236,7 +281,7 @@ void DimAnalysis::analyze() {
   }
 
   LLVM_DEBUG(
-      llvm::dbgs() << "The number of sets of same unknown dims in the IR: "
+      llvm::dbgs() << "The number of sets of same dynamic dims in the IR: "
                    << dimSetMap.size() << "\n");
 }
 
@@ -252,7 +297,7 @@ bool DimAnalysis::updateDimSets() {
     // Update the dim set.
     for (auto &d : newSameDims) {
       if (!dimSet.contains(d)) {
-        // Found new unknown dims.
+        // Found new dynamic dims.
         dimSet.insert(d);
         updated = true;
       }
@@ -348,7 +393,7 @@ void DimAnalysis::visitDim(
     // clang-format on
     bool success = exploreSameInputDims(dim, op, sameDims);
     assert(success && "dim analysis should be successful for broadcast ops ");
-    // If we know by this analysis that two unknown dims at the same index are
+    // If we know by this analysis that two dynamic dims at the same index are
     // the same, then the output dim must be the same too.
     Value A = op->getOperands()[0];
     Value B = op->getOperands()[1];
@@ -360,14 +405,14 @@ void DimAnalysis::visitDim(
     if ((aRank != 0) && (bRank != 0)) {
       ArrayRef<int64_t> aShape = onnx_mlir::getShape(aType);
       ArrayRef<int64_t> bShape = onnx_mlir::getShape(bType);
-      // aDim == bDim (unknown), there is no broadcasting and aDim ==
+      // aDim == bDim (dynamic), there is no broadcasting and aDim ==
       // outputDim.
       int64_t aDimIndex = dimIndex - (maxRank - aRank);
       int64_t bDimIndex = dimIndex - (maxRank - bRank);
       if ((aDimIndex >= 0) && (bDimIndex >= 0) &&
           ShapedType::isDynamic(aShape[aDimIndex]) &&
           ShapedType::isDynamic(bShape[bDimIndex]) &&
-          onnx_mlir::DimAnalysis::sameUnknownDim(A, aDimIndex, B, bDimIndex))
+          onnx_mlir::DimAnalysis::sameDynDim(A, aDimIndex, B, bDimIndex))
         sameDims.insert(onnx_mlir::DimAnalysis::DimT(A, aDimIndex));
     }
     return;
@@ -407,7 +452,7 @@ void DimAnalysis::visitDim(
     bool success = exploreSameInputDims(dim, op, sameDims);
     assert(success && "dim analysis should be successful for matmul ops ");
 
-    // If we know by this analysis that two unknown dims at the same index in
+    // If we know by this analysis that two dynamic dims at the same index in
     // the batchsize space are the same, then the output dim must be the same
     // too.
     Value A = matmulOp.getA();
@@ -420,14 +465,14 @@ void DimAnalysis::visitDim(
     if (dimIndex <= maxRank - 2) { // In the batchsize space.
       ArrayRef<int64_t> aShape = getShape(aType);
       ArrayRef<int64_t> bShape = getShape(bType);
-      // aDim == bDim (unknown), there is no broadcasting and aDim ==
+      // aDim == bDim (dynamic), there is no broadcasting and aDim ==
       // outputDim.
       int64_t aDimIndex = dimIndex - (maxRank - aRank);
       int64_t bDimIndex = dimIndex - (maxRank - bRank);
       if ((aDimIndex >= 0) && (bDimIndex >= 0) &&
           ShapedType::isDynamic(aShape[aDimIndex]) &&
           ShapedType::isDynamic(bShape[bDimIndex]) &&
-          sameUnknownDim(A, aDimIndex, B, bDimIndex))
+          sameDynDim(A, aDimIndex, B, bDimIndex))
         sameDims.insert(DimT(A, aDimIndex));
     }
     return;
@@ -441,7 +486,7 @@ void DimAnalysis::visitDim(
     // The output dimension i can be from
     // - shape[i] or,
     // - data[j] if
-    //    - dim j and i are the only unknown dimension in data and
+    //    - dim j and i are the only dynamic dimension in data and
     // output, respectively, and
     //    - the products of the static dimensions in data and output are
     //    equal.
@@ -450,7 +495,7 @@ void DimAnalysis::visitDim(
     // we can say that arg0[ii] == arg1[jj], that can be used to verify user
     // inputs.
 
-    // Get the unknown dimension from shape. Use this to update the current
+    // Get the dynamic dimension from shape. Use this to update the current
     // dimension.
     if (areDimsFromConcat(reshapeOp.getShape())) {
       SmallVector<Value, 4> shapeDims;
@@ -460,35 +505,35 @@ void DimAnalysis::visitDim(
       sameDims.insert(newSameDim);
     }
 
-    // Get the unknown dimension from data.
+    // Get the dynamic dimension from data.
     RankedTensorType dataType =
         reshapeOp.getData().getType().dyn_cast<RankedTensorType>();
     RankedTensorType outputType =
         reshapeOp.getReshaped().getType().dyn_cast<RankedTensorType>();
-    // Check if there is only one unknown dimension in the data and output.
+    // Check if there is only one dynamic dimension in the data and output.
     bool isDataOK =
         (llvm::count(dataType.getShape(), ShapedType::kDynamic) == 1);
     bool isOutputOK =
         (llvm::count(outputType.getShape(), ShapedType::kDynamic) == 1);
     // Check if the products of static sizes in the data and output are equal.
-    // It's ok to count ShapedType::kDynamic (unknown dimension) in the size.
+    // It's ok to count ShapedType::kDynamic (dynamic dimension) in the size.
     int64_t dataSize = 1, outputSize = 1;
     for (int64_t i = 0; i < dataType.getRank(); ++i)
       dataSize *= dataType.getShape()[i];
     for (int64_t i = 0; i < outputType.getRank(); ++i)
       outputSize *= outputType.getShape()[i];
-    // Conditions hold, the unknown dimension can be from the data.
+    // Conditions hold, the dynamic dimension can be from the data.
     if (isDataOK && isOutputOK && (dataSize == outputSize)) {
-      // Find the index of the unknown dimension in the data.
-      Optional<int64_t> unknownDimIndexInData = std::nullopt;
+      // Find the index of the dynamic dimension in the data.
+      Optional<int64_t> dynamicDimIndexInData = std::nullopt;
       for (int64_t i = 0; i < dataType.getRank(); ++i)
         if (dataType.isDynamicDim(i)) {
-          unknownDimIndexInData = i;
+          dynamicDimIndexInData = i;
           break;
         }
-      assert(unknownDimIndexInData.has_value() &&
-             "Failed to obtain the index of the unknown dimension in the data");
-      DimT newSameDim(reshapeOp.getData(), *unknownDimIndexInData);
+      assert(dynamicDimIndexInData.has_value() &&
+             "Failed to obtain the index of the dynamic dimension in the data");
+      DimT newSameDim(reshapeOp.getData(), *dynamicDimIndexInData);
       sameDims.insert(newSameDim);
     }
     return;
@@ -502,7 +547,7 @@ void DimAnalysis::visitDim(
     // Only support keepdims at this moment.
     if (reduceMeanOp.getKeepdims() != 1)
       return;
-    // Reduction dims in output are always 1. So an unknown dim in the output
+    // Reduction dims in output are always 1. So a dynamic dim in the output
     // is at the same index as the one in the input.
     llvm::Optional<ArrayAttr> axesAttr = reduceMeanOp.getAxes();
     if (axesAttr.has_value()) {
@@ -528,7 +573,7 @@ void DimAnalysis::visitDim(
 namespace {
 
 /// This pass is for testing purpose. It introduces onnx.DimGroup to the IR to
-/// show group IDs. Unknown dimensions with the same group ID are supposed to be
+/// show group IDs. Dynamic dimensions with the same group ID are supposed to be
 /// equal.
 struct ONNXDimAnalysisPass
     : public PassWrapper<ONNXDimAnalysisPass, OperationPass<ModuleOp>> {

--- a/src/Dialect/ONNX/ONNXDimAnalysis.hpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.hpp
@@ -65,12 +65,16 @@ public:
   bool sameShape(mlir::Value tensor1, mlir::Value tensor2) const;
 
   /// Test if dynamic dimensions of two tensors are the same or not.
-  /// Static dimensions are ignores even thought they are different.
-  /// For example: return true for tensor<?x1xf32> and tensor<?x5xf32> if their
+  /// Static vs static dimension is ignored.
+  /// Static vs dynamic dimension is false as usual.
+  /// For example: return true for tensor<?x2xf32> and tensor<?x5xf32> if their
   /// first dimensions are the same.
   bool sameDynShape(mlir::Value tensor1, mlir::Value tensor2) const;
 
   /// Test if `tensor1` is broadcasting to `tensor2` using the last dimension.
+  /// For example: return true for tensor<?x1xf32> and tensor<?x5xf32> if their
+  /// first dimensions are the same.
+  /// Note that: broadcasting direction is important.
   bool broadcastLastDim(mlir::Value tensor1, mlir::Value tensor2) const;
 
   /// Dumps the analysis information.

--- a/src/Dialect/ONNX/ONNXDimAnalysis.hpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.hpp
@@ -8,7 +8,7 @@
 //
 // =============================================================================
 //
-// This file implements an analysis on unknown dimensions in ONNX ops.
+// This file implements an analysis on dynamic dimensions in ONNX ops.
 //
 //===----------------------------------------------------------------------===//
 
@@ -36,10 +36,10 @@ public:
   /// Create a new analysis for all values in a module.
   DimAnalysis(mlir::ModuleOp op);
 
-  /// Analyzes the relationship among unknown dimensions.
+  /// Analyzes the relationship among dynamic dimensions.
   /// Current implementation uses a fixed-point iteration algorithm,
   /// where there are two phases at each iteration:
-  ///   - Expand: find and add same unknown dimensions to each set. Same unknown
+  ///   - Expand: find and add same dynamic dimensions to each set. Same dynamic
   ///     dimensions are discovered by utilizing ShapeHelper of an operation or
   ///     utilizing the current result of this analysis.
   ///   - Merge: sets that have common elements will be merged into a single
@@ -48,43 +48,57 @@ public:
   /// The fixed point condition is: there is no update in each set.
   void analyze();
 
-  /// Returns the grouping result of unknown dimensions.
+  /// Returns the grouping result of dynamic dimensions.
   DimSetMapT getGroupingResult() const { return dimSetMap; }
 
-  /// Test if two unknown dimensions are the same or not.
+  /// Test if two dimensions are the same or not.
   /// Each dimension is identified by its tensor and axis.
-  bool sameUnknownDim(mlir::Value tensor1, uint64_t dimAxis1,
-      mlir::Value tensor2, uint64_t dimAxis2) const;
+  bool sameDim(mlir::Value tensor1, uint64_t dimAxis1, mlir::Value tensor2,
+      uint64_t dimAxis2) const;
+
+  /// Test if two dynamic dimensions are the same or not.
+  /// Each dimension is identified by its tensor and axis.
+  bool sameDynDim(mlir::Value tensor1, uint64_t dimAxis1, mlir::Value tensor2,
+      uint64_t dimAxis2) const;
 
   /// Test if two tensors have the same shape or not.
   bool sameShape(mlir::Value tensor1, mlir::Value tensor2) const;
+
+  /// Test if dynamic dimensions of two tensors are the same or not.
+  /// Static dimensions are ignores even thought they are different.
+  /// For example: return true for tensor<?x1xf32> and tensor<?x5xf32> if their
+  /// first dimensions are the same.
+  bool sameDynShape(mlir::Value tensor1, mlir::Value tensor2) const;
+
+  /// Test if `tensor1` is broadcasting to `tensor2` using the last dimension.
+  bool broadcastLastDim(mlir::Value tensor1, mlir::Value tensor2) const;
 
   /// Dumps the analysis information.
   void dump() const;
 
 private:
   /// Initializes the internal mappings.
-  /// Each unknown dimension is initially assigned to a singleton set.
+  /// Each dynamic dimension is initially assigned to a singleton set.
   void build(mlir::Value val);
 
-  /// Update each set of unknown dimensions to include the same unknown
+  /// Update each set of dynamic dimensions to include the same dynamic
   /// dimensions. This is a local update in the sense that the search space
-  /// includes unknown dimensions that directly link to the dimensions in the
+  /// includes dynamic dimensions that directly link to the dimensions in the
   /// set via defining operations.
   bool updateDimSets();
 
-  /// Merge sets of unknown dimensions. Two sets with a common dimension will
+  /// Merge sets of dynamic dimensions. Two sets with a common dimension will
   /// be merged into a single set consisting of elements from each set.
   void mergeDimSets();
 
-  /// Visit an unknown dimension and find new same unknown dimensions.
+  /// Visit a dynamic dimension and find new same dynamic dimensions.
   void visitDim(DimT &dim, DimSetT &sameDims) const;
 
 private:
   int64_t setCounter = 0;
-  int64_t numOfUnknownDims = 0;
-  /// This mapping maps each unknown dimension in the tensor to a set of same
-  /// unknown dimensions.
+  int64_t numOfDynamicDims = 0;
+  /// This mapping maps each dynamic dimension in the tensor to a set of same
+  /// dynamic dimensions.
   DimSetMapT dimSetMap;
 };
 

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -122,6 +122,16 @@ bool hasCustomONNXTensorDataLayout(const Type type) {
          ONNXTensorEncodingAttr::DataLayout::STANDARD;
 }
 
+bool sameRank(Value tensorOrMemref1, Value tensorOrMemref2) {
+  auto type1 = dyn_cast_or_null<ShapedType>(tensorOrMemref1.getType());
+  auto type2 = dyn_cast_or_null<ShapedType>(tensorOrMemref2.getType());
+  if (!type1 || !type2)
+    return false;
+  if (!type1.hasRank() || !type2.hasRank())
+    return false;
+  return (type1.getRank() == type2.getRank());
+}
+
 // Add a tensor encoding to a rank & shaped type. Otherwise, return an unranked
 // type as it is.
 Type convertTensorTypeToTensorTypeWithEncoding(

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -90,6 +90,9 @@ bool hasConvONNXTensorDataLayout(const mlir::Type type);
 // Return true if the type has a layout, and that layout is not STANDARD.
 bool hasCustomONNXTensorDataLayout(const mlir::Type type);
 
+/// Return true if two tensors or memrefs have the same rank.
+bool sameRank(mlir::Value tensorOrMemref1, mlir::Value tensorOrMemref2);
+
 //===----------------------------------------------------------------------===//
 // Identity map
 

--- a/test/mlir/krnl/permute.mlir
+++ b/test/mlir/krnl/permute.mlir
@@ -40,6 +40,8 @@ func.func @tiling() {
   return
 }
 
+// -----
+
 func.func @tiling3d() {
   %ii, %jj, %kk = krnl.define_loops 3
   // Blocking each loop by a factor of 4.
@@ -56,9 +58,9 @@ func.func @tiling3d() {
   // CHECK-NEXT:  affine.for [[I_BLOCK_IV:%.+]] = 0 to 1024 step 4 {
   // CHECK-NEXT:    affine.for [[J_BLOCK_IV:%.+]] = 0 to 2048 step 4 {
   // CHECK-NEXT:      affine.for [[K_BLOCK_IV:%.+]] = 0 to 4096 step 4 {
-  // CHECK-NEXT:        affine.for [[I_INNER_IV:%.+]] = #map([[I_BLOCK_IV]]) to #map2([[I_BLOCK_IV]]) {
-  // CHECK-NEXT:          affine.for [[J_INNER_IV:%.+]] = #map([[J_BLOCK_IV]]) to #map2([[J_BLOCK_IV]]) {
-  // CHECK-NEXT:            affine.for [[K_INNER_IV:%.+]] = #map([[K_BLOCK_IV]]) to #map2([[K_BLOCK_IV]]) {
+  // CHECK-NEXT:        affine.for [[I_INNER_IV:%.+]] = #map([[I_BLOCK_IV]]) to #map{{.*}}([[I_BLOCK_IV]]) {
+  // CHECK-NEXT:          affine.for [[J_INNER_IV:%.+]] = #map([[J_BLOCK_IV]]) to #map{{.*}}([[J_BLOCK_IV]]) {
+  // CHECK-NEXT:            affine.for [[K_INNER_IV:%.+]] = #map([[K_BLOCK_IV]]) to #map{{.*}}([[K_BLOCK_IV]]) {
   // CHECK-NEXT:            }
   // CHECK-NEXT:          }
   // CHECK-NEXT:        }


### PR DESCRIPTION
This patch adds some additional functions to DimAnalysis:
- `sameDynShape` to check if dynamic dimensions from two tensors are the same or not by ignoring static dimensions
- `broadcastLastDim` to check if one tensor is broadcasting to the other tensor using **the last dimension**

For example:
- For `tensor<?x1xf32>` and `tensor<?x5xf32`:  `sameDynShape` and `broadcastLastDim` return `true` if their dynamic dimensions are the same.
- For `tensor<?x2xf32>` and `tensor<?x5xf32`, `sameDynShape` returns `true` but `broadcastLastDim` return `false`  if their dynamic dimensions are the same.
- For `tensor<?x2x1xf32>` and `tensor<?x?x5xf32`, `sameDynShape` and `broadcastLastDim` return `false` because it cannot check equality of the second dimension: `2` vs `?`.


This patch also re-words `unknown` to `dynamic` in DimAnalysis to make it consistent with `ShapedType::kDynamic`.