### PR TITLE
move ConstProp implementations to ElementsAttrBuilder methods

### DIFF
--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -514,37 +514,36 @@ void IndexExpr::debugPrint(
 // Helpers for IndexExpressions
 //===----------------------------------------------------------------------===//
 
-/*static*/ void IndexExpr::getLiteral(SmallVectorImpl<IndexExpr> &indexExprList,
-    SmallVectorImpl<int64_t> &intList) {
+/*static*/ void IndexExpr::getLiteral(
+    ArrayRef<IndexExpr> indexExprArray, SmallVectorImpl<int64_t> &intList) {
   intList.clear();
-  llvm::transform(indexExprList, std::back_inserter(intList),
-      [](const auto &indexExpr) { return indexExpr.getLiteral(); });
+  llvm::transform(indexExprArray, std::back_inserter(intList),
+      [](IndexExpr expr) { return expr.getLiteral(); });
 }
 
-/*static*/ void IndexExpr::getShape(SmallVectorImpl<IndexExpr> &indexExprList,
+/*static*/ void IndexExpr::getShape(ArrayRef<IndexExpr> indexExprArray,
     SmallVectorImpl<int64_t> &intDimList, bool uniqueQuestionMark) {
   intDimList.clear();
-  for (IndexExpr &expr : indexExprList)
+  for (IndexExpr expr : indexExprArray)
     intDimList.emplace_back(expr.getShape(uniqueQuestionMark));
 }
 
 /*static*/ void IndexExpr::getDynSymbols(
-    llvm::SmallVectorImpl<IndexExpr> &indexExprList, // Input list.
-    llvm::SmallVectorImpl<Value> &dynSymbols) {      // Symbol for dyn ref.
-  // Set shape.
-  int64_t rank = indexExprList.size();
+    ArrayRef<IndexExpr> indexExprArray,         // Input list.
+    llvm::SmallVectorImpl<Value> &dynSymbols) { // Symbol for dyn ref.
   // For each dyn shape, enqueue its value in dynamic symbol list.
   dynSymbols.clear();
-  for (int64_t i = 0; i < rank; ++i)
-    if (!indexExprList[i].isLiteral())
-      dynSymbols.emplace_back(indexExprList[i].getValue());
+  for (IndexExpr expr : indexExprArray) {
+    if (!expr.isLiteral())
+      dynSymbols.emplace_back(expr.getValue());
+  }
 }
 
 /*static*/ void IndexExpr::getOpOrFoldResults(
-    SmallVectorImpl<IndexExpr> &indexExprList,
+    ArrayRef<IndexExpr> indexExprArray,
     SmallVectorImpl<OpFoldResult> &resList) {
   resList.clear();
-  for (IndexExpr &expr : indexExprList) {
+  for (IndexExpr expr : indexExprArray) {
     if (expr.isLiteral()) {
       assert(!expr.isFloat() && "missing support for float");
       auto val = expr.getRewriter().getIndexAttr(expr.getLiteral());
@@ -557,7 +556,7 @@ void IndexExpr::debugPrint(
 /*static*/ void IndexExpr::getValues(
     ArrayRef<IndexExpr> indexExprArray, SmallVectorImpl<Value> &valueList) {
   valueList.clear();
-  for (IndexExpr const &expr : indexExprArray)
+  for (IndexExpr expr : indexExprArray)
     valueList.emplace_back(expr.getValue());
 }
 

--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -485,18 +485,17 @@ public:
   // Helpers for list of IndexExpressions: given a (list of) IndexExpr, provide
   // the (list of) Shape/Value/OpFoldResult corresponding to the original (list
   // of) IndexExpr.
-  static void getLiteral(llvm::SmallVectorImpl<IndexExpr> &indexExprList,
+  static void getLiteral(mlir::ArrayRef<IndexExpr> indexExprArray,
       llvm::SmallVectorImpl<int64_t> &intList);
-  static void getShape(llvm::SmallVectorImpl<IndexExpr> &indexExprList,
+  static void getShape(mlir::ArrayRef<IndexExpr> indexExprArray,
       llvm::SmallVectorImpl<int64_t> &intDimList,
       bool uniqueQuestionMark = false);
   static void getDynSymbols(
-      llvm::SmallVectorImpl<IndexExpr> &indexExprList, // Input list.
+      mlir::ArrayRef<IndexExpr> indexExprArray,        // Input list.
       llvm::SmallVectorImpl<mlir::Value> &dynSymbols); // Symbol for dyn ref.
   static void getValues(mlir::ArrayRef<IndexExpr> indexExprArray,
       llvm::SmallVectorImpl<mlir::Value> &valueList);
-  static void getOpOrFoldResults(
-      llvm::SmallVectorImpl<IndexExpr> &indexExprList,
+  static void getOpOrFoldResults(mlir::ArrayRef<IndexExpr> indexExprArray,
       llvm::SmallVectorImpl<mlir::OpFoldResult> &resList);
 
   // Possibly Affine Operations. Return a new IndexExpr

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.cpp
@@ -532,7 +532,6 @@ ElementsAttr ElementsAttrBuilder::gather(
   auto outType = inputType.clone(outShape);
   return fromWideNums(outType, [&](MutableArrayRef<WideNum> dst) {
     size_t postAxisNumElements = ShapedType::getNumElements(postAxisShape);
-    // TODO: Use getWideNumsAndStrides() instead of getElementsWideNums()
     ArrayBuffer<WideNum> src = getElementsWideNums(input);
     ArrayBuffer<int64_t> indicesArray = getElementsArray<int64_t>(indices);
     size_t axisInputSize = inputShape[axis];

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -167,6 +167,12 @@ public:
   mlir::ElementsAttr gather(
       mlir::ElementsAttr input, mlir::ElementsAttr indices, unsigned axis);
 
+  // Returns copy of input with updates from a tensor of update values at the
+  // index positions given by a tensor of indices.
+  // Follows the specification of the onnx ScatterND operation.
+  mlir::ElementsAttr scatterND(mlir::ElementsAttr input,
+      mlir::ElementsAttr indices, mlir::ElementsAttr updates);
+
   // Assumptions: elms is non-empty, reducer is associative and commutative.
   mlir::ElementsAttr reduce(mlir::ElementsAttr elms,
       llvm::ArrayRef<unsigned> axes, bool keepdims,

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -144,7 +144,7 @@ public:
   // Splits the tensor in elms along axis into sizes.size() tensors where
   // tensor[i].shape[axis] == sizes[i], and they all sum to elms.shape[axis].
   //
-  // The returned tensors don't reuse elms' underlyind data, unless sizes.size()
+  // The returned tensors don't reuse elms' underlying data, unless sizes.size()
   // is 1 and elms is returned.
   std::vector<mlir::ElementsAttr> split(
       mlir::ElementsAttr elms, unsigned axis, llvm::ArrayRef<int64_t> sizes);

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -149,6 +149,10 @@ public:
   std::vector<mlir::ElementsAttr> split(
       mlir::ElementsAttr elms, unsigned axis, llvm::ArrayRef<int64_t> sizes);
 
+  // Concatenates the tensors along axis.
+  mlir::ElementsAttr concat(
+      llvm::ArrayRef<mlir::ElementsAttr> elms, unsigned axis);
+
   // Assumptions: elms is non-empty, reducer is associative and commutative.
   mlir::ElementsAttr reduce(mlir::ElementsAttr elms,
       llvm::ArrayRef<unsigned> axes, bool keepdims,

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -153,6 +153,14 @@ public:
   mlir::ElementsAttr concat(
       llvm::ArrayRef<mlir::ElementsAttr> elms, unsigned axis);
 
+  // Slices the tensor.
+  // shape, start, steps lengths must equal the tensor rank.
+  // shape and start must be non-negative.
+  // Negative steps means slicing backwards.
+  mlir::ElementsAttr slice(mlir::ElementsAttr elms,
+      llvm::ArrayRef<int64_t> shape, llvm::ArrayRef<int64_t> starts,
+      llvm::ArrayRef<int64_t> steps);
+
   // Assumptions: elms is non-empty, reducer is associative and commutative.
   mlir::ElementsAttr reduce(mlir::ElementsAttr elms,
       llvm::ArrayRef<unsigned> axes, bool keepdims,

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrBuilder.hpp
@@ -161,6 +161,12 @@ public:
       llvm::ArrayRef<int64_t> shape, llvm::ArrayRef<int64_t> starts,
       llvm::ArrayRef<int64_t> steps);
 
+  // Gathers a tensor of the values from an input tensor given by a tensor of
+  // indices, along the specified axis.
+  // Follows the specification of the onnx Gather operation.
+  mlir::ElementsAttr gather(
+      mlir::ElementsAttr input, mlir::ElementsAttr indices, unsigned axis);
+
   // Assumptions: elms is non-empty, reducer is associative and commutative.
   mlir::ElementsAttr reduce(mlir::ElementsAttr elms,
       llvm::ArrayRef<unsigned> axes, bool keepdims,

--- a/src/Dialect/ONNX/ElementsAttr/ElementsAttrHelper.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/ElementsAttrHelper.cpp
@@ -60,7 +60,12 @@ ArrayBuffer<WideNum> getElementsWideNums(ElementsAttr elms) {
   if (auto disposable = elms.dyn_cast<DisposableElementsAttr>())
     return disposable.getWideNums();
 
-  // TODO: If elms is DenseElementsAttr and elm type is wide, return raw data.
+  // Return raw data if non-splat DenseElementsAttr and element type is wide.
+  if (auto dense = elms.dyn_cast<DenseElementsAttr>()) {
+    auto isWideType = [](Type t) { return t.isInteger(64) || t.isF64(); };
+    if (isWideType(dense.getElementType()) && !dense.isSplat())
+      return castArrayRef<WideNum>(dense.getRawData());
+  }
 
   ArrayBuffer<WideNum>::Vector dst;
   dst.resize_for_overwrite(elms.size());

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -732,7 +732,7 @@ Value ConstPropSlice(
   auto outcome = shapeHelper.computeShape();
   assert(succeeded(outcome) && "Failed to scan slice op parameters");
   SmallVector<int64_t> shape, starts, steps;
-  IndexExpr::getLiteral(shapeHelper.getOutputDims(), shape);
+  IndexExpr::getShape(shapeHelper.getOutputDims(), shape);
   IndexExpr::getLiteral(shapeHelper.starts, starts);
   IndexExpr::getLiteral(shapeHelper.steps, steps);
 

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -731,12 +731,10 @@ Value ConstPropSlice(
   ONNXSliceOpShapeHelper shapeHelper(op, {});
   auto outcome = shapeHelper.computeShape();
   assert(succeeded(outcome) && "Failed to scan slice op parameters");
-  auto toLiterals = [](ArrayRef<IndexExpr> ies) {
-    return llvm::map_range(ies, [](IndexExpr ie) { return ie.getLiteral(); });
-  };
-  SmallVector<int64_t> shape(toLiterals(shapeHelper.getOutputDims()));
-  SmallVector<int64_t> starts(toLiterals(shapeHelper.starts));
-  SmallVector<int64_t> steps(toLiterals(shapeHelper.steps));
+  SmallVector<int64_t> shape, starts, steps;
+  IndexExpr::getLiteral(shapeHelper.getOutputDims(), shape);
+  IndexExpr::getLiteral(shapeHelper.starts, starts);
+  IndexExpr::getLiteral(shapeHelper.steps, steps);
 
   OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
   ElementsAttr inputElements = getConstValueElements(constValue);

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -22,8 +22,6 @@
 #include "llvm/ADT/STLExtras.h"
 
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
-#include "src/Dialect/ONNX/ElementsAttr/ElementsAttrHelper.hpp"
-#include "src/Dialect/ONNX/ElementsAttr/StridesRange.hpp"
 #include "src/Dialect/ONNX/ElementsAttr/WideNum.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"


### PR DESCRIPTION
This addresses leftover TODOs from PR #1874 and will make it easier to migrate current constant propagation for ScatterND, Slice, Concat, and Gather to constant folding in the future, see issue #2143.

Also made IndexExpr::getLiteral/Shape/DynSymbols/OpOrFoldResults use ArrayRef like IndexExpr::getValues.