### PR TITLE
Do not remove LLVM "internal" options

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -152,7 +152,7 @@ add_onnx_mlir_library(OMCompilerUtils
   EXCLUDE_FROM_OM_LIBS
 
   DEPENDS
-  ExternalUtil  
+  ExternalUtil
   llc
   opt
 
@@ -163,12 +163,10 @@ add_onnx_mlir_library(OMCompilerUtils
   ${ONNX_MLIR_SRC_ROOT}/include
 
   LINK_LIBS PUBLIC
-  ${OMLibs}
   OMCompilerDialects
   OMCompilerPasses
   OMAccelerator
   OMVersion
-  MLIRIR
 
   # Link LLVM libraries necessary to query which target architectures
   # are configured.
@@ -193,7 +191,6 @@ add_onnx_mlir_library(OMCompiler
 
   DEPENDS
   OMCompilerUtils
-  ExternalUtil
 
   INCLUDE_DIRS PRIVATE
   ${FILE_GENERATE_DIR}
@@ -204,7 +201,6 @@ add_onnx_mlir_library(OMCompiler
   EXCLUDE_FROM_OM_LIBS
 
   LINK_LIBS PRIVATE
-  OMCompilerDialects
   OMCompilerUtils
   )
 

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -1017,10 +1017,10 @@ void removeUnrelatedOptions(
   for (auto n = optMap.begin(); n != optMap.end(); n++) {
     llvm::cl::Option *opt = n->getValue();
     if (opt->getOptionHiddenFlag() == llvm::cl::ReallyHidden &&
-	// Do not remove LLVM "internal" options such as --debug
-	// that do not have a category (and therefore placed
-	// under the general category
-	opt->Categories[0] != &llvm::cl::getGeneralCategory())
+        // Do not remove LLVM "internal" options such as --debug
+        // that do not have a category (and therefore placed
+        // under the general category
+        opt->Categories[0] != &llvm::cl::getGeneralCategory())
       opt->removeArgument();
   }
 }

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -1016,7 +1016,11 @@ void removeUnrelatedOptions(
       llvm::cl::getRegisteredOptions();
   for (auto n = optMap.begin(); n != optMap.end(); n++) {
     llvm::cl::Option *opt = n->getValue();
-    if (opt->getOptionHiddenFlag() == llvm::cl::ReallyHidden)
+    if (opt->getOptionHiddenFlag() == llvm::cl::ReallyHidden &&
+	// Do not remove LLVM "internal" options such as --debug
+	// that do not have a category (and therefore placed
+	// under the general category
+	opt->Categories[0] != &llvm::cl::getGeneralCategory())
       opt->removeArgument();
   }
 }

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -39,7 +39,6 @@
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerPasses.hpp"
 #include "src/Compiler/HeapReporter.hpp"
-#include "src/Dialect/ONNX/ONNXDialect.hpp"
 #include "src/Version/Version.hpp"
 
 #include <fstream>

--- a/src/Compiler/OnnxMlirCompiler.cpp
+++ b/src/Compiler/OnnxMlirCompiler.cpp
@@ -10,7 +10,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "include/OnnxMlirCompiler.h"
-#include "src/Compiler/CompilerDialects.hpp"
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 #include "llvm/Support/FileSystem.h"


### PR DESCRIPTION
- Do not remove LLVM "internal" options such as --debug
- Clean up some header includes and library link dependencies