### PR TITLE
constant propagate in lowering_with_canonicalize lit tests

### DIFF
--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -1,7 +1,10 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --constprop-onnx --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
 
 // Adding canonicalize is important here as this is the only way to check the values of the map,
 // which are otherwise before the function, and thus are hard to test.
+
+// Constant propagation has no effect on most tests, except it hoists constants
+// out of if and else branches in test_if_sign which affects lowering.
 
 // -----
 
@@ -194,11 +197,7 @@ func.func @test_if_sign(%arg0: tensor<f32>) -> tensor<i32> {
 // CHECK-DAG:         [[VAR_8_:%.+]] = arith.cmpf ogt, [[LOAD_PARAM_0_MEM_1_]], [[LOAD_VAR_0_MEM_1_]] : f32
 // CHECK-DAG:         krnl.store [[VAR_8_]], [[RES_1_]][] : memref<i1>
 // CHECK-DAG:         [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<i1>
-// CHECK-DAG:         [[VAR_10_:%.+]] = scf.if [[LOAD_RES_1_MEM_]] -> (memref<i32>) {
-// CHECK-DAG:           scf.yield [[CONSTANT_2_]] : memref<i32>
-// CHECK-DAG:         } else {
-// CHECK-DAG:           scf.yield [[CONSTANT_1_]] : memref<i32>
-// CHECK-DAG:         }
+// CHECK:             [[VAR_10_:%.+]] = arith.select [[LOAD_RES_1_MEM_]], [[CONSTANT_2_]], [[CONSTANT_1_]] : memref<i32>
 // CHECK:             scf.yield [[VAR_10_]] : memref<i32>
 // CHECK:           }
 // CHECK:           return [[VAR_5_]] : memref<i32>


### PR DESCRIPTION
The lowering_with_canonicalize lit tests lowered test_if_sign differently than the real compiler because it skipped constant propagation which hoists constants out of the if and else branches and somehow leads to different lowered code.