### PR TITLE
make inferShapes() not crash on unranked inputs

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
@@ -37,7 +37,7 @@ LogicalResult ONNXLoopOp::inferShapes(
   // Body inputs: trip count, termination condition, loop carried dependencies.
   // TODO: Add verifier to check this.
   assert(loopBody.getNumArguments() == 2 + numCarried &&
-         "Loop body must take at least 2 inputs.");
+         "LoopOp inputs count must match body operands count");
 
   // We proceed to set types for loop body function inputs.
   // Set type for iteration number (trip count):
@@ -58,7 +58,8 @@ LogicalResult ONNXLoopOp::inferShapes(
   // shape inference to obtain body output types.
   doShapeInference(loopBody);
   Operation *terminator = loopBody.back().getTerminator();
-  assert(terminator->getNumOperands() == 1 + getVFinalAndScanOutputs().size());
+  assert(terminator->getNumOperands() == 1 + getVFinalAndScanOutputs().size() &&
+         "LoopOp outputs count must match body results count");
   // Skip the termination condition.
   auto bodyOuputTys = llvm::drop_begin(terminator->getOperandTypes(), 1);
 

--- a/src/Dialect/ONNX/ONNXOps/ControlFlow/Scan.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ControlFlow/Scan.cpp
@@ -18,6 +18,18 @@ using namespace mlir;
 using namespace mlir::OpTrait::util;
 using namespace onnx_mlir;
 
+namespace {
+template <typename Range>
+Range take_begin(Range range, size_t N) {
+  assert(range.size() >= N);
+  return llvm::make_range(range.begin(), range.begin() + N);
+}
+
+size_t getNumStateVariables(ONNXScanOp *op) {
+  return op->getInitialStateAndScanInputs().size() - op->getNumScanInputs();
+}
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // Verify
 //===----------------------------------------------------------------------===//
@@ -28,77 +40,69 @@ using namespace onnx_mlir;
 
 LogicalResult ONNXScanOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  auto &loopBody = getRegion();
-  assert(!getScanInputAxes().has_value());
+  // TODO: Support scan_input/output_axes.
+  assert(!getScanInputAxes() && "scan_input_axes are unsupported");
+  assert(!getScanOutputAxes() && "scan_output_axes are unsupported");
 
-  // We proceed to set types for loop body function inputs.
-  // Set types for loop carried dependencies (i.e., set these loop carried
-  // dependencies that appear in the body function input signature to have
-  // the same type as their counterpart in LoopOp inputs).
-  auto bodyInputs = loopBody.getArguments();
-  auto bodyVRange = llvm::make_range(bodyInputs.begin(), bodyInputs.end());
-  for (auto opVToBodyVTy : llvm::zip(getVInitial(), bodyVRange)) {
-    auto opVTy = std::get<0>(opVToBodyVTy).getType();
-    std::get<1>(opVToBodyVTy).setType(opVTy);
+  assert(!scan_inputs().empty() && "there must be 1 or more scan inputs");
+  ShapedType firstScanInputType = scan_inputs().front().getType();
+  // Number of body iterations is the dim size of the scan input sequence axis,
+  // which is also the dim size of the scan outputs concat axis.
+  int64_t sequence_length = firstScanInputType.hasRank()
+                                ? firstScanInputType.getDimSize(0)
+                                : ShapedType::kDynamic;
+
+  // ScanOp and body inputs/outputs are state variables followed by scan
+  // inputs/outputs.
+  unsigned numStateVariables = getNumStateVariables(this);
+
+  auto &body = getRegion();
+  assert(body.getNumArguments() == getInitialStateAndScanInputs().size());
+  auto bodyInputs = body.getArguments();
+
+  // We proceed to set types for scan body state variables inputs to have
+  // the same type as their counterpart in ScanOp inputs.
+  // zip() runs through the shortest range which is getVInitial().
+  for (auto [opStateVar, bodyStateVar] : llvm::zip(getVInitial(), bodyInputs))
+    bodyStateVar.setType(opStateVar.getType());
+
+  auto bodyScanInputs = llvm::drop_begin(bodyInputs, numStateVariables);
+  for (auto [opScanInput, bodyScanInput] :
+      llvm::zip(scan_inputs(), bodyScanInputs)) {
+    if (auto rankedTy = opScanInput.getType().dyn_cast<RankedTensorType>()) {
+      ArrayRef<int64_t> squeezedShape(rankedTy.getShape().drop_front(1));
+      updateType(bodyScanInput, squeezedShape, rankedTy.getElementType(),
+          /*encoding=*/nullptr,
+          /*refineShape=*/false);
+    }
   }
 
-  auto bodyScanInputs = llvm::make_range(
-      bodyInputs.begin() + getVInitial().size(), bodyInputs.end());
-  for (auto vScanOutputValToTy : llvm::zip(scan_inputs(), bodyScanInputs)) {
-    auto rankedScanTy =
-        std::get<0>(vScanOutputValToTy).getType().cast<RankedTensorType>();
-    auto shape = rankedScanTy.getShape();
-    SmallVector<int64_t, 4> squeezedShape(shape.begin() + 1, shape.end());
+  // Now we have modified scan body input types according to
+  // the knowledge we have on the inputs we pass to the body. Dispatch
+  // shape inference to obtain body output types.
+  doShapeInference(body);
+  Operation *terminator = body.back().getTerminator();
+  assert(terminator->getNumOperands() == getFinalStateAndScanOutputs().size());
+  auto bodyOuputTys = terminator->getOperandTypes();
 
-    // Note that we may know the extent of the scan output leading
-    // dimension, which is very likely just the trip count specified as an
-    // input to Loop operation, but we need to eliminate the possibility of
-    // early termination to be sure.
-    updateType(std::get<1>(vScanOutputValToTy), squeezedShape,
-        rankedScanTy.getElementType(), /*encoding=*/nullptr,
-        /*refineShape=*/false);
-  }
-
-  // Now we have modified loop body function input signatures according to
-  // the knowledge we have on the inputs we pass to this function. Dispatch
-  // shape inference to obtain body function output types.
-  doShapeInference(loopBody);
-
-  // Output loop variables should have the same type as their input
-  // counterparts.
-  auto bodyResultTys = loopBody.back().getTerminator()->getOperandTypes();
-  // Compute the type range corresponding to the final values of
-  // loop-carried dependencies/scan outputs in the body function output
-  // types.
-  auto scanStartItr = std::next(bodyResultTys.begin(), getVInitial().size());
-  auto bodyResVFinalTys = llvm::make_range(bodyResultTys.begin(), scanStartItr);
-  auto bodyResScanTys = llvm::make_range(scanStartItr, bodyResultTys.end());
-
-  // Set shape for loop operation outputs corresponding to the final
-  // values of loop-carried dependencies to be shape of their counterparts
-  // in the body function output.
-  for (auto vFinalValToTy : llvm::zip(v_final(), bodyResVFinalTys)) {
-    std::get<0>(vFinalValToTy).setType(std::get<1>(vFinalValToTy));
-  }
+  // Set state variable ScanOp output types (and shapes) to the types
+  // and inferred shapes of their counterparts in the body output.
+  // zip() runs through the shortest range which is v_final().
+  for (auto [val, ty] : llvm::zip(v_final(), bodyOuputTys))
+    val.setType(ty);
 
   // For scan outputs, we set their shape to be the shape of the return
-  // values of the loop body function corresponding to scan outputs, but
+  // values of the body corresponding to scan outputs, but
   // with an extra leading dimension.
-  for (auto vScanOutputValToTy : llvm::zip(scan_outputs(), bodyResScanTys)) {
-    auto rankedScanTy =
-        std::get<1>(vScanOutputValToTy).cast<RankedTensorType>();
-    auto shape = rankedScanTy.getShape();
-    SmallVector<int64_t, 4> unsqueezedShape(shape.begin(), shape.end());
-    // Note that we may know the extent of the scan output leading
-    // dimension, which is very likely just the trip count specified as an
-    // input to Loop operation, but we need to eliminate the possibility of
-    // early termination to be sure.
-    auto scanExtent =
-        scan_inputs().front().getType().cast<ShapedType>().getDimSize(0);
-    unsqueezedShape.insert(unsqueezedShape.begin(), scanExtent);
-    updateType(std::get<0>(vScanOutputValToTy), unsqueezedShape,
-        rankedScanTy.getElementType(), /*encoding=*/nullptr,
-        /*refineShape=*/false);
+  auto bodyScanOutputTys = llvm::drop_begin(bodyOuputTys, numStateVariables);
+  for (auto [opScanOutput, ty] : llvm::zip(scan_outputs(), bodyScanOutputTys)) {
+    if (auto rankedTy = ty.dyn_cast<RankedTensorType>()) {
+      SmallVector<int64_t, 4> unsqueezedShape(rankedTy.getShape());
+      unsqueezedShape.insert(unsqueezedShape.begin(), sequence_length);
+      updateType(opScanOutput, unsqueezedShape, rankedTy.getElementType(),
+          /*encoding=*/nullptr,
+          /*refineShape=*/false);
+    }
   }
 
   return success();
@@ -109,29 +113,23 @@ LogicalResult ONNXScanOp::inferShapes(
 //===----------------------------------------------------------------------===//
 
 Operation::operand_range ONNXScanOp::getVInitial() {
-  auto numVInit = getInitialStateAndScanInputs().size() - getNumScanInputs();
-  auto operands = getOperands();
-  return llvm::make_range(operands.begin(), operands.begin() + numVInit);
+  return take_begin(getInitialStateAndScanInputs(), getNumStateVariables(this));
 }
 
 Operation::operand_range ONNXScanOp::scan_inputs() {
-  auto numVInit = getInitialStateAndScanInputs().size() - getNumScanInputs();
-  auto operands = getOperands();
-  return llvm::make_range(operands.begin() + numVInit, operands.end());
+  return llvm::drop_begin(
+      getInitialStateAndScanInputs(), getNumStateVariables(this));
 }
 
 // Helper function to obtain subset of op results corresponding to the final
-// value of loop carried dependencies.
+// value of state variables.
 Operation::result_range ONNXScanOp::v_final() {
-  auto results = getResults();
-  return llvm::make_range(
-      results.begin(), results.begin() + getVInitial().size());
+  return take_begin(getFinalStateAndScanOutputs(), getNumStateVariables(this));
 }
 
 // Helper function to obtain subset of op results corresponding to the scan
 // outputs.
 Operation::result_range ONNXScanOp::scan_outputs() {
-  auto results = getResults();
-  return llvm::make_range(
-      results.begin() + getVInitial().size(), results.end());
+  return llvm::drop_begin(
+      getFinalStateAndScanOutputs(), getNumStateVariables(this));
 }

--- a/src/Dialect/ONNX/ONNXOps/ControlFlow/Scan.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ControlFlow/Scan.cpp
@@ -57,7 +57,8 @@ LogicalResult ONNXScanOp::inferShapes(
   unsigned numStateVariables = getNumStateVariables(this);
 
   auto &body = getRegion();
-  assert(body.getNumArguments() == getInitialStateAndScanInputs().size());
+  assert(body.getNumArguments() == getInitialStateAndScanInputs().size() &&
+         "ScanOp inputs count must match body operands count");
   auto bodyInputs = body.getArguments();
 
   // We proceed to set types for scan body state variables inputs to have
@@ -82,7 +83,8 @@ LogicalResult ONNXScanOp::inferShapes(
   // shape inference to obtain body output types.
   doShapeInference(body);
   Operation *terminator = body.back().getTerminator();
-  assert(terminator->getNumOperands() == getFinalStateAndScanOutputs().size());
+  assert(terminator->getNumOperands() == getFinalStateAndScanOutputs().size() &&
+         "ScanOp outputs count must match body results count");
   auto bodyOuputTys = terminator->getOperandTypes();
 
   // Set state variable ScanOp output types (and shapes) to the types

--- a/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
@@ -167,6 +167,9 @@ LogicalResult ONNXGlobalLpPoolOp::inferShapes(
 
 LogicalResult ONNXGlobalMaxPoolOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
+  if (!hasShapeAndRank(getX()))
+    return success();
+
   Type elementType = getX().getType().cast<ShapedType>().getElementType();
   ONNXGlobalMaxPoolOpShapeHelper shapeHelper(getOperation(), {});
   return shapeHelper.computeShapeAndUpdateType(elementType);

--- a/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
@@ -153,6 +153,9 @@ LogicalResult ONNXGlobalAveragePoolOp::inferShapes(
 
 LogicalResult ONNXGlobalLpPoolOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
+  if (!hasShapeAndRank(getX()))
+    return success();
+
   Type elementType = getX().getType().cast<ShapedType>().getElementType();
   ONNXGlobalLpPoolOpShapeHelper shapeHelper(getOperation(), {});
   return shapeHelper.computeShapeAndUpdateType(elementType);

--- a/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
@@ -139,6 +139,9 @@ LogicalResult ONNXAveragePoolOp::inferShapes(
 
 LogicalResult ONNXGlobalAveragePoolOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
+  if (!hasShapeAndRank(getX()))
+    return success();
+
   Type elementType = getX().getType().cast<ShapedType>().getElementType();
   ONNXGlobalAveragePoolOpShapeHelper shapeHelper(getOperation(), {});
   return shapeHelper.computeShapeAndUpdateType(elementType);

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -2745,7 +2745,7 @@ func.func private @test_loop_simple_main_graph(%arg0: tensor<i64>, %arg1: tensor
 
 func.func @test_loop(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<?xf32>) -> (tensor<?x?xf32>) {
   %0 = "onnx.Loop"(%arg0, %arg1) ({
-  ^bb0(%arg3: tensor<i64>, %arg4: tensor<i1>, %arg5: tensor<?xf32>):
+  ^bb0(%arg3: tensor<i64>, %arg4: tensor<i1>):
     %7 = "onnx.Add"(%arg2, %arg2) : (tensor<?xf32>, tensor<?xf32>) -> (tensor<?xf32>)
     onnx.Return %arg4,  %7 : tensor<i1>, tensor<?xf32>
   }) : (tensor<i64>, tensor<i1>) -> tensor<?x?xf32>

--- a/test/mlir/onnx/onnx_lowering_O3.mlir
+++ b/test/mlir/onnx/onnx_lowering_O3.mlir
@@ -3947,7 +3947,7 @@ func.func private @test_loop_simple_main_graph(%arg0: tensor<i64>, %arg1: tensor
 
 func.func @test_loop(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<?xf32>) -> (tensor<?x?xf32>) {
   %0 = "onnx.Loop"(%arg0, %arg1) ({
-  ^bb0(%arg3: tensor<i64>, %arg4: tensor<i1>, %arg5: tensor<?xf32>):
+  ^bb0(%arg3: tensor<i64>, %arg4: tensor<i1>):
     %7 = "onnx.Add"(%arg2, %arg2) : (tensor<?xf32>, tensor<?xf32>) -> (tensor<?xf32>)
     onnx.Return %arg4,  %7 : tensor<i1>, tensor<?xf32>
   }) : (tensor<i64>, tensor<i1>) -> tensor<?x?xf32>

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -767,6 +767,17 @@ func.func @test_global_averagepool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf3
 
 // -----
 
+func.func @test_global_averagepool_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: test_global_averagepool_unranked
+  // CHECK: [[RES:%.+]] = "onnx.GlobalAveragePool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  // CHECK: return [[RES]] : tensor<*xf32>
+}
+
+// -----
+
 func.func @test_global_lppool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.GlobalLpPool"(%arg0) : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2484,12 +2484,13 @@ func.func @test_loop_simple_no_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor
 
 // -----
 
-func.func @test_loop_simple_one_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<1xi64>) ->(tensor<*xi64>, tensor<*xi64>) { %0:2 = "onnx.Loop"(%arg0, %arg1, %arg2) ({
+func.func @test_loop_simple_one_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<1xi64>) ->(tensor<*xi64>, tensor<*xi64>) {
+  %0:2 = "onnx.Loop"(%arg0, %arg1, %arg2) ({
   ^bb0(%body_arg0: tensor<*xi64>, %body_arg1: tensor<*xi1>, %body_arg2: tensor<*xi64>):
-  %body_0 = "onnx.Identity"(%body_arg1) : (tensor<*xi1>) -> tensor<*xi1>
-  %body_1 = "onnx.Add"(%body_arg2, %body_arg0) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
-  %body_2 = "onnx.Identity"(%body_1) : (tensor<*xi64>) -> tensor<*xi64>
-  onnx.Return %body_0, %body_1, %body_2 : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
+    %body_0 = "onnx.Identity"(%body_arg1) : (tensor<*xi1>) -> tensor<*xi1>
+    %body_1 = "onnx.Add"(%body_arg2, %body_arg0) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
+    %body_2 = "onnx.Identity"(%body_1) : (tensor<*xi64>) -> tensor<*xi64>
+    onnx.Return %body_0, %body_1, %body_2 : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<*xi64>, tensor<*xi64>)
   return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
   // CHECK-LABEL:       func @test_loop_simple_one_scan_main_graph

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -789,6 +789,17 @@ func.func @test_global_lppool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
 
 // -----
 
+func.func @test_global_lppool_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.GlobalLpPool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: test_global_lppool_unranked
+  // CHECK: [[RES:%.+]] = "onnx.GlobalLpPool"(%arg0) {p = 2 : si64} : (tensor<*xf32>) -> tensor<*xf32>
+  // CHECK: return [[RES]] : tensor<*xf32>
+}
+
+// -----
+
 func.func @test_global_maxpool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.GlobalMaxPool"(%arg0) : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -811,6 +811,17 @@ func.func @test_global_maxpool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
 
 // -----
 
+func.func @test_global_maxpool_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
+  %0 = "onnx.GlobalMaxPool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL: test_global_maxpool_unranked
+  // CHECK: [[RES:%.+]] = "onnx.GlobalMaxPool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  // CHECK: return [[RES]] : tensor<*xf32>
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 /// Test the reshape op inference when constants are present.
 //===----------------------------------------------------------------------===//

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2581,6 +2581,27 @@ func.func @test_scan_simple_main_graph(%arg0: tensor<2xf32>, %arg1: tensor<3x2xf
 
 // -----
 
+func.func @test_scan_simple_unranked_main_graph(%arg0: tensor<2xf32>, %arg1: tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>) {
+  %0:2 = "onnx.Scan"(%arg0, %arg1) ( {
+  ^bb0(%arg2: tensor<*xf32>, %arg3: tensor<*xf32>):  // no predecessors
+    %1 = "onnx.Add"(%arg2, %arg3) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
+    onnx.Return %1, %1 : tensor<*xf32>, tensor<*xf32>
+  }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>)
+  return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
+// CHECK-LABEL:       func @test_scan_simple_unranked_main_graph
+// CHECK-SAME:     ([[SUM_INIT:%.+]]: tensor<2xf32>, [[TO_SUM:%.+]]: tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>) {
+// CHECK:           [[SCAN_OUT:%.+]]:2 = "onnx.Scan"([[SUM_INIT]], [[TO_SUM]]) (
+// CHECK:           ^bb0([[SUM_PREV:%.+]]: tensor<2xf32>, [[SUM_CURR:%.+]]: tensor<*xf32>):
+// CHECK:             [[ADD:%.+]] = "onnx.Add"([[SUM_PREV]], [[SUM_CURR]]) : (tensor<2xf32>, tensor<*xf32>) -> tensor<*xf32>
+// CHECK:             onnx.Return [[ADD]], [[ADD]] : tensor<*xf32>, tensor<*xf32>
+// CHECK:           }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>)
+// CHECK:           return [[SCAN_OUT]]#0, [[SCAN_OUT]]#1 : tensor<*xf32>, tensor<*xf32>
+// CHECK:         }
+// CHECK:       }
+}
+
+// -----
+
 func.func @test_range(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<*xf32> {
   %0 = "onnx.Range"(%arg0, %arg1, %arg2) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<*xf32>
   return %0 : tensor<*xf32>


### PR DESCRIPTION
Fixed inferShapes() crashes on unranked inputs in LoopOp, ScanOp, ONNXGlobalAveragePoolOp, ONNXGlobalLpPoolOp, ONNXGlobalMaxPoolOp. Added lit tests which would crash before these fixes. These crashes were discovered in draft PR #2098.

Cleaned up the LoopOp and ScanOp inferShapes() implementations to make them easier to read and compare.

Also fixed ill-formed loops in test_loop lit test is onnx_lowering.mlir and onnx_lowering_O3.mlir which crashed on a new assert 
```
assert(loopBody.getNumArguments() == 2 + getVInitial().size())
```
in ONNXLoopOp::inferShapes(). I added a TODO to add a verify() method to check this.