### PR TITLE
[NNPA] Remove consecutive zlow.unstick and zlow.stick ops if they use the same layout

### DIFF
--- a/test/mlir/accelerators/nnpa/driver/softmax-matmul-in-attention-layer.mlir
+++ b/test/mlir/accelerators/nnpa/driver/softmax-matmul-in-attention-layer.mlir
@@ -1,0 +1,16 @@
+// RUN: onnx-mlir --maccel=NNPA --EmitMLIR --printIR %s | FileCheck %s
+
+// Check whether the compiler can remove unstick/stick so that the output of zdnn softmax is passed directly to zdnn matmul.
+func.func @softmax_matmul(%arg0: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  %0 = "onnx.Transpose"(%arg0) {perm = [0, 1, 3, 2]} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+  %1 = "onnx.Softmax"(%arg0) {axis = 3 : si64} : (tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+  %2 = "onnx.MatMul"(%0, %1) {axis = 3 : si64} : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+  "onnx.Return"(%2) : (tensor<?x?x?x?xf32>) -> ()
+
+// CHECK-LABEL: @softmax_matmul
+// CHECK:        "zlow.stick"
+// CHECK:        [[ALLOC:%.+]] = memref.alloc({{.*}}, {{.*}}, {{.*}}) {alignment = 4096 : i64} : memref<?x?x1x?x32x64xf16>
+// CHECK:        [[SOFTMAX_OUT:%.+]] = memref.cast [[ALLOC]] : memref<?x?x1x?x32x64xf16> to memref<?x?x1x?x?x?xf16>
+// CHECK:        "zlow.softmax"({{.*}}, {{.*}}, {{.*}}, [[SOFTMAX_OUT]]) {act_func = "ACT_NONE"} {{.*}}
+// CHECK:        "zlow.matmul"({{.*}}, [[SOFTMAX_OUT]], {{.*}}, {{.*}}, {{.*}}) {{.*}} 
+}

--- a/test/mlir/accelerators/nnpa/transform/zlow-rewrite.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zlow-rewrite.mlir
@@ -1,25 +1,42 @@
 // RUN: onnx-mlir-opt --maccel=NNPA --zlow-rewrite --canonicalize %s -split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 32, d0 mod 32, d1 mod 64)>
-func.func @dangling_stick(%arg0: memref<?x?xf16>) -> memref<?x?xf16> {
+func.func @remove_dangling_stick(%arg0: memref<?x?xf32>) -> memref<?x?xf32> {
   %cst0 = arith.constant 0 : index
   %cst1 = arith.constant 1 : index
-  %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf16>
-  %dim1 = memref.dim %arg0, %cst1:  memref<?x?xf16>
+  %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf32>
+  %dim1 = memref.dim %arg0, %cst1:  memref<?x?xf32>
   // Stick
-  %0 = memref.alloc(%dim0, %dim1) {alignment = 4096 : i64} : memref<?x?xf32, #map>
-  "zlow.stick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf16>, memref<?x?xf32, #map>) -> ()
-  return %arg0 : memref<?x?xf16>
+  %0 = memref.alloc(%dim0, %dim1) {alignment = 4096 : i64} : memref<?x?xf16, #map>
+  "zlow.stick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf32>, memref<?x?xf16, #map>) -> ()
+  return %arg0 : memref<?x?xf32>
 
-// CHECK-LABEL: dangling_stick
-// CHECK-NEXT: return %arg0 : memref<?x?xf16>
+// CHECK-LABEL: remove_dangling_stick
+// CHECK-NEXT: return %arg0 : memref<?x?xf32>
 // CHECK-NOT: "zlow.stick"
 }
 
 // -----
 
 #map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 32, d0 mod 32, d1 mod 64)>
-func.func @dangling_unstick(%arg0: memref<?x?xf16, #map>) -> memref<?x?xf16, #map> {
+func.func @donot_remove_stick(%arg0: memref<?x?xf32>) -> memref<?x?xf16, #map> {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf32>
+  %dim1 = memref.dim %arg0, %cst1:  memref<?x?xf32>
+  // Stick
+  %0 = memref.alloc(%dim0, %dim1) {alignment = 4096 : i64} : memref<?x?xf16, #map>
+  "zlow.stick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf32>, memref<?x?xf16, #map>) -> ()
+  return %0 : memref<?x?xf16, #map>
+
+// CHECK-LABEL: donot_remove_stick
+// CHECK: "zlow.stick"
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 32, d0 mod 32, d1 mod 64)>
+func.func @remove_dangling_unstick(%arg0: memref<?x?xf16, #map>) -> memref<?x?xf16, #map> {
   %cst0 = arith.constant 0 : index
   %cst1 = arith.constant 1 : index
   %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf16, #map>
@@ -29,9 +46,26 @@ func.func @dangling_unstick(%arg0: memref<?x?xf16, #map>) -> memref<?x?xf16, #ma
   "zlow.unstick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf16, #map>, memref<?x?xf32>) -> ()
   return %arg0 : memref<?x?xf16, #map>
 
-// CHECK-LABEL: dangling_unstick
+// CHECK-LABEL: remove_dangling_unstick
 // CHECK-NEXT: return %arg0 : memref<?x?xf16, #map>
 // CHECK-NOT: "zlow.unstick"
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 32, d0 mod 32, d1 mod 64)>
+func.func @donot_remove_unstick(%arg0: memref<?x?xf16, #map>) -> memref<?x?xf32> {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf16, #map>
+  %dim1 = memref.dim %arg0, %cst1:  memref<?x?xf16, #map>
+  // Unstick
+  %0 = memref.alloc(%dim0, %dim1) {alignment = 4096 : i64} : memref<?x?xf32>
+  "zlow.unstick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf16, #map>, memref<?x?xf32>) -> ()
+  return %0 : memref<?x?xf32>
+
+// CHECK-LABEL: donot_remove_unstick
+// CHECK: "zlow.unstick"
 }
 
 // -----

--- a/test/mlir/accelerators/nnpa/transform/zlow-rewrite.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zlow-rewrite.mlir
@@ -1,5 +1,92 @@
 // RUN: onnx-mlir-opt --maccel=NNPA --zlow-rewrite --canonicalize %s -split-input-file | FileCheck %s
 
+#map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 32, d0 mod 32, d1 mod 64)>
+func.func @dangling_stick(%arg0: memref<?x?xf16>) -> memref<?x?xf16> {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf16>
+  %dim1 = memref.dim %arg0, %cst1:  memref<?x?xf16>
+  // Stick
+  %0 = memref.alloc(%dim0, %dim1) {alignment = 4096 : i64} : memref<?x?xf32, #map>
+  "zlow.stick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf16>, memref<?x?xf32, #map>) -> ()
+  return %arg0 : memref<?x?xf16>
+
+// CHECK-LABEL: dangling_stick
+// CHECK-NEXT: return %arg0 : memref<?x?xf16>
+// CHECK-NOT: "zlow.stick"
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 32, d0 mod 32, d1 mod 64)>
+func.func @dangling_unstick(%arg0: memref<?x?xf16, #map>) -> memref<?x?xf16, #map> {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf16, #map>
+  %dim1 = memref.dim %arg0, %cst1:  memref<?x?xf16, #map>
+  // Unstick
+  %0 = memref.alloc(%dim0, %dim1) {alignment = 4096 : i64} : memref<?x?xf32>
+  "zlow.unstick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf16, #map>, memref<?x?xf32>) -> ()
+  return %arg0 : memref<?x?xf16, #map>
+
+// CHECK-LABEL: dangling_unstick
+// CHECK-NEXT: return %arg0 : memref<?x?xf16, #map>
+// CHECK-NOT: "zlow.unstick"
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 32, d0 mod 32, d1 mod 64)>
+func.func @unstick_stick_removal(%arg0: memref<?x?xf16, #map>) -> memref<?x?xf16, #map> {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf16, #map>
+  %dim1 = memref.dim %arg0, %cst1:  memref<?x?xf16, #map>
+  // Unstick
+  %0 = memref.alloc(%dim0, %dim1) {alignment = 4096 : i64} : memref<?x?xf32>
+  "zlow.unstick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf16, #map>, memref<?x?xf32>) -> ()
+  // Stick
+  %dim0_ = memref.dim %0, %cst0:  memref<?x?xf32>
+  %dim1_ = memref.dim %0, %cst1:  memref<?x?xf32>
+  %1 = memref.alloc(%dim1_, %dim0_) {alignment = 4096 : i64} : memref<?x?xf16, #map>
+  "zlow.stick"(%0, %1) {layout = "2D"} : (memref<?x?xf32>, memref<?x?xf16, #map>) -> ()
+  return %1 : memref<?x?xf16, #map>
+
+// CHECK-LABEL:  func.func @unstick_stick_removal
+// CHECK:        return %arg0 : memref<?x?xf16, #map>
+// CHECK-NOT: "zlow.unstick"
+// CHECK-NOT: "zlow.stick"
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 32, d0 mod 32, d1 mod 64)>
+#pseudo_2ds_map = affine_map<(d0, d1) -> (0, d1 floordiv 64, 0, d0 floordiv 64, d0 mod 64, d1 mod 64)>
+func.func @unstick_stick_not_removal_diff_layout(%arg0: memref<?x?xf16, #map>) -> memref<?x?xf16, #pseudo_2ds_map> {
+  %cst0 = arith.constant 0 : index
+  %cst1 = arith.constant 1 : index
+  %dim0 = memref.dim %arg0, %cst0:  memref<?x?xf16, #map>
+  %dim1 = memref.dim %arg0, %cst1:  memref<?x?xf16, #map>
+  // Unstick
+  %0 = memref.alloc(%dim0, %dim1) {alignment = 4096 : i64} : memref<?x?xf32>
+  "zlow.unstick"(%arg0, %0) {layout = "2D"} : (memref<?x?xf16, #map>, memref<?x?xf32>) -> ()
+  // Stick
+  %dim0_ = memref.dim %0, %cst0:  memref<?x?xf32>
+  %dim1_ = memref.dim %0, %cst1:  memref<?x?xf32>
+  %1 = memref.alloc(%dim1_, %dim0_) {alignment = 4096 : i64} : memref<?x?xf16, #pseudo_2ds_map>
+  "zlow.stick"(%0, %1) {layout = "2DS"} : (memref<?x?xf32>, memref<?x?xf16, #pseudo_2ds_map>) -> ()
+  return %1 : memref<?x?xf16, #pseudo_2ds_map>
+
+// CHECK-LABEL:  func.func @unstick_stick_not_removal_diff_layout
+// CHECK: [[OUT:%.+]] = memref.alloc{{.*}}
+// CHECK: "zlow.unstick"({{.*}}, [[OUT]]) {{.*}}
+// CHECK: [[RES:%.+]] = memref.alloc{{.*}}
+// CHECK: "zlow.stick"([[OUT]], [[RES]]) {{.*}}
+// CHECK: return [[RES]] {{.*}}
+}
+
+// -----
+
 func.func @test_remove_unstick_view_stick(%arg0: memref<7x4x1x8x32x64xf16>) -> (memref<7x4x1x8x32x64xf16>){
     %0 = memref.alloc() {alignment = 16 : i64} : memref<7x1x256x200xf32>
     "zlow.unstick"(%arg0, %0) {layout = "4DS"} : (memref<7x4x1x8x32x64xf16>, memref<7x1x256x200xf32>) -> ()


### PR DESCRIPTION
This patch is to remove consecutive zlow.unstick and zlow.stick ops if they use the same layout.

For example,
```mlir
zlow.unstick(%x, %y) {layout = 3DS}
zlow.stick(%y, %z) {layout = 3DS}
zlow.relu(%z)
```

will be replaced by
```mlir
zlow.relu(%x)
```
where `zlow.unstick` and `zlow.stick` are removed if they don't have any other use.