### PR TITLE
NonZero constant propagation

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -800,7 +800,8 @@ template <typename AP_TYPE>
 SmallVector<int64_t> nonZeroIndices(ElementsAttr elms) {
   SmallVector<int64_t> indices;
   auto values = elms.getValues<AP_TYPE>();
-  for (const auto &idxpos : StridesRange<0>(elms.getType().getShape(), {})) {
+  for (const auto &idxpos :
+      StridesRange<0>(elms.getShapedType().getShape(), {})) {
     if (!values[idxpos.flattenedIndex].isZero())
       indices.append(idxpos.index.begin(), idxpos.index.end());
   }
@@ -812,7 +813,7 @@ ElementsAttr ElementsAttrBuilder::nonZero(ElementsAttr elms) {
   SmallVector<int64_t> indices = isa<FloatType>(elms.getElementType())
                                      ? nonZeroIndices<APFloat>(elms)
                                      : nonZeroIndices<APInt>(elms);
-  int64_t rank = elms.getType().getRank();
+  int64_t rank = elms.getShapedType().getRank();
   assert(indices.size() % rank == 0);
   int64_t count = indices.size() / rank;
   Type I64 = IntegerType::get(elms.getContext(), 64);

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -790,6 +790,12 @@ ElementsAttr ElementsAttrBuilder::range(
 }
 
 namespace {
+// Returns indices with non-zero values. The indices are placed back to back,
+// lexicographically sorted. Can be viewed as a [count, rank] shaped matrix
+// linearized in row-major order, where rank is the rank of elms' shape and
+// count is the number of non-zero values. AP_TYPE should be APFloat or APInt.
+// TODO: If this is too slow then reimplement in the style of allEqual()
+//       with WideNum instead of APFloat/APInt.
 template <typename AP_TYPE>
 SmallVector<int64_t> nonZeroIndices(ElementsAttr elms) {
   SmallVector<int64_t> indices;

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -185,6 +185,11 @@ public:
   // for i in [0, type.getNumElements()) in row-major order.
   mlir::ElementsAttr range(mlir::ShapedType, WideNum start, WideNum delta);
 
+  // Returns indices of non-zero elements like numpy.nonzero,
+  // but for scalar input produces output shape [0, N] instead of [1, N],
+  // which is different from Numpy's behavior.
+  mlir::ElementsAttr nonZero(mlir::ElementsAttr elms);
+
 private:
   struct ElementsProperties;
 

--- a/src/Dialect/ONNX/ElementsAttr/StridesRange.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/StridesRange.hpp
@@ -93,7 +93,7 @@ public:
   }
 
   // End iterator: ends after the given number of iterations.
-  StridesIterator(size_t iterations) : value{0, iterations} {}
+  StridesIterator(size_t iterations) : strides{}, value{0, iterations} {}
 
   // End iterator: ends after one traversal of shape.
   StridesIterator(llvm::ArrayRef<int64_t> shape)

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -869,6 +869,19 @@ Value ConstPropRange(PatternRewriter &rewriter, Value replacingValue,
 }
 
 //===----------------------------------------------------------------------===//
+// Code to perform constant propagation for NonZero.
+//===----------------------------------------------------------------------===//
+
+Value ConstPropNonZero(
+    PatternRewriter &rewriter, Value replacingValue, Value constValue) {
+  ConstPropCounters::count("NonZero", {constValue});
+  ElementsAttr constElements = getConstValueElements(constValue);
+  OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
+  ElementsAttr nonZeroElements = elementsBuilder.nonZero(constElements);
+  return createReplacingConstantOp(rewriter, replacingValue, nonZeroElements);
+}
+
+//===----------------------------------------------------------------------===//
 // Pattern definition.
 //===----------------------------------------------------------------------===//
 

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -170,6 +170,9 @@ def CreateConstantOfShapeOfConst:
 def CreateRangeOfThreeConst :
    NativeCodeCall<"ConstPropRange($_builder, $0, $1, $2, $3)">;
 
+def CreateNonZeroOfConst :
+   NativeCodeCall<"ConstPropNonZero($_builder, $0, $1)">;
+
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise ADD operations.
 //===----------------------------------------------------------------------===//
@@ -683,5 +686,14 @@ def RangeConstProp : Pat<
     (CreateRangeOfThreeConst $rangeOp, $start, $limit, $delta),
     [(IsFromDenseONNXConstantOp:$start), (IsFromDenseONNXConstantOp:$limit),
      (IsFromDenseONNXConstantOp:$delta), (HasStaticShape:$rangeOp)]>;
+
+//===----------------------------------------------------------------------===//
+// Patterns for NonZero.
+//===----------------------------------------------------------------------===//
+
+def NonZeroOfConst : Pat<
+    (ONNXNonZeroOp:$nonZeroOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
+    (CreateNonZeroOfConst $nonZeroOp, $input),
+    [(IsFromDenseONNXConstantOp:$input)]>;
 
 #endif // ONNX_CONSTPROP

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1349,7 +1349,6 @@ func.func @test_nonzero() -> tensor<2x?xi64> {
   //
   //   error: type of return operand 0 ('tensor<2x4xi64>') doesn't match function result type ('tensor<2x?xi64>') in function @test_nonzero
   //
-  // Therefore we use onnx.Return instead, although it isn't meant for function return.
   onnx.Return %1 : tensor<2x?xi64>
 
 // CHECK-LABEL:  func.func @test_nonzero

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1344,11 +1344,6 @@ func.func @test_range_fp() -> tensor<3xf32> {
 func.func @test_nonzero() -> tensor<2x?xi64> {
   %0 = "onnx.Constant"() {value = dense<[[2, 1], [0, 2], [0, 1]]> : tensor<3x2xi8>} : () -> tensor<3x2xi8>
   %1 = "onnx.NonZero"(%0) : (tensor<3x2xi8>) -> tensor<2x?xi64>
-  // NOTE: We cannot use return (i.e. "func.return") because the change of shape makes
-  // func::ReturnOp::verify() fail with:
-  //
-  //   error: type of return operand 0 ('tensor<2x4xi64>') doesn't match function result type ('tensor<2x?xi64>') in function @test_nonzero
-  //
   onnx.Return %1 : tensor<2x?xi64>
 
 // CHECK-LABEL:  func.func @test_nonzero


### PR DESCRIPTION
This PR illustrates the problem with changing shape in constant propagation, which doesn't work with `func.return` and was solved with `onnx.Return` in PR #2239. See the lit test in onnx_constprop.mlir:
```
func.func @test_nonzero() -> tensor<2x?xi64> {
  %0 = "onnx.Constant"() {value = dense<[[2, 1], [0, 2], [0, 1]]> : tensor<3x2xi8>} : () -> tensor<3x2xi8>
  %1 = "onnx.NonZero"(%0) : (tensor<3x2xi8>) -> tensor<2x?xi64>
  // NOTE: We cannot use return (i.e. "func.return") because the change of shape makes
  // func::ReturnOp::verify() fail with:
  //
  //   error: type of return operand 0 ('tensor<2x4xi64>') doesn't match function result type ('tensor<2x?xi64>') in function @test_nonzero
  //
  onnx.Return %1 : tensor<2x?xi64>
}
```