### PR TITLE
Expand const prop lit test with short shape operand

### DIFF
--- a/test/mlir/onnx/onnx_constprop.mlir
+++ b/test/mlir/onnx/onnx_constprop.mlir
@@ -1618,6 +1618,22 @@ func.func @test_expand_broadcast() -> tensor<*xf32> {
 
 // -----
 
+// Expand's shape can be shorter than the data input shape.
+func.func @test_expand_2_broadcast() -> tensor<*xf32> {
+  %0 = onnx.Constant dense<[[[1.0], [3.0], [5.0]]]> : tensor<1x3x1xf32>
+  %1 = onnx.Constant dense<[1, 2]> : tensor<2xi64>
+  %2 = "onnx.Expand"(%0, %1) : (tensor<1x3x1xf32>, tensor<2xi64>) -> tensor<*xf32>
+  "onnx.Return"(%2) : (tensor<*xf32>) -> ()
+
+  // CHECK-LABEL:  func.func @test_expand_2_broadcast
+  // CHECK-SAME:   () -> tensor<1x3x2xf32> {
+  // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<{{.}}{{.}}[1.000000e+00, 1.000000e+00], [3.000000e+00, 3.000000e+00], [5.000000e+00, 5.000000e+00]{{.}}{{.}}> : tensor<1x3x2xf32>
+  // CHECK:           onnx.Return [[VAR_0_]] : tensor<1x3x2xf32>
+  // CHECK:         }
+}
+
+// -----
+
 func.func @test_gather_axis_0() -> tensor<*xf32>{
   %0 = onnx.Constant dense<[[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]]> : tensor<3x2xf32>
   %1 = onnx.Constant dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>


### PR DESCRIPTION
To remind that Expand's shape can be shorter than the data input shape.
