### PR TITLE
Fix memory leak due to unallocated tensor data

### DIFF
--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -504,6 +504,10 @@ OMTensorList *omtl_java_to_native(
       omTensorListCreate(jni_omts, (int64_t)jomtl_omtn), jni_omtl != NULL, env,
       japi->jecpt_cls, "jni_omtl=%p", jni_omtl);
 
+  /* omTensorListCreate makes a copy of the tensor list, so we must free the
+     list that we allocateed. */
+  free(jni_omts);
+
   return jni_omtl;
 }
 

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -603,6 +603,13 @@ jobject omtl_native_to_java(
      * tensor data to ensure Java ownership of the underlying tensor data.
      * Creation of the DirectByteBuffer here is merely a passthrough mechanism
      * to allow for the copy to occur.
+     *
+     * If jni_owning is false, it means the data buffer is not freeable
+     * due to one of the two following cases:
+     *
+     *   - user has malloc-ed the data buffer so the user is
+     *     responsible for freeing it
+     *   - the data buffer is static
      */
     void *jbytebuffer_data = jni_data;
     JNI_TYPE_VAR_CALL(env, jobject, jomt_data,

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -497,8 +497,7 @@ OMTensorList *omtl_java_to_native(
   free(jobj_omts);
 
   /* Create OMTensorList to be constructed and passed to the model
-   * shared library. Note that we do own the pointers to the native
-   * OMTensor structs, jni_omts.
+   * shared library.
    */
   LIB_TYPE_VAR_CALL(OMTensorList *, jni_omtl,
       omTensorListCreate(jni_omts, (int64_t)jomtl_omtn), jni_omtl != NULL, env,

--- a/src/Runtime/jni/src/com/ibm/onnxmlir/OMTensor.java
+++ b/src/Runtime/jni/src/com/ibm/onnxmlir/OMTensor.java
@@ -605,7 +605,10 @@ public class OMTensor {
         if (dataType < 0 || dataType > ONNX_TYPE_BFLOAT16)
             throw new IllegalArgumentException(
                     "data type " + dataType + " unknown");
-        _data = data.order(nativeEndian);
+        /* data is owned by the native code. Make a copy to allow the JNI
+           wrapper to clean up the native memory. */
+        _data = ByteBuffer.allocateDirect(data.capacity()).order(nativeEndian);
+        _data.slice().put(data.order(nativeEndian));
         _dataType = dataType;
         _rank = shape.length;
         _shape = shape;


### PR DESCRIPTION
Fixes https://github.com/onnx/onnx-mlir/issues/2171. The Java `OMTensor` object was not taking full ownership duties of the backing data within the native `OMTensor` object, leading to a memory leak. This fix solves the issue by allocating a new `ByteBuffer` in the JNI `OMTensor` constructor with a copy, leaving the original data to be freed along with the jni `OMTensor`.

Some initial timings suggest that there isn't any meaningful difference in timing due to the copy in the YOLOv3-12 and MNIST models.