### PR TITLE
support string input for c interface

### DIFF
--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -82,7 +82,14 @@ private:
         .Case<ShapedType>([&](ShapedType tensorTy) {
           auto et = tensorTy.getElementType();
           dstream << "   { \"type\" : ";
-          et.print(dstream);
+          if (et.isa<krnl::StringType>()) {
+            // If use "et.print(dstream)", the output is !krnl.StringType.
+            // The missing of quotation will fail the jason parser.
+            // Use just "string" for brief
+            dstream << "\"string\"";
+          } else {
+            et.print(dstream);
+          }
           dstream << " , \"dims\" : [";
           if (tensorTy.hasRank()) {
             int64_t rank = tensorTy.getRank();

--- a/utils/RunONNXLib.cpp
+++ b/utils/RunONNXLib.cpp
@@ -383,6 +383,27 @@ OMTensorList *omTensorListCreateFromInputSignature(
         assert(data && "failed to allocate data");
       }
       tensor = OM_TENSOR_CREATE(data, shape, rank, ONNX_TYPE_DOUBLE, true);
+    } else if (type.equals("string")) {
+      // Add the handling of string type. "string" is the type in function
+      // signature.
+      char **data = nullptr;
+      if (dataPtrList) {
+        data = (char **)dataPtrList[i];
+      } else if (dataAlloc) {
+        data = (char **)malloc(size * sizeof(char *));
+        assert(data && "failed to allocate data");
+        // Need to initialize the pointer for string
+        // The complexity is to free the space for string when the OMTensor
+        // is destroyed. Change in the OMTensor is needed.
+        // For test purpose, just assign a pointer of the static string
+        // example_str. Should be replaced with random initialization for
+        // string type (omTensorCreateWithRandomData)
+        static char example_str[] = "randomstr";
+        for (size_t j = 0; j < size; j++) {
+          data[j] = example_str;
+        }
+      }
+      tensor = OM_TENSOR_CREATE(data, shape, rank, ONNX_TYPE_DOUBLE, true);
     }
 
     assert(tensor && "add support for the desired type");

--- a/utils/build-run-onnx-lib.sh
+++ b/utils/build-run-onnx-lib.sh
@@ -45,7 +45,7 @@ fi
 DRIVER_NAME=$ONNX_MLIR/utils/RunONNXLib.cpp
 RUN_BIN=$ONNX_MLIR_BIN/run-onnx-lib
 RUN_BIN_RELATIVE=${RUN_BIN#$(pwd)/}
-g++ $DRIVER_NAME -o $RUN_BIN -std=c++17 -D LOAD_MODEL_STATICALLY=$# \
+g++ -g $DRIVER_NAME -o $RUN_BIN -std=c++17 -D LOAD_MODEL_STATICALLY=$# \
 -I $LLVM_PROJECT/llvm/include -I $LLVM_PROJECT/build/include \
 -I $ONNX_MLIR/include -L $LLVM_PROJECT/build/lib \
 -lLLVMSupport -lLLVMDemangle -lcurses -lpthread -ldl "$@" &&


### PR DESCRIPTION
To me, it is easier to debug to run a model with the c interface. I found some issues in supporting string type input. 

1. The EntryPoint signature can not be parsed by llvm::Jason::parser because of the missing quotation marks. I also simplified the type from !krnl.StringType to just "string"
2. In the driver, utils/RunONNXLib.cpp, string type inputs are not handled. I added a simple workaround, which need further work. I think that the OMTensor utilities should be modified for string type, and the driver should use omTensorCreateWithRandomData().

With this PR, the test_equal_string can be ran with a tensor containing the same string for every element.
