### PR TITLE
Expand's shape inference returns success when shape input is unknown

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
@@ -104,6 +104,10 @@ LogicalResult ONNXExpandOp::inferShapes(
   if (!hasShapeAndRank(getInput()) || !hasShapeAndRank(getShape()))
     return success();
 
+  ShapedType shapeType = getShape().getType().dyn_cast_or_null<ShapedType>();
+  if (!shapeType || ShapedType::isDynamic(shapeType.getShape()[0]))
+    return success();
+
   Type elementType = getInput().getType().cast<ShapedType>().getElementType();
   ONNXExpandOpShapeHelper shapeHelper(getOperation(), {});
   return shapeHelper.computeShapeAndUpdateType(elementType);


### PR DESCRIPTION
We let shape inference of Expand pass when its shape input is still unknown (say, `tensor<*xdtype>`). Otherwise, it causes shape inference pass failed.