### PR TITLE
An option to specify axis for verification with softmax in RunONNXModel.py

### DIFF
--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -85,7 +85,7 @@ parser.add_argument('--verify-with-softmax',
                     default=None,
                     help="Verify the result obtained by applying softmax along with"
                     " specific axis. The axis can be specified"
-                    " by --verify-softmax-axis=<axis>.")
+                    " by --verify-with-softmax=<axis>.")
 parser.add_argument('--verify-every-value',
                     action='store_true',
                     help="Verify every value of the output using atol and rtol")

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -628,8 +628,9 @@ def main():
             if (args.verify_with_softmax is not None):
                 for i, name in enumerate(output_names):
                     print(
-                        "Verifying using softmax for output {}:{}".format(name,
-                                                          list(outs[i].shape)))
+                        "Verifying using softmax along with"
+                        " axis {}".format(args.verify_with_softmax),
+                        " for output {}:{}".format(name, list(outs[i].shape)))
                     total_elements = 0
                     mismatched_elements = 0
                     softmax_outs = softmax(outs[i])

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -86,10 +86,6 @@ parser.add_argument('--verify-with-softmax',
                     help="Verify the result obtained by applying softmax along with"
                     " specific axis. The axis can be specified"
                     " by --verify-softmax-axis=<axis>.")
-parser.add_argument('--axis-for-verification-with-softmax',
-                    type=int,
-                    default=-1,
-                    help="Axis used in verification with softmax")
 parser.add_argument('--verify-every-value',
                     action='store_true',
                     help="Verify every value of the output using atol and rtol")

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -84,7 +84,7 @@ parser.add_argument('--verify-with-softmax',
                     action='store_true',
                     help="Verify the result obtained by applying softmax "
                     "to the output. Axis can be specified by --verify-softmax-axis.")
-parser.add_argument('--verify-softmax-axis',
+parser.add_argument('--axis-for-verification-with-softmax',
                     type=int,
                     default=-1,
                     help="Axis used in verification with softmax")
@@ -237,7 +237,7 @@ def ordinal(n):
 
 
 def softmax(x):
-    return np.exp(x)/np.sum(np.exp(x), axis = args.verify_softmax_axis, keepdims = True)
+    return np.exp(x)/np.sum(np.exp(x), axis = args.axis_for_verification_with_softmax, keepdims = True)
 
 
 def execute_commands(cmds):


### PR DESCRIPTION
Added an argument in `--verify-with-softmax` option to specify axis along which Softmax is performed. -1 indicates last dimension.
ex.
--verify ref --verify-with-softmax -1  