### PR TITLE
reenable pattern-based shape inference by default

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -222,9 +222,9 @@ llvm::cl::opt<bool> enableSimdDataLayout("simd-data-layout",
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
 
 llvm::cl::opt<bool> enablePatternShapeInference("pattern-shape-inference",
-    llvm::cl::desc("Enable pattern based shape inference (default=false)\n"
-                   "Set to 'true' to enable."),
-    llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
+    llvm::cl::desc("Enable pattern based shape inference (default=true)\n"
+                   "Set to 'false' to disable."),
+    llvm::cl::init(true), llvm::cl::cat(OnnxMlirCommonOptions));
 
 llvm::cl::opt<bool> enableONNXHybridPass("onnx-hybrid-pass",
     llvm::cl::desc("Enable ONNX hybrid pass (default=true)\n"

--- a/src/Transform/ONNX/ShapeInference.cpp
+++ b/src/Transform/ONNX/ShapeInference.cpp
@@ -91,11 +91,17 @@ struct InferShapesPattern
   // Returns success if shapeInfOp or its result types changed.
   LogicalResult matchAndRewrite(ShapeInferenceOpInterface shapeInfOp,
       PatternRewriter &rewriter) const override {
-    // Optimization: Don't (re)infer shapes if shapeInfOp is simple (has no
-    // subgraphs) and its result shapes are known and static.
-    if (!isa<HasOnnxSubgraphOpInterface>(shapeInfOp.getOperation()) &&
-        !returnsDynamicOrUnknownShape(shapeInfOp))
-      return failure();
+    // TODO: Consider fixing all the things to reenable the optimization below.
+    //       It is disabled because inferShapes() sometimes "canonicalizes"
+    //       operations with small rewrites and some other logic depends on it,
+    //       e.g., ONNXTransposeOp::inferShapes() populates ONNXTransposeOp's
+    //       perm attribute if absent and ONNXTransposeOpLowering depends on
+    //       the attribute being set.
+    // // Optimization: Don't (re)infer shapes if shapeInfOp is simple (has no
+    // // subgraphs) and its result shapes are known and static.
+    // if (!isa<HasOnnxSubgraphOpInterface>(shapeInfOp.getOperation()) &&
+    //     !returnsDynamicOrUnknownShape(shapeInfOp))
+    //   return failure();
 
     // Verify the operation before attempting to infer the shape of the
     // produced output(s).


### PR DESCRIPTION
Reverting PR #2270 which disabled pattern-based shape inference by default.

The problems that caused us to disable it in PR #2270 were all shape inference bugs that were hidden by the legacy shape inference (see the bug fixes in PR #2273).

Let's go back to shape-based shape inference by default so we can surface and fix any other hidden bugs and ultimately phase out the legacy shape inference which has bit rotted, see PR #2243.