### PR TITLE
Update SupportedONNXOps-NNPA.md to include the correct command

### DIFF
--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -83,9 +83,15 @@ add_custom_target(onnx-mlir-docs)
 function(add_onnx_mlir_supported_ops input_file arch)
   set(GEN_DOC_FILE ${ONNX_MLIR_SRC_ROOT}/docs/SupportedONNXOps-${arch}.md)
   set(supported_ops_cmd ${Python3_EXECUTABLE} ${ONNX_MLIR_SRC_ROOT}/utils/documentOps.py -a ${arch} -i ${input_file} -p ${ONNX_MLIR_SRC_ROOT}/utils)
+  # For generating docs/SupportedONNXOps-NNPA.md we only want to use the "--notes" flag to bypass unnecessary content. 
+  set(FLAG --notes --unsupported)
+  if (${arch} STREQUAL "NNPA")
+    unset(FLAG)
+    set(FLAG --notes)
+  endif()
   add_custom_command(
     OUTPUT ${GEN_DOC_FILE} 
-    COMMAND ${supported_ops_cmd}  --notes --unsupported > ${GEN_DOC_FILE}
+    COMMAND ${supported_ops_cmd} ${FLAG} > ${GEN_DOC_FILE}
     DEPENDS ${input_file})
   add_custom_target(onnx_mlir_supported_ops_${arch} DEPENDS ${GEN_DOC_FILE})
   add_dependencies(onnx_mlir_supported_ops onnx_mlir_supported_ops_${arch})

--- a/docs/SupportedONNXOps-NNPA.md
+++ b/docs/SupportedONNXOps-NNPA.md
@@ -1,5 +1,5 @@
 <!--- Automatically generated, do not edit. -->
-<!--- python3 documentOps.py --arch NNPA --input ../test/accelerators/NNPA/backend/CMakeLists.txt --path . --notes -->
+<!--- To update, run `make onnx_mlir_supported_ops_NNPA' -->
 
 # Supported ONNX Operation for Target *NNPA*.
 

--- a/docs/SupportedONNXOps-NNPA.md
+++ b/docs/SupportedONNXOps-NNPA.md
@@ -1,5 +1,5 @@
 <!--- Automatically generated, do not edit. -->
-<!--- To update, run `make onnx_mlir_supported_ops` -->
+<!--- python3 documentOps.py --arch NNPA --input ../test/accelerators/NNPA/backend/CMakeLists.txt --path . --notes -->
 
 # Supported ONNX Operation for Target *NNPA*.
 

--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -1,5 +1,5 @@
 <!--- Automatically generated, do not edit. -->
-<!--- To update, run `make onnx_mlir_supported_ops` -->
+<!--- To update, run `make onnx_mlir_supported_ops_cpu' -->
 
 # Supported ONNX Operation for Target *cpu*.
 

--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -187,7 +187,7 @@ set(NNPA_TEST_LIST
 
     # ==OP== GRU
     # ==MIN== 7
-    # ==LIM== - `direction` and `hidden_size` in `W` must have static dimensions.<br>- `R` must have static dimensions.<br>- If `B` and `initial_h` are given, they must have static dimensions.<br>- `sequence_lens` is not supported.<br>- `activations` must be `["Sigmoid", "Tanh", "Tanh"]`.<br>- `clip` is not supported.<br>- `linear_before_reset` must be 1.<br>- `layout` is not supported.
+    # ==LIM== - `direction` and `hidden_size` in `W` must have static dimensions.<br>- `R` must have static dimensions.<br>- If `B` and `initial_h` are given, they must have static dimensions.<br>- `sequence_lens` is not supported for bidirectional GRU.<br>- `activations` must be `["Sigmoid", "Tanh", "Tanh"]`.<br>- `clip` is not supported.<br>- `linear_before_reset` must be 1.<br>- `layout` is not supported.
     # test_gru_defaults_cpu
     # test_gru_seq_length_cpu
     # test_gru_with_initial_bias_cpu

--- a/utils/documentOps.py
+++ b/utils/documentOps.py
@@ -205,7 +205,7 @@ def print_row(array):
 def print_md():
     # Header.
     print("<!--- Automatically generated, do not edit. -->")
-    print("<!--- To update, run `make onnx_mlir_supported_ops` -->")
+    print("<!--- To update, run `make onnx_mlir_supported_ops_"+ target_arch +"' -->")
     # Title
     print("\n# Supported ONNX Operation for Target *" + target_arch + "*.\n")
     # Top paragraph.

--- a/utils/documentOps.py
+++ b/utils/documentOps.py
@@ -205,7 +205,7 @@ def print_row(array):
 def print_md():
     # Header.
     print("<!--- Automatically generated, do not edit. -->")
-    print("<!--- To update, run `make onnx_mlir_supported_ops_"+ target_arch +"' -->")
+    print("<!--- To update, run `make onnx_mlir_supported_ops_" + target_arch + "' -->")
     # Title
     print("\n# Supported ONNX Operation for Target *" + target_arch + "*.\n")
     # Top paragraph.


### PR DESCRIPTION
It seems like when the documentation was being updated, the command to generate the `SupportedONNXOps-NNPA.md` was accidentally switched with `onnx_mlir_supported_ops`. The `onnx_mlir_supported_ops` only updates the `SupportedONNXOps-CPU.md` file. So when issuing the command, I received the incorrect results for the `NNPA` documentation. Changing it back to what it originally was :) 