### PR TITLE
interpret empty tensors as absent Resize inputs

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -6938,6 +6938,7 @@ def ONNXReshapeOp:ONNX_Op<"Reshape",
 
 def ONNXResizeOp:ONNX_Op<"Resize",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Resize operation";
   let description = [{
   Resize the input tensor. In general, it calculates every value in the output tensor as a weighted average of neighborhood (a.k.a. sampling locations) in the input tensor.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
@@ -92,6 +92,16 @@ LogicalResult ONNXResizeOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXResizeOp::verify() {
+  // Cannot verify if scales or sizes have unknown shapes.
+  if (auto scalesShapedType = dyn_cast<ShapedType>(getScales().getType())) {
+    if (!scalesShapedType.hasStaticShape())
+      return success();
+  }
+  if (auto sizesShapedType = dyn_cast<ShapedType>(getSizes().getType())) {
+    if (!sizesShapedType.hasStaticShape())
+      return success();
+  }
+
   bool scalesIsAbsent = isAbsent(getScales());
   bool sizesIsAbsent = isAbsent(getSizes());
   if (scalesIsAbsent && sizesIsAbsent)
@@ -99,7 +109,7 @@ LogicalResult ONNXResizeOp::verify() {
   if (!scalesIsAbsent && !sizesIsAbsent)
     return emitError("scales() and sizes() cannot both be defined");
 
-  // TODO: Test the sizes of scales or size to be the same as the rank of X.
+  // TODO: Test the size of scales or sizes to be the same as the rank of X.
   return success();
 }
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
@@ -34,8 +34,9 @@ bool isEmptyTensor(Value input) {
 }
 
 // The yolo4 model uses a float tensor with shape [0] to represent that roi
-// or scales is absent (in violation of the spec which says that empty string
-// inputs represents absent arguments in the protobuf model representation).
+// or scales is absent in accordance with the Resize v11 spec. This violates
+// the spec from v13 onwards which says that empty string
+// inputs represents absent arguments in the protobuf model representation.
 // We work around this by interpreting a tensor with empty shape as an
 // alternative way to express that an input is absent.
 bool isAbsent(Value input) {

--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -253,8 +253,9 @@ public:
 // =============================================================================
 
 // The yolo4 model uses a float tensor with shape [0] to represent that roi
-// or scales is absent (in violation of the spec which says that empty string
-// inputs represents absent arguments in the protobuf model representation).
+// or scales is absent in accordance with the Resize v11 spec. This violates
+// the spec from v13 onwards which says that empty string
+// inputs represents absent arguments in the protobuf model representation.
 // We work around this by interpreting a tensor with empty shape as an
 // alternative way to express that an input is absent.
 class EmptyTensorInputsResizePattern : public OpRewritePattern<ONNXResizeOp> {

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -229,6 +229,19 @@ func.func @test_reshape_should_not_remove(%arg0: tensor<3x5x10x20xf32>, %arg1: t
 
 // -----
 
+// Check EmptyTensorInputsResizePattern. Example from yolov4 model after --decompose-onnx.
+func.func @test_resize_empty_tensor_inputs(%8: tensor<0xf32>, %714: tensor<*xf32>, %719: tensor<*xi64>) -> tensor<*xf32> {
+  %720 = "onnx.Resize"(%714, %8, %8, %719) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor"} : (tensor<*xf32>, tensor<0xf32>, tensor<0xf32>, tensor<*xi64>) -> tensor<*xf32>
+  return %720 : tensor<*xf32>
+  // CHECK-LABEL: func @test_resize_empty_tensor_inputs
+  // CHECK-SAME:  ([[PARAM_0:%.+]]: tensor<0xf32>, [[PARAM_1:%.+]]: tensor<*xf32>, [[PARAM_2:%.+]]: tensor<*xi64>) -> tensor<*xf32> {
+  // CHECK:         [[NONE:%.+]] = "onnx.NoValue"() {value} : () -> none
+  // CHECK:         [[RES:%.+]] = "onnx.Resize"([[PARAM_1]], [[NONE]], [[NONE]], [[PARAM_2]]) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "floor"} : (tensor<*xf32>, none, none, tensor<*xi64>) -> tensor<*xf32>
+  // CHECK:         return [[RES]] : tensor<*xf32>
+}
+
+// -----
+
 // Check the combining of transposes into a simple transpose.
 // CHECK-LABEL: func @test_transpose_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10x13x12xf32> {
 func.func @test_transpose_fusion(%arg0: tensor<10x11x12x13xf32>) -> tensor<11x10x13x12xf32> {

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -330,6 +330,7 @@ OpsWithCanonicalizer = [
     'Or',
     'Pow',
     'Reshape',
+    'Resize',
     'RNN',
     'Shape',
     'Size',


### PR DESCRIPTION
The yolo4 model uses a float tensor with shape [0] to represent that roi
or scales is absent in accordance with the Resize v11 spec. This violates
the spec from v13 onwards which says that empty string
inputs represents absent arguments in the protobuf model representation.
We work around this by interpreting a tensor with empty shape as an
alternative way to express that an input is absent.

Fixes #2276