### PR TITLE
const prop expansion bound

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -237,6 +237,14 @@ llvm::cl::opt<bool> onnxConstPropReport("onnx-const-prop-report",
     llvm::cl::desc("Report diagnostic info for constant propagation passes."),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
 
+llvm::cl::opt<int> onnxConstPropExpansionBound(
+    "onnx-const-prop-expansion-bound",
+    llvm::cl::desc("ONNX dialect constant propagation maximum expansion factor."
+                   " Constants are not propagated if their bytes size exceed"
+                   " the aggregate operands' sizes by more than this factor."
+                   " Set to -1 to always propagate, which is the default."),
+    llvm::cl::init(-1), llvm::cl::cat(OnnxMlirCommonOptions));
+
 llvm::cl::opt<bool> enableParallel("parallel",
     llvm::cl::desc("Enable parallelization (default=false)\n"
                    "Set to 'true' if you want to enable parallelization."),

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -86,6 +86,7 @@ extern llvm::cl::opt<bool> enableMemoryBundling;
 extern llvm::cl::opt<int> onnxOpTransformThreshold;
 extern llvm::cl::opt<bool> onnxOpTransformReport;
 extern llvm::cl::opt<bool> onnxConstPropReport;
+extern llvm::cl::opt<int> onnxConstPropExpansionBound;
 extern llvm::cl::opt<bool> enableParallel;
 extern llvm::cl::opt<bool> disableSimdOption;
 extern llvm::cl::opt<bool> enableSimdDataLayout;

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -8,9 +8,9 @@
 //
 // =============================================================================
 //
-// Functions for adding passes.
+// Functions for configuring and adding passes.
 //
-// REQUEST: to the extend possible, passes here should not sample global
+// REQUEST: To the extent possible, passes here should not sample global
 // optimization parameters specified in CompilerOptions.hpp. The passes should
 // use parameters that are set by these global options where these passes are
 // called. The idea is to keep our code as free of "rogue" global options used
@@ -40,6 +40,10 @@
 using namespace mlir;
 
 namespace onnx_mlir {
+
+void configurePasses() {
+  configureConstPropONNXToONNXPass(onnxConstPropExpansionBound);
+}
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU) {
   // This is a transition from previous static passes to full dynamic passes

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -8,7 +8,7 @@
 //
 // =============================================================================
 //
-// Functions for adding passes.
+// Functions for configuring and adding passes.
 //
 //===----------------------------------------------------------------------===//
 
@@ -16,6 +16,9 @@
 #include "mlir/Pass/PassManager.h"
 
 namespace onnx_mlir {
+// Configures passes up front based on command line options.
+void configurePasses();
+
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU);
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
     bool enableInstrumentONNXSignature, std::string ONNXOpsStatFilename);

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -941,6 +941,8 @@ int compileModule(mlir::OwningOpRef<ModuleOp> &module,
   if (rc != CompilerSuccess)
     return rc;
 
+  configurePasses();
+
   mlir::PassManager pm(
       module.get()->getName(), mlir::OpPassManager::Nesting::Implicit);
   // TODO(tung): Revise adding passes. The current mechanism does not work if

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -41,6 +41,9 @@ std::unique_ptr<mlir::Pass> createConvOptONNXToONNXPass(
 
 std::unique_ptr<mlir::Pass> createShapeInferencePass();
 
+// To configure ConstPropONNXToONNXPass at program start.
+void configureConstPropONNXToONNXPass(int expansionBound);
+
 std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass(bool report = false);
 
 /// Pass for instrument the ops in specific stage.

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -34,6 +34,7 @@
 #include "src/Accelerators/Accelerator.hpp"
 #include "src/Compiler/CompilerDialects.hpp"
 #include "src/Compiler/CompilerOptions.hpp"
+#include "src/Compiler/CompilerPasses.hpp"
 #include "src/Compiler/DisposableGarbageCollector.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
@@ -161,6 +162,10 @@ int main(int argc, char **argv) {
     llvm::errs() << "Failure to compile file; " << error_message << "\n";
     return 1;
   }
+
+  // Passes are configured with command line options so they must be configured
+  // after command line parsing but before any passes are run.
+  configurePasses();
 
   auto passManagerSetupFn = [&](PassManager &pm) {
     MLIRContext *ctx = pm.getContext();

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -90,6 +90,9 @@ def IsMatMulIntegerRhsZero: Constraint<
     CPred<"isMatMulIntegerRhsZero($0, $1)">,
     "MatMulInteger rhs matrix is zero for given zero point">;
 
+def SatisfiesExpansionBound: Constraint<
+  CPred<"satisfiesExpansionBound($_self)">>;
+
 // Creation helpers:
 
 def CreateZeroTensorOfType: NativeCodeCall<
@@ -270,7 +273,8 @@ def AddConstProp : Pat<
     // To c1+c2
     (CreateAddOfTwoConst $addOp, $lhs, $rhs),
     // Additional constraints (dense)
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$addOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
 def AddZerosOnRhs : Pat<
@@ -294,7 +298,8 @@ def SubConstProp : Pat<
                       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     // To c1-c2
     (CreateSubOfTwoConst $subOp, $lhs, $rhs),
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$subOp)]>;
 
 // TODO: Expand $a to $result's shape instead of requiring ValuesHaveSameType.
 def SubZerosOnRhs : Pat<
@@ -359,7 +364,8 @@ def MaxConstProp : Pat<
     // To c = max(c1, c2)
     (CreateMaxOfConst $maxOp, $operandList),
     // Constraints
-    [(IsVariadicOperandDenseONNXConstantOp:$operandList)]>;
+    [(IsVariadicOperandDenseONNXConstantOp:$operandList),
+     (SatisfiesExpansionBound:$maxOp)]>;
 
 // Constant Propagation for Min
 def MinConstProp : Pat<
@@ -368,7 +374,8 @@ def MinConstProp : Pat<
     // To c = min(c1, c2)
     (CreateMinOfConst $minOp, $operandList),
     // Constraints
-    [(IsVariadicOperandDenseONNXConstantOp:$operandList)]>;
+    [(IsVariadicOperandDenseONNXConstantOp:$operandList),
+     (SatisfiesExpansionBound:$minOp)]>;
 
 // Constant Propagation for Sum
 def SumConstProp : Pat<
@@ -377,7 +384,8 @@ def SumConstProp : Pat<
     // To c = sum(c1, c2)
     (CreateSumOfConst $sumOp, $operandList),
     // Constraints
-    [(IsVariadicOperandDenseONNXConstantOp:$operandList)]>;
+    [(IsVariadicOperandDenseONNXConstantOp:$operandList),
+     (SatisfiesExpansionBound:$sumOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise MUL operations.
@@ -446,9 +454,10 @@ def MulConstProp : Pat<
     // To c1+c2
     (CreateMulOfTwoConst $mulOp, $lhs, $rhs),
     // Multiplication constraints
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$mulOp)]>;
 
-// TODO: Expand $a to $result's shape instead of requiring ValuesHaveSameType.
+// TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
 def MulOnesOnRhs : Pat<
     // From mul(x, c).
     (ONNXMulOp:$result
@@ -470,9 +479,10 @@ def DivConstProp : Pat<
     // To c1/c2
     (CreateDivOfTwoConst $divOp, $lhs, $rhs),
     // Division constraints
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$divOp)]>;
 
-// TODO: Expand $a to $result's shape instead of requiring ValuesHaveSameType.
+// TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
 def DivOnesOnRhs : Pat<
     // From div(x, c).
     (ONNXDivOp:$result
@@ -498,7 +508,8 @@ def EqualConstProp : Pat<
     // To c1 == c2
     (CreateEqualOfTwoConst $result, $lhs, $rhs),
     // constraints
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagate ONNXLessOp
@@ -509,7 +520,8 @@ def LessConstPropPattern: Pat<
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateLessOfTwoConst $result, $lhs, $rhs),
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagate ONNXGreaterOp
@@ -520,7 +532,8 @@ def GreaterConstPropPattern: Pat<
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateGreaterOfTwoConst $result, $lhs, $rhs),
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagate ONNXLessOrEqualOp
@@ -531,7 +544,8 @@ def LessOrEqualConstPropPattern: Pat<
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateLessOrEqualOfTwoConst $result, $lhs, $rhs),
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagate ONNXGreaterOrEqualOp
@@ -542,7 +556,8 @@ def GreaterOrEqualConstPropPattern: Pat<
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateGreaterOrEqualOfTwoConst $result, $lhs, $rhs),
-    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs)]>;
+    [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
+     (SatisfiesExpansionBound:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns for Where.
@@ -558,7 +573,8 @@ def WhereConstProp : Pat<
     (CreateWhereOfThreeConst $whereOp, $condition, $X, $Y),
     // Where constraints
     [(IsFromDenseONNXConstantOp:$condition),
-     (IsFromDenseONNXConstantOp:$X), (IsFromDenseONNXConstantOp:$Y)]>;
+     (IsFromDenseONNXConstantOp:$X), (IsFromDenseONNXConstantOp:$Y),
+     (SatisfiesExpansionBound:$whereOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns for Reduce ops.
@@ -646,7 +662,8 @@ def MatMulOfConsts : Pat<
       (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_)
     ),
     (CreateMatMulOfConsts $resOp, $A, $B),
-    [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B)]
+    [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
+     (SatisfiesExpansionBound:$resOp)]
     >;
 
 //===----------------------------------------------------------------------===//
@@ -683,7 +700,8 @@ def MatMulIntegerOfConsts : Pat<
     ),
     (CreateMatMulIntegerOfConsts $resOp, $A, $B, $a_zero_point, $b_zero_point),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOpOrNone:$a_zero_point),
-     (IsFromDenseONNXConstantOp:$B), (IsFromDenseONNXConstantOpOrNone:$b_zero_point)]
+     (IsFromDenseONNXConstantOp:$B), (IsFromDenseONNXConstantOpOrNone:$b_zero_point),
+     (SatisfiesExpansionBound:$resOp)]
     >;
 
 //===----------------------------------------------------------------------===//
@@ -698,7 +716,8 @@ def GemmConstProp : Pat<
       $C, $alpha, $beta, $transA, $transB),
     (CreateGemmOfConsts $gemmOp, $A, $B, $C),
     [(IsFromDenseONNXConstantOp:$A), (IsFromDenseONNXConstantOp:$B),
-     (IsFromDenseONNXConstantOpOrNone:$C)]>;
+     (IsFromDenseONNXConstantOpOrNone:$C),
+     (SatisfiesExpansionBound:$gemmOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Transpose operations.
@@ -782,7 +801,8 @@ def ExpandofConst :  Pat<
     // To c where c is the expanded value.
     (CreateExpandOfConst $resOp, $input),
     [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$shape),
-     (HasStaticShape:$resOp)]>;
+     (HasStaticShape:$resOp),
+     (SatisfiesExpansionBound:$resOp)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Gather operations.

--- a/test/mlir/onnx/onnx_constprop_expansion_bound.mlir
+++ b/test/mlir/onnx/onnx_constprop_expansion_bound.mlir
@@ -1,0 +1,23 @@
+// RUN: onnx-mlir-opt --constprop-onnx --onnx-const-prop-expansion-bound=2 %s -split-input-file | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Constant propagate ONNXAddOp only if expansion bound satisfied
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @test_add_propagates() -> tensor<2x5xf32>
+func.func @test_add_propagates() -> tensor<2x5xf32> {
+  %0 = "onnx.Constant"() {value = dense<1.0> : tensor<2x1xf32>} : () -> tensor<2x1xf32>
+  %1 = "onnx.Constant"() {value = dense<2.0> : tensor<1x5xf32>} : () -> tensor<1x5xf32>
+  %2 = "onnx.Add"(%0, %1) : (tensor<2x1xf32> , tensor<1x5xf32>) -> tensor<2x5xf32>
+  onnx.Return %2 : tensor<2x5xf32>
+  // CHECK: onnx.Constant {{.*}} : tensor<2x5xf32>
+}
+
+// CHECK-LABEL: @test_add_doesnt_propagate() -> tensor<5x5xf32>
+func.func @test_add_doesnt_propagate() -> tensor<5x5xf32> {
+  %0 = "onnx.Constant"() {value = dense<1.0> : tensor<5x1xf32>} : () -> tensor<5x1xf32>
+  %1 = "onnx.Constant"() {value = dense<2.0> : tensor<1x5xf32>} : () -> tensor<1x5xf32>
+  %2 = "onnx.Add"(%0, %1) : (tensor<5x1xf32> , tensor<1x5xf32>) -> tensor<5x5xf32>
+  onnx.Return %2 : tensor<5x5xf32>
+  // CHECK: "onnx.Add"(%0, %1) : (tensor<5x1xf32>, tensor<1x5xf32>) -> tensor<5x5xf32>
+}


### PR DESCRIPTION
Adds a command line option `--onnx-const-prop-expansion-bound`:
```
ONNX dialect constant propagation maximum expansion factor.
Constants are not propagated if their bytes size exceed
the aggregate operands' sizes by more than this factor.
Set to -1 to always propagate, which is the default.
```

This makes it possible to prevent generating very large constants at compile time, e.g. through broadcast, which are more efficient to generate during runtime.

The expansion bound is checked in tablegen DDR patterns in ConstProp.td by calling a function `satisfiesExpansionBound(result)` which reads the flag value from a global variable `ConstPropONNXToONNXPassConfiguration::expansionBound`, because we cannot pass the flag value as a pass parameter to the DDR pattern. Since the value is determined up front by a flag it makes sense to set it once at program start. This is done with a function `configureConstPropONNXToONNXPass(expansionBound)` which is exported in Pass/Passes.hpp alongside `createConstPropONNXToONNXPass()` since it's part of the pass's external API. It is called from a function `configurePasses()` which reads the `--onnx-const-prop-expansion-bound` flag value. I put `configurePasses()` in CompilerPasses alongside `addPasses()` which also reads CompilerOptions flag values and makes calls to the pass API functions from Passes.hpp. The onnx-mlir and onnx-mlir-opt programs call `configure()` after they parse the command line options and before they run any passes.

By structuring the dependencies in this fashion we avoid a direct dependency between ConstPropONNXToONNXPass in OMONNXRewrite and the command line flags in CompilerOption. This is helpful for downstream projects (like Groq) that use the passes without CompilerOptions (and CompilerPasses) in programs with their own command line options. They can call `configureConstPropONNXToONNXPass(expansionBound)` at program start, just like they call `createConstPropONNXToONNXPass()` to construct their own pass pipelines, that is, they won't depend on CompilerPasses and will create their own `configurePasses()` and `addPasses()`.