### PR TITLE
fix f16 onnx.BatchNormalizationInferenceMode canonicalization

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -411,7 +411,11 @@ ArrayAttr createArrayAttrFromConstantOp(ONNXConstantOp constOp) {
 DenseElementsAttr createDenseElementsAttrFromFloatAttr(
     PatternRewriter &rewriter, Type elementType, FloatAttr attr) {
   auto tensorType = RankedTensorType::get({1}, elementType);
-  return DenseElementsAttr::get(tensorType, {attr.getValue()});
+  auto ftype = cast<FloatType>(elementType);
+  APFloat f = attr.getValue();
+  bool ignored;
+  f.convert(ftype.getFloatSemantics(), APFloat::rmNearestTiesToEven, &ignored);
+  return DenseElementsAttr::get(tensorType, {f});
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
new lit test test_rewrite_batchnormtestmode_1d_f16 crashed in createDenseElementsAttrFromFloatAttr because DenseElementsAttr::get(t, apfloat) wants apfloat to have the semantics of t's element type

createDenseElementsAttrFromFloatAttr was called on the result element type and `$epsilon` in the RewriteBatchNormInferenceModeConvPattern1 pattern