### PR TITLE
rename ONNXReturnOp to ONNXYieldOp

### DIFF
--- a/docs/Dialects/onnx.md
+++ b/docs/Dialects/onnx.md
@@ -7572,34 +7572,6 @@ Effects: MemoryEffects::Effect{}
 | :----: | ----------- |
 | `Y` | tensor of 8-bit unsigned integer values or tensor of 16-bit unsigned integer values or tensor of 32-bit unsigned integer values or tensor of 64-bit unsigned integer values or tensor of 8-bit signless integer values or tensor of 16-bit signless integer values or tensor of 32-bit signless integer values or tensor of 64-bit signless integer values or tensor of bfloat16 type values or tensor of 16-bit float values or tensor of 32-bit float values or tensor of 64-bit float values or tensor of string type values or tensor of 1-bit signless integer values or tensor of complex type with 32-bit float elements values or tensor of complex type with 64-bit float elements values
 
-### `onnx.Return` (::mlir::ONNXReturnOp)
-
-ONNX return operation
-
-
-Syntax:
-
-```
-operation ::= `onnx.Return` attr-dict ($operands^ `:` type($operands))?
-```
-
-The `ONNX.Return` operation represents a return operation within an ONNX subgraph.
-The operation takes variable number of operands and produces no results.
-
-This operation is not part of the standard and was added to assist onnx-mlir.
-
-Traits: AlwaysSpeculatableImplTrait, ReturnLike, Terminator
-
-Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
-
-Effects: MemoryEffects::Effect{}
-
-#### Operands:
-
-| Operand | Description |
-| :-----: | ----------- |
-| `operands` | any type
-
 ### `onnx.ReverseSequence` (::mlir::ONNXReverseSequenceOp)
 
 ONNX ReverseSequence operation
@@ -10176,6 +10148,34 @@ Effects: MemoryEffects::Effect{}
 | Result | Description |
 | :----: | ----------- |
 | `C` | tensor of 1-bit signless integer values
+
+### `onnx.Yield` (::mlir::ONNXYieldOp)
+
+ONNX yield operation
+
+
+Syntax:
+
+```
+operation ::= `onnx.Yield` attr-dict ($operands^ `:` type($operands))?
+```
+
+The `onnx.Yield` operation represents a yield operation within an ONNX subgraph.
+The operation takes variable number of operands and produces no results.
+
+This operation is not part of the standard and was added to assist onnx-mlir.
+
+Traits: AlwaysSpeculatableImplTrait, ReturnLike, Terminator
+
+Interfaces: ConditionallySpeculatable, NoMemoryEffect (MemoryEffectOpInterface)
+
+Effects: MemoryEffects::Effect{}
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+| `operands` | any type
 
 ### `onnx.ZipMap` (::mlir::ONNXZipMapOp)
 

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -338,7 +338,7 @@ private:
    * @param op operations whose attributes will be updated to contain
    * input/output names.
    * @param useStdReturn if set to true, will emit standard return op as
-   * terminator, otherwise, will use OnnxReturn op as terminator.
+   * terminator, otherwise, will use ONNXYield op as terminator.
    * @return function type corresponding to the subgraph input/output signature.
    */
   FunctionType importGraph(const onnx::GraphProto &graph, Region &region,
@@ -423,7 +423,7 @@ private:
       builder_.create<func::ReturnOp>(UnknownLoc(), retVals);
     else
       // Create a return operation to return all ONNX output tensors.
-      builder_.create<ONNXReturnOp>(UnknownLoc(), retVals);
+      builder_.create<ONNXYieldOp>(UnknownLoc(), retVals);
 
     op->setAttr("input_names", builder_.getStrArrayAttr(inputNames));
     op->setAttr("output_names", builder_.getStrArrayAttr(outputNames));

--- a/src/Conversion/ONNXToKrnl/ControlFlow/If.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/If.cpp
@@ -55,12 +55,12 @@ private:
     scfBranch.takeBody(graph);
     rewriter.setInsertionPointToEnd(&scfBranch.back());
 
-    Operation *returnOp = scfBranch.back().getTerminator();
+    Operation *yieldOp = scfBranch.back().getTerminator();
     llvm::SmallVector<Value> outputs;
-    if (failed(rewriter.getRemappedValues(returnOp->getOperands(), outputs))) {
+    if (failed(rewriter.getRemappedValues(yieldOp->getOperands(), outputs))) {
       llvm_unreachable("failed to convert branch return values");
     }
-    rewriter.replaceOpWithNewOp<scf::YieldOp>(returnOp, outputs);
+    rewriter.replaceOpWithNewOp<scf::YieldOp>(yieldOp, outputs);
   }
 };
 

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -12,7 +12,7 @@
 // Ops are listed in alphabetical order, in 2 sections.
 //
 // * First are ops that are used to assist the processing of ONNX dialect.
-//   Example are CallOp, ReturnOp,...
+//   Example are CallOp, YieldOp,...
 //
 // * Second are ops that are used to handle optional arguments/special cases
 //   of original ONNX ops. These ops may possibly be removed in the future.
@@ -347,12 +347,11 @@ def ONNXPrintSignatureOp:ONNX_Op<"PrintSignature", []> {
 }
 
 //===----------------------------------------------------------------------===//
-// ONNX ReturnOp
-def ONNXReturnOp : ONNX_Op<"Return", [Pure,
-                                ReturnLike, Terminator]> {
-  let summary = "ONNX return operation";
+// ONNX YieldOp
+def ONNXYieldOp : ONNX_Op<"Yield", [Pure, ReturnLike, Terminator]> {
+  let summary = "ONNX yield operation";
   let description = [{
-    The `ONNX.Return` operation represents a return operation within an ONNX subgraph.
+    The `onnx.Yield` operation represents a yield operation within an ONNX subgraph.
     The operation takes variable number of operands and produces no results.
 
     This operation is not part of the standard and was added to assist onnx-mlir.

--- a/src/Transform/ONNX/InstrumentPass.cpp
+++ b/src/Transform/ONNX/InstrumentPass.cpp
@@ -135,7 +135,7 @@ public:
           if (instrumentBefore)
             opBuilder.create<mlir::KrnlInstrumentOp>(loc, op, beforeTag());
 
-          // Can not insert after Op (e.g. ONNXReturnOP) with IsTerminator Trait
+          // Can not insert after Op (e.g. ONNXYieldOP) with IsTerminator Trait
           if (instrumentAfter && !op->hasTrait<OpTrait::IsTerminator>()) {
             opBuilder.setInsertionPointAfter(op);
             opBuilder.create<mlir::KrnlInstrumentOp>(loc, op, afterTag());

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -31,7 +31,7 @@ namespace {
 // inference cascades through the ops from the graph's inputs to outputs, and
 // recursively into subgraphs. Ops with subgraphs, namely if/loop/scan, are
 // matched by the first pattern before the pass recurses into the subgraph. The
-// recursive subgraph pass ends with the ONNXReturnOp whose pattern reruns shape
+// recursive subgraph pass ends with the ONNXYieldOp whose pattern reruns shape
 // inference for the parent if/loop/scan op. The effect is that the 2 or 3 runs
 // of the parent if/loop/scan op accomplish two phases of shape propagation to
 // and from the subgraph(s): The first run propagates input shapes from the

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -308,10 +308,10 @@ func.func @test_if_verifier_1(%arg0: tensor<i1>) -> tensor<2xf32> {
   %0 = "onnx.If"(%arg0) ({
     %1 = "onnx.Constant"() {value = dense<[2.000000e+00, 1.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
     %2 = "onnx.NoValue"() {value} : () -> none
-    onnx.Return %1, %2 : tensor<2xf32>, none
+    onnx.Yield %1, %2 : tensor<2xf32>, none
   }, {
     %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
-    onnx.Return %1 : tensor<2xf32>
+    onnx.Yield %1 : tensor<2xf32>
   }) : (tensor<i1>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
@@ -322,11 +322,11 @@ func.func @test_if_verifier_2(%arg0: tensor<i1>) -> !onnx.Seq<tensor<*xf32>> {
   // expected-error @+1 {{'onnx.If' op else branch #results=2 differ from if #results=1}}
   %0 = "onnx.If"(%arg0) ({
     %1 = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
-    onnx.Return %1 : !onnx.Seq<tensor<*xf32>>
+    onnx.Yield %1 : !onnx.Seq<tensor<*xf32>>
   }, {
     %1 = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
     %2 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
-    onnx.Return %1, %2 : !onnx.Seq<tensor<*xf32>>, tensor<2xf32>
+    onnx.Yield %1, %2 : !onnx.Seq<tensor<*xf32>>, tensor<2xf32>
   }) : (tensor<i1>) -> !onnx.Seq<tensor<*xf32>>
   return %0 : !onnx.Seq<tensor<*xf32>>
 }
@@ -337,10 +337,10 @@ func.func @test_if_verifier_3(%arg0: tensor<i1>) -> tensor<2xf32> {
   // expected-error @+1 {{'onnx.If' op then branch disagrees on result type #1 of 1}}
   %0 = "onnx.If"(%arg0) ({
     %1 = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
-    onnx.Return %1 : !onnx.Seq<tensor<*xf32>>
+    onnx.Yield %1 : !onnx.Seq<tensor<*xf32>>
   }, {
     %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
-    onnx.Return %1 : tensor<2xf32>
+    onnx.Yield %1 : tensor<2xf32>
   }) : (tensor<i1>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
@@ -351,10 +351,10 @@ func.func @test_if_verifier_4(%arg0: tensor<i1>) -> !onnx.Seq<tensor<*xf32>> {
   // expected-error @+1 {{'onnx.If' op else branch disagrees on result type #1 of 1}}
   %0 = "onnx.If"(%arg0) ({
     %1 = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
-    onnx.Return %1 : !onnx.Seq<tensor<*xf32>>
+    onnx.Yield %1 : !onnx.Seq<tensor<*xf32>>
   }, {
     %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
-    onnx.Return %1 : tensor<2xf32>
+    onnx.Yield %1 : tensor<2xf32>
   }) : (tensor<i1>) -> !onnx.Seq<tensor<*xf32>>
   return %0 : !onnx.Seq<tensor<*xf32>>
 }

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -810,7 +810,7 @@ func.func @test_loop_derive_max_trip_count(%arg0: tensor<?x30xf32>) -> tensor<?x
     %6 = "onnx.Add"(%arg3, %5) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     %7 = "onnx.Relu"(%arg5) : (tensor<?x30xf32>) -> tensor<?x30xf32>
     %8 = "onnx.Less"(%6, %arg4) : (tensor<i32>, tensor<i32>) -> tensor<i1>
-    onnx.Return %8, %6, %arg4, %7 : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
+    onnx.Yield %8, %6, %arg4, %7 : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
   }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
   return %4#3 : tensor<?x?x30xf32>
 // CHECK-LABEL:  func.func @test_loop_derive_max_trip_count
@@ -824,7 +824,7 @@ func.func @test_loop_derive_max_trip_count(%arg0: tensor<?x30xf32>) -> tensor<?x
 // CHECK:           ^bb0([[arg1_:%.+]]: tensor<i64>, [[arg2_:%.+]]: tensor<i1>, [[arg3_:%.+]]: tensor<i32>, [[arg4_:%.+]]: tensor<i32>, [[arg5_:%.+]]: tensor<?x30xf32>):
 // CHECK-DAG:         [[VAR_6_:%.+]] = "onnx.Add"([[arg3_]], [[VAR_1_]]) : (tensor<i32>, tensor<i32>) -> tensor<i32>
 // CHECK-DAG:         [[VAR_7_:%.+]] = "onnx.Relu"([[arg5_]]) : (tensor<?x30xf32>) -> tensor<?x30xf32>
-// CHECK:             onnx.Return [[arg2_]], [[VAR_6_]], [[arg4_]], [[VAR_7_]] : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
+// CHECK:             onnx.Yield [[arg2_]], [[VAR_6_]], [[arg4_]], [[VAR_7_]] : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
 // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
 // CHECK:           return [[VAR_5_]]#3 : tensor<?x?x30xf32>
 
@@ -844,7 +844,7 @@ func.func @test_loop_derive_max_trip_count_non_constant_ub(%arg0: tensor<?x30xf3
     %5 = "onnx.Add"(%arg4, %4) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     %6 = "onnx.Relu"(%arg6) : (tensor<?x30xf32>) -> tensor<?x30xf32>
     %7 = "onnx.Less"(%5, %arg5) : (tensor<i32>, tensor<i32>) -> tensor<i1>
-    onnx.Return %7, %5, %arg5, %6 : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
+    onnx.Yield %7, %5, %arg5, %6 : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
   }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
   return %3#3 : tensor<?x?x30xf32>
 // CHECK-LABEL:  func @test_loop_derive_max_trip_count_non_constant_ub
@@ -866,7 +866,7 @@ func.func @test_loop_derive_max_trip_count_non_constant_ub(%arg0: tensor<?x30xf3
 // CHECK:           ^bb0([[arg2_:%.+]]: tensor<i64>, [[arg3_:%.+]]: tensor<i1>, [[arg4_:%.+]]: tensor<i32>, [[arg5_:%.+]]: tensor<i32>, [[arg6_:%.+]]: tensor<?x30xf32>):
 // CHECK-DAG:         [[VAR_14_:%.+]] = "onnx.Add"([[arg4_]], [[VAR_0_]]) : (tensor<i32>, tensor<i32>) -> tensor<i32>
 // CHECK-DAG:         [[VAR_15_:%.+]] = "onnx.Relu"([[arg6_]]) : (tensor<?x30xf32>) -> tensor<?x30xf32>
-// CHECK:             onnx.Return [[arg3_]], [[VAR_14_]], [[arg5_]], [[VAR_15_]] : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
+// CHECK:             onnx.Yield [[arg3_]], [[VAR_14_]], [[arg5_]], [[VAR_15_]] : tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>
 // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<i32>, tensor<i32>, tensor<?x30xf32>) -> (tensor<i32>, tensor<i32>, tensor<?x30xf32>, tensor<?x?x30xf32>)
 // CHECK:           return [[VAR_13_]]#3 : tensor<?x?x30xf32>
 

--- a/test/mlir/onnx/onnx_lowering.mlir
+++ b/test/mlir/onnx/onnx_lowering.mlir
@@ -1920,9 +1920,9 @@ func.func @test_prelu_broadcast2(%arg0: tensor<3x4x5xf32>, %arg1: tensor<1x5xf32
 // COM: Check simple if lowering.
 func.func @test_if_simple(%arg0: tensor<i1>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<i64> {
   %0 = "onnx.If"(%arg0) ({
-    onnx.Return %arg1 : tensor<i64>
+    onnx.Yield %arg1 : tensor<i64>
   }, {
-    onnx.Return %arg2 : tensor<i64>
+    onnx.Yield %arg2 : tensor<i64>
   }) : (tensor<i1>) -> tensor<i64>
   return %0 : tensor<i64>
 // CHECK-LABEL:  @test_if_simple
@@ -1945,7 +1945,7 @@ func.func private @test_loop_simple_main_graph(%arg0: tensor<i64>, %arg1: tensor
   %0 = "onnx.Loop"(%arg0, %arg1, %arg2) ({
     ^bb0(%body_arg0: tensor<i64>, %body_arg1: tensor<i1>, %body_arg2: tensor<1xi64>):
     %1 = "onnx.Add"(%body_arg2, %body_arg0) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
-    onnx.Return %body_arg1, %1 : tensor<i1>, tensor<1xi64>
+    onnx.Yield %body_arg1, %1 : tensor<i1>, tensor<1xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> tensor<1xi64>
   return %0 : tensor<1xi64>
 
@@ -2021,7 +2021,7 @@ func.func @test_loop(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<?xf32>
   %0 = "onnx.Loop"(%arg0, %arg1) ({
   ^bb0(%arg3: tensor<i64>, %arg4: tensor<i1>):
     %7 = "onnx.Add"(%arg2, %arg2) : (tensor<?xf32>, tensor<?xf32>) -> (tensor<?xf32>)
-    onnx.Return %arg4,  %7 : tensor<i1>, tensor<?xf32>
+    onnx.Yield %arg4,  %7 : tensor<i1>, tensor<?xf32>
   }) : (tensor<i64>, tensor<i1>) -> tensor<?x?xf32>
   return  %0 : tensor<?x?xf32>
 

--- a/test/mlir/onnx/onnx_lowering_O3.mlir
+++ b/test/mlir/onnx/onnx_lowering_O3.mlir
@@ -1728,9 +1728,9 @@ func.func private @test_pown(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>)
 // COM: Check simple if lowering.
 func.func @test_if_simple(%arg0: tensor<i1>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<i64> {
   %0 = "onnx.If"(%arg0) ({
-    onnx.Return %arg1 : tensor<i64>
+    onnx.Yield %arg1 : tensor<i64>
   }, {
-    onnx.Return %arg2 : tensor<i64>
+    onnx.Yield %arg2 : tensor<i64>
   }) : (tensor<i1>) -> tensor<i64>
   return %0 : tensor<i64>
 // CHECK-LABEL:  @test_if_simple
@@ -1753,7 +1753,7 @@ func.func private @test_loop_simple_main_graph(%arg0: tensor<i64>, %arg1: tensor
   %0 = "onnx.Loop"(%arg0, %arg1, %arg2) ({
     ^bb0(%body_arg0: tensor<i64>, %body_arg1: tensor<i1>, %body_arg2: tensor<1xi64>):
     %1 = "onnx.Add"(%body_arg2, %body_arg0) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
-    onnx.Return %body_arg1, %1 : tensor<i1>, tensor<1xi64>
+    onnx.Yield %body_arg1, %1 : tensor<i1>, tensor<1xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> tensor<1xi64>
   return %0 : tensor<1xi64>
 
@@ -1829,7 +1829,7 @@ func.func @test_loop(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<?xf32>
   %0 = "onnx.Loop"(%arg0, %arg1) ({
   ^bb0(%arg3: tensor<i64>, %arg4: tensor<i1>):
     %7 = "onnx.Add"(%arg2, %arg2) : (tensor<?xf32>, tensor<?xf32>) -> (tensor<?xf32>)
-    onnx.Return %arg4,  %7 : tensor<i1>, tensor<?xf32>
+    onnx.Yield %arg4,  %7 : tensor<i1>, tensor<?xf32>
   }) : (tensor<i64>, tensor<i1>) -> tensor<?x?xf32>
   return  %0 : tensor<?x?xf32>
 

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize.mlir
@@ -161,15 +161,15 @@ func.func @test_if_sign(%arg0: tensor<f32>) -> tensor<i32> {
   %0 = onnx.Constant {value = dense<0.0> : tensor<f32>} : tensor<f32>
   %1 = "onnx.Less"(%arg0, %0) : (tensor<f32>, tensor<f32>) -> tensor<i1>
   %2 = "onnx.If"(%1) ({
-    onnx.Return %minus : tensor<i32>
+    onnx.Yield %minus : tensor<i32>
   }, {
     %3 = "onnx.Greater"(%arg0, %0) : (tensor<f32>, tensor<f32>) -> tensor<i1>
     %4 = "onnx.If"(%3) ({
-      onnx.Return %plus : tensor<i32>
+      onnx.Yield %plus : tensor<i32>
     }, {
-      onnx.Return %zero : tensor<i32>
+      onnx.Yield %zero : tensor<i32>
     }) : (tensor<i1>) -> tensor<i32>
-    onnx.Return %4 : tensor<i32>
+    onnx.Yield %4 : tensor<i32>
   }) : (tensor<i1>) -> tensor<i32>
   return %2 : tensor<i32>
 // mlir2FileCheck.py
@@ -3746,7 +3746,7 @@ func.func @test_loop_tiny_yolo() -> tensor<?xi32> {
     ^bb0(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<i32>):  // no predecessors
       %4 = onnx.Constant dense<1> : tensor<i32>
       %5 = "onnx.Add"(%arg2, %4) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-      onnx.Return %arg1, %5, %arg2 : tensor<i1>, tensor<i32>, tensor<i32>
+      onnx.Yield %arg1, %5, %arg2 : tensor<i1>, tensor<i32>, tensor<i32>
     }) {input_names = ["i", "cond", "prev"], output_names = ["cond_out", "current", "range"]} : (tensor<i64>, tensor<i1>, tensor<i32>) -> (tensor<i32>, tensor<?xi32>)
     return %3#1 : tensor<?xi32>
 

--- a/test/mlir/onnx/onnx_lowering_with_canonicalize_O3.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_canonicalize_O3.mlir
@@ -164,15 +164,15 @@ func.func @test_if_sign(%arg0: tensor<f32>) -> tensor<i32> {
   %0 = onnx.Constant {value = dense<0.0> : tensor<f32>} : tensor<f32>
   %1 = "onnx.Less"(%arg0, %0) : (tensor<f32>, tensor<f32>) -> tensor<i1>
   %2 = "onnx.If"(%1) ({
-    onnx.Return %minus : tensor<i32>
+    onnx.Yield %minus : tensor<i32>
   }, {
     %3 = "onnx.Greater"(%arg0, %0) : (tensor<f32>, tensor<f32>) -> tensor<i1>
     %4 = "onnx.If"(%3) ({
-      onnx.Return %plus : tensor<i32>
+      onnx.Yield %plus : tensor<i32>
     }, {
-      onnx.Return %zero : tensor<i32>
+      onnx.Yield %zero : tensor<i32>
     }) : (tensor<i1>) -> tensor<i32>
-    onnx.Return %4 : tensor<i32>
+    onnx.Yield %4 : tensor<i32>
   }) : (tensor<i1>) -> tensor<i32>
   return %2 : tensor<i32>
 // mlir2FileCheck.py
@@ -3839,7 +3839,7 @@ func.func @test_loop_tiny_yolo() -> tensor<?xi32> {
     ^bb0(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<i32>):  // no predecessors
       %4 = onnx.Constant dense<1> : tensor<i32>
       %5 = "onnx.Add"(%arg2, %4) : (tensor<i32>, tensor<i32>) -> tensor<i32>
-      onnx.Return %arg1, %5, %arg2 : tensor<i1>, tensor<i32>, tensor<i32>
+      onnx.Yield %arg1, %5, %arg2 : tensor<i1>, tensor<i32>, tensor<i32>
     }) {input_names = ["i", "cond", "prev"], output_names = ["cond_out", "current", "range"]} : (tensor<i64>, tensor<i1>, tensor<i32>) -> (tensor<i32>, tensor<?xi32>)
     return %3#1 : tensor<?xi32>
 

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2528,7 +2528,7 @@ func.func @test_loop_simple_no_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor
   ^bb0(%arg3: tensor<*xi64>, %arg4: tensor<*xi1>, %arg5: tensor<*xi64>):
     %1 = "onnx.Identity"(%arg4) : (tensor<*xi1>) -> tensor<*xi1>
     %2 = "onnx.Add"(%arg5, %arg3) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
-    onnx.Return %1, %2 : tensor<*xi1>, tensor<*xi64>
+    onnx.Yield %1, %2 : tensor<*xi1>, tensor<*xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> tensor<*xi64>
   return %0 : tensor<*xi64>
 // CHECK-LABEL:   func @test_loop_simple_no_scan_main_graph
@@ -2537,7 +2537,7 @@ func.func @test_loop_simple_no_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor
 // CHECK:           ^bb0([[I:%.+]]: tensor<i64>, [[BODY_COND:%.+]]: tensor<i1>, [[Y_PREV:%.+]]: tensor<1xi64>):
 // CHECK:             [[NEXT_COND:%.+]] = "onnx.Identity"([[BODY_COND]]) : (tensor<i1>) -> tensor<i1>
 // CHECK:             [[Y_CURR:%.+]] = "onnx.Add"([[Y_PREV]], [[I]]) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
-// CHECK:             onnx.Return [[NEXT_COND]], [[Y_CURR]] : tensor<i1>, tensor<1xi64>
+// CHECK:             onnx.Yield [[NEXT_COND]], [[Y_CURR]] : tensor<i1>, tensor<1xi64>
 // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> tensor<1xi64>
 // CHECK:           return [[Y_FINAL]] : tensor<1xi64>
 // CHECK:         }
@@ -2551,7 +2551,7 @@ func.func @test_loop_simple_one_scan_main_graph(%arg0: tensor<i64>, %arg1: tenso
     %body_0 = "onnx.Identity"(%body_arg1) : (tensor<*xi1>) -> tensor<*xi1>
     %body_1 = "onnx.Add"(%body_arg2, %body_arg0) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
     %body_2 = "onnx.Identity"(%body_1) : (tensor<*xi64>) -> tensor<*xi64>
-    onnx.Return %body_0, %body_1, %body_2 : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
+    onnx.Yield %body_0, %body_1, %body_2 : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<*xi64>, tensor<*xi64>)
   return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
   // CHECK-LABEL:       func @test_loop_simple_one_scan_main_graph
@@ -2561,7 +2561,7 @@ func.func @test_loop_simple_one_scan_main_graph(%arg0: tensor<i64>, %arg1: tenso
   // CHECK:             [[COND_NEXT:%.+]] = "onnx.Identity"([[BODY_COND]]) : (tensor<i1>) -> tensor<i1>
   // CHECK:             [[Y_CURR:%.+]] = "onnx.Add"([[Y_PREV]], [[I]]) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
   // CHECK:             [[Y_CURR_SCAN:%.+]] = "onnx.Identity"([[Y_CURR]]) : (tensor<1xi64>) -> tensor<1xi64>
-  // CHECK:             onnx.Return [[COND_NEXT]], [[Y_CURR]], [[Y_CURR_SCAN]] : tensor<i1>, tensor<1xi64>, tensor<1xi64>
+  // CHECK:             onnx.Yield [[COND_NEXT]], [[Y_CURR]], [[Y_CURR_SCAN]] : tensor<i1>, tensor<1xi64>, tensor<1xi64>
   // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<1xi64>, tensor<?x1xi64>)
   // CHECK:           return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1 : tensor<1xi64>, tensor<?x1xi64>
   // CHECK:         }
@@ -2575,7 +2575,7 @@ func.func @test_loop_simple_one_scan_unranked_main_graph(%arg0: tensor<i64>, %ar
     %body_0 = "onnx.Identity"(%body_arg1) : (tensor<*xi1>) -> tensor<*xi1>
     %body_1 = "onnx.Add"(%body_arg2, %body_arg0) : (tensor<*xi64>, tensor<*xi64>) -> tensor<*xi64>
     %body_2 = "onnx.Identity"(%body_1) : (tensor<*xi64>) -> tensor<*xi64>
-    onnx.Return %body_0, %body_1, %body_2 : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
+    onnx.Yield %body_0, %body_1, %body_2 : tensor<*xi1>, tensor<*xi64>, tensor<*xi64>
   }) : (tensor<i64>, tensor<i1>, tensor<*xi64>) -> (tensor<*xi64>, tensor<*xi64>)
   return %0#0, %0#1 : tensor<*xi64>, tensor<*xi64>
   // CHECK-LABEL:       func @test_loop_simple_one_scan_unranked_main_graph
@@ -2585,7 +2585,7 @@ func.func @test_loop_simple_one_scan_unranked_main_graph(%arg0: tensor<i64>, %ar
   // CHECK:             [[COND_NEXT:%.+]] = "onnx.Identity"([[BODY_COND]]) : (tensor<i1>) -> tensor<i1>
   // CHECK:             [[Y_CURR:%.+]] = "onnx.Add"([[Y_PREV]], [[I]]) : (tensor<*xi64>, tensor<i64>) -> tensor<*xi64>
   // CHECK:             [[Y_CURR_SCAN:%.+]] = "onnx.Identity"([[Y_CURR]]) : (tensor<*xi64>) -> tensor<*xi64>
-  // CHECK:             onnx.Return [[COND_NEXT]], [[Y_CURR]], [[Y_CURR_SCAN]] : tensor<i1>, tensor<*xi64>, tensor<*xi64>
+  // CHECK:             onnx.Yield [[COND_NEXT]], [[Y_CURR]], [[Y_CURR_SCAN]] : tensor<i1>, tensor<*xi64>, tensor<*xi64>
   // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<*xi64>) -> (tensor<*xi64>, tensor<*xi64>)
   // CHECK:           return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1 : tensor<*xi64>, tensor<*xi64>
   // CHECK:         }
@@ -2601,7 +2601,7 @@ func.func @test_loop_multi_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>
   %body_2 = "onnx.Identity"(%body_1) : (tensor<*xi64>) -> tensor<*xi64>
   %body_3 = "onnx.Add"(%body_arg3, %body_arg3) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
   %body_4 = "onnx.Identity"(%body_3) : (tensor<*xf32>) -> tensor<*xf32>
-  onnx.Return %body_0, %body_1, %body_3, %body_2, %body_4 : tensor<*xi1>, tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>
+  onnx.Yield %body_0, %body_1, %body_3, %body_2, %body_4 : tensor<*xi1>, tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>
 }) : (tensor<i64>, tensor<i1>, tensor<1xi64>, tensor<1xf32>) -> (tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>)
   return %0#0, %0#1, %0#2, %0#3 : tensor<*xi64>, tensor<*xf32>, tensor<*xi64>, tensor<*xf32>
   // CHECK-LABEL:       func @test_loop_multi_scan_main_graph
@@ -2613,7 +2613,7 @@ func.func @test_loop_multi_scan_main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>
   // CHECK:             [[Y_CURR_SCAN:%.+]] = "onnx.Identity"([[Y_CURR]]) : (tensor<1xi64>) -> tensor<1xi64>
   // CHECK:             [[Z_CURR:%.+]] = "onnx.Add"([[Z_PREV]], [[Z_PREV]]) : (tensor<1xf32>, tensor<1xf32>) -> tensor<1xf32>
   // CHECK:             [[Z_CURR_SCAN:%.+]] = "onnx.Identity"([[Z_CURR]]) : (tensor<1xf32>) -> tensor<1xf32>
-  // CHECK:             onnx.Return [[COND_NEXT]], [[Y_CURR]], [[Z_CURR]], [[Y_CURR_SCAN]], [[Z_CURR_SCAN]] : tensor<i1>, tensor<1xi64>, tensor<1xf32>, tensor<1xi64>, tensor<1xf32>
+  // CHECK:             onnx.Yield [[COND_NEXT]], [[Y_CURR]], [[Z_CURR]], [[Y_CURR_SCAN]], [[Z_CURR_SCAN]] : tensor<i1>, tensor<1xi64>, tensor<1xf32>, tensor<1xi64>, tensor<1xf32>
   // CHECK:           }) : (tensor<i64>, tensor<i1>, tensor<1xi64>, tensor<1xf32>) -> (tensor<1xi64>, tensor<1xf32>, tensor<?x1xi64>, tensor<?x1xf32>)
   // CHECK:           return [[LOOP_OUT]]#0, [[LOOP_OUT]]#1, [[LOOP_OUT]]#2, [[LOOP_OUT]]#3 : tensor<1xi64>, tensor<1xf32>, tensor<?x1xi64>, tensor<?x1xf32>
   // CHECK:         }
@@ -2625,7 +2625,7 @@ func.func @test_scan_simple_main_graph(%arg0: tensor<2xf32>, %arg1: tensor<3x2xf
   %0:2 = "onnx.Scan"(%arg0, %arg1) ( {
   ^bb0(%arg2: tensor<*xf32>, %arg3: tensor<*xf32>):  // no predecessors
     %1 = "onnx.Add"(%arg2, %arg3) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    onnx.Return %1, %1 : tensor<*xf32>, tensor<*xf32>
+    onnx.Yield %1, %1 : tensor<*xf32>, tensor<*xf32>
   }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<3x2xf32>) -> (tensor<*xf32>, tensor<*xf32>)
   return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
 // CHECK-LABEL:       func @test_scan_simple_main_graph
@@ -2633,7 +2633,7 @@ func.func @test_scan_simple_main_graph(%arg0: tensor<2xf32>, %arg1: tensor<3x2xf
 // CHECK:           [[SCAN_OUT:%.+]]:2 = "onnx.Scan"([[SUM_INIT]], [[TO_SUM]]) (
 // CHECK:           ^bb0([[SUM_PREV:%.+]]: tensor<2xf32>, [[SUM_CURR:%.+]]: tensor<2xf32>):
 // CHECK:             [[ADD:%.+]] = "onnx.Add"([[SUM_PREV]], [[SUM_CURR]]) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-// CHECK:             onnx.Return [[ADD]], [[ADD]] : tensor<2xf32>, tensor<2xf32>
+// CHECK:             onnx.Yield [[ADD]], [[ADD]] : tensor<2xf32>, tensor<2xf32>
 // CHECK:           }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<3x2xf32>) -> (tensor<2xf32>, tensor<3x2xf32>)
 // CHECK:           return [[SCAN_OUT]]#0, [[SCAN_OUT]]#1 : tensor<2xf32>, tensor<3x2xf32>
 // CHECK:         }
@@ -2646,7 +2646,7 @@ func.func @test_scan_simple_unranked_main_graph(%arg0: tensor<2xf32>, %arg1: ten
   %0:2 = "onnx.Scan"(%arg0, %arg1) ( {
   ^bb0(%arg2: tensor<*xf32>, %arg3: tensor<*xf32>):  // no predecessors
     %1 = "onnx.Add"(%arg2, %arg3) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    onnx.Return %1, %1 : tensor<*xf32>, tensor<*xf32>
+    onnx.Yield %1, %1 : tensor<*xf32>, tensor<*xf32>
   }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>)
   return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
 // CHECK-LABEL:       func @test_scan_simple_unranked_main_graph
@@ -2654,7 +2654,7 @@ func.func @test_scan_simple_unranked_main_graph(%arg0: tensor<2xf32>, %arg1: ten
 // CHECK:           [[SCAN_OUT:%.+]]:2 = "onnx.Scan"([[SUM_INIT]], [[TO_SUM]]) (
 // CHECK:           ^bb0([[SUM_PREV:%.+]]: tensor<2xf32>, [[SUM_CURR:%.+]]: tensor<*xf32>):
 // CHECK:             [[ADD:%.+]] = "onnx.Add"([[SUM_PREV]], [[SUM_CURR]]) : (tensor<2xf32>, tensor<*xf32>) -> tensor<*xf32>
-// CHECK:             onnx.Return [[ADD]], [[ADD]] : tensor<*xf32>, tensor<*xf32>
+// CHECK:             onnx.Yield [[ADD]], [[ADD]] : tensor<*xf32>, tensor<*xf32>
 // CHECK:           }) {num_scan_inputs = 1 : si64} : (tensor<2xf32>, tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>)
 // CHECK:           return [[SCAN_OUT]]#0, [[SCAN_OUT]]#1 : tensor<*xf32>, tensor<*xf32>
 // CHECK:         }
@@ -3457,12 +3457,12 @@ func.func @test_if_1(%arg0: tensor<i1>) -> (tensor<*xf32>, tensor<*xi16>, tensor
     %3 = onnx.Constant {value = dense<[2.000000e+00, 1.000000e+00]> : tensor<2xf32>} : tensor<*xf32>
     %4 = onnx.Constant {value = dense<[1, 2]> : tensor<2xi16>} : tensor<*xi16>
     %5 = onnx.Constant {value = dense<1> : tensor<2x3xui8>} : tensor<*xui8>
-    onnx.Return %3, %4, %5 : tensor<*xf32>, tensor<*xi16>, tensor<*xui8>
+    onnx.Yield %3, %4, %5 : tensor<*xf32>, tensor<*xi16>, tensor<*xui8>
   }, {
     %3 = onnx.Constant {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : tensor<*xf32>
     %4 = onnx.Constant {value = dense<[1, 2, 3]> : tensor<3xi16>} : tensor<*xi16>
     %5 = onnx.Constant {value = dense<[1, 2, 3]> : tensor<3xui8>} : tensor<*xui8>
-    onnx.Return %3, %4, %5 : tensor<*xf32>, tensor<*xi16>, tensor<*xui8>
+    onnx.Yield %3, %4, %5 : tensor<*xf32>, tensor<*xi16>, tensor<*xui8>
   }) : (tensor<i1>) -> (tensor<*xf32>, tensor<*xi16>, tensor<*xui8>)
   return %0, %1, %2 : tensor<*xf32>, tensor<*xi16>, tensor<*xui8>
 
@@ -3475,9 +3475,9 @@ func.func @test_if_1(%arg0: tensor<i1>) -> (tensor<*xf32>, tensor<*xi16>, tensor
 // CHECK-DAG:       [[VAR_2_1_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi16>
 // CHECK-DAG:       [[VAR_3_1_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_0_:%.+]]:3 = "onnx.If"([[PARAM_0_]]) ({
-// CHECK-DAG:         onnx.Return [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : tensor<2xf32>, tensor<2xi16>, tensor<2x3xui8>
+// CHECK-DAG:         onnx.Yield [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : tensor<2xf32>, tensor<2xi16>, tensor<2x3xui8>
 // CHECK-DAG:       }, {
-// CHECK-DAG:         onnx.Return [[VAR_1_1_]], [[VAR_2_1_]], [[VAR_3_1_]] : tensor<2xf32>, tensor<3xi16>, tensor<3xui8>
+// CHECK-DAG:         onnx.Yield [[VAR_1_1_]], [[VAR_2_1_]], [[VAR_3_1_]] : tensor<2xf32>, tensor<3xi16>, tensor<3xui8>
 // CHECK-DAG:       }) : (tensor<i1>) -> (tensor<2xf32>, tensor<?xi16>, tensor<*xui8>)
 // CHECK:           return [[VAR_0_]]#0, [[VAR_0_]]#1, [[VAR_0_]]#2 : tensor<2xf32>, tensor<?xi16>, tensor<*xui8>
 }
@@ -3489,12 +3489,12 @@ func.func @test_if_2(%arg0: tensor<i1>, %arg1: !onnx.Seq<tensor<2xf32>>) -> (!on
     %3 = "onnx.NoValue"() {value} : () -> none
     %4 = "onnx.Optional"(%3) {type = tensor<2xi1>} : (none) -> !onnx.Opt<tensor<*xi1>>
     %5 = "onnx.Optional"(%3) {type = !onnx.Seq<tensor<1xf32>>} : (none) -> !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
-    onnx.Return %arg1, %4, %5 : !onnx.Seq<tensor<2xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
+    onnx.Yield %arg1, %4, %5 : !onnx.Seq<tensor<2xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
   }, {
     %3 = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
     %4 = "onnx.Optional"(%arg0) : (tensor<i1>) -> !onnx.Opt<tensor<*xi1>>
     %5 = "onnx.Optional"(%arg1) : (!onnx.Seq<tensor<2xf32>>) -> !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
-    onnx.Return %3, %4, %5 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
+    onnx.Yield %3, %4, %5 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
   }) : (tensor<i1>) -> (!onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>)
   return %0, %1, %2 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<*xf32>>>
 
@@ -3505,12 +3505,12 @@ func.func @test_if_2(%arg0: tensor<i1>, %arg1: !onnx.Seq<tensor<2xf32>>) -> (!on
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_2_:%.+]] = "onnx.Optional"([[VAR_1_]]) {type = tensor<2xi1>} : (none) -> !onnx.Opt<tensor<2xi1>>
 // CHECK-DAG:         [[VAR_3_:%.+]] = "onnx.Optional"([[VAR_1_]]) {type = !onnx.Seq<tensor<1xf32>>} : (none) -> !onnx.Opt<!onnx.Seq<tensor<1xf32>>>
-// CHECK:             onnx.Return [[PARAM_1_]], [[VAR_2_]], [[VAR_3_]] : !onnx.Seq<tensor<2xf32>>, !onnx.Opt<tensor<2xi1>>, !onnx.Opt<!onnx.Seq<tensor<1xf32>>>
+// CHECK:             onnx.Yield [[PARAM_1_]], [[VAR_2_]], [[VAR_3_]] : !onnx.Seq<tensor<2xf32>>, !onnx.Opt<tensor<2xi1>>, !onnx.Opt<!onnx.Seq<tensor<1xf32>>>
 // CHECK:           }, {
 // CHECK-DAG:         [[VAR_1_1_:%.+]] = "onnx.SequenceEmpty"() : () -> !onnx.Seq<tensor<*xf32>>
 // CHECK-DAG:         [[VAR_2_1_:%.+]] = "onnx.Optional"([[PARAM_0_]]) : (tensor<i1>) -> !onnx.Opt<tensor<i1>>
 // CHECK-DAG:         [[VAR_3_1_:%.+]] = "onnx.Optional"([[PARAM_1_]]) : (!onnx.Seq<tensor<2xf32>>) -> !onnx.Opt<!onnx.Seq<tensor<2xf32>>>
-// CHECK:             onnx.Return [[VAR_1_1_]], [[VAR_2_1_]], [[VAR_3_1_]] : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<i1>>, !onnx.Opt<!onnx.Seq<tensor<2xf32>>>
+// CHECK:             onnx.Yield [[VAR_1_1_]], [[VAR_2_1_]], [[VAR_3_1_]] : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<i1>>, !onnx.Opt<!onnx.Seq<tensor<2xf32>>>
 // CHECK:           }) : (tensor<i1>) -> (!onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<?xf32>>>)
 // CHECK:           return [[VAR_0_]]#0, [[VAR_0_]]#1, [[VAR_0_]]#2 : !onnx.Seq<tensor<*xf32>>, !onnx.Opt<tensor<*xi1>>, !onnx.Opt<!onnx.Seq<tensor<?xf32>>>
 }

--- a/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
+++ b/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
@@ -272,7 +272,7 @@
 // CHECK-DAG:         [[VAR_9_:%.+]] = "onnx.Identity"([[PARAM_4_]]) : (tensor<i1>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_10_:%.+]] = "onnx.Add"([[PARAM_5_]], [[PARAM_2_]]) : (tensor<*xf32>, tensor<f32>) -> tensor<*xf32>
 // CHECK-DAG:         [[VAR_11_:%.+]] = "onnx.Identity"([[PARAM_5_]]) : (tensor<*xf32>) -> tensor<*xf32>
-// CHECK:             onnx.Return [[VAR_9_]], [[VAR_10_]], [[VAR_11_]] : tensor<i1>, tensor<*xf32>, tensor<*xf32>
+// CHECK:             onnx.Yield [[VAR_9_]], [[VAR_10_]], [[VAR_11_]] : tensor<i1>, tensor<*xf32>, tensor<*xf32>
 // CHECK:           }) {{.*}} : (tensor<i64>, tensor<i1>, tensor<f32>) -> (tensor<i1>, tensor<2xf32>)
 // CHECK:           return [[VAR_8_]]#1 : tensor<2xf32>
 // CHECK:         }

--- a/test/modellib/ScanModel.cpp
+++ b/test/modellib/ScanModel.cpp
@@ -70,7 +70,7 @@ module {
       %2 = "onnx.Add"(%body_arg0, %body_arg1) :
            (tensor<%Bx%Ixf32>, tensor<%Bx%Ixf32>) -> tensor<%Bx%Ixf32>
       %3 = "onnx.Identity"(%2) : (tensor<%Bx%Ixf32>) -> tensor<%Bx%Ixf32>
-      "onnx.Return"(%2, %3) : (tensor<%Bx%Ixf32>, tensor<%Bx%Ixf32>) -> ()
+      "onnx.Yield"(%2, %3) : (tensor<%Bx%Ixf32>, tensor<%Bx%Ixf32>) -> ()
     }) {num_scan_inputs = 1 : si64} :
         (tensor<%Bx%Ixf32>, tensor<%Bx%Sx%Ixf32>)
         -> (tensor<%Bx%Ixf32>, tensor<%Bx%Sx%Ixf32>)
@@ -88,7 +88,7 @@ module {
       %2 = "onnx.Add"(%body_arg0, %body_arg1) :
            (tensor<%Ixf32>, tensor<%Ixf32>) -> tensor<%Ixf32>
       %3 = "onnx.Identity"(%2) : (tensor<%Ixf32>) -> tensor<%Ixf32>
-      "onnx.Return"(%2, %3) : (tensor<%Ixf32>, tensor<%Ixf32>) -> ()
+      "onnx.Yield"(%2, %3) : (tensor<%Ixf32>, tensor<%Ixf32>) -> ()
     }) {num_scan_inputs = 1 : si64} :
         (tensor<%Ixf32>, tensor<%Sx%Ixf32>)
         -> (tensor<%Ixf32>, tensor<%Sx%Ixf32>)
@@ -130,7 +130,7 @@ bool ScanLibBuilder::prepareInputs() {
 
 bool ScanLibBuilder::prepareInputs(float dataRangeLB, float dataRangeUB) {
   constexpr int num = 2;
-  OMTensor* list[num];
+  OMTensor *list[num];
   list[0] = omTensorCreateWithRandomData<float>(
       llvm::ArrayRef(initialShape), dataRangeLB, dataRangeUB);
   list[1] = omTensorCreateWithRandomData<float>(

--- a/test/numerical/TestLoop.cpp
+++ b/test/numerical/TestLoop.cpp
@@ -32,7 +32,7 @@ module {
     ^bb0(%body_arg0: tensor<i64>, %body_arg1: tensor<i1>, %body_arg2: tensor<1xi64>):
       %body_0 = "onnx.Identity"(%body_arg1) : (tensor<i1>) -> tensor<i1>
       %body_1 = "onnx.Add"(%body_arg0, %body_arg2) : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
-      onnx.Return %body_0, %body_1, %body_1 : tensor<i1>, tensor<1xi64>, tensor<1xi64>
+      onnx.Yield %body_0, %body_1, %body_1 : tensor<i1>, tensor<1xi64>, tensor<1xi64>
     }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<1xi64>, tensor<?x1xi64>)
     return %0#0, %0#1 : tensor<1xi64>, tensor<?x1xi64>
   }
@@ -50,7 +50,7 @@ module {
       %0 = "onnx.Constant"() {value = dense<3> : tensor<i64>} : () -> tensor<i64>
       %1 = "onnx.Less"(%body_arg0, %0) : (tensor<i64>, tensor<i64>) -> tensor<i1>
       %2 = "onnx.Add"(%body_arg2, %body_arg0) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
-    onnx.Return %1, %2, %2 : tensor<i1>, tensor<1xi64>, tensor<1xi64>
+    onnx.Yield %1, %2, %2 : tensor<i1>, tensor<1xi64>, tensor<1xi64>
     }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<1xi64>, tensor<?x1xi64>)
     return %0#0, %0#1 : tensor<1xi64>, tensor<?x1xi64>
   }
@@ -65,7 +65,7 @@ module {
       %0 = "onnx.Constant"() {value = dense<3> : tensor<i64>} : () -> tensor<i64>
       %1 = "onnx.Less"(%body_arg0, %0) : (tensor<i64>, tensor<i64>) -> tensor<i1>
       %2 = "onnx.Add"(%body_arg2, %body_arg0) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
-    onnx.Return %1, %2 : tensor<i1>, tensor<1xi64>
+    onnx.Yield %1, %2 : tensor<i1>, tensor<1xi64>
     }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> tensor<1xi64>
     return %0 : tensor<1xi64>
   }
@@ -81,7 +81,7 @@ module {
     ^bb0(%i: tensor<i64>, %body_cond: tensor<i1>, %y_prev: tensor<1xi64>):
       %2 = "onnx.Add"(%y_prev, %i) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
       %3 = "onnx.Add"(%2, %const_offset) : (tensor<1xi64>, tensor<i64>) -> tensor<1xi64>
-      onnx.Return %body_cond, %3, %3 : tensor<i1>, tensor<1xi64>, tensor<1xi64>
+      onnx.Yield %body_cond, %3, %3 : tensor<i1>, tensor<1xi64>, tensor<1xi64>
     }) : (tensor<i64>, tensor<i1>, tensor<1xi64>) -> (tensor<1xi64>, tensor<?x1xi64>)
     return %y_final, %y_scan : tensor<1xi64>, tensor<?x1xi64>
   }


### PR DESCRIPTION
to follow the MLIR naming scheme in the SCF dialect:
https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td

follows the suggestion by @AlexandreEichenberger: https://github.com/onnx/onnx-mlir/pull/2239#discussion_r1200101718