### PR TITLE
add --make_raw flag to onnxExternalizeData.py

### DIFF
--- a/utils/onnxExternalizeData.py
+++ b/utils/onnxExternalizeData.py
@@ -10,6 +10,12 @@
 # eligible to become external data, otherwise
 # onnx.save_model(model, path, save_as_external_data=True)
 # doesn't convert them to external data.
+# For example, given the 249MB arcfaceresnet100-8.onnx file from the model zoo
+#
+#   utils/onnxExternalizeData.py arcfaceresnet100-8.onnx --make_raw
+#
+# creates a 249MB external data file arcfaceresnet100-8.onnx.ext and shrinks
+# arcfaceresnet100-8.onnx to 189KB.
 #
 ################################################################################
 

--- a/utils/onnxExternalizeData.py
+++ b/utils/onnxExternalizeData.py
@@ -6,27 +6,54 @@
 # Converts the data in tensors in an onnx model to external data.
 # Useful tool for constructing external data examples for testing.
 #
+# Call with --make_raw to convert non-raw tensors to raw_data to make them
+# eligible to become external data, otherwise
+# onnx.save_model(model, path, save_as_external_data=True)
+# doesn't convert them to external data.
+#
 ################################################################################
 
 import argparse
-import os
 import onnx
+import os
+import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument('model_path', type=str, help="Path to the ONNX model")
+parser.add_argument('--size_threshold', type=int, default=0, help="Only convert tensors with byte size no smaller than this")
 parser.add_argument('--no_all_tensors_to_one_file', action='store_true', help="Save tensors to multiple files")
 parser.add_argument('--no_convert_attribute', action='store_true', help="Only convert initializer tensors to external data")
+parser.add_argument('--make_raw', action='store_true', help="Convert non-raw tensors to raw_data")
 args = parser.parse_args()
+
+def get_all_tensors(onnx_model_proto):
+    return onnx.external_data_helper._get_all_tensors(onnx_model_proto)
+
+def get_initializer_tensors(onnx_model_proto):
+    return onnx.external_data_helper._get_initializer_tensors(onnx_model_proto)
 
 def main():
     filepath = args.model_path
     basename = os.path.basename(filepath)
     model = onnx.load_model(filepath)
+    if args.make_raw:
+        tensors = get_initializer_tensors(model) if args.no_convert_attribute else get_all_tensors(model)
+        for tensor in tensors:
+            if not tensor.HasField("raw_data") and tensor.data_type != onnx.TensorProto.STRING:
+                arr = onnx.numpy_helper.to_array(tensor)
+                bytes = arr.tobytes()
+                if sys.getsizeof(bytes) >= args.size_threshold:
+                    storage_field = onnx.helper.tensor_dtype_to_field(tensor.data_type)
+                    tensor.ClearField(storage_field)
+                    tensor.raw_data = bytes
+                    if sys.byteorder == "big":
+                        # Convert endian from big to little
+                        onnx.numpy_helper.convert_endian(tensor)
     onnx.save_model(model, args.model_path,
         save_as_external_data=True,
         all_tensors_to_one_file=not args.no_all_tensors_to_one_file,
         location=f"{basename}.ext",
-        size_threshold=0,
+        size_threshold=args.size_threshold,
         convert_attribute=not args.no_convert_attribute
     )
 


### PR DESCRIPTION
This makes it possible to turn large constants which are not raw into external data.

I tested this on arcfaceresnet100-8.onnx (size 249MB) from the model zoo.

Without --make_raw it produced no external data, because none its constants are raw.

With --make_raw almost all the 249MB went into a flat .ext file and the .onnx protobuf file was reduced 1345x to 189KB.