### PR TITLE
only decompose ConvTranspose when spatial dims are static

### DIFF
--- a/src/Transform/ONNX/Decompose.td
+++ b/src/Transform/ONNX/Decompose.td
@@ -87,8 +87,6 @@ def ONNXDataType : NativeCodeCall<
   "IntegerAttr::get($_builder.getIntegerType(64, /*isSigned=*/true), "
   "::onnx_mlir::mlirTypeToOnnxType($0.getType().front().cast<ShapedType>().getElementType()))">;
 
-def HasShapeAndRank : Constraint<CPred<"onnx_mlir::hasShapeAndRank($0)">>;
-
 //===----------------------------------------------------------------------===//
 // ONNXReduceL1Op %X = ONNXReduceSumOp (ONNXAbsOp %X)
 //===----------------------------------------------------------------------===//
@@ -467,11 +465,9 @@ def ReduceSumSquareV13OpPattern2
 //    Emit ONNXSplitOp, ONNXPadOp, and ONNXConcatOp in insertPadsConvTransposeInput().
 // 3. Calculate new pads attribute from kernel_shape, original pads, and dilation.
 //    Emit no ONNX op in getPadsConvTranspose().
-// 4. Create unit strides if `strides` is not unit strides.
-//    Emit no ONNX op in createUnitStrides().
-// 5. Use ONNXConv op using converted weight tensor, input data tensor, other
+// 4. Use ONNXConv op using converted weight tensor, input data tensor, other
 //    attributes.
-// 6. Insert additional pads if needed.
+// 5. Insert additional pads if needed.
 //    Emit ONNXPadOp in insertAdditionalPadsConvTranspose().
 // TODO: Consider to write C++ code instead of using tablegen because some code
 //       are redundant. (eg. currently shapeHelper is calld multiple times.)
@@ -488,8 +484,10 @@ def HasUnitStrides: Constraint<
   "has unit strides"
 >;
 
-def createUnitStrides: NativeCodeCall<
-  "onnx_mlir::createUnitStrides($_builder, $0)">;
+def HasStaticSpatialDims: Constraint<
+  CPred<"onnx_mlir::hasStaticSpatialDims($_self)">,
+  "has static spatial dims"
+>;
 
 def insertPadsConvTransposeInput: NativeCodeCall<
   "onnx_mlir::insertPadsConvTransposeInput($_builder, $_loc, $0.getDefiningOp<ONNXConvTransposeOp>(), $1)">;
@@ -508,7 +506,7 @@ def ConvTransposeOpPattern1: Pattern<
        (GetNullStringAttr), $dilation, $group, $kernel_shape, $new_pads, $strides),
     (insertAdditionalPadsConvTranspose $conv_res, $res)
    ],
-   [(HasUnitStrides:$strides), (HasShapeAndRank $x), (HasShapeAndRank $w)],
+   [(HasUnitStrides:$strides), (HasStaticSpatialDims:$x), (HasStaticSpatialDims:$w)],
    (addBenefit 1)
 >;
 
@@ -525,7 +523,7 @@ def ConvTransposeOpPattern2: Pattern<
     (insertAdditionalPadsConvTranspose
         $conv_res, $res)
    ],
-   [(HasShapeAndRank $x), (HasShapeAndRank $w)],
+   [(HasStaticSpatialDims:$x), (HasStaticSpatialDims:$w)],
    (addBenefit 0)
 >;
 


### PR DESCRIPTION
addresses failure of MaskRCNN-10.onnx from model zoo

before it failed with:
```
Assertion failed: (!inputType.isDynamicDim(axis) && "Spatial dimensions for input data tensor need to be static."), function emitSplitAxisOutputLength1, file Decompose.cpp, line 326
```
after it fails with:
```
loc("1140"): error: 'arith.extui' op result #0 must be signless-fixed-width-integer-like, but got 'ui8'
```