### PR TITLE
remove unsafe LessOpSameCastPattern canonicalization pattern

### DIFF
--- a/src/Dialect/ONNX/Rewrite.cpp
+++ b/src/Dialect/ONNX/Rewrite.cpp
@@ -904,7 +904,6 @@ void ONNXLayoutTransformOp::getCanonicalizationPatterns(
 /// on the ONNXLessOp.
 void ONNXLessOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
-  results.insert<LessOpSameCastPattern>(context);
   results.insert<BinaryOpBroadcastAxisPattern<ONNXLessOp>>(context);
 }
 

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -931,21 +931,8 @@ def ConstantOpNormalizationPattern6: Pat<
 >;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXLessOp
-//===----------------------------------------------------------------------===//
-
-def LessOpSameCastPattern: Pat<
-   (ONNXLessOp (ONNXCastOp:$cast_a $a, $to1), (ONNXCastOp $b, $to2)),
-   (ONNXLessOp $a, $b),
-   [(HaveSameElementType $a, $b), (Equal $to1, $to2),
-    (HaveSameElementTypeBitWidth $a, $cast_a),
-    (ElementTypeIsNotUnsigned:$cast_a)]
->;
-
-//===----------------------------------------------------------------------===//
 // Canonicalization for ONNXDimOp
 //===----------------------------------------------------------------------===//
-
 
 def DimOpToConstantPattern: Pat<
    (ONNXDimOp $input, $axis),

--- a/src/Dialect/ONNX/Rewrite.td
+++ b/src/Dialect/ONNX/Rewrite.td
@@ -157,15 +157,6 @@ def HaveSameElementType : Constraint<
           "$1.getType().dyn_cast<ShapedType>().getElementType())">,
     "have same element types">;
 
-def HaveSameElementTypeBitWidth: Constraint<
-    CPred<"($0.getType().dyn_cast<ShapedType>().getElementTypeBitWidth() == "
-          "$1.getType().dyn_cast<ShapedType>().getElementTypeBitWidth())">,
-    "has same element type bitwidth">;
-
-def  ElementTypeIsNotUnsigned: Constraint<
-    CPred<"!$_self.getType().dyn_cast<ShapedType>().getElementType().isUnsignedInteger()">,
-    "element type is not unsigned int">;
-
 def HaveSameEncodingAttr: Constraint<
     CPred<"sameEncodingAttr($0.getType(), $1.getType())">,
     "have same RankedTensorType's encoding attribute">;

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -784,32 +784,6 @@ func.func @test_fuse_mul_conv(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
 
 // -----
 
-func.func @test_less(%arg0 : tensor<i32>, %arg1 : tensor<i32>) -> tensor<i1> {
-  %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<i32>) -> tensor<f32>
-  %1 = "onnx.Cast"(%arg1) {to = f32} : (tensor<i32>) -> tensor<f32>
-  %2 = "onnx.Less"(%0, %1) : (tensor<f32>, tensor<f32>) -> tensor<i1>
-  onnx.Return %2 : tensor<i1>
-  // CHECK-LABEL: test_less
-  // CHECK: [[RES:%.]] = "onnx.Less"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i1>
-  // CHECK: onnx.Return [[RES]] : tensor<i1>
-}
-
-// -----
-
-// Cast is not removed because of unsigned integers.
-func.func @test_less_should_not_remove_cast(%arg0 : tensor<f32>, %arg1 : tensor<f32>) -> tensor<i1> {
-  %0 = "onnx.Cast"(%arg0) {to = ui32} : (tensor<f32>) -> tensor<ui32>
-  %1 = "onnx.Cast"(%arg1) {to = ui32} : (tensor<f32>) -> tensor<ui32>
-  %2 = "onnx.Less"(%0, %1) : (tensor<ui32>, tensor<ui32>) -> tensor<i1>
-  onnx.Return %2 : tensor<i1>
-  // CHECK-LABEL: test_less_should_not_remove_cast
-  // CHECK: "onnx.Cast"
-  // CHECK: "onnx.Cast"
-  // CHECK: "onnx.Less"
-}
-
-// -----
-
 // Check deriving a new maximum trip count from the break condition of the loop.
 // In this test, the new maximum trip count is a constant.
 func.func @test_loop_derive_max_trip_count(%arg0: tensor<?x30xf32>) -> tensor<?x?x30xf32> {


### PR DESCRIPTION
the LessOpSameCastPattern canonicalization pattern
```
def LessOpSameCastPattern: Pat<
   (ONNXLessOp (ONNXCastOp:$cast_a $a, $to1), (ONNXCastOp $b, $to2)),
   (ONNXLessOp $a, $b),
   [(HaveSameElementType $a, $b), (Equal $to1, $to2),
    (HaveSameElementTypeBitWidth $a, $cast_a),
    (ElementTypeIsNotUnsigned:$cast_a)]
>;
```
is quite limited in which types it applies to, it seems like the only practical uses are to convert between i64 and f64, i32 and f32, or i16 and f16 (or between i8 and the upcoming 8 bit floating point types)

in all cases, it's unsafe because there are always different numbers in one data type that get rounded or saturated to the same number

for instance, this lit test in onnx_canonicalization.mlir
```
func.func @test_less(%arg0 : tensor<i32>, %arg1 : tensor<i32>) -> tensor<i1> {
  %0 = "onnx.Cast"(%arg0) {to = f32} : (tensor<i32>) -> tensor<f32>
  %1 = "onnx.Cast"(%arg1) {to = f32} : (tensor<i32>) -> tensor<f32>
  %2 = "onnx.Less"(%0, %1) : (tensor<f32>, tensor<f32>) -> tensor<i1>
  onnx.Return %2 : tensor<i1>
  // CHECK-LABEL: test_less
  // CHECK: [[RES:%.]] = "onnx.Less"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i1>
  // CHECK: onnx.Return [[RES]] : tensor<i1>
}
```
returns `false` instead of the correct `true` if arg0 is N and arg1 is N+1 for most N greater than 2^24 or smaller than -2^24 because N and N+1 typically get rounded to the same f32 numbers given that f32 only has 24 bit mantissa