### PR TITLE
fix deprecated warnings in gen_onnx_mlir.py

### DIFF
--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -701,8 +701,8 @@ def get_allowed_elem_types(schema, input):
     # allowed_types_str = None
     # return allowed_types_str
     # TODO: enable type constraints.
-    if input.typeStr :
-        tstr = input.typeStr
+    if input.type_str :
+        tstr = input.type_str
         structure, element = get_data_structure_element(tstr);
         # In case the type is directly specified.
         if structure and element :
@@ -776,7 +776,7 @@ def get_operands_or_results(schema, type_str_dict, op_name, is_input):
             types.append("NoneType")
 
         if OpSchema.FormalParameterOption.Variadic == value.option:
-            if value.isHomogeneous:
+            if value.is_homogeneous:
                 types = ["Variadic<{}>".format(any_type_of(types))]
             else:
                 #TODO handle(variadic, heterogeneous) "
@@ -876,11 +876,11 @@ def get_output_type_mapping(schema):
             continue
 
         # Map the type string.
-        if output.typeStr :
-            tstr = output.typeStr
+        if output.type_str :
+            tstr = output.type_str
             found = False
             for i, input in enumerate(schema.inputs):
-                if input.typeStr and input.typeStr == tstr:
+                if input.type_str and input.type_str == tstr:
                     mapping.append(str(i+MAX_NUM_TYPES))
                     found = True
                     break
@@ -1000,16 +1000,16 @@ def parse_type_constraints(schema):
     return type_str_dict
 
 def get_onnx_mlir_types(schema, type_str_dict, input):
-    if input.typeStr :
-         if not input.typeStr in type_str_dict :
+    if input.type_str :
+         if not input.type_str in type_str_dict :
              # Some arguments use type description directly
              # instead of constraint.
-             type_str = parse_type_str(input.typeStr)
+             type_str = parse_type_str(input.type_str)
              return [type_str]
          else :
-             return type_str_dict[input.typeStr]
+             return type_str_dict[input.type_str]
     else :
-        print('No typeStr ', schema.name)
+        print('No type_str ', schema.name)
         return []
 
 


### PR DESCRIPTION
removes these warnings
```
utils/gen_onnx_mlir.py:1003: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  if input.typeStr :
utils/gen_onnx_mlir.py:1004: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  if not input.typeStr in type_str_dict :
utils/gen_onnx_mlir.py:1010: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  return type_str_dict[input.typeStr]
utils/gen_onnx_mlir.py:704: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  if input.typeStr :
utils/gen_onnx_mlir.py:705: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  tstr = input.typeStr
utils/gen_onnx_mlir.py:879: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  if output.typeStr :
gen_onnx_mlir.py:880: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  tstr = output.typeStr
utils/gen_onnx_mlir.py:883: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  if input.typeStr and input.typeStr == tstr:
utils/gen_onnx_mlir.py:1007: UserWarning: OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.type_str instead.
  type_str = parse_type_str(input.typeStr)
utils/gen_onnx_mlir.py:779: UserWarning: OpSchema.FormalParameter.isHomogeneous is deprecated and will be removed in 1.16. Use OpSchema.FormalParameter.is_homogeneous instead.
  if value.isHomogeneous:
```
which started after the upgrade to onnx 1.14.0