### PR TITLE
Upgrade numpy and pillow dependencies 

### DIFF
--- a/docs/mnist_example/requirements.txt
+++ b/docs/mnist_example/requirements.txt
@@ -1,4 +1,4 @@
 numpy~=1.22.1
-pillow~=9.3.0
+pillow~=9.4.0
 torch~=1.13.1
 torchvision~=0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 lit~=15.0
 # numpy 1.24 deprecates np.object, np.bool, np.float, np.complex, np.str,
 # and np.int which are used heavily in onnx-mlir.
-numpy~=1.22.1, <=1.23.5
-pillow~=9.3.0
+numpy~=1.22.2, <=1.23.5
 protobuf~=3.20
 pytest~=7.2
 pytest-xdist~=3.0


### PR DESCRIPTION
I have upgraded the following based on the synk scan results https://app.snyk.io/org/megan-uqq:

numpy to `1.22.2`
pillow to `9.4.0`