### PR TITLE
Remove warning

### DIFF
--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -730,13 +730,16 @@ struct DecomposeONNXToONNXPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DecomposeONNXToONNXPass)
 
   DecomposeONNXToONNXPass(const std::string &target) { this->target = target; }
-#if 1
+
   DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
       : mlir::PassWrapper<DecomposeONNXToONNXPass,
             OperationPass<func::FuncOp>>() {
-    this->target = pass.target;
+    /* None of the other passes that use PassWrapper AND options copy their
+     * options; assume this should be the case here too to avoid warnings. See
+     * ONNXToZHighLoweringPass in ONNXToZHigh.cpp, for example. */
+    /* this->target = pass.target; */
   }
-#endif
+
   StringRef getArgument() const override { return "decompose-onnx"; }
 
   StringRef getDescription() const override {

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -730,12 +730,13 @@ struct DecomposeONNXToONNXPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DecomposeONNXToONNXPass)
 
   DecomposeONNXToONNXPass(const std::string &target) { this->target = target; }
+#if 1
   DecomposeONNXToONNXPass(const DecomposeONNXToONNXPass &pass)
       : mlir::PassWrapper<DecomposeONNXToONNXPass,
             OperationPass<func::FuncOp>>() {
     this->target = pass.target;
   }
-
+#endif
   StringRef getArgument() const override { return "decompose-onnx"; }
 
   StringRef getDescription() const override {


### PR DESCRIPTION
There was one warning remaining on Linux:

```
/workdir/onnx-mlir/src/Transform/ONNX/Decompose.cpp:737:25: warning: implicitly-declared 'mlir::Pass::Option<std::__cxx11::basic_string<char> >& mlir::Pass::Option<std::__cxx11::basic_string<char> >::operator=(const mlir::Pass::Option<std::__cxx11::basic_string<char> >&)' is deprecated [-Wdeprecated-copy]
  737 |     this->target = pass.target;
```

I looked at other similar passes that have options, and none updated their options in the constructor. Thus removed the copy.

MHLO, since this is an option that is used by you I believe, please check that it works.
Thanks