### PR TITLE
fix check-onnx-backend-input-verification on MacOS

### DIFF
--- a/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlToLLVMHelper.cpp
@@ -264,9 +264,10 @@ void emitErrNo(ModuleOp module, OpBuilder &builder, Location loc, int errCode) {
   Type int32PtrTy = getPointerType(builder.getContext(), int32Ty);
   LLVMBuilder createLLVM(builder, loc);
   LLVMBuilder createLLVMModuleLoc(builder, module.getLoc());
-  // Create '__errno_location' function signature: `i32 *()`
+  // Create 'om_errno_location' function signature: `i32 *()`
+  // TODO: Integrate this with RuntimeAPI.
   FlatSymbolRefAttr errnoSymbolRef = createLLVMModuleLoc.getOrInsertSymbolRef(
-      module, StringRef("__errno_location"), int32PtrTy, {});
+      module, StringRef("om_errno_location"), int32PtrTy, {});
   Value errNoPos =
       createLLVM.call(int32PtrTy, errnoSymbolRef, ArrayRef<Value>({}));
   Value errNoVal = createLLVM.constant(int32Ty, (int64_t)errCode);

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -36,12 +36,15 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 #include "onnx-mlir/Runtime/OMTensor.h"
 
 #ifdef __cplusplus
 #include "src/Runtime/OMTensorHelper.hpp"
 #endif
+
+int32_t *om_errno_location(void) { return &errno; }
 
 struct OMTensor {
 #ifdef __cplusplus

--- a/test/backend/input_verification_backend.py
+++ b/test/backend/input_verification_backend.py
@@ -167,7 +167,7 @@ def redirect_c_stdout(stream):
         # Flush the C-level buffer stdout
         # Note: this does not work on Windows.
         libc = ctypes.CDLL(None)
-        c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
+        c_stdout = ctypes.c_void_p.in_dll(libc, '__stdoutp' if sys.platform == 'darwin' else 'stdout')
         libc.fflush(c_stdout)
         # Flush and close sys.stdout - also closes the file descriptor (fd)
         sys.stdout.close()

--- a/test/mlir/conversion/krnl_to_llvm/input_verification.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/input_verification.mlir
@@ -23,7 +23,7 @@ module {
 // CHECK:           %[[VAL_4:.*]] = llvm.mlir.addressof @"om_Wrong number of input tensors: expect 2, but got {{\%}}lld\0A" : !llvm.ptr<array<54 x i8>>
 // CHECK:           %[[VAL_6:.*]] = llvm.bitcast %[[VAL_4]] : !llvm.ptr<array<54 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_6]], %[[VAL_2]]) : (!llvm.ptr, i64) -> ()
-// CHECK-DAG:       %[[VAL_7:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_7:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_7]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_9:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_9]] : !llvm.ptr
@@ -38,7 +38,7 @@ module {
 // CHECK-DAG:       %[[VAL_15:.*]] = llvm.mlir.addressof @"om_Wrong data type for the input 0: expect f32\0A" : !llvm.ptr<array<44 x i8>>
 // CHECK-DAG:       %[[VAL_17:.*]] = llvm.bitcast %[[VAL_15]] : !llvm.ptr<array<44 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_17]]) : (!llvm.ptr) -> ()
-// CHECK-DAG:       %[[VAL_18:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_18:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_18]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_20:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_20]] : !llvm.ptr
@@ -51,7 +51,7 @@ module {
 // CHECK-DAG:       %[[VAL_24:.*]] = llvm.mlir.addressof @"om_Wrong rank for the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
 // CHECK-DAG:       %[[VAL_26:.*]] = llvm.bitcast %[[VAL_24]] : !llvm.ptr<array<51 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_26]], %[[VAL_22]]) : (!llvm.ptr, i64) -> ()
-// CHECK-DAG:       %[[VAL_27:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_27:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_27]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_29:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_29]] : !llvm.ptr
@@ -65,7 +65,7 @@ module {
 // CHECK-DAG:       %[[VAL_34:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 0 of the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_36:.*]] = llvm.bitcast %[[VAL_34]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_36]], %[[VAL_31]]) : (!llvm.ptr, i64) -> ()
-// CHECK-DAG:       %[[VAL_37:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_37:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_37]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_39:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_39]] : !llvm.ptr
@@ -79,7 +79,7 @@ module {
 // CHECK-DAG:       %[[VAL_45:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 1 of the input 0: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_47:.*]] = llvm.bitcast %[[VAL_45]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_47]], %[[VAL_42]]) : (!llvm.ptr, i64) -> ()
-// CHECK-DAG:       %[[VAL_48:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_48:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_48]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_50:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_50]] : !llvm.ptr
@@ -93,7 +93,7 @@ module {
 // CHECK-DAG:       %[[VAL_56:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 2 of the input 0: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_58:.*]] = llvm.bitcast %[[VAL_56]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_58]], %[[VAL_53]]) : (!llvm.ptr, i64) -> ()
-// CHECK-DAG:       %[[VAL_59:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_59:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_59]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_61:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_61]] : !llvm.ptr
@@ -108,7 +108,7 @@ module {
 // CHECK-DAG:       %[[VAL_68:.*]] = llvm.mlir.addressof @"om_Wrong data type for the input 1: expect f32\0A" : !llvm.ptr<array<44 x i8>>
 // CHECK-DAG:       %[[VAL_70:.*]] = llvm.bitcast %[[VAL_68]] : !llvm.ptr<array<44 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_70]]) : (!llvm.ptr) -> ()
-// CHECK-DAG:       %[[VAL_71:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_71:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_71]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_73:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_73]] : !llvm.ptr
@@ -121,7 +121,7 @@ module {
 // CHECK-DAG:       %[[VAL_77:.*]] = llvm.mlir.addressof @"om_Wrong rank for the input 1: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
 // CHECK-DAG:       %[[VAL_79:.*]] = llvm.bitcast %[[VAL_77]] : !llvm.ptr<array<51 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_79]], %[[VAL_75]]) : (!llvm.ptr, i64) -> ()
-// CHECK-DAG:       %[[VAL_80:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_80:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_80]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_82:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_82]] : !llvm.ptr
@@ -135,7 +135,7 @@ module {
 // CHECK-DAG:       %[[VAL_87:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 0 of the input 1: expect a non-negative value\0A" : !llvm.ptr<array<75 x i8>>
 // CHECK-DAG:       %[[VAL_89:.*]] = llvm.bitcast %[[VAL_87]] : !llvm.ptr<array<75 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_89]]) : (!llvm.ptr) -> ()
-// CHECK-DAG:       %[[VAL_90:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_90:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_90]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_92:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_92]] : !llvm.ptr
@@ -149,7 +149,7 @@ module {
 // CHECK-DAG:       %[[VAL_98:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 1 of the input 1: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_100:.*]] = llvm.bitcast %[[VAL_98]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_100]], %[[VAL_95]]) : (!llvm.ptr, i64) -> ()
-// CHECK-DAG:       %[[VAL_101:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_101:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_101]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_103:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_103]] : !llvm.ptr
@@ -163,7 +163,7 @@ module {
 // CHECK-DAG:       %[[VAL_109:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 2 of the input 1: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_111:.*]] = llvm.bitcast %[[VAL_109]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr
 // CHECK:           llvm.call @printf(%[[VAL_111]], %[[VAL_106]]) : (!llvm.ptr, i64) -> ()
-// CHECK-DAG:       %[[VAL_112:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr
+// CHECK-DAG:       %[[VAL_112:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_112]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_114:.*]] = llvm.mlir.null : !llvm.ptr
 // CHECK:           llvm.return %[[VAL_114]] : !llvm.ptr

--- a/test/mlir/conversion/krnl_to_llvm/typed_pointer/input_verification.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/typed_pointer/input_verification.mlir
@@ -23,7 +23,7 @@ module {
 // CHECK:           %[[VAL_4:.*]] = llvm.mlir.addressof @"om_Wrong number of input tensors: expect 2, but got {{\%}}lld\0A" : !llvm.ptr<array<54 x i8>>
 // CHECK:           %[[VAL_6:.*]] = llvm.bitcast %[[VAL_4]] : !llvm.ptr<array<54 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_6]], %[[VAL_2]]) : (!llvm.ptr<i8>, i64) -> ()
-// CHECK-DAG:       %[[VAL_7:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_7:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_7]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_9:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_9]] : !llvm.ptr<i8>
@@ -38,7 +38,7 @@ module {
 // CHECK-DAG:       %[[VAL_15:.*]] = llvm.mlir.addressof @"om_Wrong data type for the input 0: expect f32\0A" : !llvm.ptr<array<44 x i8>>
 // CHECK-DAG:       %[[VAL_17:.*]] = llvm.bitcast %[[VAL_15]] : !llvm.ptr<array<44 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_17]]) : (!llvm.ptr<i8>) -> ()
-// CHECK-DAG:       %[[VAL_18:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_18:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_18]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_20:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_20]] : !llvm.ptr<i8>
@@ -51,7 +51,7 @@ module {
 // CHECK-DAG:       %[[VAL_24:.*]] = llvm.mlir.addressof @"om_Wrong rank for the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
 // CHECK-DAG:       %[[VAL_26:.*]] = llvm.bitcast %[[VAL_24]] : !llvm.ptr<array<51 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_26]], %[[VAL_22]]) : (!llvm.ptr<i8>, i64) -> ()
-// CHECK-DAG:       %[[VAL_27:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_27:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_27]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_29:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_29]] : !llvm.ptr<i8>
@@ -65,7 +65,7 @@ module {
 // CHECK-DAG:       %[[VAL_34:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 0 of the input 0: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_36:.*]] = llvm.bitcast %[[VAL_34]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_36]], %[[VAL_31]]) : (!llvm.ptr<i8>, i64) -> ()
-// CHECK-DAG:       %[[VAL_37:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_37:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_37]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_39:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_39]] : !llvm.ptr<i8>
@@ -79,7 +79,7 @@ module {
 // CHECK-DAG:       %[[VAL_45:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 1 of the input 0: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_47:.*]] = llvm.bitcast %[[VAL_45]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_47]], %[[VAL_42]]) : (!llvm.ptr<i8>, i64) -> ()
-// CHECK-DAG:       %[[VAL_48:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_48:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_48]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_50:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_50]] : !llvm.ptr<i8>
@@ -93,7 +93,7 @@ module {
 // CHECK-DAG:       %[[VAL_56:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 2 of the input 0: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_58:.*]] = llvm.bitcast %[[VAL_56]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_58]], %[[VAL_53]]) : (!llvm.ptr<i8>, i64) -> ()
-// CHECK-DAG:       %[[VAL_59:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_59:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_59]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_61:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_61]] : !llvm.ptr<i8>
@@ -108,7 +108,7 @@ module {
 // CHECK-DAG:       %[[VAL_68:.*]] = llvm.mlir.addressof @"om_Wrong data type for the input 1: expect f32\0A" : !llvm.ptr<array<44 x i8>>
 // CHECK-DAG:       %[[VAL_70:.*]] = llvm.bitcast %[[VAL_68]] : !llvm.ptr<array<44 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_70]]) : (!llvm.ptr<i8>) -> ()
-// CHECK-DAG:       %[[VAL_71:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_71:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_71]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_73:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_73]] : !llvm.ptr<i8>
@@ -121,7 +121,7 @@ module {
 // CHECK-DAG:       %[[VAL_77:.*]] = llvm.mlir.addressof @"om_Wrong rank for the input 1: expect 3, but got {{\%}}lld\0A" : !llvm.ptr<array<51 x i8>>
 // CHECK-DAG:       %[[VAL_79:.*]] = llvm.bitcast %[[VAL_77]] : !llvm.ptr<array<51 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_79]], %[[VAL_75]]) : (!llvm.ptr<i8>, i64) -> ()
-// CHECK-DAG:       %[[VAL_80:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_80:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_80]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_82:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_82]] : !llvm.ptr<i8>
@@ -135,7 +135,7 @@ module {
 // CHECK-DAG:       %[[VAL_87:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 0 of the input 1: expect a non-negative value\0A" : !llvm.ptr<array<75 x i8>>
 // CHECK-DAG:       %[[VAL_89:.*]] = llvm.bitcast %[[VAL_87]] : !llvm.ptr<array<75 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_89]]) : (!llvm.ptr<i8>) -> ()
-// CHECK-DAG:       %[[VAL_90:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_90:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_90]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_92:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_92]] : !llvm.ptr<i8>
@@ -149,7 +149,7 @@ module {
 // CHECK-DAG:       %[[VAL_98:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 1 of the input 1: expect 4, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_100:.*]] = llvm.bitcast %[[VAL_98]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_100]], %[[VAL_95]]) : (!llvm.ptr<i8>, i64) -> ()
-// CHECK-DAG:       %[[VAL_101:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_101:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_101]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_103:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_103]] : !llvm.ptr<i8>
@@ -163,7 +163,7 @@ module {
 // CHECK-DAG:       %[[VAL_109:.*]] = llvm.mlir.addressof @"om_Wrong size for the dimension 2 of the input 1: expect 5, but got {{\%}}lld\0A" : !llvm.ptr<array<70 x i8>>
 // CHECK-DAG:       %[[VAL_111:.*]] = llvm.bitcast %[[VAL_109]] : !llvm.ptr<array<70 x i8>> to !llvm.ptr<i8>
 // CHECK:           llvm.call @printf(%[[VAL_111]], %[[VAL_106]]) : (!llvm.ptr<i8>, i64) -> ()
-// CHECK-DAG:       %[[VAL_112:.*]] = llvm.call @__errno_location() : () -> !llvm.ptr<i32>
+// CHECK-DAG:       %[[VAL_112:.*]] = llvm.call @om_errno_location() : () -> !llvm.ptr<i32>
 // CHECK-DAG:       llvm.store %[[CONST_22]], %[[VAL_112]] : !llvm.ptr<i32>
 // CHECK:           %[[VAL_114:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK:           llvm.return %[[VAL_114]] : !llvm.ptr<i8>

--- a/utils/check-onnx-backend-numerical.sh
+++ b/utils/check-onnx-backend-numerical.sh
@@ -1,4 +1,4 @@
 # Run backend and numerical tests in parallel
 cd onnx-mlir/build
 CTEST_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu) \
-cmake --build . --parallel --target check-onnx-backend check-onnx-numerical
+cmake --build . --parallel --target check-onnx-backend check-onnx-backend-input-verification check-onnx-numerical


### PR DESCRIPTION
before this PR it failed with:
```
Undefined symbols for architecture x86_64 (or arm64):
  "___errno_location", referenced from:
      _run_main_graph in add_wrong_data_type.o
```
on both x86_64 and arm64

as well as:
```
  File "/Users/sorenlassen/git/onnx-mlir-einsum/build/test/backend/RelWithDebInfo/input_verification_backend.py", line 170, in _redirect_stdout
    c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: dlsym(RTLD_DEFAULT, stdout): symbol not found
```
which is fixed with the solution from stackoverflow: https://stackoverflow.com/a/47616945