### PR TITLE
avoid infinite verify() recursion in Diagnostic

### DIFF
--- a/src/Support/Diagnostic.cpp
+++ b/src/Support/Diagnostic.cpp
@@ -92,7 +92,10 @@ LogicalResult Diagnostic::emitDimensionHasUnexpectedValueError(Operation &op,
 std::string Diagnostic::getName(Value &v) {
   std::string str;
   llvm::raw_string_ostream os(str);
-  v.print(os);
+  // print without calling verify() on v's defining op to
+  // avoid infinite recursion when getName() is called from an emit
+  // method called from verify()
+  v.print(os, OpPrintingFlags().assumeVerified());
   return str;
 }
 


### PR DESCRIPTION
I looked into the model zoo ssd_mobilenet_v1_10 segfault and found it was because of infinite recursion when trying to emit an error in ONNXConcatOp::verify()

I didn't 100% understand how the infinite recursion happened but the workaround in this PR fixed it and it now fails with
```
loc("Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat"): error: onnx.Concat: operand '%8071 = "onnx.Expand"(%14, %8070) : (tensor<f32>, tensor<1xi64>) -> tensor<?xf32>' has rank 1, rank should be 2
loc("Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat"): error: 'onnx.Concat' op verification failed
loc("Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat"): error: onnx.Concat: operand '%7691 = "onnx.Expand"(%17, %7690) : (tensor<f32>, tensor<1xi64>) -> tensor<?xf32>' has rank 1, rank should be 2
loc("Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat"): error: 'onnx.Concat' op verification failed
loc("Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat"): error: onnx.Concat: operand '%7691 = "onnx.Expand"(%17, %7690) : (tensor<f32>, tensor<1xi64>) -> tensor<?xf32>' has rank 1, rank should be 2
```