### PR TITLE
override float_16::to/fromFloat() with per-CPU optimized versions 

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -42,7 +42,7 @@ The `MLIR_DIR` cmake variable must be set before building onnx-mlir. It should p
 
 This project uses lit ([LLVM's Integrated Tester](https://llvm.org/docs/CommandGuide/lit.html)) for unit tests. When running cmake, we can also specify the path to the lit tool from LLVM using the `LLVM_EXTERNAL_LIT` variable but it is not required as long as MLIR_DIR points to a build directory of llvm-project. If `MLIR_DIR` points to an install directory of llvm-project, `LLVM_EXTERNAL_LIT` is required.
 
-To build ONNX-MLIR, use the following commands:
+To build ONNX-MLIR, use the following commands (maybe with additional `-DCMAKE_CXX_FLAGS` argument described [below](#enable-cpu-optimizations)):
 
 [same-as-file]: <> ({"ref": "utils/install-onnx-mlir.sh", "skip-doc": 2})
 ```bash
@@ -75,6 +75,10 @@ Since OSX Big Sur, add the `-DCMAKE_CXX_COMPILER=/usr/bin/c++` option to the abo
 The environment variable `$pythonLocation` may be used to specify the base directory of the Python compiler.
 
 After the above commands succeed, an `onnx-mlir` executable should appear in the `Debug/bin` or `Release/bin` directory.
+
+### Enable CPU Optimizations
+
+You can pass `-DCMAKE_CXX_FLAGS=-march=native` to the `cmake -G Ninja ..` build configuration step above to generate code that exploits all the features of your local CPU, at the expense of portability. Or you can enable a specific CPU feature, e.g. `-DCMAKE_CXX_FLAGS=-mf16c` to enable the F16C feature to enable native conversion between float16 and (32 bit) float. It is used in `src/Support/FloastingPoint16.hpp`.
 
 ### Known MacOS Issues
 

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -78,7 +78,8 @@ After the above commands succeed, an `onnx-mlir` executable should appear in the
 
 ### Enable CPU Optimizations
 
-You can pass `-DCMAKE_CXX_FLAGS=-march=native` to the `cmake -G Ninja ..` build configuration step above to generate code that exploits all the features of your local CPU, at the expense of portability. Or you can enable a specific CPU feature, e.g. `-DCMAKE_CXX_FLAGS=-mf16c` to enable the F16C feature to enable native conversion between float16 and (32 bit) float. It is used in `src/Support/FloastingPoint16.hpp`.
+To make the compiler run faster (without any affect on the generated code)
+you can pass `-DCMAKE_CXX_FLAGS=-march=native` to the `cmake -G Ninja ..` build configuration step above to generate code that exploits all the features of your local CPU, at the expense of portability. Or you can enable a specific CPU feature, e.g. `-DCMAKE_CXX_FLAGS=-mf16c` to enable the F16C feature to enable native conversion between float16 and (32 bit) float. It is used in `src/Support/FloastingPoint16.hpp`.
 
 ### Known MacOS Issues
 

--- a/src/Support/FloatingPoint16.hpp
+++ b/src/Support/FloatingPoint16.hpp
@@ -14,18 +14,30 @@
 #include "llvm/ADT/APFloat.h"
 
 // When the CPU is known to support native conversion between float and float_16
-// we define FLOAT16_TO_FLOAT32(f16) and FLOAT32_TO_FLOAT16(f32) macros, used in
+// we define FLOAT16_TO_FLOAT32(u16) and FLOAT32_TO_FLOAT16(f32) macros, used in
 // class float_16 below to override the slow default APFloat-based conversions.
+//
+// FLOAT16_TO_FLOAT32(u16) takes a bit cast float_16 number as uint16_t and
+// evaluates to a float.
+//
+// FLOAT32_TO_FLOAT16(f32) takes a float f32 number and evaluates to a bit cast
+// float_16 number as uint16_t.
+//
+// clang-format off
+// On x86-64 build config -DCMAKE_CXX_FLAGS=-march=native defines __F16C__.
 #if defined(__x86_64__) && defined(__F16C__)
+// https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-9/details-about-intrinsics-for-half-floats.html
 #include <immintrin.h>
-#define FLOAT16_TO_FLOAT32(f16)                                                \
-  _cvtsh_ss(*reinterpret_cast<const uint16_t *>(&f16))
+#define FLOAT16_TO_FLOAT32(u16) _cvtsh_ss(u16)
 #define FLOAT32_TO_FLOAT16(f32) _cvtss_sh(f32, /*ROUND TO NEAREST EVEN*/ 0)
 #endif
+// On MacBook Pro no build config is needed to define __ARM_FP16_FORMAT_IEEE.
 #if defined(__ARM_FP16_FORMAT_IEEE)
-#define FLOAT16_TO_FLOAT32(f16) *reinterpret_cast<const __fp16 *>(&f16)
-#define FLOAT32_TO_FLOAT16(f32) static_cast<__fp16>(f32)
+// https://arm-software.github.io/acle/main/acle.html#half-precision-floating-point
+#define FLOAT16_TO_FLOAT32(u16) static_cast<float>(detail::bitcast<__fp16>(u16))
+#define FLOAT32_TO_FLOAT16(f32) detail::bitcast<uint16_t>(static_cast<__fp16>(f32))
 #endif
+// clang-format on
 
 namespace onnx_mlir {
 
@@ -61,7 +73,7 @@ public:
   // Same as static_cast<float>(*this).
   float toFloat() const { return toAPFloat().convertToFloat(); }
 
-  // Substitute for reinterpret_cast<uint16_t>(*this), which C++ doesn't allow.
+  // Same as bitcast<uint16_t>(*this).
   constexpr bitcasttype bitcastToU16() const { return u16; }
 
   static FP16 fromAPFloat(llvm::APFloat a);
@@ -69,7 +81,7 @@ public:
   // Same as static_cast<FP16>(f).
   static FP16 fromFloat(float f) { return fromAPFloat(llvm::APFloat(f)); }
 
-  // Substitute for reinterpret_cast<FP16>(u), which C++ doesn't allow.
+  // Same as bitcast<FP16>(u).
   static constexpr FP16 bitcastFromU16(bitcasttype u) {
     FP16 f16;
     f16.u16 = u;
@@ -90,6 +102,12 @@ private:
 extern template class FP16Base<float_16>;
 extern template class FP16Base<bfloat_16>;
 
+// TODO: Replace with std::bit_cast in C++20.
+template <class To, class From>
+To bitcast(From x) {
+  return *reinterpret_cast<To *>(&x);
+}
+
 } // namespace detail
 
 template <class T>
@@ -107,14 +125,11 @@ public:
     return llvm::APFloat::IEEEhalf();
   }
 #if defined(FLOAT16_TO_FLOAT32)
-  float toFloat() const { return FLOAT16_TO_FLOAT32(*this); }
+  float toFloat() const { return FLOAT16_TO_FLOAT32(bitcastToU16()); }
 #endif
 #if defined(FLOAT32_TO_FLOAT16)
   static float_16 fromFloat(float f) {
-    // x can be any 16 bits wide storage for float_16.
-    auto x = FLOAT32_TO_FLOAT16(f);
-    static_assert(sizeof(x) * CHAR_BIT == 16, "16 bits to store float_16");
-    return *reinterpret_cast<float_16 *>(&x);
+    return bitcastFromU16(FLOAT32_TO_FLOAT16(f));
   }
 #endif
 };

--- a/src/Support/FloatingPoint16.hpp
+++ b/src/Support/FloatingPoint16.hpp
@@ -29,14 +29,17 @@ public:
   constexpr FP16Base() : u16() {}
   constexpr explicit FP16Base(const FP16 &f16) : u16(f16.u16) {}
   // Support static_cast<FP16>(X) for any x that is convertible to float.
+  // Use FP16::fromFloat() in case FP16 overrides fromFloat().
   template <typename T, typename = std::enable_if_t<!std::is_same_v<T, FP16>>>
   explicit FP16Base(const T &x)
-      : u16(fromAPFloat(llvm::APFloat(static_cast<float>(x))).u16) {}
+      : FP16Base(FP16::fromFloat(static_cast<float>(x))) {}
 
   // Support static_cast<T>(*this) for any T that float converts to.
   template <typename T, typename = std::enable_if_t<!std::is_same_v<T, FP16>>>
   explicit operator T() const {
-    return static_cast<float>(toFloat());
+    // Down cast in case FP16 overrides FP16::toFloat().
+    FP16 fp = FP16::bitcastFromU16(u16);
+    return static_cast<float>(fp.toFloat());
   }
 
   llvm::APFloat toAPFloat() const;

--- a/test/unit/FloatingPoint16/CMakeLists.txt
+++ b/test/unit/FloatingPoint16/CMakeLists.txt
@@ -7,6 +7,7 @@ add_onnx_mlir_executable(TestFloatingPoint16
 
   LINK_LIBS PRIVATE
   OMONNXOps
+  benchmark
   )
 
 add_test(NAME TestFloatingPoint16 COMMAND TestFloatingPoint16)

--- a/test/unit/FloatingPoint16/CMakeLists.txt
+++ b/test/unit/FloatingPoint16/CMakeLists.txt
@@ -6,7 +6,7 @@ add_onnx_mlir_executable(TestFloatingPoint16
   NO_INSTALL
 
   LINK_LIBS PRIVATE
-  OMONNXOps
+  OMMlirUtilities
   benchmark
   )
 

--- a/test/unit/FloatingPoint16/TestFloatingPoint16.cpp
+++ b/test/unit/FloatingPoint16/TestFloatingPoint16.cpp
@@ -90,7 +90,7 @@ public:
 
 template <typename FP16>
 void BM_F32_TO_FP16(benchmark::State &state) {
-  uint32_t u16max = std::numeric_limits<uint16_t>::max();
+  constexpr uint32_t u16max = std::numeric_limits<uint16_t>::max();
   float f32s[u16max + 1];
   for (uint32_t u = 0; u <= u16max; ++u) {
     f32s[u] = FP16::bitcastFromU16(u).toFloat();
@@ -108,7 +108,7 @@ BENCHMARK(BM_F32_TO_FP16<bfloat_16>);
 
 template <typename FP16>
 void BM_FP16_TO_F32(benchmark::State &state) {
-  uint32_t u16max = std::numeric_limits<uint16_t>::max();
+  constexpr uint32_t u16max = std::numeric_limits<uint16_t>::max();
   FP16 fp16s[u16max + 1];
   for (uint32_t u = 0; u <= u16max; ++u) {
     fp16s[u] = FP16::bitcastFromU16(u);

--- a/test/unit/FloatingPoint16/TestFloatingPoint16.cpp
+++ b/test/unit/FloatingPoint16/TestFloatingPoint16.cpp
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//============================-- FloatingPoint16.cpp ---======================//
+//=======================-- TestFloatingPoint16.cpp ---=======================//
 //
 // Tests FloatingPoint16.
 //


### PR DESCRIPTION
When the CPU is known to support native conversion between float and float_16, use them in class float_16 below to override the slow default APFloat-based conversions.

Implemented for ARM64 when `__ARM_FP16_FORMAT_IEEE` is defined and for x86-64 when `__F16C__` is defined.

Added benchmarks of conversion between float and float_16 in TestFloatingPoint16.cpp.

Measured the benchmarks on a MacBook pro with Apple M1 Pro cpu. Before the per-CPU optimization:
```
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
BM_F32_TO_FP16<float_16>     2655030 ns      2654890 ns          263
BM_F32_TO_FP16<bfloat_16>    2741322 ns      2741320 ns          259
BM_FP16_TO_F32<float_16>     1824425 ns      1824426 ns          383
BM_FP16_TO_F32<bfloat_16>    1817702 ns      1817688 ns          385
```
After:
```
BM_F32_TO_FP16<float_16>      142300 ns       142280 ns         4855
BM_F32_TO_FP16<bfloat_16>    2312391 ns      2312290 ns          300
BM_FP16_TO_F32<float_16>      224026 ns       224026 ns         3124
BM_FP16_TO_F32<bfloat_16>    1832315 ns      1832315 ns          381
```

On another MacBook Pro with Intel Core i7-7820HQ cpu I had to configure the build with `-DCMAKE_CXX_FLAGS=-march=native` to define `__F16C__`. Before the per-CPU optimization:
```
BM_F32_TO_FP16<float_16>     4313245 ns      4304093 ns          140
BM_F32_TO_FP16<bfloat_16>    4427924 ns      4423289 ns          159
BM_FP16_TO_F32<float_16>     3426035 ns      3422583 ns          206
BM_FP16_TO_F32<bfloat_16>    3532166 ns      3517064 ns          204
```
After:
```
BM_F32_TO_FP16<float_16>       99106 ns        99069 ns         6525
BM_F32_TO_FP16<bfloat_16>    4358961 ns      4351302 ns          162
BM_FP16_TO_F32<float_16>      162100 ns       161966 ns         4204
BM_FP16_TO_F32<bfloat_16>    3459624 ns      3453559 ns          202
```