### PR TITLE
disable TEST_NOFLOAT16 on linux amd64, s390x platforms

### DIFF
--- a/docker/Dockerfile.onnx-mlir
+++ b/docker/Dockerfile.onnx-mlir
@@ -47,8 +47,8 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
     && make -j${NPROC} \
     && make -j${NPROC} LIT_OPTS=-v check-onnx-lit \
 # FLOAT16 backend tests only work on ppc64le platform at the moment
-    && TEST_NOFLOAT16=${TEST_NOFLOAT16:-$([ "$(uname -m)" = "s390x" ] && echo true || \
-                                         ([ "$(uname -m)" = "x86_64" ] &&  echo true || \
+    && TEST_NOFLOAT16=${TEST_NOFLOAT16:-$([ "$(uname -m)" = "s390x" ] && echo || \
+                                         ([ "$(uname -m)" = "x86_64" ] &&  echo || \
                                          ([ "$(uname -m)" = "ppc64le" ] && echo || echo)))} \
 # User image is built with SIMD (currently on s390x only)
     && TEST_MCPU=${TEST_MCPU:-$([ "$(uname -m)" = "s390x" ] && echo z14 || \

--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -46,8 +46,8 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
     && make -j${NPROC} \
     && make -j${NPROC} LIT_OPTS=-v check-onnx-lit \
 # FLOAT16 backend tests only work on ppc64le platform at the moment
-    && TEST_NOFLOAT16=${TEST_NOFLOAT16:-$([ "$(uname -m)" = "s390x" ] && echo true || \
-                                         ([ "$(uname -m)" = "x86_64" ] &&  echo true || \
+    && TEST_NOFLOAT16=${TEST_NOFLOAT16:-$([ "$(uname -m)" = "s390x" ] && echo || \
+                                         ([ "$(uname -m)" = "x86_64" ] &&  echo || \
                                          ([ "$(uname -m)" = "ppc64le" ] && echo || echo)))} \
 # Dev image is built without SIMD, placeholder for easy SIMD enablement
     && TEST_MCPU=$([ "$(uname -m)" = "s390x" ] && echo || \


### PR DESCRIPTION
TODO: close this PR after capturing CI failures on linux amd64 and s390x