### PR TITLE
Add --mcpu flag to ensure NNPA backend tests are executing

### DIFF
--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -360,7 +360,7 @@ foreach(test_name IN LISTS NNPA_TEST_LIST)
   set(ENV_TEST_CASE_BY_USER "${ENV_TEST_CASE_BY_USER} ${test_name}")
 endforeach()
 
-set(NNPA_TESTS_ENVS TEST_MACCEL=NNPA TEST_CASE_BY_USER=${ENV_TEST_CASE_BY_USER} TEST_ATOL=0.01 TEST_RTOL=0.05)
+set(NNPA_TESTS_ENVS TEST_MCPU=z16 TEST_MACCEL=NNPA TEST_CASE_BY_USER=${ENV_TEST_CASE_BY_USER} TEST_ATOL=0.01 TEST_RTOL=0.05)
 
 # ${ONNX_HOME} is the directory where onnx downloads real model files.
 # Model files are saved under ${ONNX_HOME}/models/model_name/model.onnx.

--- a/test/accelerators/NNPA/numerical/CMakeLists.txt
+++ b/test/accelerators/NNPA/numerical/CMakeLists.txt
@@ -41,7 +41,7 @@ function(add_numerical_test test_name)
 
   # Optimization level set by ONNX_MLIR_TEST_OPTLEVEL, defaults to 3
   add_test(NAME ${test_name}
-    COMMAND ${test_name} -O${ONNX_MLIR_TEST_OPTLEVEL} --maccel=NNPA
+    COMMAND ${test_name} -O${ONNX_MLIR_TEST_OPTLEVEL} --mcpu=z16 --maccel=NNPA
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   set_tests_properties(${test_name} PROPERTIES LABELS numerical-nnpa)


### PR DESCRIPTION
When testing on a z16, several backend tests were failing for NNPA because we included the `--mcpu` flag recently to check hw and so this was also missing from the backend tests. 