### PR TITLE
[MHLO] lowering to MHLO for ReshapeOp, ExpandOp, and reduction ops

### DIFF
--- a/src/Conversion/ONNXToMhlo/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToMhlo/DialectBuilder.cpp
@@ -49,8 +49,10 @@ Value IndexExprBuilderForMhlo::getVal(Value intArrayVal, uint64_t i) {
   Type elemType = getElementType(intArrayVal.getType());
   if (!elemType.isa<IndexType>()) {
     Type indexTensorType = RankedTensorType::get(
-        intArrayVal.getType().cast<ShapedType>().getShape(), b().getIndexType());
-    intArrayVal = b().create<arith::IndexCastOp>(loc(), indexTensorType, intArrayVal);
+        intArrayVal.getType().cast<ShapedType>().getShape(),
+        b().getIndexType());
+    intArrayVal =
+        b().create<arith::IndexCastOp>(loc(), indexTensorType, intArrayVal);
   }
   ShapeBuilder createShape(*this);
   return createShape.getExtent(intArrayVal, i);

--- a/src/Conversion/ONNXToMhlo/Tensor/Expand.cpp
+++ b/src/Conversion/ONNXToMhlo/Tensor/Expand.cpp
@@ -43,7 +43,6 @@ struct ONNXExpandOpLoweringToMhlo : public ConversionPattern {
     // LogicalResult shapeComputed = shapeHelper.computeShape();
     // assert(succeeded(shapeComputed) && "Failed to compute shape");
 
-    // Convert the output type to MemRefType.
     Type inputType = input.getType();
     Type outputType = *op->result_type_begin();
     assert(isRankedShapedType(inputType) && "Expected Ranked ShapedType");
@@ -53,8 +52,13 @@ struct ONNXExpandOpLoweringToMhlo : public ConversionPattern {
     int64_t outputRank = outputShapedType.getRank();
 
     Operation *shapeDefOp = shape.getDefiningOp();
-    Value ones = rewriter.create<mhlo::ConstantOp>(
-        loc, rewriter.getFloatAttr(elementType, 1.0));
+    Value ones;
+    if (elementType.isa<IntegerType>())
+      ones = rewriter.create<mhlo::ConstantOp>(
+          loc, rewriter.getIntegerAttr(elementType, 1));
+    else
+      ones = rewriter.create<mhlo::ConstantOp>(
+          loc, rewriter.getFloatAttr(elementType, 1.0));
     Value broadcastedOnes;
     if (ONNXShapeOp shapeOp = dyn_cast_or_null<ONNXShapeOp>(shapeDefOp)) {
       assert(shapeOp.getData().getType().isa<ShapedType>() &&

--- a/src/Conversion/ONNXToMhlo/Tensor/Reshape.cpp
+++ b/src/Conversion/ONNXToMhlo/Tensor/Reshape.cpp
@@ -40,9 +40,11 @@ struct ONNXReshapeOpLoweringToMhlo : public ConversionPattern {
     SmallVector<Value> dims;
     IndexExpr::getValues(outputDims, dims);
 
-    Type outputShapeType = RankedTensorType::get({(int64_t)dims.size()}, rewriter.getIndexType());
+    Type outputShapeType =
+        RankedTensorType::get({(int64_t)dims.size()}, rewriter.getIndexType());
     Value shape = rewriter.create<shape::FromExtentsOp>(loc, dims);
-    shape = rewriter.create<shape::ToExtentTensorOp>(loc, outputShapeType, shape);
+    shape =
+        rewriter.create<shape::ToExtentTensorOp>(loc, outputShapeType, shape);
     Value result =
         rewriter.create<mhlo::DynamicReshapeOp>(loc, outputType, data, shape);
     rewriter.replaceOp(op, result);

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -770,7 +770,9 @@ void DecomposeONNXToONNXPass::runOnOperation() {
   target.addIllegalOp<ONNXPadV11Op>();
   target.addIllegalOp<ONNXPadV13Op>();
   target.addIllegalOp<ONNXReduceL1Op>();
+  target.addIllegalOp<ONNXReduceL1V13Op>();
   target.addIllegalOp<ONNXReduceL2Op>();
+  target.addIllegalOp<ONNXReduceL2V13Op>();
   target.addIllegalOp<ONNXReduceLogSumOp>();
   target.addIllegalOp<ONNXReduceLogSumExpOp>();
   target.addIllegalOp<ONNXReduceSumSquareOp>();

--- a/test/mlir/conversion/onnx_to_mhlo/Math/GlobalPooling.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Math/GlobalPooling.mlir
@@ -18,11 +18,11 @@ func.func @test_global_average_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tens
   return %0 : tensor<1x?x1x1xf32>
   // CHECK-LABEL: test_global_average_pool_dyn_dims
   // CHECK: [[VAR_3_:%.+]] = mhlo.reduce([[PARAM_0_:%.+]] init: [[VAR_2_:%.+]]) applies mhlo.add across dimensions = [2, 3] : (tensor<1x?x?x5xf32>, tensor<f32>) -> tensor<1x?xf32>
-  // CHECK: [[VAR_4_:%.+]] = mhlo.dynamic_reshape [[VAR_3_]], [[VAR_0_:%.+]] : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
+  // CHECK: [[VAR_4_:%.+]] = mhlo.dynamic_reshape [[VAR_3_]], [[VAR_0_:%.+]] : (tensor<1x?xf32>, tensor<4xindex>) -> tensor<1x?x1x1xf32>
   // CHECK: [[VAR_5_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<1x?x?x5xf32> -> tensor<4xindex>
   // CHECK: [[VAR_6_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_1_:%.+]], [[VAR_5_]]) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<f32>, tensor<4xindex>) -> tensor<1x?x?x5xf32>
   // CHECK: [[VAR_7_:%.+]] = mhlo.reduce([[VAR_6_]] init: [[VAR_2_]]) applies mhlo.add across dimensions = [2, 3] : (tensor<1x?x?x5xf32>, tensor<f32>) -> tensor<1x?xf32>
-  // CHECK: [[VAR_8_:%.+]] = mhlo.dynamic_reshape [[VAR_7_]], [[VAR_0_]] : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
+  // CHECK: [[VAR_8_:%.+]] = mhlo.dynamic_reshape [[VAR_7_]], [[VAR_1_:%.+]] : (tensor<1x?xf32>, tensor<4xindex>) -> tensor<1x?x1x1xf32>
 }
 
 // -----
@@ -45,5 +45,5 @@ func.func @test_global_max_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tensor<1
   return %0 : tensor<1x?x1x1xf32>
   // CHECK-LABEL: test_global_max_pool_dyn_dims
   // CHECK:  [[VAR_2_:%.+]] = mhlo.reduce([[PARAM_0_:%.+]] init: [[VAR_1_:%.+]]) applies mhlo.maximum across dimensions = [2, 3] : (tensor<1x?x?x5xf32>, tensor<f32>) -> tensor<1x?xf32>
-  // CHECK:  [[VAR_3_:%.+]] = mhlo.dynamic_reshape [[VAR_2_]], [[VAR_0_:%.+]] : (tensor<1x?xf32>, tensor<4xi64>) -> tensor<1x?x1x1xf32>
+  // CHECK:  [[VAR_3_:%.+]] = mhlo.dynamic_reshape [[VAR_2_]], [[VAR_0_:%.+]] : (tensor<1x?xf32>, tensor<4xindex>) -> tensor<1x?x1x1xf32>
 }

--- a/test/mlir/conversion/onnx_to_mhlo/Math/Reduction.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Math/Reduction.mlir
@@ -10,6 +10,25 @@ func.func @test_reducemax_v13(%arg0 : tensor<3x2x2xf32>) -> tensor<3x2xf32> {
 
 // -----
 
+func.func @test_reducemax_v13_keepdims(%arg0: tensor<?x20x30xf32>) -> tensor<?x1x30xf32> {
+  %0 = "onnx.ReduceMaxV13"(%arg0) {axes = [1], keepdims = 1 : si64} : (tensor<?x20x30xf32>) -> tensor<?x1x30xf32>
+  return %0 : tensor<?x1x30xf32>
+// CHECK-LABEL:  func @test_reducemax_v13_keepdims
+// CHECK-DAG: %c2 = arith.constant 2 : index
+// CHECK-DAG: %c1 = arith.constant 1 : index
+// CHECK-DAG: %c0 = arith.constant 0 : index
+// CHECK-DAG: %0 = mhlo.constant dense<0xFF800000> : tensor<f32>
+// CHECK-DAG: %1 = mhlo.reduce(%arg0 init: %0) applies mhlo.maximum across dimensions = [1] : (tensor<?x20x30xf32>, tensor<f32>) -> tensor<?x30xf32>
+// CHECK-DAG: %2 = shape.shape_of %arg0 : tensor<?x20x30xf32> -> tensor<3xindex>
+// CHECK-DAG: %3 = shape.get_extent %2, %c0 : tensor<3xindex>, index -> index
+// CHECK-DAG: %4 = shape.get_extent %2, %c2 : tensor<3xindex>, index -> index
+// CHECK: %5 = shape.from_extents %3, %c1, %4 : index, index, index
+// CHECK: %6 = shape.to_extent_tensor %5 : !shape.shape -> tensor<3xindex>
+// CHECK: %7 = mhlo.dynamic_reshape %1, %6 : (tensor<?x30xf32>, tensor<3xindex>) -> tensor<?x1x30xf32>
+}
+
+// -----
+
 func.func @test_reducemin_v13(%arg0 : tensor<?x2x2xf32>) -> tensor<?x2xf32> {
   %0 ="onnx.ReduceMinV13"(%arg0) {axes=[1], keepdims = 0 : si64} : (tensor<?x2x2xf32>)-> tensor<?x2xf32>
   "func.return"(%0) : (tensor<?x2xf32>) -> ()
@@ -58,8 +77,6 @@ func.func @test_reducesum2(%arg0: tensor<3x2x2xf32>, %arg1: tensor<?xi64>) -> te
 // CHECK-DAG:     [[VAR_0:%.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK-DAG:     [[VAR_1:%.+]] = mhlo.reduce([[PARAM_0:%.+]] init: [[VAR_0]]) applies mhlo.add across dimensions = [1] : (tensor<3x2x2xf32>, tensor<f32>) -> tensor<3x2xf32>
 // CHECK-DAG:     [[VAR_2:%.+]] = mhlo.reshape [[VAR_1]] : (tensor<3x2xf32>) -> tensor<3x1x2xf32>
-
-
 }
 
 func.func @test_reducemean_v13(%arg0 : tensor<3x2x2xf32>) -> tensor<3x2xf32> {

--- a/test/mlir/conversion/onnx_to_mhlo/Math/Reduction.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Math/Reduction.mlir
@@ -29,12 +29,30 @@ func.func @test_reducemax_v13_keepdims(%arg0: tensor<?x20x30xf32>) -> tensor<?x1
 
 // -----
 
+func.func @test_reducemax_v13_integer_tensor(%arg0 : tensor<3x2x2xi64>) -> tensor<3x2xi64> {
+  %0 ="onnx.ReduceMaxV13"(%arg0) {axes=[1], keepdims = 0 : si64} : (tensor<3x2x2xi64>)-> tensor<3x2xi64>
+  "func.return"(%0) : (tensor<3x2xi64>) -> ()
+// CHECK-LABEL:  func @test_reducemax_v13_integer_tensor
+// CHECK: %0 = mhlo.constant dense<-9223372036854775808> : tensor<i64>
+// CHECK: %1 = mhlo.reduce(%arg0 init: %0) applies mhlo.maximum across dimensions = [1] : (tensor<3x2x2xi64>, tensor<i64>) -> tensor<3x2xi64>
+}
+
+// -----
+
 func.func @test_reducemin_v13(%arg0 : tensor<?x2x2xf32>) -> tensor<?x2xf32> {
   %0 ="onnx.ReduceMinV13"(%arg0) {axes=[1], keepdims = 0 : si64} : (tensor<?x2x2xf32>)-> tensor<?x2xf32>
   "func.return"(%0) : (tensor<?x2xf32>) -> ()
 // CHECK-LABEL:  func @test_reducemin
 // CHECK: %0 = mhlo.constant dense<0x7F800000> : tensor<f32>
 // CHECK: %1 = mhlo.reduce(%arg0 init: %0) applies mhlo.minimum across dimensions = [1] : (tensor<?x2x2xf32>, tensor<f32>) -> tensor<?x2xf32>
+}
+
+func.func @test_reducemin_v13_integer_tensor(%arg0 : tensor<?x2x2xi64>) -> tensor<?x2xi64> {
+  %0 ="onnx.ReduceMinV13"(%arg0) {axes=[1], keepdims = 0 : si64} : (tensor<?x2x2xi64>)-> tensor<?x2xi64>
+  "func.return"(%0) : (tensor<?x2xi64>) -> ()
+// CHECK-LABEL:  func @test_reducemin_v13_integer_tensor
+// CHECK: %0 = mhlo.constant dense<9223372036854775807> : tensor<i64>
+// CHECK: %1 = mhlo.reduce(%arg0 init: %0) applies mhlo.minimum across dimensions = [1] : (tensor<?x2x2xi64>, tensor<i64>) -> tensor<?x2xi64>
 }
 
 // -----
@@ -50,10 +68,10 @@ func.func @test_reducesum(%arg0 : tensor<3x2x2xf32>) -> tensor<3x2xf32> {
 
 // -----
 
-func.func @test_reducesumV11(%arg0 : tensor<3x2x2xf32>) -> tensor<3x2xf32> {
+func.func @test_reducesum_v11(%arg0 : tensor<3x2x2xf32>) -> tensor<3x2xf32> {
   %0 ="onnx.ReduceSumV11"(%arg0) {axes=[1], keepdims = 0 : si64} : (tensor<3x2x2xf32>)-> tensor<3x2xf32>
   "func.return"(%0) : (tensor<3x2xf32>) -> ()
-// CHECK-LABEL:  func @test_reducesumV11
+// CHECK-LABEL:  func @test_reducesum_v11
 // CHECK: %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK: %1 = mhlo.reduce(%arg0 init: %0) applies mhlo.add across dimensions = [1] : (tensor<3x2x2xf32>, tensor<f32>) -> tensor<3x2xf32>
 }

--- a/test/mlir/conversion/onnx_to_mhlo/Math/Softmax.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Math/Softmax.mlir
@@ -25,26 +25,37 @@ func.func @test_softmax_dynamic(%arg0 : tensor<?x20x30xf32>) -> tensor<?x20x30xf
   "func.return"(%0) : (tensor<?x20x30xf32>) -> ()
 // CHECK-LABEL:  func @test_softmax_dynamic
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20x30xf32>) -> tensor<?x20x30xf32> {
-// CHECK-DAG:     [[VAR_1_:%.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK-DAG:     [[VAR_2_:%.+]] = mhlo.constant dense<0xFF800000> : tensor<f32>
-// CHECK-NEXT:    [[VAR_3_:%.+]] = mhlo.reduce([[PARAM_0_]] init: [[VAR_2_]]) applies mhlo.maximum across dimensions = [1] : (tensor<?x20x30xf32>, tensor<f32>) -> tensor<?x30xf32>
-// CHECK-NEXT:    [[VAR_4_:%.+]] = mhlo.dynamic_reshape [[VAR_3_]], [[VAR_0_:%.+]] : (tensor<?x30xf32>, tensor<3xi64>) -> tensor<?x1x30xf32>
-// CHECK-DAG:     [[VAR_5_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<?x20x30xf32> -> tensor<3xindex>
-// CHECK-DAG:     [[VAR_6_:%.+]] = shape.shape_of [[VAR_4_]] : tensor<?x1x30xf32> -> tensor<3xindex>
-// CHECK-NEXT:    [[VAR_7_:%.+]] = shape.broadcast [[VAR_5_]], [[VAR_6_]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
-// CHECK-DAG:     [[VAR_8_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[PARAM_0_]], [[VAR_7_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x20x30xf32>, tensor<3xindex>) -> tensor<?x20x30xf32>
-// CHECK-DAG:     [[VAR_9_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_4_]], [[VAR_7_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x1x30xf32>, tensor<3xindex>) -> tensor<?x20x30xf32>
-// CHECK-NEXT:    [[VAR_10_:%.+]] = mhlo.subtract [[VAR_8_]], [[VAR_9_]] : tensor<?x20x30xf32>
-// CHECK-NEXT:    [[VAR_11_:%.+]] = mhlo.exponential [[VAR_10_]] : tensor<?x20x30xf32>
-// CHECK-NEXT:    [[VAR_12_:%.+]] = mhlo.reduce([[VAR_11_]] init: [[VAR_1_]]) applies mhlo.add across dimensions = [1] : (tensor<?x20x30xf32>, tensor<f32>) -> tensor<?x30xf32>
-// CHECK-NEXT:    [[VAR_13_:%.+]] = mhlo.dynamic_reshape [[VAR_12_]], [[VAR_0_]] : (tensor<?x30xf32>, tensor<3xi64>) -> tensor<?x1x30xf32>
-// CHECK-DAG:     [[VAR_14_:%.+]] = shape.shape_of [[VAR_11_]] : tensor<?x20x30xf32> -> tensor<3xindex>
-// CHECK-DAG:     [[VAR_15_:%.+]] = shape.shape_of [[VAR_13_]] : tensor<?x1x30xf32> -> tensor<3xindex>
-// CHECK-NEXT:    [[VAR_16_:%.+]] = shape.broadcast [[VAR_14_]], [[VAR_15_]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
-// CHECK-DAG:     [[VAR_17_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_11_]], [[VAR_16_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x20x30xf32>, tensor<3xindex>) -> tensor<?x20x30xf32>
-// CHECK-DAG:     [[VAR_18_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_13_]], [[VAR_16_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x1x30xf32>, tensor<3xindex>) -> tensor<?x20x30xf32>
-// CHECK-NEXT:    [[VAR_19_:%.+]] = mhlo.divide [[VAR_17_]], [[VAR_18_]] : tensor<?x20x30xf32>
-// CHECK-NEXT:    return [[VAR_19_]] : tensor<?x20x30xf32>
+// CHECK-DAG:     %c2 = arith.constant 2 : index
+// CHECK-DAG:     %c1 = arith.constant 1 : index
+// CHECK-DAG:     %c0 = arith.constant 0 : index
+// CHECK-DAG:     [[VAR_0_:%.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-DAG:     [[VAR_1_:%.+]] = mhlo.constant dense<0xFF800000> : tensor<f32>
+// CHECK-NEXT:    [[VAR_2_:%.+]] = mhlo.reduce([[PARAM_0_]] init: [[VAR_1_]]) applies mhlo.maximum across dimensions = [1] : (tensor<?x20x30xf32>, tensor<f32>) -> tensor<?x30xf32>
+// CHECK-DAG:     [[VAR_3_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<?x20x30xf32> -> tensor<3xindex>
+// CHECK-DAG:     [[VAR_4_:%.+]] = shape.get_extent [[VAR_3_]], %c0 : tensor<3xindex>, index -> index
+// CHECK-DAG:     [[VAR_5_:%.+]] = shape.get_extent [[VAR_3_]], %c2 : tensor<3xindex>, index -> index
+// CHECK-NEXT:    [[VAR_6_:%.+]] = shape.from_extents [[VAR_4_]], %c1, [[VAR_5_]] : index, index, index
+// CHECK-NEXT:    [[VAR_7_:%.+]] = shape.to_extent_tensor [[VAR_6_]] : !shape.shape -> tensor<3xindex>
+// CHECK-DAG:     [[VAR_8_:%.+]] = mhlo.dynamic_reshape [[VAR_2_]], [[VAR_7_]] : (tensor<?x30xf32>, tensor<3xindex>) -> tensor<?x1x30xf32>
+// CHECK-DAG:     [[VAR_9_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<?x20x30xf32> -> tensor<3xindex>
+// CHECK-NEXT:    [[VAR_10_:%.+]] = shape.broadcast [[VAR_9_]], [[VAR_7_]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
+// CHECK-DAG:     [[VAR_11_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[PARAM_0_]], [[VAR_10_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x20x30xf32>, tensor<3xindex>) -> tensor<?x20x30xf32>
+// CHECK-DAG:     [[VAR_12_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_8_]], [[VAR_10_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x1x30xf32>, tensor<3xindex>) -> tensor<?x20x30xf32>
+// CHECK-NEXT:    [[VAR_13_:%.+]] = mhlo.subtract [[VAR_11_]], [[VAR_12_]] : tensor<?x20x30xf32>
+// CHECK-NEXT:    [[VAR_14_:%.+]] = mhlo.exponential [[VAR_13_]] : tensor<?x20x30xf32>
+// CHECK-NEXT:    [[VAR_15_:%.+]] = mhlo.reduce([[VAR_14_]] init: [[VAR_0_]]) applies mhlo.add across dimensions = [1] : (tensor<?x20x30xf32>, tensor<f32>) -> tensor<?x30xf32>
+// CHECK-NEXT:    [[VAR_16_:%.+]] = shape.shape_of [[VAR_14_]] : tensor<?x20x30xf32> -> tensor<3xindex>
+// CHECK-DAG:     [[VAR_17_:%.+]] = shape.get_extent [[VAR_16_]], %c0 : tensor<3xindex>, index -> index
+// CHECK-DAG:     [[VAR_18_:%.+]] = shape.get_extent [[VAR_16_]], %c2 : tensor<3xindex>, index -> index
+// CHECK-NEXT:    [[VAR_19_:%.+]] = shape.from_extents [[VAR_17_]], %c1, [[VAR_18_]] : index, index, index
+// CHECK-NEXT:    [[VAR_20_:%.+]] = shape.to_extent_tensor [[VAR_19_]] : !shape.shape -> tensor<3xindex>
+// CHECK-NEXT:    [[VAR_21_:%.+]] = mhlo.dynamic_reshape [[VAR_15_]], [[VAR_20_]] : (tensor<?x30xf32>, tensor<3xindex>) -> tensor<?x1x30xf32>
+// CHECK-NEXT:    [[VAR_22_:%.+]] = shape.shape_of [[VAR_14_]] : tensor<?x20x30xf32> -> tensor<3xindex>
+// CHECK-NEXT:    [[VAR_23_:%.+]] = shape.broadcast [[VAR_22_]], [[VAR_20_]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
+// CHECK-DAG:     [[VAR_24_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_14_]], [[VAR_23_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x20x30xf32>, tensor<3xindex>) -> tensor<?x20x30xf32>
+// CHECK-DAG:     [[VAR_25_:%.+]] = "mhlo.dynamic_broadcast_in_dim"([[VAR_21_]], [[VAR_23_]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x1x30xf32>, tensor<3xindex>) -> tensor<?x20x30xf32>
+// CHECK-NEXT:    [[VAR_26_:%.+]] = mhlo.divide [[VAR_24_]], [[VAR_25_]] : tensor<?x20x30xf32>
+// CHECK-NEXT:    return [[VAR_26_]] : tensor<?x20x30xf32>
 }
 
 func.func @test_softmax_2d(%arg0 : tensor<1x10xf32>) -> tensor<1x10xf32> {

--- a/test/mlir/conversion/onnx_to_mhlo/Tensor/Expand.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Tensor/Expand.mlir
@@ -12,6 +12,16 @@ func.func @test_expand_with_arith_constant(%arg0 : tensor<2x1x6x1xf32>) -> tenso
 
 // -----
 
+func.func @test_expand_integer_tensor(%arg0 : tensor<2x1x6x1xi64>) -> tensor<*xi64> {
+  %0 = "onnx.Constant"() {value = dense<[7, 1, 5]> : tensor<3xi64> } : () -> tensor<3xi64>
+  %1 = "onnx.Expand"(%arg0, %0) : (tensor<2x1x6x1xi64>, tensor<3xi64>) -> tensor<*xi64>
+  "func.return"(%1) : (tensor<*xi64>) -> ()
+// CHECK-LABEL: func @test_expand_integer_tensor
+// CHECK-NEXT: %0 = "mhlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0, 1, 2, 3]> : tensor<4xi64>} : (tensor<2x1x6x1xi64>) -> tensor<2x7x6x5xi64>
+}
+
+// -----
+
 func.func @test_expand_with_shape(%arg0 : tensor<2x1x6x1xf32>, %arg1: tensor<6x2xf32>) -> tensor<*xf32> {
   %0 = "onnx.Shape"(%arg1) : (tensor<6x2xf32>) -> tensor<*xi64>
   %1 = "onnx.Expand"(%arg0, %0) : (tensor<2x1x6x1xf32>, tensor<*xi64>) -> tensor<*xf32>

--- a/test/mlir/conversion/onnx_to_mhlo/Tensor/Reshape.mlir
+++ b/test/mlir/conversion/onnx_to_mhlo/Tensor/Reshape.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --convert-onnx-to-mhlo %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-mhlo --canonicalize --cse %s -split-input-file | FileCheck %s
 
 //===----------------------------------------------------------------------===//
 /// Test the reshape op inference when constants are present.
@@ -7,8 +7,48 @@
 func.func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi64>) -> tensor<*xf32> {
   %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
-  // CHECK-LABEL: test_reshape_dynamic
-  // CHECK: %0 = mhlo.dynamic_reshape %arg0, %arg1 : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
+  // CHECK-LABEL: func.func @test_reshape_dynamic
+  // CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<5x5x1x32xf32>, [[PARAM_1_:%.+]]: tensor<4xi64>) -> tensor<?x?x?x?xf32> {
+  // CHECK-DAG: %c3 = arith.constant 3 : index
+  // CHECK-DAG: %c2 = arith.constant 2 : index
+  // CHECK-DAG: %c-1 = arith.constant -1 : index
+  // CHECK-DAG: %c0 = arith.constant 0 : index
+  // CHECK-DAG: %c1 = arith.constant 1 : index
+  // CHECK-DAG: %c5 = arith.constant 5 : index
+  // CHECK-DAG: %c32 = arith.constant 32 : index
+  // CHECK-DAG: %c800 = arith.constant 800 : index
+  // CHECK: [[VAR_0_:%.+]] = arith.index_cast [[PARAM_1_]] : tensor<4xi64> to tensor<4xindex>
+  // CHECK: [[VAR_1_:%.+]] = shape.get_extent [[VAR_0_]], %c0 : tensor<4xindex>, index -> index
+  // CHECK: [[VAR_2_:%.+]] = arith.cmpi eq, [[VAR_1_]], %c0 : index
+  // CHECK: [[VAR_3_:%.+]] = arith.select [[VAR_2_]], %c5, [[VAR_1_]] : index
+  // CHECK: [[VAR_4_:%.+]] = arith.cmpi eq, [[VAR_3_]], %c-1 : index
+  // CHECK: [[VAR_5_:%.+]] = arith.select [[VAR_4_]], %c1, [[VAR_3_]] : index
+  // CHECK: [[VAR_6_:%.+]] = shape.get_extent [[VAR_0_]], %c1 : tensor<4xindex>, index -> index
+  // CHECK: [[VAR_7_:%.+]] = arith.cmpi eq, [[VAR_6_]], %c0 : index
+  // CHECK: [[VAR_8_:%.+]] = arith.select [[VAR_7_]], %c5, [[VAR_6_]] : index
+  // CHECK: [[VAR_9_:%.+]] = arith.cmpi eq, [[VAR_8_]], %c-1 : index
+  // CHECK: [[VAR_10_:%.+]] = arith.select [[VAR_9_]], %c1, [[VAR_8_]] : index
+  // CHECK: [[VAR_11_:%.+]] = arith.muli [[VAR_5_]], [[VAR_10_]] : index
+  // CHECK: [[VAR_12_:%.+]] = shape.get_extent [[VAR_0_]], %c2 : tensor<4xindex>, index -> index
+  // CHECK: [[VAR_13_:%.+]] = arith.cmpi eq, [[VAR_12_]], %c0 : index
+  // CHECK: [[VAR_14_:%.+]] = arith.select [[VAR_13_]], %c1, [[VAR_12_]] : index
+  // CHECK: [[VAR_15_:%.+]] = arith.cmpi eq, [[VAR_14_]], %c-1 : index
+  // CHECK: [[VAR_16_:%.+]] = arith.select [[VAR_15_]], %c1, [[VAR_14_]] : index
+  // CHECK: [[VAR_17_:%.+]] = arith.muli [[VAR_11_]], [[VAR_16_]] : index
+  // CHECK: [[VAR_18_:%.+]] = shape.get_extent [[VAR_0_]], %c3 : tensor<4xindex>, index -> index
+  // CHECK: [[VAR_19_:%.+]] = arith.cmpi eq, [[VAR_18_]], %c0 : index
+  // CHECK: [[VAR_20_:%.+]] = arith.select [[VAR_19_]], %c32, [[VAR_18_]] : index
+  // CHECK: [[VAR_21_:%.+]] = arith.cmpi eq, [[VAR_20_]], %c-1 : index
+  // CHECK: [[VAR_22_:%.+]] = arith.select [[VAR_21_]], %c1, [[VAR_20_]] : index
+  // CHECK: [[VAR_23_:%.+]] = arith.muli [[VAR_17_]], [[VAR_22_]] : index
+  // CHECK: [[VAR_24_:%.+]] = arith.floordivsi %c800, [[VAR_23_]] : index
+  // CHECK: [[VAR_25_:%.+]] = arith.select [[VAR_4_]], [[VAR_24_]], [[VAR_3_]] : index
+  // CHECK: [[VAR_26_:%.+]] = arith.select [[VAR_9_]], [[VAR_24_]], [[VAR_8_]] : index
+  // CHECK: [[VAR_27_:%.+]] = arith.select [[VAR_15_]], [[VAR_24_]], [[VAR_14_]] : index
+  // CHECK: [[VAR_28_:%.+]] = arith.select [[VAR_21_]], [[VAR_24_]], [[VAR_20_]] : index
+  // CHECK: [[VAR_29_:%.+]] = shape.from_extents [[VAR_25_]], [[VAR_26_]], [[VAR_27_]], [[VAR_28_]] : index, index, index, index
+  // CHECK: [[VAR_30_:%.+]] = shape.to_extent_tensor [[VAR_29_]] : !shape.shape -> tensor<4xindex>
+  // CHECK: [[VAR_31_:%.+]] = mhlo.dynamic_reshape [[PARAM_0_]], [[VAR_30_]] : (tensor<5x5x1x32xf32>, tensor<4xindex>) -> tensor<?x?x?x?xf32>
 }
 
 // -----
@@ -18,7 +58,7 @@ func.func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
   "func.return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_reshape_1
-  // CHECK: %1 = mhlo.dynamic_reshape %arg0, %0 : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
+  // CHECK: %0 = mhlo.reshape %arg0 : (tensor<5x5x1x32xf32>) -> tensor<5x5x16x2xf32>
 }
 
 // -----
@@ -28,7 +68,7 @@ func.func @test_reshape_2(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
   "func.return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_reshape_2
-  // CHECK: %1 = mhlo.dynamic_reshape %arg0, %0 : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
+  // CHECK: %0 = mhlo.reshape %arg0 : (tensor<5x5x1x32xf32>) -> tensor<25x16x2xf32>
 }
 
 // -----
@@ -38,7 +78,7 @@ func.func @test_reshape_3(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
   "func.return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_reshape_3
-  // CHECK: %1 = mhlo.dynamic_reshape %arg0, %0 : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
+  // CHECK: %0 = mhlo.reshape %arg0 : (tensor<5x5x1x32xf32>) -> tensor<80x5x2xf32>
 }
 
 // -----


### PR DESCRIPTION
This pull request lowers the following ops to MHLO:

1. reduction ops with dynamic shape
2. ONNXReshapeOp with dynamic shape (shape-related IR generated with IndexExpr)
3. reduction ops on integer input tensor
4. ONNXExpandOp on integer input tensor

1 & 2 together solve issue https://github.com/onnx/onnx-mlir/issues/2181
LIT tests are added correspondingly.
@AlexandreEichenberger @tungld @hamptonm1 @yaochengji 