### PR TITLE
reduce repeated pattern-based shape inference computations

### DIFF
--- a/src/Transform/ONNX/ShapeInference.hpp
+++ b/src/Transform/ONNX/ShapeInference.hpp
@@ -15,6 +15,10 @@
 
 namespace onnx_mlir {
 
+// Returns false if the rank or any dimension of any result types is unknown or
+// dynamic.
+bool returnsDynamicOrUnknownShape(mlir::Operation *op);
+
 void getShapeInferencePatterns(mlir::RewritePatternSet &set);
 
 void inferFunctionReturnShapes(mlir::func::FuncOp f);

--- a/src/Transform/ONNX/ShapeInferencePass.cpp
+++ b/src/Transform/ONNX/ShapeInferencePass.cpp
@@ -99,7 +99,7 @@ public:
       // However, shape inference is still needed on these ops to infer optional
       // attributes.
       if (!containSubgraph(op) && !isUsedByReturnOp(op) &&
-          !returnsDynamicOrUnknownShape(op))
+          !returnsDynamicOrUnknownShape(&op))
         continue;
 
       if (auto shape_op = llvm::dyn_cast<ShapeInferenceOpInterface>(op)) {
@@ -128,19 +128,6 @@ public:
   // Op needs shape inference when contains a subgraph
   // Temporary fix: only LoopOp is checked
   static bool containSubgraph(Operation &op) { return isa<ONNXLoopOp>(op); }
-
-  /*!
-   *  Check if the given operation has a dynamically shaped result.
-   */
-  static bool returnsDynamicOrUnknownShape(Operation &op) {
-    return llvm::any_of(op.getResultTypes(), [](Type result_type) {
-      if (result_type.isa<RankedTensorType>())
-        return llvm::any_of(result_type.dyn_cast<RankedTensorType>().getShape(),
-            [](int64_t dim) { return dim < 0; });
-      else
-        return !result_type.isa<NoneType>();
-    });
-  }
 };
 } // end anonymous namespace
 


### PR DESCRIPTION
Made matchAndRewrite() in shape inference patterns InferShapesPattern and YieldShapesPattern return failure() when no op changes are made. Otherwise applyPatternsAndFoldGreedily() would repeat GreedyRewriteConfig.maxIterations==10 times.

Also copied the optimization from the old shape inference to not (re)infer shapes for simple ops (without subgraphs) with known and static result shapes.