### PR TITLE
OperationFingerPrint instead of printing to sha1_ostream

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.cpp
@@ -233,14 +233,11 @@ void DisposableElementsAttr::printAsDenseElementsAttr(
     // NOTE: This creates a copy which is never garbage collected. This is not
     // only slow but also defeats the garbage collection benefits of
     // DisposableElementsAttr, depending on when the printing
-    // takes place (the print at the end of onnx-mlir-opt in lit tests is ok
-    // but the print in ONNXOpTransformPass::createTagForIR() is bad).
+    // takes place (the print at the end of onnx-mlir-opt in lit tests is ok).
     printer.printAttribute(toDenseElementsAttr());
     // TODO: Do the work to print without constructing DenseElementsAttr.
   } else {
-    // This special case is easy and by avoiding conversion to DenseElementsAttr
-    // we save a lot of time in ONNXOpTransformPass::createTagForIR() if we set:
-    // --mlir-elide-elementsattrs-if-larger=1
+    // In this special case it's easy to avoid conversion to DenseElementsAttr.
     printer << "dense<__elided__> : " << getType();
   }
 }

--- a/src/Transform/ONNX/ONNXOpTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXOpTransformPass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
-#include "llvm/Support/raw_sha1_ostream.h"
 
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Pass/Passes.hpp"
@@ -60,30 +60,15 @@ struct ONNXOpTransformPass : public mlir::PassWrapper<ONNXOpTransformPass,
   }
 
   void runOnOperation() final;
-
-private:
-  uint64_t createTagForIR(mlir::ModuleOp module) {
-    // NOTE: This is slow for real models because they contain large
-    // constant tensors that are expensive to print. A workaround is to
-    // elide them from printing with --mlir-elide-elementsattrs-if-larger=1
-    //
-    // TODO: Hash without printing to speed this up, e.g. along the lines of
-    // how blocks are hashed in mlir/lib/Transforms/Utils/RegionUtils.cpp
-    llvm::raw_sha1_ostream sha1_ostream;
-    module->print(sha1_ostream, mlir::OpPrintingFlags());
-    std::array<uint8_t, 20> sha1 = sha1_ostream.sha1();
-    return *reinterpret_cast<uint64_t *>(sha1.data());
-  }
 };
 
 void ONNXOpTransformPass::runOnOperation() {
   auto module = getOperation();
 
-  uint64_t currentTag = createTagForIR(module);
-  uint64_t previousTag;
+  assert(onnxOpTransformThreshold > 0);
   int n = onnxOpTransformThreshold;
+  OperationFingerPrint before(module);
   do {
-    previousTag = currentTag;
     OpPassManager dynamicPM("builtin.module");
     dynamicPM.addNestedPass<func::FuncOp>(
         onnx_mlir::createDecomposeONNXToONNXPass());
@@ -101,9 +86,12 @@ void ONNXOpTransformPass::runOnOperation() {
         onnx_mlir::createConstPropONNXToONNXPass());
     if (failed(runPipeline(dynamicPM, module)))
       return signalPassFailure();
-    currentTag = createTagForIR(module);
-  } while (currentTag != previousTag && --n > 0);
-  if (currentTag != previousTag) {
+    OperationFingerPrint after(module);
+    if (after == before)
+      break;
+    before = after;
+  } while (--n > 0);
+  if (n == 0) {
     module->emitWarning()
         << "ONNXOpTransform did not converge after " << onnxOpTransformThreshold
         << "iterations. "
@@ -111,8 +99,7 @@ void ONNXOpTransformPass::runOnOperation() {
   }
   if (onnxOpTransformReport) {
     llvm::outs() << "ONNXOpTransform iterated " << onnxOpTransformThreshold - n
-                 << " times, converged "
-                 << ((currentTag == previousTag) ? "true" : "false") << "\n";
+                 << " times, converged " << (n > 0 ? "true" : "false") << "\n";
   }
 }
 


### PR DESCRIPTION
fixes #1963

Tested on the arcfaceresnet100-8.onnx model. On my MacBook when I run:
```
RelWithDebInfo/bin/onnx-mlir arcfaceresnet100-8.onnx --mlir-timing
```
ONNXOpTransformPass takes 2.7387s before the change and 0.0032s after the change.