### PR TITLE
Fix JNI memory leak for tensor data

### DIFF
--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -499,8 +499,7 @@ OMTensorList *omtl_java_to_native(
   free(jobj_omts);
 
   /* Create OMTensorList to be constructed and passed to the model
-   * shared library. Note that we do own the pointers to the native
-   * OMTensor structs, jni_omts.
+   * shared library.
    */
   LIB_TYPE_VAR_CALL(OMTensorList *, jni_omtl,
       omTensorListCreate(jni_omts, (int64_t)jomtl_omtn), jni_omtl != NULL, env,

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -506,6 +506,10 @@ OMTensorList *omtl_java_to_native(
       omTensorListCreate(jni_omts, (int64_t)jomtl_omtn), jni_omtl != NULL, env,
       japi->jecpt_cls, "jni_omtl=%p", jni_omtl);
 
+  /* omTensorListCreate makes a copy of the tensor list, so we must free the
+     list that we allocateed. */
+  free(jni_omts);
+
   return jni_omtl;
 }
 


### PR DESCRIPTION
Fixes #2171. This is yet another approach that is compatible with Java 8+. It mirrors a Java 9 `Cleaner`-based approach, but utilizing `WeakReference`s to keep track of the lifetime of the object. A `ByteBuffer` is used to keep track of the underlying allocation, and when the reference to the data expires, the allocation will be freed. It is also tied to the lifetime of the `ByteBuffer` created by the JNI instead of the `OMTensor` to handle scenarios where the `OMTensor` is updated. In such scenarios, the GC will grab the original `ByteBuffer` well before the `OMTensor` is destroyed, allowing for the allocation to be more aggressively reclaimed.

This fix also removes the extra copy that would occur if the model did _not_ allocate storage for the returned `OMTensor` object.
