### PR TITLE
flag -onnx-const-prop-disable-pattern

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -24,59 +24,60 @@
 namespace onnx_mlir {
 
 // Use external storage for the options so that they are globally accessible
-std::string inputFilename;                     // common for both
-std::string outputBaseName;                    // common for both
-std::vector<accel::Accelerator::Kind> maccel;  // common for both
-OptLevel OptimizationLevel;                    // common for both
-std::string mtriple;                           // common for both
-std::string mcpu;                              // common for both
-std::string march;                             // common for both
-InstrumentStages instrumentStage;              // common for both
-int onnxConstPropExpansionBound;               // common for both
-bool enableONNXHybridPass;                     // common for both
-std::vector<std::string> functionsToDecompose; // common for both
-EmissionTargetType emissionTarget;             // onnx-mlir only
-bool invokeOnnxVersionConverter;               // onnx-mlir only
-bool preserveLocations;                        // onnx-mlir only
-bool printIR;                                  // onnx-mlir only
-bool preserveBitcode;                          // onnx-mlir only
-bool preserveLLVMIR;                           // onnx-mlir only
-bool preserveMLIR;                             // onnx-mlir only
-bool useOnnxModelTypes;                        // onnx-mlir only
-int repeatOnnxTransform;                       // onnx-mlir only
-std::string shapeInformation;                  // onnx-mlir only
-ModelSize modelSize;                           // onnx-mlir only
-bool storeConstantsToFile;                     // onnx-mlir only
-float constantsToFileTotalThreshold;           // onnx-mlir only
-float constantsToFileSingleThreshold;          // onnx-mlir only
-bool VerboseOutput;                            // onnx-mlir only
-std::vector<std::string> Xopt;                 // onnx-mlir only
-std::vector<std::string> Xllc;                 // onnx-mlir only
-std::string mllvm;                             // onnx-mlir only
-std::string instrumentOps;                     // onnx-mlir only
-unsigned instrumentControlBits;                // onnx-mlir only
-bool instrumentONNXSignature;                  // onnx-mlir only
-std::string ONNXOpStats;                       // onnx-mlir only
-bool enableMemoryBundling;                     // onnx-mlir only
-int onnxOpTransformThreshold;                  // onnx-mlir only
-bool onnxOpTransformReport;                    // onnx-mlir only
-bool enableParallel;                           // onnx-mlir only
-bool disableSimdOption;                        // onnx-mlir only
-bool enableSimdDataLayout;                     // onnx-mlir only
-bool verifyInputTensors;                       // onnx-mlir only
-bool allowSorting;                             // onnx-mlir only
-std::string reportHeapBefore;                  // onnx-mlir only
-std::string reportHeapAfter;                   // onnx-mlir only
-std::string modelTag;                          // onnx-mlir only
-bool enableConvOptPass;                        // onnx-mlir only
-std::vector<std::string> extraLibPaths;        // onnx-mlir only
-std::vector<std::string> extraLibs;            // onnx-mlir only
-ProfileIRs profileIR;                          // onnx-mlir only
-OptReport optReport;                           // onnx-mlir only
-bool split_input_file;                         // onnx-mlir-opt only
-bool verify_diagnostics;                       // onnx-mlir-opt only
-bool verify_passes;                            // onnx-mlir-opt only
-bool allowUnregisteredDialects;                // onnx-mlir-opt only
+std::string inputFilename;                             // common for both
+std::string outputBaseName;                            // common for both
+std::vector<accel::Accelerator::Kind> maccel;          // common for both
+OptLevel OptimizationLevel;                            // common for both
+std::string mtriple;                                   // common for both
+std::string mcpu;                                      // common for both
+std::string march;                                     // common for both
+InstrumentStages instrumentStage;                      // common for both
+int onnxConstPropExpansionBound;                       // common for both
+std::vector<std::string> onnxConstPropDisablePatterns; // common for both
+bool enableONNXHybridPass;                             // common for both
+std::vector<std::string> functionsToDecompose;         // common for both
+EmissionTargetType emissionTarget;                     // onnx-mlir only
+bool invokeOnnxVersionConverter;                       // onnx-mlir only
+bool preserveLocations;                                // onnx-mlir only
+bool printIR;                                          // onnx-mlir only
+bool preserveBitcode;                                  // onnx-mlir only
+bool preserveLLVMIR;                                   // onnx-mlir only
+bool preserveMLIR;                                     // onnx-mlir only
+bool useOnnxModelTypes;                                // onnx-mlir only
+int repeatOnnxTransform;                               // onnx-mlir only
+std::string shapeInformation;                          // onnx-mlir only
+ModelSize modelSize;                                   // onnx-mlir only
+bool storeConstantsToFile;                             // onnx-mlir only
+float constantsToFileTotalThreshold;                   // onnx-mlir only
+float constantsToFileSingleThreshold;                  // onnx-mlir only
+bool VerboseOutput;                                    // onnx-mlir only
+std::vector<std::string> Xopt;                         // onnx-mlir only
+std::vector<std::string> Xllc;                         // onnx-mlir only
+std::string mllvm;                                     // onnx-mlir only
+std::string instrumentOps;                             // onnx-mlir only
+unsigned instrumentControlBits;                        // onnx-mlir only
+bool instrumentONNXSignature;                          // onnx-mlir only
+std::string ONNXOpStats;                               // onnx-mlir only
+bool enableMemoryBundling;                             // onnx-mlir only
+int onnxOpTransformThreshold;                          // onnx-mlir only
+bool onnxOpTransformReport;                            // onnx-mlir only
+bool enableParallel;                                   // onnx-mlir only
+bool disableSimdOption;                                // onnx-mlir only
+bool enableSimdDataLayout;                             // onnx-mlir only
+bool verifyInputTensors;                               // onnx-mlir only
+bool allowSorting;                                     // onnx-mlir only
+std::string reportHeapBefore;                          // onnx-mlir only
+std::string reportHeapAfter;                           // onnx-mlir only
+std::string modelTag;                                  // onnx-mlir only
+bool enableConvOptPass;                                // onnx-mlir only
+std::vector<std::string> extraLibPaths;                // onnx-mlir only
+std::vector<std::string> extraLibs;                    // onnx-mlir only
+ProfileIRs profileIR;                                  // onnx-mlir only
+OptReport optReport;                                   // onnx-mlir only
+bool split_input_file;                                 // onnx-mlir-opt only
+bool verify_diagnostics;                               // onnx-mlir-opt only
+bool verify_passes;                                    // onnx-mlir-opt only
+bool allowUnregisteredDialects;                        // onnx-mlir-opt only
 
 // Category for common options shared between onnx-mlir and onnx-mlir-opt.
 llvm::cl::OptionCategory OnnxMlirCommonOptions("common options",

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -163,6 +163,14 @@ static llvm::cl::opt<int, true> onnxConstPropExpansionBoundOpt(
     llvm::cl::location(onnxConstPropExpansionBound), llvm::cl::init(-1),
     llvm::cl::cat(OnnxMlirCommonOptions));
 
+static llvm::cl::list<std::string, std::vector<std::string>>
+    onnxConstPropDisablePatternsOpt("onnx-const-prop-disable-pattern",
+        llvm::cl::desc("Named constant propagation pattern to disable. "
+                       "Repeat the flag to disable multiple patterns."),
+        llvm::cl::value_desc("named constant propagation patterns to disable"),
+        llvm::cl::location(onnxConstPropDisablePatterns),
+        llvm::cl::cat(OnnxMlirCommonOptions));
+
 static llvm::cl::opt<bool, true> enableONNXHybridPassOpt("onnx-hybrid-pass",
     llvm::cl::desc("Enable ONNX hybrid pass (default=true)\n"
                    "Set to 'false' if you want to disable ONNX hybrid pass."),

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -66,59 +66,60 @@ extern llvm::cl::OptionCategory OnnxMlirOptions;
 extern llvm::cl::OptionCategory OnnxMlirOptOptions;
 
 // Options known to onnx-mlir and/or onnx-mlir-opt
-extern std::string inputFilename;                     // common for both
-extern std::string outputBaseName;                    // common for both
-extern std::vector<accel::Accelerator::Kind> maccel;  // common for both
-extern OptLevel OptimizationLevel;                    // common for both
-extern std::string mtriple;                           // common for both
-extern std::string mcpu;                              // common for both
-extern std::string march;                             // common for both
-extern InstrumentStages instrumentStage;              // common for both
-extern int onnxConstPropExpansionBound;               // common for both
-extern bool enableONNXHybridPass;                     // common for both
-extern std::vector<std::string> functionsToDecompose; // common for both
-extern EmissionTargetType emissionTarget;             // onnx-mlir only
-extern bool invokeOnnxVersionConverter;               // onnx-mlir only
-extern bool preserveLocations;                        // onnx-mlir only
-extern bool printIR;                                  // onnx-mlir only
-extern bool preserveBitcode;                          // onnx-mlir only
-extern bool preserveLLVMIR;                           // onnx-mlir only
-extern bool preserveMLIR;                             // onnx-mlir only
-extern bool useOnnxModelTypes;                        // onnx-mlir only
-extern int repeatOnnxTransform;                       // onnx-mlir only
-extern std::string shapeInformation;                  // onnx-mlir only
-extern ModelSize modelSize;                           // onnx-mlir only
-extern bool storeConstantsToFile;                     // onnx-mlir only
-extern float constantsToFileTotalThreshold;           // onnx-mlir only
-extern float constantsToFileSingleThreshold;          // onnx-mlir only
-extern bool VerboseOutput;                            // onnx-mlir only
-extern std::vector<std::string> Xopt;                 // onnx-mlir only
-extern std::vector<std::string> Xllc;                 // onnx-mlir only
-extern std::string mllvm;                             // onnx-mlir only
-extern std::string instrumentOps;                     // onnx-mlir only
-extern unsigned instrumentControlBits;                // onnx-mlir only
-extern bool instrumentONNXSignature;                  // onnx-mlir only
-extern std::string ONNXOpStats;                       // onnx-mlir only
-extern bool enableMemoryBundling;                     // onnx-mlir only
-extern int onnxOpTransformThreshold;                  // onnx-mlir only
-extern bool onnxOpTransformReport;                    // onnx-mlir only
-extern bool enableParallel;                           // onnx-mlir only
-extern bool disableSimdOption;                        // onnx-mlir only
-extern bool enableSimdDataLayout;                     // onnx-mlir only
-extern bool verifyInputTensors;                       // onnx-mlir only
-extern bool allowSorting;                             // onnx-mlir only
-extern std::string reportHeapBefore;                  // onnx-mlir only
-extern std::string reportHeapAfter;                   // onnx-mlir only
-extern std::string modelTag;                          // onnx-mlir only
-extern bool enableConvOptPass;                        // onnx-mlir only
-extern std::vector<std::string> extraLibPaths;        // onnx-mlir only
-extern std::vector<std::string> extraLibs;            // onnx-mlir only
-extern ProfileIRs profileIR;                          // onnx-mlir only
-extern OptReport optReport;                           // onnx-mlir only
-extern bool split_input_file;                         // onnx-mlir-opt only
-extern bool verify_diagnostics;                       // onnx-mlir-opt only
-extern bool verify_passes;                            // onnx-mlir-opt only
-extern bool allowUnregisteredDialects;                // onnx-mlir-opt only
+extern std::string inputFilename;                             // common for both
+extern std::string outputBaseName;                            // common for both
+extern std::vector<accel::Accelerator::Kind> maccel;          // common for both
+extern OptLevel OptimizationLevel;                            // common for both
+extern std::string mtriple;                                   // common for both
+extern std::string mcpu;                                      // common for both
+extern std::string march;                                     // common for both
+extern InstrumentStages instrumentStage;                      // common for both
+extern int onnxConstPropExpansionBound;                       // common for both
+extern std::vector<std::string> onnxConstPropDisablePatterns; // common for both
+extern bool enableONNXHybridPass;                             // common for both
+extern std::vector<std::string> functionsToDecompose;         // common for both
+extern EmissionTargetType emissionTarget;                     // onnx-mlir only
+extern bool invokeOnnxVersionConverter;                       // onnx-mlir only
+extern bool preserveLocations;                                // onnx-mlir only
+extern bool printIR;                                          // onnx-mlir only
+extern bool preserveBitcode;                                  // onnx-mlir only
+extern bool preserveLLVMIR;                                   // onnx-mlir only
+extern bool preserveMLIR;                                     // onnx-mlir only
+extern bool useOnnxModelTypes;                                // onnx-mlir only
+extern int repeatOnnxTransform;                               // onnx-mlir only
+extern std::string shapeInformation;                          // onnx-mlir only
+extern ModelSize modelSize;                                   // onnx-mlir only
+extern bool storeConstantsToFile;                             // onnx-mlir only
+extern float constantsToFileTotalThreshold;                   // onnx-mlir only
+extern float constantsToFileSingleThreshold;                  // onnx-mlir only
+extern bool VerboseOutput;                                    // onnx-mlir only
+extern std::vector<std::string> Xopt;                         // onnx-mlir only
+extern std::vector<std::string> Xllc;                         // onnx-mlir only
+extern std::string mllvm;                                     // onnx-mlir only
+extern std::string instrumentOps;                             // onnx-mlir only
+extern unsigned instrumentControlBits;                        // onnx-mlir only
+extern bool instrumentONNXSignature;                          // onnx-mlir only
+extern std::string ONNXOpStats;                               // onnx-mlir only
+extern bool enableMemoryBundling;                             // onnx-mlir only
+extern int onnxOpTransformThreshold;                          // onnx-mlir only
+extern bool onnxOpTransformReport;                            // onnx-mlir only
+extern bool enableParallel;                                   // onnx-mlir only
+extern bool disableSimdOption;                                // onnx-mlir only
+extern bool enableSimdDataLayout;                             // onnx-mlir only
+extern bool verifyInputTensors;                               // onnx-mlir only
+extern bool allowSorting;                                     // onnx-mlir only
+extern std::string reportHeapBefore;                          // onnx-mlir only
+extern std::string reportHeapAfter;                           // onnx-mlir only
+extern std::string modelTag;                                  // onnx-mlir only
+extern bool enableConvOptPass;                                // onnx-mlir only
+extern std::vector<std::string> extraLibPaths;                // onnx-mlir only
+extern std::vector<std::string> extraLibs;                    // onnx-mlir only
+extern ProfileIRs profileIR;                                  // onnx-mlir only
+extern OptReport optReport;                                   // onnx-mlir only
+extern bool split_input_file;          // onnx-mlir-opt only
+extern bool verify_diagnostics;        // onnx-mlir-opt only
+extern bool verify_passes;             // onnx-mlir-opt only
+extern bool allowUnregisteredDialects; // onnx-mlir-opt only
 
 extern std::string customEnvFlags;
 

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -45,7 +45,8 @@ namespace onnx_mlir {
 void configurePasses() {
   // Set global vector machine support.
   VectorMachineSupport::setGlobalVectorMachineSupport(march, mcpu, "");
-  configureConstPropONNXToONNXPass(onnxConstPropExpansionBound);
+  configureConstPropONNXToONNXPass(
+      onnxConstPropExpansionBound, onnxConstPropDisablePatterns);
   configureOnnxToKrnlLoweringPass(optReport == OptReport::Parallel,
       enableParallel, optReport == OptReport::Simd, !disableSimdOption);
 }

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+#include "llvm/ADT/ArrayRef.h"
+
 namespace mlir {
 class MLIRContext;
 class Pass;
@@ -42,7 +44,8 @@ std::unique_ptr<mlir::Pass> createConvOptONNXToONNXPass(
 std::unique_ptr<mlir::Pass> createShapeInferencePass();
 
 // To configure ConstPropONNXToONNXPass at program start.
-void configureConstPropONNXToONNXPass(int expansionBound);
+void configureConstPropONNXToONNXPass(
+    int expansionBound, llvm::ArrayRef<std::string> disabledPatterns = {});
 
 std::unique_ptr<mlir::Pass> createConstPropONNXToONNXPass();
 

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -20,6 +20,8 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Debug.h"
 
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ElementsAttr/WideNum.hpp"
@@ -32,6 +34,8 @@
 
 #include <math.h>
 #include <numeric>
+
+#define DEBUG_TYPE "constprop-onnx"
 
 using namespace mlir;
 using namespace onnx_mlir;
@@ -58,9 +62,11 @@ namespace {
 // Populated by configureConstPropONNXToONNXPass().
 struct ConstPropONNXToONNXPassConfiguration {
   static int expansionBound;
+  static StringSet<> disabledPatterns;
 };
 
 int ConstPropONNXToONNXPassConfiguration::expansionBound = -1; // -1 == no bound
+StringSet<> ConstPropONNXToONNXPassConfiguration::disabledPatterns;
 
 // Precondition: result has ranked tensor type with static shape and int or
 // float element type.
@@ -78,6 +84,14 @@ bool satisfiesExpansionBound(Value result) {
   }
   return sum * ConstPropONNXToONNXPassConfiguration::expansionBound >=
          getSizeInBytes(resultType);
+}
+
+bool isNotDisabled(StringRef name) {
+  bool ok =
+      !ConstPropONNXToONNXPassConfiguration::disabledPatterns.contains(name);
+  LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE " isNotDisabled " << name << " " << ok
+                          << "\n");
+  return ok;
 }
 
 ElementsAttr getConstValueElements(Value constValue) {
@@ -700,123 +714,19 @@ Value ConstPropSqueeze(
 }
 
 //===----------------------------------------------------------------------===//
-// Code to perform constant propagation for split.
-//===----------------------------------------------------------------------===//
-
-template <typename Op>
-LogicalResult ConstPropSplitPatternCommon(
-    Op splitOp, PatternRewriter &rewriter, std::optional<ArrayAttr> splitAttr) {
-  // Basic info.
-  unsigned numResults = splitOp.getNumResults();
-  Value input = splitOp.getInput();
-  if (!isDenseONNXConstant(input))
-    return failure();
-  ShapedType inputType = input.getType().cast<ShapedType>();
-  ArrayRef<int64_t> inputShape = inputType.getShape();
-
-  uint64_t splitAxis = splitOp.getAxis();
-  int64_t splitAxisSize = inputShape[splitAxis];
-  std::vector<int64_t> splitSizes(numResults, splitAxisSize / numResults);
-  if (splitAttr.has_value()) {
-    for (unsigned int i = 0; i < numResults; ++i)
-      splitSizes[i] = ArrayAttrIntVal(splitAttr, i);
-    // TODO: Figure out why std::reduce() doesn't work on Linux s390x. Until
-    //       then we're using std::accumulate() instead.
-    assert(splitAxisSize ==
-               std::accumulate(splitSizes.begin(), splitSizes.end(), 0) &&
-           "split values must sum to axis size");
-  } else {
-    // If split attribute is not specified, split size is equally divided.
-    // TODO: Follow the onnx spec which is more relaxed (albeit incomplete).
-    assert(splitAxisSize % numResults == 0 &&
-           "The dimension at the split axis is expected to be divisible by "
-           "the number of results");
-  }
-
-  OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
-  ElementsAttr inputElements = getConstValueElements(input);
-  std::vector<ElementsAttr> resElements =
-      elementsBuilder.split(inputElements, splitAxis, splitSizes);
-  std::vector<Value> resValues;
-  resValues.reserve(numResults);
-  for (unsigned int i = 0; i < numResults; ++i) {
-    Value replacingValue = splitOp.getResult(i);
-    ElementsAttr splitElements = resElements[i];
-    resValues.push_back(
-        createReplacingConstantOp(rewriter, replacingValue, splitElements));
-  }
-  rewriter.replaceOp(splitOp, resValues);
-  return success();
-}
-
-class ConstPropSplitPattern : public OpRewritePattern<ONNXSplitOp> {
-public:
-  using OpRewritePattern<ONNXSplitOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXSplitOp splitOp, PatternRewriter &rewriter) const override {
-    std::optional<ArrayAttr> optionalAttr;
-
-    auto split = splitOp.getSplit();
-    if (auto splitConstOp = getONNXConstantOp(split)) {
-      // Checking value of split parameter.
-      optionalAttr.emplace(createArrayAttrFromConstantOp(splitConstOp));
-    } else if (!split.getType().isa<NoneType>()) {
-      llvm_unreachable("dynamic split not yet supported");
-    }
-
-    return ConstPropSplitPatternCommon(splitOp, rewriter, optionalAttr);
-  }
-};
-
-class ConstPropSplitV11Pattern : public OpRewritePattern<ONNXSplitV11Op> {
-public:
-  using OpRewritePattern<ONNXSplitV11Op>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXSplitV11Op splitOp, PatternRewriter &rewriter) const override {
-    return ConstPropSplitPatternCommon(splitOp, rewriter, splitOp.getSplit());
-  }
-};
-
-//===----------------------------------------------------------------------===//
 // Code to perform constant propagation for ScatterND.
 //===----------------------------------------------------------------------===//
 
-class ConstPropScatterNDPattern : public OpRewritePattern<ONNXScatterNDOp> {
-public:
-  using OpRewritePattern<ONNXScatterNDOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(
-      ONNXScatterNDOp scatterNdOp, PatternRewriter &rewriter) const override {
-    // Match
-    if (!scatterNdOp.getResult().getType().isa<RankedTensorType>())
-      return failure();
-
-    if (!isDenseONNXConstant(scatterNdOp.getData()))
-      return failure();
-
-    if (!isDenseONNXConstant(scatterNdOp.getIndices()))
-      return failure();
-
-    if (!isDenseONNXConstant(scatterNdOp.getUpdates()))
-      return failure();
-
-    OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
-    ElementsAttr dataElements = getConstValueElements(scatterNdOp.getData());
-    ElementsAttr indicesElements =
-        getConstValueElements(scatterNdOp.getIndices());
-    ElementsAttr updatesElements =
-        getConstValueElements(scatterNdOp.getUpdates());
-    ElementsAttr scatteredElements = elementsBuilder.scatterND(
-        dataElements, indicesElements, updatesElements);
-    Value constOpResult = createReplacingConstantOp(
-        rewriter, scatterNdOp.getData(), scatteredElements);
-
-    rewriter.replaceOp(scatterNdOp, constOpResult);
-    return success();
-  }
-};
+Value ConstPropScatterND(PatternRewriter &rewriter, Value replacingValue,
+    Value data, Value indices, Value updates) {
+  OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
+  ElementsAttr dataElements = getConstValueElements(data);
+  ElementsAttr indicesElements = getConstValueElements(indices);
+  ElementsAttr updatesElements = getConstValueElements(updates);
+  ElementsAttr scatteredElements =
+      elementsBuilder.scatterND(dataElements, indicesElements, updatesElements);
+  return createReplacingConstantOp(rewriter, replacingValue, scatteredElements);
+}
 
 //===----------------------------------------------------------------------===//
 // Code to perform constant propagation for CastOp.
@@ -1036,6 +946,74 @@ Value ConstPropNonZero(
 #include "src/Transform/ONNX/ONNXConstProp.inc"
 
 //===----------------------------------------------------------------------===//
+// Code to perform constant propagation for split.
+// Not done with tablegen which doesn't support variadic results.
+//===----------------------------------------------------------------------===//
+
+std::vector<Value> ConstPropSplit(PatternRewriter &rewriter,
+    ResultRange replacingValues, Value input, Value split, int64_t axis) {
+  unsigned numResults = replacingValues.size();
+  ShapedType inputType = input.getType().cast<ShapedType>();
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+
+  int64_t splitAxisSize = inputShape[axis];
+  SmallVector<int64_t> splitSizes(numResults, splitAxisSize / numResults);
+  if (isa<NoneType>(split.getType())) {
+    // If split attribute is not specified, split size is equally divided.
+    // TODO: Follow the onnx spec which is more relaxed (albeit incomplete).
+    assert(splitAxisSize % numResults == 0 &&
+           "The dimension at the split axis is expected to be divisible by "
+           "the number of results");
+  } else {
+    ElementsAttr splitElements = getConstValueElements(split);
+    assert(splitElements.size() == numResults &&
+           "split length should match the number of results");
+    auto splitValues = splitElements.getValues<int64_t>();
+    splitSizes.assign(splitValues.begin(), splitValues.end());
+    // TODO: Figure out why std::reduce() doesn't work on Linux s390x. Until
+    //       then we're using std::accumulate() instead.
+    assert(splitAxisSize ==
+               std::accumulate(splitSizes.begin(), splitSizes.end(), 0) &&
+           "split values must sum to axis size");
+  }
+
+  OnnxElementsAttrBuilder elementsBuilder(rewriter.getContext());
+  ElementsAttr inputElements = getConstValueElements(input);
+  std::vector<ElementsAttr> resElements =
+      elementsBuilder.split(inputElements, axis, splitSizes);
+  std::vector<Value> resValues;
+  resValues.reserve(numResults);
+  for (unsigned int i = 0; i < numResults; ++i) {
+    ElementsAttr splitElements = resElements[i];
+    resValues.push_back(
+        createReplacingConstantOp(rewriter, replacingValues[i], splitElements));
+  }
+  return resValues;
+}
+
+class SplitOfConst : public OpRewritePattern<ONNXSplitOp> {
+public:
+  using OpRewritePattern<ONNXSplitOp>::OpRewritePattern;
+
+  LogicalResult match(ONNXSplitOp splitOp) const override {
+    if (!isNotDisabled("SplitOfConst"))
+      return failure();
+    if (!isDenseONNXConstant(splitOp.getInput()))
+      return failure();
+    Value split = splitOp.getSplit();
+    if (!(isa<NoneType>(split.getType()) || isDenseONNXConstant(split)))
+      return failure();
+    return success();
+  }
+
+  void rewrite(ONNXSplitOp splitOp, PatternRewriter &rewriter) const override {
+    rewriter.replaceOp(splitOp,
+        ConstPropSplit(rewriter, splitOp.getResults(), splitOp.getInput(),
+            splitOp.getSplit(), splitOp.getAxis()));
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Code to manage the pass.
 //===----------------------------------------------------------------------===//
 
@@ -1059,9 +1037,7 @@ void ConstPropONNXToONNXPass::runOnOperation() {
 
   RewritePatternSet patterns(context);
   populateWithGenerated(patterns);
-  patterns.insert<ConstPropSplitPattern>(&getContext());
-  patterns.insert<ConstPropSplitV11Pattern>(&getContext());
-  patterns.insert<ConstPropScatterNDPattern>(&getContext());
+  patterns.insert<SplitOfConst>(context);
   if (failed(applyPatternsAndFoldGreedily(function, std::move(patterns))))
     signalPassFailure();
 }
@@ -1071,6 +1047,8 @@ void ConstPropONNXToONNXPass::runOnOperation() {
 void onnx_mlir::configureConstPropONNXToONNXPass(
     int expansionBound, ArrayRef<std::string> disabledPatterns) {
   ConstPropONNXToONNXPassConfiguration::expansionBound = expansionBound;
+  ConstPropONNXToONNXPassConfiguration::disabledPatterns.insert(
+      disabledPatterns.begin(), disabledPatterns.end());
 }
 
 /*!

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -996,8 +996,6 @@ public:
   using OpRewritePattern<ONNXSplitOp>::OpRewritePattern;
 
   LogicalResult match(ONNXSplitOp splitOp) const override {
-    if (!isNotDisabled("SplitOfConst"))
-      return failure();
     if (!isDenseONNXConstant(splitOp.getInput()))
       return failure();
     Value split = splitOp.getSplit();
@@ -1037,7 +1035,8 @@ void ConstPropONNXToONNXPass::runOnOperation() {
 
   RewritePatternSet patterns(context);
   populateWithGenerated(patterns);
-  patterns.insert<SplitOfConst>(context);
+  if (isNotDisabled("SplitOfConst"))
+    patterns.insert<SplitOfConst>(context);
   if (failed(applyPatternsAndFoldGreedily(function, std::move(patterns))))
     signalPassFailure();
 }

--- a/src/Transform/ONNX/ConstProp.cpp
+++ b/src/Transform/ONNX/ConstProp.cpp
@@ -1068,7 +1068,8 @@ void ConstPropONNXToONNXPass::runOnOperation() {
 
 } // end anonymous namespace.
 
-void onnx_mlir::configureConstPropONNXToONNXPass(int expansionBound) {
+void onnx_mlir::configureConstPropONNXToONNXPass(
+    int expansionBound, ArrayRef<std::string> disabledPatterns) {
   ConstPropONNXToONNXPassConfiguration::expansionBound = expansionBound;
 }
 

--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -99,6 +99,14 @@ def IsMatMulIntegerRhsZero: Constraint<
 def SatisfiesExpansionBound: Constraint<
   CPred<"satisfiesExpansionBound($_self)">>;
 
+class IsNotDisabled<string name>: Constraint<
+  CPred<"isNotDisabled(\"" # name # "\")">>;
+
+// Takes initial name parameter which is checked to see if disabled.
+class NamedPat<string name, dag pattern, dag result, list<dag> preds = [],
+  dag benefitAdded = (addBenefit 0)> :
+  Pat<pattern, result, !listconcat([(IsNotDisabled<name>)], preds), benefitAdded>;
+
 class EqualString<string s> : Constraint<CPred<"$0 == \"" # s # "\"">>;
 
 // Creation helpers:
@@ -218,12 +226,15 @@ def CreateRangeOfThreeConst :
 def CreateNonZeroOfConst :
    NativeCodeCall<"ConstPropNonZero($_builder, $0, $1)">;
 
+def CreateScatterNDOfConst :
+    NativeCodeCall<"ConstPropScatterND($_builder, $0, $1, $2, $3)">;
+
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with elementwise ADD operations.
 //===----------------------------------------------------------------------===//
 
 // Use commutativity to normalize constants in the second position of Add.
-def AddConstCommutative1 : Pat<
+def AddConstCommutative1 : NamedPat<"AddConstCommutative1",
   // From add(c, x).
   (ONNXAddOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
   // To add(x, c).
@@ -232,7 +243,7 @@ def AddConstCommutative1 : Pat<
   [(IsNotAConstant:$x)]>;
 
 // Use associativity to add constants together.
-def AddConstAssociative1 : Pat<
+def AddConstAssociative1 : NamedPat<"AddConstAssociative1",
   // From add(add(x, c1), c2).
   (ONNXAddOp
     (ONNXAddOp:$lhs $x, (ONNXConstantOp:$c1 $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -243,7 +254,7 @@ def AddConstAssociative1 : Pat<
     (ONNXAddOp $c1, $c2)),
   [(IsNotAConstant:$x), (HasOneUse:$lhs)]>;
 
-def AddConstAssociative2 : Pat<
+def AddConstAssociative2 : NamedPat<"AddConstAssociative2",
   // From add(add(x, c), y).
   (ONNXAddOp
     (ONNXAddOp:$lhs $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -254,7 +265,7 @@ def AddConstAssociative2 : Pat<
     $c),
   [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$lhs)]>;
 
-def AddConstAssociative3 : Pat<
+def AddConstAssociative3 : NamedPat<"AddConstAssociative3",
   // From add(x, add(y, c)).
   (ONNXAddOp
     $x,
@@ -265,7 +276,7 @@ def AddConstAssociative3 : Pat<
     $c),
   [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$rhs)]>;
 
-def AddConstAssociative4 : Pat<
+def AddConstAssociative4 : NamedPat<"AddConstAssociative4",
   // From add(add(x, c1), add(y, c2)).
   (ONNXAddOp
     (ONNXAddOp:$lhs $x, (ONNXConstantOp:$c1 $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -277,7 +288,7 @@ def AddConstAssociative4 : Pat<
   [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$lhs), (HasOneUse:$rhs)]>;
 
 // Constant Propagation for Add
-def AddConstProp : Pat<
+def AddConstProp : NamedPat<"AddConstProp",
     // From add(c1, c2).
     (ONNXAddOp:$addOp (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
                       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -288,7 +299,7 @@ def AddConstProp : Pat<
      (SatisfiesExpansionBound:$addOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
-def AddZerosOnRhs : Pat<
+def AddZerosOnRhs : NamedPat<"AddZerosOnRhs",
     // From add(x, c).
     (ONNXAddOp:$result
       $x,
@@ -303,7 +314,7 @@ def AddZerosOnRhs : Pat<
 //===----------------------------------------------------------------------===//
 
 // Constant Propagation for Sub
-def SubConstProp : Pat<
+def SubConstProp : NamedPat<"SubConstProp",
     // From sub(c1, c2).
     (ONNXSubOp:$subOp (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
                       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -313,7 +324,7 @@ def SubConstProp : Pat<
      (SatisfiesExpansionBound:$subOp)]>;
 
 // TODO: Expand $a to $result's shape instead of requiring ValuesHaveSameType.
-def SubZerosOnRhs : Pat<
+def SubZerosOnRhs : NamedPat<"SubZerosOnRhs",
     // From sub(x, c).
     (ONNXSubOp:$result
       $x,
@@ -324,7 +335,7 @@ def SubZerosOnRhs : Pat<
     [(IsNotAConstant:$x), (ValuesHaveSameType $result, $x), (IsConstOfZeros:$c)]>;
 
 // Cast of constant is simply a constant with the new type.
-def CastofConst :  Pat<
+def CastofConst : NamedPat<"CastofConst",
     // From (c)
     (ONNXCastOp:$castOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $saturate, $to),
     // To (c)
@@ -332,7 +343,7 @@ def CastofConst :  Pat<
     [(IsFromDenseONNXConstantOp:$input)]>;
 
 // Neg of constant is simply -const
-def NegofConst :  Pat<
+def NegofConst : NamedPat<"NegofConst",
     // From - (c)
     (ONNXNegOp:$negOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To (-c)
@@ -341,7 +352,7 @@ def NegofConst :  Pat<
 
 // Change a subtraction of a constant c by an addition of -c. Helpfull to combine
 // with other add optimizations.
-def SubConstToNeg : Pat<
+def SubConstToNeg : NamedPat<"SubConstToNeg",
     // From x - c.
     (ONNXSubOp:$subOp $x, (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To x + (-c).
@@ -349,7 +360,7 @@ def SubConstToNeg : Pat<
     [(IsNotAConstant:$x), (IsFromDenseONNXConstantOp:$input)]>;
 
 // Constant Propagation for Sqrt
-def SqrtofConst :  Pat<
+def SqrtofConst : NamedPat<"SqrtofConst",
     // From  onnx.Sqrt(c)
     (ONNXSqrtOp:$sqrtOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To sqrt(c)
@@ -357,7 +368,7 @@ def SqrtofConst :  Pat<
     [(IsFromDenseONNXConstantOp:$input)]>;
 
 // Constant Propagation for Relu
-def ReluofConst :  Pat<
+def ReluofConst : NamedPat<"ReluofConst",
     // From  onnx.Relu(c)
     (ONNXReluOp:$reluOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     // To relu(c)
@@ -369,7 +380,7 @@ def ReluofConst :  Pat<
 //===----------------------------------------------------------------------===//
 
 // Constant Propagation for Max
-def MaxConstProp : Pat<
+def MaxConstProp : NamedPat<"MaxConstProp",
     // From max(c1, c2).
     (ONNXMaxOp:$maxOp $operandList),
     // To c = max(c1, c2)
@@ -379,7 +390,7 @@ def MaxConstProp : Pat<
      (SatisfiesExpansionBound:$maxOp)]>;
 
 // Constant Propagation for Min
-def MinConstProp : Pat<
+def MinConstProp : NamedPat<"MinConstProp",
     // From min(c1, c2).
     (ONNXMinOp:$minOp $operandList),
     // To c = min(c1, c2)
@@ -389,7 +400,7 @@ def MinConstProp : Pat<
      (SatisfiesExpansionBound:$minOp)]>;
 
 // Constant Propagation for Sum
-def SumConstProp : Pat<
+def SumConstProp : NamedPat<"SumConstProp",
     // From sum(c1, c2).
     (ONNXSumOp:$sumOp $operandList),
     // To c = sum(c1, c2)
@@ -404,7 +415,7 @@ def SumConstProp : Pat<
 //===----------------------------------------------------------------------===//
 
 // Use commutativity to normalize constants in the second position of Mul.
-def MulConstCommutative1 : Pat<
+def MulConstCommutative1 : NamedPat<"MulConstCommutative1",
   // From mul(c, x).
   (ONNXMulOp (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_), $x),
   // To mul(x, c).
@@ -413,7 +424,7 @@ def MulConstCommutative1 : Pat<
   [(IsNotAConstant:$x)]>;
 
 // Use associativity to mul constants together.
-def MulConstAssociative1 : Pat<
+def MulConstAssociative1 : NamedPat<"MulConstAssociative1",
   // From mul(mul(x, c1), c2).
   (ONNXMulOp
     (ONNXMulOp:$lhs $x, (ONNXConstantOp:$c1 $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -424,7 +435,7 @@ def MulConstAssociative1 : Pat<
     (ONNXMulOp $c1, $c2)),
   [(IsNotAConstant:$x), (HasOneUse:$lhs)]>;
 
-def MulConstAssociative2 : Pat<
+def MulConstAssociative2 : NamedPat<"MulConstAssociative2",
   // From mul(mul(x, c), y).
   (ONNXMulOp
     (ONNXMulOp:$lhs $x, (ONNXConstantOp:$c $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -435,7 +446,7 @@ def MulConstAssociative2 : Pat<
     $c),
   [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$lhs)]>;
 
-def MulConstAssociative3 : Pat<
+def MulConstAssociative3 : NamedPat<"MulConstAssociative3",
   // From mul(x, mul(y, c)).
   (ONNXMulOp
     $x,
@@ -446,7 +457,7 @@ def MulConstAssociative3 : Pat<
     $c),
   [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$rhs)]>;
 
-def MulConstAssociative4 : Pat<
+def MulConstAssociative4 : NamedPat<"MulConstAssociative4",
   // From mul(mul(x, c1), mul(y, c2)).
   (ONNXMulOp
     (ONNXMulOp:$lhs $x, (ONNXConstantOp:$c1 $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -458,7 +469,7 @@ def MulConstAssociative4 : Pat<
   [(IsNotAConstant:$x), (IsNotAConstant:$y), (HasOneUse:$lhs), (HasOneUse:$rhs)]>;
 
 // Constant Propagation for Mul
-def MulConstProp : Pat<
+def MulConstProp : NamedPat<"MulConstProp",
     // From mul(c1, c2).
     (ONNXMulOp:$mulOp (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
                       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -469,7 +480,7 @@ def MulConstProp : Pat<
      (SatisfiesExpansionBound:$mulOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
-def MulOnesOnRhs : Pat<
+def MulOnesOnRhs : NamedPat<"MulOnesOnRhs",
     // From mul(x, c).
     (ONNXMulOp:$result
       $x,
@@ -483,7 +494,7 @@ def MulOnesOnRhs : Pat<
     ]>;
 
 // Constant Propagation for Div
-def DivConstProp : Pat<
+def DivConstProp : NamedPat<"DivConstProp",
     // From div(c1, c2).
     (ONNXDivOp:$divOp (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
                       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -494,7 +505,7 @@ def DivConstProp : Pat<
      (SatisfiesExpansionBound:$divOp)]>;
 
 // TODO: Expand $x to $result's shape instead of requiring ValuesHaveSameType.
-def DivOnesOnRhs : Pat<
+def DivOnesOnRhs : NamedPat<"DivOnesOnRhs",
     // From div(x, c).
     (ONNXDivOp:$result
       $x,
@@ -511,7 +522,7 @@ def DivOnesOnRhs : Pat<
 // Constant propagate ONNXEqualOp
 //===----------------------------------------------------------------------===//
 
-def EqualConstProp : Pat<
+def EqualConstProp : NamedPat<"EqualConstProp",
     // From equal(c1, c2).
     (ONNXEqualOp:$result
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
@@ -526,7 +537,7 @@ def EqualConstProp : Pat<
 // Constant propagate ONNXLessOp
 //===----------------------------------------------------------------------===//
 
-def LessConstPropPattern: Pat<
+def LessConstPropPattern : NamedPat<"LessConstPropPattern",
     (ONNXLessOp:$result
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -538,7 +549,7 @@ def LessConstPropPattern: Pat<
 // Constant propagate ONNXGreaterOp
 //===----------------------------------------------------------------------===//
 
-def GreaterConstPropPattern: Pat<
+def GreaterConstPropPattern : NamedPat<"GreaterConstPropPattern",
     (ONNXGreaterOp:$result
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -550,7 +561,7 @@ def GreaterConstPropPattern: Pat<
 // Constant propagate ONNXLessOrEqualOp
 //===----------------------------------------------------------------------===//
 
-def LessOrEqualConstPropPattern: Pat<
+def LessOrEqualConstPropPattern : NamedPat<"LessOrEqualConstPropPattern",
     (ONNXLessOrEqualOp:$result
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -562,7 +573,7 @@ def LessOrEqualConstPropPattern: Pat<
 // Constant propagate ONNXGreaterOrEqualOp
 //===----------------------------------------------------------------------===//
 
-def GreaterOrEqualConstPropPattern: Pat<
+def GreaterOrEqualConstPropPattern : NamedPat<"GreaterOrEqualConstPropPattern",
     (ONNXGreaterOrEqualOp:$result
       (ONNXConstantOp:$lhs $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$rhs $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -575,7 +586,7 @@ def GreaterOrEqualConstPropPattern: Pat<
 //===----------------------------------------------------------------------===//
 
 // Constant Propagation for Where
-def WhereConstProp : Pat<
+def WhereConstProp : NamedPat<"WhereConstProp",
     // From where(c0, c1, c2).
     (ONNXWhereOp:$whereOp (ONNXConstantOp:$condition $_, $_, $_, $_, $_, $_, $_, $_),
                       (ONNXConstantOp:$X $_, $_, $_, $_, $_, $_, $_, $_),
@@ -591,7 +602,7 @@ def WhereConstProp : Pat<
 // Patterns for Reduce ops.
 //===----------------------------------------------------------------------===//
 
-def ReduceSumConstProp: Pat<
+def ReduceSumConstProp : NamedPat<"ReduceSumConstProp",
       (ONNXReduceSumOp:$reduceSumOp
         (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
         $axes,
@@ -601,7 +612,7 @@ def ReduceSumConstProp: Pat<
     [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
-def ReduceProdConstProp: Pat<
+def ReduceProdConstProp : NamedPat<"ReduceProdConstProp",
       (ONNXReduceProdOp:$reduceProdOp
         (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
         $axes,
@@ -611,7 +622,7 @@ def ReduceProdConstProp: Pat<
     [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
-def ReduceMinConstProp: Pat<
+def ReduceMinConstProp : NamedPat<"ReduceMinConstProp",
       (ONNXReduceMinOp:$reduceMinOp
         (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
         $axes,
@@ -621,7 +632,7 @@ def ReduceMinConstProp: Pat<
     [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
-def ReduceMaxConstProp: Pat<
+def ReduceMaxConstProp : NamedPat<"ReduceMaxConstProp",
       (ONNXReduceMaxOp:$reduceMaxOp
         (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
         $axes,
@@ -631,7 +642,7 @@ def ReduceMaxConstProp: Pat<
     [(IsFromDenseONNXConstantOp:$data), (IsFromDenseONNXConstantOpOrNone:$axes)]
     >;
 
-def ReduceMeanConstProp: Pat<
+def ReduceMeanConstProp : NamedPat<"ReduceMeanConstProp",
       (ONNXReduceMeanOp:$reduceMeanOp
         (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
         $axes,
@@ -646,7 +657,7 @@ def ReduceMeanConstProp: Pat<
 //===----------------------------------------------------------------------===//
 
 // Limited to integers because 0 * NaN is NaN, not 0.
-def MatMulZerosOnLhs : Pat<
+def MatMulZerosOnLhs : NamedPat<"MatMulZerosOnLhs",
     (ONNXMatMulOp:$resOp
       (ONNXConstantOp:$A $_, $_, $_, $_, $_, $_, $_, $_),
       $B
@@ -657,7 +668,7 @@ def MatMulZerosOnLhs : Pat<
     >;
 
 // Limited to integers because NaN * 0 is NaN, not 0.
-def MatMulZerosOnRhs : Pat<
+def MatMulZerosOnRhs : NamedPat<"MatMulZerosOnRhs",
     (ONNXMatMulOp:$resOp
       $A,
       (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_)
@@ -667,7 +678,7 @@ def MatMulZerosOnRhs : Pat<
      (HasStaticShape:$resOp), (IsConstOfZeros:$B)]
     >;
 
-def MatMulOfConsts : Pat<
+def MatMulOfConsts : NamedPat<"MatMulOfConsts",
     (ONNXMatMulOp:$resOp
       (ONNXConstantOp:$A $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_)
@@ -681,7 +692,7 @@ def MatMulOfConsts : Pat<
 // Patterns for MatMulInteger.
 //===----------------------------------------------------------------------===//
 
-def MatMulIntegerConstZeroLhs : Pat<
+def MatMulIntegerConstZeroLhs : NamedPat<"MatMulIntegerConstZeroLhs",
     (ONNXMatMulIntegerOp:$resOp
       (ONNXConstantOp:$A $_, $_, $_, $_, $_, $_, $_, $_),
       $B,
@@ -692,7 +703,7 @@ def MatMulIntegerConstZeroLhs : Pat<
      (IsMatMulIntegerLhsZero $A, $a_zero_point), (HasStaticShape:$resOp)]
     >;
 
-def MatMulIntegerConstZeroRhs : Pat<
+def MatMulIntegerConstZeroRhs : NamedPat<"MatMulIntegerConstZeroRhs",
     (ONNXMatMulIntegerOp:$resOp
       $A,
       (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_),
@@ -703,7 +714,7 @@ def MatMulIntegerConstZeroRhs : Pat<
      (IsMatMulIntegerRhsZero $B, $b_zero_point), (HasStaticShape:$resOp)]
     >;
 
-def MatMulIntegerOfConsts : Pat<
+def MatMulIntegerOfConsts : NamedPat<"MatMulIntegerOfConsts",
     (ONNXMatMulIntegerOp:$resOp
       (ONNXConstantOp:$A $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_),
@@ -720,7 +731,7 @@ def MatMulIntegerOfConsts : Pat<
 //===----------------------------------------------------------------------===//
 
 // Attributes are not passed to CreateGemmOfConsts. It reads them from gemmOp.
-def GemmConstProp : Pat<
+def GemmConstProp : NamedPat<"GemmConstProp",
     (ONNXGemmOp:$gemmOp
       (ONNXConstantOp:$A $_, $_, $_, $_, $_, $_, $_, $_),
       (ONNXConstantOp:$B $_, $_, $_, $_, $_, $_, $_, $_),
@@ -734,7 +745,7 @@ def GemmConstProp : Pat<
 // Patterns to enable opportunities with Transpose operations.
 //===----------------------------------------------------------------------===//
 
-def TransposeofConst :  Pat<
+def TransposeofConst : NamedPat<"TransposeofConst",
     // From TransposeOp(c, p)
     (ONNXTransposeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is transposed attribute
@@ -745,14 +756,14 @@ def TransposeofConst :  Pat<
 // Patterns to enable opportunities with Unsqueeze operations.
 //===----------------------------------------------------------------------===//
 
-def UnsqueezeofConst :  Pat<
+def UnsqueezeofConst : NamedPat<"UnsqueezeofConst",
     // From Unsqueeze (c, axis)
     (ONNXUnsqueezeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateUnsqueezeOfConst $resOp, $input),
     [(IsFromDenseONNXConstantOp:$input)]>;
 
-def UnsqueezeV11ofConst :  Pat<
+def UnsqueezeV11ofConst : NamedPat<"UnsqueezeV11ofConst",
     // From Unsqueeze (c, axis)
     (ONNXUnsqueezeV11Op:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
@@ -763,14 +774,14 @@ def UnsqueezeV11ofConst :  Pat<
 // Patterns to enable opportunities with Squeeze operations.
 //===----------------------------------------------------------------------===//
 
-def SqueezeofConst :  Pat<
+def SqueezeofConst : NamedPat<"SqueezeofConst",
     // From Squeeze (c, axis)
     (ONNXSqueezeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
     (CreateSqueezeOfConst $resOp, $input),
     [(IsFromDenseONNXConstantOp:$input)]>;
 
-def SqueezeV11ofConst :  Pat<
+def SqueezeV11ofConst : NamedPat<"SqueezeV11ofConst",
     // From Squeeze (c, axis)
     (ONNXSqueezeV11Op:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_), $_),
     // To c' where c' is the unsqueezed value.
@@ -781,7 +792,7 @@ def SqueezeV11ofConst :  Pat<
 // Patterns to enable opportunities with Slice operations.
 //===----------------------------------------------------------------------===//
 
-def SliceofConst :  Pat<
+def SliceofConst : NamedPat<"SliceofConst",
     // From Slice (x, starts, ends, axes, steps)
     (ONNXSliceOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_),
                         $starts, $ends, $axes, $steps),
@@ -796,7 +807,7 @@ def SliceofConst :  Pat<
 //===----------------------------------------------------------------------===//
 
 // TODO: Support axes. For now it's required to be none.
-def PadOfConst : Pat<
+def PadOfConst : NamedPat<"PadOfConst",
     // From Pad (x, pads, constant_value, axes)
     (ONNXPadOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_),
                       $pads, $constant_value, $axes, $mode),
@@ -811,7 +822,7 @@ def PadOfConst : Pat<
 // Patterns to enable opportunities with Concat operations.
 //===----------------------------------------------------------------------===//
 
-def ConcatofConst: Pat<
+def ConcatofConst : NamedPat<"ConcatofConst",
   (ONNXConcatOp:$resOp $input, $axis),
   (CreateConcatOfConst $resOp, $input, $axis),
   [(IsVariadicOperandDenseONNXConstantOp:$input)]
@@ -821,7 +832,7 @@ def ConcatofConst: Pat<
 // Patterns to enable opportunities with Expand operations.
 //===----------------------------------------------------------------------===//
 
-def ExpandofConst :  Pat<
+def ExpandofConst : NamedPat<"ExpandofConst",
     // From Expand (x, shape)
     (ONNXExpandOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_),
                          (ONNXConstantOp:$shape $_, $_, $_, $_, $_, $_, $_, $_)),
@@ -835,7 +846,7 @@ def ExpandofConst :  Pat<
 // Patterns to enable opportunities with Gather operations.
 //===----------------------------------------------------------------------===//
 
-def GatherofConst :  Pat<
+def GatherofConst : NamedPat<"GatherofConst",
     // From Gather (x, indices, axis)
     (ONNXGatherOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_),
                          (ONNXConstantOp:$indices $_, $_, $_, $_, $_, $_, $_, $_),
@@ -848,7 +859,7 @@ def GatherofConst :  Pat<
 // Patterns to enable opportunities with Reshape operations.
 //===----------------------------------------------------------------------===//
 
-def ReshapeofConst :  Pat<
+def ReshapeofConst : NamedPat<"ReshapeofConst",
     // From Reshape (x, shape)
     (ONNXReshapeOp:$resOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_),
                           (ONNXConstantOp:$shape $_, $_, $_, $_, $_, $_, $_, $_),
@@ -862,7 +873,7 @@ def ReshapeofConst :  Pat<
 // Patterns to enable opportunities with ConstantOfShape operations.
 //===----------------------------------------------------------------------===//
 
-def ConstantOfShapeofConst :  Pat<
+def ConstantOfShapeofConst : NamedPat<"ConstantOfShapeofConst",
     // From ConstantOfShape (shape, x)
     (ONNXConstantOfShapeOp:$resOp (ONNXConstantOp:$shape $_, $_, $_, $_, $_, $_, $_, $_), $value),
     // To c where c is the expanded value.
@@ -875,7 +886,7 @@ def ConstantOfShapeofConst :  Pat<
 //===----------------------------------------------------------------------===//
 
 // Constant Propagation for Range if shape inference has calculated the length.
-def RangeConstProp : Pat<
+def RangeConstProp : NamedPat<"RangeConstProp",
     // From range(c0, c1, c2).
     (ONNXRangeOp:$rangeOp (ONNXConstantOp:$start $_, $_, $_, $_, $_, $_, $_, $_),
                       (ONNXConstantOp:$limit $_, $_, $_, $_, $_, $_, $_, $_),
@@ -890,9 +901,25 @@ def RangeConstProp : Pat<
 // Patterns for NonZero.
 //===----------------------------------------------------------------------===//
 
-def NonZeroOfConst : Pat<
+def NonZeroOfConst : NamedPat<"NonZeroOfConst",
     (ONNXNonZeroOp:$nonZeroOp (ONNXConstantOp:$input $_, $_, $_, $_, $_, $_, $_, $_)),
     (CreateNonZeroOfConst $nonZeroOp, $input),
     [(IsFromDenseONNXConstantOp:$input)]>;
+
+//===----------------------------------------------------------------------===//
+// Patterns for ScatterND.
+//===----------------------------------------------------------------------===//
+
+def ScatterNDOfConst : NamedPat<"ScatterNDOfConst",
+    (ONNXScatterNDOp:$scatterNDOp
+      (ONNXConstantOp:$data $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$indices $_, $_, $_, $_, $_, $_, $_, $_),
+      (ONNXConstantOp:$updates $_, $_, $_, $_, $_, $_, $_, $_),
+      $reduction),
+    (CreateScatterNDOfConst $scatterNDOp, $data, $indices, $updates),
+    [(IsFromDenseONNXConstantOp:$data),
+     (IsFromDenseONNXConstantOp:$indices),
+     (IsFromDenseONNXConstantOp:$updates),
+     (EqualString<"none"> $reduction)]>;
 
 #endif // ONNX_CONSTPROP

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1234,44 +1234,6 @@ func.func @test_split_axis_2(%arg0 : tensor<2x10xf32>) -> (tensor<2x5xf32>, tens
 
 // -----
 
-// CHECK-LABEL: @test_splitv11_axis_0() -> (tensor<1x10xf32>, tensor<1x10xf32>) {
-func.func @test_splitv11_axis_0() -> (tensor<1x10xf32>, tensor<1x10xf32>) {
-  %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
-  %1, %2 = "onnx.SplitV11"(%0) { axis = 0 : si64, split = [1, 1]} : (tensor<2x10xf32>) -> (tensor<1x10xf32>, tensor<1x10xf32>)
-  "onnx.Return"(%1, %2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> ()
-
-  // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00]]> : tensor<1x10xf32>
-  // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<1x10xf32>
-  // CHECK-NOT: {{.*}} = "onnx.SplitV11"{{.*}}
-}
-
-// -----
-
-// CHECK-LABEL: @test_splitv11_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
-func.func @test_splitv11_axis_1() -> (tensor<2x5xf32>, tensor<2x5xf32>) {
-  %0 = onnx.Constant dense<[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0]]> : tensor<2x10xf32>
-  %1, %2 = "onnx.SplitV11"(%0) { axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-  "onnx.Return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
-
-  // CHECK: {{.*}} = onnx.Constant dense<{{\[}}[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [1.000000e+01, 1.100000e+01, 1.200000e+01, 1.300000e+01, 1.400000e+01]]> : tensor<2x5xf32>
-  // CHECK: {{.*}}  = onnx.Constant dense<{{\[}}[5.000000e+00, 6.000000e+00, 7.000000e+00, 8.000000e+00, 9.000000e+00], [1.500000e+01, 1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01]]> : tensor<2x5xf32>
-  // CHECK-NOT: {{.*}} = "onnx.SplitV11"{{.*}}
-}
-
-// -----
-
-// COM: There is no constant propagation if the split's input is not a constant.
-
-// CHECK-LABEL: @test_splitv11_axis_2(%arg0: tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>) {
-func.func @test_splitv11_axis_2(%arg0 : tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>) {
-  %1, %2 = "onnx.SplitV11"(%arg0) { axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-  "onnx.Return"(%1, %2) : (tensor<2x5xf32>, tensor<2x5xf32>) -> ()
-
-  // CHECK: {{.*}} = "onnx.SplitV11"(%arg0) {axis = 1 : si64, split = [5, 5]} : (tensor<2x10xf32>) -> (tensor<2x5xf32>, tensor<2x5xf32>)
-}
-
-// -----
-
 func.func @test_mul_folding(%arg0: tensor<1x1x28x28xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<[[[[0.0234164055, 0.0228030644], [2.442580e-02, 0.0237577036]]], [[[-0.0410864502, 0.0488203131], [0.164448678, -0.0200194642]]], [[[-4.34581793E-9, 0.025325032], [0.0373019315, 0.165243402]]], [[[-0.0198689923, 0.131284416], [0.0572107285, 2.33985098E-8]]], [[[0.0187684372, -0.148515195], [0.0154875498, 0.019133633]]], [[[0.0176953916, -0.0154658081], [0.0233727545, -0.274110436]]], [[[-0.021181887, 0.0936150252], [0.135688141, -0.0202601217]]], [[[-0.0201558527, 0.0192655921], [0.227748245, -0.196346223]]]]> : tensor<8x1x2x2xf32>
   %1 = "onnx.NoValue"() {value} : () -> none

--- a/test/mlir/onnx/onnx_constprop_no_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_constprop_no_shape_inference.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --constprop-onnx %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --decompose-onnx --constprop-onnx %s -split-input-file | FileCheck %s
 
 //===----------------------------------------------------------------------===//
 /// Split tests


### PR DESCRIPTION
Added a flag to disable select onnx const prop patterns. This upstreams logic that proved useful at Groq on a specific model where an onnx const prop pattern was counter-productive.

Removed ConstPropSplitV11Pattern because it should be unnecessary since we canonicalize SplitV11 to Split.

Migrated ConstPropScatterNDPattern to tablegen. Couldn't migrate ConstPropSplitPattern to tablegen because it has a variadic return value but refactored it to follow the style of the tablegen const prop patterns.

For the record, I modified the tablegen file with this script:
```
sed -i 's/^def \(\w\w*\) : Pat<$/def \1 : NamedPat<"\1",/' ConstProp.td
```