### PR TITLE
remove src/Compiler dependencies from src/{Builder,Transform,Conversion}

### DIFF
--- a/src/Builder/CMakeLists.txt
+++ b/src/Builder/CMakeLists.txt
@@ -11,7 +11,6 @@ add_onnx_mlir_library(OMBuilder
   ModelInputShaper.cpp
 
   LINK_LIBS PUBLIC
-  OMCompilerOptions
   OMHasOnnxSubgraphOpInterface
   OMONNXOps
   OMResultTypeInferenceOpInterface

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -31,7 +31,6 @@
 #include "src/Builder/ImportONNXUtils.hpp"
 #include "src/Builder/ModelInputShaper.hpp"
 #include "src/Builder/SymbolTable.hpp"
-#include "src/Compiler/CompilerOptions.hpp"
 #include "src/Dialect/ONNX/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
@@ -165,7 +164,7 @@ public:
     opset_map_ = GetOpsetImportsFromProto(model); // Which opsets to use.
     in_model_functions_ = GetModelLocalFunctions(model);
     importGraph(model.graph());
-    if (VerboseOutput) {
+    if (options_.verboseOutput) {
       llvm::outs()
           << "The ONNX model has " << num_of_parameters_
           << " elements in its initializers. This value would be close to and "

--- a/src/Builder/FrontendDialectTransformer.hpp
+++ b/src/Builder/FrontendDialectTransformer.hpp
@@ -39,6 +39,7 @@ namespace onnx_mlir {
  * Options to control the translation of an ONNX model to ONNX-MLIR.
  */
 struct ImportOptions {
+  bool verboseOutput = false;
   // Use types/shapes in the input-model for translation (for intermediate
   // variables)
   bool useOnnxModelTypes = false;

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -90,7 +90,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU) {
     // Dynamic iterate in ONNXOpTransformPass
     pm.addPass(onnx_mlir::createONNXOpTransformPass(onnxOpTransformThreshold,
         onnxOpTransformReport, targetCPU,
-        enableSimdDataLayout && !disableSimdOption));
+        enableSimdDataLayout && !disableSimdOption, enableConvOptPass));
   } else {
     // Statically add extra passes
     for (int i = 0; i < repeatOnnxTransform; i++) {

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -589,6 +589,7 @@ int processInputFile(StringRef inputFilename, mlir::MLIRContext &context,
 
   if (inputIsSTDIN || inputIsONNX || inputIsONNXText || inputIsJSON) {
     ImportOptions options;
+    options.verboseOutput = VerboseOutput;
     options.useOnnxModelTypes = useOnnxModelTypes;
     options.invokeOnnxVersionConverter = invokeOnnxVersionConverter;
     options.shapeInformation = shapeInformation;

--- a/src/Conversion/KrnlToAffine/CMakeLists.txt
+++ b/src/Conversion/KrnlToAffine/CMakeLists.txt
@@ -13,7 +13,6 @@ add_onnx_mlir_library(OMKrnlToAffine
 
   LINK_LIBS PUBLIC
   OMSpecializedKernelOpInterface
-  OMCompilerOptions
   OMONNXOps
   OMSupport
   MLIRTransforms

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -25,7 +25,6 @@
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 #include "llvm/Support/Debug.h"
 
-#include "src/Compiler/CompilerOptions.hpp"
 #include "src/Conversion/KrnlToAffine/ConvertKrnlToAffine.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/Mlir/VectorMachineSupport.hpp"
@@ -712,7 +711,6 @@ void ConvertKrnlToAffinePass::runOnOperation() {
 
   MLIRContext *ctx = &getContext();
   OpBuilder builder(ctx);
-  VectorMachineSupport::setGlobalVectorMachineSupport(march, mcpu, "");
 
   const auto &dataLayoutAnalysis = getAnalysis<DataLayoutAnalysis>();
   LowerToLLVMOptions options(
@@ -821,7 +819,6 @@ void ConvertKrnlToAffinePass::runOnOperation() {
   }
 
   delete currUnrollAndJamList;
-  VectorMachineSupport::clearGlobalVectorMachineSupport();
 }
 
 std::unique_ptr<Pass> createConvertKrnlToAffinePass() {

--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -79,7 +79,6 @@ add_onnx_mlir_library(OMONNXToKrnl
 
   LINK_LIBS PUBLIC
   OMAccelerator
-  OMCompilerOptions
   OMONNXOps
   OMSupport
   MLIRFuncDialect

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -19,7 +19,6 @@
 
 #include "src/Accelerators/Accelerator.hpp"
 #include "src/Builder/ModelInputShaper.hpp"
-#include "src/Compiler/CompilerOptions.hpp"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 #include "src/Dialect/Mlir/VectorMachineSupport.hpp"
 
@@ -335,8 +334,6 @@ public:
 
 void FrontendToKrnlLoweringPass::runOnOperation() {
   ModuleOp module = getOperation();
-  // Define vector machine.
-  VectorMachineSupport::setGlobalVectorMachineSupport(march, mcpu, "");
   // Perform dim analysis (useful for SIMD but also to avoid broadcast
   // expressions in index access patterns).
   DimAnalysis *dimAnalysis = new DimAnalysis(module);
@@ -441,7 +438,6 @@ void FrontendToKrnlLoweringPass::runOnOperation() {
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();
   }
-  VectorMachineSupport::clearGlobalVectorMachineSupport();
   delete dimAnalysis;
 }
 

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -31,8 +31,9 @@ std::unique_ptr<mlir::Pass> createScrubDisposablePass(bool closeAfter = true);
 
 /// Pass for ONNX graph level optimization
 std::unique_ptr<mlir::Pass> createONNXOpTransformPass();
-std::unique_ptr<mlir::Pass> createONNXOpTransformPass(
-    int threshold, bool report, bool targetCPU, bool enableSimdDataLayoutOpt);
+std::unique_ptr<mlir::Pass> createONNXOpTransformPass(int threshold,
+    bool report, bool targetCPU, bool enableSimdDataLayoutOpt,
+    bool enableConvOptPass);
 
 /// Pass for rewriting inside frontend dialect.
 std::unique_ptr<mlir::Pass> createDecomposeONNXToONNXPass(

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -38,7 +38,6 @@ add_onnx_mlir_library(OMShapeInferencePass
   OMShapeInferenceOpInterface
   MLIRFuncDialect
   MLIRPass
-  OMCompilerOptions
   OMShapeInference
   )
 


### PR DESCRIPTION
to make it easy to use each of the dialects and passes as libraries that people can link into their own compiler binaries without using the onnx-mlir binary, and to avoid unnecessary cyclical dependencies, we should avoid making the dialects and passes depend on anything in src/Compiler (with #include or cmake LINK_LIBS)