### PR TITLE
Avoid constant folding for EqualOp on string type

### DIFF
--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -43,7 +43,7 @@ include "src/Dialect/ONNX/ONNX.td"
 
 def IsNoneType : Constraint<CPred<"isa<NoneType>(($_self).getType())">>;
 
-def IsNotStringType : Constraint<CPred<"! isa<ONNXStringType>(($_self).getType().cast<ShapedType>().getElementType())">>;
+def IsIntOrFloatType : Constraint<CPred<"isa<IntegerType, FloatType>(($_self).getType().cast<ShapedType>().getElementType())">>;
 
 def IsNotAConstant :
   Constraint<CPred<"! isa_and_nonnull<ONNXConstantOp>(($_self).getDefiningOp())">,
@@ -518,7 +518,7 @@ def EqualConstProp : Pat<
     (CreateEqualOfTwoConst $result, $lhs, $rhs),
     // constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (IsNotStringType:$lhs), (SatisfiesExpansionBound:$result)]>;
+     (IsIntOrFloatType:$lhs), (SatisfiesExpansionBound:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagate ONNXLessOp

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -43,6 +43,8 @@ include "src/Dialect/ONNX/ONNX.td"
 
 def IsNoneType : Constraint<CPred<"isa<NoneType>(($_self).getType())">>;
 
+def IsNotStringType : Constraint<CPred<"! isa<ONNXStringType>(($_self).getType().cast<ShapedType>().getElementType())">>;
+
 def IsNotAConstant :
   Constraint<CPred<"! isa_and_nonnull<ONNXConstantOp>(($_self).getDefiningOp())">,
   "operation is not a constant">;
@@ -516,7 +518,7 @@ def EqualConstProp : Pat<
     (CreateEqualOfTwoConst $result, $lhs, $rhs),
     // constraints
     [(IsFromDenseONNXConstantOp:$lhs), (IsFromDenseONNXConstantOp:$rhs),
-     (SatisfiesExpansionBound:$result)]>;
+     (IsNotStringType:$lhs), (SatisfiesExpansionBound:$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Constant propagate ONNXLessOp


### PR DESCRIPTION
Since we have problem in importing string type input to model, I used the following test case to see whether the new implementation of EqualOp on string type is correct or not.
```
func.func @test_equal_string() -> tensor<*xi1> {
  %c1 = onnx.Constant dense<["string1"]> : tensor<1x!onnx.String>
  %c2 = onnx.Constant dense<["string2"]> : tensor<1x!onnx.String>
  %0 = "onnx.Equal"(%c1, %c2) : (tensor<1x!onnx.String>, tensor<1x!onnx.String>) -> tensor<*xi1>
   return %0 : tensor<*xi1>
}
```
This test case caused trouble in constant propagation for string type. 
This PR is a hack to turn off constant propagation for EqualOp on string type. 
@sorenlassen This PR is not  needed, if you can fix the problem in constant folding quickly. With this PR, I found the test case exposed another issue in lowering to llvm. 