### PR TITLE
Fix constant propagation pass issue for onnx.Gather op.

### DIFF
--- a/src/Transform/ONNX/ConstProp.td
+++ b/src/Transform/ONNX/ConstProp.td
@@ -84,6 +84,12 @@ def IsConstOfOnes : Constraint<
   CPred<"isDenseONNXConstant($_self) && isConstOf($_self, 1.0)">,
   "Value is an all-ones constant tensor">;
 
+// Check the rank of a value is greater than a given integer.
+class HasRankGT<int rank> :
+  Constraint<CPred<"$0.getType().isa<ShapedType>() && "
+                   "$0.getType().cast<ShapedType>().hasRank() && "
+                   "$0.getType().cast<ShapedType>().getRank() > " # rank>>;
+
 def ValuesHaveSameType : Constraint<
   CPred<"$0.getType() == $1.getType()">,
   "Values have same type">;
@@ -853,7 +859,8 @@ def GatherofConst : NamedPat<"GatherofConst",
                          $_),
     // To c' where c' is the gathered value.
     (CreateGatherOfConst $resOp, $input, $indices),
-    [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$indices)]>;
+    [(IsFromDenseONNXConstantOp:$input), (IsFromDenseONNXConstantOp:$indices),
+     (HasRankGT<0> $indices)]>;
 
 //===----------------------------------------------------------------------===//
 // Patterns to enable opportunities with Reshape operations.

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1650,14 +1650,14 @@ func.func @test_gather_axis_1() -> tensor<*xf32>{
 
 func.func @test_gather_no_rank_indices() -> tensor<*xi64>{
   %0 = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-  %1 = onnx.Constant dense<0> : tensor<i64>
-  %2 = "onnx.Gather"(%0, %1) {axis = 0 : si64} : (tensor<2xi64>, tensor<i64>) -> tensor<*xi64>
+  %1 = onnx.Constant dense<0> : tensor<i32>
+  %2 = "onnx.Gather"(%0, %1) {axis = 0 : si64} : (tensor<2xi64>, tensor<i32>) -> tensor<*xi64>
   "onnx.Return"(%2) : (tensor<*xi64>) -> ()
 
   // CHECK-LABEL:  func @test_gather_no_rank_indices
   // CHECK:        [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
-  // CHECK:        [[VAR_1_:%.+]] = onnx.Constant dense<0> : tensor<i64>
-  // CHECK:        [[VAR_2_:%.+]] = "onnx.Gather"([[VAR_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<i64>) -> tensor<i64>
+  // CHECK:        [[VAR_1_:%.+]] = onnx.Constant dense<0> : tensor<i32>
+  // CHECK:        [[VAR_2_:%.+]] = "onnx.Gather"([[VAR_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<i32>) -> tensor<i64>
   // CHECK:        onnx.Return [[VAR_2_]] : tensor<i64>
 }
 

--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1648,6 +1648,21 @@ func.func @test_gather_axis_1() -> tensor<*xf32>{
 
 // -----
 
+func.func @test_gather_no_rank_indices() -> tensor<*xi64>{
+  %0 = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  %1 = onnx.Constant dense<0> : tensor<i64>
+  %2 = "onnx.Gather"(%0, %1) {axis = 0 : si64} : (tensor<2xi64>, tensor<i64>) -> tensor<*xi64>
+  "onnx.Return"(%2) : (tensor<*xi64>) -> ()
+
+  // CHECK-LABEL:  func @test_gather_no_rank_indices
+  // CHECK:        [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  // CHECK:        [[VAR_1_:%.+]] = onnx.Constant dense<0> : tensor<i64>
+  // CHECK:        [[VAR_2_:%.+]] = "onnx.Gather"([[VAR_0_]], [[VAR_1_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<i64>) -> tensor<i64>
+  // CHECK:        onnx.Return [[VAR_2_]] : tensor<i64>
+}
+
+// -----
+
 func.func @test_gather_negative_index() -> tensor<*xf32>{
   %0 = onnx.Constant dense<[[1.0, 1.2, 1.9], [2.3, 3.4, 3.9], [4.5, 5.7, 5.9]]> : tensor<3x3xf32>
   %1 = onnx.Constant dense<[[0, -1]]> : tensor<1x2xi64>


### PR DESCRIPTION
Fix constant propagation pass issue for onnx.Gather op.
Current constant propagation pass does not work for onnx.Gather with unranked indices (e.g. Tensor<i32>).
This PR stops constant propagation with the case. 

[X] Prepare LIT test to check errors

```
onnx-mlir: ./src/Dialect/ONNX/ElementsAttr/DisposableElementsAttr.hpp.inc:75: onnx_mlir::ArrayBuffer<X> mlir::DisposableElementsAttr::getArray() const [with X = long int]: Assertion `onnx_mlir::toBType<X> == getBType() && “X must match element type”‘ failed.
```