### PR TITLE
implement ONNXReshapeOp::verify() and don't fail in inferShapes()

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -6811,6 +6811,7 @@ def ONNXReshapeOp:ONNX_Op<"Reshape",
       return sh;
     }
   }];
+  let hasVerifier = 1;
 }
 
 def ONNXResizeOp:ONNX_Op<"Resize",

--- a/test/mlir/onnx/onnx_shape_inference_error.mlir
+++ b/test/mlir/onnx/onnx_shape_inference_error.mlir
@@ -43,18 +43,8 @@ func.func @unsupport_maxpool_column_storage(%arg0 : tensor<5x5x32x32xf32>) -> te
 //===----------------------------------------------------------------------===//
 
 func.func @test_reshape_2D_shape(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<1x2xi64>) -> tensor<*xf32> {
-  // expected-error @+2 {{Shape tensor must have rank one}}
-  // expected-error @+1 {{shape inference failed}}
+  // expected-error @+1 {{Shape tensor must have rank one}}
   %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<1x2xi64>) -> tensor<*xf32>
-  "onnx.Return"(%0) : (tensor<*xf32>) -> ()
-}
-
-// -----
-
-func.func @test_reshape_1D_constant_shape(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<?xi64>) -> tensor<*xf32> {
-  // expected-error @+2 {{Shape tensor must have constant shape}}
-  // expected-error @+1 {{shape inference failed}}
-  %0 = "onnx.Reshape"(%arg0, %arg1) : (tensor<5x5x1x32xf32>, tensor<?xi64>) -> tensor<*xf32>
   "onnx.Return"(%0) : (tensor<*xf32>) -> ()
 }
 

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -399,6 +399,7 @@ OpsWithVerifier = [
     'Pow',
     'RandomNormalLike',
     'Range',
+    'Reshape',
     'Resize',
     'ReverseSequence',
     'RoiAlign',


### PR DESCRIPTION
with this change tiny-yolov3-11.onnx compiles without error message and no longer fails shape inference with `-pattern-shape-inference=false`

see the last comments in PR #2301