### PR TITLE
Call canonicalizer after decomposition

### DIFF
--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -62,6 +62,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU) {
     // here. The plan is to replace most of the passes in addONNXToMLIRPasses.
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createONNXHybridTransformPass());
   } else {
+    pm.addPass(mlir::createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     pm.addPass(mlir::createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());


### PR DESCRIPTION
I see this pattern in a GPT-2 model generated from HuggingFace:
```
%155 = onnx.Constant dense<2> : tensor<1xi64>
%348 = "onnx.Identity"(%155) {onnx_node_name = "Identity_189"} : (tensor<1xi64>) -> tensor<*xi64>
%675 = "onnx.Slice"(%379, %672, %673, %348, %674) {onnx_node_name = "Slice_516"} : (tensor<*xui8>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>, tensor<1xi64>) ->     tensor<*xui8>
```
where `Identity` of a constant is imported and it caused `slice` think axes (`%348`) is not a constant and failed to verify the slice op during shape inference.

Identity is removed by canonicalizer. So this patch calls canonicalizer just after decompostion to clean up ops before shape-inference.

I think HybridTransformPass would finally solves this issue once it is completed and enabled.

A side note: here onnx-mlir imported `Identity` with an unranked output type, but we can import it using the input type.