### PR TITLE
use graph nodes with substituted attributes

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1207,7 +1207,7 @@ private:
         BindOnnxName(name, value);
       }
 
-      for (auto &fb_node : functionProto.node()) {
+      for (auto &fb_node : graph.node()) {
         ImportNode(fb_node);
       }
 

--- a/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
+++ b/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
@@ -25,4 +25,3 @@ prims_convert_element_type <dtype>(tensor) => (return_val)
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {to = f32} : (tensor<i64>) -> tensor<f32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<f32>
 // CHECK:         }
-// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
+++ b/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
@@ -1,0 +1,28 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+// prims_convert_element_type.onnxtext is excerpted from
+// maf_gpt2_tiny_display_name.onnx
+<
+   ir_version: 8,
+   opset_import: ["" : 18, "pkg.onnxscript.torch_lib" : 1, "torch.onnx" : 1, "torch_export" : 1],
+   producer_name: "pytorch",
+   producer_version: "2.0.0"
+>
+torch_jit (int64 slice_2) => (float convert_element_type) {
+  convert_element_type = torch.onnx.prims_convert_element_type <dtype = 1> (slice_2)
+}
+
+<
+  domain: "torch.onnx",
+  opset_import: ["" : 18]
+>
+prims_convert_element_type <dtype>(tensor) => (return_val)
+{
+   return_val = Cast <to: int = @dtype> (tensor)
+}
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64>) -> tensor<f32> attributes {input_names = ["slice_2"], output_names = ["convert_element_type"]} {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {to = f32} : (tensor<i64>) -> tensor<f32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<f32>
+// CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()


### PR DESCRIPTION
This PR fixes a bug in function inlining where the substituted attributes were lost (accidentally imported the nodes before substitution).

I discovered the bug with @MikeHolman's  model maf_gpt2_tiny_display_name.onnx with model local function.

Before the fix in this PR compilation failed with:
```
$ onnx-mlir maf_gpt2_tiny_display_name.onnx
Unsupported data type encountered.
UNREACHABLE executed at /Users/slassen/git/onnx-mlir-einsum/src/Dialect/ONNX/ONNXOps/OpHelper.cpp:619!
```
after the fix the compilation fails with:
```
Assertion failed: (isa<To>(Val) && "cast<Ty>() argument of incompatible type!"), function cast, file Casting.h, line 566.
```
because there is an If op where the then branch has a tensor type `tensor<?xf32>` and the else branch has NoneType - let's get back to fixing that after this PR