### PR TITLE
enable multi-threading in onnx-mlir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_onnx_mlir_executable(onnx-mlir
   onnx-mlir.cpp
 
   LINK_LIBS PRIVATE
+  MLIROpenMPToLLVMIRTranslation
   OMCompilerOptions
   OMCompilerUtils
   )

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -90,6 +90,8 @@ add_onnx_mlir_library(OMCompilerPasses
   MLIRLinalgTransforms
   MLIRLLVMToLLVMIRTranslation
   MLIRBuiltinToLLVMIRTranslation
+  MLIROpenMPToLLVM
+  MLIRSCFToOpenMP
   )
 
 # ONNX_MLIR_PRODUCT_VERSION is specified/cached.

--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -34,6 +34,7 @@ DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
   registry.insert<ONNXDialect>();
   registry.insert<KrnlDialect>();
   registry.insert<cf::ControlFlowDialect>();
+  registry.insert<mlir::omp::OpenMPDialect>();
 
   // Initialize accelerator(s) if required.
   accel::initAccelerators(accels);

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -180,6 +180,10 @@ void addKrnlToLLVMPasses(
     pm.addPass(mlir::createCSEPass());
   pm.addNestedPass<func::FuncOp>(mlir::createConvertVectorToSCFPass());
   pm.addPass(mlir::createLowerAffinePass());
+  if (enableParallel){
+    pm.addPass(mlir::createConvertSCFToOpenMPPass());
+    pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
+  }
 
   // After affine is lowered, KrnlRegion for affine scope can be removed.
   pm.addNestedPass<func::FuncOp>(krnl::createLowerKrnlRegionPass());
@@ -212,7 +216,7 @@ void addKrnlToLLVMPasses(
       /*useLRODATA=*/(modelSize == ModelSize::large),
       /*storeConstantsToFile=*/storeConstantsToFile,
       constantsToFileSingleThreshold, constantsToFileTotalThreshold,
-      outputNameNoExt));
+      outputNameNoExt, enableParallel));
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
   pm.addPass(mlir::createCanonicalizerPass());
 }

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -180,7 +180,7 @@ void addKrnlToLLVMPasses(
     pm.addPass(mlir::createCSEPass());
   pm.addNestedPass<func::FuncOp>(mlir::createConvertVectorToSCFPass());
   pm.addPass(mlir::createLowerAffinePass());
-  if (enableParallel){
+  if (enableParallel) {
     pm.addPass(mlir::createConvertSCFToOpenMPPass());
     pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
   }

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -256,13 +256,13 @@ public:
                           loopRefToOp[transferPt.loopsToSkip.value().front()]);
 
         // Move iterator to point to the next AffineFor Op.
-          while (insertPt != loopBody.end() &&
-               (!dyn_cast_or_null<AffineForOp>(&*insertPt) ||
-               !dyn_cast_or_null<AffineParallelOp>(&*insertPt))
-               && loopToSkip) {
-            assert(dyn_cast_or_null<KrnlMovableOp>(&*insertPt) &&
-                  "Expecting a KrnlMovableOp");
-            insertPt++;
+        while (insertPt != loopBody.end() &&
+              (!dyn_cast_or_null<AffineForOp>(&*insertPt) ||
+              !dyn_cast_or_null<AffineParallelOp>(&*insertPt))
+              && loopToSkip) {
+          assert(dyn_cast_or_null<KrnlMovableOp>(&*insertPt) &&
+                "Expecting a KrnlMovableOp");
+          insertPt++;
         }
 
         // Assert that now insertion point points to the loop to skip.
@@ -385,15 +385,15 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
           operands.end(), operandItr, operandItr + map.getNumInputs());
       std::advance(operandItr, map.getNumInputs());
     }
-      auto forOp = builder.create<AffineForOp>(
-          iterateOp.getLoc(), lbOperands, lbMap, ubOperands, ubMap);
+    auto forOp = builder.create<AffineForOp>(
+        iterateOp.getLoc(), lbOperands, lbMap, ubOperands, ubMap);
 
-      currentNestedForOps.emplace_back(std::make_pair(unoptimizedLoopRef, forOp));
-      builder.setInsertionPoint(
-        llvm::cast<AffineForOp>(currentNestedForOps.back().second).getBody(),
-        llvm::cast<AffineForOp>(currentNestedForOps.back().second).getBody()
-        ->begin()
-      );
+    currentNestedForOps.emplace_back(std::make_pair(unoptimizedLoopRef, forOp));
+    builder.setInsertionPoint(
+      llvm::cast<AffineForOp>(currentNestedForOps.back().second).getBody(),
+      llvm::cast<AffineForOp>(currentNestedForOps.back().second).getBody()
+      ->begin()
+    );
   }
 
   // Replace induction variable references from those introduced by a
@@ -404,8 +404,8 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
     BlockArgument forIV =
         llvm::cast<AffineForOp>(currentNestedForOps[i].second).getBody()
         ->getArgument(0);
-      iterateIV.replaceAllUsesWith(forIV);
-      iterateOp.getBodyRegion().front().eraseArgument(0);
+    iterateIV.replaceAllUsesWith(forIV);
+    iterateOp.getBodyRegion().front().eraseArgument(0);
     }
     
   // Pop krnl.iterate body region block arguments, leave the last one
@@ -428,10 +428,10 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
     // Transfer krnl.iterate region to innermost for op.
     auto innermostForOp = llvm::cast<AffineForOp>(
                                 currentNestedForOps.back().second); 
-      innermostForOp.getRegion().getBlocks().clear();
-      Region &innerMostRegion = innermostForOp.getRegion();
-      innerMostRegion.getBlocks().splice(
-          innerMostRegion.end(), iterateOp.getBodyRegion().getBlocks());
+    innermostForOp.getRegion().getBlocks().clear();
+    Region &innerMostRegion = innermostForOp.getRegion();
+    innerMostRegion.getBlocks().splice(
+        innerMostRegion.end(), iterateOp.getBodyRegion().getBlocks());
     }
 
   for (const auto &pair : currentNestedForOps) 

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Analysis/DataLayoutAnalysis.h"
+#include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -205,12 +206,14 @@ public:
    * this action.
    */
   void moveOne(Value loopRef,
-      llvm::SmallDenseMap<Value, AffineForOp, 4> &loopRefToOp,
+      llvm::SmallDenseMap<Value, Operation *, 4> &loopRefToOp,
       bool erase = true) {
     // Find the forOp associated with loopRef, get ready to insert into
     // forOp body.
-    AffineForOp forOp = loopRefToOp[loopRef];
-    Block &loopBody = forOp.getLoopBody().front();
+    // Cast to affine.forOp or affine.parallelOp
+    Block &loopBody = dyn_cast_or_null<AffineForOp>(loopRefToOp[loopRef]) ?
+     llvm::cast<AffineForOp>(loopRefToOp[loopRef]).getLoopBody().front(): 
+     llvm::cast<AffineParallelOp>(loopRefToOp[loopRef]).getLoopBody().front();
     auto insertPt = loopBody.begin();
 
     // Find the ops to transfer (saved into a Movable) associated with
@@ -249,14 +252,17 @@ public:
         std::optional<AffineForOp> loopToSkip;
         loopToSkip = transferPt.loopsToSkip.value().empty()
                          ? loopToSkip
-                         : loopRefToOp[transferPt.loopsToSkip.value().front()];
+                         : llvm::cast<AffineForOp>(
+                          loopRefToOp[transferPt.loopsToSkip.value().front()]);
 
         // Move iterator to point to the next AffineFor Op.
-        while (insertPt != loopBody.end() &&
-               !dyn_cast_or_null<AffineForOp>(&*insertPt) && loopToSkip) {
-          assert(dyn_cast_or_null<KrnlMovableOp>(&*insertPt) &&
-                 "Expecting a KrnlMovableOp");
-          insertPt++;
+          while (insertPt != loopBody.end() &&
+               (!dyn_cast_or_null<AffineForOp>(&*insertPt) ||
+               !dyn_cast_or_null<AffineParallelOp>(&*insertPt))
+               && loopToSkip) {
+            assert(dyn_cast_or_null<KrnlMovableOp>(&*insertPt) &&
+                  "Expecting a KrnlMovableOp");
+            insertPt++;
         }
 
         // Assert that now insertion point points to the loop to skip.
@@ -269,7 +275,7 @@ public:
     }
   }
 
-  void moveAll(llvm::SmallDenseMap<Value, AffineForOp, 4> &loopRefToOp) {
+  void moveAll(llvm::SmallDenseMap<Value, Operation *, 4> &loopRefToOp) {
     for (const auto &pair : movingPlan)
       moveOne(pair.first, loopRefToOp, /*erase=*/false);
   }
@@ -334,21 +340,26 @@ static void markLoopBodyAsMovable(
 
 static void lowerGetInductionVariableValueOp(
     KrnlGetInductionVariableValueOp &getIVOp,
-    llvm::SmallDenseMap<Value, AffineForOp, 4> &loopRefToOp) {
+    llvm::SmallDenseMap<Value, Operation *, 4> &loopRefToOp) {
   auto zippedOperandsResults =
       llvm::zip(getIVOp->getOperands(), getIVOp->getResults());
   for (const auto &operandAndResult : zippedOperandsResults) {
     auto operand = std::get<0>(operandAndResult);
     auto result = std::get<1>(operandAndResult);
-    result.replaceAllUsesWith(loopRefToOp[operand].getInductionVar());
+    if (auto forOp =  dyn_cast_or_null<AffineForOp>(loopRefToOp[operand])) {
+      result.replaceAllUsesWith(forOp.getInductionVar());
+    } else if (auto parallelOp =  
+              dyn_cast_or_null<AffineParallelOp>(loopRefToOp[operand])) {
+      result.replaceAllUsesWith(parallelOp.getIVs()[0]);
+    }
   }
 }
 
 static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
-    llvm::SmallDenseMap<Value, AffineForOp, 4> &refToOps) {
+    llvm::SmallDenseMap<Value, Operation *, 4> &refToOps) {
   builder.setInsertionPointAfter(iterateOp);
   // Map from unoptimizedLoopRef to the (original, unoptimized) AffineForOp.
-  SmallVector<std::pair<Value, AffineForOp>, 4> currentNestedForOps;
+  SmallVector<std::pair<Value, Operation *>, 4> currentNestedForOps;
   ArrayRef<Attribute> boundMapAttrs =
       iterateOp->getAttrOfType<ArrayAttr>(KrnlIterateOp::getBoundsAttrName())
           .getValue();
@@ -374,12 +385,15 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
           operands.end(), operandItr, operandItr + map.getNumInputs());
       std::advance(operandItr, map.getNumInputs());
     }
-    auto forOp = builder.create<AffineForOp>(
-        iterateOp.getLoc(), lbOperands, lbMap, ubOperands, ubMap);
+      auto forOp = builder.create<AffineForOp>(
+          iterateOp.getLoc(), lbOperands, lbMap, ubOperands, ubMap);
 
-    currentNestedForOps.emplace_back(std::make_pair(unoptimizedLoopRef, forOp));
-    builder.setInsertionPoint(currentNestedForOps.back().second.getBody(),
-        currentNestedForOps.back().second.getBody()->begin());
+      currentNestedForOps.emplace_back(std::make_pair(unoptimizedLoopRef, forOp));
+      builder.setInsertionPoint(
+        llvm::cast<AffineForOp>(currentNestedForOps.back().second).getBody(),
+        llvm::cast<AffineForOp>(currentNestedForOps.back().second).getBody()
+        ->begin()
+      );
   }
 
   // Replace induction variable references from those introduced by a
@@ -388,11 +402,12 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
   for (int64_t i = 0; i < (int64_t)currentNestedForOps.size() - 1; i++) {
     auto iterateIV = iterateOp.getBodyRegion().front().getArgument(0);
     BlockArgument forIV =
-        currentNestedForOps[i].second.getBody()->getArgument(0);
-    iterateIV.replaceAllUsesWith(forIV);
-    iterateOp.getBodyRegion().front().eraseArgument(0);
-  }
-
+        llvm::cast<AffineForOp>(currentNestedForOps[i].second).getBody()
+        ->getArgument(0);
+      iterateIV.replaceAllUsesWith(forIV);
+      iterateOp.getBodyRegion().front().eraseArgument(0);
+    }
+    
   // Pop krnl.iterate body region block arguments, leave the last one
   // for convenience (it'll be taken care of by region inlining).
   while (iterateOp.getBodyRegion().front().getNumArguments() > 1)
@@ -411,14 +426,15 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
         iterateOpEntryBlock.getTerminator()->getIterator());
   } else {
     // Transfer krnl.iterate region to innermost for op.
-    AffineForOp innermostForOp = currentNestedForOps.back().second;
-    innermostForOp.getRegion().getBlocks().clear();
-    Region &innerMostRegion = innermostForOp.getRegion();
-    innerMostRegion.getBlocks().splice(
-        innerMostRegion.end(), iterateOp.getBodyRegion().getBlocks());
-  }
+    auto innermostForOp = llvm::cast<AffineForOp>(
+                                currentNestedForOps.back().second); 
+      innermostForOp.getRegion().getBlocks().clear();
+      Region &innerMostRegion = innermostForOp.getRegion();
+      innerMostRegion.getBlocks().splice(
+          innerMostRegion.end(), iterateOp.getBodyRegion().getBlocks());
+    }
 
-  for (const auto &pair : currentNestedForOps)
+  for (const auto &pair : currentNestedForOps) 
     refToOps.try_emplace(pair.first, pair.second);
 }
 
@@ -455,7 +471,7 @@ static void removeOps(llvm::SmallPtrSetImpl<Operation *> &opsToErase) {
 }
 
 static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
-    llvm::SmallDenseMap<Value, AffineForOp, 4> &loopRefToOp,
+    llvm::SmallDenseMap<Value, Operation *, 4> &loopRefToOp,
     llvm::SmallPtrSetImpl<Operation *> &opsToErase, LoopBodyMover &mover) {
   // Recursively interpret nested operations.
   for (auto &region : op->getRegions())
@@ -509,7 +525,8 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     LLVM_DEBUG(llvm::dbgs()
                << DEBUG_TYPE << " interpret block op " << blockOp << "\n");
     SmallVector<AffineForOp, 2> tiledLoops;
-    SmallVector<AffineForOp, 1> loopsToTile = {loopRefToOp[blockOp.getLoop()]};
+    SmallVector<AffineForOp, 1> loopsToTile = {llvm::cast<AffineForOp>(
+                                              loopRefToOp[blockOp.getLoop()])};
 
     if (failed(tilePerfectlyNested(
             loopsToTile, blockOp.getTileSizeAttr().getInt(), &tiledLoops))) {
@@ -523,7 +540,7 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     // for loops in loopRefToLoop.
     loopRefToOp.erase(loopRefToOp.find_as(blockOp.getLoop()));
     loopRefToOp[blockOp.getResult(0)] = tiledLoops[0];
-    loopRefToOp[blockOp.getResult(1)] = tiledLoops[1];
+    loopRefToOp[blockOp.getResult(1)] = tiledLoops[1]; 
 
     opsToErase.insert(op);
     return success();
@@ -536,7 +553,9 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     SmallVector<AffineForOp, 4> loopsToPermute;
     std::transform(permuteOp.operand_begin(), permuteOp.operand_end(),
         std::back_inserter(loopsToPermute),
-        [&](const Value &val) { return loopRefToOp[val]; });
+        [&](const Value &val) {
+          return llvm::cast<AffineForOp>(loopRefToOp[val]); 
+        });
 
     // Construct permutation map from integer array attribute.
     SmallVector<unsigned int, 4> permuteMap;
@@ -553,7 +572,7 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
                << DEBUG_TYPE << " interpret unroll op " << unrollOp << "\n");
     // Unroll the affine for loop fully.
     Value loopRef = unrollOp.getLoop();
-    auto loopToUnroll = loopRefToOp[loopRef];
+    auto loopToUnroll = llvm::cast<AffineForOp>(loopRefToOp[loopRef]);
 
     mover.moveOne(loopRef, loopRefToOp);
 
@@ -581,8 +600,62 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     assert(succeeded(res) && "failed to unroll");
     opsToErase.insert(op);
     return success();
-  }
+  } else if (auto parallelOp = dyn_cast_or_null<KrnlParallelOp>(op)) {
+    // Parallelism the given loop by transform the tagged affine.for op to 
+    // affine.parallel
+    LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE 
+              << " interpret parallel op " << parallelOp << "\n");
 
+    Value loopRef = parallelOp.getLoop();
+    AffineForOp loopToParallel = llvm::cast<AffineForOp>(loopRefToOp[loopRef]);
+    OpBuilder opBuilder(loopToParallel);
+
+    Location loc = loopToParallel.getLoc();
+    AffineMap lbsMap = loopToParallel.getLowerBoundMap();
+    ValueRange lbsOperands = loopToParallel.getLowerBoundOperands();
+    AffineMap ubsMap = loopToParallel.getUpperBoundMap();
+    ValueRange ubsOperands = loopToParallel.getUpperBoundOperands();
+
+    SmallVector<LoopReduction> parallelReductions;
+    unsigned numReductions = parallelReductions.size();
+    auto reducedValues = llvm::to_vector<4>(llvm::map_range(
+      parallelReductions, [](const LoopReduction &red) { 
+        return red.value; 
+        }));
+    auto reductionKinds = llvm::to_vector<4>(llvm::map_range(
+        parallelReductions, [](const LoopReduction &red) { 
+        return red.kind; 
+        }));
+    AffineParallelOp parallelLoop = opBuilder.create<AffineParallelOp>(loc, 
+          ValueRange(reducedValues).getTypes(), reductionKinds,
+          ArrayRef(lbsMap), lbsOperands,
+          ArrayRef(ubsMap), ubsOperands,
+          ArrayRef(loopToParallel.getStep()));
+    parallelLoop.getRegion().takeBody(loopToParallel.getRegion());
+    Operation *yieldOp = &parallelLoop.getBody()->back();
+
+    SmallVector<Value> newResults;
+    newResults.reserve(numReductions);
+    for (unsigned i = 0; i < numReductions; ++i) {
+      Value init = loopToParallel.getIterOperands()[i];
+      Operation *reductionOp = yieldOp->getOperand(i).getDefiningOp();
+      assert(reductionOp && "yielded value is expected to be produced by an op");
+      opBuilder.getInsertionBlock()->getOperations().splice(
+          opBuilder.getInsertionPoint(), loopToParallel.getBody()->getOperations(),
+          reductionOp);
+      reductionOp->setOperands({init, parallelLoop->getResult(i)});
+      loopToParallel->getResult(i).replaceAllUsesWith(reductionOp->getResult(0));
+    }
+
+    unsigned numIVs = 1;
+    yieldOp->setOperands(reducedValues);
+    parallelLoop.getBody()->eraseArguments(numIVs, numReductions);
+    loopToParallel.erase();
+    // Replace the affine.forOp with affine.parallelOp in loopRefToTop 
+    loopRefToOp[loopRef] = parallelLoop;
+    opsToErase.insert(parallelOp);
+    return success();
+  }
   return success();
 }
 
@@ -663,7 +736,7 @@ void ConvertKrnlToAffinePass::runOnOperation() {
   // while iterating is tricky because it can invalidate the iterator, so we
   // collect the operations to be erased in a small ptr set `opsToErase`, and
   // only erase after iteration completes.
-  llvm::SmallDenseMap<Value, AffineForOp, 4> loopRefToOp;
+  llvm::SmallDenseMap<Value, Operation *, 4> loopRefToOp;
   llvm::SmallPtrSet<Operation *, 4> opsToErase;
   if (failed(interpretOperation(
           funcOp, builder, loopRefToOp, opsToErase, mover))) {

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -211,9 +211,11 @@ public:
     // Find the forOp associated with loopRef, get ready to insert into
     // forOp body.
     // Cast to affine.forOp or affine.parallelOp
-    Block &loopBody = dyn_cast_or_null<AffineForOp>(loopRefToOp[loopRef]) ?
-     llvm::cast<AffineForOp>(loopRefToOp[loopRef]).getLoopBody().front(): 
-     llvm::cast<AffineParallelOp>(loopRefToOp[loopRef]).getLoopBody().front();
+    Block &loopBody = dyn_cast_or_null<AffineForOp>(loopRefToOp[loopRef]) 
+                          ? llvm::cast<AffineForOp>(loopRefToOp[loopRef])
+                                .getLoopBody().front()
+                          : llvm::cast<AffineParallelOp>(loopRefToOp[loopRef])
+                                .getLoopBody().front();
     auto insertPt = loopBody.begin();
 
     // Find the ops to transfer (saved into a Movable) associated with

--- a/src/Conversion/KrnlToLLVM/CMakeLists.txt
+++ b/src/Conversion/KrnlToLLVM/CMakeLists.txt
@@ -31,6 +31,7 @@ add_onnx_mlir_library(OMKrnlToLLVM
   MLIRMathTransforms
   MLIRMemRefToLLVM
   MLIRMemRefTransforms
+  MLIROpenMPToLLVM
   MLIRReconcileUnrealizedCasts
   MLIRSCFToControlFlow
   MLIRShapeToStandard

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -874,11 +874,14 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
   LLVMTypeConverter typeConverter(ctx, options);
   customizeTypeConverter(typeConverter);
 
+  // omp::ParallelOp can only be legalized when its region is legal
   target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsLoopOp>(
       [&](Operation *op) { return typeConverter.isLegal(&op->getRegion(0)); });
-  target.addLegalOp<mlir::omp::TerminatorOp, mlir::omp::TaskyieldOp,
-      mlir::omp::FlushOp, mlir::omp::YieldOp, mlir::omp::BarrierOp, 
-      mlir::omp::TaskwaitOp>();
+  // Currently, only minimum required OpenMP Ops are marked as legal, in the
+  // future integration of OpenMP, probably more OpenMP Ops are required to be
+  // marked as legal. Please refer the OpenMPtoLLVM.cpp in MLIR repo to see see
+  // how to legalize them.
+  target.addLegalOp<omp::TerminatorOp, omp::YieldOp>();
   // We have a combination of `krnl`, `affine`, `vector`, and `std` operations.
   // We lower in stages until all the code is in the LLVM dialect.
   RewritePatternSet patterns(ctx);

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -879,8 +879,8 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
       [&](Operation *op) { return typeConverter.isLegal(&op->getRegion(0)); });
   // Currently, only minimum required OpenMP Ops are marked as legal, in the
   // future integration of OpenMP, probably more OpenMP Ops are required to be
-  // marked as legal. Please refer the OpenMPtoLLVM.cpp in MLIR repo to see see
-  // how to legalize them.
+  // marked as legal. Please refer the Conversion/OpenMPToLLVM/OpenMPtoLLVM.cpp
+  // in MLIR repo to see see how to legalize them.
   target.addLegalOp<omp::TerminatorOp, omp::YieldOp>();
   // We have a combination of `krnl`, `affine`, `vector`, and `std` operations.
   // We lower in stages until all the code is in the LLVM dialect.

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -215,7 +215,7 @@ void populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);
   populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
   // Enable OpenMP-to-LLVM pass when enable parallelism
-  if (enableParallel){
+  if (enableParallel) {
     populateOpenMPToLLVMConversionPatterns(typeConverter, patterns);
   }
   arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
@@ -875,12 +875,10 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
   customizeTypeConverter(typeConverter);
 
   target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsLoopOp>(
-          [&](Operation *op) { 
-            return typeConverter.isLegal(&op->getRegion(0));
-          });
+      [&](Operation *op) { return typeConverter.isLegal(&op->getRegion(0)); });
   target.addLegalOp<mlir::omp::TerminatorOp, mlir::omp::TaskyieldOp,
-                    mlir::omp::FlushOp, mlir::omp::YieldOp,
-                    mlir::omp::BarrierOp, mlir::omp::TaskwaitOp>();
+      mlir::omp::FlushOp, mlir::omp::YieldOp, mlir::omp::BarrierOp, 
+      mlir::omp::TaskwaitOp>();
   // We have a combination of `krnl`, `affine`, `vector`, and `std` operations.
   // We lower in stages until all the code is in the LLVM dialect.
   RewritePatternSet patterns(ctx);

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
+#include "mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Conversion/ShapeToStandard/ShapeToStandard.h"
@@ -37,6 +38,7 @@
 #include "mlir/Dialect/Math/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
@@ -184,7 +186,7 @@ void populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
     SmallVectorImpl<LLVM::GlobalOp> &outSigGlobalOps,
     std::map<std::string, SmallVector<MemRefType, 4>> &inputMemRefTypes,
     std::map<std::string, SmallVector<MemRefType, 4>> &outputMemRefTypes,
-    bool verifyInputTensors) {
+    bool verifyInputTensors, bool enableParallel) {
   // TODO: look at what is done in
   // mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.cpp in function
   // LowerVectorToLLVMPass::runOnOperation() and see what we should do about it.
@@ -212,6 +214,10 @@ void populateAffineAndKrnlToLLVMConversion(RewritePatternSet &patterns,
   populateMathToLLVMConversionPatterns(typeConverter, patterns);
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);
   populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  // Enable OpenMP-to-LLVM pass when enable parallelism
+  if (enableParallel){
+    populateOpenMPToLLVMConversionPatterns(typeConverter, patterns);
+  }
   arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
 
@@ -724,7 +730,8 @@ struct ConvertKrnlToLLVMPass
   ConvertKrnlToLLVMPass(bool verifyInputTensors, bool useOpaquePointers,
       bool useLRODATA, bool storeConstantsToFile,
       uint64_t constantsToFileSingleThreshold,
-      uint64_t constantsToFileTotalThreshold, std::string outputNameNoExt) {
+      uint64_t constantsToFileTotalThreshold, std::string outputNameNoExt,
+      bool enableParallel) {
     this->verifyInputTensors = verifyInputTensors;
     this->useOpaquePointers = useOpaquePointers;
     // Exclusive options. no option or only one option can be True.
@@ -733,6 +740,7 @@ struct ConvertKrnlToLLVMPass
     this->constantsToFileSingleThreshold = constantsToFileSingleThreshold;
     this->constantsToFileTotalThreshold = constantsToFileTotalThreshold;
     this->outputNameNoExt = outputNameNoExt;
+    this->enableParallel = enableParallel;
   }
 
   StringRef getArgument() const override { return "convert-krnl-to-llvm"; }
@@ -789,6 +797,7 @@ struct ConvertKrnlToLLVMPass
 
 private:
   std::string outputNameNoExt = "./model";
+  bool enableParallel;
 };
 
 void ConvertKrnlToLLVMPass::runOnOperation() {
@@ -865,6 +874,13 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
   LLVMTypeConverter typeConverter(ctx, options);
   customizeTypeConverter(typeConverter);
 
+  target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsLoopOp>(
+          [&](Operation *op) { 
+            return typeConverter.isLegal(&op->getRegion(0));
+          });
+  target.addLegalOp<mlir::omp::TerminatorOp, mlir::omp::TaskyieldOp,
+                    mlir::omp::FlushOp, mlir::omp::YieldOp,
+                    mlir::omp::BarrierOp, mlir::omp::TaskwaitOp>();
   // We have a combination of `krnl`, `affine`, `vector`, and `std` operations.
   // We lower in stages until all the code is in the LLVM dialect.
   RewritePatternSet patterns(ctx);
@@ -872,7 +888,7 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
   populateAffineAndKrnlToLLVMConversion(patterns, typeConverter, ctx,
       outputOMTensorOwnerships, singleEntryPoint, entryGlobalOps,
       inSigGlobalOps, outSigGlobalOps, inputMemRefTypes, outputMemRefTypes,
-      verifyInputTensors);
+      verifyInputTensors, enableParallel);
 
   // Rewrite patterns for accelerators.
   for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators())
@@ -922,11 +938,11 @@ std::unique_ptr<Pass> createConvertKrnlToLLVMPass() {
 std::unique_ptr<Pass> createConvertKrnlToLLVMPass(bool verifyInputTensors,
     bool useOpaquePointers, bool useLRODATA, bool storeConstantsToFile,
     float constantsToFileSingleThreshold, float constantsToFileTotalThreshold,
-    std::string outputNameNoExt) {
+    std::string outputNameNoExt, bool enableParallel) {
   return std::make_unique<ConvertKrnlToLLVMPass>(verifyInputTensors,
       useOpaquePointers, useLRODATA, storeConstantsToFile,
       constantsToFileSingleThreshold, constantsToFileTotalThreshold,
-      outputNameNoExt);
+      outputNameNoExt, enableParallel);
 }
 
 void populateKrnlToLLVMConversion(LLVMTypeConverter &typeConverter,

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.hpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.hpp
@@ -33,7 +33,7 @@ void populateAffineAndKrnlToLLVMConversion(mlir::RewritePatternSet &patterns,
         &inputMemRefTypes,
     std::map<std::string, llvm::SmallVector<mlir::MemRefType, 4>>
         &outputMemRefTypes,
-    bool verifyInputTensors);
+    bool verifyInputTensors, bool enableParallel);
 
 void populateKrnlToLLVMConversion(mlir::LLVMTypeConverter &typeConverter,
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx,

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -12,7 +12,7 @@
 // Krnl IR and standard operations.
 //
 //===----------------------------------------------------------------------===//
-
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -189,14 +189,14 @@ void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
   populateLoweringONNXScanOpPattern(patterns, typeConverter, ctx);
   // Math
   populateLoweringONNXCumSumOpPattern(patterns, typeConverter, ctx);
-  populateLoweringONNXElementwiseOpPattern(patterns, typeConverter, ctx, dimAnalysis, enableSIMD);
-  populateLoweringONNXGemmOpPattern(patterns, typeConverter, ctx, enableTiling, enableSIMD);
+  populateLoweringONNXElementwiseOpPattern(patterns, typeConverter, ctx, dimAnalysis, enableSIMD, enableParallel);
+  populateLoweringONNXGemmOpPattern(patterns, typeConverter, ctx, enableTiling, enableSIMD, enableParallel);
   populateLoweringONNXHardmaxOpPattern(patterns, typeConverter, ctx);
-  populateLoweringONNXReductionOpPattern(patterns, typeConverter, ctx, enableSIMD);
-  populateLoweringONNXSoftmaxOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXReductionOpPattern(patterns, typeConverter, ctx, enableSIMD, enableParallel);
+  populateLoweringONNXSoftmaxOpPattern(patterns, typeConverter, ctx, enableParallel);
   populateLoweringONNXTopKOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXTriluOpPattern(patterns, typeConverter, ctx);
-  populateLoweringONNXMatMulOpPattern(patterns, typeConverter, ctx, dimAnalysis, enableTiling, enableSIMD);
+  populateLoweringONNXMatMulOpPattern(patterns, typeConverter, ctx, dimAnalysis, enableTiling, enableSIMD, enableParallel);
   populateLoweringONNXMatMulIntegerOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXRandomNormalOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXRandomNormalLikeOpPattern(patterns, typeConverter, ctx);
@@ -215,14 +215,14 @@ void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
   populateLoweringONNXPadOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXUnsqueezeOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXUnsqueezeV11OpPattern(patterns, typeConverter, ctx);
-  populateLoweringONNXTransposeOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXTransposeOpPattern(patterns, typeConverter, ctx, enableParallel);
   populateLoweringONNXGatherOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXGatherElementsOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXGatherNDOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXIdentityOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXConstantOfShapeOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXConstantOpPattern(patterns, typeConverter, ctx);
-  populateLoweringONNXConcatOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXConcatOpPattern(patterns, typeConverter, ctx, enableParallel);
   populateLoweringONNXConcatShapeTransposeOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXDepthToSpaceOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXScatterElementsOpPattern(patterns, typeConverter, ctx);

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2252,7 +2252,6 @@ struct ONNXElementwiseVariadicOpLowering
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
 
-      // FIXME fix in the future
       if (enableParallel) {
         create.krnl.parallel(loopDef[0]);
         LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
@@ -2363,7 +2362,6 @@ struct ONNXWhereOpLowering : public ConversionPattern {
       SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
-      // FIXME in the future
       if (enableParallel) {
         create.krnl.parallel(loopDef[0]);
         LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1367,7 +1367,7 @@ static LogicalResult getPartiallyFlattenedSimdCode(
     ONNXBroadcastOpShapeHelper *shapeHelper, Operation *op,
     MemRefType outputMemRefType, ValueRange operands, int64_t alignment,
     int64_t VL, int64_t collapsedInnermostLoops, bool ruledOutBroadcast,
-    bool isUnaryOp) {
+    bool isUnaryOp, bool enableParallel = false) {
   Type outputElementType = outputMemRefType.getElementType();
   unsigned numArgs = op->getNumOperands();
   LLVM_DEBUG(llvm::dbgs() << "  partial SIMD code for elementwise op "
@@ -1423,6 +1423,10 @@ static LogicalResult getPartiallyFlattenedSimdCode(
   VectorType vecElementType = VectorType::get({VL}, outputElementType);
   // Iterate only over the blocks.
   SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+  if (enableParallel) {
+    create.krnl.parallel(optimizedLoopDef[0]);
+    LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+  }
   create.krnl.iterateIE(loopDef, optimizedLoopDef, lbs, flattenedOutputDims,
       [&](KrnlBuilder &ck, ValueRange loopInd) {
         MultiDialectBuilder<KrnlBuilder, VectorBuilder> create(ck);
@@ -1858,11 +1862,13 @@ struct ONNXElementwiseUnaryOpLowering
   using OpAdaptor = typename ElementwiseUnaryOp::Adaptor;
   DimAnalysis *dimAnalysis;
   bool enableSIMD = false;
+  bool enableParallel = false;
 
   ONNXElementwiseUnaryOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
-      DimAnalysis *dimAnalysis, bool enableSIMD)
+      DimAnalysis *dimAnalysis, bool enableSIMD, bool enableParallel = false)
       : OpConversionPattern<ElementwiseUnaryOp>(typeConverter, ctx),
-        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD) {}
+        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
+        enableParallel(enableParallel) {}
 
   LogicalResult matchAndRewrite(ElementwiseUnaryOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
@@ -1923,7 +1929,7 @@ struct ONNXElementwiseUnaryOpLowering
         return getPartiallyFlattenedSimdCode<ElementwiseUnaryOp>(rewriter,
             create, &shapeHelper, op, outputMemRefType, operands, alignment,
             uVL, /*collapsedInnermostLoop*/ outputRank,
-            /*ruleOutBroadcast*/ true, /*unary*/ true);
+            /*ruleOutBroadcast*/ true, /*unary*/ true, enableParallel);
     }
     LLVM_DEBUG(llvm::dbgs() << "  scalar execution\n");
 
@@ -1942,6 +1948,10 @@ struct ONNXElementwiseUnaryOpLowering
       SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(X, ubs);
+      if (enableParallel) {
+        create.krnl.parallel(loopDef[0]);
+        LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+      }
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
             SmallVector<Value> args;
@@ -2006,13 +2016,14 @@ struct ONNXElementwiseBinaryOpLowering
   DimAnalysis *dimAnalysis;
   bool enableSIMD = false;
   bool isUniBroadcasting = false;
+  bool enableParallel = false;
 
   ONNXElementwiseBinaryOpLowering(TypeConverter &typeConverter,
       MLIRContext *ctx, DimAnalysis *dimAnalysis, bool enableSIMD,
-      bool isUniBroadcasting = false)
+      bool isUniBroadcasting = false, bool enableParallel = false)
       : OpConversionPattern<ElementwiseBinaryOp>(typeConverter, ctx),
         dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        isUniBroadcasting(isUniBroadcasting) {}
+        isUniBroadcasting(isUniBroadcasting), enableParallel(enableParallel) {}
 
   LogicalResult matchAndRewrite(ElementwiseBinaryOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
@@ -2072,7 +2083,7 @@ struct ONNXElementwiseBinaryOpLowering
         return getPartiallyFlattenedSimdCode<ElementwiseBinaryOp>(rewriter,
             create, &shapeHelper, op, outputMemRefType, operands, alignment,
             uVL, collapsedInnermostLoops, hasNoBroadcast,
-            /*unary*/ false);
+            /*unary*/ false, enableParallel);
     }
     LLVM_DEBUG(llvm::dbgs() << "  scalar execution\n");
 
@@ -2091,6 +2102,11 @@ struct ONNXElementwiseBinaryOpLowering
       SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
+      // TODO adjust in the future
+      if (enableParallel) {
+        create.krnl.parallel(loopDef[0]);
+        LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+      }
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
             IndexExprScope innerScope(createKrnl, shapeHelper.getScope());
@@ -2150,11 +2166,14 @@ struct ONNXElementwiseVariadicOpLowering
   using OpAdaptor = typename ElementwiseVariadicOp::Adaptor;
   DimAnalysis *dimAnalysis;
   bool enableSIMD = false;
+  bool enableParallel = false;
 
   ONNXElementwiseVariadicOpLowering(TypeConverter &typeConverter,
-      MLIRContext *ctx, DimAnalysis *dimAnalysis, bool enableSIMD)
+      MLIRContext *ctx, DimAnalysis *dimAnalysis, bool enableSIMD,
+      bool enableParallel = false)
       : OpConversionPattern<ElementwiseVariadicOp>(typeConverter, ctx),
-        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD) {}
+        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
+        enableParallel(enableParallel) {}
 
   LogicalResult matchAndRewrite(ElementwiseVariadicOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
@@ -2213,7 +2232,7 @@ struct ONNXElementwiseVariadicOpLowering
         return getPartiallyFlattenedSimdCode<ElementwiseVariadicOp>(rewriter,
             create, &shapeHelper, op, outputMemRefType, operands, alignment,
             uVL, collapsedInnermostLoops, hasNoBroadcast,
-            /*unary*/ false);
+            /*unary*/ false, enableParallel);
     }
     LLVM_DEBUG(llvm::dbgs() << "  scalar execution\n");
 
@@ -2233,6 +2252,11 @@ struct ONNXElementwiseVariadicOpLowering
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
 
+      // FIXME fix in the future
+      if (enableParallel) {
+        create.krnl.parallel(loopDef[0]);
+        LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+      }
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
             IndexExprScope innerScope(createKrnl, shapeHelper.getScope());
@@ -2299,12 +2323,14 @@ struct ONNXElementwiseVariadicOpLowering
 struct ONNXWhereOpLowering : public ConversionPattern {
   DimAnalysis *dimAnalysis;
   bool enableSIMD = false;
+  bool enableParallel = false;
 
   ONNXWhereOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
-      DimAnalysis *dimAnalysis, bool enableSIMD)
+      DimAnalysis *dimAnalysis, bool enableSIMD, bool enableParallel = false)
       : ConversionPattern(
             typeConverter, ONNXWhereOp::getOperationName(), 1, ctx),
-        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD) {}
+        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
+        enableParallel(enableParallel) {}
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
@@ -2337,6 +2363,11 @@ struct ONNXWhereOpLowering : public ConversionPattern {
       SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
+      // FIXME in the future
+      if (enableParallel) {
+        create.krnl.parallel(loopDef[0]);
+        LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+      }
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
             IndexExprScope innerScope(&rewriter, shapeHelper.getScope());
@@ -2402,7 +2433,7 @@ struct ONNXWhereOpLowering : public ConversionPattern {
 
 void populateLoweringONNXElementwiseOpPattern(RewritePatternSet &patterns,
     TypeConverter &typeConverter, MLIRContext *ctx, DimAnalysis *dimAnalysis,
-    bool enableSIMD) {
+    bool enableSIMD, bool enableParallel) {
   patterns.insert<ONNXElementwiseUnaryOpLowering<mlir::ONNXAbsOp>,
       ONNXElementwiseVariadicOpLowering<mlir::ONNXAddOp>,
       ONNXElementwiseVariadicOpLowering<mlir::ONNXAndOp>,
@@ -2461,9 +2492,10 @@ void populateLoweringONNXElementwiseOpPattern(RewritePatternSet &patterns,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXTanOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXTanhOp>, ONNXWhereOpLowering,
       ONNXElementwiseVariadicOpLowering<mlir::ONNXXorOp>>(
-      typeConverter, ctx, dimAnalysis, enableSIMD);
+      typeConverter, ctx, dimAnalysis, enableSIMD, enableParallel);
   patterns.insert<ONNXElementwiseBinaryOpLowering<mlir::ONNXPReluOp>>(
-      typeConverter, ctx, dimAnalysis, enableSIMD, /*isUniBroadcasting=*/true);
+      typeConverter, ctx, dimAnalysis, enableSIMD, /*isUniBroadcasting=*/true,
+      enableParallel);
 }
 
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -295,9 +295,9 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
     }
     ValueRange outerLoops = create.krnl.defineLoops(2);
     if (enableParallel) {
-        create.krnl.parallel(outerLoops[0]);
-        LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.GEMM\n");
-      }
+      create.krnl.parallel(outerLoops[0]);
+      LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.GEMM\n");
+    }
     create.krnl.iterateIE(outerLoops, outerLoops, {zeroIE, zeroIE}, {I, J},
         [&](KrnlBuilder &createKrnl, ValueRange outerIndices) {
           // Handle alpha/beta coefficients.
@@ -403,7 +403,7 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
 };
 
 void populateLoweringONNXGemmOpPattern(RewritePatternSet &patterns,
-    TypeConverter &typeConverter, MLIRContext *ctx, bool enableTiling, 
+    TypeConverter &typeConverter, MLIRContext *ctx, bool enableTiling,
     bool enableSIMD, bool enableParallel) {
   patterns.insert<ONNXGemmOpLowering<ONNXGemmOp>>(
       typeConverter, ctx, enableTiling, enableSIMD, enableParallel);

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -30,10 +30,10 @@ namespace onnx_mlir {
 
 struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
   ONNXMatMulOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
-      DimAnalysis *dimAnalysis, bool enableTiling, bool enableSIMD, 
+      DimAnalysis *dimAnalysis, bool enableTiling, bool enableSIMD,
       bool enableParallel = false)
       : OpConversionPattern(typeConverter, ctx), dimAnalysis(dimAnalysis),
-        enableTiling(enableTiling), enableSIMD(enableSIMD), 
+        enableTiling(enableTiling), enableSIMD(enableSIMD),
         enableParallel(enableParallel) {}
   DimAnalysis *dimAnalysis;
   bool enableTiling;
@@ -70,7 +70,7 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
       create.krnl.parallel(outerLoops[0]);
       LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.MatMul\n");
     }
-  
+
     // Non-reduction loop iterations: output-rank.
     create.krnl.iterateIE(loopDef, outerLoops, loopLbs, loopUbs,
         [&](KrnlBuilder &createKrnl, ValueRange outerIndices) {
@@ -240,7 +240,7 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
   // substitution.
   void replace2x2Matmul2d(ONNXMatMulOpAdaptor &operandAdaptor, Type elementType,
       ONNXMatMulOpShapeHelper &shapeHelper, Value alloc, Value zeroVal,
-      ConversionPatternRewriter &rewriter,Location loc,
+      ConversionPatternRewriter &rewriter, Location loc,
       bool enableParallel = false) const {
     // Prepare: loop bounds and zero
     Value A(operandAdaptor.getA()), B(operandAdaptor.getB()), C(alloc);
@@ -440,9 +440,8 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
     if (enableTiling && aRank == 2 && bRank == 2) {
       // Optimized Matmul only when 2D and allowed to tile and unroll.
       assert(cRank == 2 && "expected IxK * KxJ = IxJ 2D result");
-      replace2x2Matmul2d(
-          adaptor, elementType, shapeHelper, alloc, zero, rewriter, loc,
-          enableParallel);
+      replace2x2Matmul2d(adaptor, elementType, shapeHelper, alloc, zero,
+          rewriter, loc, enableParallel);
     } else if (enableTiling && aRank == 2 && bRank > 2) {
       // Broadcasting B.
       assert(cRank == bRank && "expected IxK * *xKxJ = *xIxJ result");
@@ -478,9 +477,8 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
             /*same static broadcast*/ true, alloc, zero, rewriter, loc,
             enableParallel);
       } else {
-        replaceGenericMatmul(
-            adaptor, elementType, shapeHelper, alloc, zero, rewriter, loc,
-            enableParallel);
+        replaceGenericMatmul(adaptor, elementType, shapeHelper, alloc, zero,
+            rewriter, loc, enableParallel);
       }
     }
     // Done.
@@ -492,9 +490,8 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
 void populateLoweringONNXMatMulOpPattern(RewritePatternSet &patterns,
     TypeConverter &typeConverter, MLIRContext *ctx, DimAnalysis *dimAnalysis,
     bool enableTiling, bool enableSIMD, bool enableParallel) {
-  patterns.insert<ONNXMatMulOpLowering>(
-      typeConverter, ctx, dimAnalysis, enableTiling, enableSIMD, 
-      enableParallel);
+  patterns.insert<ONNXMatMulOpLowering>(typeConverter, ctx, dimAnalysis,
+      enableTiling, enableSIMD, enableParallel);
 }
 
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -603,7 +603,8 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
         ValueRange loopDef = createKrnl.defineLoops(1);
         if (enableParallel) {
           create.krnl.parallel(loopDef[0]);
-          LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+          LLVM_DEBUG(
+              llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
         }
         createKrnl.iterateIE(loopDef, loopDef, {LiteralIndexExpr(0)},
             {axisShape0}, [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
@@ -704,8 +705,7 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
       MDBuilder &create, Operation *op, Type elementType, Value input,
       Value alloc, int64_t inRank, int64_t outRank, bool dynamicAxes,
       Value maskVal, std::map<int64_t, int64_t> &outInDimMap,
-      Value divisorForMean,
-      bool enableParallel = false) const {
+      Value divisorForMean, bool enableParallel = false) const {
     //////////////////////////////////////////////////////////////////////
     // There are two required and one optional Krnl loops:
     // - One to initialize the result memref,
@@ -843,8 +843,8 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
   void genHorizontalSimdReduction(ConversionPatternRewriter &rewriter,
       MDBuilder &create, Operation *op, Type elementType, Value input,
       Value alloc, int64_t inRank, int64_t outRank, int64_t VL,
-      int64_t collapsedInnermostLoops, bool isKeepDims,
-      Value divisorForMean, bool enableParallel = false) const {
+      int64_t collapsedInnermostLoops, bool isKeepDims, Value divisorForMean,
+      bool enableParallel = false) const {
 
     assert(VL > 1 && "expected simd here");
     VectorType vecType = VectorType::get({VL}, elementType);
@@ -959,8 +959,8 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
   void genShuffleHorizontalSimdReduction(ConversionPatternRewriter &rewriter,
       MDBuilder &create, Operation *op, Type elementType, Value input,
       Value alloc, int64_t inRank, int64_t outRank, int64_t VL,
-      int64_t collapsedInnermostLoops, bool isKeepDims,
-      Value divisorForMean, bool enableParallel = false) const {
+      int64_t collapsedInnermostLoops, bool isKeepDims, Value divisorForMean,
+      bool enableParallel = false) const {
 
     assert(VL > 1 && "expected simd here");
     IndexExpr VLIndexExpr = LiteralIndexExpr(VL);

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -330,15 +330,17 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
   using OpAdaptor = typename ONNXReductionOp::Adaptor;
   bool enableSIMD = false;
   bool computeMean = false;
+  bool enableParallel = false;
 
   using MDBuilder =
       MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MathBuilder,
           MemRefBuilder, VectorBuilder, AffineBuilderKrnlMem, SCFBuilder>;
 
   ONNXReductionOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
-      bool enableSIMD, bool computeMean = false)
+      bool enableSIMD, bool computeMean = false, bool enableParallel = false)
       : OpConversionPattern<ONNXReductionOp>(typeConverter, ctx),
-        enableSIMD(enableSIMD), computeMean(computeMean) {}
+        enableSIMD(enableSIMD), computeMean(computeMean),
+        enableParallel(enableParallel) {}
 
   LogicalResult matchAndRewrite(ONNXReductionOp reduceOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
@@ -599,6 +601,10 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
         // When axes is dynamic, generate a Krnl loop
         KrnlBuilder createKrnl(rewriter, loc);
         ValueRange loopDef = createKrnl.defineLoops(1);
+        if (enableParallel) {
+          create.krnl.parallel(loopDef[0]);
+          LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+        }
         createKrnl.iterateIE(loopDef, loopDef, {LiteralIndexExpr(0)},
             {axisShape0}, [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
               Value axe = createKrnl.load(axesVal, loopInd[0]);
@@ -679,15 +685,16 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
       if (hasHorizontalSimdSupport) {
         genHorizontalSimdReduction(rewriter, create, op, elementOutType, input,
             alloc, inRank, outRank, VL, innermostLoopCollapse, isKeepdims,
-            divisorForMean);
+            divisorForMean, enableParallel);
       } else {
         genShuffleHorizontalSimdReduction(rewriter, create, op, elementOutType,
             input, alloc, inRank, outRank, VL, innermostLoopCollapse,
-            isKeepdims, divisorForMean);
+            isKeepdims, divisorForMean, enableParallel);
       }
     } else {
       genScalarReduction(rewriter, create, op, elementOutType, input, alloc,
-          inRank, outRank, dynamicAxes, maskVal, outInDimMap, divisorForMean);
+          inRank, outRank, dynamicAxes, maskVal, outInDimMap, divisorForMean,
+          enableParallel);
     }
     rewriter.replaceOp(op, alloc);
     return success();
@@ -697,7 +704,8 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
       MDBuilder &create, Operation *op, Type elementType, Value input,
       Value alloc, int64_t inRank, int64_t outRank, bool dynamicAxes,
       Value maskVal, std::map<int64_t, int64_t> &outInDimMap,
-      Value divisorForMean) const {
+      Value divisorForMean,
+      bool enableParallel = false) const {
     //////////////////////////////////////////////////////////////////////
     // There are two required and one optional Krnl loops:
     // - One to initialize the result memref,
@@ -710,6 +718,10 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
     SmallVector<IndexExpr, 4> lbs1(outRank, LiteralIndexExpr(0));
     SmallVector<IndexExpr, 4> ubs1;
     create.krnlIE.getShapeAsSymbols(alloc, ubs1);
+    if (enableParallel) {
+      create.krnl.parallel(loop1Def[0]);
+      LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+    }
     create.krnl.iterateIE(loop1Def, loop1Def, lbs1, ubs1,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           Value identity = getIdentityValue<ONNXReductionOp>(
@@ -722,6 +734,10 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
     SmallVector<IndexExpr, 4> ubs2;
     create.krnlIE.getShapeAsSymbols(input, ubs2);
     Value trueVal = create.math.constant(rewriter.getIntegerType(1), 1);
+    if (enableParallel) {
+      create.krnl.parallel(loop2Def[0]);
+      LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+    }
     create.krnl.iterateIE(loop2Def, loop2Def, lbs2, ubs2,
         [&](KrnlBuilder &kb, ValueRange loopInd) {
           MultiDialectBuilder<KrnlBuilder, MathBuilder> create(kb);
@@ -756,6 +772,11 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
       SmallVector<IndexExpr, 4> lbs3(outRank, LiteralIndexExpr(0));
       SmallVector<IndexExpr, 4> ubs3;
       create.krnlIE.getShapeAsSymbols(alloc, ubs3);
+      // TODO adjust in the future
+      if (enableParallel) {
+        create.krnl.parallel(loop3Def[0]);
+        LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+      }
       create.krnl.iterateIE(loop3Def, loop3Def, lbs3, ubs3,
           [&](KrnlBuilder &kb, ValueRange loopInd) {
             MultiDialectBuilder<KrnlBuilder, MathBuilder> create(kb);
@@ -823,7 +844,7 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
       MDBuilder &create, Operation *op, Type elementType, Value input,
       Value alloc, int64_t inRank, int64_t outRank, int64_t VL,
       int64_t collapsedInnermostLoops, bool isKeepDims,
-      Value divisorForMean) const {
+      Value divisorForMean, bool enableParallel = false) const {
 
     assert(VL > 1 && "expected simd here");
     VectorType vecType = VectorType::get({VL}, elementType);
@@ -852,6 +873,10 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
     // Define loops for input dimensions, blocking the inner dim by VL
     ValueRange outLoopDef = create.krnl.defineLoops(flatOutRank);
     SmallVector<IndexExpr, 4> lbs(flatOutRank, LiteralIndexExpr(0));
+    if (enableParallel) {
+      create.krnl.parallel(outLoopDef[0]);
+      LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+    }
     create.krnl.iterateIE(outLoopDef, outLoopDef, lbs, flatOutDims,
         [&](KrnlBuilder &ck, ValueRange outLoopInd) {
           MDBuilder create(ck);
@@ -935,7 +960,7 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
       MDBuilder &create, Operation *op, Type elementType, Value input,
       Value alloc, int64_t inRank, int64_t outRank, int64_t VL,
       int64_t collapsedInnermostLoops, bool isKeepDims,
-      Value divisorForMean) const {
+      Value divisorForMean, bool enableParallel = false) const {
 
     assert(VL > 1 && "expected simd here");
     IndexExpr VLIndexExpr = LiteralIndexExpr(VL);
@@ -975,6 +1000,10 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
     optimizedOutLoopDef.emplace_back(blockedOutLoopDef[0]);
     // Iterate only over all but the inner loop of the flattened input.
     SmallVector<IndexExpr, 4> lbs(flatOutRank, LiteralIndexExpr(0));
+    if (enableParallel) {
+      create.krnl.parallel(optimizedOutLoopDef[0]);
+      LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
+    }
     create.krnl.iterateIE(outLoopDef, optimizedOutLoopDef, lbs, flatOutDims,
         [&](KrnlBuilder &ck, ValueRange blockedOutLoopInd) {
           MDBuilder create(ck);
@@ -1026,7 +1055,8 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
 }; /* struct ONNXReductionOpLowering */
 
 void populateLoweringONNXReductionOpPattern(RewritePatternSet &patterns,
-    TypeConverter &typeConverter, MLIRContext *ctx, bool enableSIMD) {
+    TypeConverter &typeConverter, MLIRContext *ctx, bool enableSIMD,
+    bool enableParallel) {
   patterns.insert<
       ONNXReductionOpLowering<mlir::ONNXReduceMaxV13Op, RLegacy::UpTo13>,
       ONNXReductionOpLowering<mlir::ONNXReduceMinV13Op, RLegacy::UpTo13>,
@@ -1036,10 +1066,10 @@ void populateLoweringONNXReductionOpPattern(RewritePatternSet &patterns,
       ONNXReductionOpLowering<mlir::ONNXReduceMinOp, RLegacy::Latest>,
       ONNXReductionOpLowering<mlir::ONNXReduceProdOp, RLegacy::Latest>,
       ONNXReductionOpLowering<mlir::ONNXReduceSumOp, RLegacy::Latest>>(
-      typeConverter, ctx, enableSIMD);
+      typeConverter, ctx, enableSIMD, enableParallel);
   patterns.insert<
       ONNXReductionOpLowering<mlir::ONNXReduceMeanV13Op, RLegacy::UpTo13>,
       ONNXReductionOpLowering<mlir::ONNXReduceMeanOp, RLegacy::Latest>>(
-      typeConverter, ctx, enableSIMD, /*computeMean=*/true);
+      typeConverter, ctx, enableSIMD, /*computeMean=*/true, enableParallel);
 }
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -218,9 +218,9 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
       outerUbs.emplace_back(create.krnlIE.getShapeAsDim(input, i));
 
   if (enableParallel) {
-      create.krnl.parallel(outerLoops[0]);
-      LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.Softmax \n");
-    }
+    create.krnl.parallel(outerLoops[0]);
+    LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.Softmax \n");
+  }
 
   // Emit outer loops.
   create.krnl.iterateIE(outerLoops, outerLoops, outerLbs, outerUbs,
@@ -247,9 +247,9 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
 template <typename SoftmaxOp>
 struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
   ONNXSoftmaxLowering(TypeConverter &typeConverter, MLIRContext *ctx,
-                      bool enableParallel = false)
+      bool enableParallel = false)
       : OpConversionPattern<SoftmaxOp>(typeConverter, ctx),
-      enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {}
   using OpAdaptor = typename SoftmaxOp::Adaptor;
   bool enableParallel = false;
 
@@ -290,9 +290,8 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
     Value negInfinity = create.math.constant(
         elementType, -std::numeric_limits<float>::infinity());
 
-    emitInstForSoftmax<SoftmaxOp>(
-        rewriter, loc, alloc, input, sumOp, maxOp, zero, negInfinity, axis,
-        enableParallel);
+    emitInstForSoftmax<SoftmaxOp>(rewriter, loc, alloc, input, sumOp, maxOp,
+        zero, negInfinity, axis, enableParallel);
 
     rewriter.replaceOp(op, alloc);
     return success();
@@ -302,8 +301,8 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
 void populateLoweringONNXSoftmaxOpPattern(RewritePatternSet &patterns,
     TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel) {
   patterns.insert<ONNXSoftmaxLowering<ONNXSoftmaxOp>,
-      ONNXSoftmaxLowering<ONNXSoftmaxV11Op>>(typeConverter, ctx, 
-                                             enableParallel);
+      ONNXSoftmaxLowering<ONNXSoftmaxV11Op>>(
+      typeConverter, ctx, enableParallel);
 }
 
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -16,6 +16,8 @@
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include <src/Dialect/ONNX/ONNXOps.hpp>
 
+#define DEBUG_TYPE "lowering-to-krnl"
+
 using namespace mlir;
 
 namespace onnx_mlir {
@@ -124,14 +126,14 @@ static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
 template <typename T>
 void emitInstForSoftmax(ConversionPatternRewriter &rewriter, Location loc,
     Value alloc, Value input, Value sumOp, Value maxOp, Value zero,
-    Value negInfinity, int64_t axis) = delete;
+    Value negInfinity, int64_t axis, bool enableParallel) = delete;
 
 // For Softmax opset < 13, `axis` is the coerced point. All dimensions
 // after `axis` will be logically coerced into a single dimension.
 template <>
 void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
     Location loc, Value alloc, Value input, Value sumOp, Value maxOp,
-    Value zero, Value negInfinity, int64_t axis) {
+    Value zero, Value negInfinity, int64_t axis, bool enableParallel) {
   int64_t rank = alloc.getType().cast<MemRefType>().getRank();
 
   MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl> create(
@@ -166,6 +168,10 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
     SmallVector<IndexExpr, 4> outerUbs;
     for (int i = 0; i < axis; ++i)
       outerUbs.emplace_back(create.krnlIE.getShapeAsDim(input, i));
+    if (enableParallel) {
+      create.krnl.parallel(outerLoops[0]);
+      LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.SoftmaxV110p \n");
+    }
     create.krnl.iterateIE(outerLoops, outerLoops, outerLbs, outerUbs,
         [&](KrnlBuilder &ck, ValueRange outerIndices) {
           MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl> create(ck);
@@ -195,7 +201,7 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
 template <>
 void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
     Location loc, Value alloc, Value input, Value sumOp, Value maxOp,
-    Value zero, Value negInfinity, int64_t axis) {
+    Value zero, Value negInfinity, int64_t axis, bool enableParallel) {
   int64_t rank = alloc.getType().cast<MemRefType>().getRank();
 
   MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl> create(
@@ -210,6 +216,11 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
   for (int i = 0; i < rank; ++i)
     if (i != axis)
       outerUbs.emplace_back(create.krnlIE.getShapeAsDim(input, i));
+
+  if (enableParallel) {
+      create.krnl.parallel(outerLoops[0]);
+      LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.Softmax \n");
+    }
 
   // Emit outer loops.
   create.krnl.iterateIE(outerLoops, outerLoops, outerLbs, outerUbs,
@@ -235,9 +246,12 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
 
 template <typename SoftmaxOp>
 struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
-  ONNXSoftmaxLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : OpConversionPattern<SoftmaxOp>(typeConverter, ctx) {}
+  ONNXSoftmaxLowering(TypeConverter &typeConverter, MLIRContext *ctx,
+                      bool enableParallel = false)
+      : OpConversionPattern<SoftmaxOp>(typeConverter, ctx),
+      enableParallel(enableParallel) {}
   using OpAdaptor = typename SoftmaxOp::Adaptor;
+  bool enableParallel = false;
 
   LogicalResult matchAndRewrite(SoftmaxOp softmaxOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
@@ -277,7 +291,8 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
         elementType, -std::numeric_limits<float>::infinity());
 
     emitInstForSoftmax<SoftmaxOp>(
-        rewriter, loc, alloc, input, sumOp, maxOp, zero, negInfinity, axis);
+        rewriter, loc, alloc, input, sumOp, maxOp, zero, negInfinity, axis,
+        enableParallel);
 
     rewriter.replaceOp(op, alloc);
     return success();
@@ -285,9 +300,10 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
 };
 
 void populateLoweringONNXSoftmaxOpPattern(RewritePatternSet &patterns,
-    TypeConverter &typeConverter, MLIRContext *ctx) {
+    TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel) {
   patterns.insert<ONNXSoftmaxLowering<ONNXSoftmaxOp>,
-      ONNXSoftmaxLowering<ONNXSoftmaxV11Op>>(typeConverter, ctx);
+      ONNXSoftmaxLowering<ONNXSoftmaxV11Op>>(typeConverter, ctx, 
+                                             enableParallel);
 }
 
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -304,7 +304,7 @@ void populateLoweringONNXElementwiseOpPattern(mlir::RewritePatternSet &,
     mlir::TypeConverter &, mlir::MLIRContext *, DimAnalysis *, bool enableSIMD,
     bool enableParallel);
 void populateLoweringONNXGemmOpPattern(mlir::RewritePatternSet &,
-    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling, 
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling,
     bool enableSIMD, bool enableParallel);
 void populateLoweringONNXHardmaxOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
@@ -322,9 +322,8 @@ void populateLoweringONNXRandomNormalLikeOpPattern(
 void populateLoweringONNXReductionOpPattern(mlir::RewritePatternSet &,
     mlir::TypeConverter &, mlir::MLIRContext *, bool enableSIMD,
     bool enableParallel);
-void populateLoweringONNXSoftmaxOpPattern(
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
-    bool enableParallel);
+void populateLoweringONNXSoftmaxOpPattern(mlir::RewritePatternSet &,
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableParallel);
 void populateLoweringONNXTopKOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXTriluOpPattern(
@@ -381,9 +380,8 @@ void populateLoweringONNXUnsqueezeOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXUnsqueezeV11OpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
-void populateLoweringONNXTransposeOpPattern(
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
-    bool enableParallel);
+void populateLoweringONNXTransposeOpPattern(mlir::RewritePatternSet &,
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableParallel);
 void populateLoweringONNXGatherOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXGatherElementsOpPattern(
@@ -404,9 +402,8 @@ void populateLoweringONNXConstantOfShapeOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXConstantOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
-void populateLoweringONNXConcatOpPattern(
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
-    bool enableParallel);
+void populateLoweringONNXConcatOpPattern(mlir::RewritePatternSet &,
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableParallel);
 void populateLoweringONNXConcatShapeTransposeOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXDepthToSpaceOpPattern(

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -284,7 +284,8 @@ public:
 
 // For all ONNX operations.
 void populateONNXToKrnlConversionPattern(mlir::RewritePatternSet &,
-    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling);
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling,
+    bool enableParallel);
 
 // `ControlFlow` directory methods:
 void populateLoweringONNXIfOpPattern(
@@ -300,17 +301,18 @@ void populateLoweringONNXClipOpPattern(
 void populateLoweringONNXCumSumOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXElementwiseOpPattern(mlir::RewritePatternSet &,
-    mlir::TypeConverter &, mlir::MLIRContext *, DimAnalysis *, bool enableSIMD);
+    mlir::TypeConverter &, mlir::MLIRContext *, DimAnalysis *, bool enableSIMD,
+    bool enableParallel);
 void populateLoweringONNXGemmOpPattern(mlir::RewritePatternSet &,
-    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling,
-    bool enableSIMD);
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableTiling, 
+    bool enableSIMD, bool enableParallel);
 void populateLoweringONNXHardmaxOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXLRNOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXMatMulOpPattern(mlir::RewritePatternSet &,
     mlir::TypeConverter &, mlir::MLIRContext *, DimAnalysis *,
-    bool enableTiling, bool enableSIMD);
+    bool enableTiling, bool enableSIMD, bool enableParallel);
 void populateLoweringONNXMatMulIntegerOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXRandomNormalOpPattern(
@@ -318,9 +320,11 @@ void populateLoweringONNXRandomNormalOpPattern(
 void populateLoweringONNXRandomNormalLikeOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXReductionOpPattern(mlir::RewritePatternSet &,
-    mlir::TypeConverter &, mlir::MLIRContext *, bool enableSIMD);
+    mlir::TypeConverter &, mlir::MLIRContext *, bool enableSIMD,
+    bool enableParallel);
 void populateLoweringONNXSoftmaxOpPattern(
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
+    bool enableParallel);
 void populateLoweringONNXTopKOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXTriluOpPattern(
@@ -378,7 +382,8 @@ void populateLoweringONNXUnsqueezeOpPattern(
 void populateLoweringONNXUnsqueezeV11OpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXTransposeOpPattern(
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
+    bool enableParallel);
 void populateLoweringONNXGatherOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXGatherElementsOpPattern(
@@ -400,7 +405,8 @@ void populateLoweringONNXConstantOfShapeOpPattern(
 void populateLoweringONNXConstantOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXConcatOpPattern(
-    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *,
+    bool enableParallel);
 void populateLoweringONNXConcatShapeTransposeOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXDepthToSpaceOpPattern(

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -16,13 +16,18 @@
 #include "src/Dialect/Krnl/KrnlHelper.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
 
+#define DEBUG_TYPE "lowering-to-krnl"
+
 using namespace mlir;
 
 namespace onnx_mlir {
 
 struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
-  ONNXConcatOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
-      : OpConversionPattern(typeConverter, ctx) {}
+  ONNXConcatOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
+  bool enableParallel = false)
+      : OpConversionPattern(typeConverter, ctx),
+        enableParallel(enableParallel) {}
+  bool enableParallel = false;
 
   LogicalResult matchAndRewrite(ONNXConcatOp concatOp,
       ONNXConcatOpAdaptor adaptor,
@@ -79,6 +84,10 @@ struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
       create.krnlIE.getShapeAsDims(operands[i], ubs);
       // For each input, only the dimension 'axis' is different
       commonUB[axis] = ubs[axis];
+      if (enableParallel) {
+        create.krnl.parallel(loopDef[0]);
+        LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.Concat \n");
+      }
       create.krnl.iterateIE(loopDef, loopDef, lbs, commonUB,
           [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
             // Indices for the read and write.
@@ -108,8 +117,8 @@ struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
 };
 
 void populateLoweringONNXConcatOpPattern(RewritePatternSet &patterns,
-    TypeConverter &typeConverter, MLIRContext *ctx) {
-  patterns.insert<ONNXConcatOpLowering>(typeConverter, ctx);
+    TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel) {
+  patterns.insert<ONNXConcatOpLowering>(typeConverter, ctx, enableParallel);
 }
 
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -24,7 +24,7 @@ namespace onnx_mlir {
 
 struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
   ONNXConcatOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
-  bool enableParallel = false)
+      bool enableParallel = false)
       : OpConversionPattern(typeConverter, ctx),
         enableParallel(enableParallel) {}
   bool enableParallel = false;

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -27,7 +27,7 @@ struct ONNXTransposeOpLowering : public OpConversionPattern<ONNXTransposeOp> {
   bool enableParallel = false;
 
   ONNXTransposeOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
-                          bool enableParallel = false)
+      bool enableParallel = false)
       : OpConversionPattern(typeConverter, ctx),
         enableParallel(enableParallel) {}
 
@@ -75,7 +75,8 @@ struct ONNXTransposeOpLowering : public OpConversionPattern<ONNXTransposeOp> {
 
     if (auto numLastDims =
             unchangedInnerDimensions(inMemRefType, outMemRefType, permAttr))
-      blockTranspose(data, alloc, permAttr, &create, numLastDims, enableParallel);
+      blockTranspose(
+          data, alloc, permAttr, &create, numLastDims, enableParallel);
     else
       scalarTranspose(data, alloc, permAttr, &create, enableParallel);
 
@@ -132,7 +133,7 @@ private:
 
   // Do transpose by copying elements one-by-one.
   void scalarTranspose(Value inputMemRef, Value outputMemRef,
-      std::optional<ArrayAttr> permAttr, MDBuilder *create, 
+      std::optional<ArrayAttr> permAttr, MDBuilder *create,
       bool enableParallel = false) const {
     uint64_t rank = outputMemRef.getType().cast<MemRefType>().getRank();
     ValueRange loopDef = create->krnl.defineLoops(rank);
@@ -140,7 +141,6 @@ private:
     SmallVector<IndexExpr, 4> ubs;
     create->krnlIE.getShapeAsDims(inputMemRef, ubs);
 
-    //FIXME
     if (enableParallel) {
       create->krnl.parallel(loopDef[0]);
       LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.Transpose \n");
@@ -162,8 +162,8 @@ private:
   // Do transpose by copying block of consecutive elements in the inner-most
   // dimensions.
   void blockTranspose(Value inputMemRef, Value outputMemRef,
-      std::optional<ArrayAttr> permAttr, MDBuilder *create,
-      int numLastDims, bool enableParallel = false) const {
+      std::optional<ArrayAttr> permAttr, MDBuilder *create, int numLastDims,
+      bool enableParallel = false) const {
     Type i64Ty = create->math.getBuilder().getI64Type();
     MemRefType inMemRefType = inputMemRef.getType().cast<MemRefType>();
     uint64_t rank = inMemRefType.getRank();
@@ -207,7 +207,6 @@ private:
     // Main loop defined over the outer-most dimensions.
     ValueRange loopDef = create->krnl.defineLoops(outerRank);
     SmallVector<IndexExpr, 4> lbs(outerRank, LiteralIndexExpr(0));
-    //FIXME
     if (enableParallel) {
       create->krnl.parallel(loopDef[0]);
       LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.Transpose \n");

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -126,6 +126,10 @@ ValueRange KrnlBuilder::getInductionVarValue(ValueRange loops) const {
       .getResults();
 }
 
+void KrnlBuilder::parallel(Value loop) const {
+   b().template create<KrnlParallelOp>(loc(), loop);
+}
+
 void KrnlBuilder::iterate(ValueRange originalLoops, ValueRange optimizedLoops,
     ValueRange lbs, ValueRange ubs,
     function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -127,7 +127,7 @@ ValueRange KrnlBuilder::getInductionVarValue(ValueRange loops) const {
 }
 
 void KrnlBuilder::parallel(Value loop) const {
-   b().template create<KrnlParallelOp>(loc(), loop);
+  b().template create<KrnlParallelOp>(loc(), loop);
 }
 
 void KrnlBuilder::iterate(ValueRange originalLoops, ValueRange optimizedLoops,

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -52,6 +52,7 @@ struct KrnlBuilder : public DialectBuilder {
   mlir::ValueRange block(mlir::Value loop, int64_t blockSize) const;
   void permute(mlir::ValueRange loops, mlir::ArrayRef<int64_t> map) const;
   mlir::ValueRange getInductionVarValue(mlir::ValueRange loops) const;
+  void parallel(mlir::Value loop) const;
 
   // Lambda passes loop indices as 2nd parameter.
   void iterate(mlir::ValueRange originalLoops, mlir::ValueRange optimizedLoops,

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -500,6 +500,23 @@ def KrnlUnrollOp : Op<Krnl_Dialect, "unroll"> {
   }];
 }
 
+def KrnlParallelOp : Op<Krnl_Dialect, "parallel"> {
+  let summary = "Krnl parallel operation";
+  let description = [{
+    Parallelize the specified loops.
+    ```
+    krnl.parallel %i
+    ```
+  }];
+
+  let arguments = (ins AnyType:$loop);
+
+  let assemblyFormat = [{
+      $loop attr-dict `:` type($loop)
+  }];
+}
+
+
 def KrnlDimOp : Op<Krnl_Dialect, "dim", [MemRefsNormalizable]> {
   let summary = "Krnl dimensions operation.";
   let description = [{

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -114,7 +114,7 @@ std::unique_ptr<mlir::Pass> createConvertKrnlToLLVMPass();
 std::unique_ptr<mlir::Pass> createConvertKrnlToLLVMPass(bool verifyInputTensors,
     bool useOpaquePointer, bool useLRODATA, bool storeConstantsToFile,
     float constantsToFileSingleThreshold, float constantsToFileTotalThreshold,
-    std::string outputNameNoExt);
+    std::string outputNameNoExt, bool enableParallel);
 
 } // namespace krnl
 

--- a/src/Tools/onnx-mlir-opt/CMakeLists.txt
+++ b/src/Tools/onnx-mlir-opt/CMakeLists.txt
@@ -16,5 +16,7 @@ add_onnx_mlir_executable(onnx-mlir-opt
   MLIRAffineTransforms
   MLIRLinalgTransforms
   MLIRMemRefTransforms
+  MLIROpenMPToLLVM
   MLIROptLib
+  MLIRSCFToOpenMP
   )

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -162,6 +162,15 @@ void registerMLIRPasses() {
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return mlir::createPrintOpStatsPass();
   });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return mlir::createConvertSCFToOpenMPPass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return mlir::createConvertOpenMPToLLVMPass();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return mlir::createFinalizeMemRefToLLVMConversionPass();
+  });
 }
 
 void registerPasses(int optLevel) {

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -11,6 +11,7 @@
 // Implements main for onnx-mlir driver.
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 #include "src/Version/Version.hpp"
@@ -76,6 +77,7 @@ int main(int argc, char *argv[]) {
 
   // Create context after MLIRContextCLOptions are registered and parsed.
   mlir::MLIRContext context;
+  mlir::registerOpenMPDialectTranslation(context);
   if (!context.isMultithreadingEnabled()) {
     assert(context.getNumThreads() == 1 && "1 thread if no multithreading");
     LLVM_DEBUG(llvm::dbgs() << "multithreading is disabled\n");

--- a/test/mlir/onnx/onnx_lowering_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_parallel_canonicalize_O3.mlir
@@ -1,0 +1,85 @@
+// RUN: onnx-mlir-opt -O3 --march=x86-64 --shape-inference --convert-onnx-to-krnl=enable-parallel --canonicalize %s -split-input-file | FileCheck %s
+
+// -----
+// Parallel GEMM
+func.func @test_gemm_parallel(%arg0 : tensor<5x10xf32>, %arg1 : tensor<5x10xf32>, %arg2: tensor<10xf32>) -> tensor<*xf32> {
+  %0 ="onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.0 : f32, beta = 5.0 : f32, transA = 1 : si64, transB = 0 : si64} : (tensor<5x10xf32>, tensor<5x10xf32>, tensor<10xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+  // mlir2FileCheck.py
+  // CHECK-LABEL:  func.func @test_gemm
+  // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<5x10xf32>, [[PARAM_1_:%.+]]: memref<5x10xf32>, [[PARAM_2_:%.+]]: memref<10xf32>) -> memref<10x10xf32> {
+  // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+  // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+  // CHECK-DAG:       [[CST_5_dot_000000_:%.+]] = arith.constant 5.000000e+00 : f32
+  // CHECK-DAG:       [[CST_10_:%.+]] = arith.constant 10 : index
+  // CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : index
+  // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<10x10xf32>
+  // CHECK:           krnl.memset [[RES_]], [[CST_0_dot_000000_]] : memref<10x10xf32>
+  // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<32x256xf32>
+  // CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<256x64xf32>
+  // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
+  // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]]#0 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  // CHECK:           [[BLOCK_TILE__1_:%.+]], [[BLOCK_IN__1_:%.+]] = krnl.block [[BLOCK_IN__0_]] 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  // CHECK:           [[BLOCK_TILE__2_:%.+]], [[BLOCK_IN__2_:%.+]] = krnl.block [[LOOP_0_]]#1 64 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  // CHECK:           [[BLOCK_TILE__3_:%.+]], [[BLOCK_IN__3_:%.+]] = krnl.block [[BLOCK_IN__2_]] 16 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  // CHECK:           [[BLOCK_TILE__4_:%.+]], [[BLOCK_IN__4_:%.+]] = krnl.block [[LOOP_0_]]#2 256 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  // CHECK:           krnl.permute([[BLOCK_TILE__2_]], [[BLOCK_TILE__3_]], [[BLOCK_IN__3_]], [[BLOCK_TILE__4_]], [[BLOCK_IN__4_]], [[BLOCK_TILE__0_]], [[BLOCK_TILE__0_]]_3, [[BLOCK_IN__1_]]) [0, 3, 5, 1, 6, 2, 4, 7] : !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop
+  // CHECK:           krnl.parallel [[BLOCK_TILE__2_]] : !krnl.loop
+  // CHECK:           krnl.iterate([[BLOCK_TILE__2_]], [[BLOCK_TILE__4_]]) with ([[LOOP_0_]]#1 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#2 -> [[I_1_:%.+]] = 0 to 5, [[LOOP_0_]]#0 -> [[I_2_:%.+]] = 0 to 10){
+  // CHECK:             [[VAR_2_:%.+]]:2 = krnl.get_induction_var_value([[BLOCK_TILE__2_]], [[BLOCK_TILE__4_]]) : (!krnl.loop, !krnl.loop) -> (index, index)
+  // CHECK:             krnl.copy_to_tile_buffer [[RES_2_]], [[PARAM_1_]]{{.}}[[VAR_2_]]#1, [[VAR_2_]]#0], [[CST_0_dot_000000_]] {padToNext = [], tileSize = []} : memref<256x64xf32>, memref<5x10xf32>
+  // CHECK:             krnl.iterate([[BLOCK_TILE__0_]]) with (){
+  // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
+  // CHECK:               krnl.copy_to_tile_buffer [[RES_1_]], [[PARAM_0_]]{{.}}[[VAR_2_]]#1, [[VAR_3_]]{{.}}, [[CST_0_dot_000000_]] {padToNext = [], tileSize = [], transpose = true} : memref<32x256xf32>, memref<5x10xf32>
+  // CHECK:               krnl.iterate([[BLOCK_TILE__3_]], [[BLOCK_TILE__1_]]) with (){
+  // CHECK:                 [[VAR_4_:%.+]]:2 = krnl.get_induction_var_value([[BLOCK_TILE__3_]], [[BLOCK_TILE__1_]]) : (!krnl.loop, !krnl.loop) -> (index, index)
+  // CHECK:                 krnl.matmul [[RES_1_]]{{.}}[[VAR_3_]], [[VAR_2_]]#1], [[RES_2_]]{{.}}[[VAR_2_]]#1, [[VAR_2_]]#0], [[RES_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, ([[BLOCK_IN__1_]], [[BLOCK_IN__3_]], [[BLOCK_IN__4_]]), ([[VAR_4_]]#1, [[VAR_4_]]#0, [[VAR_2_]]#1), ([[CST_10_]], [[CST_10_]], [[CST_5_]]) {aTileSize = [], bTileSize = [], cTileSize = [], computeTileSize = [4, 16, 256], simdize = false} : memref<32x256xf32>, memref<256x64xf32>, memref<10x10xf32>, (!krnl.loop, !krnl.loop, !krnl.loop)
+  // CHECK:               }
+  // CHECK:             }
+  // CHECK:           }
+  // CHECK:           [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
+  // CHECK:           krnl.parallel [[LOOP_1_]]#0 : !krnl.loop
+  // CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_3_:%.+]] = 0 to 10, [[LOOP_1_]]#1 -> [[I_4_:%.+]] = 0 to 10){
+  // CHECK:             [[VAR_2_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+  // CHECK-DAG:         [[VAR_3_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#1] : memref<10x10xf32>
+  // CHECK-DAG:         [[VAR_4_1_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[VAR_2_1_]]#1] : memref<10xf32>
+  // CHECK:             [[VAR_5_:%.+]] = arith.mulf [[VAR_4_1_]], [[CST_5_dot_000000_]] : f32
+  // CHECK:             [[VAR_6_:%.+]] = arith.addf [[VAR_3_1_]], [[VAR_5_]] : f32
+  // CHECK:             krnl.store [[VAR_6_]], [[RES_]]{{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#1] : memref<10x10xf32>
+  // CHECK:           }
+  // CHECK:           return [[RES_]] : memref<10x10xf32>
+  // CHECK:         }
+
+}
+
+// -----
+
+
+func.func @test_matmul_parallel(%arg0 : tensor<4x8xf32>, %arg1 : tensor<8x16xf32>) -> tensor<*xf32> {
+  %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<4x8xf32>, tensor<8x16xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+  // mlir2FileCheck.py
+  // CHECK-LABEL:  func.func @test_matmul_parallel
+  // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<4x8xf32>, [[PARAM_1_:%.+]]: memref<8x16xf32>) -> memref<4x16xf32> {
+  // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+  // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+  // CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : index
+  // CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : index
+  // CHECK-DAG:       [[CST_16_:%.+]] = arith.constant 16 : index
+  // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<4x16xf32>
+  // CHECK:           krnl.memset [[RES_]], [[CST_0_dot_000000_]] : memref<4x16xf32>
+  // CHECK:           [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
+  // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]]#0 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  // CHECK:           [[BLOCK_TILE__1_:%.+]], [[BLOCK_IN__1_:%.+]] = krnl.block [[LOOP_0_]]#1 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  // CHECK:           [[BLOCK_TILE__2_:%.+]], [[BLOCK_IN__2_:%.+]] = krnl.block [[LOOP_0_]]#2 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  // CHECK:           krnl.permute([[BLOCK_TILE__0_]], [[BLOCK_IN__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_IN__0_]]_1, [[BLOCK_TILE__0_]]_2, [[BLOCK_IN__0_]]_3) [0, 3, 1, 4, 2, 5] : !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop
+  // CHECK:           krnl.parallel [[BLOCK_TILE__0_]] : !krnl.loop
+  // CHECK:           krnl.iterate([[BLOCK_TILE__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_TILE__0_]]_2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = [[CST_0_]] to [[CST_4_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = [[CST_0_]] to [[CST_16_]], [[LOOP_0_]]#2 -> [[I_2_:%.+]] = [[CST_0_]] to [[CST_8_]]){
+  // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[BLOCK_TILE__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_TILE__0_]]_2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
+  // CHECK:             krnl.matmul [[PARAM_0_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, [[PARAM_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, [[RES_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, ([[BLOCK_IN__0_]], [[BLOCK_IN__0_]]_1, [[BLOCK_IN__0_]]_3), ([[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2), ([[CST_4_]], [[CST_16_]], [[CST_8_]]) {aTileSize = [], bTileSize = [], cTileSize = [], computeTileSize = [4, 8, 8]} : memref<4x8xf32>, memref<8x16xf32>, memref<4x16xf32>, (!krnl.loop, !krnl.loop, !krnl.loop)
+  // CHECK:           }
+  // CHECK:           return [[RES_]] : memref<4x16xf32>
+  // CHECK:         }
+}

--- a/test/mlir/onnx/onnx_lowering_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/onnx/onnx_lowering_with_parallel_canonicalize_O3.mlir
@@ -83,3 +83,5 @@ func.func @test_matmul_parallel(%arg0 : tensor<4x8xf32>, %arg1 : tensor<8x16xf32
   // CHECK:           return [[RES_]] : memref<4x16xf32>
   // CHECK:         }
 }
+
+//TODO add test for transpose, softmax, reduction, concatenate, element wise


### PR DESCRIPTION
Enable the multi-threading in onnx-mlir by utilizing OpenMP.  Tested on x86 with performance gain. 

Introduced a new operator in krnl dialect: krnl.parallel which takes a loop as input to specify the loop will be parallelized. 

To parallelization is **enabled** with the argument `--parallel` in `onnx-mlir` and  `--convert-onnx-to-krnl=enable-parallel` in `onnx-mlir-opt`.


To parallel an operator while lowering, you can follow the attached example below: 

```diff
ValueRange loopDef = create.krnl.defineLoops(outputRank);
SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
SmallVector<IndexExpr, 4> ubs;
+ create.krnl.parallel(loopDef[0]) // parallelize the outermost loop
create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
          [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
      ...
}
```

To run your model with parallelization, please build your MLIR along with OpenMP with following code and set the dependency with `export LD_PRELOAD=../llvm-project/build/lib/libomp.so`.

```diff
+ DLLVM_ENABLE_PROJECTS="mlir;openmp;clang" 
- DLLVM_ENABLE_PROJECTS="mlir" 
```


The parallelization is done by transforming the affine.forOp to affine.parallelOp this happens in the Pass:  `convert-krnl-to-affine`. krnl.parallel is interpreted after krnl.defineloop, krnl.iterate, krnl.block, krnl.permute and krnl.unroll. The further lowering will be handled by `convert-scf-to-openmp` and `convert-openmp-to-llvm` automatically.


Current parallelized operators (outermost loop):
- [x] Elementwise Operator
- [x] GEMM
- [x] MatMul
- [x] Transpose
- [x] Softmax
- [x] Reduction
- [x] Concat

Signed-off-by: @lixi-zhou 
Co-authored-by:  @AlexandreEichenberger 
