### PR TITLE
FuseAddConvPattern: skip if returnType is unranked

### DIFF
--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -142,7 +142,7 @@ def HasNoneType : Constraint<CPred<"$0.getType().isa<NoneType>()">>;
 
 def NotNoneType : Constraint<CPred<"!($0.getType().isa<NoneType>())">>;
 
-def HasShapeAndRank : Constraint<CPred<"onnx_mlir::hasShapeAndRank($0)">>;
+def HasShapeAndRank : Constraint<CPred<"onnx_mlir::hasShapeAndRank($_self)">>;
 
 def HasSameElementType : Constraint<
     CPred<"($0.getType().dyn_cast<ShapedType>().getElementType() == "
@@ -304,7 +304,8 @@ def FuseAddConvNullBiasPattern: Pat<
         (createArrayAttrOfOneToRankOf $y)),
      // unchanged operands and attributes.
      $auto_pad, $dilation, $group, $kernel_shape, $pads, $strides),
-  [(HasNoneType $b),
+  [(HasShapeAndRank:$res),
+   (HasNoneType $b),
    (AttributeIsNotNull:$denseAttr),
    (AllDimsFromAxisToEndAre<1, 1>:$y),
    (RankXMinusRankYIs<1> $res, $y)]
@@ -325,7 +326,8 @@ def FuseAddConvPattern: Pat<
            (createArrayAttrOfOneToRankOf $y))),
      // unchanged operands and attributes.
      $auto_pad, $dilation, $group, $kernel_shape, $pads, $strides),
-  [(NotNoneType $b),
+  [(HasShapeAndRank:$res),
+   (NotNoneType $b),
    (AttributeIsNotNull:$denseAttr),
    (AllDimsFromAxisToEndAre<1, 1>:$y),
    (RankXMinusRankYIs<1> $res, $y)]

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -699,7 +699,53 @@ func.func @test_fuse_add_conv(%arg0 : tensor<1x1x28x28xf32>, %arg1 : tensor<8x1x
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
 // CHECK:           return [[VAR_1_]] : tensor<1x8x28x28xf32>
+}
 
+// -----
+
+func.func @test_fuse_add_conv_bias(%arg0 : tensor<1x1x28x28xf32>, %arg1 : tensor<8x1x5x5xf32>, %arg2 : tensor<8xf32>) -> tensor<1x8x28x28xf32> {
+    %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
+    %1 = onnx.Constant dense<[[[-0.161539719]], [[-0.433835655]], [[0.091641359]], [[-0.0168522168]], [[-0.0650264397]], [[-0.131737873]], [[0.0204175506]], [[-0.121110231]]]> : tensor<8x1x1xf32>
+    %2 = "onnx.Add"(%0, %1) : (tensor<1x8x28x28xf32>, tensor<8x1x1xf32>) -> tensor<1x8x28x28xf32>
+    return %2 : tensor<1x8x28x28xf32>
+// CHECK-LABEL:  func.func @test_fuse_add_conv_bias
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>, [[PARAM_2_:%.+]]: tensor<8xf32>) -> tensor<1x8x28x28xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[PARAM_2_]], [[VAR_0_]]) : (tensor<8xf32>, tensor<8xf32>) -> tensor<*xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<*xf32>) -> tensor<1x8x28x28xf32>
+// CHECK:           return [[VAR_2_]] : tensor<1x8x28x28xf32>
+}
+
+// -----
+
+func.func @test_fuse_add_conv_unranked(%arg0 : tensor<*xf32>, %arg1 : tensor<8x1x5x5xf32>) -> tensor<*xf32> {
+    %cst = "onnx.NoValue"() {value} : () -> none
+    %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<*xf32>, tensor<8x1x5x5xf32>, none) -> tensor<*xf32>
+    %1 = onnx.Constant dense<[[[-0.161539719]], [[-0.433835655]], [[0.091641359]], [[-0.0168522168]], [[-0.0650264397]], [[-0.131737873]], [[0.0204175506]], [[-0.121110231]]]> : tensor<8x1x1xf32>
+    %2 = "onnx.Add"(%0, %1) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
+    return %2 : tensor<*xf32>
+// CHECK-LABEL:  func.func @test_fuse_add_conv_unranked
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>) -> tensor<*xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[{{\[}}[-0.161539719]{{\], \[}}[-0.433835655]{{\], \[}}[0.091641359]{{\], \[}}[-0.0168522168]{{\], \[}}[-0.0650264397]{{\], \[}}[-0.131737873]{{\], \[}}[0.0204175506]{{\], \[}}[-0.121110231]{{\]}}]> : tensor<8x1x1xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<*xf32>, tensor<8x1x5x5xf32>, none) -> tensor<*xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_2_]], [[VAR_0_]]) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
+// CHECK:           return [[VAR_3_]] : tensor<*xf32>
+}
+
+// -----
+
+func.func @test_fuse_add_conv_bias_unranked(%arg0 : tensor<*xf32>, %arg1 : tensor<8x1x5x5xf32>, %arg2 : tensor<8xf32>) -> tensor<*xf32> {
+    %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<*xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<*xf32>
+    %1 = onnx.Constant dense<[[[-0.161539719]], [[-0.433835655]], [[0.091641359]], [[-0.0168522168]], [[-0.0650264397]], [[-0.131737873]], [[0.0204175506]], [[-0.121110231]]]> : tensor<8x1x1xf32>
+    %2 = "onnx.Add"(%0, %1) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
+    return %2 : tensor<*xf32>
+// CHECK-LABEL:  func.func @test_fuse_add_conv_bias_unranked
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>, [[PARAM_2_:%.+]]: tensor<8xf32>) -> tensor<*xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[{{\[}}[-0.161539719]{{\], \[}}[-0.433835655]{{\], \[}}[0.091641359]{{\], \[}}[-0.0168522168]{{\], \[}}[-0.0650264397]{{\], \[}}[-0.131737873]{{\], \[}}[0.0204175506]{{\], \[}}[-0.121110231]{{\]}}]> : tensor<8x1x1xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<*xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<*xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], [[VAR_0_]]) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
+// CHECK:           return [[VAR_2_]] : tensor<*xf32>
 }
 
 // -----


### PR DESCRIPTION
instead of crashing in (RankXMinusRankYIs<1> $res, $y)

Added lit test test_fuse_add_conv_bias for FuseAddConvPattern by adapting the existing lit test test_fuse_add_conv for FuseAddConvNullBiasPattern, and then added unranked variants of the lit tests which crashed without the fixes to FuseAddConvPattern and FuseAddConvNullBiasPattern in Rewrite.td.

This problem was discovered in PR #2098.