### PR TITLE
[NNPA] Not using either in tablegen

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -217,8 +217,8 @@ def replaceONNXDivPattern : Pat<
   (addBenefit 0)
 >;
 
-def replaceONNXDivBroadcastPattern : Pat<
-  (ONNXDivOp (either $x, $y)),
+def replaceONNXDivBroadcastPattern1 : Pat<
+  (ONNXDivOp $x, $y),
   (ZHighUnstickOp
     (ZHighDivOp
       (ZHighStickOp:$s_x $x, (NoneLayoutAttr)),
@@ -228,6 +228,20 @@ def replaceONNXDivBroadcastPattern : Pat<
         (NoneLayoutAttr)),
       (returnType $s_x))),
   [(IsF32ScalarConstantTensor $y)], [],
+  (addBenefit 1)
+>;
+
+def replaceONNXDivBroadcastPattern2 : Pat<
+  (ONNXDivOp $x, $y),
+  (ZHighUnstickOp
+    (ZHighDivOp
+      (ZHighStickifiedConstantOfShapeOp
+        (GetDynShape $y),
+        (GetScalarF32AttrFromConstant $x),
+        (NoneLayoutAttr)),
+      (ZHighStickOp:$s_y $y, (NoneLayoutAttr)),
+      (returnType $s_y))),
+  [(IsF32ScalarConstantTensor $x)], [],
   (addBenefit 1)
 >;
 

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/div.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/div.mlir
@@ -33,12 +33,12 @@ func.func @test_div_3ds(%arg0 : tensor<10x10x10xf32>, %arg1 : tensor<10x10x10xf3
 // -----
 
 // COM: Division by a scalar in case of dynamic dimensions.
-func.func @test_div_unknown_scalar(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
+func.func @test_div_unknown_scalar1(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = onnx.Constant dense<8.000000e+00> : tensor<f32>
   %1 = "onnx.Div"(%arg0, %0) : (tensor<?x10xf32>, tensor<f32>) -> tensor<*xf32>
   "func.return"(%1) : (tensor<*xf32>) -> ()
 
-// CHECK-LABEL:  func.func @test_div_unknown_scalar
+// CHECK-LABEL:  func.func @test_div_unknown_scalar1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x10xf32>) -> tensor<?x10xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<8.000000e+00> : tensor<f32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "2D"} : (tensor<?x10xf32>) -> tensor<?x10xf32, #zhigh.layout<{dataLayout = "2D"}>>
@@ -47,6 +47,28 @@ func.func @test_div_unknown_scalar(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 // CHECK:           [[VAR_4_:%.+]] = "onnx.Concat"([[VAR_2_]], [[VAR_3_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
 // CHECK:           [[VAR_5_:%.+]] = "zhigh.StickifiedConstantOfShape"([[VAR_4_]]) {layout = "2D", value = 8.000000e+00 : f32} : (tensor<2xi64>) -> tensor<?x?xf32, #zhigh.layout<{dataLayout = "2D"}>>
 // CHECK:           [[VAR_6_:%.+]] = "zhigh.Div"([[VAR_1_]], [[VAR_5_]]) : (tensor<?x10xf32, #zhigh.layout<{dataLayout = "2D"}>>, tensor<?x?xf32, #zhigh.layout<{dataLayout = "2D"}>>) -> tensor<?x10xf32, #zhigh.layout<{dataLayout = "2D"}>>
+// CHECK:           [[VAR_7_:%.+]] = "zhigh.Unstick"([[VAR_6_]]) : (tensor<?x10xf32, #zhigh.layout<{dataLayout = "2D"}>>) -> tensor<?x10xf32>
+// CHECK:           return [[VAR_7_]] : tensor<?x10xf32>
+// CHECK:         }
+}
+
+// -----
+
+// COM: Division by a scalar in case of dynamic dimensions.
+func.func @test_div_unknown_scalar2(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
+  %0 = onnx.Constant dense<8.000000e+00> : tensor<f32>
+  %1 = "onnx.Div"(%0, %arg0) : (tensor<f32>, tensor<?x10xf32>) -> tensor<*xf32>
+  "func.return"(%1) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_div_unknown_scalar2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x10xf32>) -> tensor<?x10xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<8.000000e+00> : tensor<f32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 0 : si64} : (tensor<?x10xf32>) -> tensor<1xi64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 1 : si64} : (tensor<?x10xf32>) -> tensor<1xi64>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Concat"([[VAR_1_]], [[VAR_2_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// CHECK-DAG:       [[VAR_4_:%.+]] = "zhigh.StickifiedConstantOfShape"([[VAR_3_]]) {layout = "2D", value = 8.000000e+00 : f32} : (tensor<2xi64>) -> tensor<?x?xf32, #zhigh.layout<{dataLayout = "2D"}>>
+// CHECK-DAG:       [[VAR_5_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "2D"} : (tensor<?x10xf32>) -> tensor<?x10xf32, #zhigh.layout<{dataLayout = "2D"}>>
+// CHECK:           [[VAR_6_:%.+]] = "zhigh.Div"([[VAR_4_]], [[VAR_5_]]) : (tensor<?x?xf32, #zhigh.layout<{dataLayout = "2D"}>>, tensor<?x10xf32, #zhigh.layout<{dataLayout = "2D"}>>) -> tensor<?x10xf32, #zhigh.layout<{dataLayout = "2D"}>>
 // CHECK:           [[VAR_7_:%.+]] = "zhigh.Unstick"([[VAR_6_]]) : (tensor<?x10xf32, #zhigh.layout<{dataLayout = "2D"}>>) -> tensor<?x10xf32>
 // CHECK:           return [[VAR_7_]] : tensor<?x10xf32>
 // CHECK:         }

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -671,7 +671,7 @@ def main():
         # Use the generated shared library to create an execution session.
         print("Loading the compiled model ...")
         start = time.perf_counter()
-        sess = OMExecutionSession(shared_lib_path, tag="None")
+        sess = OMExecutionSession(shared_lib_path)
         end = time.perf_counter()
         print("  took ", end - start, " seconds.\n")
 

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -671,7 +671,7 @@ def main():
         # Use the generated shared library to create an execution session.
         print("Loading the compiled model ...")
         start = time.perf_counter()
-        sess = OMExecutionSession(shared_lib_path)
+        sess = OMExecutionSession(shared_lib_path, tag="None")
         end = time.perf_counter()
         print("  took ", end - start, " seconds.\n")
 


### PR DESCRIPTION
I was trying to use `either` keyword in tablegen for operations to avoid writing two patterns with swapped operands for lowering ONNXDiv to ZHigh, but it seems it did not work as expected.
So this patch removes `either` keyword and explicitly defines two patterns.