### PR TITLE
limit onnx constant value attribute to dense or disposable ElementsAttr

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -28,6 +28,7 @@
 #include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.hpp"
 #include "src/Accelerators/NNPA/Pass/NNPAPasses.hpp"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXDimAnalysis.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
@@ -42,14 +43,13 @@ namespace onnx_mlir {
 Value getSqrtResultBatchNormA(
     Location loc, PatternRewriter &rewriter, Value var, FloatAttr epsilon) {
   Type elementType = var.getType().cast<ShapedType>().getElementType();
+  MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
 
   // epsilon
   RankedTensorType epsilonType = RankedTensorType::get({1}, elementType);
   DenseElementsAttr epsilonConstAttr =
       DenseElementsAttr::get<float>(epsilonType, epsilon.getValueAsDouble());
-  Value epsilonConst = rewriter.create<ONNXConstantOp>(loc, epsilonType,
-      nullptr, epsilonConstAttr, nullptr, nullptr, nullptr, nullptr, nullptr,
-      nullptr);
+  Value epsilonConst = create.onnx.constant(epsilonConstAttr);
 
   // sqrt(var + epsilon)
   Value var_plus_epsilon = rewriter.create<ONNXAddOp>(loc, var, epsilonConst);

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -32,6 +32,7 @@
 #include "src/Builder/ModelInputShaper.hpp"
 #include "src/Builder/SymbolTable.hpp"
 #include "src/Compiler/CompilerOptions.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Interface/HasOnnxSubgraphOpInterface.hpp"
@@ -226,6 +227,15 @@ private:
     return builder_.create<ONNXNoneOp>(UnknownLoc()).getResult();
   }
 
+  Value createConstantValue(ElementsAttr value, Location loc) {
+    OnnxBuilder createONNX(builder_, loc);
+    return createONNX.constant(value);
+  }
+
+  Value createConstantValue(ElementsAttr value) {
+    return createConstantValue(value, UnknownLoc());
+  }
+
   void AddValueInfo(const onnx::ValueInfoProto &vi, bool allowExist = false) {
     if (allowExist && onnx_type_map.ContainsKey(vi.name()))
       return;
@@ -269,8 +279,7 @@ private:
     // Use the tensor name as Location.
     auto loc =
         NameLoc::get(builder_.getStringAttr("Initializer_" + tensor.name()));
-    Value initializer =
-        builder_.create<ONNXConstantOp>(loc, Attribute(), mlirAttr);
+    Value initializer = createConstantValue(mlirAttr, loc);
     num_of_parameters_ += mlirAttr.getShapedType().getNumElements();
     return initializer;
   }
@@ -912,9 +921,7 @@ private:
       auto tensorType = RankedTensorType::get(tensorDims, elementType);
       auto constantDenseAttribute =
           DenseElementsAttr::get(tensorType, llvm::ArrayRef(values));
-      auto constantOp = builder_.create<ONNXConstantOp>(
-          UnknownLoc(), Attribute(), constantDenseAttribute);
-      Value constantResult = *(constantOp.getODSResults(0).begin());
+      Value constantResult = createConstantValue(constantDenseAttribute);
       inputs.push_back(constantResult);
     }
 
@@ -929,9 +936,7 @@ private:
       auto tensorType = RankedTensorType::get(tensorDims, elementType);
       auto constantDenseAttribute =
           DenseElementsAttr::get(tensorType, llvm::ArrayRef(values));
-      auto constantOp = builder_.create<ONNXConstantOp>(
-          UnknownLoc(), Attribute(), constantDenseAttribute);
-      Value constantResult = *(constantOp.getODSResults(0).begin());
+      Value constantResult = createConstantValue(constantDenseAttribute);
       inputs.push_back(constantResult);
     }
     int nOut = ONNXDropoutOp::getNumberOfResults();
@@ -962,9 +967,7 @@ private:
           DenseElementsAttr::get(tensorType, llvm::ArrayRef(values));
 
       // Use the special builder defined in ONNXOp.td.inc.
-      auto constantOp = builder_.create<ONNXConstantOp>(
-          UnknownLoc(), Attribute(), constantDenseAttribute);
-      Value constantResult = *(constantOp.getODSResults(0).begin());
+      Value constantResult = createConstantValue(constantDenseAttribute);
       inputs.push_back(constantResult);
 
       int nIn = ONNXPadOp::getNumberOfOperands();
@@ -1000,9 +1003,7 @@ private:
             RankedTensorType::get({(int64_t)arrayAttr.size()}, elementType);
         auto constantDenseAttribute =
             DenseElementsAttr::get(tensorType, arrayAttr.getValue());
-        auto constantOp = builder_.create<ONNXConstantOp>(
-            UnknownLoc(), Attribute(), constantDenseAttribute);
-        Value constantValue = constantOp.getOutput();
+        Value constantValue = createConstantValue(constantDenseAttribute);
 
         // Map from ONNX attributes to indices, which are
         // matched with ONNXSliceOp::build ordering.

--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -16,6 +16,7 @@
 
 #include "src/Dialect/Mlir/IndexExpr.hpp"
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
+#include "src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Support/TypeUtilities.hpp"
@@ -75,6 +76,8 @@ Value OnnxBuilder::concat(
 }
 
 Value OnnxBuilder::constant(Attribute denseAttr) const {
+  assert((isa<DenseElementsAttr, DisposableElementsAttr>(denseAttr)) &&
+         "unsupported onnx constant value attribute");
   return createOpAndInferShapes<ONNXConstantOp>(Attribute(), denseAttr);
 }
 

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -476,33 +476,6 @@ void getDims(Value val, SmallVectorImpl<Value> &dims) {
     dims.emplace_back(val);
 }
 
-Value normalizeConstantOp(
-    PatternRewriter &rewriter, Value output, Attribute attr) {
-  ShapedType outputType = output.getType().cast<ShapedType>();
-  Type elementType = outputType.getElementType();
-
-  DenseElementsAttr denseAttr;
-  if (ArrayAttr arrayAttr = attr.dyn_cast<ArrayAttr>()) {
-    int64_t dim = arrayAttr.size();
-    auto tensorType = RankedTensorType::get({dim}, elementType);
-    denseAttr = DenseElementsAttr::get(tensorType, arrayAttr.getValue());
-  } else {
-    auto tensorType = RankedTensorType::get({}, elementType);
-    if (FloatAttr floatAttr = attr.dyn_cast<FloatAttr>()) {
-      denseAttr = DenseElementsAttr::get(tensorType, {floatAttr.getValue()});
-    } else if (IntegerAttr intAttr = attr.dyn_cast<IntegerAttr>()) {
-      denseAttr = DenseElementsAttr::get(tensorType, intAttr.getSInt());
-    } else if (StringAttr strAttr = attr.dyn_cast<StringAttr>()) {
-      denseAttr = DenseElementsAttr::get(tensorType, {strAttr.getValue()});
-    } else {
-      llvm_unreachable("unexpected Attribute");
-    }
-  }
-  return rewriter.create<ONNXConstantOp>(output.getLoc(), output.getType(),
-      Attribute(), denseAttr, FloatAttr(), ArrayAttr(), IntegerAttr(),
-      ArrayAttr(), StringAttr(), ArrayAttr());
-}
-
 // Create a DenseElementsAttr based on the shape of type at the given index.
 DenseElementsAttr createDenseElementsAttrFromShapeAtIndex(
     PatternRewriter &rewriter, Value value, IntegerAttr indexAttr) {

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -507,16 +507,13 @@ bool isDenseONNXConstant(Value result) {
   if (!constOp)
     return false;
 
-  // The value attribute must be an ElementsAttr (which is one of
-  // DenseElementsAttr, DenseResourceElementsAttr, DisposableElementsAttr).
-  if (!isa_and_nonnull<ElementsAttr>(constOp.getValueAttr()))
+  // Must have value attribute.
+  Attribute value = constOp.getValueAttr();
+  if (!value)
     return false;
 
-  // Except DenseResourceElementsAttr is too hard to work with, since it
-  // sometimes has a different shape and element type than constOp, plus
-  // DenseResourceElementsAttr has a limited API.
-  if (isa<DenseResourceElementsAttr>(constOp.getValueAttr()))
-    return false;
+  assert((isa<DenseElementsAttr, DisposableElementsAttr>(value)) &&
+         "unsupported onnx constant value attribute");
 
   // No other attribute must be set.
   return !constOp.getValueFloatAttr() && !constOp.getValueFloatsAttr() &&

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.hpp
@@ -203,9 +203,6 @@ mlir::DenseElementsAttr createDenseElementsAttrFromFloatAttr(
     mlir::PatternRewriter &rewriter, mlir::Type elementType,
     mlir::FloatAttr attr);
 
-mlir::Value normalizeConstantOp(
-    mlir::PatternRewriter &rewriter, mlir::Value output, mlir::Attribute attr);
-
 // Create a DenseElementsAttr based on the shape of type at the given index.
 mlir::DenseElementsAttr createDenseElementsAttrFromShapeAtIndex(
     mlir::PatternRewriter &rewriter, mlir::Value value,

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -168,6 +168,7 @@ LogicalResult ONNXSliceOp::inferShapes(
   auto startsDim = startsType.getShape()[0];
   {
     OpBuilder builder(this->getContext());
+    OnnxBuilder createONNX(builder, this->getLoc());
     const Type elementType = builder.getIntegerType(64);
     const auto tensorType = RankedTensorType::get({startsDim}, elementType);
 
@@ -179,9 +180,7 @@ LogicalResult ONNXSliceOp::inferShapes(
       auto constantDenseAttribute =
           DenseElementsAttr::get(tensorType, llvm::ArrayRef(vals));
       builder.setInsertionPoint(*this);
-      auto constantOp = builder.create<ONNXConstantOp>(
-          this->getLoc(), Attribute(), constantDenseAttribute);
-      Value constantResult = constantOp.getOutput();
+      Value constantResult = createONNX.constant(constantDenseAttribute);
       this->setOperand(3, constantResult);
     }
 
@@ -191,9 +190,7 @@ LogicalResult ONNXSliceOp::inferShapes(
       auto constantDenseAttribute =
           DenseElementsAttr::get(tensorType, llvm::ArrayRef(vals));
       builder.setInsertionPoint(*this);
-      auto constantOp = builder.create<ONNXConstantOp>(
-          this->getLoc(), Attribute(), constantDenseAttribute);
-      Value constantResult = constantOp.getOutput();
+      Value constantResult = createONNX.constant(constantDenseAttribute);
       this->setOperand(4, constantResult);
     }
   }

--- a/src/Transform/ONNX/Decompose.cpp
+++ b/src/Transform/ONNX/Decompose.cpp
@@ -485,6 +485,9 @@ struct SoftmaxPattern : public ConversionPattern {
 
     // Rewrite
     Location odsLoc = op0->getLoc();
+    onnx_mlir::MultiDialectBuilder<onnx_mlir::OnnxBuilder> create(
+        rewriter, odsLoc);
+
     IntegerAttr keepDimsAttr = rewriter.getIntegerAttr(
         rewriter.getIntegerType(64, /*isSigned=*/true), 1);
     ArrayAttr axisAttr = rewriter.getI64ArrayAttr({axisValue});
@@ -495,8 +498,7 @@ struct SoftmaxPattern : public ConversionPattern {
     Value subValue =
         rewriter.create<ONNXSubOp>(odsLoc, inputType, input, maxInput);
     Value expValue = rewriter.create<ONNXExpOp>(odsLoc, inputType, subValue);
-    Value axisOp = rewriter.create<ONNXConstantOp>(odsLoc, nullptr,
-        /*value=*/rewriter.getI64TensorAttr({axisValue}));
+    Value axisOp = create.onnx.constantInt64({axisValue});
     IntegerAttr noopWithEmptyAxes = rewriter.getIntegerAttr(
         rewriter.getIntegerType(64, /*isSigned=*/true), 0);
     Value sumValue = rewriter.create<ONNXReduceSumOp>(odsLoc, resultType,


### PR DESCRIPTION
changed all non-test code paths to create onnx constants using OnnxBuilder::constant()

added assert in OnnxBuilder::constant() and isDenseONNXConstant() to enforce the invariant that the value attribute is always a DenseElementsAttr or DisposableElementsAttr, since the way we use the value attribute of onnx constants throughout the code base generally assumes that it behaves like those, namely that getValues<T>() works for all data types T and that you can use ElementsAttrBuilder for constant propagation and constant folding

this PR could also help track down how a DenseResourceElementsAttr ends up in a constant operand to onnx.Reshape in issue #2344

