### PR TITLE
Upgrade torch and torchvision

### DIFF
--- a/docs/mnist_example/requirements.txt
+++ b/docs/mnist_example/requirements.txt
@@ -1,4 +1,4 @@
 numpy~=1.22.2
 pillow~=9.4.0
-torch~=2.0.0
+torch~=1.13.1
 torchvision~=0.15.1

--- a/docs/mnist_example/requirements.txt
+++ b/docs/mnist_example/requirements.txt
@@ -1,4 +1,4 @@
 numpy~=1.22.2
 pillow~=9.4.0
-torch~=1.13.1
-torchvision~=0.14.1
+torch~=2.0.0
+torchvision~=0.15.1

--- a/docs/mnist_example/requirements.txt
+++ b/docs/mnist_example/requirements.txt
@@ -1,4 +1,4 @@
 numpy~=1.22.2
 pillow~=9.4.0
-torch~=1.13.1
+torch~=2.0.0
 torchvision~=0.15.1


### PR DESCRIPTION
We have to upgrade torch and torchvision to avoid vulnerabilities mentioned in the LFX and snyk scans. 

`torchvision 0.15.1 depends on torch==2.0.0`