### PR TITLE
fix check-onnx-backend-input-verification on MacOS

### DIFF
--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -36,11 +36,18 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 #include "onnx-mlir/Runtime/OMTensor.h"
 
 #ifdef __cplusplus
 #include "src/Runtime/OMTensorHelper.hpp"
+#endif
+
+#if defined(__APPLE__)
+// __errno_location() is called from krnl::emitErrNo() to set errno in
+// generated llvm IR, but it somehow doesn't come out of the box on MacOS.
+int * __attribute__((__weak__)) __errno_location(void) { return &errno; }
 #endif
 
 struct OMTensor {

--- a/test/backend/input_verification_backend.py
+++ b/test/backend/input_verification_backend.py
@@ -167,7 +167,7 @@ def redirect_c_stdout(stream):
         # Flush the C-level buffer stdout
         # Note: this does not work on Windows.
         libc = ctypes.CDLL(None)
-        c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
+        c_stdout = ctypes.c_void_p.in_dll(libc, '__stdoutp' if sys.platform == 'darwin' else 'stdout')
         libc.fflush(c_stdout)
         # Flush and close sys.stdout - also closes the file descriptor (fd)
         sys.stdout.close()

--- a/utils/check-onnx-backend-numerical.sh
+++ b/utils/check-onnx-backend-numerical.sh
@@ -1,4 +1,4 @@
 # Run backend and numerical tests in parallel
 cd onnx-mlir/build
 CTEST_PARALLEL_LEVEL=$(sysctl -n hw.logicalcpu) \
-cmake --build . --parallel --target check-onnx-backend check-onnx-numerical
+cmake --build . --parallel --target check-onnx-backend check-onnx-backend-input-verification check-onnx-numerical


### PR DESCRIPTION
before this PR it failed with:
```
Undefined symbols for architecture x86_64 (or arm64):
  "___errno_location", referenced from:
      _run_main_graph in add_wrong_data_type.o
```
on both x86_64 and arm64, because `__errno_location` is not defined on MacOS

as well as:
```
  File "/Users/sorenlassen/git/onnx-mlir-einsum/build/test/backend/RelWithDebInfo/input_verification_backend.py", line 170, in _redirect_stdout
    c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: dlsym(RTLD_DEFAULT, stdout): symbol not found
```
which is fixed with the solution from stackoverflow: https://stackoverflow.com/a/47616945