### PR TITLE
replace ONNXOpTransformPass with hybrid transform

### DIFF
--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -68,8 +68,6 @@ std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();
 /// Pass that combines multiple ONNX dialect transformations,
 /// including shape inference.
 std::unique_ptr<mlir::Pass> createONNXHybridTransformPass();
-std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
-    bool enableConvOpt, bool enableSimdDataLayoutOpt = false);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -68,6 +68,8 @@ std::unique_ptr<mlir::Pass> createStandardFuncReturnPass();
 /// Pass that combines multiple ONNX dialect transformations,
 /// including shape inference.
 std::unique_ptr<mlir::Pass> createONNXHybridTransformPass();
+std::unique_ptr<mlir::Pass> createONNXHybridTransformPass(
+    bool enableConvOpt, bool enableSimdDataLayoutOpt = false);
 
 /// Pass for analyzing unknown dimension in ONNX operations.
 std::unique_ptr<mlir::Pass> createONNXDimAnalysisPass();

--- a/src/Transform/ONNX/ConvOpt.cpp
+++ b/src/Transform/ONNX/ConvOpt.cpp
@@ -213,7 +213,7 @@ struct Conv1x1ToMatmulPattern : public ConversionPattern {
 } // namespace
 
 void onnx_mlir::getConvOptONNXToONNXPatterns(
-    RewritePatternSet &patterns, bool enableSimdDataLayoutOpt) {
+    bool enableSimdDataLayoutOpt, RewritePatternSet &patterns) {
   // TODO: if enable simd layout opt, we still need to determine how 1x1 and
   // simd layout interact. Right now, only enable the one or the other. Will
   // need to refine this later.
@@ -280,7 +280,7 @@ void ConvOptONNXToONNXPass::runOnOperation() {
   });
 
   RewritePatternSet patterns(context);
-  onnx_mlir::getConvOptONNXToONNXPatterns(patterns, enableSimdDataLayoutOpt);
+  onnx_mlir::getConvOptONNXToONNXPatterns(enableSimdDataLayoutOpt, patterns);
 
   if (failed(applyPartialConversion(function, target, std::move(patterns))))
     signalPassFailure();

--- a/src/Transform/ONNX/ConvOpt.hpp
+++ b/src/Transform/ONNX/ConvOpt.hpp
@@ -9,6 +9,7 @@
 namespace onnx_mlir {
 
 // Exports the ConvOptONNXToONNXPass patterns.
-void getConvOptONNXToONNXPatterns(mlir::RewritePatternSet &patterns, bool enableSimdDataLayoutOpt);
+void getConvOptONNXToONNXPatterns(
+    bool enableSimdDataLayoutOpt, mlir::RewritePatternSet &patterns);
 
 } // namespace onnx_mlir

--- a/src/Transform/ONNX/ConvOpt.hpp
+++ b/src/Transform/ONNX/ConvOpt.hpp
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace onnx_mlir {
+
+// Exports the ConvOptONNXToONNXPass patterns.
+void getConvOptONNXToONNXPatterns(mlir::RewritePatternSet &patterns, bool enableSimdDataLayoutOpt);
+
+} // namespace onnx_mlir

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -138,7 +138,7 @@ struct ONNXHybridTransformPass
     if (failed(applyPatternsAndFoldGreedily(body, patterns, config))) {
       llvm::errs() << "Warning: onnx-hybrid-transform didn't converge with "
                       "max-num-rewrites="
-                   << maxNumRewrites << "\n";
+                   << maxNumRewrites.getValue() << "\n";
     }
 
     inferFunctionReturnShapes(f);

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -68,11 +68,11 @@ struct ONNXHybridTransformPass
       llvm::cl::desc("Enable decomposition in hybrid transform"),
       llvm::cl::init(true)};
 
-  Option<bool> enableConvOpt{*this, "enable-conv-opt",
+  Option<bool> convOpt{*this, "conv-opt",
       llvm::cl::desc("Enable convolution optimization for CPU"),
       llvm::cl::init(false)};
 
-  Option<bool> enableSimdDataLayoutOpt{*this, "simd-data-layout",
+  Option<bool> simdDataLayout{*this, "simd-data-layout",
       llvm::cl::desc("Enable SIMD data layout optimizations"),
       llvm::cl::init(false)};
 
@@ -90,8 +90,8 @@ struct ONNXHybridTransformPass
   }
 
   ONNXHybridTransformPass(bool enableConvOpt, bool enableSimdDataLayoutOpt) {
-    this->enableConvOpt = enableConvOpt;
-    this->enableSimdDataLayoutOpt = enableSimdDataLayoutOpt;
+    this->convOpt = enableConvOpt;
+    this->simdDataLayout = enableSimdDataLayoutOpt;
   }
 
   StringRef getArgument() const override { return "onnx-hybrid-transform"; }
@@ -119,8 +119,8 @@ struct ONNXHybridTransformPass
       getDecomposeONNXToONNXPatterns(cumulativePatterns);
     }
 
-    if (enableConvOpt) {
-      getConvOptONNXToONNXPatterns(enableSimdDataLayoutOpt, cumulativePatterns);
+    if (convOpt) {
+      getConvOptONNXToONNXPatterns(simdDataLayout, cumulativePatterns);
     }
 
     patterns = FrozenRewritePatternSet(std::move(cumulativePatterns));

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -68,14 +68,6 @@ struct ONNXHybridTransformPass
       llvm::cl::desc("Enable decomposition in hybrid transform"),
       llvm::cl::init(true)};
 
-  Option<bool> convOpt{*this, "conv-opt",
-      llvm::cl::desc("Enable convolution optimization for CPU"),
-      llvm::cl::init(false)};
-
-  Option<bool> simdDataLayout{*this, "simd-data-layout",
-      llvm::cl::desc("Enable SIMD data layout optimizations"),
-      llvm::cl::init(false)};
-
   Option<int> maxNumRewrites{*this, "max-num-rewrites",
       llvm::cl::desc("Limit the number of rewrites. -1 means no limit."),
       llvm::cl::init(300)};
@@ -87,11 +79,6 @@ struct ONNXHybridTransformPass
   ONNXHybridTransformPass(const ONNXHybridTransformPass &pass)
       : patterns(pass.patterns) {
     copyOptionValuesFrom(&pass);
-  }
-
-  ONNXHybridTransformPass(bool enableConvOpt, bool enableSimdDataLayoutOpt) {
-    this->convOpt = enableConvOpt;
-    this->simdDataLayout = enableSimdDataLayoutOpt;
   }
 
   StringRef getArgument() const override { return "onnx-hybrid-transform"; }
@@ -119,10 +106,6 @@ struct ONNXHybridTransformPass
       getDecomposeONNXToONNXPatterns(cumulativePatterns);
     }
 
-    if (convOpt) {
-      getConvOptONNXToONNXPatterns(simdDataLayout, cumulativePatterns);
-    }
-
     patterns = FrozenRewritePatternSet(std::move(cumulativePatterns));
     return success();
   }
@@ -148,10 +131,5 @@ struct ONNXHybridTransformPass
 } // namespace
 
 std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass() {
-  return std::make_unique<ONNXHybridTransformPass>();
-}
-
-std::unique_ptr<mlir::Pass> onnx_mlir::createONNXHybridTransformPass(
-    bool enableConvOpt, bool enableSimdDataLayoutOpt) {
   return std::make_unique<ONNXHybridTransformPass>();
 }

--- a/src/Transform/ONNX/ONNXHybridTransformPass.cpp
+++ b/src/Transform/ONNX/ONNXHybridTransformPass.cpp
@@ -124,8 +124,6 @@ struct ONNXHybridTransformPass
   }
 
   void runOnOperation() override {
-    // TODO: check if it's necessary to skip functions with names not
-    // ending in "main_graph" (see ShapeInferencePass.cpp)
     func::FuncOp f = getOperation();
     Region &body = f.getBody();
 

--- a/test/mlir/onnx/onnx_hybrid_transform.mlir
+++ b/test/mlir/onnx/onnx_hybrid_transform.mlir
@@ -1,6 +1,7 @@
-// RUN: onnx-mlir-opt  -onnx-hybrid-transform="constant-propagation=false decomposition=false" %s | FileCheck %s
-// RUN: onnx-mlir-opt  -onnx-hybrid-transform=constant-propagation=false %s | FileCheck --check-prefix=DECOMPOSE %s
-// RUN: onnx-mlir-opt  -onnx-hybrid-transform=decomposition=false %s | FileCheck --check-prefix=CONSTPROP %s
+// RUN: onnx-mlir-opt -onnx-hybrid-transform="constant-propagation=false decomposition=false" %s | FileCheck %s
+// RUN: onnx-mlir-opt -onnx-hybrid-transform=constant-propagation=false %s | FileCheck --check-prefix=DECOMPOSE %s
+// RUN: onnx-mlir-opt -onnx-hybrid-transform=decomposition=false %s | FileCheck --check-prefix=CONSTPROP %s
+// RUN: onnx-mlir-opt -onnx-hybrid-transform=max-num-rewrites=1 %s 2>&1 | FileCheck --check-prefix=LIMIT %s
 
 // Illustrates the back and forth between shape inference and the
 // BinaryOpBroadcastAxisPattern canonicalization pattern:
@@ -332,3 +333,6 @@ func.func @test_inception_v2_6_snippet(%arg0: tensor<1x3x224x224xf32>, %arg1: te
 // CONSTPROP:           [[VAR_34_:%.+]] = "onnx.Relu"([[VAR_33_]]) : (tensor<1x64x28x28xf32>) -> tensor<1x64x28x28xf32>
 // CONSTPROP:           return [[VAR_34_]] : tensor<1x64x28x28xf32>
 // CONSTPROP:         }
+
+// LIMIT: Warning: onnx-hybrid-transform didn't converge with max-num-rewrites=1
+// LIMIT-LABEL:  func.func @test_inception_v2_6_snippet

--- a/test/mlir/onnx/onnx_hybrid_transform.mlir
+++ b/test/mlir/onnx/onnx_hybrid_transform.mlir
@@ -1,7 +1,7 @@
 // RUN: onnx-mlir-opt -onnx-hybrid-transform="constant-propagation=false decomposition=false" %s | FileCheck %s
 // RUN: onnx-mlir-opt -onnx-hybrid-transform=constant-propagation=false %s | FileCheck --check-prefix=DECOMPOSE %s
 // RUN: onnx-mlir-opt -onnx-hybrid-transform=decomposition=false %s | FileCheck --check-prefix=CONSTPROP %s
-// RUN: onnx-mlir-opt -onnx-hybrid-transform=max-num-rewrites=1 %s 2>&1 | FileCheck --check-prefix=LIMIT %s
+// RUN: onnx-mlir-opt -onnx-hybrid-transform="max-num-rewrites-offset=1 max-num-rewrites-multiplier=0" %s 2>&1 | FileCheck --check-prefix=LIMIT %s
 
 // Illustrates the back and forth between shape inference and the
 // BinaryOpBroadcastAxisPattern canonicalization pattern:
@@ -334,5 +334,5 @@ func.func @test_inception_v2_6_snippet(%arg0: tensor<1x3x224x224xf32>, %arg1: te
 // CONSTPROP:           return [[VAR_34_]] : tensor<1x64x28x28xf32>
 // CONSTPROP:         }
 
-// LIMIT: Warning: onnx-hybrid-transform didn't converge with max-num-rewrites=1
+// LIMIT: Warning: onnx-hybrid-transform didn't converge with max-num-rewrites-offset=1, max-num-rewrites-multiplier=0.000000e+00
 // LIMIT-LABEL:  func.func @test_inception_v2_6_snippet


### PR DESCRIPTION
replaces ONNXOpTransformPass and the repeatOnnxTransform loop in addONNXToMLIRPasses() with hybrid transform, unless disabled with `--onnx-hybrid-pass=false`

set maxNumRewrites in onnx-hybrid-transform to 300 and tested that the model https://huggingface.co/xlnet-large-cased succeeds without warning with this value

prints warning to stderr if onnx-hybrid-transform doesn't converge with the given maxNumRewrites

I tested this PR on the models in the model zoo and the same models passed and failed as with main

possible future work:
- replace const-prop, shape-inference, canonicalizer passes in SimplifyShapeRelatedOpsPass with hybrid transform
- replace some shape-inference/const-prop/canonicalizer passes in addONNXToZHighPasses() with hybrid transform