### PR TITLE
miscellaneous docs fixes

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -142,14 +142,14 @@ jobs:
 
   - script: |
       call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+      call onnx-mlir\utils\check-docs.cmd
+    displayName: Run onnx-mlir doc tests
+    workingDirectory: $(Agent.BuildDirectory)
+
+  - script: |
+      call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
       call onnx-mlir\utils\check-onnx-numerical.cmd
     displayName: Run onnx-mlir numerical tests
     workingDirectory: $(Agent.BuildDirectory)
     env:
       CTEST_PARALLEL_LEVEL: ${{ parameters.CTEST_PARALLEL_LEVEL }}
-
-  - script: |
-      call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-      call onnx-mlir\utils\check-docs.cmd
-    displayName: Run onnx-mlir doc tests
-    workingDirectory: $(Agent.BuildDirectory)

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -48,6 +48,10 @@ jobs:
       run: |
         cd ~/work/onnx-mlir
         sh ~/work/onnx-mlir/onnx-mlir/utils/install-onnx-mlir.sh
+    - name: build and run docs/doc_example tests
+      run: |
+        cd ~/work/onnx-mlir
+        sh ~/work/onnx-mlir/onnx-mlir/utils/check-doc-example.sh
     - name: run onnx-mlir backend and numerical tests
       run: |
         cd ~/work/onnx-mlir

--- a/docker/Dockerfile.onnx-mlir
+++ b/docker/Dockerfile.onnx-mlir
@@ -50,13 +50,13 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
                                 [ "$(uname -m)" = "x86_64" ] &&  echo || \
                                 [ "$(uname -m)" = "ppc64le" ] && echo || echo)} \
     && TEST_ARGS="-mcpu=${TEST_MCPU}" \
+    && make check-docs \
     && make NPROC=${NPROC} \
             CTEST_PARALLEL_LEVEL=${NPROC} \
             TEST_MCPU=${TEST_MCPU} \
             TEST_ARGS="${TEST_ARGS}" \
             -j${NPROC} \
             check-onnx-backend-numerical \
-    && make check-docs \
     && make -j${NPROC} install \
     && echo -e "/usr/local/lib" > \
             /etc/ld.so.conf.d/onnx-mlir.conf && ldconfig \

--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -50,6 +50,7 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
                    [ "$(uname -m)" = "ppc64le" ] && echo || echo) \
     && TEST_ARGS="-mcpu=${TEST_MCPU}" \
     && TEST_OPTLEVEL=0 \
+    && make check-docs \
     && make NPROC=${NPROC} \
             CTEST_PARALLEL_LEVEL=${NPROC} \
             TEST_MCPU=${TEST_MCPU} \
@@ -57,7 +58,6 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
             TEST_OPTLEVEL=${TEST_OPTLEVEL} \
             -j${NPROC} \
             check-onnx-backend-numerical \
-    && make check-docs \
     && rm -f Debug/bin/*Test Debug/bin/Perf* Debug/bin/Test* \
 # When building for push event to publish the image, unshallow and
 # rename origin to upstream to make the repo a bit more dev friendly.

--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -3,7 +3,7 @@
 
 # Supported ONNX Operation for Target *cpu*.
 
-Onnx-mlir currently supports ONNX operations targeting up to opset 18. Limitations are listed when applicable.
+Onnx-mlir currently supports ONNX operations targeting up to opset 19. Limitations are listed when applicable.
 
 * Operations are defined by the [ONNX Standard](https://github.com/onnx/onnx/blob/main/docs/Operators.md).
 * Opset indicates, for each operation, the ONNX opset that (1) last modified that operation and (2) is supported by the current version of onnx-mlir. For example, "Add" was modified in Opset 14 and carries on unmodified to Opset 16. If onnx-mlir supports Opset 14, we thus list "14" as the Opset associated with the "Add" operation.
@@ -47,7 +47,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 18. Limitatio
 | **Compress** |11 | | |
 | **Concat** |13 | | |
 | **ConcatFromSequence** | |unsupported | |
-| **Constant** |13 | | |
+| **Constant** |19 | | |
 | **ConstantOfShape** |9 | | |
 | **Conv** |11 | | |
 | **ConvInteger** | |unsupported | |

--- a/docs/doc_example/CMakeLists.txt
+++ b/docs/doc_example/CMakeLists.txt
@@ -73,7 +73,6 @@ add_onnx_mlir_executable(OMRuntimeTest
 
   LINK_LIBS PRIVATE
   OMRuntimeTestModelLibrary
-  cruntime
   )
 
 set_output_directory(OMRuntimeTest BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR})

--- a/docs/doc_example/main.c
+++ b/docs/doc_example/main.c
@@ -40,11 +40,17 @@ int main() {
 
   // Get the first tensor from output list.
   OMTensor *y = omTensorListGetOmtByIndex(output_list, 0);
+  omTensorPrint("Result tensor: ", y);
   float *outputPtr = (float *) omTensorGetDataPtr(y);
 
   // Print its content, should be all 3.
-  for (int i = 0; i < 6; i++)
-    printf("%f ", outputPtr[i]);
+  for (int i = 0; i < 6; i++) {
+    float f = outputPtr[i];
+    if (f != 3.0) {
+      fprintf(stderr, "Iteration %d: expected 3.0, got %f.\n", i, f);
+      exit(100);
+    }
+  }
   printf("\n");
 
   // Destory the list and the tensors inside of it.

--- a/docs/doc_example/main.c
+++ b/docs/doc_example/main.c
@@ -19,8 +19,10 @@ OMTensorList *create_input_list() {
 
   // Use omTensorCreateWithOwnership "true" so float arrays are automatically
   // freed when the Tensors are destroyed.
-  OMTensor *x1 = omTensorCreateWithOwnership(x1Data, shape, rank, ONNX_TYPE_FLOAT, true);
-  OMTensor *x2 = omTensorCreateWithOwnership(x2Data, shape, rank, ONNX_TYPE_FLOAT, true);
+  OMTensor *x1 =
+      omTensorCreateWithOwnership(x1Data, shape, rank, ONNX_TYPE_FLOAT, true);
+  OMTensor *x2 =
+      omTensorCreateWithOwnership(x2Data, shape, rank, ONNX_TYPE_FLOAT, true);
 
   // Construct a TensorList using the Tensors
   OMTensor *list[2] = {x1, x2};
@@ -41,7 +43,7 @@ int main() {
   // Get the first tensor from output list.
   OMTensor *y = omTensorListGetOmtByIndex(output_list, 0);
   omTensorPrint("Result tensor: ", y);
-  float *outputPtr = (float *) omTensorGetDataPtr(y);
+  float *outputPtr = (float *)omTensorGetDataPtr(y);
 
   // Print its content, should be all 3.
   for (int i = 0; i < 6; i++) {

--- a/utils/check-doc-example.sh
+++ b/utils/check-doc-example.sh
@@ -1,0 +1,3 @@
+# Build and run docs/doc_example tests
+cd onnx-mlir/build
+cmake --build . --target check-doc-example

--- a/utils/documentOps.py
+++ b/utils/documentOps.py
@@ -203,7 +203,7 @@ def main(argv):
     emit_unsupported = 0
     util_path = "."
     file_name = ""
-    input_command = "python documentOps.py"
+    input_command = "python3 documentOps.py"
 
     try:
         opts, args = getopt.getopt(
@@ -236,7 +236,7 @@ def main(argv):
         print_usage()
 
     # Load gen_onnx_mlir operation version.
-    proc = subprocess.Popen(['python', util_path + '/gen_onnx_mlir.py', '--list-operation-version'], stdout=subprocess.PIPE)
+    proc = subprocess.Popen(['python3', util_path + '/gen_onnx_mlir.py', '--list-operation-version'], stdout=subprocess.PIPE)
     str = ""
     for line in  proc.stdout:
         str += line.decode("utf-8").rstrip()

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # After modifying this file, the script will need to run to rebuild the
 # onnx-mlir ONNX Dialect. This is performed by calling


### PR DESCRIPTION
Run quick check-docs or check-doc-example before slow numerical tests on all platforms.

Made OMRuntimeTest print and check the result tensor, like in OMRuntimeCppTest, and remove duplicate cruntime linkage.

Regenerated SupportedONNXOps-cpu.md. Changed documentOps.py and gen_onnx_mlir.py to use python3, otherwise 'ninja onnx_mlir_supported_ops' failed for me because I only have python3 and not python.