### PR TITLE
Add missing python file to CMakeLists.txt

### DIFF
--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -19,6 +19,11 @@ file(GENERATE
   )
 
 file(GENERATE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/onnxmlir_node_tests.py
+  INPUT ${ONNX_BACKENDTEST_SRC_DIR}/onnxmlir_node_tests.py
+  )
+
+file(GENERATE
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/signature_backend.py
   INPUT ${ONNX_BACKENDTEST_SRC_DIR}/signature_backend.py
   )


### PR DESCRIPTION
When issuing the `check-onnx-backend-nnpa` or `check-onnx-numerical-nnpa` I get the following error:

```
===================================================== ERRORS ======================================================
_________________________________________ ERROR collecting Debug/test.py __________________________________________
ImportError while importing test module '/workdir/onnx-mlir/build/test/accelerators/NNPA/backend/Debug/test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
Debug/test.py:35: in <module>
    from inference_backend import (
Debug/inference_backend.py:29: in <module>
    from onnxmlir_node_tests import load_onnxmlir_node_tests
E   ModuleNotFoundError: No module named 'onnxmlir_node_tests'
------------------------------------------------- Captured stderr -------------------------------------------------
  targeting maccel: NNPA
============================================= short test summary info =============================================
 Debug/test.py
1 error in 0.57s
gmake[3]: *** [test/accelerators/NNPA/backend/CMakeFiles/check-onnx-backend-nnpa.dir/build.make:71: test/accelerators/NNPA/backend/CMakeFiles/check-onnx-backend-nnpa] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:19694: test/accelerators/NNPA/backend/CMakeFiles/check-onnx-backend-nnpa.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:19701: test/accelerators/NNPA/backend/CMakeFiles/check-onnx-backend-nnpa.dir/rule] Error 2
gmake: *** [Makefile:7199: check-onnx-backend-nnpa] Error 2
```