### PR TITLE
Handle empty tensor from SliceOp in SimplifyShapeRelatedOps

### DIFF
--- a/src/Transform/ONNX/SimplifyShapeRelatedOps.cpp
+++ b/src/Transform/ONNX/SimplifyShapeRelatedOps.cpp
@@ -321,6 +321,10 @@ public:
       // step = 0 (invalid).
       return failure();
 
+    if (indices.size() == 0)
+      // Empty result
+      return failure();
+
     // Replace SliceOp by ConcatOp of specific dimensions.
     SmallVector<Value, 4> dims;
     getDims(input, dims);


### PR DESCRIPTION
In Llama-2-Onnx-7-32. there is SliceOp generates empty tensor, namely tensor<0xi64>. Such SliceOp cannot be replaced with DimOp, unless we introduce empty dim.
```
    %801 = "onnx.Shape"(%713) {onnx_node_name = "/transformer/block_list.0/attention/Shape_47", start = 0 : si64} : (tensor<*xf32>) -> tensor<?xi64>
    %802 = onnx.Constant dense<0> : tensor<1xi64>
    %803 = onnx.Constant dense<4> : tensor<1xi64>
    %804 = onnx.Constant dense<9223372036854775807> : tensor<1xi64>
    %805 = "onnx.NoValue"() {value} : () -> none
    %806 = "onnx.Slice"(%801, %803, %804, %802, %805) {onnx_node_name = "/transformer/block_list.0/attention/Slice_22"} : (tensor<?xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, none) -> tensor<?xi64>
     %807 = "onnx.Concat"(%763, %806) {axis = 0 : si64, onnx_node_name = "/transformer/block_list.0/attention/Concat_11"} : (tensor<4xi64>, tensor<?xi64>) -> tensor<?xi64>
```
The actually shape of %801  is <4xi64>.  Therefore, the result of slice is empty.
For future, we could add folding on Concat of empty tensor.