### PR TITLE
fix StridesIterator offsets to properly support negative values

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/Strides.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/Strides.cpp
@@ -186,8 +186,8 @@ void restrideArrayImpl(unsigned elementBytewidth, ArrayRef<int64_t> shape,
   assert(sizeof(T) == elementBytewidth && "dispatch safety check");
   ArrayRef<T> srcT = castArrayRef<T>(src);
   MutableArrayRef<T> dstT = castMutableArrayRef<T>(dst);
-  for (auto &idxpos : StridesRange<1>(shape, {srcStrides}))
-    dstT[idxpos.flattenedIndex] = srcT[idxpos[0]];
+  for (auto &idxoffs : StridesRange<1>(shape, {srcStrides}))
+    dstT[idxoffs.flattenedIndex] = srcT[idxoffs[0]];
 }
 } // namespace
 

--- a/src/Dialect/ONNX/ElementsAttr/StridesRange.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/StridesRange.hpp
@@ -21,22 +21,24 @@ namespace onnx_mlir {
 
 // Used as value_type in StridesRange and StridesIterator in the context of a
 // shape of the given rank (the length of the 'index' vector) and N strides
-// which are not represented in StridesIndexPos itself.
+// which are not represented in StridesIndexOffsets itself.
 //
 // 'flattenedIndex' and 'index' are two representations of an index into a
 // tensor of the given rank.
-// 'pos' is an array of flattened indexes into strided arrays.
+// 'offsets' is an array of flattened offsets into strided arrays. Can be
+// negative if strides are negative, e.g. to represent negative slice steps.
 template <size_t N>
-struct StridesIndexPos {
+struct StridesIndexOffsets {
   // Non-zero flattenedIndex is only used to construct end iterators
-  // with meaningless index and pos.
-  StridesIndexPos(unsigned rank, uint64_t flattenedIndex = 0)
-      : flattenedIndex(flattenedIndex), index(rank, 0), pos{} {}
+  // with meaningless index and offsets.
+  StridesIndexOffsets(unsigned rank, uint64_t flattenedIndex = 0)
+      : flattenedIndex(flattenedIndex), index(rank, 0), offsets{} {}
   uint64_t flattenedIndex;
   llvm::SmallVector<uint64_t, 6> index;
-  std::array<size_t, N> pos;
-  // idxpos[i] is convenient shorthand for idxpos.pos[i]
-  size_t operator[](int i) const { return pos[i]; }
+  std::array<int64_t, N> offsets;
+  // idxoffs[i] is convenient shorthand for idxoffs.offsets[i]
+  int64_t operator[](int i) const { return offsets[i]; }
+  int64_t at(int i) const { return offsets[i]; }
 };
 
 // Suppose (array0,strides0),...,(arrayN,stridesN) are all strided tensors with
@@ -44,9 +46,9 @@ struct StridesIndexPos {
 // it = StridesIterator<N+1>(shape, {strides0,...,stridesN}) iterates over the
 // shape's elements in row-major order, with it->index describing the shape's
 // corresponding multidimensional index, it->flattenedIndex the row-major order
-// flattened linear index, and it->pos is an array of positions pos0,...,posN
-// in array0,...,arrayN that represent the index. i.e.,
-// it->pos[0] == getStridesPosition(it->index, strides0) etc.
+// flattened linear index, and it->offsets is an array of flat linear indexes
+// offset0,...,offsetN in array0,...,arrayN that represent the index, i.e.,
+// it->at(0) == it->offsets[0] == getStridesPosition(it->index, strides0) etc.
 //
 // For example, this can be used to compare the contents of two strided tensors
 // (a0,strides0) and (a1,strides1) with the same shape:
@@ -55,7 +57,7 @@ struct StridesIndexPos {
 //   bool equal(S shape, A a0, S strides0, A a1, S strides1) {
 //     StridesIterator<2> begin(shape, {strides0, strides1}), end(shape);
 //     return std::all_of(begin, end,
-//       [](const auto &idxpos) { return a0[idxpos[0]] == a1[idxpos[1]]; });
+//       [](const auto &idxoffs) { return a0[idxoffs[0]] == a1[idxoffs[1]]; });
 //   }
 //
 // Note: The iteration example above works when shape is empty because
@@ -67,7 +69,7 @@ struct StridesIndexPos {
 template <size_t N>
 class StridesIterator {
 public:
-  using value_type = StridesIndexPos<N>;
+  using value_type = StridesIndexOffsets<N>;
   using difference_type = int64_t;
   using pointer = const value_type *;
   using reference = const value_type &;
@@ -131,13 +133,13 @@ public:
 //   template <typename T, typename A = ArrayRef<T>, S = ArrayRef<int64_t>>
 //   bool equal(S shape, A a0, S strides0, A a1, S strides1) {
 //     return llvm::all_of(StridesRange<2>(shape, {strides0, strides1}),
-//         [](const auto &idxpos) { return a0[idxpos[0]] == a1[idxpos[1]]; });
+//       [](const auto &idxoffs) { return a0[idxoffs[0]] == a1[idxoffs[1]]; });
 //   }
 template <size_t N>
 class StridesRange {
 public:
   using iterator = StridesIterator<N>;
-  using value_type = StridesIndexPos<N>;
+  using value_type = StridesIndexOffsets<N>;
 
 private:
   const llvm::ArrayRef<int64_t> shape;

--- a/src/Dialect/ONNX/ElementsAttr/StridesRange.hpp
+++ b/src/Dialect/ONNX/ElementsAttr/StridesRange.hpp
@@ -36,9 +36,11 @@ struct StridesIndexOffsets {
   uint64_t flattenedIndex;
   llvm::SmallVector<uint64_t, 6> index;
   std::array<int64_t, N> offsets;
-  // idxoffs[i] is convenient shorthand for idxoffs.offsets[i]
-  int64_t operator[](int i) const { return offsets[i]; }
-  int64_t at(int i) const { return offsets[i]; }
+  int64_t at(size_t i) const {
+    assert(i < N && "index out of range");
+    return offsets[i];
+  }
+  int64_t operator[](size_t i) const { return at(i); }
 };
 
 // Suppose (array0,strides0),...,(arrayN,stridesN) are all strided tensors with

--- a/src/Dialect/ONNX/ElementsAttr/StridesRange.hpp.inc
+++ b/src/Dialect/ONNX/ElementsAttr/StridesRange.hpp.inc
@@ -14,13 +14,13 @@ inline auto StridesIterator<N>::operator++() -> StridesIterator<N> & {
     --axis;
     uint64_t dim = shape[axis];
     for (unsigned i = 0; i < N; ++i)
-      value.pos[i] += strides[i][axis];
+      value.offsets[i] += strides[i][axis];
     if (++(value.index[axis]) < dim)
       break;
     // axis overflowed: rewind the axis and carry over to axis-1 by doing
     // the next iteration of the loop
     for (unsigned i = 0; i < N; ++i)
-      value.pos[i] -= dim * strides[i][axis];
+      value.offsets[i] -= dim * strides[i][axis];
     value.index[axis] = 0;
   }
   return *this;
@@ -35,8 +35,8 @@ template <>
 inline auto StridesIterator<2>::operator++() -> StridesIterator<2> & {
   ++(value.flattenedIndex);
   uint64_t *index = value.index.data();
-  size_t pos0 = value.pos[0];
-  size_t pos1 = value.pos[1];
+  int64_t offset0 = value.offsets[0];
+  int64_t offset1 = value.offsets[1];
   const int64_t *strides0 = strides[0].data();
   const int64_t *strides1 = strides[1].data();
   for (size_t axis = shape.size();;) {
@@ -45,17 +45,17 @@ inline auto StridesIterator<2>::operator++() -> StridesIterator<2> & {
     }
     --axis;
     uint64_t dim = shape[axis];
-    pos0 += strides0[axis];
-    pos1 += strides1[axis];
+    offset0 += strides0[axis];
+    offset1 += strides1[axis];
     if (++(index[axis]) < dim)
       break;
     // axis overflowed: rewind the axis and carry over to axis-1 by doing
     // the next iteration of the loop
-    pos0 -= dim * strides0[axis];
-    pos1 -= dim * strides1[axis];
+    offset0 -= dim * strides0[axis];
+    offset1 -= dim * strides1[axis];
     index[axis] = 0;
   }
-  value.pos[0] = pos0;
-  value.pos[1] = pos1;
+  value.offsets[0] = offset0;
+  value.offsets[1] = offset1;
   return *this;
 }


### PR DESCRIPTION
Changed `pos` to `offsets` and the type from `size_t` to `int64_t` to match how negative values are used with negative strides in the case of negative steps in `ElementsAttrBuilder::slice()`