### PR TITLE
Add a pattern for Tile op in DimAnalysis 

### DIFF
--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -592,6 +592,37 @@ void DimAnalysis::visitDim(
     return;
   }
 
+  // TileOp
+  if (auto tileOp = dyn_cast<ONNXTileOp>(op)) {
+    if (!areDimsFromConcat(tileOp.getRepeats()))
+      return;
+
+    // Special case:
+    // output_dim[i] = input_dim[i] * repeats[i]
+    //
+    // If input dimension i (input_dim[i]) is 1, output dimension i
+    // (output_dim[i]) and repeats i (repeats[i]) are equal.
+    //
+    // clang-format off
+    // ```mlir
+    // %0 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
+    // %1 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
+    // %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+    // %3 = "onnx.Tile"(%arg1, %3) : (tensor<1x1xi64>, tensor<2xi64>) -> tensor<?x?xi64>
+    // ```
+    // clang-format on
+
+    Type inputType = tileOp.getInput().getType();
+    ArrayRef<int64_t> inputShape = onnx_mlir::getShape(inputType);
+    if (inputShape[dimIndex] == 1) {
+      SmallVector<Value, 4> repeats;
+      getDims(tileOp.getRepeats(), repeats);
+      DimT newSameDim(repeats[dimIndex], dimIndex);
+      sameDims.insert(newSameDim);
+    }
+    return;
+  }
+
   ////////////////////////////////////////////////////
   // Generic cases
   exploreSameInputDims(dim, op, sameDims);

--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -605,7 +605,7 @@ void DimAnalysis::visitDim(
     // %0 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
     // %1 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
     // %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-    // %3 = "onnx.Tile"(%arg1, %3) : (tensor<1x1xi64>, tensor<2xi64>) -> tensor<?x?xi64>
+    // %3 = "onnx.Tile"(%arg1, %2) : (tensor<1x1xi64>, tensor<2xi64>) -> tensor<?x?xi64>
     // ```
     // clang-format on
     Type inputType = tileOp.getInput().getType();

--- a/test/mlir/onnx/onnx_dim_analysis.mlir
+++ b/test/mlir/onnx/onnx_dim_analysis.mlir
@@ -175,3 +175,32 @@ func.func @test_reshape_rank_2(%arg0: tensor<?x?xi64>) -> tensor<?x?xi64> {
 // CHECK:           return [[VAR_3_]] : tensor<?x?xi64>
 // CHECK:         }
 }
+
+// -----
+
+// COM: Dimension in output tensor is dimension in input tensor multiplied by value in repeats tensor.
+// (output_dim[i] = input_dim[i] * repeats[i])
+// If input_dim[i] is 1, output_dim[i] and repeats[i] are equal.
+
+func.func @test_tile_input_dim_1(%arg0: tensor<?x?xi64>, %arg1: tensor<1x1xi64>) -> tensor<?x?xi64> {
+  %0 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
+  %1 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
+  %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+  %3 = "onnx.Tile"(%arg1, %2) : (tensor<1x1xi64>, tensor<2xi64>) -> tensor<?x?xi64>
+  return %3: tensor<?x?xi64>
+
+// CHECK-LABEL:  func.func @test_tile_input_dim_1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xi64>, [[PARAM_1_:%.+]]: tensor<1x1xi64>) -> tensor<?x?xi64> {
+// CHECK:           "onnx.DimGroup"([[PARAM_0_]]) {axis = 1 : si64, group_id = 1 : si64} : (tensor<?x?xi64>) -> ()
+// CHECK:           "onnx.DimGroup"([[PARAM_0_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xi64>) -> ()
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
+// CHECK:           "onnx.DimGroup"([[PARAM_0_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xi64>) -> ()
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
+// CHECK:           "onnx.DimGroup"([[PARAM_0_]]) {axis = 1 : si64, group_id = 1 : si64} : (tensor<?x?xi64>) -> ()
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Tile"([[PARAM_1_]], [[VAR_2_]]) : (tensor<1x1xi64>, tensor<2xi64>) -> tensor<?x?xi64>
+// CHECK:           "onnx.DimGroup"([[VAR_3_]]) {axis = 1 : si64, group_id = 1 : si64} : (tensor<?x?xi64>) -> ()
+// CHECK:           "onnx.DimGroup"([[VAR_3_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xi64>) -> ()
+// CHECK:           return [[VAR_3_]] : tensor<?x?xi64>
+// CHECK:         }
+}


### PR DESCRIPTION
This patch adds a pattern for Tile op in DimAnalysis. 

Dimension in `output` tensor is dimension in `input` tensor multiplied by value in `repeats` tensor. (output_dim[i] = input_dim[i] * repeats[i])
So, if input_dim[i] is 1, output_dim[i]  and repeats[i] are equal.

Example
```
%0 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
%1 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
%2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
%3 = "onnx.Tile"(%arg1, %3) : (tensor<1x1xi64>, tensor<2xi64>) -> tensor<?x?xi64>
```
This pattern appears in `t5-decoder-with-lm-head.onnx` in model zoo.