### PR TITLE
[NNPA] Reconstruct onnx element-wise ops from zhigh ops - add a missing lit test for relu

### DIFF
--- a/test/mlir/accelerators/nnpa/conversion/zhigh-to-onnx/relu.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/zhigh-to-onnx/relu.mlir
@@ -1,0 +1,16 @@
+// RUN: onnx-mlir-opt --maccel=NNPA --convert-zhigh-to-onnx %s -split-input-file | FileCheck %s
+
+func.func @test_log() -> tensor<10x10xf32> {
+  %cst0 = onnx.Constant dense<1.0> : tensor<10x10xf32>
+  %0 = "zhigh.Stick"(%cst0) {layout = "2D"} : (tensor<10x10xf32>) -> tensor<10x10xf32, #zhigh.layout<{dataLayout = "2D"}>>
+  %1 = "zhigh.Relu"(%0) : (tensor<10x10xf32, #zhigh.layout<{dataLayout = "2D"}>>) -> tensor<10x10xf32, #zhigh.layout<{dataLayout = "2D"}>>
+  %2 = "zhigh.Unstick"(%1) : (tensor<10x10xf32, #zhigh.layout<{dataLayout = "2D"}>>) -> tensor<10x10xf32>
+  return %2 : tensor<10x10xf32>
+
+// CHECK-LABEL:  func.func @test_log
+// CHECK-SAME:   () -> tensor<10x10xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<10x10xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Relu"([[VAR_0_]]) : (tensor<10x10xf32>) -> tensor<10x10xf32>
+// CHECK:           return [[VAR_1_]] : tensor<10x10xf32>
+// CHECK:         }
+}


### PR DESCRIPTION
Just added a missing lit test for relu in PR #2463 