### PR TITLE
ONNX to Zhigh guided by cost model

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
@@ -48,4 +48,11 @@ llvm::cl::opt<bool> nnpaEnableZHighToOnnx("enable-zhigh-to-onnx",
         "level. Default is true."),
     llvm::cl::init(true), llvm::cl::cat(OnnxMlirOptions));
 
+llvm::cl::opt<bool> nnpaEnableZHighCostModel("enable-zhigh-cost-model",
+    llvm::cl::desc(
+        "Enabling a performance cost model to estimate the benefit of "
+        "migrating an eligible onnx operation to a ZHigh operation. Default is "
+        "false."),
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
+
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.hpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.hpp
@@ -46,6 +46,7 @@ extern llvm::cl::opt<onnx_mlir::NNPAEmissionTargetType> nnpaEmissionTarget;
 extern llvm::cl::list<std::string> execNodesOnCpu;
 extern llvm::cl::opt<bool> nnpaClipToDLFloatRange;
 extern llvm::cl::opt<bool> nnpaEnableZHighToOnnx;
+extern llvm::cl::opt<bool> nnpaEnableZHighCostModel;
 extern llvm::cl::opt<bool> profileZHighIR;
 
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/CMakeLists.txt
@@ -5,6 +5,7 @@ add_onnx_mlir_library(OMONNXToZHigh
   ONNXLegalityCheck.cpp
   ONNXToZHigh.cpp
   ONNXToZHighCommon.cpp
+  ZHighPerfModel.cpp
 
   DEPENDS
   OMONNXONNXToZHighIncGen
@@ -25,6 +26,7 @@ add_onnx_mlir_library(OMRewriteONNXForZHigh
   ONNXLegalityCheck.cpp
   RewriteONNXForZHigh.cpp
   ONNXToZHighCommon.cpp
+  ZHighPerfModel.cpp
 
   DEPENDS
   OMONNXRewriteONNXForZHighIncGen

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.hpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.hpp
@@ -22,9 +22,10 @@
 
 /// A function to check whether an ONNX op is suitable for being lowered to zDNN
 /// or not.
+// TODO: revisit if the cost model should not be optional.
 template <typename OP_TYPE>
-bool isSuitableForZDNN(
-    OP_TYPE op, const onnx_mlir::DimAnalysis *dimAnalysis = nullptr);
+bool isSuitableForZDNN(OP_TYPE op, bool useCostModel = false,
+    const onnx_mlir::DimAnalysis *dimAnalysis = nullptr);
 
 /// Get padding type using shape helper. This returns
 /// `SAME_PADDING`, `VALID_PADDING`, or empty.

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -301,7 +301,7 @@ def replaceONNXSoftmax3DPattern : Pat<
 //===----------------------------------------------------------------------===//
 def IsSoftmaxLegalForZDNN: Constraint<
   CPred<"isSuitableForZDNN<ONNXSoftmaxOp>(" # 
-             "dyn_cast_or_null<ONNXSoftmaxOp>($0.getDefiningOp()))">,
+             "dyn_cast_or_null<ONNXSoftmaxOp>($0.getDefiningOp()), false)">,
   "Softmax is legal for zDNN"
 >;
 def replaceONNXLogSoftmaxPattern : Pattern<
@@ -461,7 +461,7 @@ def replaceONNXMatMulPattern : Pat<
 
 def IsMatMulLegalForZDNN: Constraint<
   CPred<"isSuitableForZDNN<ONNXMatMulOp>(" # 
-             "dyn_cast_or_null<ONNXMatMulOp>($0.getDefiningOp()))">,
+             "dyn_cast_or_null<ONNXMatMulOp>($0.getDefiningOp()), false)">,
   "MatMul is legal for zDNN"
 >;
 
@@ -983,7 +983,7 @@ def replaceONNXConv2DPattern : Pattern<
 
 def IsConv2DLegalForZDNN: Constraint<
   CPred<"isSuitableForZDNN<ONNXConvOp>(" #
-             "dyn_cast_or_null<ONNXConvOp>($0.getDefiningOp()))">,
+             "dyn_cast_or_null<ONNXConvOp>($0.getDefiningOp()), false)">,
   "Conv is legal for zDNN"
 >;
 

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.hpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.hpp
@@ -21,10 +21,10 @@
 
 template <typename OP_TYPE>
 void addDynamicallyLegalOpFor(mlir::ConversionTarget *target,
-    const onnx_mlir::DimAnalysis *dimAnalysis,
+    const onnx_mlir::DimAnalysis *dimAnalysis, bool useCostModel,
     mlir::ArrayRef<std::string> execNodesOnCpu) {
-  target->addDynamicallyLegalOp<OP_TYPE>([dimAnalysis, execNodesOnCpu](
-                                             OP_TYPE op) {
+  target->addDynamicallyLegalOp<OP_TYPE>([dimAnalysis, useCostModel,
+                                             execNodesOnCpu](OP_TYPE op) {
     // Check operations to be forced to run on CPU.
     mlir::Operation *genericOp = op.getOperation();
     mlir::StringAttr nodeName =
@@ -56,7 +56,7 @@ void addDynamicallyLegalOpFor(mlir::ConversionTarget *target,
     if (exceedLimit)
       return true;
 
-    return !isSuitableForZDNN<OP_TYPE>(op, dimAnalysis);
+    return !isSuitableForZDNN<OP_TYPE>(op, useCostModel, dimAnalysis);
   });
 }
 

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -405,12 +405,13 @@ struct RewriteONNXForZHighPass
   }
 
   RewriteONNXForZHighPass() = default;
-  RewriteONNXForZHighPass(mlir::ArrayRef<std::string> execNodesOnCpu)
-      : execNodesOnCpu(execNodesOnCpu) {}
+  RewriteONNXForZHighPass(mlir::ArrayRef<std::string> execNodesOnCpu, bool useCostModel)
+      : execNodesOnCpu(execNodesOnCpu), useCostModel(useCostModel) {}
   void runOnOperation() final;
 
 public:
   mlir::ArrayRef<std::string> execNodesOnCpu = mlir::ArrayRef<std::string>();
+  bool useCostModel = false;
 };
 
 void RewriteONNXForZHighPass::runOnOperation() {
@@ -433,7 +434,7 @@ void RewriteONNXForZHighPass::runOnOperation() {
   // generating `ONNX.Add`, `ONNX.Sub`, `ONNX.Mul`, `ONNX.Div`,
   // and `ONNX.Sqrt` to calculate inputs(`a` and `b`)
   addDynamicallyLegalOpFor<ONNXBatchNormalizationInferenceModeOp>(
-      &target, &dimAnalysis, execNodesOnCpu);
+      &target, &dimAnalysis, useCostModel, execNodesOnCpu);
 
   // Illegalize BinaryOp if one of the two inputs is a constant and
   // unidirectional broadcastable to the other input. Rewrite patterns will be
@@ -549,8 +550,9 @@ std::unique_ptr<Pass> createRewriteONNXForZHighPass() {
 }
 
 std::unique_ptr<Pass> createRewriteONNXForZHighPass(
-    mlir::ArrayRef<std::string> execNodesOnCpu) {
-  return std::make_unique<RewriteONNXForZHighPass>(execNodesOnCpu);
+    mlir::ArrayRef<std::string> execNodesOnCpu, bool useCostModel) {
+  return std::make_unique<RewriteONNXForZHighPass>(
+      execNodesOnCpu, useCostModel);
 }
 
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighPerfModel.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighPerfModel.cpp
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------- ZHighPerfModel.cpp - Deciding ONNX vs ZHigh for ops -------===//
+//
+// Copyright 2023 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains model info to help decide for the relevant NNPA ops if
+// they are faster / slower than their equivalent CPU versions.
+//
+//===----------------------------------------------------------------------===//
+
+// hi alex: determine which one are really needed
+#include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighPerfModel.hpp"
+#include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/NNPALimit.h"
+#include "src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp"
+#include "src/Dialect/ONNX/ONNXDimAnalysis.hpp"
+#include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
+
+#define DEBUG_TYPE "zhigh-perf-model"
+
+using namespace mlir;
+using namespace onnx_mlir;
+
+namespace {
+
+// This is the implementation of Excel.ceiling, which result the smallest value
+// that is greater or equal to A and is a multiple of B.
+inline int64_t roundToNextMultiple(int64_t a, int64_t b) {
+  // Ceil only works with unsigned number, but shapes are given as signed
+  // numbers. Do the necessary checks/conversions here.
+  assert(a >= 0 && "expected nonnegative");
+  assert(b > 0 && "expected strictly positive");
+  uint64_t aa = a;
+  uint64_t bb = b;
+  uint64_t ceilDiv = (aa + bb - 1) / bb;
+  return ceilDiv * bb;
+}
+
+// Return true with a debug message reporting reason for success on NNPA.
+inline bool fasterOnNNPA(Operation *op, std::string msg) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "Faster on NNPA: " << msg << " for op: ";
+    op->dump();
+  });
+  return true;
+}
+
+// Return false with a debug message reporting reason for failure on NNPA.
+inline bool fasterOnCPU(Operation *op, std::string msg) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "Faster on CPU: " << msg << " for op: ";
+    op->dump();
+  });
+  return false;
+}
+
+} // namespace
+
+bool isElementwiseFasterOnNNPA(Operation *op, Value lhs, Value rhs,
+    const DimAnalysis *dimAnalysis, double relativeNNPASpeedup) {
+  // At this time, use only 1 of the two
+  ShapedType lhsType = lhs.getType().dyn_cast_or_null<ShapedType>();
+  assert(lhsType && lhsType.hasRank() && "expected shaped type with rank");
+  int64_t lhsRank = lhsType.getRank();
+  assert(lhsRank <= 4 && "expected rank <= 4");
+  llvm::ArrayRef<int64_t> shape = lhsType.getShape();
+  int64_t e4 = lhsRank >= 4 ? shape[lhsRank - 4] : 1;
+  int64_t e3 = lhsRank >= 3 ? shape[lhsRank - 3] : 1;
+  int64_t e2 = lhsRank >= 2 ? shape[lhsRank - 2] : 1;
+  int64_t e1 = lhsRank >= 1 ? shape[lhsRank - 1] : 1;
+
+  // Disqualify if e1 is too small (full is 64, so shoot for half full).
+  if (e1 > 0 && e1 < 32)
+    return fasterOnCPU(op, "elementwise has too small e1");
+  // If e1 or e2 are runtime, assume they will be large enough.
+  if (e1 == ShapedType::kDynamic || e2 == ShapedType::kDynamic)
+    return fasterOnNNPA(op, "elementwise has runtime e1 or e2");
+  // If larger dims are runtime, assume it might just be size 1.
+  if (e3 == ShapedType::kDynamic)
+    e3 = 1;
+  if (e4 == ShapedType::kDynamic)
+    e4 = 1;
+  // Cedric's spreadsheet calculations.
+  int64_t computed2dFMA =
+      e4 * e3 * roundToNextMultiple(e2, 2) * roundToNextMultiple(e1, 64);
+  computed2dFMA = (double)computed2dFMA * relativeNNPASpeedup;
+  assert(computed2dFMA > 0 && "dyn size should have been removed");
+  // Cedric's model show still significant benefits for 16 full tiles,
+  // arbitrarily assume cross over at 8. Will need new measurements on this.
+  if (computed2dFMA < 8 * 2048)
+    return fasterOnCPU(
+        op, "elementwise computed 2D FMA is too small (<8 full tiles)");
+  return fasterOnNNPA(op, "elementwise has enough computations");
+}
+
+bool isMatMulFasterOnNNPA(Operation *op, Value a, Value b, bool aTransposed,
+    bool bTransposed, const DimAnalysis *dimAnalysis) {
+  // Scanning A.
+  ShapedType aType = a.getType().dyn_cast_or_null<ShapedType>();
+  assert(aType && aType.hasRank() && "expected shaped type with A rank");
+  int64_t aRank = aType.getRank();
+  assert(aRank >= 2 && aRank <= 3 && "expected A rank 2..3");
+  llvm::ArrayRef<int64_t> aShape = aType.getShape();
+  int64_t aB = aRank >= 3 ? aShape[aRank - 3] : 1;
+  int64_t aNIndex = aTransposed ? aRank - 1 : aRank - 2;
+  int64_t aMIndex = aTransposed ? aRank - 2 : aRank - 1;
+  int64_t aN = aShape[aNIndex];
+  int64_t aM = aShape[aMIndex];
+  // Scanning B.
+  ShapedType bType = b.getType().dyn_cast_or_null<ShapedType>();
+  assert(bType && bType.hasRank() && "expected shaped type with B rank");
+  int64_t bRank = bType.getRank();
+  assert(bRank >= 2 && bRank <= 3 && "expected B rank 2..3");
+  llvm::ArrayRef<int64_t> bShape = bType.getShape();
+  int64_t bB = bRank >= 3 ? bShape[bRank - 3] : 1;
+  int64_t bMIndex = bTransposed ? bRank - 1 : bRank - 2;
+  int64_t bKIndex = bTransposed ? bRank - 2 : bRank - 1;
+  int64_t bM = bShape[bMIndex];
+  int64_t bK = bShape[bKIndex];
+  assert(aM == bM && "expected M dims to be identical");
+  // Rules common to matmul with/without broadcast.
+  // Make sure the constant lower dim of the matmul are large enough.
+  if (aM > 0 && aM < 32)
+    return fasterOnCPU(op, "matmul no-broadcast M dim too small)");
+  if (bK > 0 && bK < 32)
+    return fasterOnCPU(op, "matmul no-broadcast K dim too small)");
+  // Assume the dynamic lower dim of the matmul will be large enough.
+  if (aM == ShapedType::kDynamic || bK == ShapedType::kDynamic)
+    return fasterOnNNPA(op, "matmul no-broadcast has runtime M or K");
+  // Assume the N dim of the matmul will be small.
+  if (aN == ShapedType::kDynamic)
+    aN = 1;
+  // Determine if we have a broadcast (will change cost calculations).
+  bool hasBroadcast = true;
+  if (aRank == 2 && bRank == 2) // No broadcast dim.
+    hasBroadcast = false;
+  else if (aB == 1 && bB == 1) // No broadcast because both 1.
+    hasBroadcast = false;
+  else if (aRank == 3 && bRank == 3 &&
+           dimAnalysis->sameDim(a, aRank - 3, b, bRank - 3))
+    hasBroadcast = false;
+  // Assume the B dim of the matmul will be small.
+  if (aB == ShapedType::kDynamic)
+    aB = 1;
+  if (bB == ShapedType::kDynamic)
+    bB = 1;
+
+  // Handle case without broadcast.
+  if (!hasBroadcast) {
+    int64_t computed2dFMA = aB * roundToNextMultiple(aN, 2) *
+                            roundToNextMultiple(aM, 64) *
+                            roundToNextMultiple(bK, 64);
+    assert(computed2dFMA > 0 && "dyn size should have been removed");
+    // Cedric's model show still  benefits for 64^3 == 128 full tiles.
+    if (computed2dFMA < 64 * 64 * 64)
+      return fasterOnCPU(
+          op, "matmul no-broadcast computed 2D FMA is too small (<64^3 flops)");
+    return fasterOnNNPA(op, "matmul no-broadcast has enough computations");
+  }
+  // Else we have broadcast.
+  // Virtual E2/E4 from Cedric's spreadsheet: TODO, need refinement.
+  int B = bB == 1 ? aB : bB;
+  int64_t virtualNB;
+  if (aN >= 128)
+    virtualNB = aN; // No B?
+  else if (aM >= 64)
+    virtualNB = aN * std::min(2, B);
+  else if (aM >= 32)
+    virtualNB = aN * std::min(4, B);
+  else
+    virtualNB = aN * std::min(8, B);
+  int64_t computed2dFMA =
+      virtualNB * roundToNextMultiple(aM, 64) * roundToNextMultiple(bK, 64);
+  if (computed2dFMA < 64 * 64 * 64)
+    return fasterOnCPU(
+        op, "matmul broadcast computed 2D FMA is too small (<64^3 flops)");
+  return fasterOnNNPA(op, "matmul broadcast has enough computations");
+}

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighPerfModel.hpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighPerfModel.hpp
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------- ZHighPerfModel.hpp - Deciding ONNX vs ZHigh for ops -------===//
+//
+// Copyright 2023 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains model info to help decide for the relevant NNPA ops if
+// they are faster / slower than their equivalent CPU versions.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+#include "src/Dialect/ONNX/ONNXDimAnalysis.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+
+// Return true if operation is faster on NNPA than CPU.
+
+// Result is normalized for add/sub/mul. Operations that have an additional
+// advantage on the NNPA vs CPU execution can reflect that advantage via the
+// relativeNNPASpeedup ratio.
+bool isElementwiseFasterOnNNPA(mlir::Operation *op, mlir::Value lhs,
+    mlir::Value rhs, const onnx_mlir::DimAnalysis *dimAnalysis,
+    double relativeNNPASpeedup = 1.0);
+
+bool isElementwiseFasterOnNNPA(mlir::Operation *op, mlir::Value operand,
+    const onnx_mlir::DimAnalysis *dimAnalysis,
+    double relativeNNPASpeedup = 1.0);
+
+bool isMatMulFasterOnNNPA(mlir::Operation *op, mlir::Value a, mlir::Value b,
+    bool aTransposed, bool bTransposed,
+    const onnx_mlir::DimAnalysis *dimAnalysis);

--- a/src/Accelerators/NNPA/Pass/NNPAPasses.hpp
+++ b/src/Accelerators/NNPA/Pass/NNPAPasses.hpp
@@ -22,12 +22,12 @@ namespace onnx_mlir {
 /// Add pass for lowering ONNX ops to ZHigh ops.
 std::unique_ptr<mlir::Pass> createONNXToZHighPass();
 std::unique_ptr<mlir::Pass> createONNXToZHighPass(
-    mlir::ArrayRef<std::string> execNodesOnCpu);
+    mlir::ArrayRef<std::string> execNodesOnCpu, bool useCostModel);
 
 /// Add pass for rewriting ONNX ops for ZHigh.
 std::unique_ptr<mlir::Pass> createRewriteONNXForZHighPass();
 std::unique_ptr<mlir::Pass> createRewriteONNXForZHighPass(
-    mlir::ArrayRef<std::string> execNodesOnCpu);
+    mlir::ArrayRef<std::string> execNodesOnCpu, bool useCostModel);
 
 /// Add pass for re-construct ONNX ops from ZHigh ops.
 std::unique_ptr<mlir::Pass> createZHighToONNXPass();

--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -92,6 +92,8 @@ endif()
 # instruction name is added after test case name in each test case.
 set(NNPA_TEST_LIST
 
+    # When changing ==xxx== annotations, please run `make onnx_mlir_supported_ops`
+    # to re-actualize our support md pages. 
     # ==ARCH== NNPA
     # ==ADDITIONAL_PARAGRAPH== NNPA has hardware limitations in dimension index size and tensor size, which are described in [NNPALimit.h](../src/Accelerators/NNPA/Conversion/ONNXToZHigh/NNPALimit.h). They are large enough for normal use cases, but if your model exceeds the limitations, CPU is used instead of NNPA.
 

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -74,6 +74,8 @@ def get_test_models():
         # Elementary ops, ordered in the order they are found in
         # onnx-mlir/third_party/onnx/onnx/backend/test/case/node.
 
+        # When changing ==xxx== annotations, please run `make onnx_mlir_supported_ops`
+        # to re-actualize our support md pages. 
         # ==ARCH== cpu
 
         # ==OP== Abs


### PR DESCRIPTION
Using Cedric's cost model to make a first approximation at only migrating to zAIU the ops that appears to be beneficial according to that cost model.

Enables using the `-enable-zhigh-cost-model` flag.