### PR TITLE
support v1-v6 binary op legacy axis attribute

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -161,6 +161,7 @@ def ONNXAddOp:ONNX_Op<"Add",
 
 def ONNXAndOp:ONNX_Op<"And",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX And operation";
   let description = [{
   Returns the tensor resulted from performing the `and` logical operation
@@ -1815,6 +1816,7 @@ def ONNXDetOp:ONNX_Op<"Det",
 
 def ONNXDivOp:ONNX_Op<"Div",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Div operation";
   let description = [{
   Performs element-wise binary division (with Numpy-style broadcasting support).
@@ -2053,6 +2055,7 @@ def ONNXEluOp:ONNX_Op<"Elu",
 
 def ONNXEqualOp:ONNX_Op<"Equal",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Equal operation";
   let description = [{
   Returns the tensor resulted from performing the `equal` logical operation
@@ -2865,6 +2868,7 @@ def ONNXGlobalMaxPoolOp:ONNX_Op<"GlobalMaxPool",
 
 def ONNXGreaterOp:ONNX_Op<"Greater",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Greater operation";
   let description = [{
   Returns the tensor resulted from performing the `greater` logical operation
@@ -5047,6 +5051,7 @@ def ONNXOptionalHasElementOp:ONNX_Op<"OptionalHasElement",
 
 def ONNXOrOp:ONNX_Op<"Or",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Or operation";
   let description = [{
   Returns the tensor resulted from performing the `or` logical operation
@@ -8913,6 +8918,7 @@ def ONNXStringNormalizerOp:ONNX_Op<"StringNormalizer",
 
 def ONNXSubOp:ONNX_Op<"Sub",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Sub operation";
   let description = [{
   Performs element-wise binary subtraction (with Numpy-style broadcasting support).
@@ -9619,6 +9625,7 @@ def ONNXWhereOp:ONNX_Op<"Where",
 
 def ONNXXorOp:ONNX_Op<"Xor",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Xor operation";
   let description = [{
   Returns the tensor resulted from performing the `xor` logical operation

--- a/src/Dialect/ONNX/ONNXOps/Math/ElementwiseBroadcast.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/ElementwiseBroadcast.cpp
@@ -27,17 +27,35 @@ using namespace onnx_mlir;
 
 namespace {
 
-static LogicalResult verifyShapeForBroadcastingOps(
-    Operation *op, Type elementType = nullptr) {
+// Returns true if op is a v1-v6 binary op with legacy axis and
+// broadcast attributes set.
+static bool hasBroadcastAxisAttribute(Operation *op) {
+  IntegerAttr bcast = op->getAttrOfType<IntegerAttr>("broadcast");
+  return bcast && bcast.getValue().getSExtValue() == 1 &&
+         op->getAttrOfType<IntegerAttr>("axis");
+}
+
+static LogicalResult verifyShapeForBroadcastingOps(Operation *op) {
   if (!hasShapeAndRank(op))
     return success();
 
-  Type resultTy = op->getOperand(0).getType();
-  for (unsigned i = 1; i < op->getNumOperands(); ++i) {
-    Type nextTy = op->getOperand(i).getType();
-    resultTy = getBroadcastedType(resultTy, nextTy, elementType);
-    if (resultTy == nullptr)
-      op->emitError("Broadcast op with incompatible dimensions");
+  if (hasBroadcastAxisAttribute(op)) {
+    // Leave it to BinaryOpBroadcastAxisPattern to process and remove the axis
+    // attribute and fix up the shapes instead of trying to verify them here.
+    return success();
+  }
+
+  auto operands = op->getOperands();
+  auto it = operands.begin();
+  SmallVector<int64_t> resultShape(getShape((*it).getType()));
+  while (++it != operands.end()) {
+    ArrayRef<int64_t> nextShape = getShape((*it).getType());
+    SmallVector<int64_t> bcastShape;
+    if (!OpTrait::util::getBroadcastedShape(
+            resultShape, nextShape, bcastShape)) {
+      op->emitOpError("Broadcast op with incompatible shapes: ");
+    }
+    resultShape = bcastShape;
   }
   return success();
 }
@@ -49,6 +67,12 @@ static LogicalResult inferShapeForBroadcastingOps(
   typename OP_TYPE::Adaptor operandAdaptor(op);
   if (!hasShapeAndRank(op.getOperation()))
     return success();
+
+  if (hasBroadcastAxisAttribute(op.getOperation())) {
+    // Leave it to BinaryOpBroadcastAxisPattern to process and remove the axis
+    // attribute and fix up the shapes instead of trying to infer shapes here.
+    return success();
+  }
 
   if (!elementType)
     elementType =
@@ -392,8 +416,7 @@ LogicalResult ONNXSumOp::inferShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXWhereOp::verify() {
-  Type resultElementType = getX().getType().cast<ShapedType>().getElementType();
-  return verifyShapeForBroadcastingOps(getOperation(), resultElementType);
+  return verifyShapeForBroadcastingOps(getOperation());
 }
 
 LogicalResult ONNXWhereOp::inferShapes(

--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -186,6 +186,8 @@ bool AreTheSameAxesConstant(int64_t rank, Value lhs, Value rhs) {
 // Rewrites v1-v6 binary op with legacy axis and broadcast attributes set
 // by unsqueezing the rhs shape as needed and removing the axis attribute,
 // provided that the operand shapes' ranks are known.
+// The v1-v6 binary ops with axis and broadcast attributes are:
+// Add, And, Div, Equal, Greater, Less, Or, Pow, Sub, Xor.
 template <typename OP_TYPE>
 class BinaryOpBroadcastAxisPattern : public OpRewritePattern<OP_TYPE> {
 public:
@@ -222,7 +224,7 @@ public:
              << rhsType;
     }
 
-    rewriter.updateRootInPlace(op, [&]{
+    rewriter.updateRootInPlace(op, [&] {
       OnnxBuilder createONNX(rewriter, op->getLoc());
       SmallVector<int64_t> axesArray;
       SmallVector<int64_t> unsqueezedShape(rhsType.getShape());

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -311,18 +311,23 @@ OpsWithCustomAssemblyFormat = [
 # Operations supporting canonicalization (alphabetical order).
 OpsWithCanonicalizer = [
     'Add',
+    'And',
     'Cast',
     'Constant',
     'DepthToSpace',
+    'Div',
     'Dropout',
+    'Equal',
     'GlobalAveragePool',
     'GlobalMaxPool',
+    'Greater',
     'GRU',
     'Identity',
     'Less',
     'Loop',
     'LSTM',
     'Mul',
+    'Or',
     'Pow',
     'Reshape',
     'RNN',
@@ -332,9 +337,11 @@ OpsWithCanonicalizer = [
     'SpaceToDepth',
     'Squeeze',
     'SqueezeV11',
+    'Sub',
     'Transpose',
     'Unsqueeze',
     'UnsqueezeV11',
+    'Xor',
 ]
 
 # Operations with custom verifiers (alphabetical order).


### PR DESCRIPTION
v1-v6 of the binary ops Add, And, Div, Equal, Greater, Less, Or, Pow, Sub, Xor had axis and broadcast attributes that would unsqueeze trailing axes onto the second operand. This PR adds support with a canonicalization rewrite pattern BinaryOpBroadcastAxisPattern which inserts an Unsqueeze op and removes the axis attribute.

inception-v2-6 in the model zoo uses the axis and broadcast attributes extensively and with this PR it succeeds with extra ONNXOpTransformPass iterations:
```
onnx-mlir inception-v2-6.onnx -onnx-op-transform-threshold=64
```
the many iterations are needed because the model has 138 Mul and Add ops with axis and broadcast attributes set, and canonicalization and shape inference need to alternate to propagate the shape in between

by design `-onnx-hybrid-pass` should solve this without the many iterations but unfortunately it doesn't and needs more work