### PR TITLE
[NNPA] Call ScrubDisposablePass before ZHighConstPropagation

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -115,7 +115,7 @@ void addONNXToZHighPasses(mlir::PassManager &pm) {
   }
 
   // Replace every DisposableElementsAttr with DenseElementsAttr.
-  // ZHighConstPropagationPass currently assumes that DenseElementsAttr is used.
+  // ZHighConstPropagation currently assumes that DenseElementsAttr is used.
   pm.addPass(createScrubDisposablePass());
 
   // Constant propagation at ZHighIR: constant stickify.


### PR DESCRIPTION
Since `ZHighConstPropagation` currently works with `DenseElementAttr` only, call `ScrubDisposablePass` to replace any `DisposableElementsAttr` with `DenseElementsAttr` before calling `ZHighConstPropagation`.