### PR TITLE
Update dependencies to conform with LFX security scan

### DIFF
--- a/docs/mnist_example/requirements.txt
+++ b/docs/mnist_example/requirements.txt
@@ -1,2 +1,2 @@
-torch>=1.9.1, <=1.11.0
-torchvision>=0.10.1, <=1.12.0
+torch~=1.13.0
+torchvision~=1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ lit~=15.0
 # numpy 1.24 deprecates np.object, np.bool, np.float, np.complex, np.str,
 # and np.int which are used heavily in onnx-mlir.
 numpy>=1.17.4, <=1.23.5
+pillow~=9.0
 protobuf~=3.20
 pytest~=7.2
 pytest-xdist~=3.0


### PR DESCRIPTION
It looks like all the open Critical / High hits from the LFX Security Scan relate to the version of torch and pillow used by the requirement.txt file. Here is more information with regards to the security results from the scan:
https://security.lfx.linuxfoundation.org/#/a092M00001JWs71QAD/vulnerabilities 

I will be upgrading the following for compliance:
```
1. Torch 1.13.0
2. Torchvision 1.14.0
3. Pillow 9.0
```