### PR TITLE
use new ONNXReturnOp in place of func::ReturnOp

### DIFF
--- a/docs/Dialects/onnx.md
+++ b/docs/Dialects/onnx.md
@@ -7572,6 +7572,39 @@ Effects: MemoryEffects::Effect{}
 | :----: | ----------- |
 | `Y` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of bfloat16 type values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values
 
+### `onnx.Return` (::mlir::ONNXReturnOp)
+
+Function return operation
+
+
+Syntax:
+
+```
+operation ::= `onnx.Return` attr-dict ($operands^ `:` type($operands))?
+```
+
+The `onnx.Return` operation represents a return operation within a function.
+The operation takes variable number of operands and produces no results.
+The operand number and types must match the signature of the function
+that contains the operation, with the exception that shaped types may have
+more specific shapes than the function signature result types, which allows
+rewrites of defining ops of operands to make their result shapes more specific.
+This operation terminates a func::FuncOp in the ONNX dialect and is replaced
+by func::ReturnOp in StandardFuncReturnPass before lowering to Krnl or other
+dialects.
+
+Traits: AlwaysSpeculatableImplTrait, HasParent<func::FuncOp>, ReturnLike, Terminator
+
+Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+
+Effects: MemoryEffects::Effect{}
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+| `operands` | any type
+
 ### `onnx.ReverseSequence` (::mlir::ONNXReverseSequenceOp)
 
 ONNX ReverseSequence operation
@@ -10164,6 +10197,7 @@ The `onnx.Yield` operation represents a yield operation within an ONNX subgraph.
 The operation takes variable number of operands and produces no results.
 
 This operation is not part of the standard and was added to assist onnx-mlir.
+It terminates a ONNXLoop/Scan/IfOp region.
 
 Traits: AlwaysSpeculatableImplTrait, ReturnLike, Terminator
 

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -337,8 +337,8 @@ private:
    * @param region region to import computation graph to.
    * @param op operations whose attributes will be updated to contain
    * input/output names.
-   * @param useFuncReturn if set to true, will emit standard return op as
-   * terminator, otherwise, will use ONNXYield op as terminator.
+   * @param useFuncReturn if set to true, will emit ONNXFuncReturnOp as
+   * terminator, otherwise, will use ONNXYieldOp as terminator.
    * @return function type corresponding to the subgraph input/output signature.
    */
   FunctionType importGraph(const onnx::GraphProto &graph, Region &region,

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -337,12 +337,12 @@ private:
    * @param region region to import computation graph to.
    * @param op operations whose attributes will be updated to contain
    * input/output names.
-   * @param useFuncReturn if set to true, will emit ONNXFuncReturnOp as
+   * @param useReturn if set to true, will emit ONNXReturnOp as
    * terminator, otherwise, will use ONNXYieldOp as terminator.
    * @return function type corresponding to the subgraph input/output signature.
    */
   FunctionType importGraph(const onnx::GraphProto &graph, Region &region,
-      Operation *op, bool useFuncReturn) {
+      Operation *op, bool useReturn) {
     frontend_symbols_.pushScope(graph.name());
     onnx_type_map.pushScope(graph.name());
     Block *entryBlock = &region.back();
@@ -419,8 +419,8 @@ private:
       ImportOutputTensor(output, retTys, retVals);
     }
 
-    if (useFuncReturn)
-      builder_.create<ONNXFuncReturnOp>(UnknownLoc(), retVals);
+    if (useReturn)
+      builder_.create<ONNXReturnOp>(UnknownLoc(), retVals);
     else
       // Create a return operation to return all ONNX output tensors.
       builder_.create<ONNXYieldOp>(UnknownLoc(), retVals);
@@ -1152,7 +1152,7 @@ private:
     for (auto &v : pFunctionProto->output()) {
       ret_vals.push_back(LookupOnnxName(v));
     }
-    builder_.create<ONNXFuncReturnOp>(UnknownLoc(), ret_vals);
+    builder_.create<ONNXReturnOp>(UnknownLoc(), ret_vals);
 
     // Restore caller context
     frontend_symbols_.popScope(func_name_prefix);
@@ -1256,7 +1256,7 @@ private:
     builder_.setInsertionPointToStart(&mainFunc.getBody().back());
 
     auto funcType = importGraph(graph, /*region=*/mainFunc.getBody(),
-        /*op=*/mainFunc.getOperation(), /*useFuncReturn=*/true);
+        /*op=*/mainFunc.getOperation(), /*useReturn=*/true);
     mainFunc.setType(funcType);
 
     // Emit entry point op describing inference function signature.

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -95,7 +95,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU) {
   // Simplify shape-related ops.
   pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(onnxConstPropReport));
 
-  // Replace ONNXFuncReturnOp with func::ReturnOp.
+  // Replace ONNXReturnOp with func::ReturnOp.
   pm.addPass(onnx_mlir::createStandardFuncReturnPass());
 
   // Clean dead code.

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -95,6 +95,9 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU) {
   // Simplify shape-related ops.
   pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass(onnxConstPropReport));
 
+  // Replace ONNXFuncReturnOp with func::ReturnOp.
+  pm.addPass(onnx_mlir::createStandardFuncReturnPass());
+
   // Clean dead code.
   pm.addPass(mlir::createSymbolDCEPass());
 

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -139,12 +139,12 @@ def ONNXCallOp : ONNX_Op<"ONNX_Call",
 }
 
 //===----------------------------------------------------------------------===//
-// ONNX FuncReturnOp
-def ONNXFuncReturnOp : ONNX_Op<"FuncReturn",
+// ONNX ReturnOp
+def ONNXReturnOp : ONNX_Op<"Return",
     [Pure, HasParent<"func::FuncOp">, ReturnLike, Terminator]> {
   let summary = "Function return operation";
   let description = [{
-    The `onnx.FuncReturn` operation represents a return operation within a function.
+    The `onnx.Return` operation represents a return operation within a function.
     The operation takes variable number of operands and produces no results.
     The operand number and types must match the signature of the function
     that contains the operation, with the exception that shaped types may have

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -138,6 +138,30 @@ def ONNXCallOp : ONNX_Op<"ONNX_Call",
   }];
 }
 
+
+//===----------------------------------------------------------------------===//
+// ONNX FuncReturnOp
+def ONNXFuncReturnOp : ONNX_Op<"FuncReturn",
+    [Pure, HasParent<"func::FuncOp">, ReturnLike, Terminator]> {
+  let summary = "Function return operation";
+  let description = [{
+    The `onnx.FuncReturn` operation represents a return operation within a function.
+    The operation takes variable number of operands and produces no results.
+    The operand number and types must match the signature of the function
+    that contains the operation, with the exception that shaped types may have
+    more specific shapes than the function signature return types.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  let builders = [OpBuilder<(ins), [{
+    build($_builder, $_state, std::nullopt);
+  }]>];
+
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // ONNX CustomOp
 def ONNXCustomOp:ONNX_Op<"Custom",

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -148,7 +148,11 @@ def ONNXReturnOp : ONNX_Op<"Return",
     The operation takes variable number of operands and produces no results.
     The operand number and types must match the signature of the function
     that contains the operation, with the exception that shaped types may have
-    more specific shapes than the function signature return types.
+    more specific shapes than the function signature result types, which allows
+    rewrites of defining ops of operands to make their result shapes more specific.
+    This operation terminates a func::FuncOp in the ONNX dialect and is replaced
+    by func::ReturnOp in StandardFuncReturnPass before lowering to Krnl or other
+    dialects.
   }];
 
   let arguments = (ins Variadic<AnyType>:$operands);
@@ -374,6 +378,7 @@ def ONNXYieldOp : ONNX_Op<"Yield", [Pure, ReturnLike, Terminator]> {
     The operation takes variable number of operands and produces no results.
 
     This operation is not part of the standard and was added to assist onnx-mlir.
+    It terminates a ONNXLoop/Scan/IfOp region.
   }];
 
   let arguments = (ins Variadic<AnyType>:$operands);

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -138,7 +138,6 @@ def ONNXCallOp : ONNX_Op<"ONNX_Call",
   }];
 }
 
-
 //===----------------------------------------------------------------------===//
 // ONNX FuncReturnOp
 def ONNXFuncReturnOp : ONNX_Op<"FuncReturn",
@@ -153,10 +152,6 @@ def ONNXFuncReturnOp : ONNX_Op<"FuncReturn",
   }];
 
   let arguments = (ins Variadic<AnyType>:$operands);
-
-  let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, std::nullopt);
-  }]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
   let hasVerifier = 1;

--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -32,6 +32,7 @@ add_onnx_mlir_library(OMONNXOps
   ONNXOps/Additional/Custom.cpp
   ONNXOps/Additional/Dim.cpp
   ONNXOps/Additional/EntryPoint.cpp
+  ONNXOps/Additional/FuncReturn.cpp
   ONNXOps/Additional/LayoutTransform.cpp
   ONNXOps/Additional/None.cpp
   ONNXOps/Additional/ShapeTransform.cpp

--- a/src/Dialect/ONNX/CMakeLists.txt
+++ b/src/Dialect/ONNX/CMakeLists.txt
@@ -32,7 +32,7 @@ add_onnx_mlir_library(OMONNXOps
   ONNXOps/Additional/Custom.cpp
   ONNXOps/Additional/Dim.cpp
   ONNXOps/Additional/EntryPoint.cpp
-  ONNXOps/Additional/FuncReturn.cpp
+  ONNXOps/Additional/Return.cpp
   ONNXOps/Additional/LayoutTransform.cpp
   ONNXOps/Additional/None.cpp
   ONNXOps/Additional/ShapeTransform.cpp

--- a/src/Dialect/ONNX/ONNXOps/Additional/FuncReturn.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/FuncReturn.cpp
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----------------- FuncReturn.cpp - ONNX Operations -------------------===//
+//
+// This file provides definition of ONNX dialect FuncReturn operation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+
+using namespace mlir;
+using namespace mlir::OpTrait::util;
+using namespace onnx_mlir;
+
+//===----------------------------------------------------------------------===//
+// Verify
+//===----------------------------------------------------------------------===//
+
+LogicalResult ONNXFuncReturnOp::verify() {
+  // TODO: Implement this.
+  return success();
+}

--- a/src/Dialect/ONNX/ONNXOps/Additional/FuncReturn.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/FuncReturn.cpp
@@ -18,7 +18,68 @@ using namespace onnx_mlir;
 // Verify
 //===----------------------------------------------------------------------===//
 
+namespace {
+bool shapeIsSameOrMoreSpecific(ShapedType lhs, ShapedType rhs) {
+  // Unranked is the least specific:
+  if (!rhs.hasRank())
+    return true;
+  if (!lhs.hasRank())
+    return false;
+
+  // Otherwise the shapes are incompatible if ranks are different.
+  if (lhs.getRank() != rhs.getRank())
+    return false;
+
+  for (auto [lhsDimSize, rhsDimSize] :
+      llvm::zip(lhs.getShape(), rhs.getShape())) {
+    // Dim size is less specific or incompatible unless they are
+    // identical or rhs is dynamic ("?").
+    if (!ShapedType::isDynamic(rhsDimSize) && lhsDimSize != rhsDimSize)
+      return false;
+  }
+  return true;
+}
+
+bool typeIsSameOrMoreSpecific(Type lhs, Type rhs) {
+  ShapedType lhsShaped = dyn_cast<ShapedType>(lhs);
+  ShapedType rhsShaped = dyn_cast<ShapedType>(rhs);
+
+  if (!lhsShaped && !rhsShaped) {
+    // TODO: Check types are same or lhs is more specific than rhs
+    //       when they are not shaped types.
+    return true;
+  }
+
+  if (!lhsShaped || !rhsShaped) {
+    // lhs and rhs must agree on whether they are ShapedType.
+    return false;
+  }
+
+  return shapeIsSameOrMoreSpecific(lhsShaped, rhsShaped);
+}
+} // namespace
+
+// Implementation is adapted from mlir/lib/Dialect/Func/IR/FuncOps.cpp
+// relaxing the type check to allow more specific shapes.
 LogicalResult ONNXFuncReturnOp::verify() {
-  // TODO: Implement this.
+  auto function = cast<func::FuncOp>((*this)->getParentOp());
+
+  // The operand number and types must match the function signature.
+  const auto &results = function.getFunctionType().getResults();
+  if (getNumOperands() != results.size())
+    return emitOpError("has ")
+           << getNumOperands() << " operands, but enclosing function (@"
+           << function.getName() << ") returns " << results.size();
+
+  for (unsigned i = 0, e = results.size(); i != e; ++i)
+    if (!typeIsSameOrMoreSpecific(getOperand(i).getType(), results[i]))
+      return emitError() << "type of return operand " << i << " ("
+                         << getOperand(i).getType()
+                         << ") is incompatible with function result type ("
+                         << results[i] << ")"
+                         << " in function @" << function.getName();
+
+  return success();
+
   return success();
 }

--- a/src/Dialect/ONNX/ONNXOps/Additional/Return.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/Return.cpp
@@ -85,6 +85,4 @@ LogicalResult ONNXReturnOp::verify() {
                          << " in function @" << function.getName();
 
   return success();
-
-  return success();
 }

--- a/src/Dialect/ONNX/ONNXOps/Additional/Return.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/Return.cpp
@@ -2,9 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===----------------- FuncReturn.cpp - ONNX Operations -------------------===//
+//===----------------- Return.cpp - ONNX Operations -------------------===//
 //
-// This file provides definition of ONNX dialect FuncReturn operation.
+// This file provides definition of ONNX dialect Return operation.
 //
 //===----------------------------------------------------------------------===//
 
@@ -66,7 +66,7 @@ bool typeIsSameOrMoreSpecific(Type lhs, Type rhs) {
 
 // Implementation is adapted from mlir/lib/Dialect/Func/IR/FuncOps.cpp
 // relaxing the type check to allow more specific shapes.
-LogicalResult ONNXFuncReturnOp::verify() {
+LogicalResult ONNXReturnOp::verify() {
   auto function = cast<func::FuncOp>((*this)->getParentOp());
 
   // The operand number and types must match the function signature.

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -60,7 +60,7 @@ std::unique_ptr<mlir::Pass> createInstrumentONNXSignaturePass();
 std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass(
     bool report = false);
 
-/// Pass for replacing ONNXFuncReturnOp with func::ReturnOp.
+/// Pass for replacing ONNXReturnOp with func::ReturnOp.
 std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();
 
 /// Pass that combines multiple ONNX dialect transformations,

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -60,6 +60,9 @@ std::unique_ptr<mlir::Pass> createInstrumentONNXSignaturePass();
 std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass(
     bool report = false);
 
+/// Pass for replacing ONNXFuncReturnOp with func::ReturnOp.
+std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();
+
 /// Pass that combines multiple ONNX dialect transformations,
 /// including shape inference.
 std::unique_ptr<mlir::Pass> createONNXHybridTransformPass();

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -104,6 +104,7 @@ add_onnx_mlir_library(OMONNXStandardFuncReturnPass
 
   LINK_LIBS PUBLIC
   MLIRTransformUtils
-  OMONNXOps
   MLIRFuncDialect
+  OMONNXOps
+  OMShapeInference
   )

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -98,3 +98,12 @@ add_onnx_mlir_library(OMONNXSimplifyShapeRelatedOps
   MLIRPass
   MLIRTransforms
   )
+
+add_onnx_mlir_library(OMONNXStandardFuncReturnPass
+  StandardFuncReturnPass.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRTransformUtils
+  OMONNXOps
+  MLIRFuncDialect
+  )

--- a/src/Transform/ONNX/ShapeInference.cpp
+++ b/src/Transform/ONNX/ShapeInference.cpp
@@ -137,7 +137,8 @@ void getShapeInferencePatterns(RewritePatternSet &set) {
   set.insert<YieldShapesPattern>(set.getContext(), highPriority);
 }
 
-// TODO: Consider whether to do this in a Func::ReturnOp pattern.
+// TODO: Consider whether to do this in a ONNXFuncReturnOp pattern
+//       once lit tests are converted to use onnx.FuncReturn.
 void inferFunctionReturnShapes(func::FuncOp f) {
   Operation *returnOp = f.getBody().back().getTerminator();
   assert(returnOp && "function must return");

--- a/src/Transform/ONNX/ShapeInference.cpp
+++ b/src/Transform/ONNX/ShapeInference.cpp
@@ -137,8 +137,8 @@ void getShapeInferencePatterns(RewritePatternSet &set) {
   set.insert<YieldShapesPattern>(set.getContext(), highPriority);
 }
 
-// TODO: Consider whether to do this in a ONNXFuncReturnOp pattern
-//       once lit tests are converted to use onnx.FuncReturn.
+// TODO: Consider whether to do this in a ONNXReturnOp pattern
+//       once lit tests are converted to use onnx.Return.
 void inferFunctionReturnShapes(func::FuncOp f) {
   Operation *returnOp = f.getBody().back().getTerminator();
   assert(returnOp && "function must return");

--- a/src/Transform/ONNX/ShapeInference.hpp
+++ b/src/Transform/ONNX/ShapeInference.hpp
@@ -22,7 +22,7 @@ bool returnsDynamicOrUnknownShape(mlir::Operation *op);
 void getShapeInferencePatterns(mlir::RewritePatternSet &set);
 
 // Propagates return op's operand types to f's return types.
-// Works for both func::ReturnOp and ONNXFuncReturnOp.
+// Works for both func::ReturnOp and ONNXReturnOp.
 void inferFunctionReturnShapes(mlir::func::FuncOp f);
 
 } // namespace onnx_mlir

--- a/src/Transform/ONNX/ShapeInference.hpp
+++ b/src/Transform/ONNX/ShapeInference.hpp
@@ -21,6 +21,8 @@ bool returnsDynamicOrUnknownShape(mlir::Operation *op);
 
 void getShapeInferencePatterns(mlir::RewritePatternSet &set);
 
+// Propagates return op's operand types to f's return types.
+// Works for both func::ReturnOp and ONNXFuncReturnOp.
 void inferFunctionReturnShapes(mlir::func::FuncOp f);
 
 } // namespace onnx_mlir

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -121,8 +121,11 @@ public:
   }
 
   static bool isUsedByReturnOp(Operation &op) {
-    return llvm::any_of(op.getUsers(),
-        [](Operation *user) { return isa<func::ReturnOp>(user); });
+    return llvm::any_of(op.getUsers(), [](Operation *user) {
+      // TODO: Only test for ONNXReturnOp once lit tests are converted
+      //       to use onnx.FuncReturn.
+      return isa<func::ReturnOp, ONNXFuncReturnOp>(user);
+    });
   }
 
   // Op needs shape inference when contains a subgraph

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -123,8 +123,8 @@ public:
   static bool isUsedByReturnOp(Operation &op) {
     return llvm::any_of(op.getUsers(), [](Operation *user) {
       // TODO: Only test for ONNXReturnOp once lit tests are converted
-      //       to use onnx.FuncReturn.
-      return isa<func::ReturnOp, ONNXFuncReturnOp>(user);
+      //       to use onnx.Return.
+      return isa<func::ReturnOp, ONNXReturnOp>(user);
     });
   }
 

--- a/src/Transform/ONNX/StandardFuncReturnPass.cpp
+++ b/src/Transform/ONNX/StandardFuncReturnPass.cpp
@@ -24,14 +24,16 @@ namespace onnx_mlir {
 
 namespace {
 
-struct StandardFuncReturnPattern : public ConversionPattern {
+struct StandardFuncReturnPattern
+    : public OpConversionPattern<ONNXFuncReturnOp> {
   StandardFuncReturnPattern(MLIRContext *context)
-      : ConversionPattern(ONNXFuncReturnOp::getOperationName(), 4, context) {}
-  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      : OpConversionPattern(context) {}
+  LogicalResult matchAndRewrite(ONNXFuncReturnOp funcReturnOp,
+      ONNXFuncReturnOp::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    assert(isa<ONNXFuncReturnOp>(op));
-    rewriter.create<func::ReturnOp>(op->getLoc(), op->getOperands());
-    rewriter.eraseOp(op);
+    rewriter.create<func::ReturnOp>(
+        funcReturnOp->getLoc(), funcReturnOp.getOperands());
+    rewriter.eraseOp(funcReturnOp);
     return success();
   }
 };

--- a/src/Transform/ONNX/StandardFuncReturnPass.cpp
+++ b/src/Transform/ONNX/StandardFuncReturnPass.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------------------- StandardFuncReturnPass.cpp -----------------------===//
+//
+// Replaces each ONNXFuncReturnOp with a func::ReturnOp.
+// Assumes that shape inference has matched the operand types with the
+// parent function signature return types.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Pass/Passes.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+namespace {
+
+struct StandardFuncReturnPattern : public ConversionPattern {
+  StandardFuncReturnPattern(MLIRContext *context)
+      : ConversionPattern(ONNXFuncReturnOp::getOperationName(), 4, context) {}
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const final {
+    assert(isa<ONNXFuncReturnOp>(op));
+    rewriter.create<func::ReturnOp>(op->getLoc(), op->getOperands());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct StandardFuncReturnPass
+    : public PassWrapper<StandardFuncReturnPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(StandardFuncReturnPass)
+
+  StringRef getArgument() const override { return "scrub-disposable"; }
+
+  void runOnOperation() final {
+    func::FuncOp function = getOperation();
+    MLIRContext *context = &getContext();
+
+    ConversionTarget target(*context);
+    target
+        .addLegalDialect<ONNXDialect, arith::ArithDialect, func::FuncDialect>();
+    target.addIllegalOp<ONNXFuncReturnOp>();
+
+    RewritePatternSet patterns(context);
+    patterns.insert<StandardFuncReturnPattern>(context);
+
+    if (failed(applyPartialConversion(function, target, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> createStandardFuncReturnPass() {
+  return std::make_unique<StandardFuncReturnPass>();
+}
+
+} // namespace onnx_mlir

--- a/src/Transform/ONNX/StandardFuncReturnPass.cpp
+++ b/src/Transform/ONNX/StandardFuncReturnPass.cpp
@@ -17,6 +17,7 @@
 
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Pass/Passes.hpp"
+#include "src/Transform/ONNX/ShapeInference.hpp"
 
 using namespace mlir;
 
@@ -31,6 +32,11 @@ struct StandardFuncReturnPattern
   LogicalResult matchAndRewrite(ONNXFuncReturnOp funcReturnOp,
       ONNXFuncReturnOp::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
+    // Propagate return types to the function signature in case
+    // they changed since last ShapeInferencePass.
+    func::FuncOp function = funcReturnOp.getParentOp();
+    inferFunctionReturnShapes(function);
+
     rewriter.create<func::ReturnOp>(
         funcReturnOp->getLoc(), funcReturnOp.getOperands());
     rewriter.eraseOp(funcReturnOp);

--- a/test/mlir/accelerators/nnpa/conversion/instrument/add-onnx-level.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/instrument/add-onnx-level.mlir
@@ -2,7 +2,7 @@
 
 func.func @test_instrument_add_onnx(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL:  func.func @test_instrument_add_onnx

--- a/test/mlir/accelerators/nnpa/conversion/instrument/add-onnx-zhigh-level.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/instrument/add-onnx-zhigh-level.mlir
@@ -3,7 +3,7 @@
 func.func @test_instrument_add_onnx_zhigh(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x1xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x1xf32>) -> tensor<*xf32>
   %1 = "onnx.Add"(%arg0, %0) : (tensor<10x10xf32>, tensor<*xf32>) -> tensor<*xf32>  
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL:  func.func @test_instrument_add_onnx_zhigh

--- a/test/mlir/accelerators/nnpa/conversion/instrument/add-zhigh-level.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/instrument/add-zhigh-level.mlir
@@ -2,7 +2,7 @@
 
 func.func @test_instrument_add_zhigh(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL:  func.func @test_instrument_add_zhigh

--- a/test/mlir/accelerators/nnpa/conversion/instrument/add-zlow-level.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/instrument/add-zlow-level.mlir
@@ -2,7 +2,7 @@
 
 func.func @test_instrument_add_zlow(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL:  func.func @test_instrument_add_zlow

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/add-exec-cpu.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/add-exec-cpu.mlir
@@ -4,7 +4,7 @@ func.func @test_add_force_cpu(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf3
   %0 = "onnx.Add"(%arg0, %arg1) {onnx_node_name = "test/add0"} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   %1 = "onnx.Add"(%0, %arg0) {onnx_node_name = "test/add1"} : (tensor<*xf32>, tensor<10x10xf32>) -> tensor<*xf32>
   %2 = "onnx.Add"(%1, %arg1) {onnx_node_name = "test/add2"} : (tensor<*xf32>, tensor<10x10xf32>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_add_force_cpu
   // CHECK:           "onnx.Add"({{.*}}, {{.*}}) {onnx_node_name = "test/add0"}

--- a/test/mlir/accelerators/nnpa/driver/data-transformation-on-ztensor-num2.mlir
+++ b/test/mlir/accelerators/nnpa/driver/data-transformation-on-ztensor-num2.mlir
@@ -7,7 +7,7 @@ func.func @transpose_on_ztensor_unknown_dims(%arg0: tensor<?x?xf32>) -> tensor<?
   %0 = "onnx.Relu" (%arg0) : (tensor<?x?xf32>) -> tensor<?x?xf32>
   %1 = "onnx.Transpose"(%0) {perm = [1,0]} : (tensor<?x?xf32>) -> tensor<?x?xf32>
   %2 = "onnx.Relu" (%1) : (tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %2 : tensor<?x?xf32>
+  onnx.Return %2 : tensor<?x?xf32>
 
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<()[s0] -> (s0 ceildiv 32)>

--- a/test/mlir/accelerators/nnpa/driver/data-transformation-on-ztensor.mlir
+++ b/test/mlir/accelerators/nnpa/driver/data-transformation-on-ztensor.mlir
@@ -8,7 +8,7 @@ func.func @transpose_on_ztensor(%arg0: tensor<3x5xf32>) -> tensor<5x3xf32> {
   %0 = "onnx.Relu" (%arg0) : (tensor<3x5xf32>) -> tensor<3x5xf32>
   %1 = "onnx.Transpose"(%0) {perm = [1,0]} : (tensor<3x5xf32>) -> tensor<5x3xf32>
   %2 = "onnx.Relu" (%1) : (tensor<5x3xf32>) -> tensor<5x3xf32>
-  return %2 : tensor<5x3xf32>
+  onnx.Return %2 : tensor<5x3xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @transpose_on_ztensor

--- a/test/mlir/conversion/instrument/add.mlir
+++ b/test/mlir/conversion/instrument/add.mlir
@@ -2,7 +2,7 @@
 
 func.func @test_instrument_add_onnx(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) {onnx_node_name = "model/add1"} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL:  func.func @test_instrument_add_onnx

--- a/test/mlir/conversion/instrument/onnx_add.mlir
+++ b/test/mlir/conversion/instrument/onnx_add.mlir
@@ -2,7 +2,7 @@
 
 func.func @test_instrument_add_onnx(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) {onnx_node_name = "model/add1"} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL:  func.func @test_instrument_add_onnx

--- a/test/mlir/conversion/instrument/onnx_all.mlir
+++ b/test/mlir/conversion/instrument/onnx_all.mlir
@@ -2,7 +2,7 @@
 
 func.func @test_instrument_add_onnx(%arg0 : tensor<10x10xf32>, %arg1 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.Add"(%arg0, %arg1) {onnx_node_name = "model/add1"} : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // CHECK-LABEL:  func.func @test_instrument_add_onnx

--- a/test/mlir/driver/check_passthrough_options.mlir
+++ b/test/mlir/driver/check_passthrough_options.mlir
@@ -11,7 +11,7 @@
 module {
   func.func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
-    return %0 : tensor<1x1xf32>
+    onnx.Return %0 : tensor<1x1xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }

--- a/test/mlir/driver/invalid_output_path.mlir
+++ b/test/mlir/driver/invalid_output_path.mlir
@@ -22,7 +22,7 @@
 module {
   func.func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
-    return %0 : tensor<1x1xf32>
+    onnx.Return %0 : tensor<1x1xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }

--- a/test/mlir/driver/llvm.ident.mlir
+++ b/test/mlir/driver/llvm.ident.mlir
@@ -4,7 +4,7 @@
 module {
   func.func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
-    return %0 : tensor<1x1xf32>
+    onnx.Return %0 : tensor<1x1xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }

--- a/test/mlir/driver/product.version.mlir
+++ b/test/mlir/driver/product.version.mlir
@@ -9,7 +9,7 @@
 module {
   func.func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
-    return %0 : tensor<1x1xf32>
+    onnx.Return %0 : tensor<1x1xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }

--- a/test/mlir/driver/unix/check_verbosity.mlir
+++ b/test/mlir/driver/unix/check_verbosity.mlir
@@ -7,7 +7,7 @@
 module {
   func.func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
-    return %0 : tensor<1x1xf32>
+    onnx.Return %0 : tensor<1x1xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }

--- a/test/mlir/driver/windows/check_verbosity.mlir
+++ b/test/mlir/driver/windows/check_verbosity.mlir
@@ -7,7 +7,7 @@
 module {
   func.func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
-    return %0 : tensor<1x1xf32>
+    onnx.Return %0 : tensor<1x1xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }

--- a/test/mlir/driver/windows/dllexport.mlir
+++ b/test/mlir/driver/windows/dllexport.mlir
@@ -10,11 +10,11 @@
 module  {
   func.func @main_graph_1(%arg0: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.Relu"(%arg0) : (tensor<1x1xf32>) -> tensor<1x1xf32>
-    return %0 : tensor<1x1xf32>
+    onnx.Return %0 : tensor<1x1xf32>
   }
   func.func @main_graph_2(%arg0: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.Relu"(%arg0) : (tensor<1x1xf32>) -> tensor<1x1xf32>
-    return %0 : tensor<1x1xf32>
+    onnx.Return %0 : tensor<1x1xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph_1} : () -> ()
   "onnx.EntryPoint"() {func = @main_graph_2} : () -> ()

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -5,7 +5,7 @@
 func.func @mod(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{fmod must be 1 when the input type is floating point}}
   %0 = "onnx.Mod"(%arg0, %arg1) {fmod = 0 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 }
 
 // -----
@@ -14,7 +14,7 @@ func.func @test_depth_to_space_default(%arg0 : tensor<1x256x8x16xf32>) -> tensor
   %cst = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{The input tensor depth must be divisible by the (blocksize * blocksize)}}
   %0 = "onnx.DepthToSpace"(%arg0) {blocksize = 7 : si64} : (tensor<1x256x8x16xf32>) -> tensor<1x16x32x64xf32>
-  "func.return"(%0) : (tensor<1x16x32x64xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<1x16x32x64xf32>) -> ()
 }
 
 // -----
@@ -22,7 +22,7 @@ func.func @test_depth_to_space_default(%arg0 : tensor<1x256x8x16xf32>) -> tensor
 func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64> {
   // expected-error @+1 {{onnx.ArgMax: 'axis' value is 4, accepted range is [-4, 3]}}
   %1 = "onnx.ArgMax"(%arg0) { axis = 4 : si64} : (tensor<5x5x1x32xf32>)  -> tensor<*xi64>
-  "func.return"(%1) : (tensor<*xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<*xi64>) -> ()
 }
 
 // -----
@@ -30,7 +30,7 @@ func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64>
 func.func @test_argmin_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64> {
   // expected-error @+1 {{onnx.ArgMin: 'axis' value is 4, accepted range is [-4, 3]}}
   %1 = "onnx.ArgMin"(%arg0) { axis = 4 : si64} : (tensor<5x5x1x32xf32>)  -> tensor<*xi64>
-  "func.return"(%1) : (tensor<*xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<*xi64>) -> ()
 }
 
 // -----
@@ -38,7 +38,7 @@ func.func @test_argmin_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64>
 func.func @test_compress_verifier_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x1x32xi1>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.Compress: 'axis' value is 4, accepted range is [-4, 3]}}
   %1 = "onnx.Compress"(%arg0, %arg1) { axis = 4 : si64} : (tensor<5x5x1x32xf32>, tensor<5x5x1x32xi1>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -46,7 +46,7 @@ func.func @test_compress_verifier_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor
 func.func @test_concat_verifier_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x32xf32>, %arg2 : tensor<5x5x5x32xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.Concat: 'axis' value is 4, accepted range is [-4, 3]}}
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) { axis = 4 : si64} : (tensor<5x5x1x32xf32>, tensor<5x5x3x32xf32>, tensor<5x5x5x32xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -54,7 +54,7 @@ func.func @test_concat_verifier_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5
 func.func @test_concat_verifier_2(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x32xf32>, %arg2 : tensor<5x5x32xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.Concat: operand '<block argument> of type 'tensor<5x5x32xf32>' at index: 2' has rank 3, rank should be 4}}
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) {axis = 2 : si64} : (tensor<5x5x1x32xf32>, tensor<5x5x3x32xf32>, tensor<5x5x32xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -62,7 +62,7 @@ func.func @test_concat_verifier_2(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5
 func.func @test_concat_verifier_3(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x32xf32>, %arg2 : tensor<5x5x5x32xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.Concat: operand '<block argument> of type 'tensor<5x5x3x32xf32>' at index: 1' has dimension at index 2 with value 3, value should be 1}}
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x5x1x32xf32>, tensor<5x5x3x32xf32>, tensor<5x5x5x32xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -70,7 +70,7 @@ func.func @test_concat_verifier_3(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5
 func.func @test_concat_from_sequence_verifier_1(%arg0 : !onnx.Seq<tensor<5x5x1x32xf32>>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ConcatFromSequence: 'axis' value is 4, accepted range is [-4, 3]}}
   %1 = "onnx.ConcatFromSequence"(%arg0) {axis = 4 : si64} : (!onnx.Seq<tensor<5x5x1x32xf32>>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -78,7 +78,7 @@ func.func @test_concat_from_sequence_verifier_1(%arg0 : !onnx.Seq<tensor<5x5x1x3
 func.func @test_concat_from_sequence_verifier_2(%arg0 : !onnx.Seq<tensor<5x5x1x32xf32>>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ConcatFromSequence: 'axis' value is -6, accepted range is [-5, 4]}}
   %1 = "onnx.ConcatFromSequence"(%arg0) {axis = -6 : si64, new_axis = 1 : si64} : (!onnx.Seq<tensor<5x5x1x32xf32>>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -86,7 +86,7 @@ func.func @test_concat_from_sequence_verifier_2(%arg0 : !onnx.Seq<tensor<5x5x1x3
 func.func @test_dequantize_linear_verifier_1(%arg0 : tensor<5x5x1xi32>, %arg1 : tensor<3xf32>, %arg2 : tensor<3xi32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.DequantizeLinear: 'axis' value is 3, accepted range is [-3, 2]}}
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 3 : si64} : (tensor<5x5x1xi32>, tensor<3xf32>, tensor<3xi32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -94,7 +94,7 @@ func.func @test_dequantize_linear_verifier_1(%arg0 : tensor<5x5x1xi32>, %arg1 : 
 func.func @test_dequantize_linear_verifier_2(%arg0 : tensor<5x5x1xi32>, %arg1 : tensor<?xf32>, %arg2 : tensor<3xi32>) -> tensor<*xf32> {
   // expected-error @+1 {{'onnx.DequantizeLinear' op x_scale and x_zero_point 1-D tensor length must match the input axis dim size}}
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {} : (tensor<5x5x1xi32>, tensor<?xf32>, tensor<3xi32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -102,7 +102,7 @@ func.func @test_dequantize_linear_verifier_2(%arg0 : tensor<5x5x1xi32>, %arg1 : 
 func.func @test_dequantize_linear_verifier_3(%arg0 : tensor<5x5x1xi32>, %arg1 : tensor<3xf32>, %arg2 : tensor<3xi32>) -> tensor<*xf32> {
   // expected-error @+1 {{'onnx.DequantizeLinear' op x_scale and x_zero_point 1-D tensor length must match the input axis dim size}}
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {} : (tensor<5x5x1xi32>, tensor<3xf32>, tensor<3xi32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -110,7 +110,7 @@ func.func @test_dequantize_linear_verifier_3(%arg0 : tensor<5x5x1xi32>, %arg1 : 
 func.func @test_dequantize_linear_verifier_4(%arg0 : tensor<5x5x1xi32>, %arg1 : tensor<5xf32>, %arg2 : tensor<3xi32>) -> tensor<*xf32> {
   // expected-error @+1 {{'onnx.DequantizeLinear' op x_scale and x_zero_point must have the same shape}}
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {} : (tensor<5x5x1xi32>, tensor<5xf32>, tensor<3xi32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -118,7 +118,7 @@ func.func @test_dequantize_linear_verifier_4(%arg0 : tensor<5x5x1xi32>, %arg1 : 
 func.func @test_dequantize_linear_verifier_5(%arg0 : tensor<5x5x1xi32>, %arg1 : tensor<5xf32>, %arg2 : tensor<1x5xi32>) -> tensor<*xf32> {
   // expected-error @+1 {{'onnx.DequantizeLinear' op x_zero_point must be a scalar or 1-D tensor}}
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {} : (tensor<5x5x1xi32>, tensor<5xf32>, tensor<1x5xi32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -127,7 +127,7 @@ func.func @test_dequantize_linear_verifier_6(%arg0 : tensor<5x5x1xi32>, %arg1 : 
   // expected-error @+2 {{'onnx.DequantizeLinear' op x_scale must be a scalar or 1-D tensor}}
   %0 = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %0) {} : (tensor<5x5x1xi32>, tensor<1x5xf32>, none)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -136,7 +136,7 @@ func.func @test_dequantize_linear_verifier_7(%arg0 : tensor<5x5x1xi32>, %arg1 : 
   // expected-error @+2 {{'onnx.DequantizeLinear' op x_zero_point must be 0 for data type int32}}
   %0 = "onnx.Constant"(){ value = dense<1> : tensor<5xi32> } : () -> tensor<5xi32>
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %0) {} : (tensor<5x5x1xi32>, tensor<5xf32>, tensor<5xi32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -144,7 +144,7 @@ func.func @test_dequantize_linear_verifier_7(%arg0 : tensor<5x5x1xi32>, %arg1 : 
 func.func @test_constantofshape_verifier_1(%arg0: tensor<2x2xi64>) -> tensor<2x2xi64> {
    // expected-error @+1 {{'onnx.ConstantOfShape' op Input tensor must be a 1D tensor}}
    %1 = "onnx.ConstantOfShape"(%arg0) : (tensor<2x2xi64>) -> tensor<2x2xi64>
-  "func.return"(%1) : (tensor<2x2xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<2x2xi64>) -> ()
 }
 
 // -----
@@ -152,7 +152,7 @@ func.func @test_constantofshape_verifier_1(%arg0: tensor<2x2xi64>) -> tensor<2x2
 func.func @test_constantofshape_verifier_2(%arg0: tensor<2x2x2x2xi64>) -> tensor<2x2x2x2xi64> {
    // expected-error @+1 {{'onnx.ConstantOfShape' op Input tensor must be a 1D tensor}}
    %1 = "onnx.ConstantOfShape"(%arg0) : (tensor<2x2x2x2xi64>) -> tensor<2x2x2x2xi64>
-  "func.return"(%1) : (tensor<2x2x2x2xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<2x2x2x2xi64>) -> ()
 }
 
 // -----
@@ -161,7 +161,7 @@ func.func @test_constantofshape_verifier_4() -> tensor<2xi64> {
    // expected-error @+2 {{'onnx.ConstantOfShape' op All values of the input tensor must be >=0}}
    %0 = "onnx.Constant"(){ value = dense<[-1, -2]> : tensor<2xi64> } : () -> tensor<2xi64>
    %1 = "onnx.ConstantOfShape"(%0) : (tensor<2xi64>) -> tensor<2xi64>
-  "func.return"(%1) : (tensor<2xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<2xi64>) -> ()
 }
 
 // -----
@@ -169,7 +169,7 @@ func.func @test_constantofshape_verifier_4() -> tensor<2xi64> {
 func.func @test_flatten_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.Flatten: 'axis' value is 5, accepted range is [-4, 4]}}
   %1 = "onnx.Flatten"(%arg0) {axis = 5 : si64} : (tensor<5x5x1x32xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -177,7 +177,7 @@ func.func @test_flatten_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32
 func.func @test_gather_verifier_1(%data: tensor<2x2xf32>, %indices: tensor<2xi64>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.Gather: 'axis' value is -3, accepted range is [-2, 1]}}
   %1 = "onnx.Gather"(%data, %indices) {axis = -3 : si64 } : (tensor<2x2xf32>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -185,7 +185,7 @@ func.func @test_gather_verifier_1(%data: tensor<2x2xf32>, %indices: tensor<2xi64
 func.func @test_gatherElements_verifier_1(%data: tensor<2x2xf32>, %indices: tensor<2xi64>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.GatherElements: operand '<block argument> of type 'tensor<2xi64>' at index: 1' has rank 1, rank should be 2}}
   %1 = "onnx.GatherElements"(%data, %indices) { } : (tensor<2x2xf32>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -193,7 +193,7 @@ func.func @test_gatherElements_verifier_1(%data: tensor<2x2xf32>, %indices: tens
 func.func @test_gatherElements_verifier_2(%data: tensor<2x2xf32>, %indices: tensor<2x2xi64>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.GatherElements: 'axis' value is 2, accepted range is [-2, 1]}}
   %1 = "onnx.GatherElements"(%data, %indices) {axis = 2 : si64} : (tensor<2x2xf32>, tensor<2x2xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -201,7 +201,7 @@ func.func @test_gatherElements_verifier_2(%data: tensor<2x2xf32>, %indices: tens
 func.func @test_hardmax_verifier_1(%arg0: tensor<2x2xf32>) -> tensor<*xf32> {
    // expected-error @+1 {{onnx.Hardmax: 'axis' value is 3, accepted range is [-2, 1]}}
    %1 = "onnx.Hardmax"(%arg0) {axis = 3: si64} : (tensor<2x2xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -210,7 +210,7 @@ func.func @test_hardmax_verifier_1(%arg0: tensor<2x2xf32>) -> tensor<*xf32> {
 func.func @test_gather_elements_verifier_1(%arg0 : tensor<f32>, %arg1 : tensor<5xi64>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.GatherElements: operand '<block argument> of type 'tensor<f32>' at index: 0' has rank 0, rank should be > 0}}
   %1 = "onnx.GatherElements"(%arg0, %arg1) {axis = 4 : si64} : (tensor<f32>, tensor<5xi64>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -219,7 +219,7 @@ func.func @test_gather_elements_verifier_1(%arg0 : tensor<f32>, %arg1 : tensor<5
 func.func @test_gather_elements_verifier_2(%arg0 : tensor<5xf32>, %arg1 : tensor<5x3xi64>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.GatherElements: operand '<block argument> of type 'tensor<5x3xi64>' at index: 1' has rank 2, rank should be 1}}
   %1 = "onnx.GatherElements"(%arg0, %arg1) {axis = 4 : si64} : (tensor<5xf32>, tensor<5x3xi64>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -228,7 +228,7 @@ func.func @test_gather_elements_verifier_2(%arg0 : tensor<5xf32>, %arg1 : tensor
 func.func @test_gather_elements_verifier_3(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x1x32xi64>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.GatherElements: 'axis' value is 4, accepted range is [-4, 3]}}
   %1 = "onnx.GatherElements"(%arg0, %arg1) {axis = 4 : si64} : (tensor<5x5x1x32xf32>, tensor<5x5x1x32xi64>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -238,7 +238,7 @@ func.func @test_gather_elements_verifier_4(%arg0 : tensor<3xf32>, %arg1 : tensor
   // expected-error @+2 {{onnx.GatherElements: 'indices' value is 3, accepted range is [-3, 2]}}
   %indices = "onnx.Constant"() {value = dense<[3]> : tensor<1xi64>} : () -> tensor<1xi64>
   %1 = "onnx.GatherElements"(%arg0, %indices) {axis = 0 : si64} : (tensor<3xf32>, tensor<1xi64>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -271,7 +271,7 @@ func.func @test_gatherND_verifier_3(%arg0 : tensor<1x2x3xf32>, %arg1 : tensor<2x
 func.func @test_gatherND_verifier_4(%arg0 : tensor<2x2x3x4xf32>, %arg1 : tensor<2x3x2xi64>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.GatherND: operand '<block argument> of type 'tensor<2x3x2xi64>' at index: 1' has dimension at index 1 with value 3, value should be 2}}
   %1 = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 2 : si64} : (tensor<2x2x3x4xf32>, tensor<2x3x2xi64>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -280,7 +280,7 @@ func.func @test_gatherND_verifier_4(%arg0 : tensor<2x2x3x4xf32>, %arg1 : tensor<
 func.func @test_gatherND_verifier_5(%arg0 : tensor<1x2x3x4xf32>, %arg1 : tensor<1x4xi64>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.GatherND: operand '<block argument> of type 'tensor<1x4xi64>' at index: 1' has dimension at index 1 with value 4, value should be <= 3}}
   %1 = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 1 : si64} : (tensor<1x2x3x4xf32>, tensor<1x4xi64>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -305,7 +305,7 @@ func.func @test_if_verifier_1(%arg0: tensor<i1>) -> tensor<2xf32> {
     %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
     onnx.Yield %1 : tensor<2xf32>
   }) : (tensor<i1>) -> tensor<2xf32>
-  return %0 : tensor<2xf32>
+  onnx.Return %0 : tensor<2xf32>
 }
 
 // -----
@@ -320,7 +320,7 @@ func.func @test_if_verifier_2(%arg0: tensor<i1>) -> !onnx.Seq<tensor<*xf32>> {
     %2 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
     onnx.Yield %1, %2 : !onnx.Seq<tensor<*xf32>>, tensor<2xf32>
   }) : (tensor<i1>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 }
 
 // -----
@@ -334,7 +334,7 @@ func.func @test_if_verifier_3(%arg0: tensor<i1>) -> tensor<2xf32> {
     %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
     onnx.Yield %1 : tensor<2xf32>
   }) : (tensor<i1>) -> tensor<2xf32>
-  return %0 : tensor<2xf32>
+  onnx.Return %0 : tensor<2xf32>
 }
 
 // -----
@@ -348,7 +348,7 @@ func.func @test_if_verifier_4(%arg0: tensor<i1>) -> !onnx.Seq<tensor<*xf32>> {
     %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
     onnx.Yield %1 : tensor<2xf32>
   }) : (tensor<i1>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 }
 
 // -----
@@ -356,7 +356,7 @@ func.func @test_if_verifier_4(%arg0: tensor<i1>) -> !onnx.Seq<tensor<*xf32>> {
 func.func @test_onehotencoder_verifier_1(%arg0: tensor<2x2xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{'onnx.OneHotEncoder' op input is a tensor of float, int32, or double, but no cats_int64s attribute}}
   %1 = "onnx.OneHotEncoder"(%arg0) { cats_string = ["a","b","c"]} : (tensor<2x2xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -364,7 +364,7 @@ func.func @test_onehotencoder_verifier_1(%arg0: tensor<2x2xf32>) -> tensor<*xf32
 func.func @test_onehotencoder_verifier_2(%arg0: tensor<2x2x!onnx.String>) -> tensor<*x!onnx.String> {
   // expected-error @+1 {{'onnx.OneHotEncoder' op input is not a tensor of float, int32, or double, but no cats_strings attribute}}
   %1 = "onnx.OneHotEncoder"(%arg0) { cats_int64s = [1,2,3]} : (tensor<2x2x!onnx.String>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -372,7 +372,7 @@ func.func @test_onehotencoder_verifier_2(%arg0: tensor<2x2x!onnx.String>) -> ten
 func.func @test_scatterelements_verifier_1(%arg0: tensor<2xf32>, %arg1: tensor<2x2xi64>, %arg2: tensor<2x2xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterElements: operand '<block argument> of type 'tensor<2x2xi64>' at index: 1' has rank 2, rank should be 1}}
   %1 = "onnx.ScatterElements"(%arg0, %arg1, %arg2) {axis = 0 : si64} : (tensor<2xf32>, tensor<2x2xi64>, tensor<2x2xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -380,7 +380,7 @@ func.func @test_scatterelements_verifier_1(%arg0: tensor<2xf32>, %arg1: tensor<2
 func.func @test_scatterelements_verifier_2(%arg0: tensor<2x2xf32>, %arg1: tensor<2x2xi64>, %arg2: tensor<2x2xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterElements: 'axis' value is -3, accepted range is [-2, 1]}}
   %1 = "onnx.ScatterElements"(%arg0, %arg1, %arg2) {axis = -3 : si64} : (tensor<2x2xf32>, tensor<2x2xi64>, tensor<2x2xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -388,7 +388,7 @@ func.func @test_scatterelements_verifier_2(%arg0: tensor<2x2xf32>, %arg1: tensor
 func.func @test_shape_to_dim_positive_axis_verifier(%arg0: tensor<?x256x?xi64>) -> tensor<2xi64> {
   // expected-error @+1 {{'onnx.Shape' op Start: 2 is after End: 0}}
   %0 = "onnx.Shape"(%arg0) {end = 0 : si64, start = -1 : si64} : (tensor<?x256x?xi64>) -> tensor<2xi64>
-  return %0 : tensor<2xi64>
+  onnx.Return %0 : tensor<2xi64>
 }
 
 // -----
@@ -396,14 +396,14 @@ func.func @test_shape_to_dim_positive_axis_verifier(%arg0: tensor<?x256x?xi64>) 
 func.func @test_logsoftmax_verifier_1(%arg0: tensor<2x2xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.LogSoftmax: 'axis' value is 3, accepted range is [-2, 1]}}
   %1 = "onnx.LogSoftmax"(%arg0) {axis = 3 : si64} : (tensor<2x2xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
 
 func.func @test_pow_verifier_1(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<f32>) -> tensor<*xf32> {
   %0 = "onnx.Pow"(%arg0, %arg1) : (tensor<1x2x3x4xf32>, tensor<f32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -411,7 +411,7 @@ func.func @test_pow_verifier_1(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<f32>) -
 func.func @test_scatter_elements_verifier_1(%arg0 : tensor<f32>, %arg1 : tensor<5xi64>, %arg2 : tensor<5xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterElements: operand '<block argument> of type 'tensor<f32>' at index: 0' has rank 0, rank should be > 0}}
   %1 = "onnx.ScatterElements"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<f32>, tensor<5xi64>, tensor<5xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -419,7 +419,7 @@ func.func @test_scatter_elements_verifier_1(%arg0 : tensor<f32>, %arg1 : tensor<
 func.func @test_scatter_elements_verifier_2(%arg0 : tensor<5xf32>, %arg1 : tensor<5x3xi64>, %arg2 : tensor<5xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterElements: operand '<block argument> of type 'tensor<5x3xi64>' at index: 1' has rank 2, rank should be 1}}
   %1 = "onnx.ScatterElements"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<5xf32>, tensor<5x3xi64>, tensor<5xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -427,7 +427,7 @@ func.func @test_scatter_elements_verifier_2(%arg0 : tensor<5xf32>, %arg1 : tenso
 func.func @test_scatterelements_verifier_3(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x1x32xi64>, %arg2 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterElements: 'axis' value is 4, accepted range is [-4, 3]}}
   %1 = "onnx.ScatterElements"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<5x5x1x32xf32>, tensor<5x5x1x32xi64>, tensor<5x5x1x32xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -436,7 +436,7 @@ func.func @test_scatterelements_verifier_4(%arg0 : tensor<3xf32>, %arg1 : tensor
   // expected-error @+2 {{onnx.ScatterElements: 'indices' value is 3, accepted range is [-3, 2]}}
   %indices = "onnx.Constant"() {value = dense<[3]> : tensor<1xi64>} : () -> tensor<1xi64>
   %1 = "onnx.ScatterElements"(%arg0, %indices, %arg1) {axis = 0 : si64} : (tensor<3xf32>, tensor<1xi64>, tensor<3xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -445,7 +445,7 @@ func.func @test_scatterelements_verifier_4(%arg0 : tensor<3xf32>, %arg1 : tensor
 func.func @test_scatterND_verifier_1(%arg0 : tensor<f32>, %arg1 : tensor<5xi64>, %arg2 : tensor<5xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterND: operand '<block argument> of type 'tensor<f32>' at index: 0' has rank 0, rank should be > 0}}
   %1 = "onnx.ScatterND"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<f32>, tensor<5xi64>, tensor<5xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -454,7 +454,7 @@ func.func @test_scatterND_verifier_1(%arg0 : tensor<f32>, %arg1 : tensor<5xi64>,
 func.func @test_scatterND_verifier_2(%arg0 : tensor<2xf32>, %arg1 : tensor<i64>, %arg2 : tensor<5xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterND: operand '<block argument> of type 'tensor<i64>' at index: 1' has rank 0, rank should be > 0}}
   %1 = "onnx.ScatterND"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<2xf32>, tensor<i64>, tensor<5xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -463,7 +463,7 @@ func.func @test_scatterND_verifier_2(%arg0 : tensor<2xf32>, %arg1 : tensor<i64>,
 func.func @test_scatterND_verifier_3(%arg0 : tensor<2x3xf32>, %arg1 : tensor<1xi64>, %arg2 : tensor<2x2xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterND: operand '<block argument> of type 'tensor<2x2xf32>' at index: 2' has rank 2, rank should be 1}}
   %1 = "onnx.ScatterND"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<2x3xf32>, tensor<1xi64>, tensor<2x2xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -472,7 +472,7 @@ func.func @test_scatterND_verifier_3(%arg0 : tensor<2x3xf32>, %arg1 : tensor<1xi
 func.func @test_scatterND_verifier_4(%arg0 : tensor<1x2x3x4xf32>, %arg1 : tensor<2x5xi64>, %arg2 : tensor<f32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterND: operand '<block argument> of type 'tensor<2x5xi64>' at index: 1' has dimension at index 1 with value 5, value should be <= 4}}
   %1 = "onnx.ScatterND"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<1x2x3x4xf32>, tensor<2x5xi64>, tensor<f32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -481,7 +481,7 @@ func.func @test_scatterND_verifier_4(%arg0 : tensor<1x2x3x4xf32>, %arg1 : tensor
 func.func @test_scatterND_verifier_5(%arg0 : tensor<1x2x3x4xf32>, %arg1 : tensor<2x2xi64>, %arg2 : tensor<1x2x3xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterND: operand '<block argument> of type 'tensor<1x2x3xf32>' at index: 2' has dimension at index 0 with value 1, value should be 2}}
   %1 = "onnx.ScatterND"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<1x2x3x4xf32>, tensor<2x2xi64>, tensor<1x2x3xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -490,7 +490,7 @@ func.func @test_scatterND_verifier_5(%arg0 : tensor<1x2x3x4xf32>, %arg1 : tensor
 func.func @test_scatterND_verifier_5(%arg0 : tensor<1x2x3x4xf32>, %arg1 : tensor<2x2xi64>, %arg2 : tensor<2x3x3xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{onnx.ScatterND: operand '<block argument> of type 'tensor<2x3x3xf32>' at index: 2' has dimension at index 2 with value 3, value should be 4}}
   %1 = "onnx.ScatterND"(%arg0, %arg1, %arg2) {axis = 4 : si64} : (tensor<1x2x3x4xf32>, tensor<2x2xi64>, tensor<2x3x3xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -499,7 +499,7 @@ func.func @test_sequence_empty() -> none {
   // expected-error @+1 {{SequenceEmpty getDtype() does not match the output type}}
   %1 = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xi32>>
   %2 = "onnx.NoValue"() {value} : () -> none
-  return %2 : none
+  onnx.Return %2 : none
 }
 
 // -----
@@ -507,7 +507,7 @@ func.func @test_sequence_empty() -> none {
 func.func @test_split_verifier_1(%arg0: tensor<2x2xi64>, %arg1: tensor<2xi64>) -> tensor<*xi64> {
   // expected-error @+1 {{onnx.Split: 'axis' value is 2, accepted range is [-2, 1]}}
   %1 = "onnx.Split"(%arg0, %arg1) {axis = 2 : si64} : (tensor<2x2xi64>, tensor<2xi64>) -> tensor<*xi64>
-  "func.return"(%1) : (tensor<*xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<*xi64>) -> ()
 }
 
 // -----
@@ -515,7 +515,7 @@ func.func @test_split_verifier_1(%arg0: tensor<2x2xi64>, %arg1: tensor<2xi64>) -
 func.func @test_splitToSequence_verifier_1(%arg0: tensor<2x2xi64>, %arg1: tensor<2xi64>) -> !onnx.Seq<tensor<*xi64>> {
   // expected-error @+1 {{onnx.SplitToSequence: 'axis' value is -3, accepted range is [-2, 1]}}
   %1 = "onnx.SplitToSequence"(%arg0, %arg1) {axis = -3 : si64} : (tensor<2x2xi64>, tensor<2xi64>) -> !onnx.Seq<tensor<*xi64>>
-  "func.return"(%1) : (!onnx.Seq<tensor<*xi64>>) -> ()
+  "onnx.Return"(%1) : (!onnx.Seq<tensor<*xi64>>) -> ()
 }
 
 // -----
@@ -524,7 +524,7 @@ func.func @test_splitToSequence_verifier_2(%arg0: tensor<2x2xf32>) -> !onnx.Seq<
   // expected-error @+2 {{onnx.SplitToSequence: 'keepdims' value is 2, accepted range is [0, 1]}}
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.SplitToSequence"(%arg0, %cst) {keepdims = 2 : si64} : (tensor<2x2xf32>, none) -> !onnx.Seq<tensor<2xf32>>
-  "func.return"(%0) : (!onnx.Seq<tensor<2xf32>>) -> ()
+  "onnx.Return"(%0) : (!onnx.Seq<tensor<2xf32>>) -> ()
 }
 
 // -----
@@ -532,7 +532,7 @@ func.func @test_splitToSequence_verifier_2(%arg0: tensor<2x2xf32>) -> !onnx.Seq<
 func.func @test_splitToSequence_verifier_3(%arg0: tensor<2x2xf32>, %arg1: tensor<1x2xi64>) -> !onnx.Seq<tensor<*xf32>> {
   // expected-error @+1 {{'onnx.SplitToSequence' op : split has rank 2 > 1}}
   %0 = "onnx.SplitToSequence"(%arg0, %arg1) : (tensor<2x2xf32>, tensor<1x2xi64>) -> !onnx.Seq<tensor<*xf32>>
-  "func.return"(%0) : (!onnx.Seq<tensor<*xf32>>) -> ()
+  "onnx.Return"(%0) : (!onnx.Seq<tensor<*xf32>>) -> ()
 }
 
 // -----
@@ -541,7 +541,7 @@ func.func @test_splitToSequence_verifier_4(%arg0: tensor<2x2xf32>) -> !onnx.Seq<
   // expected-error @+2 {{'onnx.SplitToSequence' op : split scalar -1 <= 0}}
   %0 = "onnx.Constant"(){value = dense<-1> : tensor<i64>} : () -> tensor<i64>
   %1 = "onnx.SplitToSequence"(%arg0, %0) : (tensor<2x2xf32>, tensor<i64>) -> !onnx.Seq<tensor<*xf32>>
-  "func.return"(%1) : (!onnx.Seq<tensor<*xf32>>) -> ()
+  "onnx.Return"(%1) : (!onnx.Seq<tensor<*xf32>>) -> ()
 }
 
 // -----
@@ -550,7 +550,7 @@ func.func @test_splitToSequence_verifier_5(%arg0: tensor<2x2xf32>) -> !onnx.Seq<
   // expected-error @+2 {{'onnx.SplitToSequence' op : split tensor has entry -1 < 0}}
   %0 = "onnx.Constant"(){value = dense<[-1]> : tensor<1xi64>} : () -> tensor<1xi64>
   %1 = "onnx.SplitToSequence"(%arg0, %0) : (tensor<2x2xf32>, tensor<1xi64>) -> !onnx.Seq<tensor<*xf32>>
-  "func.return"(%1) : (!onnx.Seq<tensor<*xf32>>) -> ()
+  "onnx.Return"(%1) : (!onnx.Seq<tensor<*xf32>>) -> ()
 }
 
 // -----
@@ -559,7 +559,7 @@ func.func @test_splitToSequence_verifier_6(%arg0: tensor<2x2xf32>) -> !onnx.Seq<
   // expected-error @+2 {{'onnx.SplitToSequence' op : split tensor entries sum to 1 != axis dimension size 2}}
   %0 = "onnx.Constant"(){value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
   %1 = "onnx.SplitToSequence"(%arg0, %0) : (tensor<2x2xf32>, tensor<2xi64>) -> !onnx.Seq<tensor<*xf32>>
-  "func.return"(%1) : (!onnx.Seq<tensor<*xf32>>) -> ()
+  "onnx.Return"(%1) : (!onnx.Seq<tensor<*xf32>>) -> ()
 }
 
 // -----
@@ -567,7 +567,7 @@ func.func @test_splitToSequence_verifier_6(%arg0: tensor<2x2xf32>) -> !onnx.Seq<
 func.func @test_topK_verifier_1(%arg0: tensor<3x4xi64>, %arg1: tensor<1xi64>) -> (tensor<*xf32>, tensor<*xi64>) {
   // expected-error @+1 {{onnx.TopK: 'axis' value is 2, accepted range is [-2, 1]}}
   %1, %2 = "onnx.TopK"(%arg0, %arg1) {axis = 2 : si64, largest = 1 : si64, sorted = 1 : si64} : (tensor<3x4xi64>, tensor<1xi64>) -> (tensor<*xf32>, tensor<*xi64>)
-  "func.return"(%1,%2) : (tensor<*xf32>, tensor<*xi64>) -> ()
+  "onnx.Return"(%1,%2) : (tensor<*xf32>, tensor<*xi64>) -> ()
 }
 
 // -----
@@ -575,7 +575,7 @@ func.func @test_topK_verifier_1(%arg0: tensor<3x4xi64>, %arg1: tensor<1xi64>) ->
 func.func @test_topK_verifier_2(%arg0: tensor<3x4xi64>, %arg1: tensor<1x1xi64>) -> (tensor<*xf32>, tensor<*xi64>) {
   // expected-error @+1 {{onnx.TopK: operand '<block argument> of type 'tensor<1x1xi64>' at index: 1' has rank 2, rank should be < 2}}
   %1, %2 = "onnx.TopK"(%arg0, %arg1) {axis = 1 : si64, largest = 1 : si64, sorted = 1 : si64} : (tensor<3x4xi64>, tensor<1x1xi64>) -> (tensor<*xf32>, tensor<*xi64>)
-  "func.return"(%1,%2) : (tensor<*xf32>, tensor<*xi64>) -> ()
+  "onnx.Return"(%1,%2) : (tensor<*xf32>, tensor<*xi64>) -> ()
 }
 
 // -----
@@ -583,7 +583,7 @@ func.func @test_topK_verifier_2(%arg0: tensor<3x4xi64>, %arg1: tensor<1x1xi64>) 
 func.func @test_unique_verifier_1(%arg0: tensor<3x4xi64>) -> (tensor<*xf32>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>) {
   // expected-error @+1 {{onnx.Unique: 'axis' value is 2, accepted range is [-2, 1]}}
   %1,%2,%3,%4 = "onnx.Unique"(%arg0) {axis = 2 : si64, sorted = 1 : si64} : (tensor<3x4xi64>) -> (tensor<*xf32>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>)
-  "func.return"(%1,%2,%3,%4) : (tensor<*xf32>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>) -> ()
+  "onnx.Return"(%1,%2,%3,%4) : (tensor<*xf32>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>) -> ()
 }
 
 // -----
@@ -591,7 +591,7 @@ func.func @test_unique_verifier_1(%arg0: tensor<3x4xi64>) -> (tensor<*xf32>, ten
 func.func @test_unique_verifier_2(%arg0: tensor<3x4xi64>) -> (tensor<*xf32>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>) {
   // expected-error @+1 {{onnx.Unique: 'sorted' value is 2, accepted range is [0, 1]}}
   %1,%2,%3,%4 = "onnx.Unique"(%arg0) {axis = 0 : si64, sorted = 2 : si64} : (tensor<3x4xi64>) -> (tensor<*xf32>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>)
-  "func.return"(%1,%2,%3,%4) : (tensor<*xf32>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>) -> ()
+  "onnx.Return"(%1,%2,%3,%4) : (tensor<*xf32>, tensor<*xi64>, tensor<*xi64>, tensor<*xi64>) -> ()
 }
 
 // -----
@@ -599,7 +599,7 @@ func.func @test_unique_verifier_2(%arg0: tensor<3x4xi64>) -> (tensor<*xf32>, ten
 func.func @test_prelu_verifier_1(%arg0: tensor<f32>, %arg1: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{Slope tensor has a wrong shape}}
   %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<f32>, tensor<1x2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
 }
 
@@ -608,7 +608,7 @@ func.func @test_prelu_verifier_1(%arg0: tensor<f32>, %arg1: tensor<1x2x3x4xf32>)
 func.func @test_matmulinteger_wrong_A(%arg0: tensor<5x16x32xui8>, %arg1: tensor<5x32x64xui8>, %arg2: tensor<16xui8>, %arg3: tensor<1xui8>) -> tensor<5x16x64xi32> {
   // expected-error @+1 {{onnx.MatMulInteger: operand '<block argument> of type 'tensor<5x16x32xui8>' at index: 0' has rank 3, rank should be 2}}
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<5x16x32xui8>, tensor<5x32x64xui8>, tensor<16xui8>, tensor<1xui8>) -> tensor<5x16x64xi32>
-  return %0 : tensor<5x16x64xi32>
+  onnx.Return %0 : tensor<5x16x64xi32>
 }
 
 // -----
@@ -616,7 +616,7 @@ func.func @test_matmulinteger_wrong_A(%arg0: tensor<5x16x32xui8>, %arg1: tensor<
 func.func @test_matmulinteger_wrong_A_zeropoint(%arg0: tensor<5x16x32xui8>, %arg1: tensor<5x32x64xui8>, %arg2: tensor<5x16xui8>, %arg3: tensor<1xui8>) -> tensor<5x16x64xi32> {
   // expected-error @+1 {{onnx.MatMulInteger: 'A' has rank 3, 'aZeroPoint' has rank 2. The two inputs must have the same rank}}
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<5x16x32xui8>, tensor<5x32x64xui8>, tensor<5x16xui8>, tensor<1xui8>) -> tensor<5x16x64xi32>
-  return %0 : tensor<5x16x64xi32>
+  onnx.Return %0 : tensor<5x16x64xi32>
 }
 
 // -----
@@ -624,7 +624,7 @@ func.func @test_matmulinteger_wrong_A_zeropoint(%arg0: tensor<5x16x32xui8>, %arg
 func.func @test_matmulinteger_wrong_A_broadcast_last_dim(%arg0: tensor<5x16x32xui8>, %arg1: tensor<5x32x64xui8>, %arg2: tensor<5x16x2xui8>, %arg3: tensor<1xui8>) -> tensor<5x16x64xi32> {
   // expected-error @+1 {{onnx.MatMulInteger: operand '<block argument> of type 'tensor<5x16x2xui8>' at index: 2' has dimension at index 2 with value 2, value should be 1}}
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<5x16x32xui8>, tensor<5x32x64xui8>, tensor<5x16x2xui8>, tensor<1xui8>) -> tensor<5x16x64xi32>
-  return %0 : tensor<5x16x64xi32>
+  onnx.Return %0 : tensor<5x16x64xi32>
 }
 
 // -----
@@ -632,7 +632,7 @@ func.func @test_matmulinteger_wrong_A_broadcast_last_dim(%arg0: tensor<5x16x32xu
 func.func @test_matmulinteger_wrong_A_broadcast(%arg0: tensor<5x16x32xui8>, %arg1: tensor<5x32x64xui8>, %arg2: tensor<5x1x1xui8>, %arg3: tensor<1xui8>) -> tensor<5x16x64xi32> {
   // expected-error @+1 {{onnx.MatMulInteger: 'A' dimension at index 1 has value 16, 'aZeroPoint' dimension at index 1 has value 1. The two dimensions must have the same value}}
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<5x16x32xui8>, tensor<5x32x64xui8>, tensor<5x1x1xui8>, tensor<1xui8>) -> tensor<5x16x64xi32>
-  return %0 : tensor<5x16x64xi32>
+  onnx.Return %0 : tensor<5x16x64xi32>
 }
 
 // -----
@@ -640,7 +640,7 @@ func.func @test_matmulinteger_wrong_A_broadcast(%arg0: tensor<5x16x32xui8>, %arg
 func.func @test_matmulinteger_wrong_B(%arg0: tensor<16x32xui8>, %arg1: tensor<5x32x64xui8>, %arg2: tensor<16xui8>, %arg3: tensor<32xui8>) -> tensor<5x16x64xi32> {
   // expected-error @+1 {{onnx.MatMulInteger: operand '<block argument> of type 'tensor<5x32x64xui8>' at index: 1' has rank 3, rank should be 2}}
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<16x32xui8>, tensor<5x32x64xui8>, tensor<16xui8>, tensor<32xui8>) -> tensor<5x16x64xi32>
-  return %0 : tensor<5x16x64xi32>
+  onnx.Return %0 : tensor<5x16x64xi32>
 }
 
 // -----
@@ -648,7 +648,7 @@ func.func @test_matmulinteger_wrong_B(%arg0: tensor<16x32xui8>, %arg1: tensor<5x
 func.func @test_matmulinteger_wrong_B_zeropoint(%arg0: tensor<16x32xui8>, %arg1: tensor<5x32x64xui8>, %arg2: tensor<16xui8>, %arg3: tensor<5x32xui8>) -> tensor<5x16x64xi32> {
   // expected-error @+1 {{onnx.MatMulInteger: 'B' has rank 3, 'bZeroPoint' has rank 2. The two inputs must have the same rank}}
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<16x32xui8>, tensor<5x32x64xui8>, tensor<16xui8>, tensor<5x32xui8>) -> tensor<5x16x64xi32>
-  return %0 : tensor<5x16x64xi32>
+  onnx.Return %0 : tensor<5x16x64xi32>
 }
 
 // -----
@@ -656,7 +656,7 @@ func.func @test_matmulinteger_wrong_B_zeropoint(%arg0: tensor<16x32xui8>, %arg1:
 func.func @test_matmulinteger_wrong_B_broadcast_last_dim(%arg0: tensor<16x32xui8>, %arg1: tensor<5x32x64xui8>, %arg2: tensor<16xui8>, %arg3: tensor<5x2x64xui8>) -> tensor<5x16x64xi32> {
   // expected-error @+1 {{onnx.MatMulInteger: operand '<block argument> of type 'tensor<5x2x64xui8>' at index: 3' has dimension at index 1 with value 2, value should be 1}}
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<16x32xui8>, tensor<5x32x64xui8>, tensor<16xui8>, tensor<5x2x64xui8>) -> tensor<5x16x64xi32>
-  return %0 : tensor<5x16x64xi32>
+  onnx.Return %0 : tensor<5x16x64xi32>
 }
 
 // -----
@@ -664,5 +664,5 @@ func.func @test_matmulinteger_wrong_B_broadcast_last_dim(%arg0: tensor<16x32xui8
 func.func @test_matmulinteger_wrong_B_broadcast(%arg0: tensor<16x32xui8>, %arg1: tensor<5x32x64xui8>, %arg2: tensor<16xui8>, %arg3: tensor<5x1x2xui8>) -> tensor<5x16x64xi32> {
   // expected-error @+1 {{onnx.MatMulInteger: 'B' dimension at index 2 has value 64, 'bZeroPoint' dimension at index 2 has value 2. The two dimensions must have the same value}}
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<16x32xui8>, tensor<5x32x64xui8>, tensor<16xui8>, tensor<5x1x2xui8>) -> tensor<5x16x64xi32>
-  return %0 : tensor<5x16x64xi32>
+  onnx.Return %0 : tensor<5x16x64xi32>
 }

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -7,7 +7,7 @@ func.func @test_matmul_add_fused(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>,
   // CHECK-NEXT: %{{[0-9]+}} = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<10x10xf32>, tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
   %0 = "onnx.MatMul"(%a0, %a1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
   %1 = "onnx.Add"(%0, %a2) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
-  "func.return"(%1) : (tensor<10x10xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<10x10xf32>) -> ()
 }
 
 // -----
@@ -18,7 +18,7 @@ func.func @test_matmul_add_not_fused(%a0: tensor<10x10x10xf32>, %a1: tensor<10x1
   // CHECK-NEXT: %{{[0-9]+}} = "onnx.MatMul"(%{{.*}}, %{{.*}}) : (tensor<10x10x10xf32>, tensor<10x10x10xf32>) -> tensor<10x10x10xf32>
   %0 = "onnx.MatMul"(%a0, %a1) : (tensor<10x10x10xf32>, tensor<10x10x10xf32>) -> tensor<10x10x10xf32>
   %1 = "onnx.Add"(%0, %a2) : (tensor<10x10x10xf32>, tensor<10x10x10xf32>) -> tensor<10x10x10xf32>
-  "func.return"(%1) : (tensor<10x10x10xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<10x10x10xf32>) -> ()
 }
 
 // -----
@@ -31,7 +31,7 @@ func.func @test_sigmoid_add(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>, %a2:
   %1 = "onnx.Add"(%0, %a2) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
   %2 = "onnx.Add"(%0, %a1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
   %3 = "onnx.Add"(%1, %2) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
-  "func.return"(%3) : (tensor<10x10xf32>) -> ()
+  "onnx.Return"(%3) : (tensor<10x10xf32>) -> ()
 }
 
 // -----
@@ -42,7 +42,7 @@ func.func @test_identity_identity(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>
   %0 = "onnx.Identity"(%a0) : (tensor<10x10xf32>) -> tensor<10x10xf32>
   %1 = "onnx.Identity"(%a1) : (tensor<10x10xf32>) -> tensor<10x10xf32>
   %2 = "onnx.Add"(%0, %1) : (tensor<10x10xf32>, tensor<10x10xf32>) -> tensor<10x10xf32>
-  "func.return"(%2) : (tensor<10x10xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<10x10xf32>) -> ()
 }
 
 // -----
@@ -50,11 +50,11 @@ func.func @test_identity_identity(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>
 func.func @test_dropout(%arg: tensor<10x10xf32>) -> (tensor<10x10xf32>, none) {
   %0 = "onnx.NoValue"() {value} : () -> none
   %1:2 = "onnx.Dropout"(%arg, %0, %0) : (tensor<10x10xf32>, none, none) -> (tensor<10x10xf32>, none)
-  "func.return"(%1#0, %1#1) : (tensor<10x10xf32>, none) -> ()
+  "onnx.Return"(%1#0, %1#1) : (tensor<10x10xf32>, none) -> ()
   // CHECK-LABEL: test_dropout
   // CHECK-NOT: "onnx.Dropout"
   // CHECK-NEXT: [[NONE:%.+]] = "onnx.NoValue"
-  // CHECK-NEXT: return %arg0, [[NONE]] : tensor<10x10xf32>, none
+  // CHECK-NEXT: onnx.Return %arg0, [[NONE]] : tensor<10x10xf32>, none
 }
 
 // -----
@@ -64,10 +64,10 @@ func.func @test_gemm_add_fusion(%arg0: tensor<128x128xf32>, %arg1: tensor<128x12
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Gemm"(%arg0, %arg1, %cst) : (tensor<128x128xf32>, tensor<128x128xf32>, none) -> tensor<*xf32>
   %1 = "onnx.Add"(%0, %arg2) : (tensor<*xf32>, tensor<128xf32>) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
 
   // CHECK-NEXT: [[GEMM:%.+]] = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128xf32>) -> tensor<*xf32>
-  // return [[GEMM]] : tensor<*xf32>
+  // onnx.Return [[GEMM]] : tensor<*xf32>
 }
 
 // -----
@@ -77,10 +77,10 @@ func.func @test_gemm_add_fusion_beta_zero(%arg0: tensor<128x128xf32>, %arg1: ten
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Gemm"(%arg0, %arg1, %cst) {beta = 0.0 : f32}: (tensor<128x128xf32>, tensor<128x128xf32>, none) -> tensor<*xf32>
   %1 = "onnx.Add"(%0, %arg2) : (tensor<*xf32>, tensor<128xf32>) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
 
   // CHECK-NEXT: [[GEMM:%.+]] = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<128x128xf32>, tensor<128x128xf32>, tensor<128xf32>) -> tensor<*xf32>
-  // return [[GEMM]] : tensor<*xf32>
+  // onnx.Return [[GEMM]] : tensor<*xf32>
 }
 
 // -----
@@ -90,10 +90,10 @@ func.func @test_gemm_add_fusion_rank3(%arg0: tensor<128x128x256xf32>, %arg1: ten
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Gemm"(%arg0, %arg1, %cst) : (tensor<128x128x256xf32>, tensor<128x128x256xf32>, none) -> tensor<*xf32>
   %1 = "onnx.Add"(%0, %arg2) : (tensor<*xf32>, tensor<256xf32>) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
 
   // CHECK-NEXT: [[GEMM:%.+]] = "onnx.Gemm"(%{{.*}}, %{{.*}}, %{{.*}}) {alpha = 1.000000e+00 : f32, beta = 1.000000e+00 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<128x128x256xf32>, tensor<128x128x256xf32>, tensor<256xf32>) -> tensor<*xf32>
-  // return [[GEMM]] : tensor<*xf32>
+  // onnx.Return [[GEMM]] : tensor<*xf32>
 }
 
 // -----
@@ -101,9 +101,9 @@ func.func @test_gemm_add_fusion_rank3(%arg0: tensor<128x128x256xf32>, %arg1: ten
 //CHECK-LABEL: @cast_elimination(%{{.*}}: tensor<2xf32>) -> tensor<2xf32> {
 func.func @cast_elimination(%arg0: tensor<2xf32>) -> tensor<2xf32> {
   %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<2xf32>) -> tensor<2xf32>
-  return %0 : tensor<2xf32>
+  onnx.Return %0 : tensor<2xf32>
 
-  // CHECK-NEXT: return %arg0 : tensor<2xf32>
+  // CHECK-NEXT: onnx.Return %arg0 : tensor<2xf32>
 }
 
 // -----
@@ -112,7 +112,7 @@ func.func @test_conv_batchnormtestmode_fusion_nobias(%arg0: tensor<1x3x224x224xf
     %cst = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.Conv"(%arg0, %0, %cst) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [7, 7], pads = [3, 3, 3, 3], strides = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>, none) -> tensor<1x64x112x112xf32>
     %6 = "onnx.BatchNormalizationInferenceMode"(%1, %2, %3, %4, %5) {epsilon = 1.00000007E-5 : f32} : (tensor<1x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32>
-    return %6 :  tensor<1x64x112x112xf32>
+    onnx.Return %6 :  tensor<1x64x112x112xf32>
 
     // CHECK-LABEL:  func.func @test_conv_batchnormtestmode_fusion_nobias
     // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x224x224xf32>, [[PARAM_1_:%.+]]: tensor<64x3x7x7xf32>, [[PARAM_2_:%.+]]: tensor<64xf32>, [[PARAM_3_:%.+]]: tensor<64xf32>, [[PARAM_4_:%.+]]: tensor<64xf32>, [[PARAM_5_:%.+]]: tensor<64xf32>) -> tensor<1x64x112x112xf32> {
@@ -127,7 +127,7 @@ func.func @test_conv_batchnormtestmode_fusion_nobias(%arg0: tensor<1x3x224x224xf
     // CHECK:           [[VAR_8_:%.+]] = "onnx.Add"([[PARAM_3_]], [[VAR_7_]]) : (tensor<64xf32>, tensor<*xf32>) -> tensor<*xf32>
     // CHECK:           [[VAR_9_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_5_]], [[VAR_8_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [7, 7], pads = [3, 3, 3, 3], strides = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<*xf32>, tensor<*xf32>) -> tensor<1x64x112x112xf32>
     // CHECK-NOT: {{.*}} = "onnx.BatchNormalizationInferenceMode"{{.*}}
-    // CHECK:           return [[VAR_9_]] : tensor<1x64x112x112xf32>
+    // CHECK:           onnx.Return [[VAR_9_]] : tensor<1x64x112x112xf32>
 }
 
 // -----
@@ -136,7 +136,7 @@ func.func @test_conv_batchnormtestmode_fusion(%arg0 : tensor<1x3x224x224xf32>, %
     %cst = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.Conv"(%arg0, %0, %arg1) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [7, 7], pads = [3, 3, 3, 3], strides = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<64x3x7x7xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32>
     %6 = "onnx.BatchNormalizationInferenceMode"(%1, %2, %3, %4, %5) {epsilon = 1.00000007E-5 : f32} : (tensor<1x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32>
-    return %6 :  tensor<1x64x112x112xf32>
+    onnx.Return %6 :  tensor<1x64x112x112xf32>
 
     // CHECK-LABEL:  func.func @test_conv_batchnormtestmode_fusion
     // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x224x224xf32>, [[PARAM_1_:%.+]]: tensor<64xf32>, [[PARAM_2_:%.+]]: tensor<64x3x7x7xf32>, [[PARAM_3_:%.+]]: tensor<64xf32>, [[PARAM_4_:%.+]]: tensor<64xf32>, [[PARAM_5_:%.+]]: tensor<64xf32>, [[PARAM_6_:%.+]]: tensor<64xf32>) -> tensor<1x64x112x112xf32> {
@@ -151,7 +151,7 @@ func.func @test_conv_batchnormtestmode_fusion(%arg0 : tensor<1x3x224x224xf32>, %
     // CHECK:           [[VAR_8_:%.+]] = "onnx.Add"([[PARAM_4_]], [[VAR_7_]]) : (tensor<64xf32>, tensor<*xf32>) -> tensor<*xf32>
     // CHECK:           [[VAR_9_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_5_]], [[VAR_8_]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [7, 7], pads = [3, 3, 3, 3], strides = [2, 2]} : (tensor<1x3x224x224xf32>, tensor<*xf32>, tensor<*xf32>) -> tensor<1x64x112x112xf32>
     // CHECK-NOT: {{.*}} = "onnx.BatchNormalizationInferenceMode"{{.*}}
-    // CHECK:           return [[VAR_9_]] : tensor<1x64x112x112xf32>
+    // CHECK:           onnx.Return [[VAR_9_]] : tensor<1x64x112x112xf32>
 }
 
 // -----
@@ -160,8 +160,8 @@ func.func @test_conv_batchnormtestmode_fusion(%arg0 : tensor<1x3x224x224xf32>, %
 // CHECK-LABEL: func @test_transpose_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
 func.func @test_transpose_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
   %0 = "onnx.Transpose"(%arg0)  {perm = [0, 1, 2, 3]} : (tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32>
-  // CHECK-NEXT: return %arg0 : tensor<10x11x12x13xf32>
-  "func.return"(%0) : (tensor<10x11x12x13xf32>) -> ()
+  // CHECK-NEXT: onnx.Return %arg0 : tensor<10x11x12x13xf32>
+  "onnx.Return"(%0) : (tensor<10x11x12x13xf32>) -> ()
 }
 
 // -----
@@ -174,7 +174,7 @@ func.func @test_transpose_concat_reversed(%arg0: tensor<?x5x5x1xf32>, %arg1: ten
     %1 = "onnx.Transpose"(%arg1) {perm = [0, 3, 1, 2]} : (tensor<?x5x5x2xf32>) -> tensor<?x2x5x5xf32>
     %2 = "onnx.Concat"(%0, %1) {axis = 1 : si64} : (tensor<?x1x5x5xf32>, tensor<?x2x5x5xf32>) -> tensor<?x3x5x5xf32>
     %3 = "onnx.Transpose"(%2) {perm = [0, 2, 3, 1]} : (tensor<?x3x5x5xf32>) -> tensor<?x5x5x3xf32>
-    return %3 : tensor<?x5x5x3xf32>
+    onnx.Return %3 : tensor<?x5x5x3xf32>
 
     // CHECK-NEXT: "onnx.Concat"(%arg0, %arg1) {axis = 3 : si64} : (tensor<?x5x5x1xf32>, tensor<?x5x5x2xf32>) -> tensor<?x5x5x3xf32>
     // CHECK-NOT: "onnx.Transpose"
@@ -187,8 +187,8 @@ func.func @test_transpose_concat_reversed(%arg0: tensor<?x5x5x1xf32>, %arg1: ten
 func.func @test_reshape_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
   %0 = onnx.Constant dense<[10, 11, 12, 13]> : tensor<4xi64>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<10x11x12x13xf32>, tensor<4xi64>) -> tensor<10x11x12x13xf32>
-  // CHECK-NEXT: return %arg0 : tensor<10x11x12x13xf32>
-  "func.return"(%1) : (tensor<10x11x12x13xf32>) -> ()
+  // CHECK-NEXT: onnx.Return %arg0 : tensor<10x11x12x13xf32>
+  "onnx.Return"(%1) : (tensor<10x11x12x13xf32>) -> ()
 }
 
 // -----
@@ -203,7 +203,7 @@ func.func @test_reshape_removal_with_matmul_4D(%arg0: tensor<3x5x10x20xf32>, %ar
   %0 = "onnx.Reshape"(%arg0, %shape1) : (tensor<3x5x10x20xf32>, tensor<2xi64>) -> tensor<150x20xf32>
   %1 = "onnx.MatMul"(%0, %arg1) : (tensor<150x20xf32>, tensor<20x1xf32>) -> tensor<150x1xf32>
   %2 = "onnx.Reshape"(%1, %shape2)  : (tensor<150x1xf32>, tensor<4xi64>) -> tensor<3x5x10x1xf32>
-  return %2 : tensor<3x5x10x1xf32>
+  onnx.Return %2 : tensor<3x5x10x1xf32>
   // CHECK-NEXT: "onnx.MatMul"(%arg0, %arg1) : (tensor<3x5x10x20xf32>, tensor<20x1xf32>) -> tensor<3x5x10x1xf32>
   // CHECK-NOT: "onnx.Reshape"
 }
@@ -220,11 +220,11 @@ func.func @test_reshape_should_not_remove(%arg0: tensor<3x5x10x20xf32>, %arg1: t
   %0 = "onnx.Reshape"(%arg0, %shape1) : (tensor<3x5x10x20xf32>, tensor<2xi64>) -> tensor<150x20xf32>
   %1 = "onnx.MatMul"(%0, %arg1) : (tensor<150x20xf32>, tensor<20x1xf32>) -> tensor<150x1xf32>
   %2 = "onnx.Reshape"(%1, %shape2)  : (tensor<150x1xf32>, tensor<3xi64>) -> tensor<15x10x1xf32>
-  return %2 : tensor<15x10x1xf32>
+  onnx.Return %2 : tensor<15x10x1xf32>
   // CHECK: [[CST:%.+]] = onnx.Constant dense<[15, 10, 1]> : tensor<3xi64>
   // CHECK: [[MATMUL:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<3x5x10x20xf32>, tensor<20x1xf32>) -> tensor<3x5x10x1xf32>
   // CHECK: [[RES:%.+]] = "onnx.Reshape"([[MATMUL]], [[CST]]) {allowzero = 0 : si64} : (tensor<3x5x10x1xf32>, tensor<3xi64>) -> tensor<15x10x1xf32>
-  // CHECK: return [[RES]] : tensor<15x10x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<15x10x1xf32>
 }
 
 // -----
@@ -248,7 +248,7 @@ func.func @test_transpose_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10
   %0 = "onnx.Transpose"(%arg0)  {perm = [3, 2, 1, 0]} : (tensor<10x11x12x13xf32>) -> tensor<13x12x11x10xf32>
   %1 = "onnx.Transpose"(%0)  {perm = [2, 3, 0, 1]} : (tensor<13x12x11x10xf32>) -> tensor<11x10x13x12xf32>
   // CHECK-NEXT: %{{.*}} = "onnx.Transpose"(%arg0) {perm = [1, 0, 3, 2]} : (tensor<10x11x12x13xf32>) -> tensor<11x10x13x12xf32>
-  "func.return"(%1) : (tensor<11x10x13x12xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<11x10x13x12xf32>) -> ()
 }
 
 // -----
@@ -261,7 +261,7 @@ func.func @test_transpose_besides_atan_fusion(%arg0: tensor<10x11x12x13xf32>) ->
   %1 = "onnx.Atan"(%0) : (tensor<10x13x11x12xf32>) -> tensor<10x13x11x12xf32>
   %2 = "onnx.Transpose"(%1) {perm = [0, 2, 3, 1]} : (tensor<10x13x11x12xf32>) -> tensor<10x11x12x13xf32>
   // CHECK-NEXT: %{{.*}} = "onnx.Atan"(%arg0) : (tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32>
-  "func.return"(%2) : (tensor<10x11x12x13xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<10x11x12x13xf32>) -> ()
 }
 
 // -----
@@ -274,7 +274,7 @@ func.func @test_transpose_besides_leakyrelu_fusion(%arg0: tensor<10x11x12x13xf32
   %1 = "onnx.LeakyRelu"(%0) {alpha = 1.000000e-01 : f32} : (tensor<10x13x11x12xf32>) -> tensor<10x13x11x12xf32>
   %2 = "onnx.Transpose"(%1) {perm = [0, 2, 3, 1]} : (tensor<10x13x11x12xf32>) -> tensor<10x11x12x13xf32>
   // CHECK-NEXT: %{{.*}} = "onnx.LeakyRelu"(%arg0) {alpha = 1.000000e-01 : f32} : (tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32>
-  "func.return"(%2) : (tensor<10x11x12x13xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<10x11x12x13xf32>) -> ()
 }
 
 // -----
@@ -287,7 +287,7 @@ func.func @test_transpose_besides_hardsigmoid_fusion(%arg0: tensor<10x11x12x13xf
   %1 = "onnx.HardSigmoid"(%0)  {alpha = 1.000000e-01 : f32, beta = 2.000000e-01 : f32} : (tensor<10x13x11x12xf32>) -> tensor<10x13x11x12xf32>
   %2 = "onnx.Transpose"(%1)  {perm = [0, 2, 3, 1]} : (tensor<10x13x11x12xf32>) -> tensor<10x11x12x13xf32>
   // CHECK-NEXT: %{{.*}} = "onnx.HardSigmoid"(%arg0) {alpha = 1.000000e-01 : f32, beta = 2.000000e-01 : f32} : (tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32>
-  "func.return"(%2) : (tensor<10x11x12x13xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<10x11x12x13xf32>) -> ()
 }
 
 // -----
@@ -301,7 +301,7 @@ func.func @test_reshape_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10x1
   %3 = "onnx.Reshape"(%1, %2) : (tensor<10x12x11x13xf32>, tensor<4xi64>) -> tensor<11x10x13x12xf32>
   // CHECK-NEXT: [[RES:%.+]] = onnx.Constant dense<[11, 10, 13, 12]> : tensor<4xi64>
   // CHECK-NEXT: %{{.*}} = "onnx.Reshape"(%arg0, [[RES]]) {allowzero = 0 : si64} : (tensor<10x11x12x13xf32>, tensor<4xi64>) -> tensor<11x10x13x12xf32>
-  "func.return"(%3) : (tensor<11x10x13x12xf32>) -> ()
+  "onnx.Return"(%3) : (tensor<11x10x13x12xf32>) -> ()
 }
 
 // -----
@@ -311,8 +311,8 @@ func.func @test_reshape_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10x1
 func.func @test_transpose_fusion_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
   %0 = "onnx.Transpose"(%arg0)  {perm = [3, 2, 1, 0]} : (tensor<10x11x12x13xf32>) -> tensor<13x12x11x10xf32>
   %1 = "onnx.Transpose"(%0)  {perm = [3, 2, 1, 0]} : (tensor<13x12x11x10xf32>) -> tensor<10x11x12x13xf32>
-  // CHECK-NEXT: return %arg0 : tensor<10x11x12x13xf32>
-  "func.return"(%1) : (tensor<10x11x12x13xf32>) -> ()
+  // CHECK-NEXT: onnx.Return %arg0 : tensor<10x11x12x13xf32>
+  "onnx.Return"(%1) : (tensor<10x11x12x13xf32>) -> ()
 }
 
 // -----
@@ -324,30 +324,30 @@ func.func @test_reshape_fusion_removal(%arg0: tensor<10x11x12x13xf32>) -> tensor
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<10x11x12x13xf32>, tensor<4xi64>) -> tensor<10x12x11x13xf32>
   %2 = onnx.Constant dense<[10, 11, 12, 13]> : tensor<4xi64>
   %3 = "onnx.Reshape"(%1, %2) : (tensor<10x12x11x13xf32>, tensor<4xi64>) -> tensor<10x11x12x13xf32>
-  // CHECK-NEXT: return %arg0 : tensor<10x11x12x13xf32>
-  "func.return"(%3) : (tensor<10x11x12x13xf32>) -> ()
+  // CHECK-NEXT: onnx.Return %arg0 : tensor<10x11x12x13xf32>
+  "onnx.Return"(%3) : (tensor<10x11x12x13xf32>) -> ()
 }
 
 // -----
 
 func.func @test_shape1(%arg0 : tensor<2x4x8x16xf32>) -> tensor<4xi64> {
   %0 = "onnx.Shape"(%arg0) : (tensor<2x4x8x16xf32>) -> tensor<4xi64>
-  return %0 : tensor<4xi64>
+  onnx.Return %0 : tensor<4xi64>
   // CHECK-LABEL:  func.func @test_shape1
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4x8x16xf32>) -> tensor<4xi64> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[2, 4, 8, 16]> : tensor<4xi64>
-  // CHECK:           return [[VAR_0_]] : tensor<4xi64>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<4xi64>
 }
 
 // -----
 
 func.func @test_shape2(%arg0 : tensor<?x4x8x16xf32>) -> tensor<*xi64> {
   %0 = "onnx.Shape"(%arg0) : (tensor<?x4x8x16xf32>) -> tensor<*xi64>
-  return %0 : tensor<*xi64>
+  onnx.Return %0 : tensor<*xi64>
 
   // CHECK-LABEL: @test_shape2
   // CHECK-NEXT: %0 = "onnx.Shape"(%arg0) {start = 0 : si64} : (tensor<?x4x8x16xf32>) -> tensor<*xi64>
-  // CHECK-NEXT: return %0 : tensor<*xi64>
+  // CHECK-NEXT: onnx.Return %0 : tensor<*xi64>
 }
 
 
@@ -355,7 +355,7 @@ func.func @test_shape2(%arg0 : tensor<?x4x8x16xf32>) -> tensor<*xi64> {
 
 func.func @test_size1(%arg0 : tensor<2x4x8x16xf32>) -> tensor<i64> {
   %0 = "onnx.Size"(%arg0) : (tensor<2x4x8x16xf32>) -> tensor<i64>
-  return %0 : tensor<i64>
+  onnx.Return %0 : tensor<i64>
 
   // CHECK-LABEL: @test_size1
   // CHECK-NEXT: %0 = onnx.Constant dense<1024> : tensor<i64>
@@ -366,11 +366,11 @@ func.func @test_size1(%arg0 : tensor<2x4x8x16xf32>) -> tensor<i64> {
 
 func.func @test_size2(%arg0 : tensor<*xf32>) -> tensor<*xi64> {
   %0 = "onnx.Size"(%arg0) : (tensor<*xf32>) -> tensor<*xi64>
-  return %0 : tensor<*xi64>
+  onnx.Return %0 : tensor<*xi64>
 
   // CHECK-LABEL: @test_size2
   // CHECK-NEXT: %0 = "onnx.Size"(%arg0) : (tensor<*xf32>) -> tensor<*xi64>
-  // CHECK-NEXT: return %0 : tensor<*xi64>
+  // CHECK-NEXT: onnx.Return %0 : tensor<*xi64>
 }
 
 // -----
@@ -378,10 +378,10 @@ func.func @test_size2(%arg0 : tensor<*xf32>) -> tensor<*xi64> {
 // COM: Test rewriting GlobalAveragePool into ReduceMeanV13
 func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32> {
   %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>
-  return %0 : tensor<1x3x1x1xf32>
+  onnx.Return %0 : tensor<1x3x1x1xf32>
   // CHECK-LABEL: test_global_average_pool
   // CHECK: [[RES:%.+]] = "onnx.ReduceMeanV13"(%arg0) {axes = [2, 3], keepdims = 1 : si64} : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>
-  // CHECK: return [[RES]] : tensor<1x3x1x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x1x1xf32>
 }
 
 // -----
@@ -389,10 +389,10 @@ func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x
 // COM: Test rewriting GlobalAveragePool into ReduceMeanV13 with dynamic dimensions
 func.func @test_global_average_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32> {
   %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32>
-  return %0 : tensor<1x?x?x1xf32>
+  onnx.Return %0 : tensor<1x?x?x1xf32>
   // CHECK-LABEL: test_global_average_pool_dyn_dims
   // CHECK: [[RES:%.+]] = "onnx.ReduceMeanV13"(%arg0) {axes = [2, 3], keepdims = 1 : si64} : (tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32>
-  // CHECK: return [[RES]] : tensor<1x?x?x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x?x?x1xf32>
 }
 
 // -----
@@ -400,10 +400,10 @@ func.func @test_global_average_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tens
 // COM: Test rewriting GlobalMaxPool into ReduceMaxV13
 func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32> {
   %0 = "onnx.GlobalMaxPool"(%arg0) : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>
-  return %0 : tensor<1x3x1x1xf32>
+  onnx.Return %0 : tensor<1x3x1x1xf32>
   // CHECK-LABEL: test_global_average_pool
   // CHECK: [[RES:%.+]] = "onnx.ReduceMaxV13"(%arg0) {axes = [2, 3], keepdims = 1 : si64} : (tensor<1x3x5x5xf32>) -> tensor<1x3x1x1xf32>
-  // CHECK: return [[RES]] : tensor<1x3x1x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x1x1xf32>
 }
 
 // -----
@@ -411,10 +411,10 @@ func.func @test_global_average_pool(%arg0: tensor<1x3x5x5xf32>) -> tensor<1x3x1x
 // COM: Test rewriting GlobalMaxPool into ReduceMaxV13 with dynamic dimensions
 func.func @test_global_average_pool_dyn_dims(%arg0: tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32> {
   %0 = "onnx.GlobalMaxPool"(%arg0) : (tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32>
-  return %0 : tensor<1x?x?x1xf32>
+  onnx.Return %0 : tensor<1x?x?x1xf32>
   // CHECK-LABEL: test_global_average_pool_dyn_dims
   // CHECK: [[RES:%.+]] = "onnx.ReduceMaxV13"(%arg0) {axes = [2, 3], keepdims = 1 : si64} : (tensor<1x?x?x5xf32>) -> tensor<1x?x?x1xf32>
-  // CHECK: return [[RES]] : tensor<1x?x?x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x?x?x1xf32>
 }
 
 // -----
@@ -426,12 +426,12 @@ func.func @test_remove_unsqueeze_squeeze(%arg0 : tensor<10x10xf32>) -> tensor<10
   %1 = onnx.Constant dense<[0, -2]> : tensor<2xi64>
   %2 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<10x10xf32>, tensor<2xi64>) -> tensor<1x10x1x10xf32>
   %3 = "onnx.Squeeze"(%2, %1) : (tensor<1x10x1x10xf32>, tensor<2xi64>) -> tensor<10x10xf32>
-  return %3: tensor<10x10xf32>
+  onnx.Return %3: tensor<10x10xf32>
 
   // CHECK-LABEL: test_remove_unsqueeze_squeeze
   // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
   // CHECK-NOT: {{.*}} = onnx.Squeeze"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 
 }
 
@@ -440,12 +440,12 @@ func.func @test_remove_unsqueeze_squeeze(%arg0 : tensor<10x10xf32>) -> tensor<10
 func.func @test_remove_unsqueezev11_squeezev11(%arg0 : tensor<10x10xf32>) -> tensor<10x10xf32> {
   %0 = "onnx.UnsqueezeV11"(%arg0) {axes=[0, 2]} : (tensor<10x10xf32>) -> tensor<1x10x1x10xf32>
   %1 = "onnx.SqueezeV11"(%0) {axes=[0, -2]} : (tensor<1x10x1x10xf32>) -> tensor<10x10xf32>
-  return %1: tensor<10x10xf32>
+  onnx.Return %1: tensor<10x10xf32>
 
   // CHECK-LABEL: test_remove_unsqueezev11_squeezev11
   // CHECK-NOT: {{.*}} = "onnx.UnsqueezeV11"{{.*}}
   // CHECK-NOT: {{.*}} = onnx.SqueezeV11"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 
 }
 
@@ -459,13 +459,13 @@ func.func @test_remove_unsqueeze_cast_squeeze(%arg0 : tensor<10x10xf32>) -> tens
   %2 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<10x10xf32>, tensor<2xi64>) -> tensor<1x10x1x10xf32>
   %3 = "onnx.Cast"(%2) {to = i64}: (tensor<1x10x1x10xf32>) -> tensor<1x10x1x10xi64>
   %4 = "onnx.Squeeze"(%3, %1) : (tensor<1x10x1x10xi64>, tensor<2xi64>) -> tensor<10x10xi64>
-  return %4: tensor<10x10xi64>
+  onnx.Return %4: tensor<10x10xi64>
 
   // CHECK-LABEL: test_remove_unsqueeze_cast_squeeze
   // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
   // CHECK-NOT: {{.*}} = "onnx.Squeeze"{{.*}}
   // CHECK: [[RES:%.+]] = "onnx.Cast"{{.*}}
-  // CHECK: return [[RES]]
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -475,11 +475,11 @@ func.func @test_should_not_remove_unsqueeze_squeeze(%arg0 : tensor<10x10xf32>) -
   %1 = onnx.Constant dense<[0]> : tensor<1xi64>
   %2 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<10x10xf32>, tensor<2xi64>) -> tensor<1x10x1x10xf32>
   %3 = "onnx.Squeeze"(%2, %1) : (tensor<1x10x1x10xf32>, tensor<1xi64>) -> tensor<10x1x10xf32>
-  return %3: tensor<10x1x10xf32>
+  onnx.Return %3: tensor<10x1x10xf32>
   // CHECK-LABEL: test_should_not_remove_unsqueeze_squeeze
   // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
   // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 }
 
 // -----
@@ -487,11 +487,11 @@ func.func @test_should_not_remove_unsqueeze_squeeze(%arg0 : tensor<10x10xf32>) -
 func.func @test_should_not_remove_unsqueezev11_squeezev11(%arg0 : tensor<10x10xf32>) -> tensor<10x1x10xf32> {
   %0 = "onnx.UnsqueezeV11"(%arg0) {axes=[0, 2]} : (tensor<10x10xf32>) -> tensor<1x10x1x10xf32>
   %1 = "onnx.SqueezeV11"(%0) {axes=[0]} : (tensor<1x10x1x10xf32>) -> tensor<10x1x10xf32>
-  return %1: tensor<10x1x10xf32>
+  onnx.Return %1: tensor<10x1x10xf32>
   // CHECK-LABEL: test_should_not_remove_unsqueezev11_squeezev11
   // CHECK: {{.*}} = "onnx.UnsqueezeV11"{{.*}}
   // CHECK: {{.*}} = "onnx.SqueezeV11"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 }
 
 // -----
@@ -501,11 +501,11 @@ func.func @test_remove_squeeze_unsqueeze(%arg0 : tensor<10x1x10xf32>) -> tensor<
   %1 = onnx.Constant dense<[1]> : tensor<1xi64>
   %2 = "onnx.Squeeze"(%arg0, %0) : (tensor<10x1x10xf32>, tensor<1xi64>) -> tensor<10x10xf32>
   %3 = "onnx.Unsqueeze"(%2, %1) : (tensor<10x10xf32>, tensor<1xi64>) -> tensor<10x1x10xf32>
-  return %3: tensor<10x1x10xf32>
+  onnx.Return %3: tensor<10x1x10xf32>
   // CHECK-LABEL: test_remove_squeeze_unsqueeze
   // CHECK-NOT: {{.*}} = "onnx.Squeeze"{{.*}}
   // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 }
 
 // -----
@@ -516,12 +516,12 @@ func.func @test_remove_squeeze_cast_unsqueeze(%arg0 : tensor<10x1x10xf32>) -> te
   %2 = "onnx.Squeeze"(%arg0, %0) : (tensor<10x1x10xf32>, tensor<1xi64>) -> tensor<10x10xf32>
   %3 = "onnx.Cast"(%2) { to = i64 } : (tensor<10x10xf32>) -> tensor<10x10xi64>
   %4 = "onnx.Unsqueeze"(%3, %1) : (tensor<10x10xi64>, tensor<1xi64>) -> tensor<10x1x10xi64>
-  return %4: tensor<10x1x10xi64>
+  onnx.Return %4: tensor<10x1x10xi64>
   // CHECK-LABEL: test_remove_squeeze_cast_unsqueeze
   // CHECK-NOT: {{.*}} = "onnx.Squeeze"{{.*}}
   // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
   // CHECK: [[RES:%.+]] = "onnx.Cast"{{.*}}
-  // CHECK: return [[RES]]
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -529,11 +529,11 @@ func.func @test_remove_squeeze_cast_unsqueeze(%arg0 : tensor<10x1x10xf32>) -> te
 func.func @test_remove_squeezev11_unsqueezev11(%arg0 : tensor<10x1x10xf32>) -> tensor<10x1x10xf32> {
   %0 = "onnx.SqueezeV11"(%arg0) {axes=[1]} : (tensor<10x1x10xf32>) -> tensor<10x10xf32>
   %1 = "onnx.UnsqueezeV11"(%0) {axes=[1]} : (tensor<10x10xf32>) -> tensor<10x1x10xf32>
-  return %1: tensor<10x1x10xf32>
+  onnx.Return %1: tensor<10x1x10xf32>
   // CHECK-LABEL: test_remove_squeezev11_unsqueezev11
   // CHECK-NOT: {{.*}} = "onnx.SqueezeV11"{{.*}}
   // CHECK-NOT: {{.*}} = "onnx.UnsqueezeV11"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 }
 
 // -----
@@ -543,11 +543,11 @@ func.func @test_should_not_remove_squeeze_unsqueeze(%arg0 : tensor<1x10x1x10xf32
   %1 = onnx.Constant dense<[3]> : tensor<1xi64>
   %2 = "onnx.Squeeze"(%arg0, %0) : (tensor<1x10x1x10xf32>, tensor<1xi64>) -> tensor<10x1x10xf32>
   %3 = "onnx.Unsqueeze"(%2, %1) : (tensor<10x1x10xf32>, tensor<1xi64>) -> tensor<10x1x10x1xf32>
-  return %3: tensor<10x1x10x1xf32>
+  onnx.Return %3: tensor<10x1x10x1xf32>
   // CHECK-LABEL: test_should_not_remove_squeeze_unsqueeze
   // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
   // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 }
 
 // -----
@@ -555,11 +555,11 @@ func.func @test_should_not_remove_squeeze_unsqueeze(%arg0 : tensor<1x10x1x10xf32
 func.func @test_should_not_remove_squeezev11_unsqueezev11(%arg0 : tensor<1x10x1x10xf32>) -> tensor<10x1x10x1xf32> {
   %0 = "onnx.SqueezeV11"(%arg0) {axes=[0]} : (tensor<1x10x1x10xf32>) -> tensor<10x1x10xf32>
   %1 = "onnx.UnsqueezeV11"(%0) {axes=[3]} : (tensor<10x1x10xf32>) -> tensor<10x1x10x1xf32>
-  return %1: tensor<10x1x10x1xf32>
+  onnx.Return %1: tensor<10x1x10x1xf32>
   // CHECK-LABEL: test_should_not_remove_squeezev11_unsqueezev11
   // CHECK: {{.*}} = "onnx.SqueezeV11"{{.*}}
   // CHECK: {{.*}} = "onnx.UnsqueezeV11"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 }
 
 // -----
@@ -569,11 +569,11 @@ func.func @test_should_not_remove_null_axes_squeeze_unsqueeze(%arg0 : tensor<1x1
   %0 = onnx.Constant dense<[1, 3]> : tensor<2xi64>
   %1 = "onnx.Squeeze"(%arg0, %cst) : (tensor<1x10x1x10xf32>, none) -> tensor<10x10xf32>
   %2 = "onnx.Unsqueeze"(%1, %0) : (tensor<10x10xf32>, tensor<2xi64>) -> tensor<10x1x10x1xf32>
-  return %2: tensor<10x1x10x1xf32>
+  onnx.Return %2: tensor<10x1x10x1xf32>
   // CHECK-LABEL: test_should_not_remove_null_axes_squeeze_unsqueeze
   // CHECK: {{.*}} = "onnx.Squeeze"{{.*}}
   // CHECK: {{.*}} = "onnx.Unsqueeze"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 }
 
 // -----
@@ -581,11 +581,11 @@ func.func @test_should_not_remove_null_axes_squeeze_unsqueeze(%arg0 : tensor<1x1
 func.func @test_should_not_remove_null_axes_squeezev11_unsqueezev11(%arg0 : tensor<1x10x1x10xf32>) -> tensor<10x1x10x1xf32> {
   %0 = "onnx.SqueezeV11"(%arg0) : (tensor<1x10x1x10xf32>) -> tensor<10x10xf32>
   %1 = "onnx.UnsqueezeV11"(%0) {axes=[1, 3]} : (tensor<10x10xf32>) -> tensor<10x1x10x1xf32>
-  return %1: tensor<10x1x10x1xf32>
+  onnx.Return %1: tensor<10x1x10x1xf32>
   // CHECK-LABEL: test_should_not_remove_null_axes_squeezev11_unsqueezev11
   // CHECK: {{.*}} = "onnx.SqueezeV11"{{.*}}
   // CHECK: {{.*}} = "onnx.UnsqueezeV11"{{.*}}
-  // CHECK: return {{.*}}
+  // CHECK: onnx.Return {{.*}}
 }
 
 // -----
@@ -596,10 +596,10 @@ func.func @test_remove_depth_to_space_space_to_depth(%arg0 : tensor<1x16x32x64xf
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.SpaceToDepth"(%arg0) {blocksize = 4 : si64} : (tensor<1x16x32x64xf32>) -> tensor<1x256x8x16xf32>
   %1 = "onnx.DepthToSpace"(%0) {blocksize = 4 : si64, mode = "CRD"} : (tensor<1x256x8x16xf32>) -> tensor<1x16x32x64xf32>
-  "func.return"(%1) : (tensor<1x16x32x64xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<1x16x32x64xf32>) -> ()
 
   // CHECK-LABEL: test_remove_depth_to_space_space_to_depth
-  // CHECK: return %arg0 : tensor<1x16x32x64xf32>
+  // CHECK: onnx.Return %arg0 : tensor<1x16x32x64xf32>
 }
 
 // -----
@@ -608,20 +608,20 @@ func.func @test_remove_space_to_depth_depth_to_space(%arg0 : tensor<1x256x8x16xf
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.DepthToSpace"(%arg0) {blocksize = 4 : si64, mode = "CRD"} : (tensor<1x256x8x16xf32>) -> tensor<1x16x32x64xf32>
   %1 = "onnx.SpaceToDepth"(%0) {blocksize = 4 : si64} : (tensor<1x16x32x64xf32>) -> tensor<1x256x8x16xf32>
-  "func.return"(%1) : (tensor<1x256x8x16xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<1x256x8x16xf32>) -> ()
 
   // CHECK-LABEL: test_remove_space_to_depth_depth_to_space
-  // CHECK: return %arg0 : tensor<1x256x8x16xf32>
+  // CHECK: onnx.Return %arg0 : tensor<1x256x8x16xf32>
 }
 
 // -----
 
 func.func @test_constant_1() -> tensor<i64> {
   %0 = onnx.Constant {value_int = 1 : si64} : tensor<i64>
-  return %0 : tensor<i64>
+  onnx.Return %0 : tensor<i64>
 // CHECK-LABEL:       func @test_constant_1
 // CHECK:           [[VAR_0:%.+]] = onnx.Constant dense<1> : tensor<i64>
-// CHECK:           return [[VAR_0]] : tensor<i64>
+// CHECK:           onnx.Return [[VAR_0]] : tensor<i64>
 }
 
 
@@ -629,28 +629,28 @@ func.func @test_constant_1() -> tensor<i64> {
 
 func.func @test_constant_2() -> tensor<f32> {
   %0 = onnx.Constant {value_float = 2.0 : f32 } : tensor<f32>
-  return %0 : tensor<f32>
+  onnx.Return %0 : tensor<f32>
 // CHECK-LABEL:     func @test_constant_2
 // CHECK: [[VAR_0:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<f32>
-// CHECK: return [[VAR_0]] : tensor<f32>
+// CHECK: onnx.Return [[VAR_0]] : tensor<f32>
 }
 
 // -----
 
 func.func @test_constant_3() -> tensor<3xi64> {
   %0 = onnx.Constant {value_ints = [1, 2, 3] } : tensor<3xi64>
-  return %0 : tensor<3xi64>
+  onnx.Return %0 : tensor<3xi64>
 // CHECK-LABEL:       func @test_constant_3
 // CHECK-SAME:     () -> tensor<3xi64> {
 // CHECK:           [[VAR_0:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
-// CHECK:           return [[VAR_0]] : tensor<3xi64>
+// CHECK:           onnx.Return [[VAR_0]] : tensor<3xi64>
 }
 
 // -----
 
 func.func @test_rewrite_batchnormtestmode_Nd(%arg0 : tensor<1x64x112x112xf32>, %scale : tensor<64xf32>, %bias : tensor<64xf32>, %mean : tensor<64xf32>, %var : tensor<64xf32>) -> tensor<1x64x112x112xf32> {
     %0 = "onnx.BatchNormalizationInferenceMode"(%arg0, %scale, %bias, %mean, %var) {epsilon = 1.00000007E-5 : f32} : (tensor<1x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<1x64x112x112xf32>
-    return %0 :  tensor<1x64x112x112xf32>
+    onnx.Return %0 :  tensor<1x64x112x112xf32>
 
   // CHECK-LABEL:  func.func @test_rewrite_batchnormtestmode_Nd
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x112x112xf32>, [[PARAM_1_:%.+]]: tensor<64xf32>, [[PARAM_2_:%.+]]: tensor<64xf32>, [[PARAM_3_:%.+]]: tensor<64xf32>, [[PARAM_4_:%.+]]: tensor<64xf32>) -> tensor<1x64x112x112xf32> {
@@ -664,14 +664,14 @@ func.func @test_rewrite_batchnormtestmode_Nd(%arg0 : tensor<1x64x112x112xf32>, %
   // CHECK:           [[VAR_7_:%.+]] = "onnx.Sub"([[PARAM_2_]], [[VAR_6_]]) : (tensor<64xf32>, tensor<*xf32>) -> tensor<*xf32>
   // CHECK:           [[VAR_8_:%.+]] = "onnx.UnsqueezeV11"([[VAR_7_]]) {axes = [1, 2]} : (tensor<*xf32>) -> tensor<*xf32>
   // CHECK:           [[VAR_9_:%.+]] = "onnx.Add"([[VAR_5_]], [[VAR_8_]]) : (tensor<*xf32>, tensor<*xf32>) -> tensor<1x64x112x112xf32>
-  // CHECK:           return [[VAR_9_]] : tensor<1x64x112x112xf32>
+  // CHECK:           onnx.Return [[VAR_9_]] : tensor<1x64x112x112xf32>
 }
 
 // -----
 
 func.func @test_rewrite_batchnormtestmode_1d(%arg0 : tensor<64xf32>, %scale : tensor<1xf32>, %bias : tensor<1xf32>, %mean : tensor<1xf32>, %var : tensor<1xf32>) -> tensor<64xf32> {
     %0 = "onnx.BatchNormalizationInferenceMode"(%arg0, %scale, %bias, %mean, %var) {epsilon = 1.00000007E-5 : f32} : (tensor<64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<64xf32>
-    return %0 :  tensor<64xf32>
+    onnx.Return %0 :  tensor<64xf32>
 
 // CHECK-LABEL:  func.func @test_rewrite_batchnormtestmode_1d
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<64xf32>, [[PARAM_1_:%.+]]: tensor<1xf32>, [[PARAM_2_:%.+]]: tensor<1xf32>, [[PARAM_3_:%.+]]: tensor<1xf32>, [[PARAM_4_:%.+]]: tensor<1xf32>) -> tensor<64xf32> {
@@ -683,7 +683,7 @@ func.func @test_rewrite_batchnormtestmode_1d(%arg0 : tensor<64xf32>, %scale : te
 // CHECK-DAG:       [[VAR_5_:%.+]] = "onnx.Mul"([[PARAM_3_]], [[VAR_3_]]) : (tensor<1xf32>, tensor<*xf32>) -> tensor<*xf32>
 // CHECK:           [[VAR_6_:%.+]] = "onnx.Sub"([[PARAM_2_]], [[VAR_5_]]) : (tensor<1xf32>, tensor<*xf32>) -> tensor<*xf32>
 // CHECK:           [[VAR_7_:%.+]] = "onnx.Add"([[VAR_4_]], [[VAR_6_]]) : (tensor<*xf32>, tensor<*xf32>) -> tensor<64xf32>
-// CHECK:           return [[VAR_7_]] : tensor<64xf32>
+// CHECK:           onnx.Return [[VAR_7_]] : tensor<64xf32>
 }
 
 // -----
@@ -692,11 +692,11 @@ func.func @test_normalize_add(%arg0 : tensor<2xf32>) -> tensor<2xf32> {
     %cst = "onnx.NoValue"() {value} : () -> none
     %0 = onnx.Constant dense<[0.0, 1.0]> : tensor<2xf32>
     %1 = "onnx.Add"(%0, %arg0) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-    return %1 : tensor<2xf32>
+    onnx.Return %1 : tensor<2xf32>
     // CHECK-LABEL: test_normalize_add
     // CHECK: [[CONSTANT:%.+]] = onnx.Constant dense<[0.000000e+00, 1.000000e+00]> : tensor<2xf32>
     // CHECK: [[RES:%.+]] = "onnx.Add"(%arg0, [[CONSTANT]]) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-    // CHECK: return [[RES]] : tensor<2xf32>
+    // CHECK: onnx.Return [[RES]] : tensor<2xf32>
 }
 
 // -----
@@ -706,12 +706,12 @@ func.func @test_fuse_add_conv(%arg0 : tensor<1x1x28x28xf32>, %arg1 : tensor<8x1x
     %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, none) -> tensor<1x8x28x28xf32>
     %1 = onnx.Constant dense<[[[-0.161539719]], [[-0.433835655]], [[0.091641359]], [[-0.0168522168]], [[-0.0650264397]], [[-0.131737873]], [[0.0204175506]], [[-0.121110231]]]> : tensor<8x1x1xf32>
     %2 = "onnx.Add"(%0, %1) : (tensor<1x8x28x28xf32>, tensor<8x1x1xf32>) -> tensor<1x8x28x28xf32>
-    return %2 : tensor<1x8x28x28xf32>
+    onnx.Return %2 : tensor<1x8x28x28xf32>
 // CHECK-LABEL:  func.func @test_fuse_add_conv
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>) -> tensor<1x8x28x28xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
-// CHECK:           return [[VAR_1_]] : tensor<1x8x28x28xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<1x8x28x28xf32>
 }
 
 // -----
@@ -720,13 +720,13 @@ func.func @test_fuse_add_conv_bias(%arg0 : tensor<1x1x28x28xf32>, %arg1 : tensor
     %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<1x8x28x28xf32>
     %1 = onnx.Constant dense<[[[-0.161539719]], [[-0.433835655]], [[0.091641359]], [[-0.0168522168]], [[-0.0650264397]], [[-0.131737873]], [[0.0204175506]], [[-0.121110231]]]> : tensor<8x1x1xf32>
     %2 = "onnx.Add"(%0, %1) : (tensor<1x8x28x28xf32>, tensor<8x1x1xf32>) -> tensor<1x8x28x28xf32>
-    return %2 : tensor<1x8x28x28xf32>
+    onnx.Return %2 : tensor<1x8x28x28xf32>
 // CHECK-LABEL:  func.func @test_fuse_add_conv_bias
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>, [[PARAM_2_:%.+]]: tensor<8xf32>) -> tensor<1x8x28x28xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[PARAM_2_]], [[VAR_0_]]) : (tensor<8xf32>, tensor<8xf32>) -> tensor<*xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x5x5xf32>, tensor<*xf32>) -> tensor<1x8x28x28xf32>
-// CHECK:           return [[VAR_2_]] : tensor<1x8x28x28xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<1x8x28x28xf32>
 }
 
 // -----
@@ -736,14 +736,14 @@ func.func @test_fuse_add_conv_unranked(%arg0 : tensor<*xf32>, %arg1 : tensor<8x1
     %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<*xf32>, tensor<8x1x5x5xf32>, none) -> tensor<*xf32>
     %1 = onnx.Constant dense<[[[-0.161539719]], [[-0.433835655]], [[0.091641359]], [[-0.0168522168]], [[-0.0650264397]], [[-0.131737873]], [[0.0204175506]], [[-0.121110231]]]> : tensor<8x1x1xf32>
     %2 = "onnx.Add"(%0, %1) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
-    return %2 : tensor<*xf32>
+    onnx.Return %2 : tensor<*xf32>
 // CHECK-LABEL:  func.func @test_fuse_add_conv_unranked
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[{{\[}}[-0.161539719]{{\], \[}}[-0.433835655]{{\], \[}}[0.091641359]{{\], \[}}[-0.0168522168]{{\], \[}}[-0.0650264397]{{\], \[}}[-0.131737873]{{\], \[}}[0.0204175506]{{\], \[}}[-0.121110231]{{\]}}]> : tensor<8x1x1xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[VAR_1_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<*xf32>, tensor<8x1x5x5xf32>, none) -> tensor<*xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_2_]], [[VAR_0_]]) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_3_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<*xf32>
 }
 
 // -----
@@ -752,13 +752,13 @@ func.func @test_fuse_add_conv_bias_unranked(%arg0 : tensor<*xf32>, %arg1 : tenso
     %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<*xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<*xf32>
     %1 = onnx.Constant dense<[[[-0.161539719]], [[-0.433835655]], [[0.091641359]], [[-0.0168522168]], [[-0.0650264397]], [[-0.131737873]], [[0.0204175506]], [[-0.121110231]]]> : tensor<8x1x1xf32>
     %2 = "onnx.Add"(%0, %1) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
-    return %2 : tensor<*xf32>
+    onnx.Return %2 : tensor<*xf32>
 // CHECK-LABEL:  func.func @test_fuse_add_conv_bias_unranked
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<8x1x5x5xf32>, [[PARAM_2_:%.+]]: tensor<8xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[{{\[}}[-0.161539719]{{\], \[}}[-0.433835655]{{\], \[}}[0.091641359]{{\], \[}}[-0.0168522168]{{\], \[}}[-0.0650264397]{{\], \[}}[-0.131737873]{{\], \[}}[0.0204175506]{{\], \[}}[-0.121110231]{{\]}}]> : tensor<8x1x1xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {auto_pad = "SAME_UPPER", dilations = [1, 1], group = 1 : si64, kernel_shape = [5, 5], onnx_node_name = "Convolution28", strides = [1, 1]} : (tensor<*xf32>, tensor<8x1x5x5xf32>, tensor<8xf32>) -> tensor<*xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Add"([[VAR_1_]], [[VAR_0_]]) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_2_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<*xf32>
 }
 
 // -----
@@ -769,7 +769,7 @@ func.func @test_fuse_mul_conv(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
     %2 = "onnx.Conv"(%arg0, %0, %1) {kernel_shape = [2, 2], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x2x2xf32>, none) -> tensor<*xf32>
     %3 = onnx.Constant dense<[[[-0.161539719]], [[-0.433835655]], [[0.091641359]], [[-0.0168522168]], [[-0.0650264397]], [[-0.131737873]], [[0.0204175506]], [[-0.121110231]]]> : tensor<8x1x1xf32>
     %4 = "onnx.Mul"(%2, %3) : (tensor<*xf32>, tensor<8x1x1xf32>) -> tensor<*xf32>
-    return %4 : tensor<*xf32>
+    onnx.Return %4 : tensor<*xf32>
 
   // CHECK-LABEL:  func.func @test_fuse_mul_conv
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
@@ -779,7 +779,7 @@ func.func @test_fuse_mul_conv(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
   // CHECK:           [[VAR_3_:%.+]] = "onnx.UnsqueezeV11"([[VAR_0_]]) {axes = [3]} : (tensor<8x1x1xf32>) -> tensor<*xf32>
   // CHECK:           [[VAR_4_:%.+]] = "onnx.Mul"([[VAR_3_]], [[VAR_1_]]) : (tensor<*xf32>, tensor<8x1x2x2xf32>) -> tensor<*xf32>
   // CHECK:           [[VAR_5_:%.+]] = "onnx.Conv"([[PARAM_0_]], [[VAR_4_]], [[VAR_2_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2, 2], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<*xf32>, none) -> tensor<*xf32>
-  // CHECK:           return [[VAR_5_]] : tensor<*xf32>
+  // CHECK:           onnx.Return [[VAR_5_]] : tensor<*xf32>
 }
 
 // -----
@@ -788,10 +788,10 @@ func.func @test_less(%arg0 : tensor<i32>, %arg1 : tensor<i32>) -> tensor<i1> {
   %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<i32>) -> tensor<f32>
   %1 = "onnx.Cast"(%arg1) {to = f32} : (tensor<i32>) -> tensor<f32>
   %2 = "onnx.Less"(%0, %1) : (tensor<f32>, tensor<f32>) -> tensor<i1>
-  return %2 : tensor<i1>
+  onnx.Return %2 : tensor<i1>
   // CHECK-LABEL: test_less
   // CHECK: [[RES:%.]] = "onnx.Less"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i1>
-  // CHECK: return [[RES]] : tensor<i1>
+  // CHECK: onnx.Return [[RES]] : tensor<i1>
 }
 
 // -----
@@ -801,7 +801,7 @@ func.func @test_less_should_not_remove_cast(%arg0 : tensor<f32>, %arg1 : tensor<
   %0 = "onnx.Cast"(%arg0) {to = ui32} : (tensor<f32>) -> tensor<ui32>
   %1 = "onnx.Cast"(%arg1) {to = ui32} : (tensor<f32>) -> tensor<ui32>
   %2 = "onnx.Less"(%0, %1) : (tensor<ui32>, tensor<ui32>) -> tensor<i1>
-  return %2 : tensor<i1>
+  onnx.Return %2 : tensor<i1>
   // CHECK-LABEL: test_less_should_not_remove_cast
   // CHECK: "onnx.Cast"
   // CHECK: "onnx.Cast"
@@ -825,7 +825,7 @@ func.func @test_loop_derive_max_trip_count(%arg0: tensor<?x30xf32>) -> tensor<?x
     %8 = "onnx.Less"(%6, %arg4) : (tensor<i32>, tensor<i32>) -> tensor<i1>
     onnx.Yield %8, %6, %arg4, %7 : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
   }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
-  return %4#3 : tensor<?x?x30xf32>
+  onnx.Return %4#3 : tensor<?x?x30xf32>
 // CHECK-LABEL:  func.func @test_loop_derive_max_trip_count
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x30xf32>) -> tensor<?x?x30xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<8> : tensor<i64>
@@ -839,7 +839,7 @@ func.func @test_loop_derive_max_trip_count(%arg0: tensor<?x30xf32>) -> tensor<?x
 // CHECK-DAG:         [[VAR_7_:%.+]] = "onnx.Relu"([[arg5_]]) : (tensor<?x30xf32>) -> tensor<?x30xf32>
 // CHECK:             onnx.Yield [[arg2_]], [[VAR_6_]], [[arg4_]], [[VAR_7_]] : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
 // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
-// CHECK:           return [[VAR_5_]]#3 : tensor<?x?x30xf32>
+// CHECK:           onnx.Return [[VAR_5_]]#3 : tensor<?x?x30xf32>
 
 }
 
@@ -859,7 +859,7 @@ func.func @test_loop_derive_max_trip_count_non_constant_ub(%arg0: tensor<?x30xf3
     %7 = "onnx.Less"(%5, %arg5) : (tensor<i32>, tensor<i32>) -> tensor<i1>
     onnx.Yield %7, %5, %arg5, %6 : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
   }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
-  return %3#3 : tensor<?x?x30xf32>
+  onnx.Return %3#3 : tensor<?x?x30xf32>
 // CHECK-LABEL:  func @test_loop_derive_max_trip_count_non_constant_ub
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x30xf32>, [[PARAM_1_:%.+]]: tensor<i32>) -> tensor<?x?x30xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<i32>
@@ -881,7 +881,7 @@ func.func @test_loop_derive_max_trip_count_non_constant_ub(%arg0: tensor<?x30xf3
 // CHECK-DAG:         [[VAR_15_:%.+]] = "onnx.Relu"([[arg6_]]) : (tensor<?x30xf32>) -> tensor<?x30xf32>
 // CHECK:             onnx.Yield [[arg3_]], [[VAR_14_]], [[arg5_]], [[VAR_15_]] : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
 // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
-// CHECK:           return [[VAR_13_]]#3 : tensor<?x?x30xf32>
+// CHECK:           onnx.Return [[VAR_13_]]#3 : tensor<?x?x30xf32>
 
 }
 
@@ -890,7 +890,7 @@ func.func @test_loop_derive_max_trip_count_non_constant_ub(%arg0: tensor<?x30xf3
 func.func @test_rnn_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<1x3x3xf32>, %arg3: tensor<5x1x3xf32>) -> tensor<5x1x3xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %arg3) {layout = 1 : si64} : (tensor<5x4x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, tensor<5x1x3xf32>) -> (tensor<5x4x1x3xf32>, tensor<5x1x3xf32>)
-  return %Y_h : tensor<5x1x3xf32>
+  onnx.Return %Y_h : tensor<5x1x3xf32>
 // CHECK-LABEL:  func.func @test_rnn_layout1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x4x2xf32>, [[PARAM_1_:%.+]]: tensor<1x3x2xf32>, [[PARAM_2_:%.+]]: tensor<1x3x3xf32>, [[PARAM_3_:%.+]]: tensor<5x1x3xf32>) -> tensor<5x1x3xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
@@ -898,7 +898,7 @@ func.func @test_rnn_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x3x2xf32>, 
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Transpose"([[PARAM_3_]]) {perm = [1, 0, 2]} : (tensor<5x1x3xf32>) -> tensor<1x5x3xf32>
 // CHECK:           %Y, %Y_h = "onnx.RNN"([[VAR_1_]], [[PARAM_1_]], [[PARAM_2_]], [[VAR_0_]], [[VAR_0_]], [[VAR_2_]]) {activations = ["Tanh", "Tanh"], direction = "forward", hidden_size = 3 : si64, layout = 0 : si64} : (tensor<4x5x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, tensor<1x5x3xf32>) -> (tensor<4x1x5x3xf32>, tensor<1x5x3xf32>)
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Transpose"(%Y_h) {perm = [1, 0, 2]} : (tensor<1x5x3xf32>) -> tensor<5x1x3xf32>
-// CHECK:           return [[VAR_3_]] : tensor<5x1x3xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<5x1x3xf32>
 // CHECK:         }
 }
 
@@ -907,7 +907,7 @@ func.func @test_rnn_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x3x2xf32>, 
 func.func @test_gru_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x9x2xf32>, %arg2: tensor<1x9x3xf32>) -> (tensor<5x4x1x3xf32>, tensor<5x1x3xf32>) {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {layout = 1 : si64} : (tensor<5x4x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<5x4x1x3xf32>, tensor<5x1x3xf32>)
-  return %Y, %Y_h : tensor<5x4x1x3xf32>, tensor<5x1x3xf32>
+  onnx.Return %Y, %Y_h : tensor<5x4x1x3xf32>, tensor<5x1x3xf32>
 // CHECK-LABEL:  func.func @test_gru_layout1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x4x2xf32>, [[PARAM_1_:%.+]]: tensor<1x9x2xf32>, [[PARAM_2_:%.+]]: tensor<1x9x3xf32>) -> (tensor<5x4x1x3xf32>, tensor<5x1x3xf32>) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
@@ -915,7 +915,7 @@ func.func @test_gru_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x9x2xf32>, 
 // CHECK:           %Y, %Y_h = "onnx.GRU"([[VAR_1_]], [[PARAM_1_]], [[PARAM_2_]], [[VAR_0_]], [[VAR_0_]], [[VAR_0_]]) {direction = "forward", hidden_size = 3 : si64, layout = 0 : si64, linear_before_reset = 0 : si64} : (tensor<4x5x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<4x1x5x3xf32>, tensor<1x5x3xf32>)
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Transpose"(%Y) {perm = [2, 0, 1, 3]} : (tensor<4x1x5x3xf32>) -> tensor<5x4x1x3xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Transpose"(%Y_h) {perm = [1, 0, 2]} : (tensor<1x5x3xf32>) -> tensor<5x1x3xf32>
-// CHECK:           return [[VAR_2_]], [[VAR_3_]] : tensor<5x4x1x3xf32>, tensor<5x1x3xf32>
+// CHECK:           onnx.Return [[VAR_2_]], [[VAR_3_]] : tensor<5x4x1x3xf32>, tensor<5x1x3xf32>
 // CHECK:         }
 }
 
@@ -924,7 +924,7 @@ func.func @test_gru_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x9x2xf32>, 
 func.func @test_lstm_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>, %arg3: tensor<5x1x3xf32>) -> tensor<5x1x3xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %arg3, %cst) {layout = 1 : si64} : (tensor<5x4x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, tensor<5x1x3xf32>, none) -> (tensor<5x4x1x3xf32>, none, tensor<5x1x3xf32>)
-  return %Y_c : tensor<5x1x3xf32>
+  onnx.Return %Y_c : tensor<5x1x3xf32>
 // CHECK-LABEL:  func.func @test_lstm_layout1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x4x2xf32>, [[PARAM_1_:%.+]]: tensor<1x12x2xf32>, [[PARAM_2_:%.+]]: tensor<1x12x3xf32>, [[PARAM_3_:%.+]]: tensor<5x1x3xf32>) -> tensor<5x1x3xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
@@ -932,7 +932,7 @@ func.func @test_lstm_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x12x2xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Transpose"([[PARAM_3_]]) {perm = [1, 0, 2]} : (tensor<5x1x3xf32>) -> tensor<1x5x3xf32>
 // CHECK:           %Y, %Y_h, %Y_c = "onnx.LSTM"([[VAR_1_]], [[PARAM_1_]], [[PARAM_2_]], [[VAR_0_]], [[VAR_0_]], [[VAR_0_]], [[VAR_2_]], [[VAR_0_]]) {direction = "forward", hidden_size = 3 : si64, input_forget = 0 : si64, layout = 0 : si64} : (tensor<4x5x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, tensor<1x5x3xf32>, none) -> (tensor<4x1x5x3xf32>, none, tensor<1x5x3xf32>)
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Transpose"(%Y_c) {perm = [1, 0, 2]} : (tensor<1x5x3xf32>) -> tensor<5x1x3xf32>
-// CHECK:           return [[VAR_3_]] : tensor<5x1x3xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<5x1x3xf32>
 // CHECK:         }
 }
 
@@ -940,35 +940,35 @@ func.func @test_lstm_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x12x2xf32>
 
 func.func @test_dim_to_constant(%arg0: tensor<?x256xi64>) -> (tensor<1xi64>) {
   %0 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
-  return %0 : tensor<1xi64>
+  onnx.Return %0 : tensor<1xi64>
 
 // CHECK-LABEL: test_dim_to_constant
 // CHECK-NOT: "onnx.Dim"
 // CHECK:     [[RES:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
-// CHECK:     return [[RES]] : tensor<1xi64>
+// CHECK:     onnx.Return [[RES]] : tensor<1xi64>
 }
 
 // -----
 
 func.func @test_layout_transform(%arg0: tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>) -> tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>> {
     %0 = "onnx.LayoutTransform"(%arg0) {target_layout = #onnx.layout<{dataLayout = "NCHW4C"}>} : (tensor<5x3x32x32xf32,#onnx.layout<{dataLayout = "NCHW4C"}>>) -> tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>
-    return %0 : tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>
+    onnx.Return %0 : tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>
 
 // CHECK-LABEL: test_layout_transform
 // CHECK-NOT: "onnx.LayoutTransform"
-// CHECK: return
+// CHECK: onnx.Return
 }
 
 // -----
 
 func.func @test_softmax_v11_ranked(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
   %0 = "onnx.SoftmaxV11"(%arg0) {axis = 2 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
-  return %0 : tensor<10x20x30xf32>
+  onnx.Return %0 : tensor<10x20x30xf32>
 
 // CHECK-LABEL:  func.func @test_softmax_v11_ranked
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x20x30xf32>) -> tensor<10x20x30xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = 2 : si64} : (tensor<10x20x30xf32>) -> tensor<10x20x30xf32>
-// CHECK:           return [[VAR_0_]] : tensor<10x20x30xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<10x20x30xf32>
 // CHECK:         }
 }
 
@@ -976,7 +976,7 @@ func.func @test_softmax_v11_ranked(%arg0 : tensor<10x20x30xf32>) -> tensor<10x20
 
 func.func @test_softmax_v11_unranked_unchanged(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.SoftmaxV11"(%arg0) {axis = 2 : si64} : (tensor<*xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
 // CHECK-LABEL:  func.func @test_softmax_v11_unranked_unchanged
 // CHECK: "onnx.SoftmaxV11"
@@ -986,12 +986,12 @@ func.func @test_softmax_v11_unranked_unchanged(%arg0 : tensor<*xf32>) -> tensor<
 
 func.func @test_softmax_v11_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.SoftmaxV11"(%arg0) {axis = -1 : si64} : (tensor<*xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
 // CHECK-LABEL:  func.func @test_softmax_v11_unranked
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Softmax"([[PARAM_0_]]) {axis = -1 : si64} : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_0_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
 // CHECK:         }
 }
 
@@ -1002,13 +1002,13 @@ func.func @test_softmax_v11_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
 func.func @shape_transform_compose(%arg0: tensor<128x128xf32>) -> tensor<2x4x32x64xf32> {
   %0 = "onnx.ShapeTransform"(%arg0) {index_map = #reshape} : (tensor<128x128xf32>) -> tensor<4x32x2x64xf32>
   %1 = "onnx.ShapeTransform"(%0) {index_map = #transpose} : (tensor<4x32x2x64xf32>) -> tensor<2x4x32x64xf32>
-  return %1 : tensor<2x4x32x64xf32>
+  onnx.Return %1 : tensor<2x4x32x64xf32>
 
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d1 floordiv 64, d0 floordiv 32, d0 mod 32, d1 mod 64)>
 // CHECK-LABEL:  func.func @shape_transform_compose
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x128xf32>) -> tensor<2x4x32x64xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ShapeTransform"([[PARAM_0_]]) {index_map = #map} : (tensor<128x128xf32>) -> tensor<2x4x32x64xf32>
-// CHECK:           return [[VAR_0_]] : tensor<2x4x32x64xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<2x4x32x64xf32>
 // CHECK:         }
 }
 
@@ -1018,11 +1018,11 @@ func.func @shape_transform_compose(%arg0: tensor<128x128xf32>) -> tensor<2x4x32x
 #identity = affine_map<(d0, d1) -> (d0, d1)>
 func.func @shape_transform_identity_map(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
   %0 = "onnx.ShapeTransform"(%arg0) {index_map = #identity} : (tensor<128x128xf32>) -> tensor<128x128xf32>
-  return %0 : tensor<128x128xf32>
+  onnx.Return %0 : tensor<128x128xf32>
 
 // CHECK-LABEL:  func.func @shape_transform_identity_map
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x128xf32>) -> tensor<128x128xf32> {
-// CHECK:           return [[PARAM_0_]] : tensor<128x128xf32>
+// CHECK:           onnx.Return [[PARAM_0_]] : tensor<128x128xf32>
 // CHECK:         }
 }
 
@@ -1032,14 +1032,14 @@ func.func @shape_transform_identity_map(%arg0: tensor<128x128xf32>) -> tensor<12
 func.func @expand_pow_into_mul(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
     %cst = onnx.Constant dense<5.0> : tensor<f32>
     %0 = "onnx.Pow"(%arg0, %cst) : (tensor<3x4x5xf32>, tensor<f32>) -> tensor<3x4x5xf32>
-    return %0 : tensor<3x4x5xf32>
+    onnx.Return %0 : tensor<3x4x5xf32>
 
 // CHECK-LABEL:  func.func @expand_pow_into_mul
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[PARAM_0_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_1_]], [[VAR_1_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-// CHECK:           return [[VAR_3_]] : tensor<3x4x5xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<3x4x5xf32>
 // CHECK:        }
 }
 
@@ -1050,7 +1050,7 @@ func.func @expand_pow_into_mul(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
 func.func @expand_pow_into_mul13(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
     %cst = onnx.Constant dense<13.0> : tensor<f32>
     %0 = "onnx.Pow"(%arg0, %cst) : (tensor<3x4x5xf32>, tensor<f32>) -> tensor<3x4x5xf32>
-    return %0 : tensor<3x4x5xf32>
+    onnx.Return %0 : tensor<3x4x5xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @expand_pow_into_mul13
@@ -1060,7 +1060,7 @@ func.func @expand_pow_into_mul13(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> 
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Mul"([[VAR_1_]], [[VAR_1_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
 // CHECK:           [[VAR_4_:%.+]] = "onnx.Mul"([[VAR_2_]], [[VAR_3_]]) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-// CHECK:           return [[VAR_4_]] : tensor<3x4x5xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<3x4x5xf32>
 // CHECK:         }
 }
 
@@ -1069,12 +1069,12 @@ func.func @expand_pow_into_mul13(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> 
 func.func @expand_pow_into_constant(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
     %cst = onnx.Constant dense<0.0> : tensor<f32>
     %0 = "onnx.Pow"(%arg0, %cst) : (tensor<3x4x5xf32>, tensor<f32>) -> tensor<3x4x5xf32>
-    return %0 : tensor<3x4x5xf32>
+    onnx.Return %0 : tensor<3x4x5xf32>
 
 // CHECK-LABEL:  func.func @expand_pow_into_constant
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<3x4x5xf32>
-// CHECK:           return [[VAR_0_]] : tensor<3x4x5xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4x5xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -232,12 +232,12 @@ func.func @test_reshape_should_not_remove(%arg0: tensor<3x5x10x20xf32>, %arg1: t
 // Check EmptyTensorInputsResizePattern. Example from yolov4 model after --decompose-onnx.
 func.func @test_resize_empty_tensor_inputs(%8: tensor<0xf32>, %714: tensor<*xf32>, %719: tensor<*xi64>) -> tensor<*xf32> {
   %720 = "onnx.Resize"(%714, %8, %8, %719) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor"} : (tensor<*xf32>, tensor<0xf32>, tensor<0xf32>, tensor<*xi64>) -> tensor<*xf32>
-  return %720 : tensor<*xf32>
+  onnx.Return %720 : tensor<*xf32>
   // CHECK-LABEL: func @test_resize_empty_tensor_inputs
   // CHECK-SAME:  ([[PARAM_0:%.+]]: tensor<0xf32>, [[PARAM_1:%.+]]: tensor<*xf32>, [[PARAM_2:%.+]]: tensor<*xi64>) -> tensor<*xf32> {
   // CHECK:         [[NONE:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:         [[RES:%.+]] = "onnx.Resize"([[PARAM_1]], [[NONE]], [[NONE]], [[PARAM_2]]) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor"} : (tensor<*xf32>, none, none, tensor<*xi64>) -> tensor<*xf32>
-  // CHECK:         return [[RES]] : tensor<*xf32>
+  // CHECK:         onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
@@ -1083,13 +1083,13 @@ func.func @expand_pow_into_constant(%arg0: tensor<3x4x5xf32>) -> tensor<3x4x5xf3
 // Check BinaryOpBroadcastAxisPattern. Example from inception-v2-6 model.
 func.func @mul_broadcast_axis_unsqueeze(%279: tensor<1x64x112x112xf32>, %138: tensor<64xf32>) -> tensor<*xf32> {
   %280 = "onnx.Mul"(%279, %138) {axis = 1 : si64, broadcast = 1 : si64} : (tensor<1x64x112x112xf32>, tensor<64xf32>) -> tensor<*xf32>
-  return %280 : tensor<*xf32>
+  onnx.Return %280 : tensor<*xf32>
 
 // CHECK-LABEL:  func.func @mul_broadcast_axis_unsqueeze
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x64x112x112xf32>, [[PARAM_1_:%.+]]: tensor<64xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[PARAM_1_]], [[VAR_0_]]) : (tensor<64xf32>, tensor<2xi64>) -> tensor<64x1x1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<1x64x112x112xf32>, tensor<64x1x1xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_2_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<*xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -10,7 +10,7 @@ func.func @test_scalar_attr() -> tensor<f32> {
   %0 = onnx.Constant dense<1.0> : tensor<f32>
   %1 = onnx.Constant dense<2.0> : tensor<f32>
   %2 = "onnx.Add"(%0, %1) : (tensor<f32> , tensor<f32>) -> tensor<f32>
-  "func.return"(%2) : (tensor<f32>) -> ()
+  "onnx.Return"(%2) : (tensor<f32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<f32>
 }
 
@@ -21,7 +21,7 @@ func.func @test_single_value_attr() -> tensor<1xf32> {
   %0 = onnx.Constant dense<[1.0]> : tensor<1xf32>
   %1 = onnx.Constant dense<[2.0]> : tensor<1xf32>
   %2 = "onnx.Add"(%0, %1) : (tensor<1xf32> , tensor<1xf32>) -> tensor<1xf32>
-  "func.return"(%2) : (tensor<1xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<1xf32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<1xf32>
 }
 
@@ -32,7 +32,7 @@ func.func @test_splat_attr() -> tensor<3xf32> {
   %0 = onnx.Constant dense<1.0> : tensor<3xf32>
   %1 = onnx.Constant dense<2.0> : tensor<3xf32>
   %2 = "onnx.Add"(%0, %1) : (tensor<3xf32> , tensor<3xf32>) -> tensor<3xf32>
-  "func.return"(%2) : (tensor<3xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<3xf32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<3xf32>
 }
 
@@ -43,7 +43,7 @@ func.func @test_splat_nonsplat_attrs() -> tensor<3xf32> {
   %0 = onnx.Constant dense<1.0> : tensor<3xf32>
   %1 = onnx.Constant dense<[0.0, 1.0, 2.0]> : tensor<3xf32>
   %2 = "onnx.Add"(%0, %1) : (tensor<3xf32> , tensor<3xf32>) -> tensor<3xf32>
-  "func.return"(%2) : (tensor<3xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<3xf32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf32>
 }
 
@@ -60,7 +60,7 @@ func.func @test_splat_nonsplat_attrs() -> tensor<3xf32> {
 func.func @test_add_constant_1(%arg0 : tensor<3xf32>) -> tensor<3xf32> {
   %0 = onnx.Constant dense<[0.0, 1.0, 2.0]> : tensor<3xf32>
   %1 = "onnx.Add"(%0, %arg0) : (tensor<3xf32> , tensor<3xf32>) -> tensor<3xf32>
-  "func.return"(%1) : (tensor<3xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<3xf32>) -> ()
   // CHECK-NEXT: [[CONST:%.+]] = onnx.Constant dense<[0.000000e+00, 1.000000e+00, 2.000000e+00]> : tensor<3xf32>
   // CHECK-NEXT: [[ADD:%.+]] =  "onnx.Add"(%arg0, [[CONST]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
 }
@@ -73,7 +73,7 @@ func.func @test_add_constant_1(%arg0 : tensor<3xf32>) -> tensor<3xf32> {
 func.func @test_add_constant_2(%arg0 : tensor<3xf32>) -> tensor<3xf32> {
   %0 = onnx.Constant dense<[0.0, 1.0, 2.0]> : tensor<3xf32>
   %1 = "onnx.Add"(%arg0, %0) : (tensor<3xf32> , tensor<3xf32>) -> tensor<3xf32>
-  "func.return"(%1) : (tensor<3xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<3xf32>) -> ()
   // CHECK-NEXT: [[CONST:%.+]] = onnx.Constant dense<[0.000000e+00, 1.000000e+00, 2.000000e+00]> : tensor<3xf32>
   // CHECK-NEXT: [[ADD:%.+]] =  "onnx.Add"(%arg0, [[CONST]]) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
 }
@@ -88,7 +88,7 @@ func.func @test_add_constant_3(%arg0 : tensor<3xi32>) -> tensor<3xi32> {
   %1 = onnx.Constant dense<[10, 11, 12]> : tensor<3xi32>
   %2 = "onnx.Add"(%0, %arg0) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
   %3 = "onnx.Add"(%1, %2) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
-  "func.return"(%3) : (tensor<3xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<3xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<[10, 12, 14]> : tensor<3xi32>
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
 }
@@ -104,7 +104,7 @@ func.func @test_add_constant_4(%arg0 : tensor<3xi32>) -> tensor<3xi32> {
   %2 = "onnx.Add"(%0, %arg0) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
   %3 = "onnx.Add"(%1, %2) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
   %4 = "onnx.Add"(%2, %3) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
-  "func.return"(%4) : (tensor<3xi32>) -> ()
+  "onnx.Return"(%4) : (tensor<3xi32>) -> ()
 // CHECK-LABEL: @test_add_constant_4(%arg0: tensor<3xi32>) -> tensor<3xi32> 
   // CHECK-DAG: [[CONST1:%.+]] = onnx.Constant dense<[10, 13, 16]> : tensor<3xi32>
   // CHECK-DAG: [[ADD1:%.+]] = "onnx.Add"(%arg0, %arg0) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
@@ -123,7 +123,7 @@ func.func @test_add_constant_5(%arg0 : tensor<3xi32>, %arg1: tensor<3xi32>, %arg
   %3 = "onnx.Add"(%2, %arg1) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
   %4 = "onnx.Add"(%1, %arg2) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
   %5 = "onnx.Add"(%3, %4) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
-  "func.return"(%5) : (tensor<3xi32>) -> ()
+  "onnx.Return"(%5) : (tensor<3xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<[10, 12, 14]> : tensor<3xi32>
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, %arg1) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
   // CHECK-NEXT: [[ADD2:%.+]] = "onnx.Add"([[ADD1]], %arg2) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
@@ -136,8 +136,8 @@ func.func @test_add_constant_5(%arg0 : tensor<3xi32>, %arg1: tensor<3xi32>, %arg
 func.func @test_add_zeros(%arg0 : tensor<3xi32>) -> tensor<3xi32> {
   %0 = onnx.Constant dense<[0, 0, 0]> : tensor<3xi32>
   %1 = "onnx.Add"(%arg0, %0) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
-  return %1 : tensor<3xi32>
-  // CHECK: return %arg0 : tensor<3xi32>
+  onnx.Return %1 : tensor<3xi32>
+  // CHECK: onnx.Return %arg0 : tensor<3xi32>
 }
 
 /// Test broadcast 1 -> 2d
@@ -150,7 +150,7 @@ func.func @test_broadcast_1(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   %1 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi32>
   %2 = "onnx.Add"(%0, %1) : (tensor<1xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
   %3 = "onnx.Add"(%2, %arg0) : (tensor<3x2xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
-  "func.return"(%3) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<3x2xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<{{.}}[3, 4], [5, 6], [7, 8]]> : tensor<3x2xi32>
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<3x2xi32>
 }
@@ -165,7 +165,7 @@ func.func @test_broadcast_2(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   %1 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi32>
   %2 = "onnx.Add"(%0, %1) : (tensor<1x1xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
   %3 = "onnx.Add"(%2, %arg0) : (tensor<3x2xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
-  "func.return"(%3) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<3x2xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<{{.}}[3, 4], [5, 6], [7, 8]]> : tensor<3x2xi32>
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<3x2xi32>
 }
@@ -180,7 +180,7 @@ func.func @test_broadcast_3(%arg0 : tensor<3x2xi32>) -> tensor<3x2xi32> {
   %1 = onnx.Constant dense<[[10, 11], [21, 22], [31, 32]]> : tensor<3x2xi32>
   %2 = "onnx.Add"(%0, %1) : (tensor<3x1xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
   %3 = "onnx.Add"(%2, %arg0) : (tensor<3x2xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
-  "func.return"(%3) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<3x2xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<{{.}}[11, 12], [23, 24], [34, 35]]> : tensor<3x2xi32>
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<3x2xi32>
 }
@@ -199,7 +199,7 @@ func.func @test_mul_constant_3(%arg0 : tensor<3xi32>) -> tensor<3xi32> {
   %1 = onnx.Constant dense<[10, 11, 12]> : tensor<3xi32>
   %2 = "onnx.Mul"(%0, %arg0) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
   %3 = "onnx.Mul"(%1, %2) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
-  "func.return"(%3) : (tensor<3xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<3xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<[0, 11, 24]> : tensor<3xi32>
   // CHECK-NEXT: [[MUL1:%.+]] = "onnx.Mul"(%arg0, [[CONST1]]) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
 }
@@ -216,7 +216,7 @@ func.func @test_mul_constant_5(%arg0 : tensor<3xi32>, %arg1: tensor<3xi32>, %arg
   %3 = "onnx.Mul"(%2, %arg1) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
   %4 = "onnx.Mul"(%1, %arg2) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
   %5 = "onnx.Mul"(%3, %4) : (tensor<3xi32> , tensor<3xi32>) -> tensor<3xi32>
-  "func.return"(%5) : (tensor<3xi32>) -> ()
+  "onnx.Return"(%5) : (tensor<3xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<[0, 11, 24]> : tensor<3xi32>
   // CHECK-NEXT: [[MUL1:%.+]] = "onnx.Mul"(%arg0, %arg1) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
   // CHECK-NEXT: [[MUL2:%.+]] = "onnx.Mul"([[MUL1]], %arg2) : (tensor<3xi32>, tensor<3xi32>) -> tensor<3xi32>
@@ -229,8 +229,8 @@ func.func @test_mul_constant_5(%arg0 : tensor<3xi32>, %arg1: tensor<3xi32>, %arg
 func.func @test_mul_ones(%arg0 : tensor<2x2xf32>) -> tensor<2x2xf32> {
   %0 = onnx.Constant dense<1.0> : tensor<2x2xf32>
   %1 = "onnx.Mul"(%arg0, %0) : (tensor<2x2xf32> , tensor<2x2xf32>) -> tensor<2x2xf32>
-  return %1 : tensor<2x2xf32>
-  // CHECK: return %arg0 : tensor<2x2xf32>
+  onnx.Return %1 : tensor<2x2xf32>
+  // CHECK: onnx.Return %arg0 : tensor<2x2xf32>
 }
 
 //===----------------------------------------------------------------------===//
@@ -245,7 +245,7 @@ func.func @test_sub_1(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   %0 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi32>
   %1 = onnx.Constant dense<[[2]]> : tensor<1x1xi32>
   %2 = "onnx.Sub"(%0, %1) : (tensor<3x2xi32>, tensor<1x1xi32>) -> tensor<3x2xi32>
-  "func.return"(%2) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<3x2xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<{{.}}[0, 1], [2, 3], [4, 5]]> : tensor<3x2xi32>
 }
 
@@ -255,8 +255,8 @@ func.func @test_sub_1(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
 func.func @test_sub_zeros(%arg0 : tensor<f32>) -> tensor<f32> {
   %0 = onnx.Constant dense<0.0> : tensor<f32>
   %1 = "onnx.Sub"(%arg0, %0) : (tensor<f32> , tensor<f32>) -> tensor<f32>
-  return %1 : tensor<f32>
-  // CHECK: return %arg0 : tensor<f32>
+  onnx.Return %1 : tensor<f32>
+  // CHECK: onnx.Return %arg0 : tensor<f32>
 }
 
 /// check sub to add of negative
@@ -267,7 +267,7 @@ func.func @test_sub_zeros(%arg0 : tensor<f32>) -> tensor<f32> {
 func.func @test_neg_1(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   %0 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi32>
   %1 = "onnx.Sub"(%arg0, %0) : (tensor<3x2xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
-  "func.return"(%1) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%1) : (tensor<3x2xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<{{.}}[-2, -3], [-4, -5], [-6, -7]]> : tensor<3x2xi32>
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<3x2xi32>
 }
@@ -280,7 +280,7 @@ func.func @test_neg_2(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   %1 = onnx.Constant dense<[[10]]> : tensor<1x1xi32>
   %2 = "onnx.Sub"(%arg0, %0) : (tensor<3x2xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
   %5 = "onnx.Add"(%2, %1) : (tensor<3x2xi32> , tensor<1x1xi32>) -> tensor<3x2xi32>
-  "func.return"(%5) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%5) : (tensor<3x2xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<{{.}}[8, 7], [6, 5], [4, 3]]> : tensor<3x2xi32>
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<3x2xi32>
 }
@@ -294,7 +294,7 @@ func.func @test_neg_3(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   %2 = "onnx.Neg"(%0) : (tensor<3x2xi32>) -> tensor<3x2xi32>
   %3 = "onnx.Add"(%arg0, %2) : (tensor<3x2xi32> , tensor<3x2xi32>) -> tensor<3x2xi32>
   %4 = "onnx.Add"(%3, %1) : (tensor<3x2xi32> , tensor<1x1xi32>) -> tensor<3x2xi32>
-  "func.return"(%4) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%4) : (tensor<3x2xi32>) -> ()
   // CHECK-NEXT: [[CONST1:%.+]] = onnx.Constant dense<{{.}}[8, 7], [6, 5], [4, 3]]> : tensor<3x2xi32>
   // CHECK-NEXT: [[ADD1:%.+]] = "onnx.Add"(%arg0, [[CONST1]]) : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<3x2xi32>
 }
@@ -308,9 +308,9 @@ func.func @test_neg_3(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
   func.func @test_default_transpose_const_1() -> tensor<*xi32> {
   %0 = onnx.Constant dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>
   %1 = "onnx.Transpose"(%0) : (tensor<2x3x4xi32>) -> tensor<*xi32>
-  "func.return"(%1) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xi32>) -> ()
   // CHECK: [[RES:%.+]] = onnx.Constant dense<[{{.}}[111, 211], [121, 221], [131, 231]{{.}}, [{{.}}112, 212], [122, 222], [132, 232]{{.}}, [{{.}}113, 213], [123, 223], [133, 233]{{.}}, [{{.}}114, 214], [124, 224], [134, 234]{{.}}]> : tensor<4x3x2xi32>
-  // CHECK: return [[RES]] : tensor<4x3x2xi32>
+  // CHECK: onnx.Return [[RES]] : tensor<4x3x2xi32>
 }
 
 // -----  
@@ -319,9 +319,9 @@ func.func @test_neg_3(%arg0: tensor<3x2xi32>) -> tensor<3x2xi32> {
 func.func @test_default_transpose_const_2() -> tensor<*xi32> {
   %0 = onnx.Constant dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>
   %1 = "onnx.Transpose"(%0) {perm = [0, 2, 1]} : (tensor<2x3x4xi32>) -> tensor<*xi32>
-  "func.return"(%1) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xi32>) -> ()
   // CHECK: [[RES:%.+]] = onnx.Constant dense<[{{.}}[111, 121, 131], [112, 122, 132], [113, 123, 133], [114, 124, 134]{{.}}, [{{.}}211, 221, 231], [212, 222, 232], [213, 223, 233], [214, 224, 234]{{.}}]> : tensor<2x4x3xi32>
-  // CHECK: return [[RES]] : tensor<2x4x3xi32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x4x3xi32>
 }
 
 // -----  
@@ -330,9 +330,9 @@ func.func @test_default_transpose_const_2() -> tensor<*xi32> {
 func.func @test_default_transpose_const_3() -> tensor<*xi32> {
   %0 = onnx.Constant dense<[[[111, 112, 113, 114], [121, 122, 123, 124], [131, 132, 133, 134]], [[211, 212, 213, 214], [221, 222, 223, 224], [231, 232, 233, 234]]]> : tensor<2x3x4xi32>
   %1 = "onnx.Transpose"(%0) {perm = [1, 0, 2]} : (tensor<2x3x4xi32>) -> tensor<*xi32>
-  "func.return"(%1) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xi32>) -> ()
   // CHECK: [[RES:%.+]] =  onnx.Constant dense<[{{.}}[111, 112, 113, 114], [211, 212, 213, 214]{{.}}, [{{.}}121, 122, 123, 124], [221, 222, 223, 224]{{.}}, [{{.}}131, 132, 133, 134], [231, 232, 233, 234]{{.}}]> : tensor<3x2x4xi32>
-  // CHECK: return [[RES]] : tensor<3x2x4xi32>
+  // CHECK: onnx.Return [[RES]] : tensor<3x2x4xi32>
 }
 
 //===----------------------------------------------------------------------===//
@@ -345,7 +345,7 @@ func.func @test_div() -> tensor<3x2xf32> {
   %0 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
   %1 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
   %2 = "onnx.Div"(%0, %1) : (tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
-  "func.return"(%2) : (tensor<3x2xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<3x2xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00]{{\]}}> : tensor<3x2xf32>
   // CHECK-NOT: {{.*}} = "onnx.Div"{{.*}}
 }
@@ -356,8 +356,8 @@ func.func @test_div() -> tensor<3x2xf32> {
 func.func @test_div_ones(%arg0 : tensor<1x2xui8>) -> tensor<1x2xui8> {
   %0 = onnx.Constant dense<[[1, 1]]> : tensor<1x2xui8>
   %1 = "onnx.Div"(%arg0, %0) : (tensor<1x2xui8> , tensor<1x2xui8>) -> tensor<1x2xui8>
-  return %1 : tensor<1x2xui8>
-  // CHECK: return %arg0 : tensor<1x2xui8>
+  onnx.Return %1 : tensor<1x2xui8>
+  // CHECK: onnx.Return %arg0 : tensor<1x2xui8>
 }
 
 //===----------------------------------------------------------------------===//
@@ -370,7 +370,7 @@ func.func @test_equal() -> tensor<1xi1> {
   %0 = onnx.Constant dense<2> : tensor<1xi64>
   %1 = onnx.Constant dense<-1> : tensor<1xi64>
   %2 = "onnx.Equal"(%0, %1) : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi1>
-  "func.return"(%2) : (tensor<1xi1>) -> ()
+  "onnx.Return"(%2) : (tensor<1xi1>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<false> : tensor<1xi1>
   // CHECK-NOT: {{.*}} = "onnx.Equal"{{.*}}
 }
@@ -384,7 +384,7 @@ func.func @test_equal() -> tensor<1xi1> {
 func.func @test_sqrt() -> tensor<1x2xf32> {
   %0 = onnx.Constant dense<[[4.0, 16.0]]> : tensor<1x2xf32>
   %1 = "onnx.Sqrt"(%0) : (tensor<1x2xf32>) -> tensor<1x2xf32>
-  "func.return"(%1) : (tensor<1x2xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<1x2xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[2.000000e+00, 4.000000e+00]{{\]}}> : tensor<1x2xf32>
   // CHECK-NOT: {{.*}} = "onnx.Sqrt"{{.*}}
 }
@@ -397,7 +397,7 @@ func.func @test_sqrt() -> tensor<1x2xf32> {
 func.func @test_relu() -> tensor<1x2xf32> {
   %0 = onnx.Constant dense<[[-4.0, 16.0]]> : tensor<1x2xf32>
   %1 = "onnx.Relu"(%0) : (tensor<1x2xf32>) -> tensor<1x2xf32>
-  "func.return"(%1) : (tensor<1x2xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<1x2xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.600000e+01]{{\]}}> : tensor<1x2xf32>
   // CHECK-NOT: {{.*}} = "onnx.Relu"{{.*}}
 }
@@ -413,7 +413,7 @@ func.func @test_where() -> tensor<3x2xf32> {
   %1 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
   %2 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
   %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
-  "func.return"(%3) : (tensor<3x2xf32>) -> ()
+  "onnx.Return"(%3) : (tensor<3x2xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[2.000000e+00, 2.000000e+00], [6.000000e+00, 2.000000e+00], [1.000000e+01, 2.000000e+00]{{\]}}> : tensor<3x2xf32>
   // CHECK-NOT: {{.*}} = "onnx.Where"{{.*}}
 }
@@ -426,7 +426,7 @@ func.func @test_where_true() -> tensor<3x2xf32> {
   %1 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
   %2 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
   %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
-  "func.return"(%3) : (tensor<3x2xf32>) -> ()
+  "onnx.Return"(%3) : (tensor<3x2xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[2.000000e+00, 4.000000e+00], [6.000000e+00, 8.000000e+00], [1.000000e+01, 1.200000e+01]{{\]}}> : tensor<3x2xf32>
   // CHECK-NOT: {{.*}} = "onnx.Where"{{.*}}
 }
@@ -439,7 +439,7 @@ func.func @test_where_false() -> tensor<3x2xf32> {
   %1 = onnx.Constant dense<[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]> : tensor<3x2xf32>
   %2 = onnx.Constant dense<[[2.0]]> : tensor<1x1xf32>
   %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
-  "func.return"(%3) : (tensor<3x2xf32>) -> ()
+  "onnx.Return"(%3) : (tensor<3x2xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<2.000000e+00> : tensor<3x2xf32>
   // CHECK-NOT: {{.*}} = "onnx.Where"{{.*}}
 }
@@ -452,7 +452,7 @@ func.func @test_where_splat_branches() -> tensor<3x2xf32> {
   %1 = onnx.Constant dense<1.0> : tensor<3x2xf32>
   %2 = onnx.Constant dense<2.0> : tensor<1x1xf32>
   %3 = "onnx.Where"(%0, %1, %2) : (tensor<2xi1>, tensor<3x2xf32>, tensor<1x1xf32>) -> tensor<3x2xf32>
-  "func.return"(%3) : (tensor<3x2xf32>) -> ()
+  "onnx.Return"(%3) : (tensor<3x2xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[1.000000e+00, 2.000000e+00], [1.000000e+00, 2.000000e+00], [1.000000e+00, 2.000000e+00]{{\]}}> : tensor<3x2xf32>
   // CHECK-NOT: {{.*}} = "onnx.Where"{{.*}}
 }
@@ -467,7 +467,7 @@ func.func @test_matmulinteger_lhs_zero(%arg0: tensor<3x2xui8>) -> tensor<4x2xi32
   %0 = onnx.Constant dense<0> : tensor<4x3xi8>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.MatMulInteger"(%0, %arg0, %1, %1) : (tensor<4x3xi8>, tensor<3x2xui8>, none, none) -> tensor<4x2xi32>
-  "func.return"(%2) : (tensor<4x2xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<4x2xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
@@ -480,7 +480,7 @@ func.func @test_matmulinteger_lhs_scalar(%arg0: tensor<3x2xui8>) -> tensor<4x2xi
   %1 = onnx.Constant dense<7> : tensor<ui8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %arg0, %1, %2) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<ui8>, none) -> tensor<4x2xi32>
-  "func.return"(%3) : (tensor<4x2xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<4x2xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
@@ -493,7 +493,7 @@ func.func @test_matmulinteger_lhs_vector(%arg0: tensor<3x4xui8>) -> tensor<2x4xi
   %1 = onnx.Constant dense<[7, 9]> : tensor<2xui8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %arg0, %1, %2) : (tensor<2x3xui8>, tensor<3x4xui8>, tensor<2xui8>, none) -> tensor<2x4xi32>
-  "func.return"(%3) : (tensor<2x4xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<2x4xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<2x4xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
@@ -506,7 +506,7 @@ func.func @test_matmulinteger_lhs_matrix(%arg0: tensor<3x4xui8>) -> tensor<2x4xi
   %1 = onnx.Constant dense<[[7], [9]]> : tensor<2x1xui8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %arg0, %1, %2) : (tensor<2x3xui8>, tensor<3x4xui8>, tensor<2x1xui8>, none) -> tensor<2x4xi32>
-  "func.return"(%3) : (tensor<2x4xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<2x4xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<2x4xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
@@ -518,7 +518,7 @@ func.func @test_matmulinteger_rhs_zero_none(%arg0: tensor<4x3xi8>) -> tensor<4x2
   %0 = onnx.Constant dense<0> : tensor<3x2xui8>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.MatMulInteger"(%arg0, %0, %1, %1) : (tensor<4x3xi8>, tensor<3x2xui8>, none, none) -> tensor<4x2xi32>
-  "func.return"(%2) : (tensor<4x2xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<4x2xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
@@ -531,7 +531,7 @@ func.func @test_matmulinteger_rhs_zero_scalar(%arg0: tensor<4x3xi8>) -> tensor<4
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = onnx.Constant dense<42> : tensor<ui8>
   %3 = "onnx.MatMulInteger"(%arg0, %0, %1, %2) : (tensor<4x3xi8>, tensor<3x2xui8>, none, tensor<ui8>) -> tensor<4x2xi32>
-  "func.return"(%3) : (tensor<4x2xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<4x2xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
@@ -544,7 +544,7 @@ func.func @test_matmulinteger_rhs_zero_vector(%arg0: tensor<4x3xi8>) -> tensor<4
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = onnx.Constant dense<[1, 2]> : tensor<2xui8>
   %3 = "onnx.MatMulInteger"(%arg0, %0, %1, %2) : (tensor<4x3xi8>, tensor<3x2xui8>, none, tensor<2xui8>) -> tensor<4x2xi32>
-  "func.return"(%3) : (tensor<4x2xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<4x2xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<4x2xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
@@ -557,7 +557,7 @@ func.func @test_matmulinteger_rhs_zero_tensor(%arg0: tensor<1x4x3xi8>) -> tensor
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = onnx.Constant dense<[[[1, 2]]]> : tensor<1x1x2xui8>
   %3 = "onnx.MatMulInteger"(%arg0, %0, %1, %2) : (tensor<1x4x3xi8>, tensor<1x3x2xui8>, none, tensor<1x1x2xui8>) -> tensor<1x4x2xi32>
-  "func.return"(%3) : (tensor<1x4x2xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<1x4x2xi32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<0> : tensor<1x4x2xi32>
   // CHECK-NOT: {{.*}} = "onnx.MatMulInteger"{{.*}}
 }
@@ -569,7 +569,7 @@ func.func @test_matmulinteger_2d() -> (tensor<2x1xi32>) {
   %1 = "onnx.Constant"() {value = dense<1> : tensor<3x1xi8>} : () -> tensor<3x1xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<2x3xi8>, tensor<3x1xi8>, none, none) -> tensor<2x1xi32>
-  return %3 : tensor<2x1xi32>
+  onnx.Return %3 : tensor<2x1xi32>
   // CHECK-LABEL: test_matmulinteger_2d
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3> : tensor<2x1xi32>
 }
@@ -579,7 +579,7 @@ func.func @test_matmulinteger_2d_batch() -> (tensor<4x2x1xi32>) {
   %1 = "onnx.Constant"() {value = dense<100> : tensor<4x3x1xi8>} : () -> tensor<4x3x1xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<4x2x3xi8>, tensor<4x3x1xi8>, none, none) -> tensor<4x2x1xi32>
-  return %3 : tensor<4x2x1xi32>
+  onnx.Return %3 : tensor<4x2x1xi32>
   // CHECK-LABEL: test_matmulinteger_2d_batch
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<30000> : tensor<4x2x1xi32>
 }
@@ -589,7 +589,7 @@ func.func @test_matmulinteger_2d_batch_lhs() -> (tensor<4x2x1xi32>) {
   %1 = "onnx.Constant"() {value = dense<3> : tensor<3x1xi8>} : () -> tensor<3x1xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<4x2x3xi8>, tensor<3x1xi8>, none, none) -> tensor<4x2x1xi32>
-  return %3 : tensor<4x2x1xi32>
+  onnx.Return %3 : tensor<4x2x1xi32>
   // CHECK-LABEL: test_matmulinteger_2d_batch_lhs
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<9> : tensor<4x2x1xi32>
 }
@@ -599,7 +599,7 @@ func.func @test_matmulinteger_2d_batch_broadcast() -> (tensor<5x4x2x1xi32>) {
   %1 = "onnx.Constant"() {value = dense<-1> : tensor<5x1x3x1xi8>} : () -> tensor<5x1x3x1xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<4x2x3xi8>, tensor<5x1x3x1xi8>, none, none) -> tensor<5x4x2x1xi32>
-  return %3 : tensor<5x4x2x1xi32>
+  onnx.Return %3 : tensor<5x4x2x1xi32>
   // CHECK-LABEL: test_matmulinteger_2d_batch_broadcast
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<-3> : tensor<5x4x2x1xi32>
 }
@@ -609,7 +609,7 @@ func.func @test_matmulinteger_lhs_vector() -> (tensor<3xi32>) {
   %1 = "onnx.Constant"() {value = dense<10> : tensor<2x3xi8>} : () -> tensor<2x3xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<2xui8>, tensor<2x3xi8>, none, none) -> tensor<3xi32>
-  return %3 : tensor<3xi32>
+  onnx.Return %3 : tensor<3xi32>
   // CHECK-LABEL: test_matmulinteger_lhs_vector
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3000> : tensor<3xi32>
 }
@@ -619,7 +619,7 @@ func.func @test_matmulinteger_lhs_vector_batch() -> (tensor<4x3xi32>) {
   %1 = "onnx.Constant"() {value = dense<10> : tensor<4x2x3xi8>} : () -> tensor<4x2x3xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<2xui8>, tensor<4x2x3xi8>, none, none) -> tensor<4x3xi32>
-  return %3 : tensor<4x3xi32>
+  onnx.Return %3 : tensor<4x3xi32>
   // CHECK-LABEL: test_matmulinteger_lhs_vector_batch
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<3000> : tensor<4x3xi32>
 }
@@ -629,7 +629,7 @@ func.func @test_matmulinteger_rhs_vector() -> (tensor<2xi32>) {
   %1 = "onnx.Constant"() {value = dense<[10, 20, 30]> : tensor<3xi8>} : () -> tensor<3xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<2x3xui8>, tensor<3xi8>, none, none) -> tensor<2xi32>
-  return %3 : tensor<2xi32>
+  onnx.Return %3 : tensor<2xi32>
   // CHECK-LABEL: test_matmulinteger_rhs_vector
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<6000> : tensor<2xi32>
 }
@@ -639,7 +639,7 @@ func.func @test_matmulinteger_rhs_vector_batch() -> (tensor<4x2xi32>) {
   %1 = "onnx.Constant"() {value = dense<[10, 20, 30]> : tensor<3xi8>} : () -> tensor<3xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<4x2x3xui8>, tensor<3xi8>, none, none) -> tensor<4x2xi32>
-  return %3 : tensor<4x2xi32>
+  onnx.Return %3 : tensor<4x2xi32>
   // CHECK-LABEL: test_matmulinteger_rhs_vector_batch
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<6000> : tensor<4x2xi32>
 }
@@ -650,7 +650,7 @@ func.func @test_matmulinteger_two_vectors() -> (tensor<i32>) {
   %1 = "onnx.Constant"() {value = dense<[7, 2, 3]> : tensor<3xi8>} : () -> tensor<3xi8>
   %2 = "onnx.NoValue"() {value} : () -> none
   %3 = "onnx.MatMulInteger"(%0, %1, %2, %2) : (tensor<3xui8>, tensor<3xi8>, none, none) -> tensor<i32>
-  return %3 : tensor<i32>
+  onnx.Return %3 : tensor<i32>
   // CHECK-LABEL: test_matmulinteger_two_vectors
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<1486> : tensor<i32>
 }
@@ -662,7 +662,7 @@ func.func @test_matmulinteger_with_1Dzeros() -> (tensor<4x2xi32>) {
   %2 = "onnx.Constant"() {value = dense<[12]> : tensor<1xui8>} : () -> tensor<1xui8>
   %3 = "onnx.Constant"() {value = dense<[0]> : tensor<1xui8>} : () -> tensor<1xui8>
   %4 = "onnx.MatMulInteger"(%0, %1, %2, %3) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<1xui8>, tensor<1xui8>) -> tensor<4x2xi32>
-  return %4 : tensor<4x2xi32>
+  onnx.Return %4 : tensor<4x2xi32>
   // CHECK-LABEL: test_matmulinteger_with_1Dzeros
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{\[}}[-38, -83], [-44, -98], [-50, -113], [-56, -128]{{\]}}> : tensor<4x2xi32>
 }
@@ -673,7 +673,7 @@ func.func @test_matmulinteger_with_0dzeros() -> (tensor<4x2xi32>) {
   %2 = "onnx.Constant"() {value = dense<12> : tensor<ui8>} : () -> tensor<ui8>
   %3 = "onnx.Constant"() {value = dense<0> : tensor<ui8>} : () -> tensor<ui8>
   %4 = "onnx.MatMulInteger"(%0, %1, %2, %3) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<ui8>, tensor<ui8>) -> tensor<4x2xi32>
-  return %4 : tensor<4x2xi32>
+  onnx.Return %4 : tensor<4x2xi32>
   // CHECK-LABEL: test_matmulinteger_with_0dzeros
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{\[}}[-38, -83], [-44, -98], [-50, -113], [-56, -128]{{\]}}> : tensor<4x2xi32>
 }
@@ -688,7 +688,7 @@ func.func @test_reduce_sum_positive_axis() -> tensor<2x1xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %2 = "onnx.ReduceSum"(%0, %1) : (tensor<2x2xi32>, tensor<i64>) -> tensor<2x1xi32>
-  "func.return"(%2) : (tensor<2x1xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<2x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[3], [7]{{.}}> : tensor<2x1xi32>
 }
 
@@ -699,7 +699,7 @@ func.func @test_reduce_sum_negative_axis() -> tensor<1x2xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.Constant"() {value = dense<[-2]> : tensor<1xi64>} : () -> tensor<1xi64>
   %2 = "onnx.ReduceSum"(%0, %1) : (tensor<2x2xi32>, tensor<1xi64>) -> tensor<1x2xi32>
-  "func.return"(%2) : (tensor<1x2xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<1x2xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[4, 6]{{.}}> : tensor<1x2xi32>
 }
 
@@ -710,7 +710,7 @@ func.func @test_reduce_sum_all_axes() -> tensor<1x1xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.Constant"() {value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
   %2 = "onnx.ReduceSum"(%0, %1) : (tensor<2x2xi32>, tensor<2xi64>) -> tensor<1x1xi32>
-  "func.return"(%2) : (tensor<1x1xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<1x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<10> : tensor<1x1xi32>
 }
 
@@ -721,7 +721,7 @@ func.func @test_reduce_sum_keedims_false() -> tensor<2xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %2 = "onnx.ReduceSum"(%0, %1) {keepdims = 0 : si64} : (tensor<2x2xi32>, tensor<i64>) -> tensor<2xi32>
-  "func.return"(%2) : (tensor<2xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<2xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<[3, 7]> : tensor<2xi32>
 }
 
@@ -732,7 +732,7 @@ func.func @test_reduce_sum_noop_with_empty_axes_unset() -> tensor<1x1xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.ReduceSum"(%0, %1) : (tensor<2x2xi32>, none) -> tensor<1x1xi32>
-  "func.return"(%2) : (tensor<1x1xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<1x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<10> : tensor<1x1xi32>
 }
 
@@ -743,7 +743,7 @@ func.func @test_reduce_sum_noop_with_empty_axes_true() -> tensor<2x2xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.ReduceSum"(%0, %1) {noop_with_empty_axes = 1 : si64} : (tensor<2x2xi32>, none) -> tensor<2x2xi32>
-  "func.return"(%2) : (tensor<2x2xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<2x2xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1, 2], [3, 4]{{.}}> : tensor<2x2xi32>
 }
 
@@ -754,7 +754,7 @@ func.func @test_reduce_sum_empty() -> tensor<1x1xi32> {
   %0 = "onnx.Constant"() {value = dense<> : tensor<0x2xi32>} : () -> tensor<0x2xi32>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.ReduceSum"(%0, %1) : (tensor<0x2xi32>, none) -> tensor<1x1xi32>
-  "func.return"(%2) : (tensor<1x1xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<1x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<0> : tensor<1x1xi32>
 }
 
@@ -765,7 +765,7 @@ func.func @test_reduce_sum_scalar() -> tensor<i32> {
   %0 = "onnx.Constant"() {value = dense<42> : tensor<i32>} : () -> tensor<i32>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.ReduceSum"(%0, %1) : (tensor<i32>, none) -> tensor<i32>
-  "func.return"(%2) : (tensor<i32>) -> ()
+  "onnx.Return"(%2) : (tensor<i32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<42> : tensor<i32>
 }
 
@@ -776,7 +776,7 @@ func.func @test_reduce_prod_positive_axis() -> tensor<2x1xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %2 = "onnx.ReduceProd"(%0, %1) : (tensor<2x2xi32>, tensor<i64>) -> tensor<2x1xi32>
-  "func.return"(%2) : (tensor<2x1xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<2x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[2], [12]{{.}}> : tensor<2x1xi32>
 }
 
@@ -787,7 +787,7 @@ func.func @test_reduce_prod_empty() -> tensor<1x1xf32> {
   %0 = "onnx.Constant"() {value = dense<> : tensor<0x2xf32>} : () -> tensor<0x2xf32>
   %1 = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.ReduceProd"(%0, %1) : (tensor<0x2xf32>, none) -> tensor<1x1xf32>
-  "func.return"(%2) : (tensor<1x1xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<1x1xf32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<1x1xf32>
 }
 
@@ -798,7 +798,7 @@ func.func @test_reduce_min_positive_axis() -> tensor<2x1xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %2 = "onnx.ReduceMin"(%0, %1) : (tensor<2x2xi32>, tensor<i64>) -> tensor<2x1xi32>
-  "func.return"(%2) : (tensor<2x1xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<2x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1], [3]{{.}}> : tensor<2x1xi32>
 }
 
@@ -809,7 +809,7 @@ func.func @test_reduce_max_positive_axis() -> tensor<2x1xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %2 = "onnx.ReduceMax"(%0, %1) : (tensor<2x2xi32>, tensor<i64>) -> tensor<2x1xi32>
-  "func.return"(%2) : (tensor<2x1xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<2x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[2], [4]{{.}}> : tensor<2x1xi32>
 }
 
@@ -820,7 +820,7 @@ func.func @test_reduce_mean_i32() -> tensor<2x1xi32> {
   %0 = "onnx.Constant"() {value = dense<[[1, 2], [4, 6]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
   %1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %2 = "onnx.ReduceMean"(%0, %1) : (tensor<2x2xi32>, tensor<i64>) -> tensor<2x1xi32>
-  "func.return"(%2) : (tensor<2x1xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<2x1xi32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1], [5]{{.}}> : tensor<2x1xi32>
 }
 
@@ -831,7 +831,7 @@ func.func @test_reduce_mean_f32() -> tensor<2x1xf32> {
   %0 = "onnx.Constant"() {value = dense<[[1.0, 2.0], [4.0, 6.0]]> : tensor<2x2xf32>} : () -> tensor<2x2xf32>
   %1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %2 = "onnx.ReduceMean"(%0, %1) : (tensor<2x2xf32>, tensor<i64>) -> tensor<2x1xf32>
-  "func.return"(%2) : (tensor<2x1xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<2x1xf32>) -> ()
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<{{.}}[1.500000e+00], [5.000000e+00]{{.}}> : tensor<2x1xf32>
 }
 
@@ -845,7 +845,7 @@ func.func @test_unsqueeze() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[4.0, 16.0]> : tensor<2xf32>
   %1 = onnx.Constant dense<[1, 2]> : tensor<2xi64>
   %2 = "onnx.Unsqueeze"(%0, %1) : (tensor<2xf32>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}{{\[}}[4.000000e+00]{{\]}}, {{\[}}[1.600000e+01]{{\]}}{{\]}}> : tensor<2x1x1xf32>
   // CHECK-NOT: {{.*}} = "onnx.Unsqueeze"{{.*}}
 }
@@ -856,7 +856,7 @@ func.func @test_unsqueeze() -> tensor<*xf32> {
 func.func @test_unsqueezev11() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[4.0, 16.0]> : tensor<2xf32>
   %1 = "onnx.UnsqueezeV11"(%0) {axes = [1, 2]} : (tensor<2xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}{{\[}}[4.000000e+00]{{\]}}, {{\[}}[1.600000e+01]{{\]}}{{\]}}> : tensor<2x1x1xf32>
   // CHECK-NOT: {{.*}} = "onnx.UnsqueezeV11"{{.*}}
 }
@@ -871,9 +871,9 @@ func.func @test_squeeze() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[[4.0]], [[16.0]]]> : tensor<2x1x1xf32>
   %1 = onnx.Constant dense<[1, 2]> : tensor<2xi64>
   %2 = "onnx.Squeeze"(%0, %1) : (tensor<2x1x1xf32>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
   // CHECK: [[RES:%.+]] = onnx.Constant dense<[4.000000e+00, 1.600000e+01]> : tensor<2xf32>
-  // CHECK: return [[RES]] : tensor<2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2xf32>
   // CHECK-NOT: {{.*}} = "onnx.Squeeze"{{.*}}
 }
 
@@ -883,9 +883,9 @@ func.func @test_squeeze() -> tensor<*xf32> {
 func.func @test_squeezev11() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[[4.0]], [[16.0]]]> : tensor<2x1x1xf32>
   %1 = "onnx.SqueezeV11"(%0) {axes = [1, 2]} : (tensor<2x1x1xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
   // CHECK: [[RES:%.+]] = onnx.Constant dense<[4.000000e+00, 1.600000e+01]> : tensor<2xf32>
-  // CHECK: return [[RES]] : tensor<2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2xf32>
   // CHECK-NOT: {{.*}} = "onnx.SqueezeV11"{{.*}}
 }
 
@@ -899,7 +899,7 @@ func.func @test_split_axis_0() -> (tensor<1x10xf32>, tensor<1x10xf32>) {
   %split = onnx.Constant dense<[1, 1]> : tensor<2xi64>
   %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
   %1, %2 = "onnx.Split"(%0, %split) {axis = 0 : si64} : (tensor<2x10xf32>, tensor<2xi64>) -> (tensor<1x10xf32>, tensor<1x10xf32>)
-  "func.return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
 
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00]]> : tensor<1x10xf32>
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<1x10xf32>
@@ -913,7 +913,7 @@ func.func @test_split_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
   %split = onnx.Constant dense<[5, 5]> : tensor<2xi64>
   %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
   %1, %2 = "onnx.Split"(%0, %split) {axis = 1 : si64} : (tensor<2x10xf32>, tensor<2xi64>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-  "func.return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
 
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01]]> : tensor<2x5xf32>
   // CHECK: {{.*}}  = onnx.Constant dense<{{\[}}[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00], [1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<2x5xf32>
@@ -928,7 +928,7 @@ func.func @test_split_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
 func.func @test_split_axis_2(%arg0 : tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>) {
   %0 = onnx.Constant dense<[5, 5]> : tensor<2xi64>
   %1, %2 = "onnx.Split"(%arg0, %0) {axis = 1 : si64} : (tensor<2x10xf32>, tensor<2xi64>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-  "func.return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
 
   // CHECK: {{.*}} = "onnx.Split"(%arg0, %0) {axis = 1 : si64} : (tensor<2x10xf32>, tensor<2xi64>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
 }
@@ -939,7 +939,7 @@ func.func @test_split_axis_2(%arg0 : tensor<2x10xf32>) -> (tensor<2x5xf32>, tens
 func.func @test_splitv11_axis_0() -> (tensor<1x10xf32>, tensor<1x10xf32>) {
   %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
   %1, %2 = "onnx.SplitV11"(%0) { axis = 0 : si64, split = [1, 1]} : (tensor<2x10xf32>) -> (tensor<1x10xf32>, tensor<1x10xf32>)
-  "func.return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
 
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00]]> : tensor<1x10xf32>
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<1x10xf32>
@@ -952,7 +952,7 @@ func.func @test_splitv11_axis_0() -> (tensor<1x10xf32>, tensor<1x10xf32>) {
 func.func @test_splitv11_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
   %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
   %1, %2 = "onnx.SplitV11"(%0) { axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-  "func.return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
 
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01]]> : tensor<2x5xf32>
   // CHECK: {{.*}}  = onnx.Constant dense<{{\[}}[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00], [1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<2x5xf32>
@@ -966,7 +966,7 @@ func.func @test_splitv11_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
 // CHECK-LABEL: @test_splitv11_axis_2(%arg0: tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>) {
 func.func @test_splitv11_axis_2(%arg0 : tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>) {
   %1, %2 = "onnx.SplitV11"(%arg0) { axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-  "func.return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
 
   // CHECK: {{.*}} = "onnx.SplitV11"(%arg0) {axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
 }
@@ -980,14 +980,14 @@ func.func @test_mul_folding(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
   %3 = "onnx.UnsqueezeV11"(%2) {axes = [3]} : (tensor<8x1x1xf32>) -> tensor<8x1x1x1xf32>
   %4 = "onnx.Mul"(%0, %3) : (tensor<8x1x2x2xf32>, tensor<8x1x1x1xf32>) -> tensor<8x1x2x2xf32>
   %5 = "onnx.Conv"(%arg0, %4, %1) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2, 2], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x2x2xf32>, none) -> tensor<*xf32>
-  return %5 : tensor<*xf32>
+  onnx.Return %5 : tensor<*xf32>
 
   // CHECK-LABEL:  func @test_mul_folding
   // CHECK-SAME:   ([[X:%.+]]: tensor<1x1x28x28xf32>) -> tensor<1x8x27x27xf32> {
   // CHECK-DAG: [[NOBIAS:%.+]] = "onnx.NoValue"() {value} : () -> none    
   // CHECK-DAG: [[W:%.+]] = onnx.Constant dense<{{.*}}[-0.00378267956, -0.00368360057], [-0.00394573715, -0.00383781269]{{.*}}, {{.*}}[0.0178247672, -0.0211799927], [-7.134370e-02, 0.00868515763]{{.*}}, {{.*}}[-3.9825665E-10, 0.00232082023], [0.00341839972, 0.01514313]{{.*}}, {{.*}}[3.34836572E-4, -0.00221243338], [-9.64127597E-4, -3.94316746E-10]{{.*}}, {{.*}}[-0.00122044468, 0.00965741463], [-0.00100710022, -0.00124419201]{{.*}}, {{.*}}[-0.00233115326, 0.00203743274], [-0.003079077, 0.0361107253]{{.*}}, {{.*}}[-4.32482251E-4, 0.00191138953], [0.00277041947, -4.13662056E-4]{{.*}}, {{.*}}[2.441080e-03, -0.00233326037], [-0.0275826417, 0.0237795357]{{.*}}> : tensor<8x1x2x2xf32>
   // CHECK: [[RES:%.+]] = "onnx.Conv"([[X]], [[W]], [[NOBIAS]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2, 2], strides = [1, 1]} : (tensor<1x1x28x28xf32>, tensor<8x1x2x2xf32>, none) -> tensor<1x8x27x27xf32>
-  // CHECK: return [[RES]] : tensor<1x8x27x27xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x8x27x27xf32>
 }
 
 // -----
@@ -995,12 +995,12 @@ func.func @test_mul_folding(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
 func.func @test_cast_i32_i64() -> tensor<3x2xi64> {
   %0 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi32>
   %1 = "onnx.Cast"(%0) {to = i64} : (tensor<3x2xi32>) -> tensor<3x2xi64>
-  "func.return"(%1) : (tensor<3x2xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<3x2xi64>) -> ()
 
   // CHECK-LABEL:  func @test_cast_i32_i64
   // CHECK-SAME:   () -> tensor<3x2xi64> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[2, 3], [4, 5], [6, 7]{{.}}> : tensor<3x2xi64>
-  // CHECK:           return [[VAR_0_]] : tensor<3x2xi64>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x2xi64>
   // CHECK:         }
 }
 
@@ -1009,12 +1009,12 @@ func.func @test_cast_i32_i64() -> tensor<3x2xi64> {
 func.func @test_cast_i64_i32() -> tensor<3x2xi32> {
   %0 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi64>
   %1 = "onnx.Cast"(%0) {to = i32} : (tensor<3x2xi64>) -> tensor<3x2xi32>
-  "func.return"(%1) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%1) : (tensor<3x2xi32>) -> ()
 
   // CHECK-LABEL:  func @test_cast_i64_i32
   // CHECK-SAME:   () -> tensor<3x2xi32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[2, 3], [4, 5], [6, 7]{{.}}> : tensor<3x2xi32>
-  // CHECK:           return [[VAR_0_]] : tensor<3x2xi32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x2xi32>
   // CHECK:         }
 }
 
@@ -1023,12 +1023,12 @@ func.func @test_cast_i64_i32() -> tensor<3x2xi32> {
 func.func @test_cast_i32_f32() -> tensor<3x2xf32> {
   %0 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi32>
   %1 = "onnx.Cast"(%0) {to = f32} : (tensor<3x2xi32>) -> tensor<3x2xf32>
-  "func.return"(%1) : (tensor<3x2xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<3x2xf32>) -> ()
 
   // CHECK-LABEL:  func @test_cast_i32_f32
   // CHECK-SAME:   () -> tensor<3x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00], [6.000000e+00, 7.000000e+00]{{.}}> : tensor<3x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<3x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x2xf32>
   // CHECK:         }
 }
 
@@ -1037,12 +1037,12 @@ func.func @test_cast_i32_f32() -> tensor<3x2xf32> {
 func.func @test_cast_f32_i32() -> tensor<3x2xi32> {
   %0 = onnx.Constant dense<[[2.3, 3.6], [4.5, 5.5], [6.0, 7.0]]> : tensor<3x2xf32>
   %1 = "onnx.Cast"(%0) {to = i32} : (tensor<3x2xf32>) -> tensor<3x2xi32>
-  "func.return"(%1) : (tensor<3x2xi32>) -> ()
+  "onnx.Return"(%1) : (tensor<3x2xi32>) -> ()
 
   // CHECK-LABEL:  func @test_cast_f32_i32
   // CHECK-SAME:   () -> tensor<3x2xi32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[2, 3], [4, 5], [6, 7]{{.}}> : tensor<3x2xi32>
-  // CHECK:           return [[VAR_0_]] : tensor<3x2xi32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x2xi32>
   // CHECK:         }
 }
 
@@ -1051,12 +1051,12 @@ func.func @test_cast_f32_i32() -> tensor<3x2xi32> {
 func.func @test_cast_f32_i64() -> tensor<3x2xi64> {
   %0 = onnx.Constant dense<[[2.3, 3.6], [4.5, 5.5], [6.0, 7.0]]> : tensor<3x2xf32>
   %1 = "onnx.Cast"(%0) {to = i64} : (tensor<3x2xf32>) -> tensor<3x2xi64>
-  "func.return"(%1) : (tensor<3x2xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<3x2xi64>) -> ()
 
   // CHECK-LABEL:  func @test_cast_f32_i64
   // CHECK-SAME:   () -> tensor<3x2xi64> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[2, 3], [4, 5], [6, 7]{{.}}> : tensor<3x2xi64>
-  // CHECK:           return [[VAR_0_]] : tensor<3x2xi64>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x2xi64>
   // CHECK:         }
 }
 
@@ -1065,12 +1065,12 @@ func.func @test_cast_f32_i64() -> tensor<3x2xi64> {
 func.func @test_cast_i64_f32() -> tensor<3x2xf32> {
   %0 = onnx.Constant dense<[[2, 3], [4, 5], [6, 7]]> : tensor<3x2xi64>
   %1 = "onnx.Cast"(%0) {to = f32} : (tensor<3x2xi64>) -> tensor<3x2xf32>
-  "func.return"(%1) : (tensor<3x2xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<3x2xf32>) -> ()
 
   // CHECK-LABEL:  func @test_cast_i64_f32
   // CHECK-SAME:   () -> tensor<3x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00], [6.000000e+00, 7.000000e+00]{{.}}> : tensor<3x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<3x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x2xf32>
   // CHECK:         }
 }
 
@@ -1083,12 +1083,12 @@ func.func @test_slice() -> tensor<*xf32> {
   %axes = onnx.Constant dense<[0, 1]> : tensor<2xi64>
   %steps = onnx.Constant dense<[1, 1]> : tensor<2xi64>
   %1 = "onnx.Slice"(%0, %starts, %ends, %axes, %steps) : (tensor<3x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_slice
   // CHECK-SAME:   () -> tensor<1x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[2.000000e+00, 3.000000e+00]{{.}}> : tensor<1x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<1x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<1x2xf32>
   // CHECK:         }
 }
 
@@ -1101,12 +1101,12 @@ func.func @test_slice_reversed() -> tensor<*xf32> {
   %axes = onnx.Constant dense<[0, 1]> : tensor<2xi64>
   %steps = onnx.Constant dense<[-1, -1]> : tensor<2xi64>
   %1 = "onnx.Slice"(%0, %starts, %ends, %axes, %steps) : (tensor<3x2xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_slice_reversed
   // CHECK-SAME:   () -> tensor<2x1xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[7.000000e+00], [5.000000e+00]{{.}}> : tensor<2x1xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<2x1xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<2x1xf32>
   // CHECK:         }
 }
 
@@ -1119,12 +1119,12 @@ func.func @test_slice_empty() -> tensor<*xf32> {
   %axes = onnx.Constant dense<0> : tensor<1xi64>
   %steps = onnx.Constant dense<1> : tensor<1xi64>
   %1 = "onnx.Slice"(%0, %starts, %ends, %axes, %steps) : (tensor<4xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_slice_empty
   // CHECK-SAME:   () -> tensor<0xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<> : tensor<0xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<0xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<0xf32>
   // CHECK:         }
 }
 
@@ -1134,12 +1134,12 @@ func.func @test_concat() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]> : tensor<3x2xf32>
   %1 = onnx.Constant dense<[[11.0, 12.0], [13.0, 14.0], [15.0, 16.0]]> : tensor<3x2xf32>
   %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<3x2xf32>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_concat
   // CHECK-SAME:   () -> tensor<6x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [1.100000e+01, 1.200000e+01], [1.300000e+01, 1.400000e+01], [1.500000e+01, 1.600000e+01]{{.}}> : tensor<6x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<6x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<6x2xf32>
   // CHECK:         }
 }
 
@@ -1149,12 +1149,12 @@ func.func @test_concat_integer() -> tensor<*xi32> {
   %0 = onnx.Constant dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi32>
   %1 = onnx.Constant dense<[[11, 12], [13, 14], [15, 16]]> : tensor<3x2xi32>
   %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<3x2xi32>, tensor<3x2xi32>) -> tensor<*xi32>
-  "func.return"(%2) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xi32>) -> ()
 
   // CHECK-LABEL:  func @test_concat_integer
   // CHECK-SAME:   () -> tensor<6x2xi32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[1, 2], [3, 4], [5, 6], [11, 12], [13, 14], [15, 16]{{.}}> : tensor<6x2xi32>
-  // CHECK:           return [[VAR_0_]] : tensor<6x2xi32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<6x2xi32>
   // CHECK:         }
 }
 
@@ -1165,12 +1165,12 @@ func.func @test_concat_3_operands() -> tensor<*xf32>{
   %1 = onnx.Constant dense<[[11.0, 12.0], [13.0, 14.0], [15.0, 16.0]]> : tensor<3x2xf32>
   %2 = onnx.Constant dense<[[21.0, 22.0], [23.0, 24.0], [25.0, 26.0]]> : tensor<3x2xf32>
   %3 = "onnx.Concat"(%0, %1, %2) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<3x2xf32>, tensor<3x2xf32>) -> tensor<*xf32>
-  "func.return"(%3) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%3) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_concat_3_operands
   // CHECK-SAME:   () -> tensor<9x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [1.100000e+01, 1.200000e+01], [1.300000e+01, 1.400000e+01], [1.500000e+01, 1.600000e+01], [2.100000e+01, 2.200000e+01], [2.300000e+01, 2.400000e+01], [2.500000e+01, 2.600000e+01]{{.}}> : tensor<9x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<9x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<9x2xf32>
   // CHECK:         }
 }
 
@@ -1180,12 +1180,12 @@ func.func @test_concat_negative_axis() -> tensor<*xf32>{
   %0 = onnx.Constant dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]> : tensor<3x2xf32>
   %1 = onnx.Constant dense<[[11.0, 12.0], [13.0, 14.0], [15.0, 16.0]]> : tensor<3x2xf32>
   %2 = "onnx.Concat"(%0, %1) {axis = -1 : si64} : (tensor<3x2xf32>, tensor<3x2xf32>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_concat_negative_axis
   // CHECK-SAME:   () -> tensor<3x4xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[1.000000e+00, 2.000000e+00, 1.100000e+01, 1.200000e+01], [3.000000e+00, 4.000000e+00, 1.300000e+01, 1.400000e+01], [5.000000e+00, 6.000000e+00, 1.500000e+01, 1.600000e+01]{{.}}> : tensor<3x4xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<3x4xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4xf32>
   // CHECK:         }
 }
 
@@ -1195,12 +1195,12 @@ func.func @test_expand() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]> : tensor<3x2xf32>
   %1 = onnx.Constant dense<[2, 3, 2]> : tensor<3xi64>
   %2 = "onnx.Expand"(%0, %1) : (tensor<3x2xf32>, tensor<3xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_expand
   // CHECK-SAME:   () -> tensor<2x3x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00]{{.}}, {{.}}[1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00]{{.}}{{.}}> : tensor<2x3x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<2x3x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<2x3x2xf32>
   // CHECK:         }
 }
 
@@ -1210,12 +1210,12 @@ func.func @test_expand_broadcast() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[1.0], [3.0], [5.0]]> : tensor<3x1xf32>
   %1 = onnx.Constant dense<[2, 3, 2]> : tensor<3xi64>
   %2 = "onnx.Expand"(%0, %1) : (tensor<3x1xf32>, tensor<3xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_expand_broadcast
   // CHECK-SAME:   () -> tensor<2x3x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[1.000000e+00, 1.000000e+00], [3.000000e+00, 3.000000e+00], [5.000000e+00, 5.000000e+00]{{.}}, {{.}}[1.000000e+00, 1.000000e+00], [3.000000e+00, 3.000000e+00], [5.000000e+00, 5.000000e+00]{{.}}{{.}}> : tensor<2x3x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<2x3x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<2x3x2xf32>
   // CHECK:         }
 }
 
@@ -1225,12 +1225,12 @@ func.func @test_gather_axis_0() -> tensor<*xf32>{
   %0 = onnx.Constant dense<[[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]]> : tensor<3x2xf32>
   %1 = onnx.Constant dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>
   %2 = "onnx.Gather"(%0, %1) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_gather_axis_0
   // CHECK-SAME:   () -> tensor<2x2x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[1.000000e+00, 1.200000e+00], [2.300000e+00, 3.400000e+00]{{.}}, {{.}}[2.300000e+00, 3.400000e+00], [4.500000e+00, 5.700000e+00]{{.}}{{.}}> : tensor<2x2x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<2x2x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<2x2x2xf32>
   // CHECK:         }
 }
 
@@ -1240,12 +1240,12 @@ func.func @test_gather_axis_1() -> tensor<*xf32>{
   %0 = onnx.Constant dense<[[1.0, 1.2, 1.9], [2.3, 3.4, 3.9], [4.5, 5.7, 5.9]]> : tensor<3x3xf32>
   %1 = onnx.Constant dense<[[0, 2]]> : tensor<1x2xi64>
   %2 = "onnx.Gather"(%0, %1) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_gather_axis_1
   // CHECK-SAME:   () -> tensor<3x1x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[1.000000e+00, 1.900000e+00]{{.}}, {{.}}[2.300000e+00, 3.900000e+00]{{.}}, {{.}}[4.500000e+00, 5.900000e+00]{{.}}{{.}}> : tensor<3x1x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<3x1x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x1x2xf32>
   // CHECK:         }
 }
 
@@ -1255,12 +1255,12 @@ func.func @test_gather_negative_index() -> tensor<*xf32>{
   %0 = onnx.Constant dense<[[1.0, 1.2, 1.9], [2.3, 3.4, 3.9], [4.5, 5.7, 5.9]]> : tensor<3x3xf32>
   %1 = onnx.Constant dense<[[0, -1]]> : tensor<1x2xi64>
   %2 = "onnx.Gather"(%0, %1) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL:  func @test_gather_negative_index
   // CHECK-SAME:   () -> tensor<3x1x2xf32> {
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[1.000000e+00, 1.900000e+00]{{.}}, {{.}}[2.300000e+00, 3.900000e+00]{{.}}, {{.}}[4.500000e+00, 5.900000e+00]{{.}}{{.}}> : tensor<3x1x2xf32>
-  // CHECK:           return [[VAR_0_]] : tensor<3x1x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x1x2xf32>
   // CHECK:         }
 }
 
@@ -1270,12 +1270,12 @@ func.func @test_reshape() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[1.0, 1.2, 1.9], [2.3, 3.4, 3.9], [4.5, 5.7, 5.9]]> : tensor<3x3xf32>
   %1 = onnx.Constant dense<[1, -1]> : tensor<2xi64>
   %2 = "onnx.Reshape"(%0, %1) : (tensor<3x3xf32>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
 // CHECK-LABEL:  func.func @test_reshape
 // CHECK-SAME:   () -> tensor<1x9xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}[1.000000e+00, 1.200000e+00, 1.900000e+00, 2.300000e+00, 3.400000e+00, 3.900000e+00, 4.500000e+00, 5.700000e+00, 5.900000e+00]{{.}}> : tensor<1x9xf32>
-// CHECK:           return [[VAR_0_]] : tensor<1x9xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x9xf32>
 // CHECK:         }
 }
 
@@ -1284,12 +1284,12 @@ func.func @test_reshape() -> tensor<*xf32> {
 func.func @test_constant_of_shape() -> tensor<3xi64> {
   %0 = onnx.Constant dense<3> : tensor<1xi64>
   %1 = "onnx.ConstantOfShape"(%0) {value = dense<2> : tensor<1xi64>} : (tensor<1xi64>) -> tensor<3xi64>
-  "func.return"(%1) : (tensor<3xi64>) -> ()
+  "onnx.Return"(%1) : (tensor<3xi64>) -> ()
 
 // CHECK-LABEL:  func.func @test_constant_of_shape
 // CHECK-SAME:   () -> tensor<3xi64> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<2> : tensor<3xi64>
-// CHECK:           return [[VAR_0_]] : tensor<3xi64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3xi64>
 // CHECK:         }
 }
 
@@ -1298,12 +1298,12 @@ func.func @test_constant_of_shape() -> tensor<3xi64> {
 func.func @test_constant_of_shape_empty_tensor() -> tensor<f32> {
   %0 = onnx.Constant dense<> : tensor<0xi64>
   %1 = "onnx.ConstantOfShape"(%0) {value = dense<2.0> : tensor<1xf32>} : (tensor<0xi64>) -> tensor<f32>
-  "func.return"(%1) : (tensor<f32>) -> ()
+  "onnx.Return"(%1) : (tensor<f32>) -> ()
 
 // CHECK-LABEL:  func.func @test_constant_of_shape_empty_tensor
 // CHECK-SAME:   () -> tensor<f32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<f32>
-// CHECK:           return [[VAR_0_]] : tensor<f32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<f32>
 // CHECK:         }
 }
 
@@ -1314,12 +1314,12 @@ func.func @test_range_int() -> tensor<8xi16> {
   %limit = onnx.Constant dense<10> : tensor<i16>
   %delta = onnx.Constant dense<1> : tensor<i16>
   %1 = "onnx.Range"(%start, %limit, %delta) : (tensor<i16>, tensor<i16>, tensor<i16>) -> tensor<8xi16>
-  return %1 : tensor<8xi16>
+  onnx.Return %1 : tensor<8xi16>
 
 // CHECK-LABEL:  func.func @test_range_int
 // CHECK-SAME:   () -> tensor<8xi16> {
 // CHECK:           [[VAR:%.+]] = onnx.Constant dense<[2, 3, 4, 5, 6, 7, 8, 9]> : tensor<8xi16>
-// CHECK:           return [[VAR]] : tensor<8xi16>
+// CHECK:           onnx.Return [[VAR]] : tensor<8xi16>
 // CHECK:         }
 }
 
@@ -1330,11 +1330,11 @@ func.func @test_range_fp() -> tensor<3xf32> {
   %limit = onnx.Constant dense<0.5> : tensor<f32>
   %delta = onnx.Constant dense<0.1> : tensor<f32>
   %1 = "onnx.Range"(%start, %limit, %delta) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
-  return %1 : tensor<3xf32>
+  onnx.Return %1 : tensor<3xf32>
 
 // CHECK-LABEL:  func.func @test_range_fp
 // CHECK-SAME:   () -> tensor<3xf32> {
 // CHECK:           [[VAR:%.+]] = onnx.Constant dense<[2.000000e-01, 3.000000e-01, 4.000000e-01]> : tensor<3xf32>
-// CHECK:           return [[VAR]] : tensor<3xf32>
+// CHECK:           onnx.Return [[VAR]] : tensor<3xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_constprop_no_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_constprop_no_shape_inference.mlir
@@ -12,7 +12,7 @@ func.func @test_split_axis_0_no_splitattr() -> (tensor<1x10xf32>, tensor<1x10xf3
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
   %1, %2 = "onnx.Split"(%0, %cst) { axis = 0 : si64} : (tensor<2x10xf32>, none) -> (tensor<1x10xf32>, tensor<1x10xf32>)
-  "func.return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
 
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00]]> : tensor<1x10xf32>
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<1x10xf32>
@@ -28,7 +28,7 @@ func.func @test_split_axis_1_no_splitattr() -> (tensor<2x5xf32>, tensor<2x5xf32>
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
   %1, %2 = "onnx.Split"(%0, %cst) { axis = 1 : si64} : (tensor<2x10xf32>, none) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-  "func.return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
 
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01]]> : tensor<2x5xf32>
   // CHECK: {{.*}}  = onnx.Constant dense<{{\[}}[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00], [1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<2x5xf32>
@@ -43,7 +43,7 @@ func.func @test_split_axis_1_no_splitattr() -> (tensor<2x5xf32>, tensor<2x5xf32>
 func.func @test_splitv11_axis_0_no_splitattr() -> (tensor<1x10xf32>, tensor<1x10xf32>) {
   %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
   %1, %2 = "onnx.SplitV11"(%0) { axis = 0 : si64} : (tensor<2x10xf32>) -> (tensor<1x10xf32>, tensor<1x10xf32>)
-  "func.return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
 
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00]]> : tensor<1x10xf32>
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<1x10xf32>
@@ -58,7 +58,7 @@ func.func @test_splitv11_axis_0_no_splitattr() -> (tensor<1x10xf32>, tensor<1x10
 func.func @test_splitv11_axis_1_no_splitattr() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
   %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
   %1, %2 = "onnx.SplitV11"(%0) { axis = 1 : si64} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-  "func.return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
+  "onnx.Return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
 
   // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01]]> : tensor<2x5xf32>
   // CHECK: {{.*}}  = onnx.Constant dense<{{\[}}[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00], [1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<2x5xf32>
@@ -76,9 +76,9 @@ func.func @test_scatternd_f32() -> (tensor<8xf32>) {
   %1 = onnx.Constant { name = "constant.1", value = dense< [[4], [3], [1], [7]]>:tensor<4x1xi64> } : tensor<4x1xi64>
   %2 = onnx.Constant { name = "constant.2", value = dense<[9., 10., 11., 12.]>:tensor<4xf32> } : tensor<4xf32>
   // CHECK : [[R1:%.+]] = "onnx.Constant"{{.*}} dense<{{\[}}1.000000e+00, 1.100000e+01, 3.000000e+00, 1.000000e+01, 9.000000e+00, 6.000000e+00, 7.000000e+00, 1.200000e+01],
-  // CHECK-NEXT : return [[R1]] : tensor<8xf32>
+  // CHECK-NEXT : onnx.Return [[R1]] : tensor<8xf32>
   %3 = "onnx.ScatterND"(%0, %1, %2) {node_name = "ScatterND_6467", node_type = "ScatterND"} : (tensor<8xf32>, tensor<4x1xi64>, tensor<4xf32>) -> tensor<8xf32>
-  return %3 : tensor<8xf32>
+  onnx.Return %3 : tensor<8xf32>
 }
 
 // -----
@@ -93,9 +93,9 @@ func.func @test_scatternd_i32() -> (tensor<4x4x4xi32>) {
   %2 = "onnx.Constant"() { name = "constant.2", value = dense<[[[5, 5, 5, 5], [6, 6, 6, 6], [7, 7, 7, 7], [8, 8, 8, 8]],
              [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]]>:tensor<2x4x4xi32> } : () -> tensor<2x4x4xi32>
   // CHECK : [[R1:%.+]] = "onnx.Constant"{{.*}} dense<{{\[\[\[}}5, 5, 5, 5], [6, 6, 6, 6], [7, 7, 7, 7], [8, 8, 8, 8]], [[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]], [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]], [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]]]>
-  // CHECK-NEXT : return [[R1]] : tensor<4x4x4xi32>
+  // CHECK-NEXT : onnx.Return [[R1]] : tensor<4x4x4xi32>
   %3 = "onnx.ScatterND"(%0, %1, %2) {node_name = "ScatterND_6467", node_type = "ScatterND"} : (tensor<4x4x4xi32>, tensor<2x1xi64>, tensor<2x4x4xi32>) -> tensor<4x4x4xi32>
-  return %3 : tensor<4x4x4xi32>
+  onnx.Return %3 : tensor<4x4x4xi32>
 }
 
 // -----

--- a/test/mlir/onnx/onnx_conv_opt.mlir
+++ b/test/mlir/onnx/onnx_conv_opt.mlir
@@ -5,7 +5,7 @@ module {
   func.func @test_onnx_conv_simple_pattern(%arg0: tensor<5x3x32x32xf32>, %arg1: tensor<?x3x2x2xf32>) -> tensor<5x?x31x31xf32> {
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.Conv"(%arg0, %arg1, %0) {auto_pad = "NOTSET", kernel_shape = [2, 2], pads = [0, 0, 0, 0]} : (tensor<5x3x32x32xf32>, tensor<?x3x2x2xf32>, none) -> tensor<5x?x31x31xf32>
-    return %1 : tensor<5x?x31x31xf32>
+    onnx.Return %1 : tensor<5x?x31x31xf32>
   }
 }
 //  use arg names: ['image', 'filter']
@@ -17,5 +17,5 @@ module {
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.LayoutTransform"([[FILTER_]]) {target_layout = #onnx.layout<{dataLayout = "KCMN4C4K"}>} : (tensor<?x3x2x2xf32>) -> tensor<?x3x2x2xf32, #onnx.layout<{dataLayout = "KCMN4C4K"}>>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Conv"([[VAR_1_]], [[VAR_2_]], [[VAR_0_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [2, 2], pads = [0, 0, 0, 0]} : (tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>, tensor<?x3x2x2xf32, #onnx.layout<{dataLayout = "KCMN4C4K"}>>, none) -> tensor<5x?x31x31xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>
 // CHECK:           [[VAR_4_:%.+]] = "onnx.LayoutTransform"([[VAR_3_]]) {target_layout = "STANDARD"} : (tensor<5x?x31x31xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>) -> tensor<5x?x31x31xf32>
-// CHECK:           return [[VAR_4_]] : tensor<5x?x31x31xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<5x?x31x31xf32>
 // CHECK:         }

--- a/test/mlir/onnx/onnx_conv_opt_conv_to_matmul.mlir
+++ b/test/mlir/onnx/onnx_conv_opt_conv_to_matmul.mlir
@@ -3,7 +3,7 @@
 func.func @conv_to_matmul(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<1x1x1x1xf32>) -> tensor<?x1x?x?xf32> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.Conv"(%arg0, %arg1, %0) {auto_pad = "VALID", dilations = [1, 1], group = 1 : si64, kernel_shape = [1, 1], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<?x?x?x?xf32>, tensor<1x1x1x1xf32>, none) -> tensor<?x1x?x?xf32>
-  return %1 : tensor<?x1x?x?xf32>
+  onnx.Return %1 : tensor<?x1x?x?xf32>
 }
 
 // CHECK-LABEL: @conv_to_matmul

--- a/test/mlir/onnx/onnx_cse.mlir
+++ b/test/mlir/onnx/onnx_cse.mlir
@@ -6,7 +6,7 @@ func.func @test_cse(%arg0: tensor<*xf32>) -> tensor<*xf32> {
   %1 = "onnx.Tanh"(%0) : (tensor<*xf32>) -> tensor<*xf32>
   %2 = "onnx.Tanh"(%0) : (tensor<*xf32>) -> tensor<*xf32>
   %3 = "onnx.Add"(%0, %1) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  return %3 : tensor<*xf32>
+  onnx.Return %3 : tensor<*xf32>
   // CHECK-LABEL: test_cse
   // CHECK-NEXT: "onnx.Log"
   // CHECK-COUNT-1: "onnx.Tanh"

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -5,7 +5,7 @@
 // CHECK-LABEL: @test_reducel1(%{{.*}}: tensor<?x?x?xf32>, %{{.*}}: tensor<?xi64>) -> tensor<*xf32>
 func.func @test_reducel1(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -> tensor<*xf32> {
   %0 ="onnx.ReduceL1"(%arg0, %arg1) {keepdims = 0 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>)-> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-NEXT: [[ABS:%.+]] =  "onnx.Abs"(%arg0) : (tensor<?x?x?xf32>) -> tensor<*xf32>
   // CHECK-NEXT: %{{[0-9]+}} = "onnx.ReduceSum"([[ABS]], %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<*xf32>, tensor<?xi64>) -> tensor<*xf32>
@@ -16,7 +16,7 @@ func.func @test_reducel1(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -> te
 // CHECK-LABEL: @test_reducel2(%{{.*}}: tensor<?x?x?xf32>, %{{.*}}: tensor<?xi64>) -> tensor<*xf32>
 func.func @test_reducel2(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -> tensor<*xf32> {
   %0 ="onnx.ReduceL2"(%arg0, %arg1) {keepdims = 0 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>)-> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-NEXT: [[MUL:%.+]] =  "onnx.Mul"(%arg0, %arg0) : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<*xf32>
   // CHECK-NEXT: [[REDUCE_SUM:%.+]] = "onnx.ReduceSum"([[MUL]], %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<*xf32>, tensor<?xi64>) -> tensor<*xf32>
@@ -28,7 +28,7 @@ func.func @test_reducel2(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -> te
 // CHECK-LABEL: @test_reducelogsum(%{{.*}}: tensor<?x?x?xf32>, %{{.*}}: tensor<?xi64>) -> tensor<*xf32>
 func.func @test_reducelogsum(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -> tensor<*xf32> {
   %0 ="onnx.ReduceLogSum"(%arg0, %arg1) {keepdims = 0 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>)-> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
   // CHECK-NEXT: [[REDUCE_SUM:%.+]] = "onnx.ReduceSum"(%arg0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>) -> tensor<*xf32>
   // CHECK-NEXT: [[LOG:%.+]] =  "onnx.Log"([[REDUCE_SUM]]) : (tensor<*xf32>) -> tensor<*xf32>
 }
@@ -38,7 +38,7 @@ func.func @test_reducelogsum(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -
 // CHECK-LABEL: @test_reducelogsumexp(%{{.*}}: tensor<?x?x?xf32>, %{{.*}}: tensor<?xi64>) -> tensor<*xf32>
 func.func @test_reducelogsumexp(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -> tensor<*xf32> {
   %0 ="onnx.ReduceLogSumExp"(%arg0, %arg1) {keepdims = 0 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>)-> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-NEXT: [[REDUCE_MAX:%.+]] = "onnx.ReduceMax"(%arg0, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>) -> tensor<*xf32>
   // CHECK-NEXT: [[SUB:%.+]] = "onnx.Sub"(%arg0, [[REDUCE_MAX]]) : (tensor<?x?x?xf32>, tensor<*xf32>) -> tensor<*xf32>
@@ -47,7 +47,7 @@ func.func @test_reducelogsumexp(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>
   // CHECK-NEXT: [[LOG:%.+]] = "onnx.Log"([[REDUCE_SUM]]) : (tensor<*xf32>) -> tensor<*xf32>
   // CHECK-NEXT: [[SQUEEZE:%.+]] = "onnx.Squeeze"([[REDUCE_MAX]], %arg1) : (tensor<*xf32>, tensor<?xi64>) -> tensor<*xf32>
   // CHECK-NEXT: [[RES:%.+]] = "onnx.Add"([[LOG]], [[SQUEEZE]]) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  // CHECK-NEXT: return [[RES]] : tensor<*xf32>
+  // CHECK-NEXT: onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
@@ -55,7 +55,7 @@ func.func @test_reducelogsumexp(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>
 // CHECK-LABEL: @test_reducelogsumexp_keepdims(%{{.*}}: tensor<?x?x?xf32>, %{{.*}}: tensor<?xi64>) -> tensor<*xf32>
 func.func @test_reducelogsumexp_keepdims(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -> tensor<*xf32> {
   %0 ="onnx.ReduceLogSumExp"(%arg0, %arg1) {keepdims = 1 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>)-> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-NEXT: [[REDUCE_MAX:%.+]] = "onnx.ReduceMax"(%arg0, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>) -> tensor<*xf32>
   // CHECK-NEXT: [[SUB:%.+]] = "onnx.Sub"(%arg0, [[REDUCE_MAX]]) : (tensor<?x?x?xf32>, tensor<*xf32>) -> tensor<*xf32>
@@ -63,7 +63,7 @@ func.func @test_reducelogsumexp_keepdims(%arg0 : tensor<?x?x?xf32>, %arg1 : tens
   // CHECK-NEXT: [[REDUCE_SUM:%.+]] = "onnx.ReduceSum"([[EXP]], %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<*xf32>, tensor<?xi64>) -> tensor<*xf32>
   // CHECK-NEXT: [[LOG:%.+]] = "onnx.Log"([[REDUCE_SUM]]) : (tensor<*xf32>) -> tensor<*xf32>
   // CHECK-NEXT: [[RES:%.+]] = "onnx.Add"([[LOG]], [[REDUCE_MAX]]) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  // CHECK-NEXT: return [[RES]] : tensor<*xf32>
+  // CHECK-NEXT: onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
@@ -71,7 +71,7 @@ func.func @test_reducelogsumexp_keepdims(%arg0 : tensor<?x?x?xf32>, %arg1 : tens
 // CHECK-LABEL: @test_reducesumsquare(%{{.*}}: tensor<?x?x?xf32>, %{{.*}}: tensor<?xi64>) -> tensor<*xf32>
 func.func @test_reducesumsquare(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>) -> tensor<*xf32> {
   %0 ="onnx.ReduceSumSquare"(%arg0, %arg1) {keepdims = 0 : si64} : (tensor<?x?x?xf32>, tensor<?xi64>)-> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-NEXT: [[SQUARE:%.+]] =  "onnx.Mul"(%arg0, %arg0) : (tensor<?x?x?xf32>, tensor<?x?x?xf32>) -> tensor<*xf32>
   // CHECK-NEXT: %{{[0-9]+}} = "onnx.ReduceSum"([[SQUARE]], %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<*xf32>, tensor<?xi64>) -> tensor<*xf32>
@@ -85,9 +85,9 @@ func.func @test_reducesumsquare(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?xi64>
 // CHECK-LABEL: func @test_scaler_null_float(%{{.*}}: tensor<3xf32>) -> tensor<3xf32> {
 func.func @test_scaler_null_float(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) : (tensor<3xf32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
-  // CHECK-NEXT: return %arg0 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %arg0 : tensor<3xf32>
 }
 
 // -----
@@ -96,10 +96,10 @@ func.func @test_scaler_null_float(%arg0: tensor<3xf32>) -> tensor<3xf32> {
 // CHECK-LABEL: func @test_scaler_null(%{{.*}}: tensor<3xi32>) -> tensor<3xf32> {
 func.func @test_scaler_null(%arg0: tensor<3xi32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) : (tensor<3xi32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-NEXT: %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<3xi32>) -> tensor<3xf32>
-  // CHECK-NEXT: return %0 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %0 : tensor<3xf32>
 }
 
 // -----
@@ -108,11 +108,11 @@ func.func @test_scaler_null(%arg0: tensor<3xi32>) -> tensor<3xf32> {
 // CHECK-LABEL: func @test_scaler_no_offset(%{{.*}}: tensor<3xf32>) -> tensor<3xf32> {
 func.func @test_scaler_no_offset(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) {scale = [3.125000e-02 : f32, 0.0909090936 : f32, 0.0333333351 : f32]} : (tensor<3xf32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-NEXT: %0 = onnx.Constant dense<[3.125000e-02, 0.0909090936, 0.0333333351]> : tensor<3xf32>
   // CHECK-NEXT: %1 = "onnx.Mul"(%arg0, %0) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
-  // CHECK-NEXT: return %1 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %1 : tensor<3xf32>
 }
 
 // -----
@@ -121,12 +121,12 @@ func.func @test_scaler_no_offset(%arg0: tensor<3xf32>) -> tensor<3xf32> {
 // CHECK-LABEL: func @test_scaler_no_offset2(%{{.*}}: tensor<3xi32>) -> tensor<3xf32> {
 func.func @test_scaler_no_offset2(%arg0: tensor<3xi32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) {scale = [3.125000e-02 : f32, 0.0909090936 : f32, 0.0333333351 : f32]} : (tensor<3xi32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-NEXT: %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<3xi32>) -> tensor<*xf32>
   // CHECK-NEXT: %1 = onnx.Constant dense<[3.125000e-02, 0.0909090936, 0.0333333351]> : tensor<3xf32>
   // CHECK-NEXT: %2 = "onnx.Mul"(%0, %1) : (tensor<*xf32>, tensor<3xf32>) -> tensor<3xf32>
-  // CHECK-NEXT: return %2 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %2 : tensor<3xf32>
 }
 
 // -----
@@ -135,11 +135,11 @@ func.func @test_scaler_no_offset2(%arg0: tensor<3xi32>) -> tensor<3xf32> {
 // CHECK-LABEL: func @test_scaler_no_scale(%{{.*}}: tensor<3xf32>) -> tensor<3xf32> {
 func.func @test_scaler_no_scale(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) {offset = [1986.99939 : f32, 0.99999988 : f32, 0.999999701 : f32]} : (tensor<3xf32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-NEXT: %0 = onnx.Constant dense<[1986.99939, 0.99999988, 0.999999701]> : tensor<3xf32>
   // CHECK-NEXT: %1 = "onnx.Sub"(%arg0, %0) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
-  // CHECK-NEXT: return %1 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %1 : tensor<3xf32>
 }
 
 // -----
@@ -148,12 +148,12 @@ func.func @test_scaler_no_scale(%arg0: tensor<3xf32>) -> tensor<3xf32> {
 // CHECK-LABEL: func @test_scaler_no_scale2(%{{.*}}: tensor<3xi32>) -> tensor<3xf32> {
 func.func @test_scaler_no_scale2(%arg0: tensor<3xi32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) {offset = [1986.99939 : f32, 0.99999988 : f32, 0.999999701 : f32]} : (tensor<3xi32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-NEXT: %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<3xi32>) -> tensor<*xf32>
   // CHECK-NEXT: %1 = onnx.Constant dense<[1986.99939, 0.99999988, 0.999999701]> : tensor<3xf32>
   // CHECK-NEXT: %2 = "onnx.Sub"(%0, %1) : (tensor<*xf32>, tensor<3xf32>) -> tensor<3xf32>
-  // CHECK-NEXT: return %2 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %2 : tensor<3xf32>
 }
 
 // -----
@@ -162,13 +162,13 @@ func.func @test_scaler_no_scale2(%arg0: tensor<3xi32>) -> tensor<3xf32> {
 // CHECK-LABEL: func @test_scaler_normal(%{{.*}}: tensor<3xf32>) -> tensor<3xf32> {
 func.func @test_scaler_normal(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) {offset = [1986.99939 : f32, 0.99999988 : f32, 0.999999701 : f32], scale = [3.125000e-02 : f32, 0.0909090936 : f32, 0.0333333351 : f32]} : (tensor<3xf32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-NEXT: %0 = onnx.Constant dense<[1986.99939, 0.99999988, 0.999999701]> : tensor<3xf32>
   // CHECK-NEXT: %1 = "onnx.Sub"(%arg0, %0) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
   // CHECK-NEXT: %2 = onnx.Constant dense<[3.125000e-02, 0.0909090936, 0.0333333351]> : tensor<3xf32>
   // CHECK-NEXT: %3 = "onnx.Mul"(%1, %2) : (tensor<3xf32>, tensor<3xf32>) -> tensor<3xf32>
-  // CHECK-NEXT: return %3 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %3 : tensor<3xf32>
 }
 
 // -----
@@ -177,14 +177,14 @@ func.func @test_scaler_normal(%arg0: tensor<3xf32>) -> tensor<3xf32> {
 // CHECK-LABEL: func @test_scaler_normal2(%{{.*}}: tensor<3xi32>) -> tensor<3xf32> {
 func.func @test_scaler_normal2(%arg0: tensor<3xi32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) {offset = [1986.99939 : f32, 0.99999988 : f32, 0.999999701 : f32], scale = [3.125000e-02 : f32, 0.0909090936 : f32, 0.0333333351 : f32]} : (tensor<3xi32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-NEXT: %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<3xi32>) -> tensor<*xf32>
   // CHECK-NEXT: %1 = onnx.Constant dense<[1986.99939, 0.99999988, 0.999999701]> : tensor<3xf32>
   // CHECK-NEXT: %2 = "onnx.Sub"(%0, %1) : (tensor<*xf32>, tensor<3xf32>) -> tensor<*xf32>
   // CHECK-NEXT: %3 = onnx.Constant dense<[3.125000e-02, 0.0909090936, 0.0333333351]> : tensor<3xf32>
   // CHECK-NEXT: %4 = "onnx.Mul"(%2, %3) : (tensor<*xf32>, tensor<3xf32>) -> tensor<3xf32>
-  // CHECK-NEXT: return %4 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %4 : tensor<3xf32>
 }
 
 // -----
@@ -193,13 +193,13 @@ func.func @test_scaler_normal2(%arg0: tensor<3xi32>) -> tensor<3xf32> {
 // CHECK-LABEL: func @test_scaler_constant(%{{.*}}: tensor<3xf32>) -> tensor<3xf32> {
 func.func @test_scaler_constant(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %0 = "onnx.Scaler"(%arg0) {offset = [1986.99939 : f32], scale = [3.125000e-02 : f32]} : (tensor<3xf32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-NEXT: %0 = onnx.Constant dense<1986.99939> : tensor<1xf32>
   // CHECK-NEXT: %1 = "onnx.Sub"(%arg0, %0) : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
   // CHECK-NEXT: %2 = onnx.Constant dense<3.125000e-02> : tensor<1xf32>
   // CHECK-NEXT: %3 = "onnx.Mul"(%1, %2) : (tensor<3xf32>, tensor<1xf32>) -> tensor<3xf32>
-  // CHECK-NEXT: return %3 : tensor<3xf32>
+  // CHECK-NEXT: onnx.Return %3 : tensor<3xf32>
 }
 
 // -----
@@ -207,74 +207,74 @@ func.func @test_scaler_constant(%arg0: tensor<3xf32>) -> tensor<3xf32> {
 // Rewrite LogSoftmax using Log and Softmax.
 func.func @test_logsoftmax(%arg0 : tensor<10x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.LogSoftmax"(%arg0) {axis=1: si64} : (tensor<10x10xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_logsoftmax
   // CHECK: [[SOFTMAX:%.+]] = "onnx.Softmax"(%arg0) {axis = 1 : si64} : (tensor<10x10xf32>) -> tensor<*xf32>
   // CHECK: [[RES:%.+]] = "onnx.Log"([[SOFTMAX]]) : (tensor<*xf32>) -> tensor<*xf32>
-  // CHECK: return [[RES]] : tensor<*xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
 
 func.func @test_upsample(%arg0: tensor<1x1x2x2xf32>, %arg1: tensor<4xf32>) -> tensor<1x1x4x6xf32> {
   %0 = "onnx.Upsample"(%arg0, %arg1) {mode = "nearest"} : (tensor<1x1x2x2xf32>, tensor<4xf32>) -> tensor<1x1x4x6xf32>
-  return %0 : tensor<1x1x4x6xf32>
+  onnx.Return %0 : tensor<1x1x4x6xf32>
   // CHECK-LABEL: test_upsample
   // CHECK: [[NONE_0:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK: [[NONE_1:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], %arg1, [[NONE_1]]) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
-  // CHECK: return [[RES]] : tensor<1x1x4x6xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x1x4x6xf32>
 }
 
 // -----
 
 func.func @test_upsamplev7(%arg0: tensor<1x1x2x2xf32>) -> tensor<1x1x4x6xf32> {
   %0 = "onnx.UpsampleV7"(%arg0) {mode = "nearest", scales = [0.1 : f32, 0.2 : f32, 0.3 : f32, 0.4 : f32]} : (tensor<1x1x2x2xf32>) -> tensor<1x1x4x6xf32>
-  return %0 : tensor<1x1x4x6xf32>
+  onnx.Return %0 : tensor<1x1x4x6xf32>
   // CHECK-LABEL: test_upsamplev7
   // CHECK: [[NONE_0:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK: [[SCALES:%.+]] = onnx.Constant dense<[1.000000e-01, 2.000000e-01, 3.000000e-01, 4.000000e-01]> : tensor<4xf32>
   // CHECK: [[NONE_1:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], [[SCALES]], [[NONE_1]]) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
-  // CHECK: return [[RES]] : tensor<1x1x4x6xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x1x4x6xf32>
 }
 
 // -----
 
 func.func @test_padv2(%arg0: tensor<1x3x224x224xf32>) -> tensor<*xf32> {
     %0 = "onnx.PadV2"(%arg0) {mode = "reflect", pads = [0, 0, 4, 4, 0, 0, 4, 4]} : (tensor<1x3x224x224xf32>) -> tensor<*xf32>
-    return %0 : tensor<*xf32>
+    onnx.Return %0 : tensor<*xf32>
     // CHECK-LABEL: test_padv2
     // CHECK: [[PAD:%.+]] = onnx.Constant dense<[0, 0, 4, 4, 0, 0, 4, 4]> : tensor<8xi64>
     // CHECK: [[CONSTANT_VALUE:%.+]] = onnx.Constant dense<0.000000e+00> : tensor<1xf32>
     // CHECK: [[NONE:%.+]] = "onnx.NoValue"() {value} : () -> none
     // CHECK: [[RES:%.+]] = "onnx.Pad"(%arg0, [[PAD]], [[CONSTANT_VALUE]], [[NONE]]) {mode = "reflect"} : (tensor<1x3x224x224xf32>, tensor<8xi64>, tensor<1xf32>, none) -> tensor<*xf32>
-    // CHECK: return [[RES]] : tensor<*xf32>
+    // CHECK: onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
 
 func.func @test_resizev10(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<4xf32>) -> tensor<*xf32> {
   %0 = "onnx.ResizeV10"(%arg0, %arg1) {mode = "nearest"} : (tensor<1x2x3x4xf32>, tensor<4xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
   // CHECK-LABEL:  func @test_resizev10
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x3x4xf32>, [[PARAM_1_:%.+]]: tensor<4xf32>) -> tensor<*xf32> {
   // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"
   // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.NoValue"
   // CHECK:           [[VAR_2_:%.+]] = "onnx.Resize"([[PARAM_0_]], [[VAR_0_]], [[PARAM_1_]], [[VAR_1_]]) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x2x3x4xf32>, none, tensor<4xf32>, none) -> tensor<*xf32>
-  // CHECK:           return [[VAR_2_]] : tensor<*xf32>
+  // CHECK:           onnx.Return [[VAR_2_]] : tensor<*xf32>
 }
 
 // -----
 
 func.func @test_resizev11(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>, %arg2: tensor<*xf32>, %arg3: tensor<*xi64>) -> tensor<*xf32> {
   %0 = "onnx.ResizeV11"(%arg0, %arg1, %arg2, %arg3) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>, tensor<*xi64>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
   // CHECK-LABEL:  func @test_resizev11
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>, [[PARAM_2_:%.+]]: tensor<*xf32>, [[PARAM_3_:%.+]]: tensor<*xi64>) -> tensor<*xf32> {
   // CHECK:           [[VAR_1_:%.+]] = "onnx.Resize"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor"} : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>, tensor<*xi64>) -> tensor<*xf32>
-  // CHECK:           return [[VAR_1_]] : tensor<*xf32>
+  // CHECK:           onnx.Return [[VAR_1_]] : tensor<*xf32>
 }
 
 // -----
@@ -282,7 +282,7 @@ func.func @test_resizev11(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>, %arg2: ten
 func.func @test_resizev13(%arg0: tensor<*xf32>, %arg1: tensor<*xi64>) -> tensor<*xf32> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.ResizeV13"(%arg0, %0, %0, %arg1) {coordinate_transformation_mode = "half_pixel", mode = "nearest", nearest_mode = "floor"} : (tensor<*xf32>, none, none, tensor<*xi64>) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
   // CHECK-LABEL:  func @test_resizev13
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xi64>) -> tensor<*xf32> {
   // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"
@@ -293,7 +293,7 @@ func.func @test_resizev13(%arg0: tensor<*xf32>, %arg1: tensor<*xi64>) -> tensor<
 
 func.func @test_seqence_construct_1(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %0 = "onnx.SequenceConstruct"(%arg0, %arg1) : (tensor<*xf32>, tensor<*xf32>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 
   // CHECK-LABEL:  func @test_seqence_construct_1
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>) -> !onnx.Seq<tensor<*xf32>> {
@@ -301,59 +301,59 @@ func.func @test_seqence_construct_1(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) 
   // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<*xf32>, none) -> !onnx.Seq<tensor<*xf32>>
   // CHECK:           [[VAR_2_:%.+]] = "onnx.SequenceInsert"([[VAR_1_]], [[PARAM_1_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<*xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-  // CHECK:           return [[VAR_2_]] : !onnx.Seq<tensor<*xf32>>
+  // CHECK:           onnx.Return [[VAR_2_]] : !onnx.Seq<tensor<*xf32>>
 }
 
 // -----
 
 func.func @test_seqence_construct_2(%arg0: tensor<*xi16>) -> !onnx.Seq<tensor<*xi16>> {
   %0 = "onnx.SequenceConstruct"(%arg0) : (tensor<*xi16>) -> !onnx.Seq<tensor<*xi16>>
-  return %0 : !onnx.Seq<tensor<*xi16>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xi16>>
 
   // CHECK-LABEL:  func @test_seqence_construct_2
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xi16>) -> !onnx.Seq<tensor<*xi16>> {
   // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() {dtype = 5 : si64} : () -> !onnx.Seq<tensor<*xi16>>
   // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xi16>>, tensor<*xi16>, none) -> !onnx.Seq<tensor<*xi16>>
-  // CHECK:           return [[VAR_1_]] : !onnx.Seq<tensor<*xi16>>
+  // CHECK:           onnx.Return [[VAR_1_]] : !onnx.Seq<tensor<*xi16>>
 }
 
 // -----
 
 func.func @test_clipv6(%arg0 : tensor<*xf32>) -> () {
   %0 = "onnx.ClipV6"(%arg0) {max = 6.000000e+00 : f32, min = 0.000000e+00 : f32} : (tensor<*xf32>) -> tensor<*xf32>
-  return 
+  onnx.Return 
 
   // CHECK-LABEL:  func @test_clipv6
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>) {
   // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<0.000000e+00> : tensor<f32>
   // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<6.000000e+00> : tensor<f32>
   // CHECK:           [[VAR_2_:%.+]] = "onnx.Clip"([[PARAM_0_]], [[VAR_0_]], [[VAR_1_]]) : (tensor<*xf32>, tensor<f32>, tensor<f32>) -> tensor<*xf32>
-  // CHECK:           return
+  // CHECK:           onnx.Return
 }
 
 // -----
 
 func.func @test_splitV11(%arg0 : tensor<*xf32>) -> () {
   %0 = "onnx.SplitV11"(%arg0) {axis = 1 : si64, split = [1]} : (tensor<*xf32>) -> tensor<*xf32>
-  return
+  onnx.Return
 
   // CHECK-LABEL:  func @test_splitV11
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
   // CHECK:           [[VAR_1_:%.+]] = "onnx.Split"(%arg0, %0) {axis = 1 : si64} : (tensor<*xf32>, tensor<1xi64>) -> tensor<*xf32>
-  // CHECK:           return
+  // CHECK:           onnx.Return
 }
 
 // -----
 
 func.func @test_splitV11_no_split(%arg0 : tensor<*xf32>) -> () {
   %0 = "onnx.SplitV11"(%arg0) {axis = 1 : si64} : (tensor<*xf32>) -> tensor<*xf32>
-  return
+  onnx.Return
 
   // CHECK-LABEL:  func @test_splitV11_no_split
   // CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:           [[VAR_1_:%.+]] = "onnx.Split"(%arg0, %0) {axis = 1 : si64} : (tensor<*xf32>, none) -> tensor<*xf32>
-  // CHECK:           return
+  // CHECK:           onnx.Return
 }
 
 // -----
@@ -361,48 +361,48 @@ func.func @test_splitV11_no_split(%arg0 : tensor<*xf32>) -> () {
 func.func @test_splitV13(%arg0 : tensor<*xf32>) -> () {
   %0 = onnx.Constant dense<1> : tensor<1xi64>
   %1 = "onnx.SplitV13"(%arg0, %0) {axis = 1 : si64} : (tensor<*xf32>, tensor<1xi64>) -> tensor<*xf32>
-  return
+  onnx.Return
 
   // CHECK-LABEL:  func @test_splitV13
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
   // CHECK:           [[VAR_1_:%.+]] = "onnx.Split"(%arg0, %0) {axis = 1 : si64} : (tensor<*xf32>, tensor<1xi64>) -> tensor<*xf32>
-  // CHECK:           return
+  // CHECK:           onnx.Return
 }
 
 // -----
 
 func.func @test_squeezeV11(%arg0 : tensor<*xf32>) -> () {
   %0 = "onnx.SqueezeV11"(%arg0) {axes = [1]} : (tensor<*xf32>) -> tensor<*xf32>
-  return
+  onnx.Return
 
   // CHECK-LABEL:  func @test_squeezeV11
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
   // CHECK:           [[VAR_1_:%.+]] = "onnx.Squeeze"(%arg0, %0) : (tensor<*xf32>, tensor<1xi64>) -> tensor<*xf32>
-  // CHECK:           return
+  // CHECK:           onnx.Return
 }
 
 // -----
 
 func.func @test_squeezeV11_no_axes(%arg0 : tensor<*xf32>) -> () {
   %0 = "onnx.SqueezeV11"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  return
+  onnx.Return
 
   // CHECK-LABEL:  func @test_squeezeV11_no_axes
   // CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:           [[VAR_1_:%.+]] = "onnx.Squeeze"(%arg0, %0) : (tensor<*xf32>, none) -> tensor<*xf32>
-  // CHECK:           return
+  // CHECK:           onnx.Return
 }
 
 // -----
 
 func.func @test_unsqueezeV11(%arg0 : tensor<*xf32>) -> () {
   %0 = "onnx.UnsqueezeV11"(%arg0) {axes = [1]} : (tensor<*xf32>) -> tensor<*xf32>
-  return
+  onnx.Return
 
   // CHECK-LABEL:  func @test_unsqueezeV11
   // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
   // CHECK:           [[VAR_1_:%.+]] = "onnx.Unsqueeze"(%arg0, %0) : (tensor<*xf32>, tensor<1xi64>) -> tensor<*xf32>
-  // CHECK:           return
+  // CHECK:           onnx.Return
 }
 
 // -----
@@ -410,24 +410,24 @@ func.func @test_unsqueezeV11(%arg0 : tensor<*xf32>) -> () {
 func.func @test_padV13(%arg0 : tensor<*xi64>, %arg1 : tensor<2xi64>) -> () {
   %0 = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.PadV13"(%arg0, %arg1, %0) : (tensor<*xi64>, tensor<2xi64>, none) -> tensor<*xi64>
-  return
+  onnx.Return
   // CHECK-LABEL:  func @test_padV13
   // CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:           [[VAR_1_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK:           [[VAR_2_:%.+]] = "onnx.Pad"(%arg0, %arg1, [[VAR_0_]], [[VAR_1_]]) {mode = "constant"} : (tensor<*xi64>, tensor<2xi64>, none, none) -> tensor<*xi64>
-  // CHECK:           return
+  // CHECK:           onnx.Return
 }
 
 // -----
 
 func.func @test_scatter(%arg0: tensor<64x25600xf32>, %arg1: tensor<64x100xi64>, %arg2: tensor<64x100xf32>) -> tensor<*xf32> {
   %0 = "onnx.Scatter"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<64x25600xf32>, tensor<64x100xi64>, tensor<64x100xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL:  func @test_scatter
   // CHECK-SAME:   ([[PARAM_0:%.+]]: tensor<64x25600xf32>, [[PARAM_1:%.+]]: tensor<64x100xi64>, [[PARAM_2:%.+]]: tensor<64x100xf32>) -> tensor<*xf32> {
   // CHECK-NEXT:      [[RES:%.+]] = "onnx.ScatterElements"(%arg0, %arg1, %arg2) {axis = 1 : si64, reduction = "none"} : (tensor<64x25600xf32>, tensor<64x100xi64>, tensor<64x100xf32>) -> tensor<*xf32>
-  // CHECK-NEXT:      return [[RES]] : tensor<*xf32>
+  // CHECK-NEXT:      onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
@@ -437,11 +437,11 @@ func.func @concat_fuse_0(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -> (t
     %1 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
     %2 = "onnx.Transpose"(%1) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
     %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
-    return %3, %2 : tensor<2xi64>, tensor<50x?xf32>
+    onnx.Return %3, %2 : tensor<2xi64>, tensor<50x?xf32>
 // CHECK-LABEL:  func.func @concat_fuse_0
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>) {
 // CHECK:           [[shape_:%.+]], [[VAR_transposed_:%.+]] = "onnx.ConcatShapeTranspose"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64, perm = [1, 0], start = 0 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>)
-// CHECK:           return [[shape_]], [[VAR_transposed_]] : tensor<2xi64>, tensor<50x?xf32>
+// CHECK:           onnx.Return [[shape_]], [[VAR_transposed_]] : tensor<2xi64>, tensor<50x?xf32>
 // CHECK:         }
 }
 
@@ -453,14 +453,14 @@ func.func @test_concatfuse_1(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -
     %2 = "onnx.Transpose"(%1) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
     %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
     %4 = "onnx.Sin"(%1) : (tensor<?x50xf32>) -> tensor<?x50xf32>
-    return %3, %2 : tensor<2xi64>, tensor<50x?xf32>
+    onnx.Return %3, %2 : tensor<2xi64>, tensor<50x?xf32>
 // CHECK-LABEL:  func.func @test_concatfuse_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<50x?xf32>) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[VAR_0_]]) {perm = [1, 0]} : (tensor<?x50xf32>) -> tensor<50x?xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Shape"([[VAR_0_]]) {start = 0 : si64} : (tensor<?x50xf32>) -> tensor<2xi64>
 // CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Sin"([[VAR_0_]]) : (tensor<?x50xf32>) -> tensor<?x50xf32>
-// CHECK:           return [[VAR_2_]], [[VAR_1_]] : tensor<2xi64>, tensor<50x?xf32>
+// CHECK:           onnx.Return [[VAR_2_]], [[VAR_1_]] : tensor<2xi64>, tensor<50x?xf32>
 // CHECK:         }
 }
 
@@ -471,12 +471,12 @@ func.func @test_concatfuse_2(%arg0: tensor<?x20xf32>, %arg1: tensor<?x30xf32>) -
     %1 = "onnx.Concat"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
     %3 = "onnx.Shape"(%1) : (tensor<?x50xf32>) -> tensor<2xi64>
     %4 = "onnx.Sin"(%1) : (tensor<?x50xf32>) -> tensor<?x50xf32>
-    return %3, %4 : tensor<2xi64>, tensor<?x50xf32>
+    onnx.Return %3, %4 : tensor<2xi64>, tensor<?x50xf32>
 // CHECK-LABEL:  func.func @test_concatfuse_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x20xf32>, [[PARAM_1_:%.+]]: tensor<?x30xf32>) -> (tensor<2xi64>, tensor<?x50xf32>) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64} : (tensor<?x20xf32>, tensor<?x30xf32>) -> tensor<?x50xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Shape"([[VAR_0_]]) {start = 0 : si64} : (tensor<?x50xf32>) -> tensor<2xi64>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Sin"([[VAR_0_]]) : (tensor<?x50xf32>) -> tensor<?x50xf32>
-// CHECK:           return [[VAR_1_]], [[VAR_2_]] : tensor<2xi64>, tensor<?x50xf32>
+// CHECK:           onnx.Return [[VAR_1_]], [[VAR_2_]] : tensor<2xi64>, tensor<?x50xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_decompose_convtranspose.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose.mlir
@@ -10,7 +10,7 @@
 
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x1x3x3xf32>, tensor<1x2x3x3xf32>, none) -> tensor<1x2x5x5xf32>
-    return %1 : tensor<1x2x5x5xf32>
+    onnx.Return %1 : tensor<1x2x5x5xf32>
 
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<1x2x3x3xf32>) -> tensor<3x3x1x2xf32>
@@ -31,7 +31,7 @@
 // CHECK-DAG:       [[VAR_14_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_15_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_16_:%.+]] = "onnx.Pad"([[VAR_12_]], [[VAR_13_]], [[VAR_14_]], [[VAR_15_]]) {mode = "constant"} : (tensor<1x2x5x5xf32>, tensor<8xi64>, none, none) -> tensor<1x2x5x5xf32>
-// CHECK:           return [[VAR_16_]] : tensor<1x2x5x5xf32>
+// CHECK:           onnx.Return [[VAR_16_]] : tensor<1x2x5x5xf32>
 
   }
 
@@ -45,7 +45,7 @@
 
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x1x3xf32>, tensor<1x2x3xf32>, none) -> tensor<1x2x5xf32>
-    return %1 : tensor<1x2x5xf32>
+    onnx.Return %1 : tensor<1x2x5xf32>
 
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 0, 1]} : (tensor<1x2x3xf32>) -> tensor<3x1x2xf32>
@@ -58,7 +58,7 @@
 // CHECK-DAG:       [[VAR_8_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_9_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_10_:%.+]] = "onnx.Pad"([[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]]) {mode = "constant"} : (tensor<1x2x5xf32>, tensor<6xi64>, none, none) -> tensor<1x2x5xf32>
-// CHECK:           return [[VAR_10_]] : tensor<1x2x5xf32>
+// CHECK:           onnx.Return [[VAR_10_]] : tensor<1x2x5xf32>
   }
 
 // -----
@@ -71,7 +71,7 @@
 
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x1x3x4x5xf32>, tensor<1x2x3x3x3xf32>, none) -> tensor<1x2x5x6x7xf32>
-    return %1 : tensor<1x2x5x6x7xf32>
+    onnx.Return %1 : tensor<1x2x5x6x7xf32>
 
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 4, 0, 1]} : (tensor<1x2x3x3x3xf32>) -> tensor<3x3x3x1x2xf32>
@@ -100,7 +100,7 @@
 // CHECK-DAG:       [[VAR_21_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_22_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_23_:%.+]] = "onnx.Pad"([[VAR_19_]], [[VAR_20_]], [[VAR_21_]], [[VAR_22_]]) {mode = "constant"} : (tensor<1x2x5x6x7xf32>, tensor<10xi64>, none, none) -> tensor<1x2x5x6x7xf32>
-// CHECK:           return [[VAR_23_]] : tensor<1x2x5x6x7xf32>
+// CHECK:           onnx.Return [[VAR_23_]] : tensor<1x2x5x6x7xf32>
   }
 
 // -----
@@ -113,7 +113,7 @@
 
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64, pads = [1, 2, 1, 2], strides = [3, 2]} : (tensor<1x1x3x3xf32>, tensor<1x2x3x3xf32>, none) -> tensor<1x2x7x3xf32>
-    return %1 : tensor<1x2x7x3xf32>
+    onnx.Return %1 : tensor<1x2x7x3xf32>
 
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<1x2x3x3xf32>) -> tensor<3x3x1x2xf32>
@@ -160,7 +160,7 @@
 // CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_38_:%.+]] = "onnx.Pad"([[VAR_34_]], [[VAR_35_]], [[VAR_36_]], [[VAR_37_]]) {mode = "constant"} : (tensor<1x2x7x3xf32>, tensor<8xi64>, none, none) -> tensor<1x2x7x3xf32>
-// CHECK:           return [[VAR_38_]] : tensor<1x2x7x3xf32>
+// CHECK:           onnx.Return [[VAR_38_]] : tensor<1x2x7x3xf32>
   }
 
 // -----
@@ -173,7 +173,7 @@
 
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64, output_shape = [10, 8], strides = [3, 2]} : (tensor<1x1x3x3xf32>, tensor<1x2x3x3xf32>, none) -> tensor<1x2x10x8xf32>
-    return %1 : tensor<1x2x10x8xf32>
+    onnx.Return %1 : tensor<1x2x10x8xf32>
 
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<1x2x3x3xf32>) -> tensor<3x3x1x2xf32>
@@ -220,7 +220,7 @@
 // CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_38_:%.+]] = "onnx.Pad"([[VAR_34_]], [[VAR_35_]], [[VAR_36_]], [[VAR_37_]]) {mode = "constant"} : (tensor<1x2x10x7xf32>, tensor<8xi64>, none, none) -> tensor<1x2x10x8xf32>
-// CHECK:           return [[VAR_38_]] : tensor<1x2x10x8xf32>
+// CHECK:           onnx.Return [[VAR_38_]] : tensor<1x2x10x8xf32>
   }
 
 // -----
@@ -232,7 +232,7 @@
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3x3xf32>, [[PARAM_1_:%.+]]: tensor<?x?x3x3xf32>)
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [3, 3], onnx_node_name = "test", output_padding = [1, 1], output_shape = [10, 8], strides = [3, 2]} : (tensor<?x?x3x3xf32>, tensor<?x?x3x3xf32>, none) -> tensor<?x?x10x8xf32>
-    return %1 : tensor<?x?x10x8xf32>
+    onnx.Return %1 : tensor<?x?x10x8xf32>
 
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [2, 3, 0, 1]} : (tensor<?x?x3x3xf32>) -> tensor<3x3x?x?xf32>
@@ -279,5 +279,5 @@
 // CHECK-DAG:       [[VAR_36_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_37_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_38_:%.+]] = "onnx.Pad"([[VAR_34_]], [[VAR_35_]], [[VAR_36_]], [[VAR_37_]]) {mode = "constant"} : (tensor<?x?x10x7xf32>, tensor<8xi64>, none, none) -> tensor<?x?x10x8xf32>
-// CHECK:           return [[VAR_38_]] : tensor<?x?x10x8xf32>
+// CHECK:           onnx.Return [[VAR_38_]] : tensor<?x?x10x8xf32>
   }

--- a/test/mlir/onnx/onnx_decompose_customop.mlir
+++ b/test/mlir/onnx/onnx_decompose_customop.mlir
@@ -4,7 +4,7 @@
 
 func.func @customop_fusedmatmul_onnxruntime(%arg0: tensor<3x5x7x9xf32>, %arg1:tensor<3x5x7x9xf32>) -> tensor<3x5x9x9xf32> {
     %0 = "onnx.Custom"(%arg0, %arg1) {alpha = 1.250000e-01 : f32, domain_name = "com.microsoft", function_name = "FusedMatMul", transA = 1 : si64, transB = 0 : si64} : (tensor<3x5x7x9xf32>, tensor<3x5x7x9xf32>) -> tensor<3x5x9x9xf32>
-    return %0: tensor<3x5x9x9xf32>
+    onnx.Return %0: tensor<3x5x9x9xf32>
 
 // CHECK-LABEL:  func.func @customop_fusedmatmul_onnxruntime
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x5x7x9xf32>, [[PARAM_1_:%.+]]: tensor<3x5x7x9xf32>) -> tensor<3x5x9x9xf32> {
@@ -12,7 +12,7 @@ func.func @customop_fusedmatmul_onnxruntime(%arg0: tensor<3x5x7x9xf32>, %arg1:te
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1.250000e-01> : tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.MatMul"([[VAR_0_]], [[PARAM_1_]]) : (tensor<3x5x9x7xf32>, tensor<3x5x7x9xf32>) -> tensor<3x5x9x9xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[VAR_1_]], [[VAR_2_]]) : (tensor<1xf32>, tensor<3x5x9x9xf32>) -> tensor<3x5x9x9xf32>
-// CHECK:           return [[VAR_3_]] : tensor<3x5x9x9xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<3x5x9x9xf32>
 // CHECK:         }
 }
 
@@ -20,14 +20,14 @@ func.func @customop_fusedmatmul_onnxruntime(%arg0: tensor<3x5x7x9xf32>, %arg1:te
 
 func.func @customop_fusedmatmul_onnxruntime_no_transpose(%arg0: tensor<*xf32>, %arg1:tensor<*xf32>) -> tensor<*xf32> {
     %0 = "onnx.Custom"(%arg0, %arg1) {alpha = 1.250000e-01 : f32, domain_name = "com.microsoft", function_name = "FusedMatMul", transA = 0 : si64, transB = 0 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    return %0: tensor<*xf32>
+    onnx.Return %0: tensor<*xf32>
 
 // CHECK-LABEL:  func.func @customop_fusedmatmul_onnxruntime_no_transpose
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.250000e-01> : tensor<1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xf32>, tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_2_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<*xf32>
 // CHECK:         }
 }
 
@@ -36,7 +36,7 @@ func.func @customop_fusedmatmul_onnxruntime_no_transpose(%arg0: tensor<*xf32>, %
 func.func @customop_fusedmatmul_onnxruntime_transA(%arg0: tensor<*xf32>, %arg1:tensor<*xf32>) -> tensor<*xf32> {
     %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 1, 3]} : (tensor<*xf32>) -> tensor<*xf32>
     %1 = "onnx.Custom"(%0, %arg1) {alpha = 1.250000e-01 : f32, domain_name = "com.microsoft", function_name = "FusedMatMul", transA = 1 : si64, transB = 0 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    return %1: tensor<*xf32>
+    onnx.Return %1: tensor<*xf32>
 
 // CHECK-LABEL:  func.func @customop_fusedmatmul_onnxruntime_transA
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
@@ -45,7 +45,7 @@ func.func @customop_fusedmatmul_onnxruntime_transA(%arg0: tensor<*xf32>, %arg1:t
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1.250000e-01> : tensor<1xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[PARAM_1_]]) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
 // CHECK:           [[VAR_4_:%.+]] = "onnx.Mul"([[VAR_2_]], [[VAR_3_]]) : (tensor<1xf32>, tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_4_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<*xf32>
 // CHECK:         }
 }
 
@@ -54,7 +54,7 @@ func.func @customop_fusedmatmul_onnxruntime_transA(%arg0: tensor<*xf32>, %arg1:t
 func.func @customop_fusedmatmul_onnxruntime_transB(%arg0: tensor<*xf32>, %arg1:tensor<*xf32>) -> tensor<*xf32> {
     %0 = "onnx.Transpose"(%arg1) {perm = [0, 2, 1, 3]} : (tensor<*xf32>) -> tensor<*xf32>
     %1 = "onnx.Custom"(%arg0, %0) {alpha = 1.250000e-01 : f32, domain_name = "com.microsoft", function_name = "FusedMatMul", transA = 0 : si64, transB = 1 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    return %1: tensor<*xf32>
+    onnx.Return %1: tensor<*xf32>
 
 // CHECK-LABEL:  func.func @customop_fusedmatmul_onnxruntime_transB
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
@@ -63,7 +63,7 @@ func.func @customop_fusedmatmul_onnxruntime_transB(%arg0: tensor<*xf32>, %arg1:t
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1.250000e-01> : tensor<1xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
 // CHECK:           [[VAR_4_:%.+]] = "onnx.Mul"([[VAR_2_]], [[VAR_3_]]) : (tensor<1xf32>, tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_4_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<*xf32>
 // CHECK:         }
 }
 
@@ -73,13 +73,13 @@ func.func @customop_fusedmatmul_onnxruntime_transB(%arg0: tensor<*xf32>, %arg1:t
 func.func @customop_fusedmatmul_not_rewrite_domain(%arg0: tensor<*xf32>, %arg1:tensor<*xf32>) -> tensor<*xf32> {
     %0 = "onnx.Transpose"(%arg1) {perm = [0, 2, 1, 3]} : (tensor<*xf32>) -> tensor<*xf32>
     %1 = "onnx.Custom"(%arg0, %0) {alpha = 1.250000e-01 : f32, domain_name = "abc.xyz", function_name = "FusedMatMul", transA = 0 : si64, transB = 1 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    return %1: tensor<*xf32>
+    onnx.Return %1: tensor<*xf32>
 
 // CHECK-LABEL:  func.func @customop_fusedmatmul_not_rewrite_domain
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [0, 2, 1, 3]} : (tensor<*xf32>) -> tensor<*xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Custom"([[PARAM_0_]], [[VAR_0_]]) {alpha = 1.250000e-01 : f32, domain_name = "abc.xyz", function_name = "FusedMatMul", transA = 0 : si64, transB = 1 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_1_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<*xf32>
 // CHECK:         }
 }
 
@@ -89,12 +89,12 @@ func.func @customop_fusedmatmul_not_rewrite_domain(%arg0: tensor<*xf32>, %arg1:t
 // COM: So, there is no information to generate a transpose op.
 func.func @customop_fusedmatmul_not_rewrite_unranked_transpose(%arg0: tensor<*xf32>, %arg1:tensor<*xf32>) -> tensor<*xf32> {
     %1 = "onnx.Custom"(%arg0, %arg1) {alpha = 1.250000e-01 : f32, domain_name = "com.microsoft", function_name = "FusedMatMul", transA = 1 : si64, transB = 0 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    return %1: tensor<*xf32>
+    onnx.Return %1: tensor<*xf32>
 
 // CHECK-LABEL:  func.func @customop_fusedmatmul_not_rewrite_unranked_transpose
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Custom"([[PARAM_0_]], [[PARAM_1_]]) {alpha = 1.250000e-01 : f32, domain_name = "com.microsoft", function_name = "FusedMatMul", transA = 1 : si64, transB = 0 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_0_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
 // CHECK:         }
 }
 
@@ -103,11 +103,11 @@ func.func @customop_fusedmatmul_not_rewrite_unranked_transpose(%arg0: tensor<*xf
 // COM: Do not rewrite because alpha is not given.
 func.func @customop_fusedmatmul_not_rewrite_no_alpha(%arg0: tensor<*xf32>, %arg1:tensor<*xf32>) -> tensor<*xf32> {
     %1 = "onnx.Custom"(%arg0, %arg1) {domain_name = "com.microsoft", function_name = "FusedMatMul", transA = 0 : si64, transB = 0 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    return %1: tensor<*xf32>
+    onnx.Return %1: tensor<*xf32>
 
 // CHECK-LABEL:  func.func @customop_fusedmatmul_not_rewrite_no_alpha
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>, [[PARAM_1_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Custom"([[PARAM_0_]], [[PARAM_1_]]) {domain_name = "com.microsoft", function_name = "FusedMatMul", transA = 0 : si64, transB = 0 : si64} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_0_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_decompose_einsum.mlir
+++ b/test/mlir/onnx/onnx_decompose_einsum.mlir
@@ -2,11 +2,11 @@
 
 func.func @test_einsum_matmul(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x4x5xf32>) -> tensor<2x3x5xf32> {
   %0 = "onnx.Einsum"(%arg0, %arg1) {equation = "...ij,...jk"} : (tensor<2x3x4xf32>, tensor<2x4x5xf32>) -> tensor<2x3x5xf32>
-  return %0 : tensor<2x3x5xf32>
+  onnx.Return %0 : tensor<2x3x5xf32>
 // CHECK-LABEL:  func @test_einsum_matmul
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>, [[PARAM_1_:%.+]]: tensor<2x4x5xf32>) -> tensor<2x3x5xf32> {
 // CHECK-NEXT:      [[VAR_0_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<2x3x4xf32>, tensor<2x4x5xf32>) -> tensor<2x3x5xf32>
-// CHECK-NEXT:      return [[VAR_0_]] : tensor<2x3x5xf32>
+// CHECK-NEXT:      onnx.Return [[VAR_0_]] : tensor<2x3x5xf32>
 }
 
 // "...ij,...jk" is not implemented with MatMul over the reduction axis j
@@ -16,7 +16,7 @@ func.func @test_einsum_matmul(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x4x5xf32>
 // ReduceSum the j axis in the second argument, and then Mul the results
 func.func @test_einsum_matmul_broadcast(%arg0: tensor<2x3x1xf32>, %arg1: tensor<1x4x5xf32>) -> tensor<2x3x5xf32> {
   %0 = "onnx.Einsum"(%arg0, %arg1) {equation = "...ij,...jk"} : (tensor<2x3x1xf32>, tensor<1x4x5xf32>) -> tensor<2x3x5xf32>
-  return %0 : tensor<2x3x5xf32>
+  onnx.Return %0 : tensor<2x3x5xf32>
 // CHECK-LABEL:  func @test_einsum_matmul_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x1xf32>, [[PARAM_1_:%.+]]: tensor<1x4x5xf32>) -> tensor<2x3x5xf32> {
 // CHECK-NEXT:      [[VAR_0_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
@@ -29,51 +29,51 @@ func.func @test_einsum_matmul_broadcast(%arg0: tensor<2x3x1xf32>, %arg1: tensor<
 // CHECK-NEXT:      [[VAR_6_:%.+]] = "onnx.Unsqueeze"([[VAR_4_]], [[VAR_5_]]) : (tensor<3x2xf32>, tensor<1xi64>) -> tensor<3x2x1xf32>
 // CHECK-NEXT:      [[VAR_7_:%.+]] = "onnx.Mul"([[VAR_6_]], [[VAR_3_]]) : (tensor<3x2x1xf32>, tensor<1x5xf32>) -> tensor<3x2x5xf32>
 // CHECK-NEXT:      [[VAR_8_:%.+]] = "onnx.Transpose"([[VAR_7_]]) {perm = [1, 0, 2]} : (tensor<3x2x5xf32>) -> tensor<2x3x5xf32>
-// CHECK-NEXT:      return [[VAR_8_]] : tensor<2x3x5xf32>
+// CHECK-NEXT:      onnx.Return [[VAR_8_]] : tensor<2x3x5xf32>
 }
 
 func.func @test_einsum_transpose(%arg0: tensor<2x3xf32>) -> tensor<3x2xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ji"} : (tensor<2x3xf32>) -> tensor<3x2xf32>
-  return %0 : tensor<3x2xf32>
+  onnx.Return %0 : tensor<3x2xf32>
 
   // CHECK-LABEL:  func @test_einsum_transpose
   // CHECK-SAME:   ([[PARAM_0:%.+]]: tensor<2x3xf32>) -> tensor<3x2xf32> {
   // CHECK-NEXT:      [[RES:%.+]] = "onnx.Transpose"(%arg0) {perm = [1, 0]} : (tensor<2x3xf32>) -> tensor<3x2xf32>
-  // CHECK-NEXT:      return [[RES]] : tensor<3x2xf32>
+  // CHECK-NEXT:      onnx.Return [[RES]] : tensor<3x2xf32>
 }
 
 func.func @test_einsum_transpose_last_first(%arg0: tensor<0x1x2xf32>) -> tensor<2x0x1xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "...i->i..."} : (tensor<0x1x2xf32>) -> tensor<2x0x1xf32>
-  return %0 : tensor<2x0x1xf32>
+  onnx.Return %0 : tensor<2x0x1xf32>
 // CHECK-LABEL:  func @test_einsum_transpose_last_first
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<0x1x2xf32>) -> tensor<2x0x1xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<> : tensor<2x0x1xf32>
-// CHECK:           return [[VAR_0_]] : tensor<2x0x1xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<2x0x1xf32>
 }
 
 func.func @test_einsum_sum(%arg0: tensor<2x3xf32>) -> tensor<2xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ij->i"} : (tensor<2x3xf32>) -> tensor<2xf32>
-  return %0 : tensor<2xf32>
+  onnx.Return %0 : tensor<2xf32>
 // CHECK-LABEL:  func @test_einsum_sum
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3xf32>) -> tensor<2xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.ReduceSum"([[PARAM_0_]], [[VAR_0_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<2x3xf32>, tensor<1xi64>) -> tensor<2xf32>
-// CHECK:           return [[VAR_1_]] : tensor<2xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<2xf32>
 }
 
 func.func @test_einsum_mul3_broadcast(%arg0: tensor<1x3xf32>, %arg1: tensor<1x1xf32>, %arg2: tensor<2x1xf32>) -> tensor<2x3xf32> {
   %0 = "onnx.Einsum"(%arg0, %arg1, %arg2) {equation = "...,...,..."} : (tensor<1x3xf32>, tensor<1x1xf32>, tensor<2x1xf32>) -> tensor<2x3xf32>
-  return %0 : tensor<2x3xf32>
+  onnx.Return %0 : tensor<2x3xf32>
 // CHECK-LABEL:  func @test_einsum_mul3_broadcast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3xf32>, [[PARAM_1_:%.+]]: tensor<1x1xf32>, [[PARAM_2_:%.+]]: tensor<2x1xf32>) -> tensor<2x3xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<1x3xf32>, tensor<1x1xf32>) -> tensor<1x3xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Mul"([[VAR_0_]], [[PARAM_2_]]) : (tensor<1x3xf32>, tensor<2x1xf32>) -> tensor<2x3xf32>
-// CHECK:           return [[VAR_1_]] : tensor<2x3xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<2x3xf32>
 }
 
 func.func @test_einsum_diagonal(%arg0: tensor<3x3xf32>) -> tensor<3xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<3x3xf32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
   // CHECK-LABEL:  func @test_einsum_diagonal
   // CHECK-SAME:   ([[PARAM_0:%.+]]: tensor<3x3xf32>) -> tensor<3xf32> {
@@ -82,12 +82,12 @@ func.func @test_einsum_diagonal(%arg0: tensor<3x3xf32>) -> tensor<3xf32> {
   // CHECK-NEXT:      [[WHER:%.+]] = "onnx.Where"([[MASK]], [[PARAM_0]], [[ZERO]]) : (tensor<3x3xi1>, tensor<3x3xf32>, tensor<f32>) -> tensor<3x3xf32>
   // CHECK-NEXT:      [[AXES:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
   // CHECK-NEXT:      [[RSUM:%.+]] = "onnx.ReduceSum"([[WHER]], [[AXES]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x3xf32>, tensor<1xi64>) -> tensor<3xf32>
-  // CHECK-NEXT:      return [[RSUM]] : tensor<3xf32>
+  // CHECK-NEXT:      onnx.Return [[RSUM]] : tensor<3xf32>
 }
 
 func.func @test_einsum_trace(%arg0: tensor<3x3xf32>) -> tensor<f32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ii"} : (tensor<3x3xf32>) -> tensor<f32>
-  return %0 : tensor<f32>
+  onnx.Return %0 : tensor<f32>
 // CHECK-LABEL:  func @test_einsum_trace
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x3xf32>) -> tensor<f32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<{{\[\[true, false, false\], \[false, true, false\], \[false, false, true\]\]}}> : tensor<3x3xi1>
@@ -99,12 +99,12 @@ func.func @test_einsum_trace(%arg0: tensor<3x3xf32>) -> tensor<f32> {
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.ReduceSum"([[VAR_2_]], [[VAR_3_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x3xf32>, tensor<1xi64>) -> tensor<3xf32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
 // CHECK:           [[VAR_6_:%.+]] = "onnx.ReduceSum"([[VAR_4_]], [[VAR_5_]]) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3xf32>, tensor<1xi64>) -> tensor<f32>
-// CHECK:           return [[VAR_6_]] : tensor<f32>
+// CHECK:           onnx.Return [[VAR_6_]] : tensor<f32>
 }
 
 func.func @test_einsum_ibh_hnd(%arg0: tensor<128x1x1024xf16>, %arg1: tensor<1024x16x64xf16>) -> tensor<128x1x16x64xf16> {
   %0 = "onnx.Einsum"(%arg0, %arg1) {equation = "ibh,hnd->ibnd"} : (tensor<128x1x1024xf16>, tensor<1024x16x64xf16>) -> tensor<128x1x16x64xf16>
-  return %0 : tensor<128x1x16x64xf16>
+  onnx.Return %0 : tensor<128x1x16x64xf16>
 // CHECK-LABEL:  func.func @test_einsum_ibh_hnd
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<128x1x1024xf16>, [[PARAM_1_:%.+]]: tensor<1024x16x64xf16>) -> tensor<128x1x16x64xf16> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[128, 1024]> : tensor<2xi64>
@@ -114,5 +114,5 @@ func.func @test_einsum_ibh_hnd(%arg0: tensor<128x1x1024xf16>, %arg1: tensor<1024
 // CHECK-DAG:       [[VAR_4_:%.+]] = "onnx.MatMul"([[VAR_1_]], [[VAR_3_]]) : (tensor<128x1024xf16>, tensor<1024x1024xf16>) -> tensor<128x1024xf16>
 // CHECK-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<[128, 1, 16, 64]> : tensor<4xi64>
 // CHECK:           [[VAR_6_:%.+]] = "onnx.Reshape"([[VAR_4_]], [[VAR_5_]]) {allowzero = 0 : si64} : (tensor<128x1024xf16>, tensor<4xi64>) -> tensor<128x1x16x64xf16>
-// CHECK:           return [[VAR_6_]] : tensor<128x1x16x64xf16>
+// CHECK:           onnx.Return [[VAR_6_]] : tensor<128x1x16x64xf16>
 }

--- a/test/mlir/onnx/onnx_decompose_error_einsum.mlir
+++ b/test/mlir/onnx/onnx_decompose_error_einsum.mlir
@@ -4,7 +4,7 @@ func.func @test_einsum_matmul(%arg0: tensor<2x3x4xi16>, %arg1: tensor<2x4x5xi16>
   // expected-error @+2 {{unsupported element type prevents Einsum decomposition}}
   // expected-error @+1 {{failed to legalize operation 'onnx.Einsum'}}
   %0 = "onnx.Einsum"(%arg0, %arg1) {equation = "...ij,...jk"} : (tensor<2x3x4xi16>, tensor<2x4x5xi16>) -> tensor<2x3x5xi16>
-  return %0 : tensor<2x3x5xi16>
+  onnx.Return %0 : tensor<2x3x5xi16>
 }
 
 // -----
@@ -13,7 +13,7 @@ func.func @test_einsum_qmark(%arg0: tensor<3x?xf32>) -> tensor<3xf32> {
   // expected-error @+2 {{unknown shapes prevent Einsum decomposition}}
   // expected-error @+1 {{failed to legalize operation 'onnx.Einsum'}}
   %0 = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<3x?xf32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 }
 
 // -----
@@ -22,5 +22,5 @@ func.func @test_einsum_qmark1(%arg0: tensor<1x?xf32>) -> tensor<?xf32> {
   // expected-error @+2 {{unknown shapes prevent Einsum decomposition}}
   // expected-error @+1 {{failed to legalize operation 'onnx.Einsum'}}
   %0 = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<1x?xf32>) -> tensor<?xf32>
-  return %0 : tensor<?xf32>
+  onnx.Return %0 : tensor<?xf32>
 }

--- a/test/mlir/onnx/onnx_dim_analysis.mlir
+++ b/test/mlir/onnx/onnx_dim_analysis.mlir
@@ -30,7 +30,7 @@ func.func @test_dim_analysis_with_bert(%arg0: tensor<?x256xi64>, %arg1: tensor<?
   %20 = "onnx.Sub"(%19, %18) {onnx_node_name = "bert/encoder/layer_0/attention/self/sub"} : (tensor<f32>, tensor<?x1x256x256xf32>) -> tensor<?x1x256x256xf32>
   %21 = onnx.Constant dense<-1.000000e+04> : tensor<f32>
   %22 = "onnx.Mul"(%20, %21) {onnx_node_name = "bert/encoder/layer_0/attention/self/mul_1"} : (tensor<?x1x256x256xf32>, tensor<f32>) -> tensor<?x1x256x256xf32>
-  return %22, %20, %16 : tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>
+  onnx.Return %22, %20, %16 : tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>
 
 // CHECK-LABEL:  func.func @test_dim_analysis_with_bert
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>, [[PARAM_1_:%.+]]: tensor<?x256xi64>) -> (tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>) {
@@ -80,7 +80,7 @@ func.func @test_dim_analysis_with_bert(%arg0: tensor<?x256xi64>, %arg1: tensor<?
 // CHECK:           [[VAR_22_:%.+]] = "onnx.Mul"([[VAR_20_]], [[VAR_21_]]) {onnx_node_name = "bert/encoder/layer_0/attention/self/mul_1"} : (tensor<?x1x256x256xf32>, tensor<f32>) -> tensor<?x1x256x256xf32>
 // CHECK:           "onnx.DimGroup"([[VAR_22_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x1x256x256xf32>) -> ()
 
-// CHECK:           return [[VAR_22_]], [[VAR_20_]], [[VAR_16_]] : tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>
+// CHECK:           onnx.Return [[VAR_22_]], [[VAR_20_]], [[VAR_16_]] : tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>, tensor<?x1x256x256xf32>
 // CHECK:         }
 }
 
@@ -88,7 +88,7 @@ func.func @test_dim_analysis_with_bert(%arg0: tensor<?x256xi64>, %arg1: tensor<?
 
 func.func @test_unary_elementwise(%arg0 : tensor<?x3x?xf32>) -> tensor<?x3x?xf32> {
   %0 = "onnx.Sigmoid"(%arg0) : (tensor<?x3x?xf32>) -> tensor<?x3x?xf32>
-  "func.return"(%0) : (tensor<?x3x?xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<?x3x?xf32>) -> ()
 
 // CHECK-LABEL:  func.func @test_unary_elementwise
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x3x?xf32>) -> tensor<?x3x?xf32> {
@@ -99,7 +99,7 @@ func.func @test_unary_elementwise(%arg0 : tensor<?x3x?xf32>) -> tensor<?x3x?xf32
 // CHECK-DAG:       "onnx.DimGroup"([[VAR_0_]]) {axis = 2 : si64, group_id = 1 : si64} : (tensor<?x3x?xf32>) -> ()
 // CHECK-DAG:       "onnx.DimGroup"([[VAR_0_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x3x?xf32>) -> ()
 
-// CHECK:           return [[VAR_0_]] : tensor<?x3x?xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<?x3x?xf32>
 // CHECK:         }
 }
 
@@ -108,7 +108,7 @@ func.func @test_unary_elementwise(%arg0 : tensor<?x3x?xf32>) -> tensor<?x3x?xf32
 func.func @test_binary_elementwise(%arg0 : tensor<?x3x?xf32>) -> tensor<?x3x?xf32> {
   %0 = "onnx.Sigmoid"(%arg0) : (tensor<?x3x?xf32>) -> tensor<?x3x?xf32>
   %1 = "onnx.Add"(%0, %arg0) : (tensor<?x3x?xf32>, tensor<?x3x?xf32>) -> tensor<?x3x?xf32>
-  "func.return"(%1) : (tensor<?x3x?xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<?x3x?xf32>) -> ()
 
 // CHECK-LABEL:  func.func @test_binary_elementwise
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x3x?xf32>) -> tensor<?x3x?xf32> {
@@ -122,7 +122,7 @@ func.func @test_binary_elementwise(%arg0 : tensor<?x3x?xf32>) -> tensor<?x3x?xf3
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[VAR_0_]], [[PARAM_0_]]) : (tensor<?x3x?xf32>, tensor<?x3x?xf32>) -> tensor<?x3x?xf32>
 // CHECK-DAG:       "onnx.DimGroup"([[VAR_1_]]) {axis = 2 : si64, group_id = 1 : si64} : (tensor<?x3x?xf32>) -> ()
 // CHECK-DAG:       "onnx.DimGroup"([[VAR_1_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x3x?xf32>) -> ()
-// CHECK:           return [[VAR_1_]] : tensor<?x3x?xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<?x3x?xf32>
 // CHECK:         }
 }
 
@@ -133,7 +133,7 @@ func.func @test_expand_from_concat_dims(%arg0: tensor<1x256xi64>, %arg1: tensor<
   %1 = "onnx.Dim"(%arg1) {axis = 0 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
   %2 = "onnx.Concat"(%1, %0) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
   %3 = "onnx.Expand"(%arg0, %2) {onnx_node_name = "Expand_30"} : (tensor<1x256xi64>, tensor<2xi64>) -> tensor<?x256xi64>
-  return %3: tensor<?x256xi64>
+  onnx.Return %3: tensor<?x256xi64>
 
 // CHECK-LABEL:  func.func @test_expand_from_concat_dims
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x256xi64>, [[PARAM_1_:%.+]]: tensor<?x256xi64>) -> tensor<?x256xi64> {
@@ -144,7 +144,7 @@ func.func @test_expand_from_concat_dims(%arg0: tensor<1x256xi64>, %arg1: tensor<
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_1_]], [[VAR_0_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Expand"([[PARAM_0_]], [[VAR_2_]]) {onnx_node_name = "Expand_30"} : (tensor<1x256xi64>, tensor<2xi64>) -> tensor<?x256xi64>
 // CHECK:           "onnx.DimGroup"([[VAR_3_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x256xi64>) -> ()
-// CHECK:           return [[VAR_3_]] : tensor<?x256xi64>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<?x256xi64>
 // CHECK:         }
 }
 
@@ -158,7 +158,7 @@ func.func @test_reshape_rank_2(%arg0: tensor<?x?xi64>) -> tensor<?x?xi64> {
   %0 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
   %1 = "onnx.Concat"(%0, %cst_minus1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
   %2 = "onnx.Reshape"(%arg0, %1) {allowzero = 0 : si64} : (tensor<?x?xi64>, tensor<2xi64>) -> tensor<?x?xi64>
-  return %2: tensor<?x?xi64>
+  onnx.Return %2: tensor<?x?xi64>
 
 // CHECK-LABEL:  func.func @test_reshape_rank_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xi64>) -> tensor<?x?xi64> {
@@ -172,7 +172,7 @@ func.func @test_reshape_rank_2(%arg0: tensor<?x?xi64>) -> tensor<?x?xi64> {
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_2_]]) {allowzero = 0 : si64} : (tensor<?x?xi64>, tensor<2xi64>) -> tensor<?x?xi64>
 // CHECK:           "onnx.DimGroup"([[VAR_3_]]) {axis = 1 : si64, group_id = 1 : si64} : (tensor<?x?xi64>) -> ()
 // CHECK:           "onnx.DimGroup"([[VAR_3_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xi64>) -> ()
-// CHECK:           return [[VAR_3_]] : tensor<?x?xi64>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<?x?xi64>
 // CHECK:         }
 }
 
@@ -187,7 +187,7 @@ func.func @test_tile_input_dim_1(%arg0: tensor<?x?xi64>, %arg1: tensor<1x1xi64>)
   %1 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
   %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
   %3 = "onnx.Tile"(%arg1, %2) : (tensor<1x1xi64>, tensor<2xi64>) -> tensor<?x?xi64>
-  return %3: tensor<?x?xi64>
+  onnx.Return %3: tensor<?x?xi64>
 
 // CHECK-LABEL:  func.func @test_tile_input_dim_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xi64>, [[PARAM_1_:%.+]]: tensor<1x1xi64>) -> tensor<?x?xi64> {
@@ -201,6 +201,6 @@ func.func @test_tile_input_dim_1(%arg0: tensor<?x?xi64>, %arg1: tensor<1x1xi64>)
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Tile"([[PARAM_1_]], [[VAR_2_]]) : (tensor<1x1xi64>, tensor<2xi64>) -> tensor<?x?xi64>
 // CHECK:           "onnx.DimGroup"([[VAR_3_]]) {axis = 1 : si64, group_id = 1 : si64} : (tensor<?x?xi64>) -> ()
 // CHECK:           "onnx.DimGroup"([[VAR_3_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xi64>) -> ()
-// CHECK:           return [[VAR_3_]] : tensor<?x?xi64>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<?x?xi64>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_fold.mlir
+++ b/test/mlir/onnx/onnx_fold.mlir
@@ -12,11 +12,11 @@ func.func @test_squeeze() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[[4.0]], [[16.0]]]> : tensor<2x1x1xf32>
   %1 = onnx.Constant dense<[1, 2]> : tensor<2xi64>
   %2 = "onnx.Squeeze"(%0, %1) : (tensor<2x1x1xf32>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 // CHECK-LABEL:  func.func @test_squeeze
 // CHECK-SAME:   () -> tensor<2xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[4.000000e+00, 1.600000e+01]> : tensor<2xf32>
-// CHECK:           return [[VAR_0_]] : tensor<2xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<2xf32>
 }
 
 // -----
@@ -24,9 +24,9 @@ func.func @test_squeeze() -> tensor<*xf32> {
 func.func @test_squeezev11() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[[4.0]], [[16.0]]]> : tensor<2x1x1xf32>
   %1 = "onnx.SqueezeV11"(%0) {axes = [1, 2]} : (tensor<2x1x1xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 // CHECK-LABEL:  func.func @test_squeezev11
 // CHECK-SAME:   () -> tensor<2xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[4.000000e+00, 1.600000e+01]> : tensor<2xf32>
-// CHECK:           return [[VAR_0_]] : tensor<2xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<2xf32>
 }

--- a/test/mlir/onnx/onnx_location.mlir
+++ b/test/mlir/onnx/onnx_location.mlir
@@ -3,7 +3,7 @@
 
   func.func @main_graph(%arg0: tensor<1x16xf32>, %arg1: tensor<1x16xf32>) -> tensor<1x16xf32>  {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<1x16xf32>, tensor<1x16xf32>) -> tensor<1x16xf32> loc("/build/workspace/addop.onnx":1:0)
-     return %0 : tensor<1x16xf32>
+    onnx.Return %0 : tensor<1x16xf32>
   }
 
 // PRESENT: #[[onnx_file_loc:.+]] = loc("{{/.+}}.onnx":1:0)

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -10,11 +10,11 @@
 // COM: Existing output shape is better, do not change the output shape.
 func.func @test_default_unary_elementwise_user_shape_1(%arg0 : tensor<2x3x?xf32>) -> tensor<2x3x4xf32> {
   %0 = "onnx.Sigmoid"(%arg0) : (tensor<2x3x?xf32>) -> tensor<2x3x4xf32>
-  "func.return"(%0) : (tensor<2x3x4xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<2x3x4xf32>) -> ()
 
   // CHECK-LABEL: test_default_unary_elementwise_user_shape_1
   // CHECK: [[RES:%.+]] = "onnx.Sigmoid"(%arg0) : (tensor<2x3x?xf32>) -> tensor<2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xf32>
 }
 
 // -----
@@ -22,11 +22,11 @@ func.func @test_default_unary_elementwise_user_shape_1(%arg0 : tensor<2x3x?xf32>
 // COM: Infered shape is better, update the output shape.
 func.func @test_default_unary_elementwise_user_shape_2(%arg0 : tensor<2x3x4xf32>) -> tensor<2x3x?xf32> {
   %0 = "onnx.Sigmoid"(%arg0) : (tensor<2x3x4xf32>) -> tensor<2x3x?xf32>
-  "func.return"(%0) : (tensor<2x3x?xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<2x3x?xf32>) -> ()
 
   // CHECK-LABEL: test_default_unary_elementwise_user_shape_2
   // CHECK: [[RES:%.+]] = "onnx.Sigmoid"(%arg0) : (tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xf32>
 }
 
 // -----
@@ -34,11 +34,11 @@ func.func @test_default_unary_elementwise_user_shape_2(%arg0 : tensor<2x3x4xf32>
 // COM: Mix of infered shape and existing output shape.
 func.func @test_default_unary_elementwise_user_shape_3(%arg0 : tensor<?x3x4xf32>) -> tensor<2x3x?xf32> {
   %0 = "onnx.Sigmoid"(%arg0) : (tensor<?x3x4xf32>) -> tensor<2x3x?xf32>
-  "func.return"(%0) : (tensor<2x3x?xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<2x3x?xf32>) -> ()
 
   // CHECK-LABEL: test_default_unary_elementwise_user_shape_3
   // CHECK: [[RES:%.+]] = "onnx.Sigmoid"(%arg0) : (tensor<?x3x4xf32>) -> tensor<2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xf32>
 }
 
 // -----
@@ -46,11 +46,11 @@ func.func @test_default_unary_elementwise_user_shape_3(%arg0 : tensor<?x3x4xf32>
 // COM: Check if unranked shape input can be handled without crashing
 func.func @test_default_unary_elementwise_user_shape_4(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.Sigmoid"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_unary_elementwise_user_shape_4
   // CHECK: [[RES:%.+]] = "onnx.Sigmoid"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  // CHECK: return [[RES]] : tensor<*xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
@@ -62,11 +62,11 @@ func.func @test_default_unary_elementwise_user_shape_4(%arg0 : tensor<*xf32>) ->
 
 func.func @test_default_argmax(%arg0 : tensor<2x3x4xf32>) -> tensor<*xi64> {
   %0 = "onnx.ArgMax"(%arg0) : (tensor<2x3x4xf32>) -> tensor<*xi64>
-  "func.return"(%0) : (tensor<*xi64>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi64>) -> ()
 
   // CHECK-LABEL: test_default_argmax
   // CHECK: [[RES:%.+]] = "onnx.ArgMax"(%arg0) {axis = 0 : si64, keepdims = 1 : si64, select_last_index = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<1x3x4xi64>
-  // CHECK: return [[RES]] : tensor<1x3x4xi64>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x4xi64>
 }
 
 // -----
@@ -78,11 +78,11 @@ func.func @test_default_argmax(%arg0 : tensor<2x3x4xf32>) -> tensor<*xi64> {
 
 func.func @test_default_argmin(%arg0 : tensor<2x3x4xf32>) -> tensor<*xi64> {
   %0 = "onnx.ArgMin"(%arg0) : (tensor<2x3x4xf32>) -> tensor<*xi64>
-  "func.return"(%0) : (tensor<*xi64>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi64>) -> ()
 
   // CHECK-LABEL: test_default_argmin
   // CHECK: [[RES:%.+]] = "onnx.ArgMin"(%arg0) {axis = 0 : si64, keepdims = 1 : si64, select_last_index = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<1x3x4xi64>
-  // CHECK: return [[RES]] : tensor<1x3x4xi64>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x4xi64>
 }
 
 // -----
@@ -94,11 +94,11 @@ func.func @test_default_argmin(%arg0 : tensor<2x3x4xf32>) -> tensor<*xi64> {
 
 func.func @test_default_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.Transpose"(%arg0) : (tensor<5x5x1x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_transpose
   // CHECK: [[RES:%.+]] = "onnx.Transpose"(%arg0) {perm = [3, 2, 1, 0]} : (tensor<5x5x1x32xf32>) -> tensor<32x1x5x5xf32>
-  // CHECK: return [[RES]] : tensor<32x1x5x5xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<32x1x5x5xf32>
 }
 
 // -----
@@ -108,13 +108,13 @@ func.func @test_default_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32>
 //===----------------------------------------------------------------------===//
 func.func @test_dft(%arg0: tensor<1x8x10x12xf32> , %arg1 : tensor<i32>) -> tensor<*xf32> {
   %0 = "onnx.DFT"(%arg0, %arg1) : (tensor<1x8x10x12xf32>, tensor<i32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_dft
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x8x10x12xf32>, [[PARAM_1_:%.+]]: tensor<i32>) -> tensor<1x8x10x12x2xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.DFT"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64, inverse = 0 : si64, onesided = 0 : si64} : (tensor<1x8x10x12xf32>, tensor<i32>) -> tensor<1x8x10x12x2xf32>
-// CHECK:           return [[VAR_0_]] : tensor<1x8x10x12x2xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x8x10x12x2xf32>
 // CHECK:         }
 }
 
@@ -122,13 +122,13 @@ func.func @test_dft(%arg0: tensor<1x8x10x12xf32> , %arg1 : tensor<i32>) -> tenso
 
 func.func @test_dft_one_sided(%arg0: tensor<1x8x10x12xf32> , %arg1 : tensor<i32>) -> tensor<*xf32> {
   %0 = "onnx.DFT"(%arg0, %arg1) { onesided = 1 : si64} : (tensor<1x8x10x12xf32>, tensor<i32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_dft_one_sided
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x8x10x12xf32>, [[PARAM_1_:%.+]]: tensor<i32>) -> tensor<1x8x6x12x2xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.DFT"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64, inverse = 0 : si64, onesided = 1 : si64} : (tensor<1x8x10x12xf32>, tensor<i32>) -> tensor<1x8x6x12x2xf32>
-// CHECK:           return [[VAR_0_]] : tensor<1x8x6x12x2xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x8x6x12x2xf32>
 // CHECK:         }
 }
 
@@ -141,12 +141,12 @@ func.func @test_dft_one_sided(%arg0: tensor<1x8x10x12xf32> , %arg1 : tensor<i32>
 func.func @test_clip(%arg0 : tensor<1x32x112x112xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %cst, %cst) {max = 6.000000e+00 : f32, min = 0.000000e+00 : f32} : (tensor<1x32x112x112xf32>, none, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_clip
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES:%.+]] = "onnx.Clip"(%arg0, [[CST]], [[CST]]) {max = 6.000000e+00 : f32, min = 0.000000e+00 : f32} : (tensor<1x32x112x112xf32>, none, none) -> tensor<1x32x112x112xf32>
-  // CHECK: return [[RES]] : tensor<1x32x112x112xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x32x112x112xf32>
 }
 
 // -----
@@ -155,11 +155,11 @@ func.func @test_clip(%arg0 : tensor<1x32x112x112xf32>) -> tensor<*xf32> {
 
 func.func @test_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.Transpose"(%arg0) {perm = [2, 0, 3, 1]} : (tensor<5x5x1x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_transpose
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Transpose"(%arg0) {perm = [2, 0, 3, 1]} : (tensor<5x5x1x32xf32>) -> tensor<1x5x32x5xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x32x5xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x32x5xf32>
 }
 
 // -----
@@ -172,11 +172,11 @@ func.func @test_transpose(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
 
 func.func @test_matmul_1(%arg0 : tensor<32xf32>, %arg1 : tensor<32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<32xf32>, tensor<32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_1
   // CHECK: [[RES1:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<32xf32>, tensor<32xf32>) -> tensor<f32>
-  // CHECK: return [[RES1]] : tensor<f32>
+  // CHECK: onnx.Return [[RES1]] : tensor<f32>
 }
 
 // -----
@@ -185,11 +185,11 @@ func.func @test_matmul_1(%arg0 : tensor<32xf32>, %arg1 : tensor<32xf32>) -> tens
 
 func.func @test_matmul_2(%arg0 : tensor<16x?x64x42xf32>, %arg1 : tensor<42x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<16x?x64x42xf32>, tensor<42x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_2
   // CHECK: [[RES2:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<16x?x64x42xf32>, tensor<42x32xf32>) -> tensor<16x?x64x32xf32>
-  // CHECK: return [[RES2]] : tensor<16x?x64x32xf32>
+  // CHECK: onnx.Return [[RES2]] : tensor<16x?x64x32xf32>
 }
 
 // -----
@@ -198,11 +198,11 @@ func.func @test_matmul_2(%arg0 : tensor<16x?x64x42xf32>, %arg1 : tensor<42x32xf3
 
 func.func @test_matmul_3(%arg0 : tensor<64x42xf32>, %arg1 : tensor<16x?x42x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<64x42xf32>, tensor<16x?x42x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_3
   // CHECK: [[RES3:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<64x42xf32>, tensor<16x?x42x32xf32>) -> tensor<16x?x64x32xf32>
-  // CHECK: return [[RES3]] : tensor<16x?x64x32xf32>
+  // CHECK: onnx.Return [[RES3]] : tensor<16x?x64x32xf32>
 }
 
 // -----
@@ -211,11 +211,11 @@ func.func @test_matmul_3(%arg0 : tensor<64x42xf32>, %arg1 : tensor<16x?x42x32xf3
 
 func.func @test_matmul_4(%arg0 : tensor<64x42xf32>, %arg1 : tensor<?x?x?x?xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<64x42xf32>, tensor<?x?x?x?xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_4
   // CHECK: [[RES4:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<64x42xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x64x?xf32>
-  // CHECK: return [[RES4]] : tensor<?x?x64x?xf32>
+  // CHECK: onnx.Return [[RES4]] : tensor<?x?x64x?xf32>
 }
 
 // -----
@@ -224,11 +224,11 @@ func.func @test_matmul_4(%arg0 : tensor<64x42xf32>, %arg1 : tensor<?x?x?x?xf32>)
 
 func.func @test_matmul_5(%arg0 : tensor<16x?x?x42xf32>, %arg1 : tensor<32x?x64x42x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<16x?x?x42xf32>, tensor<32x?x64x42x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_5
   // CHECK: [[RES5:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<16x?x?x42xf32>, tensor<32x?x64x42x32xf32>) -> tensor<32x16x64x?x32xf32>
-  // CHECK: return [[RES5]] : tensor<32x16x64x?x32xf32>
+  // CHECK: onnx.Return [[RES5]] : tensor<32x16x64x?x32xf32>
 }
 
 // -----
@@ -237,11 +237,11 @@ func.func @test_matmul_5(%arg0 : tensor<16x?x?x42xf32>, %arg1 : tensor<32x?x64x4
 
 func.func @test_matmul_6(%arg0 : tensor<32xf32>, %arg1 : tensor<32x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<32xf32>, tensor<32x64xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_6
   // CHECK: [[RES6:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<32xf32>, tensor<32x64xf32>) -> tensor<64xf32>
-  // CHECK: return [[RES6]] : tensor<64xf32>
+  // CHECK: onnx.Return [[RES6]] : tensor<64xf32>
 }
 
 // -----
@@ -250,11 +250,11 @@ func.func @test_matmul_6(%arg0 : tensor<32xf32>, %arg1 : tensor<32x64xf32>) -> t
 
 func.func @test_matmul_7(%arg0 : tensor<32x64xf32>, %arg1 : tensor<64xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<32x64xf32>, tensor<64xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_7
   // CHECK: [[RES7:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<32x64xf32>, tensor<64xf32>) -> tensor<32xf32>
-  // CHECK: return [[RES7]] : tensor<32xf32>
+  // CHECK: onnx.Return [[RES7]] : tensor<32xf32>
 }
 
 // -----
@@ -263,11 +263,11 @@ func.func @test_matmul_7(%arg0 : tensor<32x64xf32>, %arg1 : tensor<64xf32>) -> t
 
 func.func @test_matmul_8(%arg0 : tensor<32x64xf32>, %arg1 : tensor<64x128xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<32x64xf32>, tensor<64x128xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_8
   // CHECK: [[RES8:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<32x64xf32>, tensor<64x128xf32>) -> tensor<32x128xf32>
-  // CHECK: return [[RES8]] : tensor<32x128xf32>
+  // CHECK: onnx.Return [[RES8]] : tensor<32x128xf32>
 }
 
 // -----
@@ -276,11 +276,11 @@ func.func @test_matmul_8(%arg0 : tensor<32x64xf32>, %arg1 : tensor<64x128xf32>) 
 
 func.func @test_matmul_9(%arg0 : tensor<42xf32>, %arg1 : tensor<?x42x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<42xf32>, tensor<?x42x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_9
   // CHECK: [[RES1:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<42xf32>, tensor<?x42x32xf32>) -> tensor<?x32xf32>
-  // CHECK: return [[RES1]] : tensor<?x32xf32>
+  // CHECK: onnx.Return [[RES1]] : tensor<?x32xf32>
 }
 
 // -----
@@ -289,11 +289,11 @@ func.func @test_matmul_9(%arg0 : tensor<42xf32>, %arg1 : tensor<?x42x32xf32>) ->
 
 func.func @test_matmul_10(%arg0 : tensor<?x42x32xf32>, %arg1 : tensor<32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<?x42x32xf32>, tensor<32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_matmul_10
   // CHECK: [[RES1:%.+]] = "onnx.MatMul"(%arg0, %arg1) : (tensor<?x42x32xf32>, tensor<32xf32>) -> tensor<?x42xf32>
-  // CHECK: return [[RES1]] : tensor<?x42xf32>
+  // CHECK: onnx.Return [[RES1]] : tensor<?x42xf32>
 }
 
 // -----
@@ -302,12 +302,12 @@ func.func @test_matmul_10(%arg0 : tensor<?x42x32xf32>, %arg1 : tensor<32xf32>) -
 
 func.func @test_qlinearmatmul_1(%arg0: tensor<2x2x4xui8>, %arg1: tensor<1xf32>, %arg2: tensor<1xui8>, %arg3: tensor<2x4x3xui8>, %arg4: tensor<1xf32>, %arg5: tensor<1xui8>, %arg6: tensor<1xf32>, %arg7: tensor<1xui8>) -> tensor<*xui8> {
   %0 = "onnx.QLinearMatMul"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7) : (tensor<2x2x4xui8>, tensor<1xf32>, tensor<1xui8>, tensor<2x4x3xui8>, tensor<1xf32>, tensor<1xui8>, tensor<1xf32>, tensor<1xui8>) -> tensor<*xui8>
-  "func.return"(%0) : (tensor<*xui8>) -> ()
+  "onnx.Return"(%0) : (tensor<*xui8>) -> ()
 
 
   // CHECK-LABEL: test_qlinearmatmul_1
   // CHECK: [[RES1:%.+]] = "onnx.QLinearMatMul"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7) : (tensor<2x2x4xui8>, tensor<1xf32>, tensor<1xui8>, tensor<2x4x3xui8>, tensor<1xf32>, tensor<1xui8>, tensor<1xf32>, tensor<1xui8>) -> tensor<2x2x3xui8>
-  // CHECK: return [[RES1]] : tensor<2x2x3xui8>
+  // CHECK: onnx.Return [[RES1]] : tensor<2x2x3xui8>
 }
 
 // -----
@@ -316,11 +316,11 @@ func.func @test_qlinearmatmul_1(%arg0: tensor<2x2x4xui8>, %arg1: tensor<1xf32>, 
 
 func.func @test_matmulinteger_1(%arg0: tensor<4x3xui8>, %arg1: tensor<3x2xui8>, %arg2: tensor<1xui8>, %arg3: tensor<1xui8>) -> tensor<*xi32> {
     %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<1xui8>, tensor<1xui8>) -> tensor<*xi32>
-    return %0 : tensor<*xi32>
+    onnx.Return %0 : tensor<*xi32>
 
   // CHECK-LABEL: test_matmulinteger_1
   // CHECK: [[RES1:%.+]] = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<4x3xui8>, tensor<3x2xui8>, tensor<1xui8>, tensor<1xui8>) -> tensor<4x2xi32>
-  // CHECK: return [[RES1]] : tensor<4x2xi32>
+  // CHECK: onnx.Return [[RES1]] : tensor<4x2xi32>
 }
 
 // -----
@@ -334,12 +334,12 @@ func.func @test_matmulinteger_1(%arg0: tensor<4x3xui8>, %arg1: tensor<3x2xui8>, 
 func.func @test_conv_no_bias_0(%arg0 : tensor<1x2x32xf32>, %arg1 : tensor<5x2x6xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32xf32>, tensor<5x2x6xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_0
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32xf32>, tensor<5x2x6xf32>, none) -> tensor<1x5x27xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x27xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x27xf32>
 }
 
 // -----
@@ -349,12 +349,12 @@ func.func @test_conv_no_bias_0(%arg0 : tensor<1x2x32xf32>, %arg1 : tensor<5x2x6x
 func.func @test_conv_no_bias_1(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_1
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x27x58xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x27x58xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x27x58xf32>
 }
 
 // -----
@@ -364,12 +364,12 @@ func.func @test_conv_no_bias_1(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_2(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x8x9xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [8, 9]} : (tensor<1x2x32x64xf32>, tensor<5x2x8x9xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_2
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [8, 9]} : (tensor<1x2x32x64xf32>, tensor<5x2x8x9xf32>, none) -> tensor<1x5x25x56xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x25x56xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x25x56xf32>
 }
 
 // -----
@@ -380,12 +380,12 @@ func.func @test_conv_no_bias_2(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_3(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64, pads = [2, 4, 3, 5]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_3
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", group = 1 : si64, pads = [2, 4, 3, 5]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<1x5x32x64xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 }
 
 // -----
@@ -395,12 +395,12 @@ func.func @test_conv_no_bias_3(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_4(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "SAME_UPPER", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_4
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "SAME_UPPER", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<1x5x32x64xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 }
 
 // -----
@@ -408,12 +408,12 @@ func.func @test_conv_no_bias_4(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_5(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "SAME_LOWER", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_5
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "SAME_LOWER", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<1x5x32x64xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 }
 
 // -----
@@ -423,12 +423,12 @@ func.func @test_conv_no_bias_5(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_6(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x10xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "VALID", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_6
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "VALID", group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x10xf32>, none) -> tensor<1x5x27x55xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x27x55xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x27x55xf32>
 }
 
 // -----
@@ -438,12 +438,12 @@ func.func @test_conv_no_bias_6(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_7(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_7
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", group = 1 : si64, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x14x20xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x14x20xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x14x20xf32>
 }
 
 // -----
@@ -454,12 +454,12 @@ func.func @test_conv_no_bias_7(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_8(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "SAME_UPPER", group = 1 : si64, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_8
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "SAME_UPPER", group = 1 : si64, strides = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x16x22xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x16x22xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x16x22xf32>
 }
 
 // -----
@@ -469,12 +469,12 @@ func.func @test_conv_no_bias_8(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_9(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64, dilations = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_9
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x22x46xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x22x46xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x22x46xf32>
 }
 
 // -----
@@ -484,12 +484,12 @@ func.func @test_conv_no_bias_9(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2
 func.func @test_conv_no_bias_10(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64, dilations = [2, 3], strides = [2, 2]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_10
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : si64, strides = [2, 2]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x11x23xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x11x23xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x11x23xf32>
 }
 
 // -----
@@ -499,12 +499,12 @@ func.func @test_conv_no_bias_10(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x
 func.func @test_conv_no_bias_11(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x2x6x7xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "SAME_UPPER", group = 1 : si64, dilations = [2, 3]} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_no_bias_11
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, [[CST]]) {auto_pad = "SAME_UPPER", dilations = [2, 3], group = 1 : si64} : (tensor<1x2x32x64xf32>, tensor<5x2x6x7xf32>, none) -> tensor<1x5x32x64xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x32x64xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x32x64xf32>
 }
 
 // -----
@@ -513,11 +513,11 @@ func.func @test_conv_no_bias_11(%arg0 : tensor<1x2x32x64xf32>, %arg1 : tensor<5x
 
 func.func @test_conv_12(%arg0 : tensor<1x2x32xf32>, %arg1 : tensor<5x2x6xf32>, %arg2 : tensor<5xf32>) -> tensor<*xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32xf32>, tensor<5x2x6xf32>, tensor<5xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_12
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Conv"(%arg0, %arg1, %arg2) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32xf32>, tensor<5x2x6xf32>, tensor<5xf32>) -> tensor<1x5x27xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x5x27xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x5x27xf32>
 }
 
 // -----
@@ -529,12 +529,12 @@ func.func @test_conv_12(%arg0 : tensor<1x2x32xf32>, %arg1 : tensor<5x2x6xf32>, %
 func.func @test_conv_transpose_1(%arg0 : tensor<1x64x36x48xf32>, %arg1 : tensor<64x1x2x2xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.ConvTranspose"(%arg0, %arg1, %cst) {dilations = [1, 1], kernel_shape = [2, 2], pads = [0, 0, 0, 0], strides = [2, 2]} : (tensor<1x64x36x48xf32>, tensor<64x1x2x2xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_transpose_1
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.ConvTranspose"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [2, 2], pads = [0, 0, 0, 0], strides = [2, 2]} : (tensor<1x64x36x48xf32>, tensor<64x1x2x2xf32>, none) -> tensor<1x1x72x96xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x1x72x96xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x1x72x96xf32>
 }
 
 // -----
@@ -542,12 +542,12 @@ func.func @test_conv_transpose_1(%arg0 : tensor<1x64x36x48xf32>, %arg1 : tensor<
 func.func @test_conv_transpose_2(%arg0 : tensor<1x64x36x48xf32>, %arg1 : tensor<64x1x2x2xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.ConvTranspose"(%arg0, %arg1, %cst) {dilations = [1, 1], group = 64 : si64, kernel_shape = [2, 2], pads = [0, 0, 0, 0], strides = [2, 2]} : (tensor<1x64x36x48xf32>, tensor<64x1x2x2xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_transpose_2
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.ConvTranspose"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 64 : si64, kernel_shape = [2, 2], pads = [0, 0, 0, 0], strides = [2, 2]} : (tensor<1x64x36x48xf32>, tensor<64x1x2x2xf32>, none) -> tensor<1x64x72x96xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x64x72x96xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x64x72x96xf32>
 }
 
 // -----
@@ -555,12 +555,12 @@ func.func @test_conv_transpose_2(%arg0 : tensor<1x64x36x48xf32>, %arg1 : tensor<
 func.func @test_conv_transpose_3(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3x3xf32>) -> tensor<*xf32> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {output_padding = [1, 1], strides = [3, 2]} : (tensor<1x1x3x3xf32>, tensor<1x2x3x3xf32>, none) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
 
 // CHECK-LABEL: test_conv_transpose_3
 // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64, output_padding = [1, 1], strides = [3, 2]} : (tensor<1x1x3x3xf32>, tensor<1x2x3x3xf32>, none) -> tensor<1x2x10x8xf32>
-// CHECK: return [[RES_ATTR]] : tensor<1x2x10x8xf32>
+// CHECK: onnx.Return [[RES_ATTR]] : tensor<1x2x10x8xf32>
 }
 
 // -----
@@ -568,12 +568,12 @@ func.func @test_conv_transpose_3(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3
 func.func @test_conv_transpose_4(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3x3xf32>) -> tensor<*xf32> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.ConvTranspose"(%arg0, %arg1, %0) {pads = [1, 2, 1, 2], strides = [3, 2]} : (tensor<1x1x3x3xf32>, tensor<1x2x3x3xf32>, none) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
 
 // CHECK-LABEL: test_conv_transpose_4
 // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.ConvTranspose"(%arg0, %arg1, %0) {auto_pad = "NOTSET", group = 1 : si64, pads = [1, 2, 1, 2], strides = [3, 2]} : (tensor<1x1x3x3xf32>, tensor<1x2x3x3xf32>, none) -> tensor<1x2x7x3xf32>
-// CHECK: return [[RES_ATTR]] : tensor<1x2x7x3xf32>
+// CHECK: onnx.Return [[RES_ATTR]] : tensor<1x2x7x3xf32>
 }
 
 // -----
@@ -581,12 +581,12 @@ func.func @test_conv_transpose_4(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3
 func.func @test_conv_transpose_pads(%arg0 : tensor<1x64x36x48xf32>, %arg1 : tensor<64x1x2x2xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.ConvTranspose"(%arg0, %arg1, %cst) {dilations = [1, 1], group = 64 : si64, kernel_shape = [2, 2], pads = [0, 1, 0, 1], strides = [2, 2]} : (tensor<1x64x36x48xf32>, tensor<64x1x2x2xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_transpose_pads
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.ConvTranspose"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 64 : si64, kernel_shape = [2, 2], pads = [0, 1, 0, 1], strides = [2, 2]} : (tensor<1x64x36x48xf32>, tensor<64x1x2x2xf32>, none) -> tensor<1x64x72x94xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x64x72x94xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x64x72x94xf32>
 }
 
 // -----
@@ -594,12 +594,12 @@ func.func @test_conv_transpose_pads(%arg0 : tensor<1x64x36x48xf32>, %arg1 : tens
 func.func @test_conv_transpose_output_shape(%arg0 : tensor<1x64x36x48xf32>, %arg1 : tensor<64x1x2x2xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.ConvTranspose"(%arg0, %arg1, %cst) {dilations = [1, 1], group = 64 : si64, kernel_shape = [2, 2], output_shape = [72, 94], pads = [0, 0, 0, 0], strides = [2, 2]} : (tensor<1x64x36x48xf32>, tensor<64x1x2x2xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_conv_transpose_output_shape
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES_ATTR:%.+]] = "onnx.ConvTranspose"(%arg0, %arg1, [[CST]]) {auto_pad = "NOTSET", dilations = [1, 1], group = 64 : si64, kernel_shape = [2, 2], output_shape = [72, 94], pads = [0, 0, 0, 0], strides = [2, 2]} : (tensor<1x64x36x48xf32>, tensor<64x1x2x2xf32>, none) -> tensor<1x64x72x94xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<1x64x72x94xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<1x64x72x94xf32>
 }
 
 // -----
@@ -611,7 +611,7 @@ func.func @test_Pad_1(%arg0 : tensor<16x13xf32>) -> tensor<*xf32> {
   %1 = onnx.Constant dense<0.000000e+00> : tensor<1xf32>
   %cst = "onnx.NoValue"() {value} : () -> none
   %2 = "onnx.Pad"(%arg0, %0, %1, %cst) {mode = "constant"} : (tensor<16x13xf32>, tensor<4xi64>, tensor<1xf32>, none) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_Pad_1
   // CHECK-SAME:     ([[VAR_arg0:%.+]]: tensor<16x13xf32>) -> tensor<18x19xf32> {
   // CHECK: [[VAR_0:%.+]] = onnx.Constant dense<[0, 2, 2, 4]> : tensor<4xi64>
@@ -629,11 +629,11 @@ func.func @test_Pad_1(%arg0 : tensor<16x13xf32>) -> tensor<*xf32> {
 /// Test ConstantOp shape inference for 1-D dense tensor.
 func.func @test_constant_dense_1d_value() -> tensor<*xf32> {
   %0 = onnx.Constant {value = dense<[0.0, 1.0, 2.0]> : tensor<3xf32>} : tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_constant_dense_1d_value
   // CHECK: [[RES:%.+]] = onnx.Constant dense<[0.000000e+00, 1.000000e+00, 2.000000e+00]> : tensor<3xf32>
-  // CHECK: return [[RES]] : tensor<3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3xf32>
 }
 
 // -----
@@ -641,11 +641,11 @@ func.func @test_constant_dense_1d_value() -> tensor<*xf32> {
 /// Test ConstantOp shape inference for 2-D dense tensor.
 func.func @test_constant_dense_2d_value() -> tensor<*xf32> {
   %0 = onnx.Constant {value = dense<[[0.0, 0.0], [1.0, 1.1], [2.0, 2.1]]> : tensor<3x2xf32>} : tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_constant_dense_2d_value
   // CHECK: [[RES:%.+]] = onnx.Constant dense<{{\[}}[0.000000e+00, 0.000000e+00], [1.000000e+00, 1.100000e+00], [2.000000e+00, 2.100000e+00{{\]}}]> : tensor<3x2xf32>
-  // CHECK: return [[RES]] : tensor<3x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3x2xf32>
 }
 
 // -----
@@ -653,11 +653,11 @@ func.func @test_constant_dense_2d_value() -> tensor<*xf32> {
 /// Test ConstantOp shape inference for 1-D sparse tensor.
 func.func @test_constant_sparse_1d_value() -> tensor<*xf32> {
   %0 = onnx.Constant {sparse_value = sparse<[[0]], [1.0]> : tensor<3xf32>} : tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_constant_sparse_1d_value
   // CHECK: [[RES:%.+]] = onnx.Constant sparse<0, 1.000000e+00> : tensor<3xf32>
-  // CHECK: return [[RES]] : tensor<3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3xf32>
 }
 
 // -----
@@ -665,11 +665,11 @@ func.func @test_constant_sparse_1d_value() -> tensor<*xf32> {
 /// Test ConstantOp shape inference for 2-D sparse tensor.
 func.func @test_constant_sparse_2d_value() -> tensor<*xf32> {
   %0 = onnx.Constant {sparse_value = sparse<[[0, 1]], [2.0]> : tensor<3x2xf32>} : tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_constant_sparse_2d_value
   // CHECK: [[RES:%.+]] = onnx.Constant sparse<{{\[}}[0, 1{{\]}}], 2.000000e+00> : tensor<3x2xf32>
-  // CHECK: return [[RES]] : tensor<3x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3x2xf32>
 }
 
 // -----
@@ -677,11 +677,11 @@ func.func @test_constant_sparse_2d_value() -> tensor<*xf32> {
 /// Test the default behavior of Average Pool with no padding (pad are set but shoud be ignored)
 func.func @test_default_averagepool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "VALID", ceil_mode = 0 : si64, kernel_shape = [3,3] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_averagepool
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "VALID", ceil_mode = 0 : si64, count_include_pad = 0 : si64, kernel_shape = [3, 3]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
-  // CHECK: return [[RES]] : tensor<5x5x30x30xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x30x30xf32>
 }
 
 // -----
@@ -689,11 +689,11 @@ func.func @test_default_averagepool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf
 /// Test the default behavior of Average Pool with no padding (pad are not set, default to zero)
 func.func @test_default_averagepool_defpad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3,3]} : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_averagepool_defpad
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, count_include_pad = 0 : si64, kernel_shape = [3, 3]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
-  // CHECK: return [[RES]] : tensor<5x5x30x30xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x30x30xf32>
 }
 
 // -----
@@ -701,11 +701,11 @@ func.func @test_default_averagepool_defpad(%arg0 : tensor<5x5x32x32xf32>) -> ten
 /// Test the default behavior of Average Pool with uniform padding
 func.func @test_default_averagepool_pad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3,3], pads = [1, 1, 1, 1] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_averagepool_pad
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, count_include_pad = 0 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x32x32xf32>
-  // CHECK: return [[RES]] : tensor<5x5x32x32xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x32x32xf32>
 }
 
 // -----
@@ -713,11 +713,11 @@ func.func @test_default_averagepool_pad(%arg0 : tensor<5x5x32x32xf32>) -> tensor
 /// Test the default behavior of Average Pool with non uniform padding
 func.func @test_default_averagepool_pad_nonunif(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [5,3], pads = [2, 1, 1, 0] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_averagepool_pad_nonunif
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, count_include_pad = 0 : si64, kernel_shape = [5, 3], pads = [2, 1, 1, 0]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x31x31xf32>
-  // CHECK: return [[RES]] : tensor<5x5x31x31xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x31x31xf32>
 }
 
 // -----
@@ -725,11 +725,11 @@ func.func @test_default_averagepool_pad_nonunif(%arg0 : tensor<5x5x32x32xf32>) -
 /// Test the default behavior of Average Pool with non uniform padding
 func.func @test_default_averagepool_strides(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3,3], pads = [1, 1, 1, 1], strides = [2, 2] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_averagepool_strides
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, count_include_pad = 0 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [2, 2]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x16x16xf32>
-  // CHECK: return [[RES]] : tensor<5x5x16x16xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x16x16xf32>
 }
 
 // -----
@@ -737,11 +737,11 @@ func.func @test_default_averagepool_strides(%arg0 : tensor<5x5x32x32xf32>) -> te
 /// Test the default behavior of Average Pool with non uniform padding
 func.func @test_default_averagepool_strides_nonunifpad(%arg0 : tensor<5x5x30x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [2,2], pads = [1, 0, 0, 0], strides = [2, 2] } : (tensor<5x5x30x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_averagepool_strides_nonunifpad
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, count_include_pad = 0 : si64, kernel_shape = [2, 2], pads = [1, 0, 0, 0], strides = [2, 2]} : (tensor<5x5x30x32xf32>) -> tensor<5x5x15x16xf32>
-  // CHECK: return [[RES]] : tensor<5x5x15x16xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x15x16xf32>
 }
 
 // -----
@@ -749,77 +749,77 @@ func.func @test_default_averagepool_strides_nonunifpad(%arg0 : tensor<5x5x30x32x
 /// Test the default behavior of Average Pool with non uniform padding
 func.func @test_default_averagepool_strides_nonunifpad_ceil(%arg0 : tensor<5x5x30x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 1 : si64, kernel_shape = [2,2], pads = [1, 0, 0, 0], strides = [2, 2] } : (tensor<5x5x30x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_default_averagepool_strides_nonunifpad_ceil
   // CHECK: [[RES:%.+]] = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", ceil_mode = 1 : si64, count_include_pad = 0 : si64, kernel_shape = [2, 2], pads = [1, 0, 0, 0], strides = [2, 2]} : (tensor<5x5x30x32xf32>) -> tensor<5x5x16x16xf32>
-  // CHECK: return [[RES]] : tensor<5x5x16x16xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x16x16xf32>
 }
 
 // -----
 
 func.func @test_global_averagepool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_global_averagepool
   // CHECK: [[RES:%.+]] = "onnx.GlobalAveragePool"(%arg0) : (tensor<5x5x32x32xf32>) -> tensor<5x5x1x1xf32>
-  // CHECK: return [[RES]] : tensor<5x5x1x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x1x1xf32>
 }
 
 // -----
 
 func.func @test_global_averagepool_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_global_averagepool_unranked
   // CHECK: [[RES:%.+]] = "onnx.GlobalAveragePool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  // CHECK: return [[RES]] : tensor<*xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
 
 func.func @test_global_lppool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.GlobalLpPool"(%arg0) : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_global_lppool
   // CHECK: [[RES:%.+]] = "onnx.GlobalLpPool"(%arg0) {p = 2 : si64} : (tensor<5x5x32x32xf32>) -> tensor<5x5x1x1xf32>
-  // CHECK: return [[RES]] : tensor<5x5x1x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x1x1xf32>
 }
 
 // -----
 
 func.func @test_global_lppool_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.GlobalLpPool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_global_lppool_unranked
   // CHECK: [[RES:%.+]] = "onnx.GlobalLpPool"(%arg0) {p = 2 : si64} : (tensor<*xf32>) -> tensor<*xf32>
-  // CHECK: return [[RES]] : tensor<*xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
 
 func.func @test_global_maxpool(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.GlobalMaxPool"(%arg0) : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_global_maxpool
   // CHECK: [[RES:%.+]] = "onnx.GlobalMaxPool"(%arg0) : (tensor<5x5x32x32xf32>) -> tensor<5x5x1x1xf32>
-  // CHECK: return [[RES]] : tensor<5x5x1x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x1x1xf32>
 }
 
 // -----
 
 func.func @test_global_maxpool_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.GlobalMaxPool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_global_maxpool_unranked
   // CHECK: [[RES:%.+]] = "onnx.GlobalMaxPool"(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
-  // CHECK: return [[RES]] : tensor<*xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
@@ -830,11 +830,11 @@ func.func @test_global_maxpool_unranked(%arg0 : tensor<*xf32>) -> tensor<*xf32> 
 
 func.func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi64>) -> tensor<*xf32> {
   %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reshape_dynamic
   // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, %arg1) {allowzero = 0 : si64} : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<?x?x?x?xf32>
-  // CHECK: return [[RES]] : tensor<?x?x?x?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<?x?x?x?xf32>
 }
 
 // -----
@@ -842,11 +842,11 @@ func.func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi
 func.func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[5, 5, 16, 2]> : tensor<4xi64>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reshape_1
   // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, %0) {allowzero = 0 : si64} : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<5x5x16x2xf32>
-  // CHECK: return [[RES]] : tensor<5x5x16x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x16x2xf32>
 }
 
 // -----
@@ -854,11 +854,11 @@ func.func @test_reshape_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
 func.func @test_reshape_2(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[-1, 16, 2]> : tensor<3xi64>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reshape_2
   // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, %0) {allowzero = 0 : si64} : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<25x16x2xf32>
-  // CHECK: return [[RES]] : tensor<25x16x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<25x16x2xf32>
 }
 
 // -----
@@ -866,11 +866,11 @@ func.func @test_reshape_2(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
 func.func @test_reshape_3(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[-1, 0, 2]> : tensor<3xi64>
   %1 = "onnx.Reshape"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reshape_3
   // CHECK: [[RES:%.+]] = "onnx.Reshape"(%arg0, %0) {allowzero = 0 : si64} : (tensor<5x5x1x32xf32>, tensor<3xi64>) -> tensor<80x5x2xf32>
-  // CHECK: return [[RES]] : tensor<80x5x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<80x5x2xf32>
 }
 
 // -----
@@ -881,11 +881,11 @@ func.func @test_reshape_3(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
 
 func.func @test_flatten_1(%arg0 : tensor<5x2x3x4xf32>) -> tensor<*xf32> {
   %1 = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<5x2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_flatten_1
   // CHECK: [[RES:%.+]] = "onnx.Flatten"(%arg0) {axis = 1 : si64} : (tensor<5x2x3x4xf32>) -> tensor<5x24xf32>
-  // CHECK: return [[RES]] : tensor<5x24xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x24xf32>
 }
 
 // -----
@@ -893,10 +893,10 @@ func.func @test_flatten_1(%arg0 : tensor<5x2x3x4xf32>) -> tensor<*xf32> {
 // Test when axis is 0
 func.func @test_flatten_2(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf32> {
   %1 = "onnx.Flatten"(%arg0) {axis = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_flatten_2
   // CHECK: [[RES:%.+]] = "onnx.Flatten"(%arg0) {axis = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<1x24xf32>
-  // CHECK: return [[RES]] : tensor<1x24xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x24xf32>
 }
 
 // -----
@@ -904,10 +904,10 @@ func.func @test_flatten_2(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf32> {
 // Test when axis is negative
 func.func @test_flatten_3(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf32> {
   %1 = "onnx.Flatten"(%arg0) {axis = -1 : si64} : (tensor<2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_flatten_3
   // CHECK: [[RES:%.+]] = "onnx.Flatten"(%arg0) {axis = -1 : si64} : (tensor<2x3x4xf32>) -> tensor<6x4xf32>
-  // CHECK: return [[RES]] : tensor<6x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<6x4xf32>
 }
 
 // -----
@@ -915,10 +915,10 @@ func.func @test_flatten_3(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf32> {
 // Test when input is not static shape
 func.func @test_flatten_4(%arg0 : tensor<2x4x5x?xf32>) -> tensor<*xf32> {
   %1 = "onnx.Flatten"(%arg0) {axis = 2 : si64} : (tensor<2x4x5x?xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
   // CHECK-LABEL: test_flatten_4
   // CHECK: [[RES:%.+]] = "onnx.Flatten"(%arg0) {axis = 2 : si64} : (tensor<2x4x5x?xf32>) -> tensor<8x?xf32>
-  // CHECK: return [[RES]] : tensor<8x?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<8x?xf32>
 }
 
 // -----
@@ -929,44 +929,44 @@ func.func @test_flatten_4(%arg0 : tensor<2x4x5x?xf32>) -> tensor<*xf32> {
 
 func.func @test_concat_1(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5x3x32xf32>, %arg2 : tensor<5x5x5x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) { axis = 2 : si64} : (tensor<5x5x1x32xf32>, tensor<5x5x3x32xf32>, tensor<5x5x5x32xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_concat_1
   // CHECK: [[RES:%.+]] = "onnx.Concat"(%arg0, %arg1, %arg2) {axis = 2 : si64} : (tensor<5x5x1x32xf32>, tensor<5x5x3x32xf32>, tensor<5x5x5x32xf32>) -> tensor<5x5x9x32xf32>
-  // CHECK: return [[RES]] : tensor<5x5x9x32xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x5x9x32xf32>
 }
 
 // -----
 
 func.func @test_concat_2(%arg0 : tensor<5x1x32xf32>, %arg1 : tensor<5x3x32xf32>, %arg2 : tensor<5x5x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) { axis = 1 : si64} : (tensor<5x1x32xf32>, tensor<5x3x32xf32>, tensor<5x5x32xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_concat_2
   // CHECK: [[RES:%.+]] = "onnx.Concat"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x1x32xf32>, tensor<5x3x32xf32>, tensor<5x5x32xf32>) -> tensor<5x9x32xf32>
-  // CHECK: return [[RES]] : tensor<5x9x32xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x9x32xf32>
 }
 
 // -----
 
 func.func @test_concat_3(%arg0 : tensor<5x1x32xf32>, %arg1 : tensor<5x3x32xf32>, %arg2 : tensor<5x5x32xf32>) -> tensor<*xf32> {
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) { axis = -2 : si64} : (tensor<5x1x32xf32>, tensor<5x3x32xf32>, tensor<5x5x32xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_concat_3
   // CHECK: [[RES:%.+]] = "onnx.Concat"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x1x32xf32>, tensor<5x3x32xf32>, tensor<5x5x32xf32>) -> tensor<5x9x32xf32>
-  // CHECK: return [[RES]] : tensor<5x9x32xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x9x32xf32>
 }
 
 // -----
 
 func.func @test_concat_4(%arg0 : tensor<?x1x?xf32>, %arg1 : tensor<?x3x32xf32>, %arg2 : tensor<?x5x?xf32>) -> tensor<*xf32> {
   %1 = "onnx.Concat"(%arg0, %arg1, %arg2) { axis = -2 : si64} : (tensor<?x1x?xf32>, tensor<?x3x32xf32>, tensor<?x5x?xf32>)  -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 // CHECK-LABEL:  func.func @test_concat_4
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x1x?xf32>, [[PARAM_1_:%.+]]: tensor<?x3x32xf32>, [[PARAM_2_:%.+]]: tensor<?x5x?xf32>) -> tensor<?x9x32xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Concat"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]]) {axis = 1 : si64} : (tensor<?x1x?xf32>, tensor<?x3x32xf32>, tensor<?x5x?xf32>) -> tensor<?x9x32xf32>
-// CHECK:           return [[VAR_0_]] : tensor<?x9x32xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<?x9x32xf32>
 // CHECK:         }
 }
 
@@ -975,12 +975,12 @@ func.func @test_concat_4(%arg0 : tensor<?x1x?xf32>, %arg1 : tensor<?x3x32xf32>, 
 func.func @test_rnn_all_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<1x3x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_rnn_all_results
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.RNN"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {activations = ["Tanh", "Tanh"], direction = "forward", hidden_size = 3 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -988,12 +988,12 @@ func.func @test_rnn_all_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf3
 func.func @test_rnn_infer_hidden_size_from_W(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<?x?x?xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %cst) : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<?x?x?xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_rnn_infer_hidden_size_from_W
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.RNN"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {activations = ["Tanh", "Tanh"], direction = "forward", hidden_size = 3 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<?x?x?xf32>, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1001,12 +1001,12 @@ func.func @test_rnn_infer_hidden_size_from_W(%arg0: tensor<4x3x2xf32>, %arg1: te
 func.func @test_rnn_no_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<1x3x3xf32>) -> (none) {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (none, none)
-  return %Y_h : none
+  onnx.Return %Y_h : none
 
   // CHECK-LABEL: test_rnn_no_results
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.RNN"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {activations = ["Tanh", "Tanh"], direction = "forward", hidden_size = 3 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (none, none)
-  // CHECK-NEXT: return [[RES]]
+  // CHECK-NEXT: onnx.Return [[RES]]
 }
 
 // -----
@@ -1014,12 +1014,12 @@ func.func @test_rnn_no_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf32
 func.func @test_rnn_missing_first_result(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<1x3x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (none, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_rnn_missing_first_result
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.RNN"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {activations = ["Tanh", "Tanh"], direction = "forward", hidden_size = 3 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (none, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1027,12 +1027,12 @@ func.func @test_rnn_missing_first_result(%arg0: tensor<4x3x2xf32>, %arg1: tensor
 func.func @test_rnn_missing_trailing_result(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<1x3x3xf32>) -> (none) {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (tensor<*xf32>, none)
-  return %Y_h : none
+  onnx.Return %Y_h : none
 
   // CHECK-LABEL: test_rnn_missing_trailing_result
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.RNN"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {activations = ["Tanh", "Tanh"], direction = "forward", hidden_size = 3 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (tensor<4x1x3x3xf32>, none)
-  // CHECK: return [[RES]]
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -1040,12 +1040,12 @@ func.func @test_rnn_missing_trailing_result(%arg0: tensor<4x3x2xf32>, %arg1: ten
 func.func @test_rnn_all_results_no_hidden_size(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<1x3x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %cst) : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_rnn_all_results_no_hidden_size
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.RNN"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {activations = ["Tanh", "Tanh"], direction = "forward", hidden_size = 3 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1053,12 +1053,12 @@ func.func @test_rnn_all_results_no_hidden_size(%arg0: tensor<4x3x2xf32>, %arg1: 
 func.func @test_rnn_all_results_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>, %arg2: tensor<?x?x?xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %cst) : (tensor<?x?x?xf32>, tensor<?x?x?xf32>, tensor<?x?x?xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_rnn_all_results_unknown_dims
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.RNN"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {activations = ["Tanh", "Tanh"], direction = "forward", layout = 0 : si64} : (tensor<?x?x?xf32>, tensor<?x?x?xf32>, tensor<?x?x?xf32>, none, none, none) -> (tensor<?x1x?x?xf32>, tensor<1x?x?xf32>)
-  // CHECK: return [[RES]] : tensor<1x?x?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x?x?xf32>
 }
 
 // -----
@@ -1066,12 +1066,12 @@ func.func @test_rnn_all_results_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: te
 func.func @test_rnn_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x3x2xf32>, %arg2: tensor<1x3x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.RNN"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64, layout = 1 : si64} : (tensor<5x4x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_rnn_layout1
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.RNN"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {activations = ["Tanh", "Tanh"], direction = "forward", hidden_size = 3 : si64, layout = 1 : si64} : (tensor<5x4x2xf32>, tensor<1x3x2xf32>, tensor<1x3x3xf32>, none, none, none) -> (tensor<5x4x1x3xf32>, tensor<5x1x3xf32>)
-  // CHECK: return [[RES]] : tensor<5x1x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x1x3xf32>
 }
 
 // -----
@@ -1079,12 +1079,12 @@ func.func @test_rnn_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x3x2xf32>, 
 func.func @test_gru_all_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf32>, %arg2: tensor<1x9x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_gru_all_results
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.GRU"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, layout = 0 : si64, linear_before_reset = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1092,12 +1092,12 @@ func.func @test_gru_all_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf3
 func.func @test_gru_infer_hidden_size_from_W(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf32>, %arg2: tensor<?x?x?xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<?x?x?xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_gru_infer_hidden_size_from_W
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.GRU"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, layout = 0 : si64, linear_before_reset = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<?x?x?xf32>, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1105,12 +1105,12 @@ func.func @test_gru_infer_hidden_size_from_W(%arg0: tensor<4x3x2xf32>, %arg1: te
 func.func @test_gru_no_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf32>, %arg2: tensor<1x9x3xf32>) -> (none) {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (none, none)
-  return %Y_h : none
+  onnx.Return %Y_h : none
 
   // CHECK-LABEL: test_gru_no_results
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.GRU"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, layout = 0 : si64, linear_before_reset = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (none, none)
-  // CHECK: return [[RES]]
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -1118,12 +1118,12 @@ func.func @test_gru_no_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf32
 func.func @test_gru_missing_first_result(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf32>, %arg2: tensor<1x9x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (none, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_gru_missing_first_result
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.GRU"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, layout = 0 : si64, linear_before_reset = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (none, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1131,12 +1131,12 @@ func.func @test_gru_missing_first_result(%arg0: tensor<4x3x2xf32>, %arg1: tensor
 func.func @test_gru_missing_trailing_result(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf32>, %arg2: tensor<1x9x3xf32>) -> (none) {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<*xf32>, none)
-  return %Y_h : none
+  onnx.Return %Y_h : none
 
   // CHECK-LABEL: test_gru_missing_trailing_result
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.GRU"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, layout = 0 : si64, linear_before_reset = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<4x1x3x3xf32>, none)
-  // CHECK: return [[RES]]
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -1144,12 +1144,12 @@ func.func @test_gru_missing_trailing_result(%arg0: tensor<4x3x2xf32>, %arg1: ten
 func.func @test_gru_all_results_no_hidden_size(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x9x2xf32>, %arg2: tensor<1x9x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_gru_all_results_no_hidden_size
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.GRU"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, layout = 0 : si64, linear_before_reset = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1157,12 +1157,12 @@ func.func @test_gru_all_results_no_hidden_size(%arg0: tensor<4x3x2xf32>, %arg1: 
 func.func @test_gru_all_results_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>, %arg2: tensor<?x?x?xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) : (tensor<?x?x?xf32>, tensor<?x?x?xf32>, tensor<?x?x?xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_gru_all_results_unknown_dims
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.GRU"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {direction = "forward", layout = 0 : si64, linear_before_reset = 0 : si64} : (tensor<?x?x?xf32>, tensor<?x?x?xf32>, tensor<?x?x?xf32>, none, none, none) -> (tensor<?x1x?x?xf32>, tensor<1x?x?xf32>)
-  // CHECK: return [[RES]] : tensor<1x?x?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x?x?xf32>
 }
 
 // -----
@@ -1170,12 +1170,12 @@ func.func @test_gru_all_results_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: te
 func.func @test_gru_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x9x2xf32>, %arg2: tensor<1x9x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %cst, %cst, %cst) {hidden_size = 3 : si64, layout = 1 : si64} : (tensor<5x4x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_gru_layout1
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]] = "onnx.GRU"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, layout = 1 : si64, linear_before_reset = 0 : si64} : (tensor<5x4x2xf32>, tensor<1x9x2xf32>, tensor<1x9x3xf32>, none, none, none) -> (tensor<5x4x1x3xf32>, tensor<5x1x3xf32>)
-  // CHECK: return [[RES]] : tensor<5x1x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x1x3xf32>
 }
 
 // -----
@@ -1183,12 +1183,12 @@ func.func @test_gru_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x9x2xf32>, 
 func.func @test_lstm_all_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_lstm_all_results
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]], %{{.*}} = "onnx.LSTM"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, input_forget = 0 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1196,12 +1196,12 @@ func.func @test_lstm_all_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2x
 func.func @test_lstm_infer_hidden_size_from_W(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<?x?x?xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<?x?x?xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_lstm_infer_hidden_size_from_W
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]], %{{.*}} = "onnx.LSTM"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, input_forget = 0 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<?x?x?xf32>, none, none, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1209,12 +1209,12 @@ func.func @test_lstm_infer_hidden_size_from_W(%arg0: tensor<4x3x2xf32>, %arg1: t
 func.func @test_lstm_no_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>) -> (none) {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (none, none, none)
-  return %Y_h : none
+  onnx.Return %Y_h : none
 
   // CHECK-LABEL: test_lstm_no_results
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]], %{{.*}} = "onnx.LSTM"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, input_forget = 0 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (none, none, none)
-  // CHECK: return [[RES]]
+  // CHECK: onnx.Return [[RES]]
 }
 
 // -----
@@ -1222,12 +1222,12 @@ func.func @test_lstm_no_results(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf
 func.func @test_lstm_missing_first_result(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (none, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_lstm_missing_first_result
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]], %{{.*}} = "onnx.LSTM"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, input_forget = 0 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (none, tensor<1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1235,12 +1235,12 @@ func.func @test_lstm_missing_first_result(%arg0: tensor<4x3x2xf32>, %arg1: tenso
 func.func @test_lstm_missing_trailing_result(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, none)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_lstm_missing_trailing_result
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]], %{{.*}} = "onnx.LSTM"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, input_forget = 0 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>, none)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1248,12 +1248,12 @@ func.func @test_lstm_missing_trailing_result(%arg0: tensor<4x3x2xf32>, %arg1: te
 func.func @test_lstm_all_results_no_hidden_size(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_lstm_all_results_no_hidden_size
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]], %{{.*}} = "onnx.LSTM"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, input_forget = 0 : si64, layout = 0 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<4x1x3x3xf32>, tensor<1x3x3xf32>, tensor<1x3x3xf32>)
-  // CHECK: return [[RES]] : tensor<1x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x3xf32>
 }
 
 // -----
@@ -1261,12 +1261,12 @@ func.func @test_lstm_all_results_no_hidden_size(%arg0: tensor<4x3x2xf32>, %arg1:
 func.func @test_lstm_all_results_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>, %arg2: tensor<?x?x?xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) : (tensor<?x?x?xf32>, tensor<?x?x?xf32>, tensor<?x?x?xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_lstm_all_results_unknown_dims
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]], %{{.*}} = "onnx.LSTM"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]], [[CST]], [[CST]]) {direction = "forward", input_forget = 0 : si64, layout = 0 : si64} : (tensor<?x?x?xf32>, tensor<?x?x?xf32>, tensor<?x?x?xf32>, none, none, none, none, none) -> (tensor<?x1x?x?xf32>, tensor<1x?x?xf32>, tensor<1x?x?xf32>)
-  // CHECK: return [[RES]] : tensor<1x?x?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x?x?xf32>
 }
 
 // -----
@@ -1274,12 +1274,12 @@ func.func @test_lstm_all_results_unknown_dims(%arg0: tensor<?x?x?xf32>, %arg1: t
 func.func @test_lstm_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x12x2xf32>, %arg2: tensor<1x12x3xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64, layout = 1 : si64} : (tensor<5x4x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 
   // CHECK-LABEL: test_lstm_layout1
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: %{{.*}}, [[RES:%.+]], %{{.*}} = "onnx.LSTM"(%arg0, %arg1, %arg2, [[CST]], [[CST]], [[CST]], [[CST]], [[CST]]) {direction = "forward", hidden_size = 3 : si64, input_forget = 0 : si64, layout = 1 : si64} : (tensor<5x4x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<5x4x1x3xf32>, tensor<5x1x3xf32>, tensor<5x1x3xf32>)
-  // CHECK: return [[RES]] : tensor<5x1x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x1x3xf32>
 }
 
 // -----
@@ -1291,11 +1291,11 @@ func.func @test_lstm_layout1(%arg0: tensor<5x4x2xf32>, %arg1: tensor<1x12x2xf32>
 func.func @test_space_to_depth(%arg0 : tensor<1x16x32x64xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.SpaceToDepth"(%arg0) {blocksize = 4 : si64} : (tensor<1x16x32x64xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_space_to_depth
   // CHECK: [[RES:%.+]] = "onnx.SpaceToDepth"(%arg0) {blocksize = 4 : si64} : (tensor<1x16x32x64xf32>) -> tensor<1x256x8x16xf32>
-  // CHECK: return [[RES]] : tensor<1x256x8x16xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x256x8x16xf32>
 }
 
 // -----
@@ -1303,12 +1303,12 @@ func.func @test_space_to_depth(%arg0 : tensor<1x16x32x64xf32>) -> tensor<*xf32> 
 func.func @test_split_1(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0, %1 = "onnx.Split"(%arg0, %cst) { axis = 1 : si64} : (tensor<16x32x64xf32>, none) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_split_1
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES:%.+]]:2 = "onnx.Split"(%arg0, [[CST]]) {axis = 1 : si64} : (tensor<16x32x64xf32>, none) -> (tensor<16x16x64xf32>, tensor<16x16x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x16x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x16x64xf32>
 }
 
 // -----
@@ -1316,12 +1316,12 @@ func.func @test_split_1(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
 func.func @test_split_2(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0, %1 = "onnx.Split"(%arg0, %cst) { axis = -2 : si64} : (tensor<16x32x64xf32>, none) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_split_2
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES:%.+]]:2 = "onnx.Split"(%arg0, [[CST]]) {axis = 1 : si64} : (tensor<16x32x64xf32>, none) -> (tensor<16x16x64xf32>, tensor<16x16x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x16x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x16x64xf32>
 }
 
 // -----
@@ -1329,11 +1329,11 @@ func.func @test_split_2(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
 func.func @test_split_3(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %split = onnx.Constant dense<[2, 30]> : tensor<2xi64>
   %0, %1 = "onnx.Split"(%arg0, %split) {axis = 1 : si64} : (tensor<16x32x64xf32>, tensor<2xi64>) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_split_3
   // CHECK: [[RES:%.+]]:2 = "onnx.Split"(%arg0, %0) {axis = 1 : si64} : (tensor<16x32x64xf32>, tensor<2xi64>) -> (tensor<16x2x64xf32>, tensor<16x30x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x2x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x2x64xf32>
 }
 
 // -----
@@ -1341,11 +1341,11 @@ func.func @test_split_3(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
 func.func @test_split_4(%arg0 : tensor<16x?x64xf32>) -> tensor<*xf32> {
   %split = onnx.Constant dense<[2, 30]> : tensor<2xi64>
   %0, %1 = "onnx.Split"(%arg0, %split) {axis = 1 : si64} : (tensor<16x?x64xf32>, tensor<2xi64>) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_split_4
   // CHECK: [[RES:%.+]]:2 = "onnx.Split"(%arg0, %0) {axis = 1 : si64} : (tensor<16x?x64xf32>, tensor<2xi64>) -> (tensor<16x2x64xf32>, tensor<16x30x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x2x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x2x64xf32>
 }
 
 // -----
@@ -1353,12 +1353,12 @@ func.func @test_split_4(%arg0 : tensor<16x?x64xf32>) -> tensor<*xf32> {
 func.func @test_split_5(%arg0 : tensor<16x?x64xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0, %1 = "onnx.Split"(%arg0, %cst) {axis = 1 : si64} : (tensor<16x?x64xf32>, none) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_split_5
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES:%.+]]:2 = "onnx.Split"(%arg0, [[CST]]) {axis = 1 : si64} : (tensor<16x?x64xf32>, none) -> (tensor<16x?x64xf32>, tensor<16x?x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x?x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x?x64xf32>
 }
 
 // -----
@@ -1366,12 +1366,12 @@ func.func @test_split_5(%arg0 : tensor<16x?x64xf32>) -> tensor<*xf32> {
 func.func @test_split_6(%arg0 : tensor<16x39x64xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0, %1 = "onnx.Split"(%arg0, %cst) { axis = 1 : si64, num_outputs = 2 : si64} : (tensor<16x39x64xf32>, none) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_split_6
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES:%.+]]:2 = "onnx.Split"(%arg0, [[CST]]) {axis = 1 : si64, num_outputs = 2 : si64} : (tensor<16x39x64xf32>, none) -> (tensor<16x20x64xf32>, tensor<16x19x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x20x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x20x64xf32>
 }
 
 // -----
@@ -1379,67 +1379,67 @@ func.func @test_split_6(%arg0 : tensor<16x39x64xf32>) -> tensor<*xf32> {
 func.func @test_split_7(%arg0 : tensor<16x38x64xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0, %1, %2 = "onnx.Split"(%arg0, %cst) { axis = 1 : si64, num_outputs = 3 : si64} : (tensor<16x38x64xf32>, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_split_7
   // CHECK: [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[RES:%.+]]:3 = "onnx.Split"(%arg0, [[CST]]) {axis = 1 : si64, num_outputs = 3 : si64} : (tensor<16x38x64xf32>, none) -> (tensor<16x13x64xf32>, tensor<16x13x64xf32>, tensor<16x12x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x13x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x13x64xf32>
 }
 
 // -----
 
 func.func @test_splitv11_1(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0, %1 = "onnx.SplitV11"(%arg0) { axis = 1 : si64} : (tensor<16x32x64xf32>) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_splitv11_1
   // CHECK: [[RES:%.+]]:2 = "onnx.SplitV11"(%arg0) {axis = 1 : si64} : (tensor<16x32x64xf32>) -> (tensor<16x16x64xf32>, tensor<16x16x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x16x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x16x64xf32>
 }
 
 // -----
 
 func.func @test_splitv11_2(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0, %1 = "onnx.SplitV11"(%arg0) { axis = -2 : si64} : (tensor<16x32x64xf32>) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_splitv11_2
   // CHECK: [[RES:%.+]]:2 = "onnx.SplitV11"(%arg0) {axis = 1 : si64} : (tensor<16x32x64xf32>) -> (tensor<16x16x64xf32>, tensor<16x16x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x16x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x16x64xf32>
 }
 
 // -----
 
 func.func @test_splitv11_3(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0, %1 = "onnx.SplitV11"(%arg0) {axis = 1 : si64, split = [2, 30]} : (tensor<16x32x64xf32>) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_splitv11_3
   // CHECK: [[RES:%.+]]:2 = "onnx.SplitV11"(%arg0) {axis = 1 : si64, split = [2, 30]} : (tensor<16x32x64xf32>) -> (tensor<16x2x64xf32>, tensor<16x30x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x2x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x2x64xf32>
 }
 
 // -----
 
 func.func @test_splitv11_4(%arg0 : tensor<16x?x64xf32>) -> tensor<*xf32> {
   %0, %1 = "onnx.SplitV11"(%arg0) {axis = 1 : si64, split = [2, 30]} : (tensor<16x?x64xf32>) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_splitv11_4
   // CHECK: [[RES:%.+]]:2 = "onnx.SplitV11"(%arg0) {axis = 1 : si64, split = [2, 30]} : (tensor<16x?x64xf32>) -> (tensor<16x2x64xf32>, tensor<16x30x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x2x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x2x64xf32>
 }
 
 // -----
 
 func.func @test_splitv11_5(%arg0 : tensor<16x?x64xf32>) -> tensor<*xf32> {
   %0, %1 = "onnx.SplitV11"(%arg0) {axis = 1 : si64} : (tensor<16x?x64xf32>) -> (tensor<*xf32>, tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_splitv11_5
   // CHECK: [[RES:%.+]]:2 = "onnx.SplitV11"(%arg0) {axis = 1 : si64} : (tensor<16x?x64xf32>) -> (tensor<16x?x64xf32>, tensor<16x?x64xf32>)
-  // CHECK: return [[RES]]#0 : tensor<16x?x64xf32>
+  // CHECK: onnx.Return [[RES]]#0 : tensor<16x?x64xf32>
 }
 
 // -----
@@ -1447,22 +1447,22 @@ func.func @test_splitv11_5(%arg0 : tensor<16x?x64xf32>) -> tensor<*xf32> {
 func.func @test_squeeze(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[1]> : tensor<1xi64>
   %1 = "onnx.Squeeze"(%arg0, %0) : (tensor<16x1x32x1x64xf32>, tensor<1xi64>) -> (tensor<*xf32>)
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_squeeze
   // CHECK: [[RES:%.+]] = "onnx.Squeeze"(%arg0, %0) : (tensor<16x1x32x1x64xf32>, tensor<1xi64>) -> tensor<16x32x1x64xf32>
-  // CHECK: return [[RES]] : tensor<16x32x1x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x32x1x64xf32>
 }
 
 // -----
 
 func.func @test_squeezev11(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.SqueezeV11"(%arg0) { axes = [1]} : (tensor<16x1x32x1x64xf32>) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_squeezev11
   // CHECK: [[RES:%.+]] = "onnx.SqueezeV11"(%arg0) {axes = [1]} : (tensor<16x1x32x1x64xf32>) -> tensor<16x32x1x64xf32>
-  // CHECK: return [[RES]] : tensor<16x32x1x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x32x1x64xf32>
 }
 
 // -----
@@ -1470,23 +1470,23 @@ func.func @test_squeezev11(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
 func.func @test_squeeze_negative_axis(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[-2]> : tensor<1xi64>
   %1 = "onnx.Squeeze"(%arg0, %0) : (tensor<16x1x32x1x64xf32>, tensor<1xi64>) -> (tensor<*xf32>)
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_squeeze_negative_axis
   // CHECK: [[CSTPOS:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
   // CHECK: [[RES:%.+]] = "onnx.Squeeze"(%arg0, [[CSTPOS]]) : (tensor<16x1x32x1x64xf32>, tensor<1xi64>) -> tensor<16x1x32x64xf32>
-  // CHECK: return [[RES]] : tensor<16x1x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x1x32x64xf32>
 }
 
 // -----
 
 func.func @test_squeezev11_negative_axis(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.SqueezeV11"(%arg0) { axes = [-2]} : (tensor<16x1x32x1x64xf32>) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_squeezev11_negative_axis
   // CHECK: [[RES:%.+]] = "onnx.SqueezeV11"(%arg0) {axes = [3]} : (tensor<16x1x32x1x64xf32>) -> tensor<16x1x32x64xf32>
-  // CHECK: return [[RES]] : tensor<16x1x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x1x32x64xf32>
 }
 
 // -----
@@ -1494,23 +1494,23 @@ func.func @test_squeezev11_negative_axis(%arg0 : tensor<16x1x32x1x64xf32>) -> te
 func.func @test_squeeze_mix(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[1, -2]> : tensor<2xi64>
   %1 = "onnx.Squeeze"(%arg0, %0) : (tensor<16x1x32x1x64xf32>, tensor<2xi64>) -> (tensor<*xf32>)
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_squeeze_mix
   // CHECK: [[CSTPOS:%.+]] = onnx.Constant dense<[1, 3]> : tensor<2xi64>
   // CHECK: [[RES:%.+]] = "onnx.Squeeze"(%arg0, [[CSTPOS]]) : (tensor<16x1x32x1x64xf32>, tensor<2xi64>) -> tensor<16x32x64xf32>
-  // CHECK: return [[RES]] : tensor<16x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x32x64xf32>
 }
 
 // -----
 
 func.func @test_squeezev11_mix(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.SqueezeV11"(%arg0) { axes = [1, -2]} : (tensor<16x1x32x1x64xf32>) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_squeezev11_mix
   // CHECK: [[RES:%.+]] = "onnx.SqueezeV11"(%arg0) {axes = [1, 3]} : (tensor<16x1x32x1x64xf32>) -> tensor<16x32x64xf32>
-  // CHECK: return [[RES]] : tensor<16x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x32x64xf32>
 }
 
 // -----
@@ -1518,23 +1518,23 @@ func.func @test_squeezev11_mix(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32
 func.func private @test_squeeze_empty_axes(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.Squeeze"(%arg0, %cst) : (tensor<16x1x32x1x64xf32>, none) -> (tensor<*xf32>)
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_squeeze_empty_axes
   // CHECK: [[CONST:%.+]] = onnx.Constant dense<[1, 3]> : tensor<2xi64>
   // CHECK: [[RES:%.+]] = "onnx.Squeeze"(%arg0, [[CONST]]) : (tensor<16x1x32x1x64xf32>, tensor<2xi64>) -> tensor<16x32x64xf32>
-  // CHECK: return [[RES]] : tensor<16x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x32x64xf32>
 }
 
 // -----
 
 func.func private @test_squeezev11_empty_axes(%arg0 : tensor<16x1x32x1x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.SqueezeV11"(%arg0) : (tensor<16x1x32x1x64xf32>) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_squeezev11_empty_axes
   // CHECK: [[RES:%.+]] = "onnx.SqueezeV11"(%arg0) {axes = [1, 3]} : (tensor<16x1x32x1x64xf32>) -> tensor<16x32x64xf32>
-  // CHECK: return [[RES]] : tensor<16x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x32x64xf32>
 }
 
 // -----
@@ -1542,11 +1542,11 @@ func.func private @test_squeezev11_empty_axes(%arg0 : tensor<16x1x32x1x64xf32>) 
 func.func @test_unsqueeze(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[1]> : tensor<1xi64>
   %1 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<16x32x64xf32>, tensor<1xi64>) -> (tensor<*xf32>)
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_unsqueeze
   // CHECK: [[RES:%.+]] = "onnx.Unsqueeze"(%arg0, %0) : (tensor<16x32x64xf32>, tensor<1xi64>) -> tensor<16x1x32x64xf32>
-  // CHECK: return [[RES]] : tensor<16x1x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x1x32x64xf32>
 }
 
 // -----
@@ -1554,14 +1554,14 @@ func.func @test_unsqueeze(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
 func.func private @unsqueeze_of_const(%arg0: tensor<32x64xi64>) -> tensor<*xi64> {
    %1 = onnx.Constant dense<0> : tensor<i64>
    %2 = "onnx.Unsqueeze"(%arg0, %1) : (tensor<32x64xi64>, tensor<i64>) -> tensor<*xi64>
-  "func.return"(%2) : (tensor<*xi64>) -> ()
+  "onnx.Return"(%2) : (tensor<*xi64>) -> ()
 
 // mlir2FileCheck.py -a'["data"]'
 // CHECK-LABEL:  func private @unsqueeze_of_const
 // CHECK-SAME:   ([[DATA_:%.+]]: tensor<32x64xi64>) -> tensor<1x32x64xi64> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<i64>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[DATA_]], [[VAR_0_]]) : (tensor<32x64xi64>, tensor<i64>) -> tensor<1x32x64xi64>
-// CHECK:           return [[VAR_1_]] : tensor<1x32x64xi64>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<1x32x64xi64>
 // CHECK:         }
 }
 
@@ -1569,11 +1569,11 @@ func.func private @unsqueeze_of_const(%arg0: tensor<32x64xi64>) -> tensor<*xi64>
 
 func.func @test_unsqueezev11(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.UnsqueezeV11"(%arg0) { axes = [1]} : (tensor<16x32x64xf32>) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_unsqueezev11
   // CHECK: [[RES:%.+]] = "onnx.UnsqueezeV11"(%arg0) {axes = [1]} : (tensor<16x32x64xf32>) -> tensor<16x1x32x64xf32>
-  // CHECK: return [[RES]] : tensor<16x1x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x1x32x64xf32>
 }
 
 // -----
@@ -1581,23 +1581,23 @@ func.func @test_unsqueezev11(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
 func.func @test_unsqueeze_negative_axis(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[-2]> : tensor<1xi64>
   %1 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<16x32x64xf32>, tensor<1xi64>) -> (tensor<*xf32>)
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_unsqueeze_negative_axis
   // CHECK: [[CSTPOS:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
   // CHECK: [[RES:%.+]] = "onnx.Unsqueeze"(%arg0, [[CSTPOS]]) : (tensor<16x32x64xf32>, tensor<1xi64>) -> tensor<16x32x1x64xf32>
-  // CHECK: return [[RES]] : tensor<16x32x1x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x32x1x64xf32>
 }
 
 // -----
 
 func.func @test_unsqueezev11_negative_axis(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.UnsqueezeV11"(%arg0) { axes = [-2]} : (tensor<16x32x64xf32>) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_unsqueezev11_negative_axis
   // CHECK: [[RES:%.+]] = "onnx.UnsqueezeV11"(%arg0) {axes = [2]} : (tensor<16x32x64xf32>) -> tensor<16x32x1x64xf32>
-  // CHECK: return [[RES]] : tensor<16x32x1x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x32x1x64xf32>
 }
 
 // -----
@@ -1605,23 +1605,23 @@ func.func @test_unsqueezev11_negative_axis(%arg0 : tensor<16x32x64xf32>) -> tens
 func.func @test_unsqueeze_mix(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[1, -2]> : tensor<2xi64>
   %1 = "onnx.Unsqueeze"(%arg0, %0) : (tensor<16x32x64xf32>, tensor<2xi64>) -> (tensor<*xf32>)
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_unsqueeze_mix
   // CHECK: [[CSTPOS:%.+]] = onnx.Constant dense<[1, 3]> : tensor<2xi64>
   // CHECK: [[RES:%.+]] = "onnx.Unsqueeze"(%arg0, [[CSTPOS]]) : (tensor<16x32x64xf32>, tensor<2xi64>) -> tensor<16x1x32x1x64xf32>
-  // CHECK: return [[RES]] : tensor<16x1x32x1x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x1x32x1x64xf32>
 }
 
 // -----
 
 func.func @test_unsqueezev11_mix(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> {
   %0 = "onnx.UnsqueezeV11"(%arg0) { axes = [1, -2]} : (tensor<16x32x64xf32>) -> (tensor<*xf32>)
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_unsqueezev11_mix
   // CHECK: [[RES:%.+]] = "onnx.UnsqueezeV11"(%arg0) {axes = [1, 3]} : (tensor<16x32x64xf32>) -> tensor<16x1x32x1x64xf32>
-  // CHECK: return [[RES]] : tensor<16x1x32x1x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<16x1x32x1x64xf32>
 }
 
 // -----
@@ -1632,22 +1632,22 @@ func.func @test_unsqueezev11_mix(%arg0 : tensor<16x32x64xf32>) -> tensor<*xf32> 
 
 func.func @test_eyelike_1(%arg0 : tensor<8x8xi32>) -> tensor<*xf32> {
   %1 = "onnx.EyeLike"(%arg0) {dtype = 1 : si64} : (tensor<8x8xi32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_eyelike_1
   // CHECK: [[RES:%.+]] = "onnx.EyeLike"(%arg0) {dtype = 1 : si64, k = 0 : si64} : (tensor<8x8xi32>) -> tensor<8x8xf32>
-  // CHECK: return [[RES]] : tensor<8x8xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<8x8xf32>
 }
 
 // -----
 
 func.func @test_eyelike_2(%arg0 : tensor<8x8xi32>) -> tensor<*xi32> {
   %1 = "onnx.EyeLike"(%arg0) {} : (tensor<8x8xi32>) -> tensor<*xi32>
-  "func.return"(%1) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xi32>) -> ()
 
   // CHECK-LABEL: test_eyelike_2
   // CHECK: [[RES:%.+]] = "onnx.EyeLike"(%arg0) {k = 0 : si64} : (tensor<8x8xi32>) -> tensor<8x8xi32>
-  // CHECK: return [[RES]] : tensor<8x8xi32>
+  // CHECK: onnx.Return [[RES]] : tensor<8x8xi32>
 }
 
 // -----
@@ -1658,44 +1658,44 @@ func.func @test_eyelike_2(%arg0 : tensor<8x8xi32>) -> tensor<*xi32> {
 
 func.func @test_cast_1(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf32> {
   %1 = "onnx.Cast"(%arg0) {to = f32} : (tensor<2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_cast_1
   // CHECK: [[RES:%.+]] = "onnx.Cast"(%arg0) {to = f32} : (tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xf32>
 }
 
 // -----
 
 func.func @test_cast_2(%arg0 : tensor<2x3x4xf32>) -> tensor<*xui8> {
   %1 = "onnx.Cast"(%arg0) {to = ui8} : (tensor<2x3x4xf32>) -> tensor<*xui8>
-  "func.return"(%1) : (tensor<*xui8>) -> ()
+  "onnx.Return"(%1) : (tensor<*xui8>) -> ()
 
   // CHECK-LABEL: test_cast_2
   // CHECK: [[RES:%.+]] = "onnx.Cast"(%arg0) {to = ui8} : (tensor<2x3x4xf32>) -> tensor<2x3x4xui8>
-  // CHECK: return [[RES]] : tensor<2x3x4xui8>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xui8>
 }
 
 // -----
 
 func.func @test_cast_3(%arg0 : tensor<2x3x4xf32>) -> tensor<*xi8> {
   %1 = "onnx.Cast"(%arg0) {to = i8} : (tensor<2x3x4xf32>) -> tensor<*xi8>
-  "func.return"(%1) : (tensor<*xi8>) -> ()
+  "onnx.Return"(%1) : (tensor<*xi8>) -> ()
 
   // CHECK-LABEL: test_cast_3
   // CHECK: [[RES:%.+]] = "onnx.Cast"(%arg0) {to = i8} : (tensor<2x3x4xf32>) -> tensor<2x3x4xi8>
-  // CHECK: return [[RES]] : tensor<2x3x4xi8>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xi8>
 }
 
 // -----
 
 func.func @test_cast_10(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf16> {
   %1 = "onnx.Cast"(%arg0) {to = f16} : (tensor<2x3x4xf32>) -> tensor<*xf16>
-  "func.return"(%1) : (tensor<*xf16>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf16>) -> ()
 
   // CHECK-LABEL: test_cast_10
   // CHECK: [[RES:%.+]] = "onnx.Cast"(%arg0) {to = f16} : (tensor<2x3x4xf32>) -> tensor<2x3x4xf16>
-  // CHECK: return [[RES]] : tensor<2x3x4xf16>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xf16>
 }
 
 // -----
@@ -1707,11 +1707,11 @@ func.func @test_cast_10(%arg0 : tensor<2x3x4xf32>) -> tensor<*xf16> {
 
 func.func @test_castlike_1(%arg0 : tensor<2x3x4xf32>, %arg1 : tensor<2xf16>) -> tensor<*xf16> {
   %1 = "onnx.CastLike"(%arg0, %arg1) : (tensor<2x3x4xf32>, tensor<2xf16>) -> tensor<*xf16>
-  "func.return"(%1) : (tensor<*xf16>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf16>) -> ()
 
   // CHECK-LABEL: test_castlike_1
   // CHECK: [[RES:%.+]] = "onnx.CastLike"(%arg0, %arg1) : (tensor<2x3x4xf32>, tensor<2xf16>) -> tensor<2x3x4xf16>
-  // CHECK: return [[RES]] : tensor<2x3x4xf16>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xf16>
 }
 
 // -----
@@ -1725,33 +1725,33 @@ func.func @test_castlike_1(%arg0 : tensor<2x3x4xf32>, %arg1 : tensor<2xf16>) -> 
 // but tensor<i8> is generated
 func.func @test_dyn_quantize_linear_1(%arg0 : tensor<5x2x3x4xf32>) -> tensor<*xui8> {
  %1:3 = "onnx.DynamicQuantizeLinear"(%arg0) {} : (tensor<5x2x3x4xf32>) -> (tensor<*xui8>, tensor<*xf32>, tensor<*xui8>)
- "func.return"(%1#0) {} : (tensor<*xui8>) -> ()
+ "onnx.Return"(%1#0) {} : (tensor<*xui8>) -> ()
 
  // CHECK-LABEL: test_dyn_quantize_linear_1
  // CHECK: [[RES:%.+]], {{.*}}, {{.*}} = "onnx.DynamicQuantizeLinear"(%arg0) : (tensor<5x2x3x4xf32>) -> (tensor<5x2x3x4xui8>, tensor<f32>, tensor<ui8>)
- // CHECK: return [[RES]] : tensor<5x2x3x4xui8>
+ // CHECK: onnx.Return [[RES]] : tensor<5x2x3x4xui8>
 }
 
 // -----
 
 func.func @test_quantize_linear_1(%arg0 : tensor<5x2x3x4xf32>, %arg1 : tensor<f32>, %arg2 : tensor<i8>) -> tensor<*xi8> {
   %1 = "onnx.QuantizeLinear"(%arg0, %arg1, %arg2) {} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<*xi8>
-  "func.return"(%1) {} : (tensor<*xi8>) -> ()
+  "onnx.Return"(%1) {} : (tensor<*xi8>) -> ()
 
   // CHECK-LABEL: test_quantize_linear_1
   // CHECK: [[RES:%.+]] = "onnx.QuantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xi8>
-  // CHECK: return [[RES]] : tensor<5x2x3x4xi8>
+  // CHECK: onnx.Return [[RES]] : tensor<5x2x3x4xi8>
 }
 
 // -----
 
 func.func @test_quantize_linear_2(%arg0 : tensor<5x2x3x4xf32>, %arg1: tensor<f32>, %arg2: tensor<ui8>) -> tensor<*xui8> {
  %0 = "onnx.QuantizeLinear"(%arg0, %arg1, %arg2) {} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<ui8>) -> tensor<*xui8>
- "func.return"(%0) {} : (tensor<*xui8>) -> ()
+ "onnx.Return"(%0) {} : (tensor<*xui8>) -> ()
 
  // CHECK-LABEL: test_quantize_linear_2
  // CHECK: [[RES:%.+]] = "onnx.QuantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, tensor<ui8>) -> tensor<5x2x3x4xui8>
- // CHECK: return [[RES]] : tensor<5x2x3x4xui8>
+ // CHECK: onnx.Return [[RES]] : tensor<5x2x3x4xui8>
 }
 
 // -----
@@ -1759,33 +1759,33 @@ func.func @test_quantize_linear_2(%arg0 : tensor<5x2x3x4xf32>, %arg1: tensor<f32
 func.func @test_quantize_linear_3(%arg0 : tensor<5x2x3x4xf32>, %arg1: tensor<f32>) -> tensor<*xui8> {
 %none = "onnx.NoValue"() {value} : () -> none
  %0 = "onnx.QuantizeLinear"(%arg0, %arg1, %none) {} : (tensor<5x2x3x4xf32>, tensor<f32>, none) -> tensor<*xui8>
- "func.return"(%0) {} : (tensor<*xui8>) -> ()
+ "onnx.Return"(%0) {} : (tensor<*xui8>) -> ()
 
  // CHECK-LABEL: test_quantize_linear_3
  // CHECK: [[RES:%.+]] = "onnx.QuantizeLinear"(%arg0, %arg1, %0) {axis = 1 : si64} : (tensor<5x2x3x4xf32>, tensor<f32>, none) -> tensor<5x2x3x4xui8>
- // CHECK: return [[RES]] : tensor<5x2x3x4xui8>
+ // CHECK: onnx.Return [[RES]] : tensor<5x2x3x4xui8>
 }
 
 // -----
 
 func.func @test_dequantize_linear_1(%arg0 : tensor<5x2x3x4xi8>, %arg1 : tensor<f32>, %arg2 : tensor<i8>) -> tensor<*xf32> {
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {} : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<*xf32>
-  "func.return"(%1) {} : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) {} : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_dequantize_linear_1
   // CHECK: [[RES:%.+]] = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x2x3x4xi8>, tensor<f32>, tensor<i8>) -> tensor<5x2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<5x2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x2x3x4xf32>
 }
 
 // -----
 
 func.func @test_dequantize_linear_2(%arg0 : tensor<5x?x3x4xi8>, %arg1 : tensor<*xf32>, %arg2 : tensor<2xi8>) -> tensor<*xf32> {
   %1 = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {} : (tensor<5x?x3x4xi8>, tensor<*xf32>, tensor<2xi8>) -> tensor<*xf32>
-  "func.return"(%1) {} : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) {} : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_dequantize_linear_2
   // CHECK: [[RES:%.+]] = "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<5x?x3x4xi8>, tensor<*xf32>, tensor<2xi8>) -> tensor<5x2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<5x2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<5x2x3x4xf32>
 }
 
 // -----
@@ -1797,13 +1797,13 @@ func.func @test_dequantize_linear_2(%arg0 : tensor<5x?x3x4xi8>, %arg1 : tensor<*
 
 func.func @test_convinteger_0(%arg0 : tensor<1x2x32xi8>, %arg1 : tensor<5x2x6xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32xi8>, tensor<5x2x6xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_0
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x27xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32xi8>, tensor<5x2x6xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x27xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x27xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x27xi32>
 // CHECK:         }
 }
 
@@ -1813,13 +1813,13 @@ func.func @test_convinteger_0(%arg0 : tensor<1x2x32xi8>, %arg1 : tensor<5x2x6xi8
 
 func.func @test_convinteger_1(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x7xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x7xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x27x58xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x27x58xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x27x58xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x27x58xi32>
 // CHECK:         }
 }
 
@@ -1829,13 +1829,13 @@ func.func @test_convinteger_1(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_2(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x7xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [8, 9]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x7xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x25x56xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [8, 9]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x25x56xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x25x56xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x25x56xi32>
 // CHECK:         }
 }
 
@@ -1846,13 +1846,13 @@ func.func @test_convinteger_2(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_3(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x10xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "NOTSET", group = 1 : si64, pads = [2, 4, 3, 5]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x10xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_3
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x10xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x32x64xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "NOTSET", group = 1 : si64, pads = [2, 4, 3, 5]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x10xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x32x64xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x32x64xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x32x64xi32>
 // CHECK:         }
 }
 
@@ -1862,13 +1862,13 @@ func.func @test_convinteger_3(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_4(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x10xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "SAME_UPPER", group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x10xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_4
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x10xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x32x64xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "SAME_UPPER", group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x10xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x32x64xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x32x64xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x32x64xi32>
 // CHECK:         }
 }
 
@@ -1877,13 +1877,13 @@ func.func @test_convinteger_4(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_5(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x10xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "SAME_LOWER", group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x10xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_5
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x10xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x32x64xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "SAME_LOWER", group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x10xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x32x64xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x32x64xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x32x64xi32>
 // CHECK:         }
 }
 
@@ -1893,13 +1893,13 @@ func.func @test_convinteger_5(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_6(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x10xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "VALID", group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x10xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_6
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x10xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x27x55xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "VALID", group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x10xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x27x55xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x27x55xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x27x55xi32>
 // CHECK:         }
 }
 
@@ -1909,13 +1909,13 @@ func.func @test_convinteger_6(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_7(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x7xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "NOTSET", group = 1 : si64, strides = [2, 3]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_7
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x7xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x14x20xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "NOTSET", group = 1 : si64, strides = [2, 3]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x14x20xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x14x20xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x14x20xi32>
 // CHECK:         }
 }
 
@@ -1926,13 +1926,13 @@ func.func @test_convinteger_7(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_8(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x7xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "SAME_UPPER", group = 1 : si64, strides = [2, 3]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_8
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x7xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x16x22xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "SAME_UPPER", group = 1 : si64, strides = [2, 3]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x16x22xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x16x22xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x16x22xi32>
 // CHECK:         }
 }
 
@@ -1942,13 +1942,13 @@ func.func @test_convinteger_8(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_9(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x7xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "NOTSET", group = 1 : si64, dilations = [2, 3]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_9
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x7xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x22x46xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x22x46xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x22x46xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x22x46xi32>
 // CHECK:         }
 }
 
@@ -1958,13 +1958,13 @@ func.func @test_convinteger_9(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6
 
 func.func @test_convinteger_10(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x7xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "NOTSET", group = 1 : si64, dilations = [2, 3], strides = [2, 2]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_10
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x7xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x11x23xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "NOTSET", dilations = [2, 3], group = 1 : si64, strides = [2, 2]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x11x23xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x11x23xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x11x23xi32>
 // CHECK:         }
 }
 
@@ -1974,13 +1974,13 @@ func.func @test_convinteger_10(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x
 
 func.func @test_convinteger_11(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x6x7xi8>, %arg2 : tensor<i8>, %arg3 : tensor<i8>) -> tensor<*xi32> {
   %0 = "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {auto_pad = "SAME_UPPER", group = 1 : si64, dilations = [2, 3]} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<*xi32>
-  "func.return"(%0) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_convinteger_11
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x32x64xi8>, [[PARAM_1_:%.+]]: tensor<5x2x6x7xi8>, [[PARAM_2_:%.+]]: tensor<i8>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<1x5x32x64xi32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ConvInteger"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {auto_pad = "SAME_UPPER", dilations = [2, 3], group = 1 : si64} : (tensor<1x2x32x64xi8>, tensor<5x2x6x7xi8>, tensor<i8>, tensor<i8>) -> tensor<1x5x32x64xi32>
-// CHECK:           return [[VAR_0_]] : tensor<1x5x32x64xi32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1x5x32x64xi32>
 // CHECK:         }
 }
 
@@ -1988,22 +1988,22 @@ func.func @test_convinteger_11(%arg0 : tensor<1x2x32x64xi8>, %arg1 : tensor<5x2x
 
 func.func @test_shape(%arg0: tensor<?x3x2xf32>) -> tensor<*xi64> {
   %0 = "onnx.Shape"(%arg0) : (tensor<?x3x2xf32>) -> tensor<*xi64>
-  return %0 : tensor<*xi64>
+  onnx.Return %0 : tensor<*xi64>
 
   // CHECK-LABEL: test_shape
   // CHECK: [[RES:%.+]] = "onnx.Shape"(%arg0) {start = 0 : si64} : (tensor<?x3x2xf32>) -> tensor<3xi64>
-  // CHECK: return [[RES]] : tensor<3xi64>
+  // CHECK: onnx.Return [[RES]] : tensor<3xi64>
 }
 
 // -----
 
 func.func @test_tile_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi64>) -> tensor<*xf32> {
   %0 = "onnx.Tile"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_tile_dynamic
   // CHECK: [[RES:%.+]] = "onnx.Tile"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<?x?x?x?xf32>
-  // CHECK: return [[RES]] : tensor<?x?x?x?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<?x?x?x?xf32>
 }
 
 // -----
@@ -2011,44 +2011,44 @@ func.func @test_tile_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi64>
 func.func @test_tile_constant(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[5, 5, 16, 2]> : tensor<4xi64>
   %1 = "onnx.Tile"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_tile_constant
   // CHECK: [[RES:%.+]] = "onnx.Tile"(%arg0, %0) : (tensor<5x5x1x32xf32>, tensor<4xi64>) -> tensor<25x25x16x64xf32>
-  // CHECK: return [[RES]] : tensor<25x25x16x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<25x25x16x64xf32>
 }
 
 // -----
 
 func.func @test_gather_axis0(%arg0 : tensor<3x3xf32>, %arg1 : tensor<1x2xi64>) -> tensor<*xf32> {
   %0 = "onnx.Gather"(%arg0, %arg1) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_gather_axis0
   // CHECK: [[RES:%.+]] = "onnx.Gather"(%arg0, %arg1) {axis = 0 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<1x2x3xf32>
-  // CHECK: return [[RES]] : tensor<1x2x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x2x3xf32>
 }
 
 // -----
 
 func.func @test_gather_axis1(%arg0 : tensor<3x3xf32>, %arg1 : tensor<1x2xi64>) -> tensor<*xf32> {
   %0 = "onnx.Gather"(%arg0, %arg1) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_gather_axis1
   // CHECK: [[RES:%.+]] = "onnx.Gather"(%arg0, %arg1) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>
-  // CHECK: return [[RES]] : tensor<3x1x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3x1x2xf32>
 }
 
 // -----
 
 func.func @test_gather_negative_axis(%arg0 : tensor<3x3xf32>, %arg1 : tensor<1x2xi64>) -> tensor<*xf32> {
   %0 = "onnx.Gather"(%arg0, %arg1) {axis = -1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_gather_negative_axis
   // CHECK: [[RES:%.+]] = "onnx.Gather"(%arg0, %arg1) {axis = -1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>
-  // CHECK: return [[RES]] : tensor<3x1x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3x1x2xf32>
 }
 
 
@@ -2056,77 +2056,77 @@ func.func @test_gather_negative_axis(%arg0 : tensor<3x3xf32>, %arg1 : tensor<1x2
 
 func.func @test_gather_nd_1(%arg0 : tensor<2x2xf32>, %arg1 : tensor<2x2xi64>) -> tensor<*xf32> {
   %0 = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 0 : si64} : (tensor<2x2xf32>, tensor<2x2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_gather_nd_1
   // CHECK: [[RES:%.+]] = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 0 : si64} : (tensor<2x2xf32>, tensor<2x2xi64>) -> tensor<2xf32>
-  // CHECK: return [[RES]] : tensor<2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2xf32>
 }
 
 // -----
 
 func.func @test_gather_nd_2(%arg0 : tensor<2x2xf32>, %arg1 : tensor<2x1xi64>) -> tensor<*xf32> {
   %0 = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 0 : si64} : (tensor<2x2xf32>, tensor<2x1xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_gather_nd_2
   // CHECK: [[RES:%.+]] = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 0 : si64} : (tensor<2x2xf32>, tensor<2x1xi64>) -> tensor<2x2xf32>
-  // CHECK: return [[RES]] : tensor<2x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x2xf32>
 }
 
 // -----
 
 func.func @test_gather_nd_3(%arg0 : tensor<2x2x2xf32>, %arg1 : tensor<2x2xi64>) -> tensor<*xf32> {
   %0 = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 0 : si64} : (tensor<2x2x2xf32>, tensor<2x2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_gather_nd_3
   // CHECK: [[RES:%.+]] = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 0 : si64} : (tensor<2x2x2xf32>, tensor<2x2xi64>) -> tensor<2x2xf32>
-  // CHECK: return [[RES]] : tensor<2x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x2xf32>
 }
 
 // -----
 
 func.func @test_gather_nd_4(%arg0 : tensor<2x2x2xf32>, %arg1 : tensor<2x1x2xi64>) -> tensor<*xf32> {
   %0 = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 0 : si64} : (tensor<2x2x2xf32>, tensor<2x1x2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_gather_nd_4
   // CHECK: [[RES:%.+]] = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 0 : si64} : (tensor<2x2x2xf32>, tensor<2x1x2xi64>) -> tensor<2x1x2xf32>
-  // CHECK: return [[RES]] : tensor<2x1x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x1x2xf32>
 }
 
 // -----
 
 func.func @test_gather_nd_5(%arg0 : tensor<2x2x2xf32>, %arg1 : tensor<2x1xi64>) -> tensor<*xf32> {
   %0 = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 1 : si64} : (tensor<2x2x2xf32>, tensor<2x1xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_gather_nd_5
   // CHECK: [[RES:%.+]] = "onnx.GatherND"(%arg0, %arg1) {batch_dims = 1 : si64} : (tensor<2x2x2xf32>, tensor<2x1xi64>) -> tensor<2x2xf32>
-  // CHECK: return [[RES]] : tensor<2x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x2xf32>
 }
 
 // -----
 
 func.func @test_constant_of_shape_empty_tensor(%arg0 : tensor<0xi64>) -> tensor<*xf32> {
   %0 = "onnx.ConstantOfShape"(%arg0) : (tensor<0xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_constant_of_shape_empty_tensor
   // CHECK: [[RES:%.+]] = onnx.ConstantOfShape(%arg0) {value = dense<0.000000e+00> : tensor<1xf32>} : (tensor<0xi64>) -> tensor<f32>
-  // CHECK: return [[RES]] : tensor<f32>
+  // CHECK: onnx.Return [[RES]] : tensor<f32>
 }
 
 // -----
 
 func.func @test_constant_of_shape(%arg0 : tensor<3xi64>) -> tensor<*xf32> {
   %0 = "onnx.ConstantOfShape"(%arg0) {value = dense<[1.0]> : tensor<1xf32>} : (tensor<3xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_constant_of_shape
   // CHECK: [[RES:%.+]] = onnx.ConstantOfShape(%arg0) {value = dense<1.000000e+00> : tensor<1xf32>} : (tensor<3xi64>) -> tensor<?x?x?xf32>
-  // CHECK: return [[RES]] : tensor<?x?x?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<?x?x?xf32>
 }
 
 // -----
@@ -2134,12 +2134,12 @@ func.func @test_constant_of_shape(%arg0 : tensor<3xi64>) -> tensor<*xf32> {
 func.func @test_constant_of_shape_constant() -> tensor<*xf32> {
   %0 = onnx.Constant dense<[3, 4, 5]> : tensor<3xi64>
   %1 = "onnx.ConstantOfShape"(%0) {value = dense<[1.0]> : tensor<1xf32>} : (tensor<3xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_constant_of_shape_constant
   // CHECK: [[CONSTANT:%.+]] = onnx.Constant dense<[3, 4, 5]> : tensor<3xi64>
   // CHECK: [[RES:%.+]] = onnx.ConstantOfShape([[CONSTANT]]) {value = dense<1.000000e+00> : tensor<1xf32>} : (tensor<3xi64>) -> tensor<3x4x5xf32>
-  // CHECK: return [[RES]] : tensor<3x4x5xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3x4x5xf32>
 }
 
 // -----
@@ -2151,11 +2151,11 @@ func.func @test_constant_of_shape_constant() -> tensor<*xf32> {
 func.func @test_depth_to_space(%arg0 : tensor<1x256x8x16xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.DepthToSpace"(%arg0) {blocksize = 4 : si64} : (tensor<1x256x8x16xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_depth_to_space
   // CHECK: [[RES:%.+]] = "onnx.DepthToSpace"(%arg0) {blocksize = 4 : si64, mode = "DCR"} : (tensor<1x256x8x16xf32>) -> tensor<1x16x32x64xf32>
-  // CHECK: return [[RES]] : tensor<1x16x32x64xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x16x32x64xf32>
 }
 
 // -----
@@ -2165,11 +2165,11 @@ func.func @test_depth_to_space(%arg0 : tensor<1x256x8x16xf32>) -> tensor<*xf32> 
 //===----------------------------------------------------------------------===//
 func.func @test_scaler_no_scale_int(%arg0: tensor<3xi32>) -> tensor<*xf32> {
   %0 = "onnx.Scaler"(%arg0) {offset = [1986.99939 : f32, 0.99999988 : f32, 0.999999701 : f32]} : (tensor<3xi32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_scaler_no_scale_int
   // CHECK: [[RES_ATTR:%.+]] = "onnx.Scaler"(%arg0) {offset = [1986.99939 : f32, 0.99999988 : f32, 0.999999701 : f32]} : (tensor<3xi32>) -> tensor<3xf32>
-  // CHECK: return [[RES_ATTR]] : tensor<3xf32>
+  // CHECK: onnx.Return [[RES_ATTR]] : tensor<3xf32>
 }
 
 // -----
@@ -2180,11 +2180,11 @@ func.func @test_scaler_no_scale_int(%arg0: tensor<3xi32>) -> tensor<*xf32> {
 
 func.func @test_pow(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<f32>) -> tensor<*xf32> {
   %0 = "onnx.Pow"(%arg0, %arg1) : (tensor<1x2x3x4xf32>, tensor<f32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_pow
   // CHECK: [[RES:%.+]] = "onnx.Pow"(%arg0, %arg1) : (tensor<1x2x3x4xf32>, tensor<f32>) -> tensor<1x2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<1x2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x2x3x4xf32>
 }
 
 // -----
@@ -2195,11 +2195,11 @@ func.func @test_pow(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<f32>) -> tensor<*x
 
 func.func @test_erf(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
   %0 = "onnx.Erf"(%arg0) : (tensor<1x2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_erf
   // CHECK: [[RES:%.+]] = "onnx.Erf"(%arg0) : (tensor<1x2x3x4xf32>) -> tensor<1x2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<1x2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x2x3x4xf32>
 }
 
 // -----
@@ -2211,11 +2211,11 @@ func.func @test_erf(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
 func.func @test_expand_with_constant(%arg0 : tensor<2x1x6x1xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[7, 1, 5]> : tensor<3xi64>
   %1 = "onnx.Expand"(%arg0, %0) : (tensor<2x1x6x1xf32>, tensor<3xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_expand_with_constant
   // CHECK: [[RES:%.+]] = "onnx.Expand"(%arg0, %0) : (tensor<2x1x6x1xf32>, tensor<3xi64>) -> tensor<2x7x6x5xf32>
-  // CHECK: return [[RES]] : tensor<2x7x6x5xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x7x6x5xf32>
 }
 
 // -----
@@ -2223,12 +2223,12 @@ func.func @test_expand_with_constant(%arg0 : tensor<2x1x6x1xf32>) -> tensor<*xf3
 func.func @test_expand_with_shape(%arg0 : tensor<2x1x6x1xf32>, %arg1: tensor<6x2xf32>) -> tensor<*xf32> {
   %0 = "onnx.Shape"(%arg1) : (tensor<6x2xf32>) -> tensor<*xi64>
   %1 = "onnx.Expand"(%arg0, %0) : (tensor<2x1x6x1xf32>, tensor<*xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_expand_with_shape
   // CHECK: [[SHAPE:%.+]] = "onnx.Shape"(%arg1) {start = 0 : si64} : (tensor<6x2xf32>) -> tensor<2xi64>
   // CHECK: [[RES:%.+]] = "onnx.Expand"(%arg0, [[SHAPE]]) : (tensor<2x1x6x1xf32>, tensor<2xi64>) -> tensor<2x1x6x2xf32>
-  // CHECK: return [[RES]] : tensor<2x1x6x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x1x6x2xf32>
 }
 
 // -----
@@ -2239,33 +2239,33 @@ func.func @test_expand_with_shape(%arg0 : tensor<2x1x6x1xf32>, %arg1: tensor<6x2
 
 func.func @test_reduce_mean_v13_1(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
   %0 = "onnx.ReduceMeanV13"(%arg0) {axes = [-1], keepdims = 1 : si64} : (tensor<1x2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reduce_mean_v13_1
   // CHECK: [[RES:%.+]] = "onnx.ReduceMeanV13"(%arg0) {axes = [-1], keepdims = 1 : si64} : (tensor<1x2x3x4xf32>) -> tensor<1x2x3x1xf32>
-  // CHECK: return [[RES]] : tensor<1x2x3x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x2x3x1xf32>
 }
 
 // -----
 
 func.func @test_reduce_mean_v13_2(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
   %0 = "onnx.ReduceMeanV13"(%arg0) {axes = [2], keepdims = 1 : si64} : (tensor<1x2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reduce_mean_v13_2
   // CHECK: [[RES:%.+]] = "onnx.ReduceMeanV13"(%arg0) {axes = [2], keepdims = 1 : si64} : (tensor<1x2x3x4xf32>) -> tensor<1x2x1x4xf32>
-  // CHECK: return [[RES]] : tensor<1x2x1x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x2x1x4xf32>
 }
 
 // -----
 
 func.func @test_reduce_mean_v13_3(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
   %0 = "onnx.ReduceMeanV13"(%arg0) {axes = [-1], keepdims = 0 : si64} : (tensor<1x2x3x4xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reduce_mean_v13_3
   // CHECK: [[RES:%.+]] = "onnx.ReduceMeanV13"(%arg0) {axes = [-1], keepdims = 0 : si64} : (tensor<1x2x3x4xf32>) -> tensor<1x2x3xf32>
-  // CHECK: return [[RES]] : tensor<1x2x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x2x3xf32>
 }
 
 // -----
@@ -2277,12 +2277,12 @@ func.func @test_reduce_mean_v13_3(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
 func.func @test_reduce_sum_1(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
   %cst = onnx.Constant dense<[-1]> : tensor<1xi64>
   %0 = "onnx.ReduceSum"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, tensor<1xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reduce_sum_1
   // CHECK-NEXT [[CST:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
   // CHECK-NEXT [[RES:%.+]] = "onnx.ReduceSum"(%arg0, [[CST]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, tensor<1xi64>) -> tensor<1x2x3x1xf32>
-  // CHECK-NEXT return [[RES]] : tensor<1x2x3x1xf32>
+  // CHECK-NEXT onnx.Return [[RES]] : tensor<1x2x3x1xf32>
 }
 
 // -----
@@ -2290,45 +2290,45 @@ func.func @test_reduce_sum_1(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
 func.func @test_reduce_sum_2(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.ReduceSum"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reduce_sum_2
   // CHECK-NEXT [[CST:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT [[RES:%.+]] = "onnx.ReduceSum"(%arg0, [[CST]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, none) -> tensor<1x1x1x1xf32>
-  // CHECK-NEXT return [[RES]] : tensor<1x1x1x1xf32>
+  // CHECK-NEXT onnx.Return [[RES]] : tensor<1x1x1x1xf32>
 }
 
 // -----
 
 func.func @test_reduce_sum_3(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<2xi64>) -> tensor<*xf32> {
   %0 = "onnx.ReduceSum"(%arg0, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reduce_sum_3
   // CHECK-NEXT [[RES:%.+]] = "onnx.ReduceSum"(%arg0, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, tensor<2xi64>) -> tensor<?x?x?x?xf32>
-  // CHECK-NEXT return [[RES]] : tensor<?x?x?x?xf32>
+  // CHECK-NEXT onnx.Return [[RES]] : tensor<?x?x?x?xf32>
 }
 
 // -----
 
 func.func @test_reduce_sum_4(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<2xi64>) -> tensor<*xf32> {
   %0 = "onnx.ReduceSum"(%arg0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, tensor<2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reduce_sum_4
   // CHECK-NEXT [[RES:%.+]] = "onnx.ReduceSum"(%arg0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, tensor<2xi64>) -> tensor<?x?xf32>
-  // CHECK-NEXT return [[RES]] : tensor<*xf32>
+  // CHECK-NEXT onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
 
 func.func @test_reduce_sum_5(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<?xi64>) -> tensor<*xf32> {
   %0 = "onnx.ReduceSum"(%arg0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, tensor<?xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_reduce_sum_5
   // CHECK-NEXT [[RES:%.+]] = "onnx.ReduceSum"(%arg0, %arg1) {keepdims = 0 : si64, noop_with_empty_axes = 0 : si64} : (tensor<1x2x3x4xf32>, tensor<?xi64>) -> tensor<*xf32>
-  // CHECK-NEXT return [[RES]] : tensor<*xf32>
+  // CHECK-NEXT onnx.Return [[RES]] : tensor<*xf32>
 }
 
 // -----
@@ -2339,22 +2339,22 @@ func.func @test_reduce_sum_5(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<?xi64>) -
 
 func.func @test_dropout(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<1xf32>, %arg2: tensor<1xi1>) -> (tensor<*xf32>, tensor<*xi1>) {
   %output, %mask = "onnx.Dropout"(%arg0, %arg1, %arg2) {ratio =  1.000000e-01 : f32} : (tensor<1x2x3x4xf32>, tensor<1xf32>, tensor<1xi1>) -> (tensor<*xf32>, tensor<*xi1>)
-  "func.return"(%output, %mask) : (tensor<*xf32>, tensor<*xi1>) -> ()
+  "onnx.Return"(%output, %mask) : (tensor<*xf32>, tensor<*xi1>) -> ()
 
   // CHECK-LABEL: test_dropout
   // CHECK: [[RES:%.+]], [[MASK:%.+]] = "onnx.Dropout"(%arg0, %arg1, %arg2) {ratio =  1.000000e-01 : f32} : (tensor<1x2x3x4xf32>, tensor<1xf32>, tensor<1xi1>) -> (tensor<1x2x3x4xf32>, tensor<1x2x3x4xi1>)
-  // CHECK: return [[RES]], [[MASK]] : tensor<1x2x3x4xf32>, tensor<1x2x3x4xi1>
+  // CHECK: onnx.Return [[RES]], [[MASK]] : tensor<1x2x3x4xf32>, tensor<1x2x3x4xi1>
 }
 
 // -----
 
 func.func @test_dropout_no_mask(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<1xf32>, %arg2: tensor<1xi1>) -> tensor<*xf32> {
   %output, %mask = "onnx.Dropout"(%arg0, %arg1, %arg2) {ratio =  1.000000e-01 : f32} : (tensor<1x2x3x4xf32>, tensor<1xf32>, tensor<1xi1>) -> (tensor<*xf32>, none)
-  "func.return"(%output) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%output) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_dropout
   // CHECK: [[RES:%.+]], [[MASK:%.+]] = "onnx.Dropout"(%arg0, %arg1, %arg2) {ratio =  1.000000e-01 : f32} : (tensor<1x2x3x4xf32>, tensor<1xf32>, tensor<1xi1>) -> (tensor<1x2x3x4xf32>, none)
-  // CHECK: return [[RES]] : tensor<1x2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x2x3x4xf32>
 }
 
 // -----
@@ -2365,62 +2365,62 @@ func.func @test_dropout_no_mask(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<1xf32>
 
 func.func @test_onehotencoder_string1 (%arg0: tensor<20x1x!onnx.String>) -> tensor<*xf32> {
   %0 = "onnx.OneHotEncoder"(%arg0) {cats_strings = ["female", "male"], zeros = 1 : si64} : (tensor<20x1x!onnx.String>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_onehotencoder_string1
   // CHECK: [[RES:%.+]] = "onnx.OneHotEncoder"(%arg0) {cats_strings = ["female", "male"], zeros = 1 : si64} : (tensor<20x1x!onnx.String>) -> tensor<20x1x2xf32>
-  // CHECK: return [[RES]] : tensor<20x1x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<20x1x2xf32>
 }
 
 // -----
 
 func.func @test_onehotencoder_string2 (%arg0: tensor<20x2x!onnx.String>) -> tensor<*xf32> {
   %0 = "onnx.OneHotEncoder"(%arg0) {cats_strings = ["female", "male"], zeros = 1 : si64} : (tensor<20x2x!onnx.String>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_onehotencoder_string2
   // CHECK: [[RES:%.+]] = "onnx.OneHotEncoder"(%arg0) {cats_strings = ["female", "male"], zeros = 1 : si64} : (tensor<20x2x!onnx.String>) -> tensor<20x2x2xf32>
-  // CHECK: return [[RES]] : tensor<20x2x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<20x2x2xf32>
 }
 
 // -----
 
 func.func @test_onehotencoder_float1(%arg0: tensor<20x1xf32>) -> tensor<*xf32> {
   %0 = "onnx.OneHotEncoder"(%arg0) {cats_strings = ["female", "male"], cats_int64s = [1, 2, 4], zeros = 1 : si64} : (tensor<20x1xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_onehotencoder_float1
   // CHECK: [[RES:%.+]] = "onnx.OneHotEncoder"(%arg0) {cats_int64s = [1, 2, 4], cats_strings = ["female", "male"], zeros = 1 : si64} : (tensor<20x1xf32>) -> tensor<20x1x3xf32>
-  // CHECK: return [[RES]] : tensor<20x1x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<20x1x3xf32>
 }
 
 // -----
 
 func.func @test_onehotencoder_float2(%arg0: tensor<20x2x3xf32>) -> tensor<*xf32> {
   %0 = "onnx.OneHotEncoder"(%arg0) {cats_strings = ["female", "male"], cats_int64s = [1, 2, 4], zeros = 1 : si64} : (tensor<20x2x3xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_onehotencoder_float2
   // CHECK: [[RES:%.+]] = "onnx.OneHotEncoder"(%arg0) {cats_int64s = [1, 2, 4], cats_strings = ["female", "male"], zeros = 1 : si64} : (tensor<20x2x3xf32>) -> tensor<20x2x3x3xf32>
-  // CHECK: return [[RES]] : tensor<20x2x3x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<20x2x3x3xf32>
 }
 
 // -----
 
 func.func @test_size(%arg0: tensor<*xf32>) -> tensor<*xi64> {
   %0 = "onnx.Size"(%arg0) : (tensor<*xf32>) -> tensor<*xi64>
-  "func.return"(%0) : (tensor<*xi64>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi64>) -> ()
 
   // CHECK-LABEL: test_size
   // CHECK: [[RES:%.+]] = "onnx.Size"(%arg0) : (tensor<*xf32>) -> tensor<i64>
-  // CHECK: return [[RES]] : tensor<i64>
+  // CHECK: onnx.Return [[RES]] : tensor<i64>
 }
 
 // -----
 
 func.func @test_less(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tensor<*xi1> {
   %0 = "onnx.Less"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<*xi1>
-  return %0 : tensor<*xi1>
+  onnx.Return %0 : tensor<*xi1>
 
   // CHECK-LABEL: test_less
   // CHECK: {{.*}} = "onnx.Less"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xi1>
@@ -2430,7 +2430,7 @@ func.func @test_less(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tens
 
 func.func @test_less_broadcast(%arg0: tensor<3x4x5xf32>, %arg1: tensor<5xf32>) -> tensor<*xi1> {
   %0 = "onnx.Less"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<5xf32>) -> tensor<*xi1>
-  return %0 : tensor<*xi1>
+  onnx.Return %0 : tensor<*xi1>
 
   // CHECK-LABEL: test_less_broadcast
   // CHECK: {{.*}} = "onnx.Less"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<5xf32>) -> tensor<3x4x5xi1>
@@ -2440,7 +2440,7 @@ func.func @test_less_broadcast(%arg0: tensor<3x4x5xf32>, %arg1: tensor<5xf32>) -
 
 func.func @test_less_unknown_dims_1(%arg0: tensor<3x4x5xf32>, %arg1: tensor<?x4x5xf32>) -> tensor<*xi1> {
   %0 = "onnx.Less"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<?x4x5xf32>) -> tensor<*xi1>
-  return %0 : tensor<*xi1>
+  onnx.Return %0 : tensor<*xi1>
 
   // CHECK-LABEL: test_less_unknown_dims_1
   // CHECK: {{.*}} = "onnx.Less"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<?x4x5xf32>) -> tensor<3x4x5xi1>
@@ -2450,7 +2450,7 @@ func.func @test_less_unknown_dims_1(%arg0: tensor<3x4x5xf32>, %arg1: tensor<?x4x
 
 func.func @test_less_unknown_dims_2(%arg0: tensor<?x?x5xf32>, %arg1: tensor<?x4x5xf32>) -> tensor<*xi1> {
   %0 = "onnx.Less"(%arg0, %arg1) : (tensor<?x?x5xf32>, tensor<?x4x5xf32>) -> tensor<*xi1>
-  return %0 : tensor<*xi1>
+  onnx.Return %0 : tensor<*xi1>
 
   // CHECK-LABEL: test_less_unknown_dims_2
   // CHECK: {{.*}} = "onnx.Less"(%arg0, %arg1) : (tensor<?x?x5xf32>, tensor<?x4x5xf32>) -> tensor<?x4x5xi1>
@@ -2460,12 +2460,12 @@ func.func @test_less_unknown_dims_2(%arg0: tensor<?x?x5xf32>, %arg1: tensor<?x4x
 
 func.func @test_clip2(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
   %0 = "onnx.Clip"(%arg0, %arg1, %arg2) : (tensor<3xf32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
-  return %0 : tensor<3xf32>
+  onnx.Return %0 : tensor<3xf32>
 
 // CHECK-LABEL:  func @test_clip2
 // CHECK-SAME:   ([[INPUT_:%.+]]: tensor<3xf32>, [[MIN_:%.+]]: tensor<f32>, [[MAX_:%.+]]: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
 // CHECK:           [[RES_:%.+]] = "onnx.Clip"([[INPUT_]], [[MIN_]], [[MAX_]]) : (tensor<3xf32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
-// CHECK:           return [[RES_]] : tensor<3xf32>
+// CHECK:           onnx.Return [[RES_]] : tensor<3xf32>
 // CHECK:         }
   }
 
@@ -2474,11 +2474,11 @@ func.func @test_clip2(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f3
 // COM: Check PRelu without broadcasting.
 func.func @test_prelu(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tensor<*xf32> {
   %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_prelu
   // CHECK: {{.*}} = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-  // CHECK: return {{.*}} : tensor<3x4x5xf32>
+  // CHECK: onnx.Return {{.*}} : tensor<3x4x5xf32>
 }
 
 // -----
@@ -2486,11 +2486,11 @@ func.func @test_prelu(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> ten
 // COM: Check PRelu with unidirectional broadcasting.
 func.func @test_prelu_broadcast(%arg0: tensor<3x4x5xf32>, %arg1: tensor<5xf32>) -> tensor<*xf32> {
   %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<5xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_prelu_broadcast
   // CHECK: {{.*}} = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<5xf32>) -> tensor<3x4x5xf32>
-  // CHECK: return {{.*}} : tensor<3x4x5xf32>
+  // CHECK: onnx.Return {{.*}} : tensor<3x4x5xf32>
 }
 
 // -----
@@ -2499,10 +2499,10 @@ func.func @test_prelu_broadcast(%arg0: tensor<3x4x5xf32>, %arg1: tensor<5xf32>) 
 // COM: Because of unidirectional broadcasting, always get constant dimensions from X even thought their values are 1.
 func.func @test_prelu_broadcast_unknown_dims(%arg0: tensor<3x1x5xf32>, %arg1: tensor<3x?x1xf32>) -> tensor<*xf32> {
   %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x1x5xf32>, tensor<3x?x1xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
   // CHECK-LABEL: func @test_prelu_broadcast_unknown_dims
   // CHECK: {{.*}} = "onnx.PRelu"(%arg0, %arg1) : (tensor<3x1x5xf32>, tensor<3x?x1xf32>) -> tensor<3x1x5xf32>
-  // CHECK: return {{.*}} : tensor<3x1x5xf32>
+  // CHECK: onnx.Return {{.*}} : tensor<3x1x5xf32>
 }
 
 // -----
@@ -2511,10 +2511,10 @@ func.func @test_prelu_broadcast_unknown_dims(%arg0: tensor<3x1x5xf32>, %arg1: te
 // COM: If X's dimensions are unknown, get dimensions from slope whenever they are non-zero constants.
 func.func @test_prelu_broadcast_unknown_dims1(%arg0: tensor<?x1x?xf32>, %arg1: tensor<?x5xf32>) -> tensor<*xf32> {
   %0 = "onnx.PRelu"(%arg0, %arg1) : (tensor<?x1x?xf32>, tensor<?x5xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
   // CHECK-LABEL: func @test_prelu_broadcast_unknown_dims1
   // CHECK: {{.*}} = "onnx.PRelu"(%arg0, %arg1) : (tensor<?x1x?xf32>, tensor<?x5xf32>) -> tensor<?x1x5xf32>
-  // CHECK: return {{.*}} : tensor<?x1x5xf32>
+  // CHECK: onnx.Return {{.*}} : tensor<?x1x5xf32>
 }
 
 //===----------------------------------------------------------------------===//
@@ -2530,7 +2530,7 @@ func.func @test_loop_simple_no_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor
     %2 = "onnx.Add"(%arg5, %arg3) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
     onnx.Yield %1, %2 : tensor<*xi1>, tensor<*xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> tensor<*xi64>
-  return %0 : tensor<*xi64>
+  onnx.Return %0 : tensor<*xi64>
 // CHECK-LABEL:   func @test_loop_simple_no_scan_main_graph
 // CHECK-SAME:     ([[TRIP_COUNT:%.+]]: tensor<i64>, [[COND:%.+]]: tensor<i1>, [[Y_INIT:%.+]]: tensor<1xi64>) -> tensor<1xi64> {
 // CHECK:           [[Y_FINAL:%.+]] = "onnx.Loop"([[TRIP_COUNT]], [[COND]], [[Y_INIT]]) ({
@@ -2539,7 +2539,7 @@ func.func @test_loop_simple_no_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor
 // CHECK:             [[Y_CURR:%.+]] = "onnx.Add"([[Y_PREV]], [[I]]) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
 // CHECK:             onnx.Yield [[NEXT_COND]], [[Y_CURR]] : tensor<i1>, tensor<1xi64>
 // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> tensor<1xi64>
-// CHECK:           return [[Y_FINAL]] : tensor<1xi64>
+// CHECK:           onnx.Return [[Y_FINAL]] : tensor<1xi64>
 // CHECK:         }
 }
 
@@ -2553,7 +2553,7 @@ func.func @test_loop_simple_one_scan_main_graph(%arg0: tensor<i64>, %arg1: tenso
     %body_2 = "onnx.Identity"(%body_1) : (tensor<*xi64>) -> tensor<*xi64>
     onnx.Yield %body_0, %body_1, %body_2 : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<*xi64>, tensor<*xi64>)
-  return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
+  onnx.Return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
   // CHECK-LABEL:       func @test_loop_simple_one_scan_main_graph
   // CHECK-SAME:     ([[TRIP_COUNT:%.+]]: tensor<i64>, [[COND:%.+]]: tensor<i1>, [[Y_INIT:%.+]]: tensor<1xi64>) -> (tensor<1xi64>, tensor<?x1xi64>) {
   // CHECK:           [[LOOP_OUT:%.+]]:2 = "onnx.Loop"([[TRIP_COUNT]], [[COND]], [[Y_INIT]]) ({
@@ -2563,7 +2563,7 @@ func.func @test_loop_simple_one_scan_main_graph(%arg0: tensor<i64>, %arg1: tenso
   // CHECK:             [[Y_CURR_SCAN:%.+]] = "onnx.Identity"([[Y_CURR]]) : (tensor<1xi64>) -> tensor<1xi64>
   // CHECK:             onnx.Yield [[COND_NEXT]], [[Y_CURR]], [[Y_CURR_SCAN]] : tensor<i1>, tensor<1xi64>, tensor<1xi64>
   // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<1xi64>, tensor<?x1xi64>)
-  // CHECK:           return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1 : tensor<1xi64>, tensor<?x1xi64>
+  // CHECK:           onnx.Return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1 : tensor<1xi64>, tensor<?x1xi64>
   // CHECK:         }
 }
 
@@ -2577,7 +2577,7 @@ func.func @test_loop_simple_one_scan_unranked_main_graph(%arg0: tensor<i64>, %ar
     %body_2 = "onnx.Identity"(%body_1) : (tensor<*xi64>) -> tensor<*xi64>
     onnx.Yield %body_0, %body_1, %body_2 : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<*xi64>) -> (tensor<*xi64>, tensor<*xi64>)
-  return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
+  onnx.Return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
   // CHECK-LABEL:       func @test_loop_simple_one_scan_unranked_main_graph
   // CHECK-SAME:     ([[TRIP_COUNT:%.+]]: tensor<i64>, [[COND:%.+]]: tensor<i1>, [[Y_INIT:%.+]]: tensor<*xi64>) -> (tensor<*xi64>, tensor<*xi64>) {
   // CHECK:           [[LOOP_OUT:%.+]]:2 = "onnx.Loop"([[TRIP_COUNT]], [[COND]], [[Y_INIT]]) ({
@@ -2587,7 +2587,7 @@ func.func @test_loop_simple_one_scan_unranked_main_graph(%arg0: tensor<i64>, %ar
   // CHECK:             [[Y_CURR_SCAN:%.+]] = "onnx.Identity"([[Y_CURR]]) : (tensor<*xi64>) -> tensor<*xi64>
   // CHECK:             onnx.Yield [[COND_NEXT]], [[Y_CURR]], [[Y_CURR_SCAN]] : tensor<i1>, tensor<*xi64>, tensor<*xi64>
   // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<*xi64>) -> (tensor<*xi64>, tensor<*xi64>)
-  // CHECK:           return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1 : tensor<*xi64>, tensor<*xi64>
+  // CHECK:           onnx.Return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1 : tensor<*xi64>, tensor<*xi64>
   // CHECK:         }
 }
 
@@ -2603,7 +2603,7 @@ func.func @test_loop_multi_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>
   %body_4 = "onnx.Identity"(%body_3) : (tensor<*xf32>) -> tensor<*xf32>
   onnx.Yield %body_0, %body_1, %body_3, %body_2, %body_4 : tensor<*xi1>, tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>
 }) : (tensor<i64>, tensor<i1>, tensor<1xi64>, tensor<1xf32>) -> (tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>)
-  return %0#0, %0#1, %0#2, %0#3 : tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>
+  onnx.Return %0#0, %0#1, %0#2, %0#3 : tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>
   // CHECK-LABEL:       func @test_loop_multi_scan_main_graph
   // CHECK-SAME:     ([[TRIP_COUNT:%.+]]: tensor<i64>, [[COND:%.+]]: tensor<i1>, [[Y_INIT:%.+]]: tensor<1xi64>, [[Z_INIT:%.+]]: tensor<1xf32>) -> (tensor<1xi64>, tensor<1xf32>, tensor<?x1xi64>, tensor<?x1xf32>) {
   // CHECK:           [[LOOP_OUT:%.+]]:4 = "onnx.Loop"([[TRIP_COUNT]], [[COND]], [[Y_INIT]], [[Z_INIT]]) ({
@@ -2615,7 +2615,7 @@ func.func @test_loop_multi_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>
   // CHECK:             [[Z_CURR_SCAN:%.+]] = "onnx.Identity"([[Z_CURR]]) : (tensor<1xf32>) -> tensor<1xf32>
   // CHECK:             onnx.Yield [[COND_NEXT]], [[Y_CURR]], [[Z_CURR]], [[Y_CURR_SCAN]], [[Z_CURR_SCAN]] : tensor<i1>, tensor<1xi64>, tensor<1xf32>, tensor<1xi64>, tensor<1xf32>
   // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<1xi64>, tensor<1xf32>) -> (tensor<1xi64>, tensor<1xf32>, tensor<?x1xi64>, tensor<?x1xf32>)
-  // CHECK:           return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1, [[LOOP_OUT]]#2, [[LOOP_OUT]]#3 : tensor<1xi64>, tensor<1xf32>, tensor<?x1xi64>, tensor<?x1xf32>
+  // CHECK:           onnx.Return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1, [[LOOP_OUT]]#2, [[LOOP_OUT]]#3 : tensor<1xi64>, tensor<1xf32>, tensor<?x1xi64>, tensor<?x1xf32>
   // CHECK:         }
 }
 
@@ -2627,7 +2627,7 @@ func.func @test_scan_simple_main_graph(%arg0: tensor<2xf32>, %arg1: tensor<3x2xf
     %1 = "onnx.Add"(%arg2, %arg3) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
     onnx.Yield %1, %1 : tensor<*xf32>, tensor<*xf32>
   }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<3x2xf32>) -> (tensor<*xf32>, tensor<*xf32>)
-  return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
+  onnx.Return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
 // CHECK-LABEL:       func @test_scan_simple_main_graph
 // CHECK-SAME:     ([[SUM_INIT:%.+]]: tensor<2xf32>, [[TO_SUM:%.+]]: tensor<3x2xf32>) -> (tensor<2xf32>, tensor<3x2xf32>) {
 // CHECK:           [[SCAN_OUT:%.+]]:2 = "onnx.Scan"([[SUM_INIT]], [[TO_SUM]]) (
@@ -2635,7 +2635,7 @@ func.func @test_scan_simple_main_graph(%arg0: tensor<2xf32>, %arg1: tensor<3x2xf
 // CHECK:             [[ADD:%.+]] = "onnx.Add"([[SUM_PREV]], [[SUM_CURR]]) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
 // CHECK:             onnx.Yield [[ADD]], [[ADD]] : tensor<2xf32>, tensor<2xf32>
 // CHECK:           }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<3x2xf32>) -> (tensor<2xf32>, tensor<3x2xf32>)
-// CHECK:           return [[SCAN_OUT]]#0, [[SCAN_OUT]]#1 : tensor<2xf32>, tensor<3x2xf32>
+// CHECK:           onnx.Return [[SCAN_OUT]]#0, [[SCAN_OUT]]#1 : tensor<2xf32>, tensor<3x2xf32>
 // CHECK:         }
 // CHECK:       }
 }
@@ -2648,7 +2648,7 @@ func.func @test_scan_simple_unranked_main_graph(%arg0: tensor<2xf32>, %arg1: ten
     %1 = "onnx.Add"(%arg2, %arg3) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
     onnx.Yield %1, %1 : tensor<*xf32>, tensor<*xf32>
   }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>)
-  return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
+  onnx.Return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
 // CHECK-LABEL:       func @test_scan_simple_unranked_main_graph
 // CHECK-SAME:     ([[SUM_INIT:%.+]]: tensor<2xf32>, [[TO_SUM:%.+]]: tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>) {
 // CHECK:           [[SCAN_OUT:%.+]]:2 = "onnx.Scan"([[SUM_INIT]], [[TO_SUM]]) (
@@ -2656,7 +2656,7 @@ func.func @test_scan_simple_unranked_main_graph(%arg0: tensor<2xf32>, %arg1: ten
 // CHECK:             [[ADD:%.+]] = "onnx.Add"([[SUM_PREV]], [[SUM_CURR]]) : (tensor<2xf32>, tensor<*xf32>) -> tensor<*xf32>
 // CHECK:             onnx.Yield [[ADD]], [[ADD]] : tensor<*xf32>, tensor<*xf32>
 // CHECK:           }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>)
-// CHECK:           return [[SCAN_OUT]]#0, [[SCAN_OUT]]#1 : tensor<*xf32>, tensor<*xf32>
+// CHECK:           onnx.Return [[SCAN_OUT]]#0, [[SCAN_OUT]]#1 : tensor<*xf32>, tensor<*xf32>
 // CHECK:         }
 // CHECK:       }
 }
@@ -2665,7 +2665,7 @@ func.func @test_scan_simple_unranked_main_graph(%arg0: tensor<2xf32>, %arg1: ten
 
 func.func @test_range(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<*xf32> {
   %0 = "onnx.Range"(%arg0, %arg1, %arg2) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: test_range
   // CHECK: {{.*}} = "onnx.Range"(%arg0, %arg1, %arg2) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<?xf32>
@@ -2678,7 +2678,7 @@ func.func @test_range_float_constant() -> tensor<*xf32> {
   %limit = onnx.Constant dense<[10.0]> : tensor<1xf32>
   %delta = onnx.Constant dense<[1.0]> : tensor<1xf32>
   %0 = "onnx.Range"(%start, %limit, %delta) : (tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: test_range_float_constant
   // CHECK: {{.*}} = "onnx.Range"(%0, %1, %2) : (tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<8xf32>
@@ -2691,7 +2691,7 @@ func.func @test_range_int_constant() -> tensor<*xi32> {
   %limit = onnx.Constant dense<[10]> : tensor<1xi32>
   %delta = onnx.Constant dense<[1]> : tensor<1xi32>
   %0 = "onnx.Range"(%start, %limit, %delta) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<*xi32>
-  return %0 : tensor<*xi32>
+  onnx.Return %0 : tensor<*xi32>
 
   // CHECK-LABEL: test_range_int_constant
   // CHECK: {{.*}} = "onnx.Range"(%0, %1, %2) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<8xi32>
@@ -2706,12 +2706,12 @@ func.func @test_range_int_constant() -> tensor<*xi32> {
 func.func @test_upsample_cst(%arg0: tensor<1x1x2x2xf32>, %arg1: tensor<4xf32>) -> tensor<*xf32> {
 %0 = onnx.Constant dense<[1.0, 1.0, 2.0, 3.0]> : tensor<4xf32>
 %1 = "onnx.Upsample"(%arg0, %0) {mode = "nearest"} : (tensor<1x1x2x2xf32>, tensor<4xf32>) -> tensor<*xf32>
-return %1 : tensor<*xf32>
+onnx.Return %1 : tensor<*xf32>
 
 // CHECK-LABEL: test_upsample_cst
 // CHECK: [[CSTPOS:%.+]] = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<4xf32>
 // CHECK: [[RES:%.+]] = "onnx.Upsample"(%arg0, %0) {mode = "nearest"} : (tensor<1x1x2x2xf32>, tensor<4xf32>) -> tensor<1x1x4x6xf32>
-// CHECK: return [[RES]] : tensor<1x1x4x6xf32>
+// CHECK: onnx.Return [[RES]] : tensor<1x1x4x6xf32>
 
 }
 
@@ -2720,13 +2720,13 @@ return %1 : tensor<*xf32>
 
 func.func @test_upsample_dyn(%arg0: tensor<1x1x2x2xf32>, %arg1: tensor<4xf32>) -> tensor<*xf32> {
 %1 = "onnx.Upsample"(%arg0, %arg1) {mode = "nearest"} : (tensor<1x1x2x2xf32>, tensor<4xf32>) -> tensor<*xf32>
-return %1 : tensor<*xf32>
+onnx.Return %1 : tensor<*xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_upsample_dyn
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x2x2xf32>, [[PARAM_1_:%.+]]: tensor<4xf32>) -> tensor<?x?x?x?xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Upsample"([[PARAM_0_]], [[PARAM_1_]]) {mode = "nearest"} : (tensor<1x1x2x2xf32>, tensor<4xf32>) -> tensor<?x?x?x?xf32>
-// CHECK:           return [[VAR_0_]] : tensor<?x?x?x?xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<?x?x?x?xf32>
 // CHECK:         }
 }
 
@@ -2739,7 +2739,7 @@ func.func @test_resize1(%arg0 : tensor<3x4x5x6xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<8xf32>
   %1 = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>
   %2 = "onnx.Resize"(%arg0, %0, %1, %cst) {coordinate_transformation_mode = "asymmetric", mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize1"} : (tensor<3x4x5x6xf32>, tensor<8xf32>, tensor<4xf32>, none) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_resize1
   // CHECK-SAME: ([[ARG:%.+]]: tensor<3x4x5x6xf32>) -> tensor<3x4x10x12xf32> {
@@ -2756,7 +2756,7 @@ func.func @test_resize_scales_floor(%arg0 : tensor<3x4x5x6xf32>) -> tensor<*xf32
   %0 = onnx.Constant dense<[0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00]> : tensor<8xf32>
   %1 = onnx.Constant dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 1.510000e+00]> : tensor<4xf32>
   %2 = "onnx.Resize"(%arg0, %0, %1, %cst) {coordinate_transformation_mode = "asymmetric", mode = "nearest", nearest_mode = "floor", onnx_node_name = "Resize1"} : (tensor<3x4x5x6xf32>, tensor<8xf32>, tensor<4xf32>, none) -> tensor<*xf32>
-  "func.return"(%2) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_resize_scales_floor
   // CHECK-SAME: ([[ARG:%.+]]: tensor<3x4x5x6xf32>) -> tensor<3x4x10x9xf32> {
@@ -2770,22 +2770,22 @@ func.func @test_resize_scales_floor(%arg0 : tensor<3x4x5x6xf32>) -> tensor<*xf32
 
   func.func @test_reversesequence_1(%arg0: tensor<10x30xf32>, %arg1: tensor<30xi64>) -> tensor<*xf32> {
     %0 = "onnx.ReverseSequence"(%arg0, %arg1) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<10x30xf32>, tensor<30xi64>) -> tensor<*xf32>
-    return %0 : tensor<*xf32>
+    onnx.Return %0 : tensor<*xf32>
 // CHECK-LABEL:  @test_reversesequence_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x30xf32>, [[PARAM_1_:%.+]]: tensor<30xi64>) -> tensor<10x30xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ReverseSequence"([[PARAM_0_]], [[PARAM_1_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<10x30xf32>, tensor<30xi64>) -> tensor<10x30xf32>
-// CHECK:           return [[VAR_0_]] : tensor<10x30xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<10x30xf32>
   }
 
 // -----
 
   func.func @test_reversesequence_2(%arg0: tensor<10x?xf32>, %arg1: tensor<10xi64>) -> tensor<*xf32> {
     %0 = "onnx.ReverseSequence"(%arg0, %arg1) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<10x?xf32>, tensor<10xi64>) -> tensor<*xf32>
-    return %0 : tensor<*xf32>
+    onnx.Return %0 : tensor<*xf32>
 // CHECK-LABEL:  @test_reversesequence_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x?xf32>, [[PARAM_1_:%.+]]: tensor<10xi64>) -> tensor<10x?xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ReverseSequence"([[PARAM_0_]], [[PARAM_1_]]) {batch_axis = 1 : si64, time_axis = 0 : si64} : (tensor<10x?xf32>, tensor<10xi64>) -> tensor<10x?xf32>
-// CHECK:           return [[VAR_0_]] : tensor<10x?xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<10x?xf32>
   }
 
 // -----
@@ -2793,7 +2793,7 @@ func.func @test_resize_scales_floor(%arg0 : tensor<3x4x5x6xf32>) -> tensor<*xf32
 // COM: Output's shape should be the same as input's shape.
 func.func @test_cumsum(%arg0: tensor<2x3xf64>, %arg1: tensor<i32>) -> tensor<*xf64> {
   %0 = "onnx.CumSum"(%arg0, %arg1) : (tensor<2x3xf64>, tensor<i32>) -> tensor<*xf64>
-  return %0 : tensor<*xf64>
+  onnx.Return %0 : tensor<*xf64>
   // CHECK-LABEL: test_cumsum
   // CHECK: "onnx.CumSum"(%arg0, %arg1) {exclusive = 0 : si64, reverse = 0 : si64} : (tensor<2x3xf64>, tensor<i32>) -> tensor<2x3xf64>
 }
@@ -2807,7 +2807,7 @@ func.func @test_cumsum(%arg0: tensor<2x3xf64>, %arg1: tensor<i32>) -> tensor<*xf
 func.func @test_onehot(%arg0: tensor<2x2xi64>, %arg1: tensor<2xf32>) -> tensor<*xf32> {
   %depth = onnx.Constant dense<10> : tensor<i64>
   %0 = "onnx.OneHot"(%arg0, %depth, %arg1) : (tensor<2x2xi64>, tensor<i64>, tensor<2xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: test_onehot
   // CHECK: [[R0:%.+]] = onnx.Constant dense<10> : tensor<i64>
@@ -2819,7 +2819,7 @@ func.func @test_onehot(%arg0: tensor<2x2xi64>, %arg1: tensor<2xf32>) -> tensor<*
 func.func @test_onehot_axis(%arg0: tensor<2x2xi64>, %arg1: tensor<2xf32>) -> tensor<*xf32> {
   %depth = onnx.Constant dense<10.0> : tensor<f32>
   %0 = "onnx.OneHot"(%arg0, %depth, %arg1) {axis = 1 : si64} : (tensor<2x2xi64>, tensor<f32>, tensor<2xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: test_onehot_axis
   // CHECK: [[R0:%.+]] = onnx.Constant dense<1.000000e+01> : tensor<f32>
@@ -2830,7 +2830,7 @@ func.func @test_onehot_axis(%arg0: tensor<2x2xi64>, %arg1: tensor<2xf32>) -> ten
 
 func.func @test_onehot_depth(%arg0: tensor<2x2xi64>, %arg1: tensor<i64>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
   %0 = "onnx.OneHot"(%arg0, %arg1, %arg2) : (tensor<2x2xi64>, tensor<i64>, tensor<2xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: test_onehot_depth
   // CHECK: {{.*}} = "onnx.OneHot"(%arg0, %arg1, %arg2) {axis = -1 : si64} : (tensor<2x2xi64>, tensor<i64>, tensor<2xf32>) -> tensor<2x2x?xf32>
@@ -2840,7 +2840,7 @@ func.func @test_onehot_depth(%arg0: tensor<2x2xi64>, %arg1: tensor<i64>, %arg2: 
 
 func.func @test_onehot_dynamic(%arg0: tensor<?x2xi64>, %arg1: tensor<i64>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
   %0 = "onnx.OneHot"(%arg0, %arg1, %arg2) {axis = 0 : si64} : (tensor<?x2xi64>, tensor<i64>, tensor<2xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: test_onehot_dynamic
   // CHECK: {{.*}} = "onnx.OneHot"(%arg0, %arg1, %arg2)  {axis = 0 : si64} : (tensor<?x2xi64>, tensor<i64>, tensor<2xf32>) -> tensor<?x?x2xf32>
@@ -2854,7 +2854,7 @@ func.func @test_onehot_dynamic(%arg0: tensor<?x2xi64>, %arg1: tensor<i64>, %arg2
 
 func.func @test_random_normal_static_f16() -> tensor<*xf32> {
   %0 = "onnx.RandomNormal"() {shape = [3, 4, 5], dtype = 0 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : () -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_static_f16
   // CHECK: [[R0:%.+]] = "onnx.RandomNormal"() {dtype = 0 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32, shape = [3, 4, 5]} : () -> tensor<3x4x5xf16>
@@ -2864,7 +2864,7 @@ func.func @test_random_normal_static_f16() -> tensor<*xf32> {
 
 func.func @test_random_normal_static_f32() -> tensor<*xf32> {
   %0 = "onnx.RandomNormal"() {shape = [3, 4, 5], dtype = 1 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : () -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_static_f32
   // CHECK: [[R0:%.+]] = "onnx.RandomNormal"() {dtype = 1 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32, shape = [3, 4, 5]} : () -> tensor<3x4x5xf32>
@@ -2874,7 +2874,7 @@ func.func @test_random_normal_static_f32() -> tensor<*xf32> {
 
 func.func @test_random_normal_static_f64() -> tensor<*xf32> {
   %0 = "onnx.RandomNormal"() {shape = [3, 4, 5], dtype = 2 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : () -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_static_f64
   // CHECK: [[R0:%.+]] = "onnx.RandomNormal"() {dtype = 2 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32, shape = [3, 4, 5]} : () -> tensor<3x4x5xf64>
@@ -2888,7 +2888,7 @@ func.func @test_random_normal_static_f64() -> tensor<*xf32> {
 
 func.func @test_random_normal_like_static_f16(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
   %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 0 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_static_f16
   // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 0 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf32>) -> tensor<1x1x28x28xf16>
@@ -2898,7 +2898,7 @@ func.func @test_random_normal_like_static_f16(%arg0: tensor<1x1x28x28xf32>) -> t
 
 func.func @test_random_normal_like_static_f32(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
   %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 1 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_static_f32
   // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 1 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf32>) -> tensor<1x1x28x28xf32>
@@ -2908,7 +2908,7 @@ func.func @test_random_normal_like_static_f32(%arg0: tensor<1x1x28x28xf32>) -> t
 
 func.func @test_random_normal_like_static_f64(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
   %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 2 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_static_f64
   // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 2 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf32>) -> tensor<1x1x28x28xf64>
@@ -2920,7 +2920,7 @@ func.func @test_random_normal_like_static_f64(%arg0: tensor<1x1x28x28xf32>) -> t
 
 func.func @test_random_normal_like_dynamic_f16(%arg0: tensor<1x?x28x28xf32>) -> tensor<*xf32> {
   %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 0 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x?x28x28xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_dynamic_f16
   // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 0 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x?x28x28xf32>) -> tensor<1x?x28x28xf16>
@@ -2930,7 +2930,7 @@ func.func @test_random_normal_like_dynamic_f16(%arg0: tensor<1x?x28x28xf32>) -> 
 
 func.func @test_random_normal_like_dynamic_f32(%arg0: tensor<1x1x?x28xf32>) -> tensor<*xf32> {
   %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 1 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x?x28xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_dynamic_f32
   // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 1 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x?x28xf32>) -> tensor<1x1x?x28xf32>
@@ -2940,7 +2940,7 @@ func.func @test_random_normal_like_dynamic_f32(%arg0: tensor<1x1x?x28xf32>) -> t
 
 func.func @test_random_normal_like_dynamic_f64(%arg0: tensor<1x1x28x?xf32>) -> tensor<*xf32> {
   %0 = "onnx.RandomNormalLike"(%arg0) {dtype = 2 : si64, mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x?xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_dynamic_f64
   // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {dtype = 2 : si64, mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x?xf32>) -> tensor<1x1x28x?xf64>
@@ -2952,7 +2952,7 @@ func.func @test_random_normal_like_dynamic_f64(%arg0: tensor<1x1x28x?xf32>) -> t
 
 func.func @test_random_normal_like_type_default1(%arg0: tensor<1x1x28x28xf64>) -> tensor<*xf32> {
   %0 = "onnx.RandomNormalLike"(%arg0) {mean = 0.0 :f32, scale = 1.0 : f32, seed = 2.0 : f32} : (tensor<1x1x28x28xf64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: @test_random_normal_like_type_default1
   // CHECK: [[R0:%.+]] = "onnx.RandomNormalLike"(%arg0) {mean = 0.000000e+00 : f32, scale = 1.000000e+00 : f32, seed = 2.000000e+00 : f32} : (tensor<1x1x28x28xf64>) -> tensor<1x1x28x28xf64>
@@ -2965,10 +2965,10 @@ func.func @test_random_normal_like_type_default1(%arg0: tensor<1x1x28x28xf64>) -
 
 func.func @test_nonmaxsuppression(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<*xi64> {
     %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) {center_point_box = 1 : si64} : (tensor<1x6x4xf32>, tensor<1x1x6xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<*xi64>
-    return %0 : tensor<*xi64>
+    onnx.Return %0 : tensor<*xi64>
     // CHECK-LABEL: test_nonmaxsuppression
     // CHECK: [[RES:%.+]] = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) {center_point_box = 1 : si64} : (tensor<1x6x4xf32>, tensor<1x1x6xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
-    // CHECK: return [[RES]] : tensor<?x3xi64>
+    // CHECK: onnx.Return [[RES]] : tensor<?x3xi64>
 }
 
 // -----
@@ -2978,13 +2978,13 @@ func.func @test_nonmaxsuppression(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6x
 
 func.func @compress_axis0(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<?x?xf32> {
   %0 = "onnx.Compress"(%arg0, %arg1) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<?x?xf32>
-  return %0 : tensor<?x?xf32>
+  onnx.Return %0 : tensor<?x?xf32>
 
 // mlir2FileCheck.py -a'["input", "condition"]'
 // CHECK-LABEL:  func @compress_axis0
 // CHECK-SAME:   ([[INPUT_:%.+]]: tensor<3x2xf32>, [[CONDITION_:%.+]]: tensor<3xi1>) -> tensor<?x2xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Compress"([[INPUT_]], [[CONDITION_]]) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<?x2xf32>
-// CHECK:           return [[VAR_0_]] : tensor<?x2xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<?x2xf32>
 // CHECK:         }
 }
 
@@ -2992,12 +2992,12 @@ func.func @compress_axis0(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor
 
 func.func @compress_axis1(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<?x?xf32> {
     %0 = "onnx.Compress"(%arg0, %arg1) {axis = 1 : si64} : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<?x?xf32>
-    return %0 : tensor<?x?xf32>
+    onnx.Return %0 : tensor<?x?xf32>
 // mlir2FileCheck.py -a'["input", "condition"]'
 // CHECK-LABEL:  func @compress_axis1
 // CHECK-SAME:   ([[INPUT_:%.+]]: tensor<3x2xf32>, [[CONDITION_:%.+]]: tensor<3xi1>) -> tensor<3x?xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Compress"([[INPUT_]], [[CONDITION_]]) {axis = 1 : si64} : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<3x?xf32>
-// CHECK:           return [[VAR_0_]] : tensor<3x?xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3x?xf32>
 // CHECK:         }
 }
 
@@ -3005,13 +3005,13 @@ func.func @compress_axis1(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor
 
 func.func @compress_no_axis(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tensor<*xf32> {
     %0 = "onnx.Compress"(%arg0, %arg1) : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<*xf32>
-    return %0 : tensor<*xf32>
+    onnx.Return %0 : tensor<*xf32>
 
 // mlir2FileCheck.py -a'["input", "condition"]'
 // CHECK-LABEL:  func @compress_no_axis
 // CHECK-SAME:   ([[INPUT_:%.+]]: tensor<3x2xf32>, [[CONDITION_:%.+]]: tensor<3xi1>) -> tensor<?xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Compress"([[INPUT_]], [[CONDITION_]]) : (tensor<3x2xf32>, tensor<3xi1>) -> tensor<?xf32>
-// CHECK:           return [[VAR_0_]] : tensor<?xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<?xf32>
 // CHECK:         }
 }
 
@@ -3019,17 +3019,17 @@ func.func @compress_no_axis(%arg0: tensor<3x2xf32>, %arg1: tensor<3xi1>) -> tens
 
 func.func @hardmax(%arg0: tensor<3x4x5xf32>) -> tensor<*xf32>{
   %0 = "onnx.Hardmax"(%arg0) {axis = 1 : si64} : (tensor<3x4x5xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
   // CHECK-LABEL: hardmax
   // CHECK: [[RES:%.+]] = "onnx.Hardmax"(%arg0) {axis = 1 : si64} : (tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-  // CHECK: return [[RES]] : tensor<3x4x5xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3x4x5xf32>
 }
 
 // -----
 
 func.func @topk_default_axis_minus_one(%X: tensor<3x4x5xf32>, %K: tensor<i64>) -> tensor<*xf32> {
   %value, %indices = "onnx.TopK"(%X, %K) : (tensor<3x4x5xf32>, tensor<i64>) -> (tensor<*xf32>, tensor<*xi64>)
-  return %value : tensor<*xf32>
+  onnx.Return %value : tensor<*xf32>
   // CHECK-LABEL: topk_default_axis_minus_one
   // CHECK: {{.*}} = "onnx.TopK"({{.*}}, {{.*}}) {axis = -1 : si64, largest = 1 : si64, sorted = 1 : si64} : (tensor<3x4x5xf32>, tensor<i64>) -> (tensor<3x4x?xf32>, tensor<3x4x?xi64>)
 }
@@ -3038,7 +3038,7 @@ func.func @topk_default_axis_minus_one(%X: tensor<3x4x5xf32>, %K: tensor<i64>) -
 
 func.func @topk_default_axis_one(%X: tensor<3x4x5xf32>, %K: tensor<i64>) -> tensor<*xf32> {
   %value, %indices = "onnx.TopK"(%X, %K) {axis = 1 : si64} : (tensor<3x4x5xf32>, tensor<i64>) -> (tensor<*xf32>, tensor<*xi64>)
-  return %value : tensor<*xf32>
+  onnx.Return %value : tensor<*xf32>
   // CHECK-LABEL: topk_default_axis_one
   // CHECK: {{.*}} = "onnx.TopK"({{.*}}, {{.*}}) {axis = 1 : si64, largest = 1 : si64, sorted = 1 : si64} : (tensor<3x4x5xf32>, tensor<i64>) -> (tensor<3x?x5xf32>, tensor<3x?x5xi64>)
 }
@@ -3048,7 +3048,7 @@ func.func @topk_default_axis_one(%X: tensor<3x4x5xf32>, %K: tensor<i64>) -> tens
 func.func @topk_constant_k(%X: tensor<3x4x5xf32>) -> tensor<*xf32> {
   %K = onnx.Constant dense<2> : tensor<i64>
   %value, %indices = "onnx.TopK"(%X, %K) {axis = 1 : si64} : (tensor<3x4x5xf32>, tensor<i64>) -> (tensor<*xf32>, tensor<*xi64>)
-  return %value : tensor<*xf32>
+  onnx.Return %value : tensor<*xf32>
   // CHECK-LABEL: topk_constant_k
   // CHECK: {{.*}} = "onnx.TopK"({{.*}}, {{.*}}) {axis = 1 : si64, largest = 1 : si64, sorted = 1 : si64} : (tensor<3x4x5xf32>, tensor<i64>) -> (tensor<3x2x5xf32>, tensor<3x2x5xi64>)
 }
@@ -3061,22 +3061,22 @@ func.func @topk_constant_k(%X: tensor<3x4x5xf32>) -> tensor<*xf32> {
 
 func.func @test_category_mapper_string (%arg0: tensor<20x1x!onnx.String>) -> tensor<*xi64> {
   %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "human"], default_int64 = 0 : si64} : (tensor<20x1x!onnx.String>) -> tensor<*xi64>
-  "func.return"(%0) : (tensor<*xi64>) -> ()
+  "onnx.Return"(%0) : (tensor<*xi64>) -> ()
 
   // CHECK-LABEL: test_category_mapper_string
   // CHECK: [[RES:%.+]] = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "human"], default_int64 = 0 : si64, default_string = "_Unused"} : (tensor<20x1x!onnx.String>) -> tensor<20x1xi64>
-  // CHECK: return [[RES]] : tensor<20x1xi64>
+  // CHECK: onnx.Return [[RES]] : tensor<20x1xi64>
 }
 
 // -----
 
 func.func @test_category_mapper_int64 (%arg0: tensor<20x1xi64>) -> tensor<*x!onnx.String> {
   %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "human"], default_string = "unclassified" : !onnx.String} : (tensor<20x1xi64>) -> tensor<*x!onnx.String>
-  "func.return"(%0) : (tensor<*x!onnx.String>) -> ()
+  "onnx.Return"(%0) : (tensor<*x!onnx.String>) -> ()
 
   // CHECK-LABEL: test_category_mapper_int64
   // CHECK: [[RES:%.+]] = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2, 3], cats_strings = ["cat", "dog", "human"], default_int64 = -1 : si64, default_string = "unclassified" : !onnx.String} : (tensor<20x1xi64>) -> tensor<20x1x!onnx.String>
-  // CHECK: return [[RES]] : tensor<20x1x!onnx.String>
+  // CHECK: onnx.Return [[RES]] : tensor<20x1x!onnx.String>
 }
 
 // -----
@@ -3088,13 +3088,13 @@ func.func @test_scatternd_int32(%arg0: tensor<8xi32>) -> tensor<*xi32> {
   %1 = onnx.Constant dense<[[4], [3], [1], [7]]> : tensor<4x1xi64>
   %2 = onnx.Constant dense<[9, 10, 11, 12]> : tensor<4xi32>
   %3 = "onnx.ScatterND"(%arg0, %1, %2) : (tensor<8xi32>, tensor<4x1xi64>, tensor<4xi32>) ->  tensor<*xi32>
-  "func.return"(%3) : (tensor<*xi32>) -> ()
+  "onnx.Return"(%3) : (tensor<*xi32>) -> ()
 
   // CHECK-LABEL: test_scatternd_int32
   // CHECK: [[R1:%.+]] = onnx.Constant {{.*}}
   // CHECK-NEXT: [[R2:%.+]] = onnx.Constant {{.*}}
   // CHECK-NEXT: [[RES:%.+]] = "onnx.ScatterND"(%arg0, [[R1]], [[R2]]) {reduction = "none"} : (tensor<8xi32>, tensor<4x1xi64>, tensor<4xi32>) -> tensor<8xi32>
-  // CHECK-NEXT: return [[RES]] : tensor<8xi32>
+  // CHECK-NEXT: onnx.Return [[RES]] : tensor<8xi32>
 }
 
 // -----
@@ -3104,35 +3104,35 @@ func.func @test_scatternd_float32(%arg0: tensor<4x4x4xf32>) -> tensor<*xf32> {
   %2 = "onnx.Constant"() {value = dense<[[[5., 5., 5., 5.], [6., 6., 6., 6.], [7., 7., 7., 7.], [8., 8., 8., 8.]],
                                          [[1., 1., 1., 1.], [2., 2., 2., 2.], [3., 3., 3., 3.], [4., 4., 4., 4.]]]> : tensor<2x4x4xf32> } : () -> tensor<2x4x4xf32>
   %3 = "onnx.ScatterND"(%arg0, %1, %2) : (tensor<4x4x4xf32>, tensor<2x1xi64>, tensor<2x4x4xf32>) ->  tensor<*xf32>
-  "func.return"(%3) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%3) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_scatternd_float32
   // CHECK: [[R1:%.+]] = onnx.Constant {{.*}}
   // CHECK-NEXT: [[R2:%.+]] = onnx.Constant {{.*}}
   // CHECK-NEXT: [[RES:%.+]] = "onnx.ScatterND"(%arg0, [[R1]], [[R2]]) {reduction = "none"} : (tensor<4x4x4xf32>, tensor<2x1xi64>, tensor<2x4x4xf32>) -> tensor<4x4x4xf32>
-  // CHECK-NEXT: return [[RES]] : tensor<4x4x4xf32>
+  // CHECK-NEXT: onnx.Return [[RES]] : tensor<4x4x4xf32>
 }
 
 // -----
 func.func @test_seqence_length(%arg0 : !onnx.Seq<tensor<*xf32>>) -> tensor<*xi64> {
   %0 = "onnx.SequenceLength"(%arg0) : (!onnx.Seq<tensor<*xf32>>) -> tensor<*xi64>
-  return %0 : tensor<*xi64>
+  onnx.Return %0 : tensor<*xi64>
 // mlir2FileCheck.py
 // CHECK-LABEL:  func @test_seqence_length
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<*xf32>>) -> tensor<i64> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceLength"([[PARAM_0_]]) : (!onnx.Seq<tensor<*xf32>>) -> tensor<i64>
-// CHECK:           return [[VAR_0_]] : tensor<i64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<i64>
 }
 
 // -----
 func.func @test_sequence_construct(%arg0 : tensor<2x3xf16>, %arg1 : tensor<4x3xf16>) -> !onnx.Seq<tensor<*xf16>> {
   %0 = "onnx.SequenceConstruct"(%arg0, %arg1) : (tensor<2x3xf16>, tensor<4x3xf16>) -> !onnx.Seq<tensor<*xf16>>
-  return %0 : !onnx.Seq<tensor<*xf16>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf16>>
 // mlir2FileCheck.py
 // CHECK-LABEL:  func @test_sequence_construct
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3xf16>, [[PARAM_1_:%.+]]: tensor<4x3xf16>) -> !onnx.Seq<tensor<?x3xf16>> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceConstruct"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<2x3xf16>, tensor<4x3xf16>) -> !onnx.Seq<tensor<?x3xf16>>
-// CHECK:           return [[VAR_0_]] : !onnx.Seq<tensor<?x3xf16>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<?x3xf16>>
 }
 
 // -----
@@ -3141,14 +3141,14 @@ func.func @test_seqence_1(%arg0: tensor<2x4xf32>, %arg1: tensor<2x6xf32>) -> !on
   %cst = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<2x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
   %2 = "onnx.SequenceInsert"(%1, %arg1, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<2x6xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-  return %2 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %2 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_seqence_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4xf32>, [[PARAM_1_:%.+]]: tensor<2x6xf32>) -> !onnx.Seq<tensor<2x?xf32>> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
 // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<2x4xf32>, none) -> !onnx.Seq<tensor<2x4xf32>>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.SequenceInsert"([[VAR_1_]], [[PARAM_1_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<2x4xf32>>, tensor<2x6xf32>, none) -> !onnx.Seq<tensor<2x?xf32>>
-// CHECK:           return [[VAR_2_]] : !onnx.Seq<tensor<2x?xf32>>
+// CHECK:           onnx.Return [[VAR_2_]] : !onnx.Seq<tensor<2x?xf32>>
 }
 
 // -----
@@ -3158,14 +3158,14 @@ func.func @test_seqence_2(%arg0: tensor<2x4xf32>, %arg1: tensor<3x6xf32>) -> !on
   %cst = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<2x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
   %2 = "onnx.SequenceInsert"(%1, %arg1, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x6xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-  return %2 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %2 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_seqence_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4xf32>, [[PARAM_1_:%.+]]: tensor<3x6xf32>) -> !onnx.Seq<tensor<?x?xf32>> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
 // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<2x4xf32>, none) -> !onnx.Seq<tensor<2x4xf32>>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.SequenceInsert"([[VAR_1_]], [[PARAM_1_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<2x4xf32>>, tensor<3x6xf32>, none) -> !onnx.Seq<tensor<?x?xf32>>
-// CHECK:           return [[VAR_2_]] : !onnx.Seq<tensor<?x?xf32>>
+// CHECK:           onnx.Return [[VAR_2_]] : !onnx.Seq<tensor<?x?xf32>>
 }
 
 // -----
@@ -3175,14 +3175,14 @@ func.func @test_seqence_3(%arg0: tensor<2x4x8xf32>, %arg1: tensor<3x6xf32>) -> !
   %cst = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.SequenceInsert"(%0, %arg0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<2x4x8xf32>, none) -> !onnx.Seq<tensor<*xf32>>
   %2 = "onnx.SequenceInsert"(%1, %arg1, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<3x6xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-  return %2 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %2 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_seqence_3
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4x8xf32>, [[PARAM_1_:%.+]]: tensor<3x6xf32>) -> !onnx.Seq<tensor<*xf32>> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
 // CHECK-DAG:       [[VAR_cst_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SequenceInsert"([[VAR_0_]], [[PARAM_0_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<*xf32>>, tensor<2x4x8xf32>, none) -> !onnx.Seq<tensor<2x4x8xf32>>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.SequenceInsert"([[VAR_1_]], [[PARAM_1_]], [[VAR_cst_]]) : (!onnx.Seq<tensor<2x4x8xf32>>, tensor<3x6xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-// CHECK:           return [[VAR_2_]] : !onnx.Seq<tensor<*xf32>>
+// CHECK:           onnx.Return [[VAR_2_]] : !onnx.Seq<tensor<*xf32>>
 }
 
 // -----
@@ -3192,12 +3192,12 @@ func.func @test_seqence_3(%arg0: tensor<2x4x8xf32>, %arg1: tensor<3x6xf32>) -> !
 func.func @test_splittosequence_0(%arg0: tensor<0x?x4xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.SplitToSequence"(%arg0, %cst) : (tensor<0x?x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_0
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<0x?x4xf32>) -> !onnx.Seq<tensor<1x?x4xf32>> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[VAR_0_]]) {axis = 0 : si64, keepdims = 1 : si64} : (tensor<0x?x4xf32>, none) -> !onnx.Seq<tensor<1x?x4xf32>>
-// CHECK:           return [[VAR_1_]] : !onnx.Seq<tensor<1x?x4xf32>>
+// CHECK:           onnx.Return [[VAR_1_]] : !onnx.Seq<tensor<1x?x4xf32>>
 }
 
 // -----
@@ -3205,12 +3205,12 @@ func.func @test_splittosequence_0(%arg0: tensor<0x?x4xf32>) -> !onnx.Seq<tensor<
 func.func @test_splittosequence_1(%arg0: tensor<2x?x4xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.SplitToSequence"(%arg0, %cst) : (tensor<2x?x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x?x4xf32>) -> !onnx.Seq<tensor<1x?x4xf32>> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[VAR_0_]]) {axis = 0 : si64, keepdims = 1 : si64} : (tensor<2x?x4xf32>, none) -> !onnx.Seq<tensor<1x?x4xf32>>
-// CHECK:           return [[VAR_1_]] : !onnx.Seq<tensor<1x?x4xf32>>
+// CHECK:           onnx.Return [[VAR_1_]] : !onnx.Seq<tensor<1x?x4xf32>>
 }
 
 // -----
@@ -3218,12 +3218,12 @@ func.func @test_splittosequence_1(%arg0: tensor<2x?x4xf32>) -> !onnx.Seq<tensor<
 func.func @test_splittosequence_2(%arg0: tensor<2x?x4xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.SplitToSequence"(%arg0, %cst) {keepdims = 0 : si64} : (tensor<2x?x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x?x4xf32>) -> !onnx.Seq<tensor<?x4xf32>> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[VAR_0_]]) {axis = 0 : si64, keepdims = 0 : si64} : (tensor<2x?x4xf32>, none) -> !onnx.Seq<tensor<?x4xf32>>
-// CHECK:           return [[VAR_1_]] : !onnx.Seq<tensor<?x4xf32>>
+// CHECK:           onnx.Return [[VAR_1_]] : !onnx.Seq<tensor<?x4xf32>>
 }
 
 // -----
@@ -3231,34 +3231,34 @@ func.func @test_splittosequence_2(%arg0: tensor<2x?x4xf32>) -> !onnx.Seq<tensor<
 func.func @test_splittosequence_3(%arg0: tensor<2x?x4xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.SplitToSequence"(%arg0, %cst) {axis = 1 : si64} : (tensor<2x?x4xf32>, none) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_3
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x?x4xf32>) -> !onnx.Seq<tensor<2x1x4xf32>> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[VAR_0_]]) {axis = 1 : si64, keepdims = 1 : si64} : (tensor<2x?x4xf32>, none) -> !onnx.Seq<tensor<2x1x4xf32>>
-// CHECK:           return [[VAR_1_]] : !onnx.Seq<tensor<2x1x4xf32>>
+// CHECK:           onnx.Return [[VAR_1_]] : !onnx.Seq<tensor<2x1x4xf32>>
 }
 
 // -----
 
 func.func @test_splittosequence_4(%arg0: tensor<2x?x4xf32>, %arg1: tensor<3xi64>) -> !onnx.Seq<tensor<*xf32>> {
   %0 = "onnx.SplitToSequence"(%arg0, %arg1) : (tensor<2x?x4xf32>, tensor<3xi64>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_4
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x?x4xf32>, [[PARAM_1_:%.+]]: tensor<3xi64>) -> !onnx.Seq<tensor<?x?x4xf32>> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[PARAM_1_]]) {axis = 0 : si64, keepdims = 1 : si64} : (tensor<2x?x4xf32>, tensor<3xi64>) -> !onnx.Seq<tensor<?x?x4xf32>>
-// CHECK:           return [[VAR_0_]] : !onnx.Seq<tensor<?x?x4xf32>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<?x?x4xf32>>
 }
 
 // -----
 
 func.func @test_splittosequence_5(%arg0: tensor<0x?x4xf32>, %arg1: tensor<3xi64>) -> !onnx.Seq<tensor<*xf32>> {
   %0 = "onnx.SplitToSequence"(%arg0, %arg1) : (tensor<0x?x4xf32>, tensor<3xi64>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_5
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<0x?x4xf32>, [[PARAM_1_:%.+]]: tensor<3xi64>) -> !onnx.Seq<tensor<0x?x4xf32>> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[PARAM_1_]]) {axis = 0 : si64, keepdims = 1 : si64} : (tensor<0x?x4xf32>, tensor<3xi64>) -> !onnx.Seq<tensor<0x?x4xf32>>
-// CHECK:           return [[VAR_0_]] : !onnx.Seq<tensor<0x?x4xf32>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<0x?x4xf32>>
 }
 
 // -----
@@ -3266,12 +3266,12 @@ func.func @test_splittosequence_5(%arg0: tensor<0x?x4xf32>, %arg1: tensor<3xi64>
 func.func @test_splittosequence_6(%arg0: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %cst = onnx.Constant dense<2> : tensor<i64>
   %0 = "onnx.SplitToSequence"(%arg0, %cst) : (tensor<4x?x3xf32>, tensor<i64>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_6
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<2x?x3xf32>> {
 // CHECK:           [[VAR_cst_:%.+]] = onnx.Constant dense<2> : tensor<i64>
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[VAR_cst_]]) {axis = 0 : si64, keepdims = 1 : si64} : (tensor<4x?x3xf32>, tensor<i64>) -> !onnx.Seq<tensor<2x?x3xf32>>
-// CHECK:           return [[VAR_0_]] : !onnx.Seq<tensor<2x?x3xf32>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<2x?x3xf32>>
 }
 
 // -----
@@ -3279,12 +3279,12 @@ func.func @test_splittosequence_6(%arg0: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<
 func.func @test_splittosequence_7(%arg0: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %cst = onnx.Constant dense<3> : tensor<i64>
   %0 = "onnx.SplitToSequence"(%arg0, %cst) : (tensor<4x?x3xf32>, tensor<i64>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_7
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<?x?x3xf32>> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<3> : tensor<i64>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[VAR_0_]]) {axis = 0 : si64, keepdims = 1 : si64} : (tensor<4x?x3xf32>, tensor<i64>) -> !onnx.Seq<tensor<?x?x3xf32>>
-// CHECK:           return [[VAR_1_]] : !onnx.Seq<tensor<?x?x3xf32>>
+// CHECK:           onnx.Return [[VAR_1_]] : !onnx.Seq<tensor<?x?x3xf32>>
 }
 
 // -----
@@ -3292,12 +3292,12 @@ func.func @test_splittosequence_7(%arg0: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<
 func.func @test_splittosequence_8(%arg0: tensor<?x?x3xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %cst = onnx.Constant dense<[2, 2]> : tensor<2xi64>
   %0 = "onnx.SplitToSequence"(%arg0, %cst) : (tensor<?x?x3xf32>, tensor<2xi64>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_8
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3xf32>) -> !onnx.Seq<tensor<2x?x3xf32>> {
 // CHECK:           [[VAR_cst_:%.+]] = onnx.Constant dense<2> : tensor<2xi64>
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[VAR_cst_]]) {axis = 0 : si64, keepdims = 1 : si64} : (tensor<?x?x3xf32>, tensor<2xi64>) -> !onnx.Seq<tensor<2x?x3xf32>>
-// CHECK:           return [[VAR_0_]] : !onnx.Seq<tensor<2x?x3xf32>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<2x?x3xf32>>
 }
 
 // -----
@@ -3305,12 +3305,12 @@ func.func @test_splittosequence_8(%arg0: tensor<?x?x3xf32>) -> !onnx.Seq<tensor<
 func.func @test_splittosequence_9(%arg0: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<*xf32>> {
   %cst = onnx.Constant dense<[3, 1]> : tensor<2xi64>
   %0 = "onnx.SplitToSequence"(%arg0, %cst) : (tensor<4x?x3xf32>, tensor<2xi64>) -> !onnx.Seq<tensor<*xf32>>
-  return %0 : !onnx.Seq<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Seq<tensor<*xf32>>
 // CHECK-LABEL:  func @test_splittosequence_9
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<?x?x3xf32>> {
 // CHECK:           [[VAR_cst_:%.+]] = onnx.Constant dense<[3, 1]> : tensor<2xi64>
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SplitToSequence"([[PARAM_0_]], [[VAR_cst_]]) {axis = 0 : si64, keepdims = 1 : si64} : (tensor<4x?x3xf32>, tensor<2xi64>) -> !onnx.Seq<tensor<?x?x3xf32>>
-// CHECK:           return [[VAR_0_]] : !onnx.Seq<tensor<?x?x3xf32>>
+// CHECK:           onnx.Return [[VAR_0_]] : !onnx.Seq<tensor<?x?x3xf32>>
 }
 
 // -----
@@ -3320,11 +3320,11 @@ func.func @test_splittosequence_9(%arg0: tensor<4x?x3xf32>) -> !onnx.Seq<tensor<
 //===----------------------------------------------------------------------===//
 func.func @test_roialign(%arg0: tensor<1x2x4x8xf32>, %arg1: tensor<100x4xf32>, %arg2: tensor<100xi64>) -> tensor<*xf32> {
   %0 = "onnx.RoiAlign"(%arg0, %arg1, %arg2) {output_height = 7 : si64, output_width = 7 : si64, sampling_ratio = 2 : si64, spatial_scale = 1.000000e+00 : f32} : (tensor<1x2x4x8xf32>, tensor<100x4xf32>, tensor<100xi64>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_roialign
   // CHECK: [[RES:%.+]] = "onnx.RoiAlign"(%arg0, %arg1, %arg2) {coordinate_transformation_mode = "half_pixel", mode = "avg", output_height = 7 : si64, output_width = 7 : si64, sampling_ratio = 2 : si64, spatial_scale = 1.000000e+00 : f32} : (tensor<1x2x4x8xf32>, tensor<100x4xf32>, tensor<100xi64>) -> tensor<100x2x7x7xf32>
-  // CHECK: return [[RES]] : tensor<100x2x7x7xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<100x2x7x7xf32>
 }
 
 // -----
@@ -3334,11 +3334,11 @@ func.func @test_roialign(%arg0: tensor<1x2x4x8xf32>, %arg1: tensor<100x4xf32>, %
 //===----------------------------------------------------------------------===//
 func.func @test_scatterelements(%arg0: tensor<64x25600xf32>, %arg1: tensor<64x100xi64>, %arg2: tensor<64x100xf32>) -> tensor<*xf32> {
   %0 = "onnx.ScatterElements"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<64x25600xf32>, tensor<64x100xi64>, tensor<64x100xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_scatterelements
   // CHECK: [[RES:%.+]] = "onnx.ScatterElements"(%arg0, %arg1, %arg2)  {axis = 1 : si64, reduction = "none"} : (tensor<64x25600xf32>, tensor<64x100xi64>, tensor<64x100xf32>) -> tensor<64x25600xf32>
-  // CHECK: return [[RES]] : tensor<64x25600xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<64x25600xf32>
 }
 
 // -----
@@ -3348,11 +3348,11 @@ func.func @test_scatterelements(%arg0: tensor<64x25600xf32>, %arg1: tensor<64x10
 //===----------------------------------------------------------------------===//
 func.func @test_maxroipool(%arg0: tensor<1x3x64x64xf32>, %arg1: tensor<1x5xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxRoiPool"(%arg0, %arg1) {node_name = "tops_MaxRoiPool_0", pooled_shape = [2, 2], spatial_scale = 1.000000e+00 : f32} : (tensor<1x3x64x64xf32>, tensor<1x5xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_maxroipool
   // CHECK: [[RES:%.+]] = "onnx.MaxRoiPool"(%arg0, %arg1) {node_name = "tops_MaxRoiPool_0", pooled_shape = [2, 2], spatial_scale = 1.000000e+00 : f32} : (tensor<1x3x64x64xf32>, tensor<1x5xf32>) -> tensor<1x3x2x2xf32>
-  // CHECK: return [[RES]] : tensor<1x3x2x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x3x2x2xf32>
 }
 
 // -----
@@ -3362,33 +3362,33 @@ func.func @test_maxroipool(%arg0: tensor<1x3x64x64xf32>, %arg1: tensor<1x5xf32>)
 //===----------------------------------------------------------------------===//
 func.func @test_isinf(%arg0 : tensor<2x3x4xf32>) -> tensor<2x3x4xi1> {
   %0 = "onnx.IsInf"(%arg0) {detect_negative = 1 : si64, detect_positive = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<2x3x4xi1>
-  return %0 : tensor<2x3x4xi1>
+  onnx.Return %0 : tensor<2x3x4xi1>
 
   // CHECK-LABEL: func @test_isinf
   // CHECK: [[RES:%.+]] = "onnx.IsInf"(%arg0) {detect_negative = 1 : si64, detect_positive = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<2x3x4xi1>
-  // CHECK: return [[RES]] : tensor<2x3x4xi1>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xi1>
 }
 
 // -----
 
 func.func @test_isinf_positive(%arg0 : tensor<2x3x4xf32>) -> tensor<2x3x4xi1> {
   %0 = "onnx.IsInf"(%arg0) {detect_negative = 0 : si64, detect_positive = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<2x3x4xi1>
-  return %0 : tensor<2x3x4xi1>
+  onnx.Return %0 : tensor<2x3x4xi1>
 
   // CHECK-LABEL: func @test_isinf_positive
   // CHECK: [[RES:%.+]] = "onnx.IsInf"(%arg0) {detect_negative = 0 : si64, detect_positive = 1 : si64} : (tensor<2x3x4xf32>) -> tensor<2x3x4xi1>
-  // CHECK: return [[RES]] : tensor<2x3x4xi1>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xi1>
 }
 
 // -----
 
 func.func @test_isinf_negative(%arg0 : tensor<2x3x4xf32>) -> tensor<2x3x4xi1> {
   %0 = "onnx.IsInf"(%arg0) {detect_negative = 1 : si64, detect_positive = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<2x3x4xi1>
-  return %0 : tensor<2x3x4xi1>
+  onnx.Return %0 : tensor<2x3x4xi1>
 
   // CHECK-LABEL: func @test_isinf_negative
   // CHECK: [[RES:%.+]] = "onnx.IsInf"(%arg0) {detect_negative = 1 : si64, detect_positive = 0 : si64} : (tensor<2x3x4xf32>) -> tensor<2x3x4xi1>
-  // CHECK: return [[RES]] : tensor<2x3x4xi1>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xi1>
 }
 
 // -----
@@ -3398,11 +3398,11 @@ func.func @test_isinf_negative(%arg0 : tensor<2x3x4xf32>) -> tensor<2x3x4xi1> {
 //===----------------------------------------------------------------------===//
 func.func @test_isnan(%arg0 : tensor<2x3x4xf32>) -> tensor<*xi1> {
   %0 = "onnx.IsNaN"(%arg0) : (tensor<2x3x4xf32>) -> tensor<*xi1>
-  return %0 : tensor<*xi1>
+  onnx.Return %0 : tensor<*xi1>
 
   // CHECK-LABEL: func @test_isnan
   // CHECK: [[RES:%.+]] = "onnx.IsNaN"(%arg0) : (tensor<2x3x4xf32>) -> tensor<2x3x4xi1>
-  // CHECK: return [[RES]] : tensor<2x3x4xi1>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x4xi1>
 }
 
 // -----
@@ -3413,11 +3413,11 @@ func.func @test_isnan(%arg0 : tensor<2x3x4xf32>) -> tensor<*xi1> {
 
 func.func @test_celu(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
   %0 = "onnx.Celu"(%arg0) {alpha = 1.0 : f32} : (tensor<1x2x3x4xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_celu
   // CHECK: [[RES:%.+]] = "onnx.Celu"(%arg0) {alpha = 1.000000e+00 : f32} : (tensor<1x2x3x4xf32>) -> tensor<1x2x3x4xf32>
-  // CHECK: return [[RES]] : tensor<1x2x3x4xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<1x2x3x4xf32>
 }
 
 // -----
@@ -3428,22 +3428,22 @@ func.func @test_celu(%arg0: tensor<1x2x3x4xf32>) -> tensor<*xf32> {
 
 func.func @test_bernoulli_1(%arg0 : tensor<8x8xf16>) -> tensor<*xf32> {
   %1 = "onnx.Bernoulli"(%arg0) {dtype = 1 : si64, seed = 2.0 : f32} : (tensor<8x8xf16>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf32>) -> ()
 
   // CHECK-LABEL: test_bernoulli_1
   // CHECK: [[RES:%.+]] = "onnx.Bernoulli"(%arg0) {dtype = 1 : si64, seed = 2.000000e+00 : f32} : (tensor<8x8xf16>) -> tensor<8x8xf32>
-  // CHECK: return [[RES]] : tensor<8x8xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<8x8xf32>
 }
 
 // -----
 
 func.func @test_bernoulli_2(%arg0 : tensor<8x8xf16>) -> tensor<*xf16> {
   %1 = "onnx.Bernoulli"(%arg0) {seed = 2.0 : f32} : (tensor<8x8xf16>) -> tensor<*xf16>
-  "func.return"(%1) : (tensor<*xf16>) -> ()
+  "onnx.Return"(%1) : (tensor<*xf16>) -> ()
 
   // CHECK-LABEL: test_bernoulli_2
   // CHECK: [[RES:%.+]] = "onnx.Bernoulli"(%arg0) {seed = 2.000000e+00 : f32} : (tensor<8x8xf16>) -> tensor<8x8xf16>
-  // CHECK: return [[RES]] : tensor<8x8xf16>
+  // CHECK: onnx.Return [[RES]] : tensor<8x8xf16>
 }
 
 // -----
@@ -3464,7 +3464,7 @@ func.func @test_if_1(%arg0: tensor<i1>) -> (tensor<*xf32>, tensor<*xi16>, tensor
     %5 = onnx.Constant {value = dense<[1, 2, 3]> : tensor<3xui8>} : tensor<*xui8>
     onnx.Yield %3, %4, %5 : tensor<*xf32>, tensor<*xi16>, tensor<*xui8>
   }) : (tensor<i1>) -> (tensor<*xf32>, tensor<*xi16>, tensor<*xui8>)
-  return %0, %1, %2 : tensor<*xf32>, tensor<*xi16>, tensor<*xui8>
+  onnx.Return %0, %1, %2 : tensor<*xf32>, tensor<*xi16>, tensor<*xui8>
 
 // CHECK-LABEL:  func @test_if_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i1>) -> (tensor<2xf32>, tensor<?xi16>, tensor<*xui8>) {
@@ -3479,7 +3479,7 @@ func.func @test_if_1(%arg0: tensor<i1>) -> (tensor<*xf32>, tensor<*xi16>, tensor
 // CHECK-DAG:       }, {
 // CHECK-DAG:         onnx.Yield [[VAR_1_1_]], [[VAR_2_1_]], [[VAR_3_1_]] : tensor<2xf32>, tensor<3xi16>, tensor<3xui8>
 // CHECK-DAG:       }) : (tensor<i1>) -> (tensor<2xf32>, tensor<?xi16>, tensor<*xui8>)
-// CHECK:           return [[VAR_0_]]#0, [[VAR_0_]]#1, [[VAR_0_]]#2 : tensor<2xf32>, tensor<?xi16>, tensor<*xui8>
+// CHECK:           onnx.Return [[VAR_0_]]#0, [[VAR_0_]]#1, [[VAR_0_]]#2 : tensor<2xf32>, tensor<?xi16>, tensor<*xui8>
 }
 
 // -----
@@ -3496,7 +3496,7 @@ func.func @test_if_2(%arg0: tensor<i1>, %arg1: !onnx.Seq<tensor<2xf32>>) -> (!on
     %5 = "onnx.Optional"(%arg1) : (!onnx.Seq<tensor<2xf32>>) -> !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
     onnx.Yield %3, %4, %5 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
   }) : (tensor<i1>) -> (!onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>)
-  return %0, %1, %2 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
+  onnx.Return %0, %1, %2 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
 
 // CHECK-LABEL:  func @test_if_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i1>, [[PARAM_1_:%.+]]: !onnx.Seq<tensor<2xf32>>) -> (!onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<?xf32>>>) {
@@ -3512,7 +3512,7 @@ func.func @test_if_2(%arg0: tensor<i1>, %arg1: !onnx.Seq<tensor<2xf32>>) -> (!on
 // CHECK-DAG:         [[VAR_3_1_:%.+]] = "onnx.Optional"([[PARAM_1_]]) : (!onnx.Seq<tensor<2xf32>>) -> !onnx.Opt<!onnx.Seq<tensor<2xf32>>>
 // CHECK:             onnx.Yield [[VAR_1_1_]], [[VAR_2_1_]], [[VAR_3_1_]] : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<i1>>, !onnx.Opt<!onnx.Seq<tensor<2xf32>>>
 // CHECK:           }) : (tensor<i1>) -> (!onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<?xf32>>>)
-// CHECK:           return [[VAR_0_]]#0, [[VAR_0_]]#1, [[VAR_0_]]#2 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<?xf32>>>
+// CHECK:           onnx.Return [[VAR_0_]]#0, [[VAR_0_]]#1, [[VAR_0_]]#2 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<?xf32>>>
 }
 
 // -----
@@ -3520,11 +3520,11 @@ func.func @test_if_2(%arg0: tensor<i1>, %arg1: !onnx.Seq<tensor<2xf32>>) -> (!on
 func.func @test_concatshapetranspose_1(%arg0: tensor<10x20xf32>, %arg1: tensor<10x30xf32>) -> (tensor<*xi64>, tensor<*xf32>)
 {
     %1:2 = "onnx.ConcatShapeTranspose"(%arg0, %arg1) {axis = 1 : si64, perm = [1, 0]} : (tensor<10x20xf32>, tensor<10x30xf32>) -> (tensor<*xi64>, tensor<*xf32>)
-    return %1#0, %1#1 : tensor<*xi64>, tensor<*xf32>
+    onnx.Return %1#0, %1#1 : tensor<*xi64>, tensor<*xf32>
 // CHECK-LABEL:  func.func @test_concatshapetranspose_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x20xf32>, [[PARAM_1_:%.+]]: tensor<10x30xf32>) -> (tensor<2xi64>, tensor<50x10xf32>) {
 // CHECK:           [[shape_:%.+]], [[VAR_transposed_:%.+]] = "onnx.ConcatShapeTranspose"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64, perm = [1, 0], start = 0 : si64} : (tensor<10x20xf32>, tensor<10x30xf32>) -> (tensor<2xi64>, tensor<50x10xf32>)
-// CHECK:           return [[shape_]], [[VAR_transposed_]] : tensor<2xi64>, tensor<50x10xf32>
+// CHECK:           onnx.Return [[shape_]], [[VAR_transposed_]] : tensor<2xi64>, tensor<50x10xf32>
 // CHECK:         }
 }
 
@@ -3533,12 +3533,12 @@ func.func @test_concatshapetranspose_1(%arg0: tensor<10x20xf32>, %arg1: tensor<1
 func.func @test_concatshapetranpose_2(%arg0: tensor<?x?xf32>, %arg1: tensor<10x30xf32>) -> (tensor<*xi64>, tensor<*xf32>)
 {
     %1:2 = "onnx.ConcatShapeTranspose"(%arg0, %arg1) {axis = 1 : si64} : (tensor<?x?xf32>, tensor<10x30xf32>) -> (tensor<*xi64>, tensor<*xf32>)
-    return %1#0, %1#1 : tensor<*xi64>, tensor<*xf32>
+    onnx.Return %1#0, %1#1 : tensor<*xi64>, tensor<*xf32>
 }
 // CHECK-LABEL:  func.func @test_concatshapetranpose_2
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32>, [[PARAM_1_:%.+]]: tensor<10x30xf32>) -> (tensor<2xi64>, tensor<?x10xf32>) {
 // CHECK:           [[shape_:%.+]], [[VAR_transposed_:%.+]] = "onnx.ConcatShapeTranspose"([[PARAM_0_]], [[PARAM_1_]]) {axis = 1 : si64, perm = [1, 0], start = 0 : si64} : (tensor<?x?xf32>, tensor<10x30xf32>) -> (tensor<2xi64>, tensor<?x10xf32>)
-// CHECK:           return [[shape_]], [[VAR_transposed_]] : tensor<2xi64>, tensor<?x10xf32>
+// CHECK:           onnx.Return [[shape_]], [[VAR_transposed_]] : tensor<2xi64>, tensor<?x10xf32>
 // CHECK:         }
 
 // -----
@@ -3546,14 +3546,14 @@ func.func @test_concatshapetranpose_2(%arg0: tensor<?x?xf32>, %arg1: tensor<10x3
 func.func @test_onnx_layout_transform(%arg0: tensor<5x3x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.LayoutTransform"(%arg0) {target_layout = #onnx.layout<{dataLayout = "NCHW4C"}>} : (tensor<5x3x32x32xf32>) -> tensor<*xf32>
   %1 = "onnx.LayoutTransform"(%0) : (tensor<*xf32>) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_onnx_layout_transform
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<5x3x32x32xf32>) -> tensor<5x3x32x32xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.LayoutTransform"([[PARAM_0_]]) {target_layout = #onnx.layout<{dataLayout = "NCHW4C"}>} : (tensor<5x3x32x32xf32>) -> tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.LayoutTransform"([[VAR_0_]]) : (tensor<5x3x32x32xf32, #onnx.layout<{dataLayout = "NCHW4C"}>>) -> tensor<5x3x32x32xf32>
-// CHECK:           return [[VAR_1_]] : tensor<5x3x32x32xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<5x3x32x32xf32>
 // CHECK:         }
 }
 
@@ -3563,13 +3563,13 @@ func.func @test_onnx_layout_transform(%arg0: tensor<5x3x32x32xf32>) -> tensor<*x
 module {
   func.func @test_shape_transform(%arg0: tensor<3x128xf32>) -> tensor<*xf32> {
     %0 = "onnx.ShapeTransform"(%arg0) {index_map = #map} : (tensor<3x128xf32>) -> tensor<*xf32>
-    return %0 : tensor<*xf32>
+    onnx.Return %0 : tensor<*xf32>
 
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d1 floordiv 64, d0, d1 mod 64)>
 // CHECK-LABEL:  func.func @test_shape_transform
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x128xf32>) -> tensor<2x3x64xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ShapeTransform"([[PARAM_0_]]) {index_map = #map} : (tensor<3x128xf32>) -> tensor<2x3x64xf32>
-// CHECK:           return [[VAR_0_]] : tensor<2x3x64xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<2x3x64xf32>
 // CHECK:         }
   }
 }
@@ -3585,12 +3585,12 @@ module {
 
 func.func @test_clipv6(%arg0: tensor<*xf32>) -> tensor<*xf32> {
   %0 = "onnx.ClipV6"(%arg0) {max = 6.000000e+00 : f32, min = 0.000000e+00 : f32} : (tensor<*xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_clipv6
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<*xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.ClipV6"([[PARAM_0_]]) {max = 6.000000e+00 : f32, min = 0.000000e+00 : f32} : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:           return [[VAR_0_]] : tensor<*xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<*xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_shape_inference_einsum.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_einsum.mlir
@@ -4,108 +4,108 @@
 
 func.func @test_einsum_matmul(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x4x5xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0, %arg1) {equation = "...ij,...jk"} : (tensor<2x3x4xf32>, tensor<2x4x5xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_matmul
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0, %arg1) {equation = "...ij,...jk"} : (tensor<2x3x4xf32>, tensor<2x4x5xf32>) -> tensor<2x3x5xf32>
-  // CHECK: return [[RES]] : tensor<2x3x5xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x5xf32>
 }
 
 // -----
 
 func.func @test_einsum_matmul_broadcast(%arg0: tensor<2x3x1xf32>, %arg1: tensor<1x4x5xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0, %arg1) {equation = "...ij,...jk"} : (tensor<2x3x1xf32>, tensor<1x4x5xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_matmul_broadcast
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0, %arg1) {equation = "...ij,...jk"} : (tensor<2x3x1xf32>, tensor<1x4x5xf32>) -> tensor<2x3x5xf32>
-  // CHECK: return [[RES]] : tensor<2x3x5xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3x5xf32>
 }
 
 // -----
 
 func.func @test_einsum_transpose(%arg0: tensor<2x3xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ji"} : (tensor<2x3xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_transpose
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0) {equation = "ji"} : (tensor<2x3xf32>) -> tensor<3x2xf32>
-  // CHECK: return [[RES]] : tensor<3x2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3x2xf32>
 }
 
 // -----
 
 func.func @test_einsum_transpose_last_first(%arg0: tensor<0x1x2xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "...i->i..."} : (tensor<0x1x2xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_transpose_last_first
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0) {equation = "...i->i..."} : (tensor<0x1x2xf32>) -> tensor<2x0x1xf32>
-  // CHECK: return [[RES]] : tensor<2x0x1xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x0x1xf32>
 }
 
 // -----
 
 func.func @test_einsum_sum(%arg0: tensor<2x3xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ij->i"} : (tensor<2x3xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_sum
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0) {equation = "ij->i"} : (tensor<2x3xf32>) -> tensor<2xf32>
-  // CHECK: return [[RES]] : tensor<2xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2xf32>
 }
 
 // -----
 
 func.func @test_einsum_mul3_broadcast(%arg0: tensor<1x3xf32>, %arg1: tensor<1x1xf32>, %arg2: tensor<2x1xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0, %arg1, %arg2) {equation = "...,...,..."} : (tensor<1x3xf32>, tensor<1x1xf32>, tensor<2x1xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_mul3_broadcast
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0, %arg1, %arg2) {equation = "...,...,..."} : (tensor<1x3xf32>, tensor<1x1xf32>, tensor<2x1xf32>) -> tensor<2x3xf32>
-  // CHECK: return [[RES]] : tensor<2x3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<2x3xf32>
 }
 
 // -----
 
 func.func @test_einsum_diagonal(%arg0: tensor<3x3xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<3x3xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_diagonal
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<3x3xf32>) -> tensor<3xf32>
-  // CHECK: return [[RES]] : tensor<3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3xf32>
 }
 
 // -----
 
 func.func @test_einsum_trace(%arg0: tensor<3x3xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ii"} : (tensor<3x3xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_trace
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0) {equation = "ii"} : (tensor<3x3xf32>) -> tensor<f32>
-  // CHECK: return [[RES]] : tensor<f32>
+  // CHECK: onnx.Return [[RES]] : tensor<f32>
 }
 
 // -----
 
 func.func @test_einsum_qmark(%arg0: tensor<3x?xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<3x?xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_qmark
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<3x?xf32>) -> tensor<3xf32>
-  // CHECK: return [[RES]] : tensor<3xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<3xf32>
 }
 
 // -----
 
 func.func @test_einsum_qmark1(%arg0: tensor<1x?xf32>) -> tensor<*xf32> {
   %0 = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<1x?xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
 
   // CHECK-LABEL: func @test_einsum_qmark1
   // CHECK: [[RES:%.+]] = "onnx.Einsum"(%arg0) {equation = "ii->i"} : (tensor<1x?xf32>) -> tensor<?xf32>
-  // CHECK: return [[RES]] : tensor<?xf32>
+  // CHECK: onnx.Return [[RES]] : tensor<?xf32>
 }

--- a/test/mlir/onnx/onnx_shape_inference_error.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_error.mlir
@@ -11,7 +11,7 @@ func.func @unsupport_conv_bad_kernel_shape_attr(%arg0 : tensor<1x2x32x32xf32>, %
   %cst = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{Bad kernel_shape value: must be strictly positive}}
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64, kernel_shape = [-1, 7]} : (tensor<1x2x32x32xf32>, tensor<5x2x7x7xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -21,7 +21,7 @@ func.func @unsupport_conv_bad_kernel_shape(%arg0 : tensor<1x2x32x32xf32>, %arg1 
   %cst = "onnx.NoValue"() {value} : () -> none
   // expected-error @+1 {{Bad spatial filter size: cannot be zero}}
   %0 = "onnx.Conv"(%arg0, %arg1, %cst) {auto_pad = "NOTSET", group = 1 : si64} : (tensor<1x2x32x32xf32>, tensor<5x2x0x7xf32>, none) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -33,7 +33,7 @@ func.func @unsupport_conv_bad_kernel_shape(%arg0 : tensor<1x2x32x32xf32>, %arg1 
 func.func @unsupport_maxpool_column_storage(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   // expected-error @+1 {{Column major storage order not implemented yet}}
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "VALID", ceil_mode = 0 : si64, kernel_shape = [3, 3], storage_order = 1 : si64} : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -46,7 +46,7 @@ func.func @test_reshape_2D_shape(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<1x
   // expected-error @+2 {{Shape tensor must have rank one}}
   // expected-error @+1 {{shape inference failed}}
   %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<1x2xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -55,7 +55,7 @@ func.func @test_reshape_1D_constant_shape(%arg0 : tensor<5x5x1x32xf32>, %arg1 : 
   // expected-error @+2 {{Shape tensor must have constant shape}}
   // expected-error @+1 {{shape inference failed}}
   %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<?xi64>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 
 // -----
@@ -70,7 +70,7 @@ func.func @test_lstm_not_3D_input(%arg0: tensor<4x3xf32>, %arg1: tensor<1x12x2xf
   // expected-error @+2 {{Failed to scan parameters successfully}}
   // expected-error @+1 {{shape inference failed}}
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 }
 
 // -----
@@ -81,7 +81,7 @@ func.func @test_lstm_not_3D_weight(%arg0: tensor<4x3x2xf32>, %arg1: tensor<12x2x
   // expected-error @+2 {{Failed to scan parameters successfully}}
   // expected-error @+1 {{shape inference failed}}
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 }
 
 // -----
@@ -92,7 +92,7 @@ func.func @test_lstm_not_3D_recurrent(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x
   // expected-error @+2 {{Failed to scan parameters successfully}}
   // expected-error @+1 {{shape inference failed}}
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 }
 
 // -----
@@ -103,7 +103,7 @@ func.func @test_lstm_wrong_direction(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x1
   // expected-error @+2 {{Failed to scan parameters successfully}}
   // expected-error @+1 {{shape inference failed}}
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %cst, %cst, %cst, %cst, %cst) {hidden_size = 3 : si64, direction="forwadr"} : (tensor<4x3x2xf32>, tensor<1x12x2xf32>, tensor<1x12x3xf32>, none, none, none, none, none) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
-  return %Y_h : tensor<*xf32>
+  onnx.Return %Y_h : tensor<*xf32>
 }
 
 // -----
@@ -115,7 +115,7 @@ func.func @test_lstm_wrong_direction(%arg0: tensor<4x3x2xf32>, %arg1: tensor<1x1
 func.func @test_category_mapper_diff_size_attrs (%arg0: tensor<20x1xi64>) -> tensor<*x!onnx.String> {
   // expected-error @+1 {{cats_int64 and cats_strings should have the same size}}      
   %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1, 2], cats_strings = ["dog"]} : (tensor<20x1xi64>) -> tensor<*x!onnx.String>
-  "func.return"(%0) : (tensor<*x!onnx.String>) -> ()
+  "onnx.Return"(%0) : (tensor<*x!onnx.String>) -> ()
 }
 
 // -----
@@ -123,7 +123,7 @@ func.func @test_category_mapper_diff_size_attrs (%arg0: tensor<20x1xi64>) -> ten
 func.func @test_category_mapper_diff_size_attrs (%arg0: tensor<20x1xi32>) -> tensor<*x!onnx.String> {
   // expected-error @+1 {{'onnx.CategoryMapper' op operand #0 must be tensor of string type values or tensor of 64-bit signless integer values, but got 'tensor<20x1xi32>'}}      
   %0 = "onnx.CategoryMapper"(%arg0) {cats_int64s = [1], cats_strings = ["cat"]} : (tensor<20x1xi32>) -> tensor<*x!onnx.String>
-  "func.return"(%0) : (tensor<*x!onnx.String>) -> ()
+  "onnx.Return"(%0) : (tensor<*x!onnx.String>) -> ()
 }
 
 // -----

--- a/test/mlir/onnx/onnx_shape_inference_maxpool.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_maxpool.mlir
@@ -5,11 +5,11 @@
 /// Test the default behavior of Max Pool with no padding (pad are set but shoudl be ignored)
 func.func @test_default_maxpoolsingleout(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "VALID", ceil_mode = 0 : si64, kernel_shape = [3,3]} : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "VALID", ceil_mode = 0 : si64, kernel_shape = [3, 3], storage_order = 0 : si64} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
-// CHECK: return [[RES]] : tensor<5x5x30x30xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x30x30xf32>
 
 
 // -----
@@ -17,11 +17,11 @@ func.func @test_default_maxpoolsingleout(%arg0 : tensor<5x5x32x32xf32>) -> tenso
 /// Test the default behavior of Max Pool with no padding (pad are not set, default to zero)
 func.func @test_default_maxpoolsingleout_defpad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3,3]} : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_defpad
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], storage_order = 0 : si64} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
-// CHECK: return [[RES]] : tensor<5x5x30x30xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x30x30xf32>
 
 
 // -----
@@ -29,11 +29,11 @@ func.func @test_default_maxpoolsingleout_defpad(%arg0 : tensor<5x5x32x32xf32>) -
 /// Test the default behavior of Max Pool with uniform padding
 func.func @test_default_maxpoolsingleout_pad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3,3], pads = [1, 1, 1, 1] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_pad
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], storage_order = 0 : si64} : (tensor<5x5x32x32xf32>) -> tensor<5x5x32x32xf32>
-// CHECK: return [[RES]] : tensor<5x5x32x32xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x32x32xf32>
 
 
 // -----
@@ -41,44 +41,44 @@ func.func @test_default_maxpoolsingleout_pad(%arg0 : tensor<5x5x32x32xf32>) -> t
 /// Test the default behavior of Max Pool with non uniform padding
 func.func @test_default_maxpoolsingleout_pad_nonunif(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [5,3], pads = [2, 1, 1, 0] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_pad_nonunif
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [5, 3], pads = [2, 1, 1, 0], storage_order = 0 : si64} : (tensor<5x5x32x32xf32>) -> tensor<5x5x31x31xf32>
-// CHECK: return [[RES]] : tensor<5x5x31x31xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x31x31xf32>
 
 // -----
 
 /// Test the default behavior of Max Pool with non uniform padding
 func.func @test_default_maxpoolsingleout_strides(%arg0 : tensor<5x5x32x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3,3], pads = [1, 1, 1, 1], strides = [2, 2] } : (tensor<5x5x32x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_strides
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], storage_order = 0 : si64, strides = [2, 2]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x16x16xf32>
-// CHECK: return [[RES]] : tensor<5x5x16x16xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x16x16xf32>
 
 // -----
 
 /// Test the default behavior of Max Pool with non uniform padding
 func.func @test_default_maxpoolsingleout_strides_nonunifpad(%arg0 : tensor<5x5x30x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [2,2], pads = [1, 0, 0, 0], strides = [2, 2] } : (tensor<5x5x30x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_strides_nonunifpad
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [2, 2], pads = [1, 0, 0, 0], storage_order = 0 : si64, strides = [2, 2]} : (tensor<5x5x30x32xf32>) -> tensor<5x5x15x16xf32>
-// CHECK: return [[RES]] : tensor<5x5x15x16xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x15x16xf32>
 
 // -----
 
 /// Test the default behavior of Max Pool with non uniform padding
 func.func @test_default_maxpoolsingleout_strides_nonunifpad_ceil(%arg0 : tensor<5x5x30x32xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 1 : si64, kernel_shape = [2,2], pads = [1, 0, 0, 0], strides = [2, 2] } : (tensor<5x5x30x32xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_strides_nonunifpad_ceil
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 1 : si64, kernel_shape = [2, 2], pads = [1, 0, 0, 0], storage_order = 0 : si64, strides = [2, 2]} : (tensor<5x5x30x32xf32>) -> tensor<5x5x16x16xf32>
-// CHECK: return [[RES]] : tensor<5x5x16x16xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x16x16xf32>
 
 
 // -----
@@ -86,22 +86,22 @@ func.func @test_default_maxpoolsingleout_strides_nonunifpad_ceil(%arg0 : tensor<
 /// Test the default behavior of Max Pool with dilatation
 func.func @test_default_maxpoolsingleout_strides_dilatation(%arg0 : tensor<5x5x8x8xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [2,2], dilations = [2, 2], strides = [3, 3] } : (tensor<5x5x8x8xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_strides_dilatation
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0)  {auto_pad = "NOTSET", ceil_mode = 0 : si64, dilations = [2, 2], kernel_shape = [2, 2], storage_order = 0 : si64, strides = [3, 3]} : (tensor<5x5x8x8xf32>) -> tensor<5x5x2x2xf32>
-// CHECK: return [[RES]] : tensor<5x5x2x2xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x2x2xf32>
 
 // -----
 
 /// Test the default behavior of Max Pool with dilatation
 func.func @test_default_maxpoolsingleout_upper(%arg0 : tensor<5x5x16x13xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "SAME_UPPER", ceil_mode = 0 : si64, kernel_shape = [4,4], strides = [4, 4] } : (tensor<5x5x16x13xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_upper
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "SAME_UPPER", ceil_mode = 0 : si64, kernel_shape = [4, 4], storage_order = 0 : si64, strides = [4, 4]} : (tensor<5x5x16x13xf32>) -> tensor<5x5x4x4xf32>
-// CHECK: return [[RES]] : tensor<5x5x4x4xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x4x4xf32>
 
 
 // -----
@@ -109,9 +109,9 @@ func.func @test_default_maxpoolsingleout_upper(%arg0 : tensor<5x5x16x13xf32>) ->
 /// Test the default behavior of Max Pool with dilatation
 func.func @test_default_maxpoolsingleout_lower(%arg0 : tensor<5x5x16x13xf32>) -> tensor<*xf32> {
   %0 = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "SAME_LOWER", ceil_mode = 0 : si64, kernel_shape = [4,4], strides = [4, 4] } : (tensor<5x5x16x13xf32>) -> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 // CHECK-LABEL: test_default_maxpoolsingleout_lower
 // CHECK: [[RES:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "SAME_LOWER", ceil_mode = 0 : si64, kernel_shape = [4, 4], storage_order = 0 : si64, strides = [4, 4]} : (tensor<5x5x16x13xf32>) -> tensor<5x5x4x4xf32>
-// CHECK: return [[RES]] : tensor<5x5x4x4xf32>
+// CHECK: onnx.Return [[RES]] : tensor<5x5x4x4xf32>
 

--- a/test/mlir/onnx/onnx_shape_inference_optional.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_optional.mlir
@@ -5,9 +5,9 @@
 // CHECK-LABEL: func.func @check_opt_identity(%arg0: !onnx.Opt<tensor<2xf32>>) -> !onnx.Opt<tensor<2xf32>> {
 func.func @check_opt_identity(%arg0: !onnx.Opt<tensor<2xf32>>) -> !onnx.Opt<tensor<*xf32>> {
   %0 = "onnx.Identity"(%arg0) : (!onnx.Opt<tensor<2xf32>>) -> !onnx.Opt<tensor<*xf32>>
-  return %0 : !onnx.Opt<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Opt<tensor<*xf32>>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.Identity"(%arg0) : (!onnx.Opt<tensor<2xf32>>) -> !onnx.Opt<tensor<2xf32>>
-  // CHECK-NEXT: return [[VAR_0_]] : !onnx.Opt<tensor<2xf32>>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : !onnx.Opt<tensor<2xf32>>
 }
 
 // -----
@@ -15,9 +15,9 @@ func.func @check_opt_identity(%arg0: !onnx.Opt<tensor<2xf32>>) -> !onnx.Opt<tens
 // CHECK-LABEL: func.func @check_optional(%arg0: tensor<2xf32>) -> !onnx.Opt<tensor<2xf32>> {
 func.func @check_optional(%arg0: tensor<2xf32>) -> !onnx.Opt<tensor<*xf32>> {
   %0 = "onnx.Optional"(%arg0) : (tensor<2xf32>) -> !onnx.Opt<tensor<*xf32>>
-  return %0 : !onnx.Opt<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Opt<tensor<*xf32>>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.Optional"(%arg0) : (tensor<2xf32>) -> !onnx.Opt<tensor<2xf32>>
-  // CHECK-NEXT: return [[VAR_0_]] : !onnx.Opt<tensor<2xf32>>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : !onnx.Opt<tensor<2xf32>>
 }
 
 // -----
@@ -26,10 +26,10 @@ func.func @check_optional(%arg0: tensor<2xf32>) -> !onnx.Opt<tensor<*xf32>> {
 func.func @check_optional_none() -> !onnx.Opt<tensor<*xf32>> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.Optional"(%0) {type = tensor<2xf32>} : (none) -> !onnx.Opt<tensor<*xf32>>
-  return %1 : !onnx.Opt<tensor<*xf32>>
+  onnx.Return %1 : !onnx.Opt<tensor<*xf32>>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[VAR_1_:%.+]] = "onnx.Optional"([[VAR_0_]]) {type = tensor<2xf32>} : (none) -> !onnx.Opt<tensor<2xf32>>
-  // CHECK-NEXT: return [[VAR_1_]] : !onnx.Opt<tensor<2xf32>>
+  // CHECK-NEXT: onnx.Return [[VAR_1_]] : !onnx.Opt<tensor<2xf32>>
 }
 
 // -----
@@ -37,9 +37,9 @@ func.func @check_optional_none() -> !onnx.Opt<tensor<*xf32>> {
 // CHECK-LABEL: func.func @check_optionalgetelement(%arg0: !onnx.Opt<tensor<2xf32>>) -> tensor<2xf32> {
 func.func @check_optionalgetelement(%arg0: !onnx.Opt<tensor<2xf32>>) -> tensor<*xf32> {
   %0 = "onnx.OptionalGetElement"(%arg0) : (!onnx.Opt<tensor<2xf32>>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.OptionalGetElement"(%arg0) : (!onnx.Opt<tensor<2xf32>>) -> tensor<2xf32>
-  // CHECK-NEXT: return [[VAR_0_]] : tensor<2xf32>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : tensor<2xf32>
 }
 
 // -----
@@ -47,7 +47,7 @@ func.func @check_optionalgetelement(%arg0: !onnx.Opt<tensor<2xf32>>) -> tensor<*
 // CHECK-LABEL: func.func @check_optionalhaselement(%arg0: !onnx.Opt<tensor<*xf32>>) -> tensor<i1> {
 func.func @check_optionalhaselement(%arg0: !onnx.Opt<tensor<*xf32>>) -> tensor<*xi1> {
   %0 = "onnx.OptionalHasElement"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> tensor<*xi1>
-  return %0 : tensor<*xi1>
+  onnx.Return %0 : tensor<*xi1>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.OptionalHasElement"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> tensor<i1>
-  // CHECK-NEXT: return [[VAR_0_]] : tensor<i1>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : tensor<i1>
 }

--- a/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
+++ b/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
@@ -150,7 +150,7 @@ func.func @test_update_reshape_output_shape(%arg0: tensor<?x256xi64>, %arg1: ten
   %2 = onnx.Constant dense<256> : tensor<1xi64>
   %3 = "onnx.Concat"(%0, %1, %2) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
   %4 = "onnx.Reshape"(%arg1, %3) : (tensor<?x256xi64>, tensor<3xi64>) -> tensor<?x?x?xi64>
-  onnx.FuncReturn %4 : tensor<?x?x?xi64>
+  onnx.Return %4 : tensor<?x?x?xi64>
 
 // CHECK-LABEL:  func.func @test_update_reshape_output_shape
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>, [[PARAM_1_:%.+]]: tensor<?x256xi64>) -> tensor<?x1x256xi64> {
@@ -159,7 +159,7 @@ func.func @test_update_reshape_output_shape(%arg0: tensor<?x256xi64>, %arg1: ten
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
 // CHECK:           [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<?x256xi64>, tensor<3xi64>) -> tensor<?x1x256xi64>
-// CHECK:           onnx.FuncReturn [[VAR_4_]] : tensor<?x1x256xi64>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<?x1x256xi64>
 // CHECK:         }
 }
 
@@ -171,7 +171,7 @@ func.func @test_update_constantofshape_output_shape(%arg0: tensor<?x256xi64>, %a
   %2 = onnx.Constant dense<256> : tensor<1xi64>
   %3 = "onnx.Concat"(%0, %1, %2) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
   %4 = "onnx.ConstantOfShape"(%3) {value = dense<1> : tensor<1xi64>} : (tensor<3xi64>) -> tensor<?x?x?xi64>
-  onnx.FuncReturn %4 : tensor<?x?x?xi64>
+  onnx.Return %4 : tensor<?x?x?xi64>
 
 // CHECK-LABEL:  func.func @test_update_constantofshape_output_shape
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>, [[PARAM_1_:%.+]]: tensor<?x256xi64>) -> tensor<?x1x256xi64> {
@@ -180,6 +180,6 @@ func.func @test_update_constantofshape_output_shape(%arg0: tensor<?x256xi64>, %a
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
 // CHECK:           [[VAR_4_:%.+]] = onnx.ConstantOfShape([[VAR_3_]]) {value = dense<1> : tensor<1xi64>} : (tensor<3xi64>) -> tensor<?x1x256xi64>
-// CHECK:           onnx.FuncReturn [[VAR_4_]] : tensor<?x1x256xi64>
+// CHECK:           onnx.Return [[VAR_4_]] : tensor<?x1x256xi64>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
+++ b/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
@@ -150,7 +150,7 @@ func.func @test_update_reshape_output_shape(%arg0: tensor<?x256xi64>, %arg1: ten
   %2 = onnx.Constant dense<256> : tensor<1xi64>
   %3 = "onnx.Concat"(%0, %1, %2) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
   %4 = "onnx.Reshape"(%arg1, %3) : (tensor<?x256xi64>, tensor<3xi64>) -> tensor<?x?x?xi64>
-  return %4 : tensor<?x?x?xi64>
+  onnx.FuncReturn %4 : tensor<?x?x?xi64>
 
 // CHECK-LABEL:  func.func @test_update_reshape_output_shape
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>, [[PARAM_1_:%.+]]: tensor<?x256xi64>) -> tensor<?x1x256xi64> {
@@ -159,7 +159,7 @@ func.func @test_update_reshape_output_shape(%arg0: tensor<?x256xi64>, %arg1: ten
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
 // CHECK:           [[VAR_4_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<?x256xi64>, tensor<3xi64>) -> tensor<?x1x256xi64>
-// CHECK:           return [[VAR_4_]] : tensor<?x1x256xi64>
+// CHECK:           onnx.FuncReturn [[VAR_4_]] : tensor<?x1x256xi64>
 // CHECK:         }
 }
 
@@ -171,7 +171,7 @@ func.func @test_update_constantofshape_output_shape(%arg0: tensor<?x256xi64>, %a
   %2 = onnx.Constant dense<256> : tensor<1xi64>
   %3 = "onnx.Concat"(%0, %1, %2) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
   %4 = "onnx.ConstantOfShape"(%3) {value = dense<1> : tensor<1xi64>} : (tensor<3xi64>) -> tensor<?x?x?xi64>
-  return %4 : tensor<?x?x?xi64>
+  onnx.FuncReturn %4 : tensor<?x?x?xi64>
 
 // CHECK-LABEL:  func.func @test_update_constantofshape_output_shape
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>, [[PARAM_1_:%.+]]: tensor<?x256xi64>) -> tensor<?x1x256xi64> {
@@ -180,6 +180,6 @@ func.func @test_update_constantofshape_output_shape(%arg0: tensor<?x256xi64>, %a
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]], [[VAR_2_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
 // CHECK:           [[VAR_4_:%.+]] = onnx.ConstantOfShape([[VAR_3_]]) {value = dense<1> : tensor<1xi64>} : (tensor<3xi64>) -> tensor<?x1x256xi64>
-// CHECK:           return [[VAR_4_]] : tensor<?x1x256xi64>
+// CHECK:           onnx.FuncReturn [[VAR_4_]] : tensor<?x1x256xi64>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
+++ b/test/mlir/onnx/onnx_simplify_shape_related_ops.mlir
@@ -2,14 +2,14 @@
 
 func.func @test_shape_to_dim(%arg0: tensor<?x256xi64>) -> (tensor<2xi64>) {
   %0 = "onnx.Shape"(%arg0) : (tensor<?x256xi64>) -> tensor<2xi64>
-  return %0 : tensor<2xi64>
+  onnx.Return %0 : tensor<2xi64>
 
 // CHECK-LABEL:  func.func @test_shape_to_dim
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>) -> tensor<2xi64> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// CHECK:           return [[VAR_2_]] : tensor<2xi64>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<2xi64>
 // CHECK:         }
 }
 
@@ -17,14 +17,14 @@ func.func @test_shape_to_dim(%arg0: tensor<?x256xi64>) -> (tensor<2xi64>) {
 
 func.func @test_shape_to_dim_positive_axis(%arg0: tensor<?x256x?xi64>) -> (tensor<2xi64>) {
   %0 = "onnx.Shape"(%arg0) {start = 0 : si64, end = 2 : si64} : (tensor<?x256x?xi64>) -> tensor<2xi64>
-  return %0 : tensor<2xi64>
+  onnx.Return %0 : tensor<2xi64>
 
 // CHECK-LABEL:  func.func @test_shape_to_dim_positive_axis
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256x?xi64>) -> tensor<2xi64> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x256x?xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// CHECK:           return [[VAR_2_]] : tensor<2xi64>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<2xi64>
 // CHECK:         }
 }
 
@@ -32,14 +32,14 @@ func.func @test_shape_to_dim_positive_axis(%arg0: tensor<?x256x?xi64>) -> (tenso
 
 func.func @test_shape_to_dim_negative_axis(%arg0: tensor<?x256x?xi64>) -> (tensor<2xi64>) {
   %0 = "onnx.Shape"(%arg0) {start = -2 : si64, end = 3 : si64} : (tensor<?x256x?xi64>) -> tensor<2xi64>
-  return %0 : tensor<2xi64>
+  onnx.Return %0 : tensor<2xi64>
 
 // CHECK-LABEL:  func.func @test_shape_to_dim_negative_axis
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256x?xi64>) -> tensor<2xi64> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 2 : si64} : (tensor<?x256x?xi64>) -> tensor<1xi64>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// CHECK:           return [[VAR_2_]] : tensor<2xi64>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<2xi64>
 // CHECK:         }
 }
 
@@ -52,14 +52,14 @@ func.func @test_pass_dims_scalar(%arg0: tensor<?x?x200xf32>) -> tensor<i64> {
   %3 = onnx.Constant dense<200> : tensor<1xi64>
   %4 = "onnx.Concat"(%1, %2, %3) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
   %5 = "onnx.Gather"(%4, %0) {axis = 0 : si64} : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
-  return %5 : tensor<i64>
+  onnx.Return %5 : tensor<i64>
 
 // CHECK-LABEL:  func.func @test_pass_dims_scalar
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x200xf32>) -> tensor<i64> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x?x200xf32>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Squeeze"([[VAR_0_]], [[VAR_1_]]) : (tensor<1xi64>, tensor<1xi64>) -> tensor<i64>
-// CHECK:           return [[VAR_2_]] : tensor<i64>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<i64>
 // CHECK:         }
 }
 
@@ -70,7 +70,7 @@ func.func @test_pass_dims_through_cast(%arg0: tensor<?x256xi64>) -> (tensor<2xf3
   %1 = onnx.Constant dense<256> : tensor<1xi64>
   %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
   %3 = "onnx.Cast"(%2) {to = f32} : (tensor<2xi64>) -> tensor<2xf32>
-  return %3 : tensor<2xf32>
+  onnx.Return %3 : tensor<2xf32>
 
 // CHECK-LABEL:  func.func @test_pass_dims_through_cast
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>) -> tensor<2xf32> {
@@ -78,7 +78,7 @@ func.func @test_pass_dims_through_cast(%arg0: tensor<?x256xi64>) -> (tensor<2xf3
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Cast"([[VAR_0_]]) {to = f32} : (tensor<1xi64>) -> tensor<1xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Concat"([[VAR_1_]], [[VAR_2_]]) {axis = 0 : si64} : (tensor<1xf32>, tensor<1xf32>) -> tensor<2xf32>
-// CHECK:           return [[VAR_3_]] : tensor<2xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<2xf32>
 // CHECK:         }
 }
 
@@ -90,14 +90,14 @@ func.func @test_pass_dims_through_concat(%arg0: tensor<?x256xi64>) -> (tensor<4x
   %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
   %3 = "onnx.Concat"(%2, %0) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>) -> tensor<3xi64>
   %4 = "onnx.Concat"(%3, %0) {axis = 0 : si64} : (tensor<3xi64>, tensor<1xi64>) -> tensor<4xi64>
-  return %4 : tensor<4xi64>
+  onnx.Return %4 : tensor<4xi64>
 
 // CHECK-LABEL:  func.func @test_pass_dims_through_concat
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>) -> tensor<4xi64> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<256> : tensor<1xi64>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]], [[VAR_0_]], [[VAR_0_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
-// CHECK:           return [[VAR_2_]] : tensor<4xi64>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<4xi64>
 // CHECK:         }
 }
 
@@ -110,7 +110,7 @@ func.func @test_pass_dims_through_cast_2(%arg0: tensor<?x?x200xf32>) -> tensor<2
   %3 = onnx.Constant dense<200> : tensor<1xi64>
   %4 = "onnx.Concat"(%1, %2, %3) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
   %5 = "onnx.Gather"(%4, %0) {axis = 0 : si64} : (tensor<3xi64>, tensor<2xi64>) -> tensor<2xi64>
-  return %5 : tensor<2xi64>
+  onnx.Return %5 : tensor<2xi64>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_pass_dims_through_cast_2
@@ -118,7 +118,7 @@ func.func @test_pass_dims_through_cast_2(%arg0: tensor<?x?x200xf32>) -> tensor<2
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x?x200xf32>) -> tensor<1xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 1 : si64} : (tensor<?x?x200xf32>) -> tensor<1xi64>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// CHECK:           return [[VAR_2_]] : tensor<2xi64>
+// CHECK:           onnx.Return [[VAR_2_]] : tensor<2xi64>
 // CHECK:         }
 }
 
@@ -133,12 +133,12 @@ func.func @test_pass_dims_through_slice(%arg0: tensor<?x256xi64>) -> (tensor<1xi
   %5 = onnx.Constant dense<0> : tensor<1xi64>
   %6 = onnx.Constant dense<1> : tensor<1xi64>
   %7 = "onnx.Slice"(%2, %3, %4, %5, %6) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-  return %7 : tensor<1xi64>
+  onnx.Return %7 : tensor<1xi64>
 
 // CHECK-LABEL:  func.func @test_pass_dims_through_slice
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x256xi64>) -> tensor<1xi64> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x256xi64>) -> tensor<1xi64>
-// CHECK:           return [[VAR_0_]] : tensor<1xi64>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1xi64>
 // CHECK:         }
 }
 

--- a/test/mlir/onnx/onnx_structure.mlir
+++ b/test/mlir/onnx/onnx_structure.mlir
@@ -4,14 +4,14 @@
 // CHECK-LABEL: @check_map1(%arg0: tuple<i64, f32>) -> tensor<*xf32> {
 func.func @check_map1(%arg0: tuple<i64, f32>) -> tensor<*xf32> {
   %0 = "onnx.CastMap"(%arg0) {cast_to = "TO_FLOAT", map_form = "DENSE", max_map = 1 : si64} : (tuple<i64, f32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
   // CHECK-NEXT: %0 = "onnx.CastMap"(%arg0) {cast_to = "TO_FLOAT", map_form = "DENSE", max_map = 1 : si64} : (tuple<i64, f32>) -> tensor<*xf32>
 }
 
 // CHECK-LABEL: @check_string(%arg0: tensor<10x20x!onnx.String>) -> tensor<10x20x!onnx.String> {
 func.func @check_string(%arg0: tensor<10x20x!onnx.String>) -> tensor<10x20x!onnx.String> {
-  return %arg0 : tensor<10x20x!onnx.String>
-  // CHECK-NEXT: return %arg0 : tensor<10x20x!onnx.String>
+  onnx.Return %arg0 : tensor<10x20x!onnx.String>
+  // CHECK-NEXT: onnx.Return %arg0 : tensor<10x20x!onnx.String>
 }
 
 // CHECK-LABEL: @check_seq(%arg0: tensor<10x20xf32>, %arg1: tensor<5x20xf32>) -> tensor<*xf32> {
@@ -19,7 +19,7 @@ func.func @check_seq(%arg0: tensor<10x20xf32>, %arg1: tensor<5x20xf32>) -> tenso
   %cst = onnx.Constant dense<[0]> : tensor<1xi32>
   %0 = "onnx.SequenceConstruct"(%arg0, %arg1) : (tensor<10x20xf32>, tensor<5x20xf32>) -> !onnx.Seq<tensor<*xf32>>
   %1 = "onnx.SequenceAt"(%0, %cst) : (!onnx.Seq<tensor<*xf32>>, tensor<1xi32>) -> tensor<*xf32>
-  return %1 : tensor<*xf32>
+  onnx.Return %1 : tensor<*xf32>
   // CHECK-NEXT: %0 = onnx.Constant dense<0> : tensor<1xi32>
   // CHECK-NEXT: %1 = "onnx.SequenceConstruct"(%arg0, %arg1) : (tensor<10x20xf32>, tensor<5x20xf32>) -> !onnx.Seq<tensor<*xf32>>
   // CHECK-NEXT: %2 = "onnx.SequenceAt"(%1, %0) : (!onnx.Seq<tensor<*xf32>>, tensor<1xi32>) -> tensor<*xf32>
@@ -28,57 +28,57 @@ func.func @check_seq(%arg0: tensor<10x20xf32>, %arg1: tensor<5x20xf32>) -> tenso
 // CHECK-LABEL: func.func @check_opt(%arg0: !onnx.Opt<tensor<*xf32>>) -> !onnx.Opt<tensor<*xf32>> {
 func.func @check_opt(%arg0: !onnx.Opt<tensor<*xf32>>) -> !onnx.Opt<tensor<*xf32>> {
   %0 = "onnx.Identity"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> !onnx.Opt<tensor<*xf32>>
-  return %0 : !onnx.Opt<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Opt<tensor<*xf32>>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.Identity"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> !onnx.Opt<tensor<*xf32>>
-  // CHECK-NEXT: return [[VAR_0_]] : !onnx.Opt<tensor<*xf32>>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : !onnx.Opt<tensor<*xf32>>
 }
 
 // CHECK-LABEL: func.func @check_opt_seq(%arg0: !onnx.Opt<!onnx.Seq<tensor<*xf32>>>) -> !onnx.Opt<!onnx.Seq<tensor<*xf32>>> {
 func.func @check_opt_seq(%arg0: !onnx.Opt<!onnx.Seq<tensor<*xf32>>>) -> !onnx.Opt<!onnx.Seq<tensor<*xf32>>> {
   %0 = "onnx.Identity"(%arg0) : (!onnx.Opt<!onnx.Seq<tensor<*xf32>>>) -> !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
-  return %0 : !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
+  onnx.Return %0 : !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.Identity"(%arg0) : (!onnx.Opt<!onnx.Seq<tensor<*xf32>>>) -> !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
-  // CHECK-NEXT: return [[VAR_0_]] : !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
 }
 
 // CHECK-LABEL: func.func @check_optional(%arg0: tensor<*xf32>) -> !onnx.Opt<tensor<*xf32>> {
 func.func @check_optional(%arg0: tensor<*xf32>) -> !onnx.Opt<tensor<*xf32>> {
   %0 = "onnx.Optional"(%arg0) : (tensor<*xf32>) -> !onnx.Opt<tensor<*xf32>>
-  return %0 : !onnx.Opt<tensor<*xf32>>
+  onnx.Return %0 : !onnx.Opt<tensor<*xf32>>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.Optional"(%arg0) : (tensor<*xf32>) -> !onnx.Opt<tensor<*xf32>>
-  // CHECK-NEXT: return [[VAR_0_]] : !onnx.Opt<tensor<*xf32>>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : !onnx.Opt<tensor<*xf32>>
 }
 
 // CHECK-LABEL: func.func @check_optional_none() -> !onnx.Opt<tensor<*xf32>> {
 func.func @check_optional_none() -> !onnx.Opt<tensor<*xf32>> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %1 = "onnx.Optional"(%0) {type = tensor<*xf32>} : (none) -> !onnx.Opt<tensor<*xf32>>
-  return %1 : !onnx.Opt<tensor<*xf32>>
+  onnx.Return %1 : !onnx.Opt<tensor<*xf32>>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK-NEXT: [[VAR_1_:%.+]] = "onnx.Optional"([[VAR_0_]]) {type = tensor<*xf32>} : (none) -> !onnx.Opt<tensor<*xf32>>
-  // CHECK-NEXT: return [[VAR_1_]] : !onnx.Opt<tensor<*xf32>>
+  // CHECK-NEXT: onnx.Return [[VAR_1_]] : !onnx.Opt<tensor<*xf32>>
 }
 
 // CHECK-LABEL: func.func @check_optionalgetelement(%arg0: !onnx.Opt<tensor<*xf32>>) -> tensor<*xf32> {
 func.func @check_optionalgetelement(%arg0: !onnx.Opt<tensor<*xf32>>) -> tensor<*xf32> {
   %0 = "onnx.OptionalGetElement"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+  onnx.Return %0 : tensor<*xf32>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.OptionalGetElement"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> tensor<*xf32>
-  // CHECK-NEXT: return [[VAR_0_]] : tensor<*xf32>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : tensor<*xf32>
 }
 
 // CHECK-LABEL: func.func @check_optionalhaselement(%arg0: !onnx.Opt<tensor<*xf32>>) -> tensor<i1> {
 func.func @check_optionalhaselement(%arg0: !onnx.Opt<tensor<*xf32>>) -> tensor<i1> {
   %0 = "onnx.OptionalHasElement"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> tensor<i1>
-  return %0 : tensor<i1>
+  onnx.Return %0 : tensor<i1>
   // CHECK-NEXT: [[VAR_0_:%.+]] = "onnx.OptionalHasElement"(%arg0) : (!onnx.Opt<tensor<*xf32>>) -> tensor<i1>
-  // CHECK-NEXT: return [[VAR_0_]] : tensor<i1>
+  // CHECK-NEXT: onnx.Return [[VAR_0_]] : tensor<i1>
 }
 
 // CHECK-LABEL: @check_seq_map(%arg0: tensor<*xf32>) -> !onnx.Seq<tuple<i64, f32>> {
 func.func @check_seq_map(%arg0: tensor<*xf32>) -> !onnx.Seq<tuple<i64, f32>> {
   %0 = "onnx.ZipMap"(%arg0) {classlabels_int64s = [10, 20, 30]} : (tensor<*xf32>) -> !onnx.Seq<tuple<i64, f32>>
-  return %0 : !onnx.Seq<tuple<i64, f32>>
+  onnx.Return %0 : !onnx.Seq<tuple<i64, f32>>
   // CHECK-NEXT: %0 = "onnx.ZipMap"(%arg0) {classlabels_int64s = [10, 20, 30]} : (tensor<*xf32>) -> !onnx.Seq<tuple<i64, f32>>
-  // CHECK-NEXT: return %0 : !onnx.Seq<tuple<i64, f32>>
+  // CHECK-NEXT: onnx.Return %0 : !onnx.Seq<tuple<i64, f32>>
 }

--- a/test/mlir/onnx/parse/external_data.json
+++ b/test/mlir/onnx/parse/external_data.json
@@ -621,5 +621,5 @@
 // CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui64>
-// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
+// CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
 // CHECK:         }

--- a/test/mlir/onnx/parse/external_data.json
+++ b/test/mlir/onnx/parse/external_data.json
@@ -621,5 +621,5 @@
 // CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui64>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
+// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
 // CHECK:         }

--- a/test/mlir/onnx/parse/fp16_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp16_nonraw_data.json
@@ -99,5 +99,5 @@
 // CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_names = [], output_names = ["output_f16", "output_bf16"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xbf16>
-// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
+// CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
 // CHECK:         }

--- a/test/mlir/onnx/parse/fp16_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp16_nonraw_data.json
@@ -99,5 +99,5 @@
 // CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_names = [], output_names = ["output_f16", "output_bf16"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xbf16>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
+// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
 // CHECK:         }

--- a/test/mlir/onnx/parse/fp16_raw_data.json
+++ b/test/mlir/onnx/parse/fp16_raw_data.json
@@ -94,5 +94,5 @@
 // CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_names = [], output_names = ["output_f16", "output_bf16"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xbf16>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
+// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
 // CHECK:         }

--- a/test/mlir/onnx/parse/fp16_raw_data.json
+++ b/test/mlir/onnx/parse/fp16_raw_data.json
@@ -94,5 +94,5 @@
 // CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_names = [], output_names = ["output_f16", "output_bf16"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xbf16>
-// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
+// CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
 // CHECK:         }

--- a/test/mlir/onnx/parse/fusedmatmul.onnxtext
+++ b/test/mlir/onnx/parse/fusedmatmul.onnxtext
@@ -24,5 +24,5 @@ fusedmatmuller (float[2,3] lhs, float[4,3] rhs) => (float[2,4] output) {
 // CHECK:         [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {perm = [1, 0]} : (tensor<4x3xf32>) -> tensor<3x4xf32>
 // CHECK:         [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<2x3xf32>, tensor<3x4xf32>) -> tensor<2x4xf32>
 // CHECK:         [[VAR_3_:%.+]] = "onnx.Mul"([[VAR_2_]], [[VAR_0_]]) : (tensor<2x4xf32>, tensor<1xf32>) -> tensor<2x4xf32>
-// CHECK:          return [[VAR_3_]] : tensor<2x4xf32>
+// CHECK:         return [[VAR_3_]] : tensor<2x4xf32>
 // CHECK:       }

--- a/test/mlir/onnx/parse/nonraw_data.json
+++ b/test/mlir/onnx/parse/nonraw_data.json
@@ -500,5 +500,5 @@
 // CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui64>
-// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
+// CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
 // CHECK:         }

--- a/test/mlir/onnx/parse/nonraw_data.json
+++ b/test/mlir/onnx/parse/nonraw_data.json
@@ -500,5 +500,5 @@
 // CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui64>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
+// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
 // CHECK:         }

--- a/test/mlir/onnx/parse/raw_data.json
+++ b/test/mlir/onnx/parse/raw_data.json
@@ -453,5 +453,5 @@
 // CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui64>
-// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
+// CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
 // CHECK:         }

--- a/test/mlir/onnx/parse/raw_data.json
+++ b/test/mlir/onnx/parse/raw_data.json
@@ -453,5 +453,5 @@
 // CHECK-DAG:       [[VAR_9_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf64>
 // CHECK-DAG:       [[VAR_10_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui32>
 // CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui64>
-// CHECK:           return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
+// CHECK:           onnx.FuncReturn [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
 // CHECK:         }

--- a/test/mlir/onnx/parse/string_data.json
+++ b/test/mlir/onnx/parse/string_data.json
@@ -59,5 +59,5 @@
 // CHECK-LABEL:  func.func @main_graph
 // CHECK-SAME:   () -> tensor<2x!onnx.String> attributes {input_names = [], output_names = ["output"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<["hello", "world"]> : tensor<2x!onnx.String>
-// CHECK:           return %0 : tensor<2x!onnx.String>
+// CHECK:           onnx.FuncReturn %0 : tensor<2x!onnx.String>
 // CHECK:         }

--- a/test/mlir/onnx/parse/string_data.json
+++ b/test/mlir/onnx/parse/string_data.json
@@ -59,5 +59,5 @@
 // CHECK-LABEL:  func.func @main_graph
 // CHECK-SAME:   () -> tensor<2x!onnx.String> attributes {input_names = [], output_names = ["output"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<["hello", "world"]> : tensor<2x!onnx.String>
-// CHECK:           onnx.FuncReturn %0 : tensor<2x!onnx.String>
+// CHECK:           onnx.Return %0 : tensor<2x!onnx.String>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_abs.onnxtext
+++ b/test/mlir/onnx/parse/test_abs.onnxtext
@@ -16,5 +16,5 @@ test_abs (float[3,4,5] x) => (float[3,4,5] y) {
 // CHECK-LABEL:  func.func @main_graph
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {{.*}} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Abs"([[PARAM_0_]]) : (tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-// CHECK:           return [[VAR_0_]] : tensor<3x4x5xf32>
+// CHECK:           onnx.FuncReturn [[VAR_0_]] : tensor<3x4x5xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_abs.onnxtext
+++ b/test/mlir/onnx/parse/test_abs.onnxtext
@@ -16,5 +16,5 @@ test_abs (float[3,4,5] x) => (float[3,4,5] y) {
 // CHECK-LABEL:  func.func @main_graph
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {{.*}} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Abs"([[PARAM_0_]]) : (tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
-// CHECK:           onnx.FuncReturn [[VAR_0_]] : tensor<3x4x5xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4x5xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
+++ b/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
@@ -274,5 +274,5 @@
 // CHECK-DAG:         [[VAR_11_:%.+]] = "onnx.Identity"([[PARAM_5_]]) : (tensor<*xf32>) -> tensor<*xf32>
 // CHECK:             onnx.Yield [[VAR_9_]], [[VAR_10_]], [[VAR_11_]] : tensor<i1>, tensor<*xf32>, tensor<*xf32>
 // CHECK:           }) {{.*}} : (tensor<i64>, tensor<i1>, tensor<f32>) -> (tensor<i1>, tensor<2xf32>)
-// CHECK:           return [[VAR_8_]]#1 : tensor<2xf32>
+// CHECK:           onnx.FuncReturn [[VAR_8_]]#1 : tensor<2xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
+++ b/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
@@ -274,5 +274,5 @@
 // CHECK-DAG:         [[VAR_11_:%.+]] = "onnx.Identity"([[PARAM_5_]]) : (tensor<*xf32>) -> tensor<*xf32>
 // CHECK:             onnx.Yield [[VAR_9_]], [[VAR_10_]], [[VAR_11_]] : tensor<i1>, tensor<*xf32>, tensor<*xf32>
 // CHECK:           }) {{.*}} : (tensor<i64>, tensor<i1>, tensor<f32>) -> (tensor<i1>, tensor<2xf32>)
-// CHECK:           onnx.FuncReturn [[VAR_8_]]#1 : tensor<2xf32>
+// CHECK:           onnx.Return [[VAR_8_]]#1 : tensor<2xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
+++ b/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
@@ -83,5 +83,5 @@
 // CHECK-LABEL:  func.func @main_graph
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x!onnx.String>) -> tensor<3x!onnx.String> attributes {input_names = ["x"], output_names = ["y"]} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.StringNormalizer"([[PARAM_0_]]) {case_change_action = "NONE", is_case_sensitive = 1 : si64, stopwords = ["monday"]} : (tensor<4x!onnx.String>) -> tensor<3x!onnx.String>
-// CHECK:           onnx.FuncReturn [[VAR_0_]] : tensor<3x!onnx.String>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3x!onnx.String>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
+++ b/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
@@ -83,5 +83,5 @@
 // CHECK-LABEL:  func.func @main_graph
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x!onnx.String>) -> tensor<3x!onnx.String> attributes {input_names = ["x"], output_names = ["y"]} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.StringNormalizer"([[PARAM_0_]]) {case_change_action = "NONE", is_case_sensitive = 1 : si64, stopwords = ["monday"]} : (tensor<4x!onnx.String>) -> tensor<3x!onnx.String>
-// CHECK:           return [[VAR_0_]] : tensor<3x!onnx.String>
+// CHECK:           onnx.FuncReturn [[VAR_0_]] : tensor<3x!onnx.String>
 // CHECK:         }


### PR DESCRIPTION
Introduces ONNX-specific ONNXReturnOp which allows operand types to have more specific shapes than the function signature return types. The shapes will be propagated to the function signature during the next shape inference pass. The ONNXReturnOp is replaced by func::ReturnOp in a new pass StandardFuncReturnPass, similar to how ScrubDisposablePass replaces DisposableElementsAttr with DenseElementsAttr. (This was the easiest way to make the new op not conflict with existing lowering implementations. We might consider moving both to the passes that lower ONNX to Krnl/Mhlo/etc.)

This is intended to solve the problem with changing shape in constant propagation illustrated by PR #2186.

As discussed in issue #2185 and issue #1787 I plan to remove the ONNXCallOp and remove the construction of mlir functions to represent ONNX functions and instead inline ONNX functions during import in FrontendDialectTransformer. Therefore ONNXReturnOp will only be used to terminate the single top-level main graph function that represents an ONNX model in the ONNX dialect.