### PR TITLE
restrict MatMulIntegerConstZero patterns to ops with static result shape

### DIFF
--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -523,7 +523,7 @@ def MatMulIntegerConstZeroLhs : Pat<
     ),
     (CreateZeroTensorOfType $resOp),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOpOrNone:$a_zero_point),
-     (IsMatMulIntegerLhsZero $A, $a_zero_point)]
+     (IsMatMulIntegerLhsZero $A, $a_zero_point), (HasStaticShape:$resOp)]
     >;
 
 def MatMulIntegerConstZeroRhs : Pat<
@@ -534,7 +534,7 @@ def MatMulIntegerConstZeroRhs : Pat<
     ),
     (CreateZeroTensorOfType $resOp),
     [(IsFromDenseONNXConstantOp:$B), (IsFromDenseONNXConstantOpOrNone:$b_zero_point),
-     (IsMatMulIntegerRhsZero $B, $b_zero_point)]
+     (IsMatMulIntegerRhsZero $B, $b_zero_point), (HasStaticShape:$resOp)]
     >;
 
 def MatMulIntegerOfConsts : Pat<


### PR DESCRIPTION
bidaf-11-int8.onnx from model zoo failed with
```
Assertion failed: (type.hasStaticShape() && "type must have static shape"), function getRaw, file BuiltinAttributes.cpp, line 1317.
```

after this PR it fails in lowering because of unranked types