### PR TITLE
fix inferShapes() for inputs without static shapes

### DIFF
--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/Stick.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/Stick.cpp
@@ -107,7 +107,7 @@ LogicalResult ZHighStickOpShapeHelper::computeShape() {
 LogicalResult ZHighStickOp::inferShapes(
     std::function<void(mlir::Region &)> doShapeInference) {
   Value input = getIn();
-  if (!hasRankedType(input))
+  if (isa<NoneType>(input.getType()) || !hasRankedType(input))
     return success();
 
   auto inputType = input.getType().cast<RankedTensorType>();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Compress.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Compress.cpp
@@ -111,7 +111,7 @@ LogicalResult ONNXCompressOp::verify() {
 LogicalResult ONNXCompressOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   // Cannot infer the output shape if the input shape is not yet knwon.
-  if (!hasShapeAndRank(getInput()))
+  if (!hasShapeAndRank(getOperation()))
     return success();
 
   Type elementType = getInput().getType().cast<ShapedType>().getElementType();

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ConstantOfShape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ConstantOfShape.cpp
@@ -59,8 +59,9 @@ LogicalResult ONNXConstantOfShapeOp::verify() {
   auto inputShape = input.getType().cast<RankedTensorType>().getShape();
   if (inputShape.size() != 1)
     return emitOpError("Input tensor must be a 1D tensor");
+
   if (ShapedType::isDynamic(inputShape[0]))
-    return emitOpError("Input tensor must have static shape");
+    return success();
 
   // Calculate output dimensions.
   SmallVector<int64_t, 4> outputDims(inputShape[0], ShapedType::kDynamic);
@@ -91,6 +92,10 @@ LogicalResult ONNXConstantOfShapeOp::verify() {
 
 LogicalResult ONNXConstantOfShapeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
+  ShapedType inputType = cast<ShapedType>(getInput().getType());
+  if (!inputType.hasStaticShape())
+    return success();
+
   Type elementType;
 
   // 'value' attribute is a one-element tensor whose value and datatype are

--- a/test/mlir/onnx/invalid.mlir
+++ b/test/mlir/onnx/invalid.mlir
@@ -157,14 +157,6 @@ func.func @test_constantofshape_verifier_2(%arg0: tensor<2x2x2x2xi64>) -> tensor
 
 // -----
 
-func.func @test_constantofshape_verifier_3(%arg0: tensor<?xi64>) -> tensor<?xi64> {
-   // expected-error @+1 {{'onnx.ConstantOfShape' op Input tensor must have static shape}}
-   %1 = "onnx.ConstantOfShape"(%arg0) : (tensor<?xi64>) -> tensor<?xi64>
-  "func.return"(%1) : (tensor<?xi64>) -> ()
-}
-
-// -----
-
 func.func @test_constantofshape_verifier_4() -> tensor<2xi64> {
    // expected-error @+2 {{'onnx.ConstantOfShape' op All values of the input tensor must be >=0}}
    %0 = "onnx.Constant"(){ value = dense<[-1, -2]> : tensor<2xi64> } : () -> tensor<2xi64>


### PR DESCRIPTION
Don't run inferShapes() on inputs the shape helper computeShape() cannot handle.

Fixes #2271.