### PR TITLE
don't treat DenseResourceElementsAttr as dense ONNXConstant

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -539,6 +539,12 @@ bool isDenseONNXConstant(Value result) {
   if (!isa_and_nonnull<ElementsAttr>(constOp.getValueAttr()))
     return false;
 
+  // Except DenseResourceElementsAttr is too hard to work with, since it
+  // sometimes has a different shape and element type than constOp, plus
+  // DenseResourceElementsAttr has a limited API.
+  if (isa<DenseResourceElementsAttr>(constOp.getValueAttr()))
+    return false;
+
   // No other attribute must be set.
   return !constOp.getValueFloatAttr() && !constOp.getValueFloatsAttr() &&
          !constOp.getValueIntAttr() && !constOp.getValueIntsAttr() &&

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -71,11 +71,11 @@ def HasIntegerElementType: Constraint<CPred<
 >;
 
 def IsConstOfZeros : Constraint<
-  CPred<"isConstOf($_self, 0.0)">,
+  CPred<"isDenseONNXConstant($_self) && isConstOf($_self, 0.0)">,
   "Value is an all-zeros constant tensor">;
 
 def IsConstOfOnes : Constraint<
-  CPred<"isConstOf($_self, 1.0)">,
+  CPred<"isDenseONNXConstant($_self) && isConstOf($_self, 1.0)">,
   "Value is an all-ones constant tensor">;
 
 def ValuesHaveSameType : Constraint<


### PR DESCRIPTION
This should prevent any ONNXConstantOp with a DenseResourceElementsAttr value from getting into constant propagation (which doesn't support DenseResourceElementsAttr).

fixes #2344 