### PR TITLE
fix op fuse error

### DIFF
--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1613,7 +1613,8 @@ public:
   // procedureResult is the scalar value from producer
   // alloc is used to get the tensor for the producer, which is required by
   // by the shape helper.
-  Value emitFuseOps(Value producerResult, Value alloc, ValueRange loopInd = {});
+  Value emitFuseOps(
+      Value producerResult, const Value alloc, ValueRange loopInd = {});
 
   void replaceOrEraseONNXOps(Value alloc);
 
@@ -1839,7 +1840,7 @@ MemRefType OpFusionHelper::getOutputType(MemRefType outputType) {
 
 // Emit fusion Ops
 Value OpFusionHelper::emitFuseOps(
-    Value defOpResult, Value alloc, ValueRange loopInd) {
+    Value defOpResult, const Value alloc, ValueRange loopInd) {
   if (isFusibleListEmpty())
     return defOpResult;
 
@@ -1862,8 +1863,23 @@ Value OpFusionHelper::emitFuseOps(
       if (oper.getDefiningOp() != defOp)
         useOperands.emplace_back(rewriter.getRemappedValue(oper));
       else
-        // load will not needed because of useOpResult.
-        // This value is only needed by shape helper.
+        // Due to the op fusion, we will not generate a tensor for the current
+        // oper, but only the scalar result from defOp.
+        // This scalar value cannot be used to initialize ShapeHelper.
+        // Instead, alloc is used because it has the same shape as the oper.
+        // This is one of the prerequisits for fusion.
+        // However, they may have different element type for some ops, such as
+        // comparison and cast.
+        // ONNXBroadcastOpShapeHelper cares only the shape of the operands,
+        // not the element type.
+        // In a previous implementation, the original output of defOp is used
+        // with 'alloc = defOp->getResult(0)' at the end of the loop.
+        // But ONNXBroadcastOpShapeHelper.computeShape() unexpectedly used
+        // this parameter to generate some code (memref.dim) that is not really
+        // needed. Due to this live user, the original op can not be erased.
+        // This error occurred when there were more than one op with dynamic dim
+        // to be fused in the previous implementation.
+        // Therefore, alloc is used for all the fused op.
         useOperands.emplace_back(alloc);
     }
     // Use shape helper to generate load index
@@ -1893,21 +1909,6 @@ Value OpFusionHelper::emitFuseOps(
     defOpResult =
         emitScalar(rewriter, loc, useOp, currentElementType, inputValues);
     defOp = useOp;
-
-    // Explanation:
-    // The variable, alloc, is used to initialize ONNXBroadcastOpShapeHelper.
-    // The output of defOp should have the same shape as the alloc, which is
-    // one of the prerequisits for fusion.
-    // However, they may have different element type for some ops, such as
-    // comparison and cast.
-    // The issue is that ONNXBroadcastOpShapeHelper.computeShape() may use
-    // this parameter to generate some code (memref.dim) that is not really
-    // needed here. Due to this live user, the original op can not be erased.
-    // This error occurs when there are more than one op with dynamic dim
-    // to be fused.
-    // Luckily, the ShapeHelper does not check the element type.
-    // Therefore, alloc is used for all the fused op.
-    // alloc = defOp->getResult(0);
   }
   return defOpResult;
 }

--- a/test/mlir/conversion/onnx_to_krnl/onnx_lowering_fuse.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/onnx_lowering_fuse.mlir
@@ -269,3 +269,84 @@ func.func @fuse_element_17(%arg0: tensor<?x5xf32>, %arg1: tensor<?xf32>) -> tens
 // CHECK:           return [[RES_]] : memref<?x5xf32>
 // CHECK:         }
 
+// -----
+
+func.func @fuse_element_20(%533: tensor<?x?x768xf32>, %537 : tensor<?x?x1xf32>,  %361: tensor<768xf32>, %360: tensor<768xf32>) -> tensor<?x?x768xf32> {
+    %538 = "onnx.Div"(%533, %537) : (tensor<?x?x768xf32>, tensor<?x?x1xf32>) -> tensor<?x?x768xf32>
+    %539 = "onnx.Mul"(%538, %361) : (tensor<?x?x768xf32>, tensor<768xf32>) -> tensor<?x?x768xf32>
+    %540 = "onnx.Add"(%539, %360) : (tensor<?x?x768xf32>, tensor<768xf32>) -> tensor<?x?x768xf32>
+    return %540 : tensor<?x?x768xf32>
+}
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1, s0)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5)>
+// CHECK-LABEL:  func.func @fuse_element_20
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<?x?x1xf32>, [[PARAM_2_:%.+]]: memref<768xf32>, [[PARAM_3_:%.+]]: memref<768xf32>) -> memref<?x?x768xf32> {
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x?x768xf32>
+// CHECK-DAG:       [[VAR_dim_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x768xf32>
+// CHECK-DAG:       [[VAR_dim_1_:%.+]] = memref.dim [[PARAM_1_]], [[CST_0_]] : memref<?x?x1xf32>
+// CHECK-DAG:       [[VAR_dim_2_:%.+]] = memref.dim [[PARAM_1_]], [[CST_1_]] : memref<?x?x1xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_0_:%.+]] = affine.max [[MAP_0_]](){{.}}[[VAR_dim_]], [[VAR_dim_]]_1]
+// CHECK-DAG:       [[VAR_1_:%.+]] = affine.max [[MAP_0_]](){{.}}[[VAR_dim_0_]], [[VAR_dim_2_]]{{.}}
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_0_]], [[VAR_1_]]) {{.*}}: memref<?x?x768xf32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_1_]]([[VAR_dim_]], [[VAR_dim_]]_1, [[VAR_dim_]]_0, [[VAR_dim_]]_2, [[VAR_0_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to [[MAP_2_]]([[VAR_dim_]], [[VAR_dim_]]_1, [[VAR_dim_]]_0, [[VAR_dim_]]_2, [[VAR_0_]], [[VAR_1_]]), [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 768){
+// CHECK-DAG:         [[VAR_3_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
+// CHECK-DAG:         [[VAR_4_:%.+]] = arith.cmpi sgt, [[VAR_dim_]], [[CST_1_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.select [[VAR_4_]], [[VAR_3_]]#0, [[CST_0_]] : index
+// CHECK-DAG:         [[VAR_6_:%.+]] = arith.cmpi sgt, [[VAR_dim_0_]], [[CST_1_]] : index
+// CHECK:             [[VAR_7_:%.+]] = arith.select [[VAR_6_]], [[VAR_3_]]#1, [[CST_0_]] : index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_5_]], [[VAR_7_]], [[VAR_3_]]#2] : memref<?x?x768xf32>
+// CHECK-DAG:         [[VAR_9_:%.+]] = arith.cmpi sgt, [[VAR_dim_1_]], [[CST_1_]] : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_10_:%.+]] = arith.select [[VAR_9_]], [[VAR_3_]]#0, [[CST_0_]] : index
+// CHECK-DAG:         [[VAR_11_:%.+]] = arith.cmpi sgt, [[VAR_dim_2_]], [[CST_1_]] : index
+// CHECK:             [[VAR_12_:%.+]] = arith.select [[VAR_11_]], [[VAR_3_]]#1, [[CST_0_]] : index
+// CHECK:             [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[VAR_10_]], [[VAR_12_]], [[CST_0_]]{{.}} : memref<?x?x1xf32>
+// CHECK-DAG:         [[VAR_14_:%.+]] = arith.divf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[VAR_3_]]#2] : memref<768xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_16_:%.+]] = arith.mulf [[VAR_14_]], [[LOAD_PARAM_2_MEM_]] : f32
+// CHECK-DAG:         [[LOAD_PARAM_3_MEM_:%.+]] = krnl.load [[PARAM_3_]]{{.}}[[VAR_3_]]#2] : memref<768xf32>
+// CHECK:             [[VAR_18_:%.+]] = arith.addf [[VAR_16_]], [[LOAD_PARAM_3_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_18_]], [[RES_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1, [[VAR_3_]]#2] : memref<?x?x768xf32>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<?x?x768xf32>
+// CHECK:         }
+
+// -----
+
+func.func @test_fuse_element21(%arg0: tensor<?xf32>, %arg1: tensor<1xf32>, %arg2 : tensor<1xi8>) -> tensor<?xi8> {
+  %0 = "onnx.Pow"(%arg0, %arg1) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32> 
+  %1 = "onnx.Cast"(%0) {to = i8} : (tensor<?xf32>) -> tensor<?xi8>
+  %2 = "onnx.Add"(%1, %arg2) : (tensor<?xi8>, tensor<1xi8>) -> tensor<?xi8>
+  return %2 : tensor<?xi8>
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @test_fuse_element21
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?xf32>, [[PARAM_1_:%.+]]: memref<1xf32>, [[PARAM_2_:%.+]]: memref<1xi8>) -> memref<?xi8> {
+// CHECK:           [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK:           [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?xf32>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_dim_]]) {{.*}}: memref<?xi8>
+// CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to [[MAP_0_]]([[VAR_dim_]])){
+// CHECK:             [[VAR_1_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]{{.}} : memref<?xf32>
+// CHECK-DAG:         [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]]{{.}}[[CST_0_]]{{.}} : memref<1xf32>
+// CHECK:             [[VAR_4_:%.+]] = math.powf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.fptosi [[VAR_4_]] : f32 to i8
+// CHECK-DAG:         [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]]{{.}}[[CST_0_]]{{.}} : memref<1xi8>
+// CHECK:             [[VAR_7_:%.+]] = arith.addi [[VAR_5_]], [[LOAD_PARAM_2_MEM_]] : i8
+// CHECK:             krnl.store [[VAR_7_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<?xi8>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<?xi8>
+// CHECK:         }
+
+


### PR DESCRIPTION
Op fuse use ONNXBroadcastOpShapeHelper to generate access expression. However, memref.dim, which is not needed, is also generated. 
Details explanation can be found in the code.
More test cases are added.