### PR TITLE
Added logic for simple min/max when generating the md files that describe our support

### DIFF
--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -77,6 +77,7 @@ def get_test_models():
         # ==ARCH== cpu
 
         # ==OP== Abs
+        # ==MIN== 9
         "test_abs_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
 
         # ==OP== Acos

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -77,7 +77,6 @@ def get_test_models():
         # ==ARCH== cpu
 
         # ==OP== Abs
-        # ==MIN== 9
         "test_abs_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
 
         # ==OP== Acos

--- a/utils/documentOps.py
+++ b/utils/documentOps.py
@@ -18,18 +18,18 @@
 #
 ################################################################################
 
+################################################################################
+# Default min/max opset supported (when not explicitly specified).
+# Default values are used when no explicit ==MIN==/==MAX== values are used.
+min_opset_default = 9 
+max_opset_default = 18
+
 import sys
 import getopt
 import fileinput
 import re
 import json
 import subprocess
-
-################################################################################
-# Default min/max opset supported (when not explicitly specified).
-# Default values are used when no explicit ==MIN==/==MAX== values are used.
-min_opset_default = 9 
-max_opset_default = 18
 
 ################################################################################
 # SEMANTIC for LABELING (one line per directive)


### PR DESCRIPTION
Can add `==MIN== <num>` or `==MAX== <num>` comments to specify min/max onset supported. 

Otherwise, the min/max is defined by a default min/max value in conjunction with the values of `version_dict` in `gen_onnx_mlir.pl` 

```
        # ==OP== Abs
        # ==MIN== 8
        "test_abs_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
```

The resulting table is as below:

== Table ===========================

Onnx-mlir currently supports ONNX operations targeting up to opset 19. Limitations are listed when applicable.

* Operations are defined by the [ONNX Standard](https://github.com/onnx/onnx/blob/main/docs/Operators.md).
* Opset indicates, for each operation, the minimum and the maximum ONNX opset that is supported by the current version of onnx-mlir. Limitation field indicates limitations in the current implementation, if any.


| Op |Min Opset |Max Opset |Limitations |
| --- |--- |--- |--- |
| **Abs** |9 |18 | |
| **Acos** |7 |18 | |
| **Acosh** |9 |18 | |
| **Add** |9 |18 |No support for short integers. |
