### PR TITLE
Fix ifThenElse function of LLVMBuilder.

### DIFF
--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1717,14 +1717,14 @@ void LLVMBuilder::ifThenElse(
   // Split the current block into IF, THEN, ELSE and END blocks.
   Block *ifBlock, *thenBlock, *elseBlock, *endBlock;
   ifBlock = b().getInsertionBlock();
-  thenBlock = ifBlock->splitBlock(b().getInsertionPoint());
-  elseBlock = b().createBlock(
-      thenBlock->getParent(), std::next(Region::iterator(thenBlock)));
+  endBlock = ifBlock->splitBlock(b().getInsertionPoint());
+  thenBlock = b().createBlock(
+      ifBlock->getParent(), std::next(Region::iterator(ifBlock)));
   if (elseFn)
-    endBlock = b().createBlock(
-        elseBlock->getParent(), std::next(Region::iterator(elseBlock)));
+    elseBlock = b().createBlock(
+        thenBlock->getParent(), std::next(Region::iterator(thenBlock)));
   else
-    endBlock = elseBlock;
+    elseBlock = endBlock;
 
   // Emit code for the IF block.
   b().setInsertionPointToEnd(ifBlock);


### PR DESCRIPTION
When I fix PR #2267, I found simple ifThenElse didn't work. So I investigated it.

In original code, original Block is split into `ifBlock` and `thenBlock`, and create additional blocks for `elseBlock` and `endBlock`. In this PR, `thenBlock` and `elseBlock` are inserted between `ifBlock` and `endBlock`.

Following figure shows my understanding. if there is "instruction A" in ifBlock, it seems to put unexpected place, but in this PR, the instruction put in expected place. I referred to [llvm-project/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp#L177-L184)

I want to hear your comments. 

<img width="593" alt="image" src="https://github.com/onnx/onnx-mlir/assets/18550698/93d88d38-2bc1-4f79-9cf6-72e0670fca89">
