### PR TITLE
Add header guard for SmallFPConversion

### DIFF
--- a/src/Support/SmallFPConversion.h
+++ b/src/Support/SmallFPConversion.h
@@ -8,7 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef ONNX_MLIR_SMALLFPCONVERSION_H
+#define ONNX_MLIR_SMALLFPCONVERSION_H
 
 #include <stdint.h>
 
@@ -30,4 +31,6 @@ uint16_t om_f32_to_bf16(float f32);
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif


### PR DESCRIPTION
The '#pragma once' is not supported on z/OS and causes a warning during compile.  This warning shows up when compiling the Runtime code to be used when linking a z/OS shared object model.

This PR changes the  '#pragma once' to a header guard in SmallFPConversion.h.