### PR TITLE
parallel scrub

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
@@ -101,7 +101,7 @@ void DisposablePool::scrub(ModuleOp moduleOp, OpAttrDictionary opsAttrs) {
       size_t count = 0, aggregateSize = 0;
       // To avoid excessive parallel coordination overhead if there are many
       // small attributes: keep growing the batch until next has at least 10
-      // attributes or their aggregate size (elements count) exceeds 1000.
+      // attributes or their aggregate size (elements count) is at least 1000.
       constexpr size_t minCount = 10, minAggregateCount = 1000;
       while (count < minCount && aggregateSize < minAggregateCount &&
              batchEnd != translations.end()) {

--- a/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
@@ -103,7 +103,8 @@ void DisposablePool::scrub(ModuleOp moduleOp, OpAttrDictionary opsAttrs) {
       // small attributes: keep growing the batch until next has at least 10
       // attributes or their aggregate size (elements count) exceeds 1000.
       constexpr size_t minCount = 10, minAggregateCount = 1000;
-      while (count < minCount && aggregateSize < minAggregateCount && batchEnd != translations.end()) {
+      while (count < minCount && aggregateSize < minAggregateCount &&
+             batchEnd != translations.end()) {
         auto [disposable, _] = next->second;
         aggregateSize += disposable.size();
         ++count;

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -14,17 +14,17 @@
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 #include "src/Version/Version.hpp"
+#include "llvm/Support/Debug.h"
 #include <iostream>
 #include <regex>
+
+#define DEBUG_TYPE "onnx_mlir_main"
 
 using namespace onnx_mlir;
 
 extern llvm::cl::OptionCategory onnx_mlir::OnnxMlirOptions;
 
 int main(int argc, char *argv[]) {
-  mlir::MLIRContext context;
-  registerDialects(context);
-
   llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional,
       llvm::cl::desc("<input file>"), llvm::cl::init("-"),
       llvm::cl::cat(OnnxMlirOptions));
@@ -73,6 +73,14 @@ int main(int argc, char *argv[]) {
     llvm::errs()
         << "Warning: --onnx-op-stats requires targets like --EmitMLIR, "
            "--EmitLLVMIR, or binary-generating emit commands.\n";
+
+  // Create context after registerMLIRContextCLOptions() is called.
+  mlir::MLIRContext context;
+  if (!context.isMultithreadingEnabled()) {
+    assert(context.getNumThreads() == 1 && "1 thread if no multithreading");
+    LLVM_DEBUG(llvm::dbgs() << "multithreading is disabled\n");
+  }
+  registerDialects(context);
 
   mlir::OwningOpRef<mlir::ModuleOp> module;
   std::string errorMessage;


### PR DESCRIPTION
ScrubDisposablePass can be slow if there are large constants to rewrite from DisposableElementsAttr to DenseElementsAttr. This change parallelizes the work with each worker rewriting a subset of the constants. This speeds things up provided that the work is not all in a single large constant.

Tested it on arcfaceresnet100-8.onnx from the model zoo on a MacBook M1
```
RelWithDebInfo/bin/onnx-mlir arcfaceresnet100-8.onnx -mlir-timing --EmitMLIR
```
and saw the time spent in ScrubDisposablePass drop by 45% from 85ms to 47ms.

Also fixed MLIRContext creation in onnx-mlir.cpp to make the `--mlir-disable-threading` flag work and added debug logging, so you can see a debug log message confirming that threading is disabled if you call
```
onnx-mlir --mlir-disable-threading -debug-only=onnx_mlir_main
```
With this fix it's easy to see the effect of parallel scrub or not by calling the above arcfaceresnet100-8.onnx example with and without `--mlir-disable-threading`