### PR TITLE
reuse dialect registration/loading

### DIFF
--- a/docs/AddCustomAccelerators.md
+++ b/docs/AddCustomAccelerators.md
@@ -50,9 +50,6 @@ We provide a base class [onnx_mlir::accel::Accelerator](../src/Accelerators/Acce
 // Hooks for onnx-mlir driver
 //===--------------------------------------------------------------------===//
 
-/// Load the MLIR dialects necessary to generate code for an accelerator.
-virtual void getOrLoadDialects(mlir::MLIRContext &context) const = 0;
-
 /// Add the transformations necessary to support the accelerator.
 virtual void addPasses(mlir::OwningOpRef<mlir::ModuleOp> &module,
     mlir::PassManager &pm,

--- a/src/Accelerators/Accelerator.hpp
+++ b/src/Accelerators/Accelerator.hpp
@@ -85,9 +85,6 @@ public:
   // Hooks for onnx-mlir driver
   //===--------------------------------------------------------------------===//
 
-  /// Load the MLIR dialects necessary to generate code for an accelerator.
-  virtual void getOrLoadDialects(mlir::MLIRContext &context) const = 0;
-
   /// Add the transformations necessary to support the accelerator.
   virtual void addPasses(mlir::OwningOpRef<mlir::ModuleOp> &module,
       mlir::PassManager &pm, onnx_mlir::EmissionTargetType &emissionTarget,

--- a/src/Accelerators/NNPA/NNPAAccelerator.cpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.cpp
@@ -57,12 +57,6 @@ NNPAAccelerator::~NNPAAccelerator() { delete instance; }
 
 uint64_t NNPAAccelerator::getVersionNumber() const { return ZDNN_VERNUM; }
 
-void NNPAAccelerator::getOrLoadDialects(mlir::MLIRContext &context) const {
-  LLVM_DEBUG(llvm::dbgs() << "Loading dialects for NNPA accelerator\n");
-  context.getOrLoadDialect<zhigh::ZHighDialect>();
-  context.getOrLoadDialect<zlow::ZLowDialect>();
-}
-
 void NNPAAccelerator::addPasses(mlir::OwningOpRef<mlir::ModuleOp> &module,
     mlir::PassManager &pm, onnx_mlir::EmissionTargetType &emissionTarget,
     std::string outputNameNoExt) const {

--- a/src/Accelerators/NNPA/NNPAAccelerator.hpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.hpp
@@ -48,7 +48,6 @@ public:
   //===--------------------------------------------------------------------===//
   // Hooks for onnx-mlir-opt driver
   //===--------------------------------------------------------------------===//
-  virtual void getOrLoadDialects(mlir::MLIRContext &context) const final;
   virtual void addPasses(mlir::OwningOpRef<mlir::ModuleOp> &module,
       mlir::PassManager &pm, onnx_mlir::EmissionTargetType &emissionTarget,
       std::string outputNameNoExt) const final;

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -64,6 +64,7 @@ add_onnx_mlir_library(OMCompilerDialects
 
   LINK_LIBS PUBLIC
   OMAccelerator
+  OMInitAccelerators
   OMKrnlOps
   OMONNXOps
   MLIRIR
@@ -164,7 +165,6 @@ add_onnx_mlir_library(OMCompilerUtils
   OMCompilerDialects
   OMCompilerPasses
   OMAccelerator
-  OMInitAccelerators
   OMVersion
   MLIRIR
 

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -58,6 +58,17 @@ add_onnx_mlir_library(OMCompilerOptions
   OMAccelerator
   )
 
+
+add_onnx_mlir_library(OMCompilerDialects
+  CompilerDialects.cpp
+
+  LINK_LIBS PUBLIC
+  OMAccelerator
+  OMKrnlOps
+  OMONNXOps
+  MLIRIR
+  )
+
 add_onnx_mlir_library(OMCompilerPasses
   CompilerPasses.cpp
   DisposableGarbageCollector.cpp
@@ -150,6 +161,7 @@ add_onnx_mlir_library(OMCompilerUtils
 
   LINK_LIBS PUBLIC
   ${OMLibs}
+  OMCompilerDialects
   OMCompilerPasses
   OMAccelerator
   OMInitAccelerators
@@ -190,6 +202,7 @@ add_onnx_mlir_library(OMCompiler
   EXCLUDE_FROM_OM_LIBS
 
   LINK_LIBS PRIVATE
+  OMCompilerDialects
   OMCompilerUtils
   )
 

--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------------------------ CompilerDialects.cpp ------------------------===//
+
+#include "CompilerDialects.hpp"
+
+#include "src/Dialect/Krnl/KrnlOps.hpp"
+#include "src/Dialect/ONNX/ONNXDialect.hpp"
+
+#include "mlir/InitAllDialects.h"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
+  DialectRegistry registry;
+
+  // Note that we cannot consult command line options because they have not yet
+  // been parsed when registerDialects() is called.
+
+  registry.insert<arith::ArithDialect>();
+  registry.insert<linalg::LinalgDialect>();
+  registry.insert<affine::AffineDialect>();
+  registry.insert<LLVM::LLVMDialect>();
+  registry.insert<scf::SCFDialect>();
+  registry.insert<func::FuncDialect>();
+  registry.insert<vector::VectorDialect>();
+  registry.insert<shape::ShapeDialect>();
+  registry.insert<math::MathDialect>();
+  registry.insert<memref::MemRefDialect>();
+  registry.insert<ONNXDialect>();
+  registry.insert<KrnlDialect>();
+  registry.insert<cf::ControlFlowDialect>();
+
+  // Initialize accelerator(s) if required.
+  accel::initAccelerators(accels);
+
+  // Register dialects for accelerators.
+  for (auto *accel : accel::Accelerator::getAccelerators())
+    accel->registerDialects(registry);
+
+  return registry;
+}
+
+}

--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -45,4 +45,4 @@ DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
   return registry;
 }
 
-}
+} // namespace onnx_mlir

--- a/src/Compiler/CompilerDialects.hpp
+++ b/src/Compiler/CompilerDialects.hpp
@@ -14,6 +14,7 @@
 namespace onnx_mlir {
 
 // Adds the mlir and onnx-mlir dialects needed to compile end to end.
+// Initializes accelerator(s) if required.
 mlir::DialectRegistry registerDialects(llvm::ArrayRef<accel::Accelerator::Kind> accels);
 
 }

--- a/src/Compiler/CompilerDialects.hpp
+++ b/src/Compiler/CompilerDialects.hpp
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------------------------ CompilerDialects.hpp ------------------------===//
+
+#pragma once
+
+#include "src/Accelerators/Accelerator.hpp"
+
+#include "mlir/IR/DialectRegistry.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace onnx_mlir {
+
+// Adds the mlir and onnx-mlir dialects needed to compile end to end.
+mlir::DialectRegistry registerDialects(llvm::ArrayRef<accel::Accelerator::Kind> accels);
+
+}

--- a/src/Compiler/CompilerDialects.hpp
+++ b/src/Compiler/CompilerDialects.hpp
@@ -15,6 +15,7 @@ namespace onnx_mlir {
 
 // Adds the mlir and onnx-mlir dialects needed to compile end to end.
 // Initializes accelerator(s) if required.
-mlir::DialectRegistry registerDialects(llvm::ArrayRef<accel::Accelerator::Kind> accels);
+mlir::DialectRegistry registerDialects(
+    llvm::ArrayRef<accel::Accelerator::Kind> accels);
 
-}
+} // namespace onnx_mlir

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -12,14 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CompilerUtils.hpp"
+#include "ExternalUtil.hpp"
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
-#include "llvm/IR/Constants.h"
-#include "llvm/IR/DataLayout.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/MC/TargetRegistry.h"
-#include "llvm/Support/Debug.h"
+#include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/SourceMgr.h"
@@ -27,21 +32,16 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Target/TargetMachine.h"
 
-#include "ExternalUtil.hpp"
-
 #include "src/Accelerators/Accelerator.hpp"
+#include "src/Builder/FrontendDialectTransformer.hpp"
 #include "src/Compiler/CompilerDialects.hpp"
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerPasses.hpp"
-#include "src/Compiler/CompilerUtils.hpp"
 #include "src/Compiler/HeapReporter.hpp"
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 #include "src/Version/Version.hpp"
 
 #include <fstream>
-#include <regex>
-
-#define DEBUG_TYPE "compiler_utils"
 
 using namespace mlir;
 using namespace onnx_mlir;

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -44,6 +44,7 @@
 #include "src/Version/Version.hpp"
 
 #include <fstream>
+#include <regex>
 
 using namespace mlir;
 using namespace onnx_mlir;

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -23,6 +23,8 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/GlobalValue.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/Path.h"

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -20,7 +20,6 @@
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
-#include "mlir/InitAllDialects.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
@@ -51,8 +50,6 @@
 
 namespace onnx_mlir {
 
-std::string getVendorName();
-
 std::optional<std::string> getEnvVar(std::string name);
 
 struct Command {
@@ -71,7 +68,7 @@ struct Command {
   int exec(std::string wdir = "") const;
 };
 
-void registerDialects(mlir::MLIRContext &context);
+void loadDialects(mlir::MLIRContext &context);
 
 // Get Tool path, see comments in CompilerUtils.cpp for more details.
 std::string getToolPath(

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -14,39 +14,16 @@
 
 #pragma once
 
-#include "llvm/Bitcode/BitcodeWriter.h"
-#include "llvm/Support/FileUtilities.h"
-
-#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
-#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
-#include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
-#include "mlir/Parser/Parser.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
-#include "mlir/Target/LLVMIR/Export.h"
-#include "mlir/Transforms/Passes.h"
 #include "onnx-mlir/Compiler/OMCompilerTypes.h"
-#include "src/Builder/FrontendDialectTransformer.hpp"
-#include "src/Compiler/CompilerOptions.hpp"
-#include "src/Compiler/CompilerPasses.hpp"
-#include "src/Dialect/Krnl/KrnlOps.hpp"
-#include "src/Pass/Passes.hpp"
-#include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/IR/Constants.h"
-#include "llvm/IR/DataLayout.h"
-#include "llvm/MC/TargetRegistry.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/Path.h"
-#include "llvm/Support/Program.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/ToolOutputFile.h"
-#include "llvm/Target/TargetMachine.h"
 
-#include "src/Accelerators/Accelerator.hpp"
-#include "src/Version/Version.hpp"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
+
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace onnx_mlir {
 

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -45,6 +45,8 @@ struct Command {
   int exec(std::string wdir = "") const;
 };
 
+// Registers and loads the mlir and onnx-mlir dialects needed to compile
+// end to end. Initializes accelerator(s) if required.
 void loadDialects(mlir::MLIRContext &context);
 
 // Get Tool path, see comments in CompilerUtils.cpp for more details.

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -11,6 +11,7 @@
 
 #include "include/OnnxMlirCompiler.h"
 #include "ExternalUtil.hpp"
+#include "src/Compiler/CompilerDialects.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 
 using namespace mlir;
@@ -141,8 +142,8 @@ ONNX_MLIR_EXPORT int64_t omCompileFromArray(const void *inputBuffer,
     *errorMessage = nullptr;
 
   mlir::OwningOpRef<mlir::ModuleOp> module;
-  mlir::MLIRContext context;
-  registerDialects(context);
+  mlir::MLIRContext context(registerDialects(maccel));
+  context.loadAllAvailableDialects();
 
   std::string internalErrorMessage;
   int rc = processInputArray(

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -13,6 +13,7 @@
 #include "ExternalUtil.hpp"
 #include "src/Compiler/CompilerDialects.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
+#include "llvm/Support/FileSystem.h"
 
 using namespace mlir;
 using namespace onnx_mlir;
@@ -141,9 +142,9 @@ ONNX_MLIR_EXPORT int64_t omCompileFromArray(const void *inputBuffer,
   if (errorMessage)
     *errorMessage = nullptr;
 
-  mlir::OwningOpRef<mlir::ModuleOp> module;
-  mlir::MLIRContext context(registerDialects(maccel));
-  context.loadAllAvailableDialects();
+  OwningOpRef<ModuleOp> module;
+  MLIRContext context;
+  loadDialects(context);
 
   std::string internalErrorMessage;
   int rc = processInputArray(

--- a/src/Tools/onnx-mlir-opt/CMakeLists.txt
+++ b/src/Tools/onnx-mlir-opt/CMakeLists.txt
@@ -8,10 +8,12 @@ add_onnx_mlir_executable(onnx-mlir-opt
 
   LINK_LIBS PRIVATE
   ${OMLibs}
+  OMCompilerDialects
   OMCompilerOptions
-  OMCompilerUtils
+  OMCompilerPasses
   OMAccelerator
   OMInitAccelerators
+  OMVersion
   MLIRAffineTransforms
   MLIRLinalgTransforms
   MLIRMemRefTransforms

--- a/src/Tools/onnx-mlir-opt/CMakeLists.txt
+++ b/src/Tools/onnx-mlir-opt/CMakeLists.txt
@@ -12,7 +12,6 @@ add_onnx_mlir_executable(onnx-mlir-opt
   OMCompilerOptions
   OMCompilerPasses
   OMAccelerator
-  OMInitAccelerators
   OMVersion
   MLIRAffineTransforms
   MLIRLinalgTransforms

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -153,13 +153,13 @@ int main(int argc, char **argv) {
   auto file = openInputFile(input_filename, &error_message);
   if (!error_message.empty()) {
     llvm::errs() << "Failure to open file; " << error_message << "\n";
-    return failed(LogicalResult::failure());
+    return 1;
   }
 
   auto output = openOutputFile(output_filename, &error_message);
   if (!error_message.empty()) {
     llvm::errs() << "Failure to compile file; " << error_message << "\n";
-    return failed(LogicalResult::failure());
+    return 1;
   }
 
   auto passManagerSetupFn = [&](PassManager &pm) {
@@ -185,8 +185,8 @@ int main(int argc, char **argv) {
       .useExplicitModule(false);
 
   if (failed(MlirOptMain(output->os(), std::move(file), registry, config)))
-    return asMainReturnCode(failure());
+    return 1;
 
   output->keep();
-  return asMainReturnCode(success());
+  return 0;
 }

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -19,10 +19,10 @@
 #include <llvm/Support/ToolOutputFile.h>
 #include <mlir/Dialect/Bufferization/Transforms/Passes.h>
 #include <mlir/Dialect/MemRef/Transforms/Passes.h>
+#include <mlir/Dialect/Tosa/IR/TosaOps.h>
 #include <mlir/IR/AsmState.h>
 #include <mlir/IR/Dialect.h>
 #include <mlir/IR/MLIRContext.h>
-#include <mlir/InitAllDialects.h>
 #include <mlir/InitAllPasses.h>
 #include <mlir/Interfaces/ViewLikeInterface.h>
 #include <mlir/Pass/Pass.h>
@@ -32,12 +32,13 @@
 
 #include "RegisterPasses.hpp"
 #include "src/Accelerators/Accelerator.hpp"
+#include "src/Compiler/CompilerDialects.hpp"
 #include "src/Compiler/CompilerOptions.hpp"
-#include "src/Compiler/CompilerUtils.hpp"
 #include "src/Compiler/DisposableGarbageCollector.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Version/Version.hpp"
 
 using namespace mlir;
 using namespace onnx_mlir;
@@ -84,7 +85,7 @@ void scanAndSetOptLevel(int argc, char **argv) {
       num = atoi(&argv[i][2]); // Get the number starting 2 char down.
     // Silently ignore out of bound opt levels.
     if (num >= 0 && num <= 3) {
-      OptimizationLevel = (onnx_mlir::OptLevel)num;
+      OptimizationLevel = (OptLevel)num;
       return;
     }
   }
@@ -122,43 +123,22 @@ int main(int argc, char **argv) {
 
   // Hide unrelated options except common ones and the onnx-mlir-opt options
   // defined above.
-  llvm::cl::HideUnrelatedOptions(
-      {&onnx_mlir::OnnxMlirCommonOptions, &OnnxMlirOptOptions});
+  llvm::cl::HideUnrelatedOptions({&OnnxMlirCommonOptions, &OnnxMlirOptOptions});
 
-  mlir::DialectRegistry registry;
-  registry.insert<mlir::arith::ArithDialect>();
-  registry.insert<mlir::linalg::LinalgDialect>();
-  registry.insert<mlir::affine::AffineDialect>();
-  registry.insert<mlir::LLVM::LLVMDialect>();
-  registry.insert<mlir::scf::SCFDialect>();
-  registry.insert<mlir::func::FuncDialect>();
-  registry.insert<mlir::vector::VectorDialect>();
-  registry.insert<mlir::shape::ShapeDialect>();
-  registry.insert<mlir::math::MathDialect>();
-  registry.insert<mlir::memref::MemRefDialect>();
-  registry.insert<mlir::ONNXDialect>();
-  registry.insert<mlir::KrnlDialect>();
-  registry.insert<mlir::tosa::TosaDialect>();
-  registry.insert<mlir::cf::ControlFlowDialect>();
-
-  // Initialize accelerators if they exist.
-  onnx_mlir::accel::initAccelerators(maccel);
-
-  // Register dialects for accelerators.
-  for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators())
-    accel->registerDialects(registry);
+  DialectRegistry registry = registerDialects(maccel);
+  registry.insert<tosa::TosaDialect>();
 
   // Registered passes can be expressed as command line flags, so they must
   // must be registered before command line options are parsed.
   registerPasses(OptimizationLevel);
 
   // Register any command line options.
-  mlir::registerAsmPrinterCLOptions();
-  mlir::registerMLIRContextCLOptions();
-  mlir::registerPassManagerCLOptions();
-  mlir::registerDefaultTimingManagerCLOptions();
+  registerAsmPrinterCLOptions();
+  registerMLIRContextCLOptions();
+  registerPassManagerCLOptions();
+  registerDefaultTimingManagerCLOptions();
 
-  mlir::PassPipelineCLParser passPipeline("", "Compiler passes to run");
+  PassPipelineCLParser passPipeline("", "Compiler passes to run");
 
   if (!parseCustomEnvFlagsCommandLineOption(argc, argv, &llvm::errs()) ||
       !llvm::cl::ParseCommandLineOptions(argc, argv,
@@ -170,24 +150,23 @@ int main(int argc, char **argv) {
 
   // Set up the input file.
   std::string error_message;
-  auto file = mlir::openInputFile(input_filename, &error_message);
+  auto file = openInputFile(input_filename, &error_message);
   if (!error_message.empty()) {
     llvm::errs() << "Failure to open file; " << error_message << "\n";
     return failed(LogicalResult::failure());
   }
 
-  auto output = mlir::openOutputFile(output_filename, &error_message);
+  auto output = openOutputFile(output_filename, &error_message);
   if (!error_message.empty()) {
     llvm::errs() << "Failure to compile file; " << error_message << "\n";
     return failed(LogicalResult::failure());
   }
 
   auto passManagerSetupFn = [&](PassManager &pm) {
-    mlir::MLIRContext *ctx = pm.getContext();
-    registerDialects(*ctx);
-    ctx->getOrLoadDialect<mlir::tosa::TosaDialect>();
-    for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators())
-      accel->getOrLoadDialects(*ctx);
+    MLIRContext *ctx = pm.getContext();
+    // MlirOptMain constructed ctx with our registry so we just load all our
+    // already registered dialects.
+    ctx->loadAllAvailableDialects();
     pm.addInstrumentation(std::make_unique<DisposableGarbageCollector>(ctx));
     auto errorHandler = [ctx](const Twine &msg) {
       emitError(UnknownLoc::get(ctx)) << msg;
@@ -205,10 +184,9 @@ int main(int argc, char **argv) {
       .emitBytecode(false)
       .useExplicitModule(false);
 
-  if (failed(
-          mlir::MlirOptMain(output->os(), std::move(file), registry, config)))
-    return mlir::asMainReturnCode(failure());
+  if (failed(MlirOptMain(output->os(), std::move(file), registry, config)))
+    return asMainReturnCode(failure());
 
   output->keep();
-  return mlir::asMainReturnCode(success());
+  return asMainReturnCode(success());
 }

--- a/src/Tools/onnx-mlir-reduce/CMakeLists.txt
+++ b/src/Tools/onnx-mlir-reduce/CMakeLists.txt
@@ -7,8 +7,6 @@ add_onnx_mlir_executable(onnx-mlir-reduce
 
   LINK_LIBS PRIVATE
   ${OMLibs}
-  OMAccelerator
-  OMInitAccelerators
   MLIRAffineTransforms
   MLIRLinalgTransforms
   MLIRReduceLib

--- a/src/Tools/onnx-mlir-reduce/onnx-mlir-reduce.cpp
+++ b/src/Tools/onnx-mlir-reduce/onnx-mlir-reduce.cpp
@@ -17,7 +17,6 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Tools/mlir-reduce/MlirReduceMain.h"
-#include "src/Accelerators/Accelerator.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
@@ -26,10 +25,6 @@ using namespace mlir;
 static void registerDialects(DialectRegistry &registry) {
   registry.insert<mlir::ONNXDialect>();
   registry.insert<mlir::KrnlDialect>();
-
-  // Initialize and register dialects used by accelerators.
-  for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators())
-    accel->registerDialects(registry);
 }
 
 int main(int argc, char **argv) {

--- a/src/Version/Version.cpp
+++ b/src/Version/Version.cpp
@@ -19,6 +19,14 @@
 
 namespace onnx_mlir {
 
+std::string getVendorName() {
+#if defined(ONNX_MLIR_VENDOR)
+  return ONNX_MLIR_VENDOR;
+#else
+  return "ONNX-MLIR";
+#endif
+}
+
 std::string getOnnxMlirRepositoryPath() {
 #if defined(ONNX_MLIR_REPOSITORY)
   return ONNX_MLIR_REPOSITORY;

--- a/src/Version/Version.hpp
+++ b/src/Version/Version.hpp
@@ -19,6 +19,9 @@
 
 namespace onnx_mlir {
 
+/// Return the vendor name if specified during make processing or the default.
+std::string getVendorName();
+
 /// Retrieves the repository path from which onnx-mlir was built.
 std::string getOnnxMlirRepositoryPath();
 

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -11,6 +11,7 @@
 // Implements main for onnx-mlir driver.
 //===----------------------------------------------------------------------===//
 
+#include "src/Accelerators/Accelerator.hpp"
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 #include "src/Version/Version.hpp"
@@ -74,13 +75,16 @@ int main(int argc, char *argv[]) {
         << "Warning: --onnx-op-stats requires targets like --EmitMLIR, "
            "--EmitLLVMIR, or binary-generating emit commands.\n";
 
-  // Create context after registerMLIRContextCLOptions() is called.
+  // Initialize accelerator(s) if required.
+  accel::initAccelerators(maccel);
+
+  // Create context after MLIRContextCLOptions are registered and parsed.
   mlir::MLIRContext context;
   if (!context.isMultithreadingEnabled()) {
     assert(context.getNumThreads() == 1 && "1 thread if no multithreading");
     LLVM_DEBUG(llvm::dbgs() << "multithreading is disabled\n");
   }
-  registerDialects(context);
+  loadDialects(context);
 
   mlir::OwningOpRef<mlir::ModuleOp> module;
   std::string errorMessage;

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -11,7 +11,6 @@
 // Implements main for onnx-mlir driver.
 //===----------------------------------------------------------------------===//
 
-#include "src/Accelerators/Accelerator.hpp"
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 #include "src/Version/Version.hpp"
@@ -74,9 +73,6 @@ int main(int argc, char *argv[]) {
     llvm::errs()
         << "Warning: --onnx-op-stats requires targets like --EmitMLIR, "
            "--EmitLLVMIR, or binary-generating emit commands.\n";
-
-  // Initialize accelerator(s) if required.
-  accel::initAccelerators(maccel);
 
   // Create context after MLIRContextCLOptions are registered and parsed.
   mlir::MLIRContext context;

--- a/test/modellib/ModelLib.cpp
+++ b/test/modellib/ModelLib.cpp
@@ -29,7 +29,7 @@ ModelLibBuilder::ModelLibBuilder(const std::string &name)
     : sharedLibBaseName(name), ctx(), loc(UnknownLoc::get(&ctx)), builder(&ctx),
       module(ModuleOp::create(loc)), inputs(nullptr), outputs(nullptr),
       exec(nullptr) {
-  registerDialects(ctx);
+  loadDialects(ctx);
 }
 
 ModelLibBuilder::~ModelLibBuilder() {

--- a/test/modellib/ModelLib.hpp
+++ b/test/modellib/ModelLib.hpp
@@ -22,7 +22,9 @@
 
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/FileUtilities.h"
 
+#include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Runtime/ExecutionSession.hpp"
@@ -242,10 +244,10 @@ private:
   bool verifyResults(const OMTensor *out, const OMTensor *expected) const;
 
 private:
-  const CMAttributes &attributes;     // CategoryMapper attributes.
-  const llvm::ArrayRef<T1> input;     // model input data.
-  const llvm::ArrayRef<T2> expOutput; // expected result.
-  const int inputRank;                // rank of input
+  const CMAttributes &attributes;              // CategoryMapper attributes.
+  const llvm::ArrayRef<T1> input;              // model input data.
+  const llvm::ArrayRef<T2> expOutput;          // expected result.
+  const int inputRank;                         // rank of input
   int64_t inputShape[MAX_INPUT_RANK_FOR_TEST]; // shape of input
 };
 

--- a/test/modellib/ScanModel.cpp
+++ b/test/modellib/ScanModel.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Parser/Parser.h"
 
 #include "include/OnnxMlirRuntime.h"
 #include "src/Compiler/CompilerUtils.hpp"

--- a/test/numerical/TestLoop.cpp
+++ b/test/numerical/TestLoop.cpp
@@ -97,7 +97,7 @@ bool isOMLoopTheSameAsNaiveImplFor(std::string moduleIR,
         std::numeric_limits<int64_t>::max(),
     const int64_t constOffset = 0) {
   MLIRContext ctx;
-  registerDialects(ctx);
+  loadDialects(ctx);
 
   auto module = mlir::parseSourceString<ModuleOp>(moduleIR, &ctx);
   OwningOpRef<ModuleOp> moduleRef(std::move(module));

--- a/test/numerical/TestLoop.cpp
+++ b/test/numerical/TestLoop.cpp
@@ -18,6 +18,8 @@
 
 #include "src/Runtime/OMTensorHelper.hpp"
 
+#include "mlir/Parser/Parser.h"
+
 static const llvm::StringRef SHARED_LIB_BASE("./TestLoop_main_graph");
 
 using namespace mlir;

--- a/test/unit/CustomFn/TestCustomFn.cpp
+++ b/test/unit/CustomFn/TestCustomFn.cpp
@@ -73,14 +73,14 @@ void RegisterFunSchema() {
   registered = true;
 }
 
-void registerDialects(mlir::MLIRContext &context) {
+void loadDialects(mlir::MLIRContext &context) {
   context.getOrLoadDialect<mlir::func::FuncDialect>();
   context.getOrLoadDialect<mlir::ONNXDialect>();
 }
 
 int check(ModelProto &model) {
   mlir::MLIRContext context;
-  registerDialects(context);
+  loadDialects(context);
   mlir::OwningOpRef<mlir::ModuleOp> module;
 
   onnx_mlir::ImportOptions options;


### PR DESCRIPTION
Replaced duplicated dialect regitration and loading with the `registerDialects(maccel)` and `loadDialects(context)` functions.

Removed accelerator support from onx-mlir-reduce because it didn't seem to be working since there is no call to `accel::initAccelerators(maccel)` and there are no command line options to specify `maccel`.