### PR TITLE
Import dim_param for model inputs and outputs

### DIFF
--- a/docs/LocationInfo.md
+++ b/docs/LocationInfo.md
@@ -72,9 +72,9 @@ Then location info can be found in the output of test_add.onnx.onnx.mlir
 The test_add.onnx.mlir content:
 
 ```
-  1 module attributes {llvm.data_layout = "e-m:o-p270:32:32-p271:32:32-p    272:64:64-i64:64-f80:128-n8:16:32:64-S128", llvm.target_triple = "x8    6_64-apple-darwin22.3.0", "onnx-mlir.symbol-postfix" = "test_add"} {
-  2   func.func @main_graph(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x    5xf32>) -> tensor<3x4x5xf32> attributes {input_names = ["x", "y"], o    utput_names = ["sum"]} {
-  3     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5    xf32>) -> tensor<3x4x5xf32>
+  1 module attributes {llvm.data_layout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-apple-darwin22.3.0", "onnx-mlir.symbol-postfix" = "test_add"} {
+  2   func.func @main_graph(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
+  3     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
   4     onnx.Return %0 : tensor<3x4x5xf32>
   5   }
   6   "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -316,7 +316,7 @@ $gdb Debug/bin/run-onnx-lib
 (gdb) run ./test_add.so
 (gdb) list
 1	builtin.module  {
-2	  builtin.func @main_graph(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+2	  builtin.func @main_graph(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
 3	    %0 = "onnx.Add"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
 4	    return %0 : tensor<3x4x5xf32>
 5	  }

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -500,7 +500,6 @@ private:
         std::string dimParam = "";
         Type argTy = ImportType(input.type(), dimParam);
         argTy = modelInputShaper_.reshape(inputIndex, argTy);
-        llvm::outs() << "input dim: " << dimParam << "\n";
         inputDimParams.emplace_back(dimParam);
 
         argTypes.emplace_back(argTy);
@@ -549,7 +548,6 @@ private:
     for (const auto &output : graph.output()) {
       std::string dimParam = "";
       ImportOutputTensor(output, retTys, retVals, dimParam);
-      llvm::outs() << "output dim: " << dimParam << "\n";
       outputDimParams.emplace_back(dimParam);
     }
 

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1455,9 +1455,9 @@ private:
     // Move function attributes for argument/result names and dim_params into
     // argument/result attributes.
     moveFuncAttrsToArgAttrs(mainFunc, {"input_names", "input_dim_params"},
-        {"onnx.names", "onnx.dim_params"}, /*isArg=*/true);
+        {"onnx.name", "onnx.dim_params"}, /*isArg=*/true);
     moveFuncAttrsToArgAttrs(mainFunc, {"output_names", "output_dim_params"},
-        {"onnx.names", "onnx.dim_params"}, /*isArg=*/false);
+        {"onnx.name", "onnx.dim_params"}, /*isArg=*/false);
 
     // Emit entry point op describing inference function signature.
     auto entryPoint = ONNXEntryPointOp::create(UnknownLoc(), mainFunc);

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -131,8 +131,8 @@ private:
       StringAttr inputName = b.getStringAttr({"input_" + std::to_string(i)});
       if (argAttrs) {
         DictionaryAttr dictAttrs = llvm::dyn_cast<DictionaryAttr>(argAttrs[i]);
-        if (dictAttrs && dictAttrs.contains("onnx.names"))
-          inputName = dictAttrs.getNamed("onnx.names")
+        if (dictAttrs && dictAttrs.contains("onnx.name"))
+          inputName = dictAttrs.getNamed("onnx.name")
                           .value()
                           .getValue()
                           .cast<StringAttr>();
@@ -150,8 +150,8 @@ private:
       StringAttr outputName = b.getStringAttr({"output_" + std::to_string(i)});
       if (argAttrs) {
         DictionaryAttr dictAttrs = llvm::dyn_cast<DictionaryAttr>(resAttrs[i]);
-        if (dictAttrs && dictAttrs.contains("onnx.names"))
-          outputName = dictAttrs.getNamed("onnx.names")
+        if (dictAttrs && dictAttrs.contains("onnx.name"))
+          outputName = dictAttrs.getNamed("onnx.name")
                            .value()
                            .getValue()
                            .cast<StringAttr>();

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -118,33 +118,9 @@ private:
     parsingFailure = false;
     auto inputs = funcType.getInputs();
     auto outputs = funcType.getResults();
-
-    ArrayAttr inputNames = op->getAttrOfType<ArrayAttr>("input_names");
-    if (!inputNames) {
-      SmallVector<StringRef, 4> names;
-      for (uint64_t i = 0; i < inputs.size(); ++i)
-        names.emplace_back(StringRef("input_" + std::to_string(i)));
-      inputNames = b.getStrArrayAttr(names);
-    } else if (inputNames.size() != inputs.size()) {
-      llvm::errs()
-          << "Please ensure that the 'input_name' function attribute has "
-             "the same number of names as function parameters.";
-      parsingFailure = true;
-      return "";
-    }
-    ArrayAttr outputNames = op->getAttrOfType<ArrayAttr>("output_names");
-    if (!outputNames) {
-      SmallVector<StringRef, 4> names;
-      for (uint64_t i = 0; i < outputs.size(); ++i)
-        names.emplace_back(StringRef("output_" + std::to_string(i)));
-      outputNames = b.getStrArrayAttr(names);
-    } else if (outputNames.size() != outputs.size()) {
-      llvm::errs()
-          << "Please ensure that the 'output_name' function attribute has "
-             "the same number of names as function results.";
-      parsingFailure = true;
-      return "";
-    }
+    auto funcOp = dyn_cast_or_null<func::FuncOp>(op);
+    ArrayAttr argAttrs = funcOp.getArgAttrsAttr();
+    ArrayAttr resAttrs = funcOp.getResAttrsAttr();
 
     std::string dString;
     llvm::raw_string_ostream dstream(dString);
@@ -152,7 +128,16 @@ private:
     std::string comma = std::string("");
     for (unsigned int i = 0; i < funcType.getNumInputs(); i++) {
       dstream << comma;
-      concatTypeString(inputs[i], inputNames[i], dstream);
+      StringAttr inputName = b.getStringAttr({"input_" + std::to_string(i)});
+      if (argAttrs) {
+        DictionaryAttr dictAttrs = llvm::dyn_cast<DictionaryAttr>(argAttrs[i]);
+        if (dictAttrs && dictAttrs.contains("onnx.names"))
+          inputName = dictAttrs.getNamed("onnx.names")
+                          .value()
+                          .getValue()
+                          .cast<StringAttr>();
+      }
+      concatTypeString(inputs[i], inputName, dstream);
       comma = std::string(" , ");
     }
     dstream << "\n]";
@@ -162,7 +147,16 @@ private:
     comma = std::string("");
     for (unsigned int i = 0; i < funcType.getNumResults(); i++) {
       dstream << comma;
-      concatTypeString(outputs[i], outputNames[i], dstream);
+      StringAttr outputName = b.getStringAttr({"output_" + std::to_string(i)});
+      if (argAttrs) {
+        DictionaryAttr dictAttrs = llvm::dyn_cast<DictionaryAttr>(resAttrs[i]);
+        if (dictAttrs && dictAttrs.contains("onnx.names"))
+          outputName = dictAttrs.getNamed("onnx.names")
+                           .value()
+                           .getValue()
+                           .cast<StringAttr>();
+      }
+      concatTypeString(outputs[i], outputName, dstream);
       comma = std::string(" , ");
     }
     dstream << "\n]";

--- a/test/mlir/accelerators/nnpa/conversion/device-placement/device_placement_pass.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/device-placement/device_placement_pass.mlir
@@ -1,7 +1,7 @@
 // RUN: onnx-mlir-opt --device-placement --mcpu=z16 --maccel=NNPA --split-input-file %s | FileCheck %s
 
 module attributes {llvm.data_layout = "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64", llvm.target_triple = "s390x-ibm-linux", "onnx-mlir.symbol-postfix" = "model"} {
-  func.func @mnist(%arg0: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> attributes {input_names = ["Input3"], output_names = ["Plus214_Output_0"]} {
+  func.func @mnist(%arg0: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> {
     %0 = onnx.Constant dense<[-0.0822488219, -0.108868778, -0.141039595, -0.204869166, -0.17913565, -0.215438381, -0.133805066, -0.195724562, -0.268250644, -0.258212209, -0.0761560649, 0.0132841459, -0.00444464432, -0.414740831, -0.17879115, -0.0386558883]> : tensor<16xf32>
     %1 = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
     %2 = onnx.Constant dense_resource<__elided__> : tensor<16x4x4x10xf32>
@@ -25,7 +25,7 @@ module attributes {llvm.data_layout = "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @mnist
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> attributes {input_names = ["Input3"], output_names = ["Plus214_Output_0"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-0.0822488219, -0.108868778, -0.141039595, -0.204869166, -0.17913565, -0.215438381, -0.133805066, -0.195724562, -0.268250644, -0.258212209, -0.0761560649, 0.0132841459, -0.00444464432, -0.414740831, -0.17879115, -0.0386558883]> : tensor<16xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense_resource<__elided__> : tensor<16x4x4x10xf32>

--- a/test/mlir/accelerators/nnpa/conversion/device-placement/device_placement_pass_perf_model.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/device-placement/device_placement_pass_perf_model.mlir
@@ -2,13 +2,13 @@
 // -----
 
 // Shape is such that this op is nearly guaranteed to be faster on CPU.
-func.func @add_cpu(%arg0: tensor<1024x32x1xf32>) -> tensor<1024x32x1xf32> attributes {input_names = ["x"], output_names = ["output"]} {
+func.func @add_cpu(%arg0: tensor<1024x32x1xf32>) -> tensor<1024x32x1xf32> {
   %0 = "onnx.Add"(%arg0, %arg0) : (tensor<1024x32x1xf32>, tensor<1024x32x1xf32>) -> tensor<1024x32x1xf32>
   return %0 : tensor<1024x32x1xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @add_cpu
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1024x32x1xf32>) -> tensor<1024x32x1xf32> attributes {input_names = ["x"], output_names = ["output"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1024x32x1xf32>) -> tensor<1024x32x1xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_0_]]) {device = "cpu"} : (tensor<1024x32x1xf32>, tensor<1024x32x1xf32>) -> tensor<1024x32x1xf32>
 // CHECK:           return [[VAR_0_]] : tensor<1024x32x1xf32>
 // CHECK:         }
@@ -18,13 +18,13 @@ func.func @add_cpu(%arg0: tensor<1024x32x1xf32>) -> tensor<1024x32x1xf32> attrib
 
 // Shape is such that this op is nearly guaranteed to be faster on NNPA; so no device="cpu" here.
 
-func.func @matmul_nnpa(%arg0: tensor<1024x1024x1024xf32>) -> tensor<1024x1024x1024xf32> attributes {input_names = ["x"], output_names = ["output"]} {
+func.func @matmul_nnpa(%arg0: tensor<1024x1024x1024xf32>) -> tensor<1024x1024x1024xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg0) : (tensor<1024x1024x1024xf32>, tensor<1024x1024x1024xf32>) -> tensor<1024x1024x1024xf32>
   return %0 : tensor<1024x1024x1024xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @matmul_nnpa
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1024x1024x1024xf32>) -> tensor<1024x1024x1024xf32> attributes {input_names = ["x"], output_names = ["output"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1024x1024x1024xf32>) -> tensor<1024x1024x1024xf32> {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_0_]]) {device = "nnpa"} : (tensor<1024x1024x1024xf32>, tensor<1024x1024x1024xf32>) -> tensor<1024x1024x1024xf32>
 // CHECK:           return [[VAR_0_]] : tensor<1024x1024x1024xf32>
 // CHECK:         }

--- a/test/mlir/accelerators/nnpa/conversion/device-placement/emit-onnxir.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/device-placement/emit-onnxir.mlir
@@ -2,7 +2,7 @@
 // RUN: onnx-mlir --EmitONNXIR --mcpu=z16 --maccel=NNPA --disable-constant-prop=true --printIR %s | FileCheck %s
 
 module attributes {llvm.data_layout = "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64", llvm.target_triple = "s390x-ibm-linux", "onnx-mlir.symbol-postfix" = "model"} {
-  func.func @mnist(%arg0: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> attributes {input_names = ["Input3"], output_names = ["Plus214_Output_0"]} {
+  func.func @mnist(%arg0: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> {
     %0 = onnx.Constant dense<[-0.0822488219, -0.108868778, -0.141039595, -0.204869166, -0.17913565, -0.215438381, -0.133805066, -0.195724562, -0.268250644, -0.258212209, -0.0761560649, 0.0132841459, -0.00444464432, -0.414740831, -0.17879115, -0.0386558883]> : tensor<16xf32>
     %1 = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
     %2 = onnx.Constant dense_resource<__elided__> : tensor<16x4x4x10xf32>
@@ -25,7 +25,7 @@ module attributes {llvm.data_layout = "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128
   "onnx.EntryPoint"() {func = @mnist} : () -> ()
 
 // CHECK-LABEL:  func.func @mnist
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> attributes {input_names = ["Input3"], output_names = ["Plus214_Output_0"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-0.0822488219, -0.108868778, -0.141039595, -0.204869166, -0.17913565, -0.215438381, -0.133805066, -0.195724562, -0.268250644, -0.258212209, -0.0761560649, 0.0132841459, -0.00444464432, -0.414740831, -0.17879115, -0.0386558883]> : tensor<16xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense_resource<__elided__> : tensor<16x4x4x10xf32>

--- a/test/mlir/accelerators/nnpa/conversion/device-placement/emit-zhighir.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/device-placement/emit-zhighir.mlir
@@ -3,7 +3,7 @@
 
 // Note that, we intentionally add `device=cpu` into onnx.Gemm to force it run on CPU.
 module { 
-  func.func @mnist(%arg0: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> attributes {input_names = ["Input3"], output_names = ["Plus214_Output_0"]} {
+  func.func @mnist(%arg0: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> {
     %0 = onnx.Constant dense<[-0.0822488219, -0.108868778, -0.141039595, -0.204869166, -0.17913565, -0.215438381, -0.133805066, -0.195724562, -0.268250644, -0.258212209, -0.0761560649, 0.0132841459, -0.00444464432, -0.414740831, -0.17879115, -0.0386558883]> : tensor<16xf32>
     %1 = onnx.Constant dense<[-0.161539719, -0.433835655, 0.091641359, -0.0168522168, -0.0650264397, -0.131737873, 0.0204175506, -0.121110231]> : tensor<8xf32>
     %2 = onnx.Constant dense_resource<__elided__> : tensor<16x4x4x10xf32>
@@ -26,7 +26,7 @@ module {
   "onnx.EntryPoint"() {func = @mnist} : () -> ()
 
 // CHECK-LABEL:  func.func @mnist
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> attributes {input_names = ["Input3"], output_names = ["Plus214_Output_0"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x28x28xf32>) -> tensor<1x10xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense_resource<__elided__> : tensor<16x4x4x10xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense_resource<__elided__> : tensor<16x8x5x5xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense_resource<__elided__> : tensor<8x1x5x5xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Additional/EntryPoint.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Additional/EntryPoint.mlir
@@ -5,7 +5,7 @@
 
 // type: i1/bool
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi1>, %arg1: tensor<?x3xi1>) -> (tensor<?x3xi1>, tensor<?x3xi1>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+  func.func @main_graph(%arg0: tensor<?x3xi1> {onnx.names = "a"}, %arg1: tensor<?x3xi1> {onnx.names = "b"}) -> (tensor<?x3xi1> {onnx.names = "c"}, tensor<?x3xi1> {onnx.names = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi1>, tensor<?x3xi1>
   }
 // CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
@@ -16,7 +16,7 @@ module {
 
 // type: i8
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi8>, %arg1: tensor<?x3xi8>) -> (tensor<?x3xi8>, tensor<?x3xi8>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+  func.func @main_graph(%arg0: tensor<?x3xi8> {onnx.names = "a"}, %arg1: tensor<?x3xi8> {onnx.names = "b"}) -> (tensor<?x3xi8> {onnx.names = "c"}, tensor<?x3xi8> {onnx.names = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi8>, tensor<?x3xi8>
   }
 // CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
@@ -27,7 +27,7 @@ module {
 
 // type: i16
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi16>, %arg1: tensor<?x3xi16>) -> (tensor<?x3xi16>, tensor<?x3xi16>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+  func.func @main_graph(%arg0: tensor<?x3xi16> {onnx.names = "a"}, %arg1: tensor<?x3xi16> {onnx.names = "b"}) -> (tensor<?x3xi16> {onnx.names = "c"}, tensor<?x3xi16> {onnx.names = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi16>, tensor<?x3xi16>
   }
 
@@ -39,7 +39,7 @@ module {
 
 // type: i32
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi32>, %arg1: tensor<?x3xi32>) -> (tensor<?x3xi32>, tensor<?x3xi32>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+  func.func @main_graph(%arg0: tensor<?x3xi32> {onnx.names = "a"}, %arg1: tensor<?x3xi32> {onnx.names = "b"}) -> (tensor<?x3xi32> {onnx.names = "c"}, tensor<?x3xi32> {onnx.names = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi32>, tensor<?x3xi32>
   }
 
@@ -51,7 +51,7 @@ module {
 
 // type: i64
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi64>, %arg1: tensor<?x3xi64>) -> (tensor<?x3xi64>, tensor<?x3xi64>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+  func.func @main_graph(%arg0: tensor<?x3xi64> {onnx.names = "a"}, %arg1: tensor<?x3xi64> {onnx.names = "b"}) -> (tensor<?x3xi64> {onnx.names = "c"}, tensor<?x3xi64> {onnx.names = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi64>, tensor<?x3xi64>
   }
 
@@ -63,7 +63,7 @@ module {
 
 // type: f16
 module {
-  func.func @main_graph(%arg0: tensor<?x3xf16>, %arg1: tensor<?x3xf16>) -> (tensor<?x3xf16>, tensor<?x3xf16>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+  func.func @main_graph(%arg0: tensor<?x3xf16> {onnx.names = "a"}, %arg1: tensor<?x3xf16> {onnx.names = "b"}) -> (tensor<?x3xf16> {onnx.names = "c"}, tensor<?x3xf16> {onnx.names = "d"}) {
     return %arg0, %arg1 : tensor<?x3xf16>, tensor<?x3xf16>
   }
 
@@ -75,7 +75,7 @@ module {
 
 // type: f32
 module {
-  func.func @main_graph(%arg0: tensor<?x3xf32>, %arg1: tensor<?x3xf32>) -> (tensor<?x3xf32>, tensor<?x3xf32>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+  func.func @main_graph(%arg0: tensor<?x3xf32> {onnx.names = "a"}, %arg1: tensor<?x3xf32> {onnx.names = "b"}) -> (tensor<?x3xf32> {onnx.names = "c"}, tensor<?x3xf32> {onnx.names = "d"}) {
     return %arg0, %arg1 : tensor<?x3xf32>, tensor<?x3xf32>
   }
 
@@ -87,7 +87,7 @@ module {
 
 // type: f64
 module {
-  func.func @main_graph(%arg0: tensor<?x3xf64>, %arg1: tensor<?x3xf64>) -> (tensor<?x3xf64>, tensor<?x3xf64>) attributes {input_names = ["a", "b"], output_names = ["c", "d"]} {
+  func.func @main_graph(%arg0: tensor<?x3xf64> {onnx.names = "a"}, %arg1: tensor<?x3xf64> {onnx.names = "b"}) -> (tensor<?x3xf64> {onnx.names = "c"}, tensor<?x3xf64> {onnx.names = "d"}) {
     return %arg0, %arg1 : tensor<?x3xf64>, tensor<?x3xf64>
   }
 

--- a/test/mlir/conversion/onnx_to_krnl/Additional/EntryPoint.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Additional/EntryPoint.mlir
@@ -5,7 +5,7 @@
 
 // type: i1/bool
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi1> {onnx.names = "a"}, %arg1: tensor<?x3xi1> {onnx.names = "b"}) -> (tensor<?x3xi1> {onnx.names = "c"}, tensor<?x3xi1> {onnx.names = "d"}) {
+  func.func @main_graph(%arg0: tensor<?x3xi1> {onnx.name = "a"}, %arg1: tensor<?x3xi1> {onnx.name = "b"}) -> (tensor<?x3xi1> {onnx.name = "c"}, tensor<?x3xi1> {onnx.name = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi1>, tensor<?x3xi1>
   }
 // CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i1\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
@@ -16,7 +16,7 @@ module {
 
 // type: i8
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi8> {onnx.names = "a"}, %arg1: tensor<?x3xi8> {onnx.names = "b"}) -> (tensor<?x3xi8> {onnx.names = "c"}, tensor<?x3xi8> {onnx.names = "d"}) {
+  func.func @main_graph(%arg0: tensor<?x3xi8> {onnx.name = "a"}, %arg1: tensor<?x3xi8> {onnx.name = "b"}) -> (tensor<?x3xi8> {onnx.name = "c"}, tensor<?x3xi8> {onnx.name = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi8>, tensor<?x3xi8>
   }
 // CHECK: "krnl.entry_point"() {func = @main_graph, numInputs = 2 : i32, numOutputs = 2 : i32, signature = "[    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22a\22 }\0A ,    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22b\22 }\0A\0A]\00@[   { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22c\22 }\0A ,    { \22type\22 : \22i8\22 , \22dims\22 : [-1 , 3] , \22name\22 : \22d\22 }\0A\0A]\00"} : () -> ()
@@ -27,7 +27,7 @@ module {
 
 // type: i16
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi16> {onnx.names = "a"}, %arg1: tensor<?x3xi16> {onnx.names = "b"}) -> (tensor<?x3xi16> {onnx.names = "c"}, tensor<?x3xi16> {onnx.names = "d"}) {
+  func.func @main_graph(%arg0: tensor<?x3xi16> {onnx.name = "a"}, %arg1: tensor<?x3xi16> {onnx.name = "b"}) -> (tensor<?x3xi16> {onnx.name = "c"}, tensor<?x3xi16> {onnx.name = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi16>, tensor<?x3xi16>
   }
 
@@ -39,7 +39,7 @@ module {
 
 // type: i32
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi32> {onnx.names = "a"}, %arg1: tensor<?x3xi32> {onnx.names = "b"}) -> (tensor<?x3xi32> {onnx.names = "c"}, tensor<?x3xi32> {onnx.names = "d"}) {
+  func.func @main_graph(%arg0: tensor<?x3xi32> {onnx.name = "a"}, %arg1: tensor<?x3xi32> {onnx.name = "b"}) -> (tensor<?x3xi32> {onnx.name = "c"}, tensor<?x3xi32> {onnx.name = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi32>, tensor<?x3xi32>
   }
 
@@ -51,7 +51,7 @@ module {
 
 // type: i64
 module {
-  func.func @main_graph(%arg0: tensor<?x3xi64> {onnx.names = "a"}, %arg1: tensor<?x3xi64> {onnx.names = "b"}) -> (tensor<?x3xi64> {onnx.names = "c"}, tensor<?x3xi64> {onnx.names = "d"}) {
+  func.func @main_graph(%arg0: tensor<?x3xi64> {onnx.name = "a"}, %arg1: tensor<?x3xi64> {onnx.name = "b"}) -> (tensor<?x3xi64> {onnx.name = "c"}, tensor<?x3xi64> {onnx.name = "d"}) {
     return %arg0, %arg1 : tensor<?x3xi64>, tensor<?x3xi64>
   }
 
@@ -63,7 +63,7 @@ module {
 
 // type: f16
 module {
-  func.func @main_graph(%arg0: tensor<?x3xf16> {onnx.names = "a"}, %arg1: tensor<?x3xf16> {onnx.names = "b"}) -> (tensor<?x3xf16> {onnx.names = "c"}, tensor<?x3xf16> {onnx.names = "d"}) {
+  func.func @main_graph(%arg0: tensor<?x3xf16> {onnx.name = "a"}, %arg1: tensor<?x3xf16> {onnx.name = "b"}) -> (tensor<?x3xf16> {onnx.name = "c"}, tensor<?x3xf16> {onnx.name = "d"}) {
     return %arg0, %arg1 : tensor<?x3xf16>, tensor<?x3xf16>
   }
 
@@ -75,7 +75,7 @@ module {
 
 // type: f32
 module {
-  func.func @main_graph(%arg0: tensor<?x3xf32> {onnx.names = "a"}, %arg1: tensor<?x3xf32> {onnx.names = "b"}) -> (tensor<?x3xf32> {onnx.names = "c"}, tensor<?x3xf32> {onnx.names = "d"}) {
+  func.func @main_graph(%arg0: tensor<?x3xf32> {onnx.name = "a"}, %arg1: tensor<?x3xf32> {onnx.name = "b"}) -> (tensor<?x3xf32> {onnx.name = "c"}, tensor<?x3xf32> {onnx.name = "d"}) {
     return %arg0, %arg1 : tensor<?x3xf32>, tensor<?x3xf32>
   }
 
@@ -87,7 +87,7 @@ module {
 
 // type: f64
 module {
-  func.func @main_graph(%arg0: tensor<?x3xf64> {onnx.names = "a"}, %arg1: tensor<?x3xf64> {onnx.names = "b"}) -> (tensor<?x3xf64> {onnx.names = "c"}, tensor<?x3xf64> {onnx.names = "d"}) {
+  func.func @main_graph(%arg0: tensor<?x3xf64> {onnx.name = "a"}, %arg1: tensor<?x3xf64> {onnx.name = "b"}) -> (tensor<?x3xf64> {onnx.name = "c"}, tensor<?x3xf64> {onnx.name = "d"}) {
     return %arg0, %arg1 : tensor<?x3xf64>, tensor<?x3xf64>
   }
 

--- a/test/mlir/conversion/onnx_to_krnl/ControlFlow/Loop_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/ControlFlow/Loop_with_canonicalize.mlir
@@ -12,7 +12,7 @@ func.func @test_loop_tiny_yolo() -> tensor<?xi32> {
       %4 = onnx.Constant dense<1> : tensor<i32>
       %5 = "onnx.Add"(%arg2, %4) : (tensor<i32>, tensor<i32>) -> tensor<i32>
       onnx.Yield %arg1, %5, %arg2 : tensor<i1>, tensor<i32>, tensor<i32>
-    }) {input_names = ["i", "cond", "prev"], output_names = ["cond_out", "current", "range"]} : (tensor<i64>, tensor<i1>, tensor<i32>) -> (tensor<i32>, tensor<?xi32>)
+    }) : (tensor<i64>, tensor<i1>, tensor<i32>) -> (tensor<i32>, tensor<?xi32>)
     return %3#1 : tensor<?xi32>
 
 // CHECK-LABEL:  func @test_loop_tiny_yolo

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise.mlir
@@ -619,13 +619,13 @@ func.func private @test_less_broadcast(%arg0: tensor<3x4x5xf32>, %arg1: tensor<5
 // -----
 
 
-func.func private @test_clip(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func private @test_clip(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> {
   %0 = "onnx.Clip"(%arg0, %arg1, %arg2) : (tensor<3xf32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func private @test_clip
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3xf32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<f32>) -> memref<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3xf32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<f32>) -> memref<3xf32> {
 // CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<3xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
@@ -648,13 +648,13 @@ func.func private @test_clip(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: te
 
 // -----
 
-func.func private @test_clip_default_min(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func private @test_clip_default_min(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %cst, %arg2) : (tensor<3xf32>, none, tensor<f32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 
 // CHECK-LABEL: test_clip_default_min
-// CHECK-SAME:   ([[INPUT:%.+]]: memref<3xf32>, [[MIN:%.+]]: memref<f32>, [[MAX:%.+]]: memref<f32>) -> memref<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[INPUT:%.+]]: memref<3xf32>, [[MIN:%.+]]: memref<f32>, [[MAX:%.+]]: memref<f32>) -> memref<3xf32> {
 // CHECK-DAG:       [[RES:%.+]] = memref.alloc() {{.*}}: memref<3xf32>
 // CHECK-DAG:       [[LOOP_0:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_0]]) with ([[LOOP_0]] -> [[I_0:%.+]] = 0 to 3){
@@ -671,11 +671,11 @@ func.func private @test_clip_default_min(%arg0: tensor<3xf32>, %arg1: tensor<f32
 
 // -----
 
-func.func private @test_pow(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> attributes {input_names = ["x", "y"], output_names = ["z"]} {
+func.func private @test_pow(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
     %0 = "onnx.Pow"(%arg0, %arg1) : (tensor<3x4x5xf32>, tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
     return %0 : tensor<3x4x5xf32>
 // CHECK-LABEL: test_pow
-// CHECK-SAME:   ([[INPUT_:%.+]]: memref<3x4x5xf32>, [[POWER_:%.+]]: memref<3x4x5xf32>) -> memref<3x4x5xf32> attributes {input_names = ["x", "y"], output_names = ["z"]} {
+// CHECK-SAME:   ([[INPUT_:%.+]]: memref<3x4x5xf32>, [[POWER_:%.+]]: memref<3x4x5xf32>) -> memref<3x4x5xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<3x4x5xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5){

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -221,13 +221,13 @@ func.func @test_prelu_broadcast4(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x1x5xf
 
 // -----
 
-func.func @test_nonzero(%arg0: tensor<2x2xi1>) -> tensor<*xi64> attributes {input_names = ["condition"], output_names = ["result"]} {
+func.func @test_nonzero(%arg0: tensor<2x2xi1>) -> tensor<*xi64> {
     %0 = "onnx.NonZero"(%arg0) : (tensor<2x2xi1>) -> tensor<*xi64>
     return %0 : tensor<*xi64>
 
 // mlir2FileCheck.py -a'["input"]'
 // CHECK-LABEL:  func @test_nonzero
-// CHECK-SAME:   ([[INPUT_:%.+]]: memref<2x2xi1>) -> memref<2x?xi64> attributes {input_names = ["condition"], output_names = ["result"]} {
+// CHECK-SAME:   ([[INPUT_:%.+]]: memref<2x2xi1>) -> memref<2x?xi64> {
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
 // CHECK-DAG:       [[VAR_false_:%.+]] = arith.constant false
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index
@@ -425,7 +425,7 @@ func.func @round(%arg0: tensor<15xf32>) -> tensor<*xf32> {
 
 // -----
 
-func.func @roberta_partial_simd_1dim_v1(%arg0: tensor<?x?x768xf32>, %arg1: tensor<?x?x768xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_v1(%arg0: tensor<?x?x768xf32>, %arg1: tensor<?x?x768xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<?x?x768xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
@@ -434,7 +434,7 @@ func.func @roberta_partial_simd_1dim_v1(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4)>
 // CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_v1
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<?x?x768xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<?x?x768xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -471,7 +471,7 @@ func.func @roberta_partial_simd_1dim_v1(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 
 // -----
 
-func.func @roberta_partial_simd_1dim_v2(%arg0: tensor<?x?x768xf32>, %arg1: tensor<768xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_v2(%arg0: tensor<?x?x768xf32>, %arg1: tensor<768xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<768xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
@@ -479,7 +479,7 @@ func.func @roberta_partial_simd_1dim_v2(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (d1)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_v2
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<768xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<768xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -501,7 +501,7 @@ func.func @roberta_partial_simd_1dim_v2(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 
 // -----
 
-func.func @roberta_partial_simd_1dim_scalar(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_scalar(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<1xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
@@ -509,7 +509,7 @@ func.func @roberta_partial_simd_1dim_scalar(%arg0: tensor<?x?x768xf32>, %arg1: t
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (d1)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_scalar
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -533,7 +533,7 @@ func.func @roberta_partial_simd_1dim_scalar(%arg0: tensor<?x?x768xf32>, %arg1: t
 
 // has ?x? in the first 2 dims for both params
 
-func.func @roberta_partial_simd_2dim_v1(%arg0: tensor<?x?x96x8xf32>, %arg1: tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_2dim_v1(%arg0: tensor<?x?x96x8xf32>, %arg1: tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x96x8xf32>, tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32>
     return %0 : tensor<?x?x96x8xf32>
 
@@ -542,7 +542,7 @@ func.func @roberta_partial_simd_2dim_v1(%arg0: tensor<?x?x96x8xf32>, %arg1: tens
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4)>
 // CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_2dim_v1
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x?x96x8xf32>) -> memref<?x?x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x?x96x8xf32>) -> memref<?x?x96x8xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -581,7 +581,7 @@ func.func @roberta_partial_simd_2dim_v1(%arg0: tensor<?x?x96x8xf32>, %arg1: tens
 
 // has ?x2 and ?x? in the first 2 dims
 
-func.func @roberta_partial_simd_2dim_v2(%arg0: tensor<?x2x96x8xf32>, %arg1: tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_2dim_v2(%arg0: tensor<?x2x96x8xf32>, %arg1: tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x2x96x8xf32>, tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32>
     return %0 : tensor<?x?x96x8xf32>
 
@@ -589,7 +589,7 @@ func.func @roberta_partial_simd_2dim_v2(%arg0: tensor<?x2x96x8xf32>, %arg1: tens
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1, s0)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1, d2) -> (d2)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_2dim_v2
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x2x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x?x96x8xf32>) -> memref<?x2x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x2x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x?x96x8xf32>) -> memref<?x2x96x8xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -621,7 +621,7 @@ func.func @roberta_partial_simd_2dim_v2(%arg0: tensor<?x2x96x8xf32>, %arg1: tens
 
 // has ?x2 and ?x1 in the first 2 dims
 
-func.func @roberta_partial_simd_2dim_v3(%arg0: tensor<?x2x96x8xf32>, %arg1: tensor<?x1x96x8xf32>) -> tensor<?x?x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_2dim_v3(%arg0: tensor<?x2x96x8xf32>, %arg1: tensor<?x1x96x8xf32>) -> tensor<?x?x96x8xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x2x96x8xf32>, tensor<?x1x96x8xf32>) -> tensor<?x?x96x8xf32>
     return %0 : tensor<?x?x96x8xf32>
 
@@ -629,7 +629,7 @@ func.func @roberta_partial_simd_2dim_v3(%arg0: tensor<?x2x96x8xf32>, %arg1: tens
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1, s0)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1, d2) -> (d2)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_2dim_v3
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x2x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x1x96x8xf32>) -> memref<?x2x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x2x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x1x96x8xf32>) -> memref<?x2x96x8xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -655,7 +655,7 @@ func.func @roberta_partial_simd_2dim_v3(%arg0: tensor<?x2x96x8xf32>, %arg1: tens
 
 // -----
 
-func.func @roberta_partial_simd_2dim_not_0_mod_vl(%arg0: tensor<?x?x95x7xf32>, %arg1: tensor<?x?x95x7xf32>) -> tensor<?x?x95x7xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_2dim_not_0_mod_vl(%arg0: tensor<?x?x95x7xf32>, %arg1: tensor<?x?x95x7xf32>) -> tensor<?x?x95x7xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x95x7xf32>, tensor<?x?x95x7xf32>) -> tensor<?x?x95x7xf32>
     return %0 : tensor<?x?x95x7xf32>
 
@@ -664,7 +664,7 @@ func.func @roberta_partial_simd_2dim_not_0_mod_vl(%arg0: tensor<?x?x95x7xf32>, %
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4)>
 // CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_2dim_not_0_mod_vl
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x95x7xf32>, [[PARAM_1_:%.+]]: memref<?x?x95x7xf32>) -> memref<?x?x95x7xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x95x7xf32>, [[PARAM_1_:%.+]]: memref<?x?x95x7xf32>) -> memref<?x?x95x7xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -799,13 +799,13 @@ func.func @test_erf(%arg0: tensor<?x10xf32>) -> (tensor<*xf32>) attributes {} {
 
 // -----
 
-func.func @add_partial_splat(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3x1x1xf32>) -> tensor<*xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @add_partial_splat(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3x1x1xf32>) -> tensor<*xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<2x3x4x5xf32>, tensor<3x1x1xf32>) -> tensor<*xf32>
     return %0 : tensor<*xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @add_partial_splat
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3x4x5xf32>, [[PARAM_1_:%.+]]: memref<3x1x1xf32>) -> memref<2x3x4x5xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3x4x5xf32>, [[PARAM_1_:%.+]]: memref<3x1x1xf32>) -> memref<2x3x4x5xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x3x4x5xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:4 = krnl.define_loops 4

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
@@ -183,7 +183,7 @@ func.func private @test_elementwise_op_with_array_and_scalar_values_2(%arg0 : te
 // -----
 
 // SIMD for the lowest dim; possible broadcast for the top 2 dims.
-func.func @roberta_partial_simd_1dim_v1(%arg0: tensor<?x?x768xf32>, %arg1: tensor<?x?x768xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_v1(%arg0: tensor<?x?x768xf32>, %arg1: tensor<?x?x768xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<?x?x768xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
@@ -191,7 +191,7 @@ func.func @roberta_partial_simd_1dim_v1(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1, s0)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<()[s0, s1] -> (s1)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_v1
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<?x?x768xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<?x?x768xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -230,14 +230,14 @@ func.func @roberta_partial_simd_1dim_v1(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 // -----
 
 // Same as above, but now the second arg is "constant" in the top 2 dims; and thus no need for broadcast select for the top 2 either.
-func.func @roberta_partial_simd_1dim_v2(%arg0: tensor<?x?x768xf32>, %arg1: tensor<768xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_v2(%arg0: tensor<?x?x768xf32>, %arg1: tensor<768xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<768xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
 // mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_v2
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<768xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<768xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -261,14 +261,14 @@ func.func @roberta_partial_simd_1dim_v2(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 // -----
 
 // same as above, 2nd param has a useless 1 added in front.
-func.func @roberta_partial_simd_1dim_v3(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1x768xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_v3(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1x768xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<1x768xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
 // mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_v3
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x768xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x768xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -292,14 +292,14 @@ func.func @roberta_partial_simd_1dim_v3(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 // -----
 
 // same as above, 2nd param has 2 useless 1 added in front.
-func.func @roberta_partial_simd_1dim_v4(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1x1x768xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_v4(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1x1x768xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<1x1x768xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
 // mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_v4
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x1x768xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x1x768xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -323,13 +323,13 @@ func.func @roberta_partial_simd_1dim_v4(%arg0: tensor<?x?x768xf32>, %arg1: tenso
 // -----
 
 // SIMD can compute over the entire data at once for an array of dynamic dimension.
-func.func @roberta_partial_simd_1dim_tensor1(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_tensor1(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<1xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_tensor1
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_768_:%.+]] = arith.constant 768 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
@@ -368,13 +368,13 @@ func.func @roberta_partial_simd_1dim_tensor1(%arg0: tensor<?x?x768xf32>, %arg1: 
 // -----
 
 // Same as above, now two 1 dim attribute for the scalar.
-func.func @roberta_partial_simd_1dim_tensor2(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1x1xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_tensor2(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1x1xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<1x1xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_tensor2
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x1xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x1xf32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_768_:%.+]] = arith.constant 768 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
@@ -413,13 +413,13 @@ func.func @roberta_partial_simd_1dim_tensor2(%arg0: tensor<?x?x768xf32>, %arg1: 
 // -----
 
 // Same as above, now 3 ones above.
-func.func @roberta_partial_simd_1dim_tensor3(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1x1x1xf32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_tensor3(%arg0: tensor<?x?x768xf32>, %arg1: tensor<1x1x1xf32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<1x1x1xf32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_tensor3
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x1x1xf32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<1x1x1xf32>) -> memref<?x?x768xf32> 
 // CHECK-DAG:       [[CST_768_:%.+]] = arith.constant 768 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
@@ -458,13 +458,13 @@ func.func @roberta_partial_simd_1dim_tensor3(%arg0: tensor<?x?x768xf32>, %arg1: 
 // -----
 
 // Same, now with a true scalar.
-func.func @roberta_partial_simd_1dim_scalar(%arg0: tensor<?x?x768xf32>, %arg1: tensor<f32>) -> tensor<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_1dim_scalar(%arg0: tensor<?x?x768xf32>, %arg1: tensor<f32>) -> tensor<?x?x768xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x768xf32>, tensor<f32>) -> tensor<?x?x768xf32>
     return %0 : tensor<?x?x768xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @roberta_partial_simd_1dim_scalar
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<f32>) -> memref<?x?x768xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x768xf32>, [[PARAM_1_:%.+]]: memref<f32>) -> memref<?x?x768xf32> {
 // CHECK-DAG:       [[CST_768_:%.+]] = arith.constant 768 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
@@ -503,7 +503,7 @@ func.func @roberta_partial_simd_1dim_scalar(%arg0: tensor<?x?x768xf32>, %arg1: t
 // -----
 
 // has ?x? in the first 2 dims for both params; collapse of the lowest 2 dims.
-func.func @roberta_partial_simd_2dim_v1(%arg0: tensor<?x?x96x8xf32>, %arg1: tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_2dim_v1(%arg0: tensor<?x?x96x8xf32>, %arg1: tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x96x8xf32>, tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32>
     return %0 : tensor<?x?x96x8xf32>
 
@@ -511,7 +511,7 @@ func.func @roberta_partial_simd_2dim_v1(%arg0: tensor<?x?x96x8xf32>, %arg1: tens
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1, s0)>
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<()[s0, s1] -> (s1)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_2dim_v1
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x?x96x8xf32>) -> memref<?x?x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x?x96x8xf32>) -> memref<?x?x96x8xf32> {
 // CHECK-DAG:       [[CST_768_:%.+]] = arith.constant 768 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
@@ -570,14 +570,14 @@ func.func @roberta_partial_simd_2dim_v1(%arg0: tensor<?x?x96x8xf32>, %arg1: tens
 // -----
 
 // has ?x2 and ?x? in the first 2 dims
-func.func @roberta_partial_simd_2dim_v2(%arg0: tensor<?x2x96x8xf32>, %arg1: tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_2dim_v2(%arg0: tensor<?x2x96x8xf32>, %arg1: tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x2x96x8xf32>, tensor<?x?x96x8xf32>) -> tensor<?x?x96x8xf32>
     return %0 : tensor<?x?x96x8xf32>
 
 // mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1, s0)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_2dim_v2
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x2x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x?x96x8xf32>) -> memref<?x2x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x2x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x?x96x8xf32>) -> memref<?x2x96x8xf32> {
 // CHECK-DAG:       [[CST_768_:%.+]] = arith.constant 768 : index
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
@@ -629,14 +629,14 @@ func.func @roberta_partial_simd_2dim_v2(%arg0: tensor<?x2x96x8xf32>, %arg1: tens
 // -----
 
 // has ?x2 and ?x1 in the first 2 dims
-func.func @roberta_partial_simd_2dim_v3(%arg0: tensor<?x2x96x8xf32>, %arg1: tensor<?x1x96x8xf32>) -> tensor<?x?x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_2dim_v3(%arg0: tensor<?x2x96x8xf32>, %arg1: tensor<?x1x96x8xf32>) -> tensor<?x?x96x8xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x2x96x8xf32>, tensor<?x1x96x8xf32>) -> tensor<?x?x96x8xf32>
     return %0 : tensor<?x?x96x8xf32>
 
 // mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0, s1] -> (s1, s0)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_2dim_v3
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x2x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x1x96x8xf32>) -> memref<?x2x96x8xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x2x96x8xf32>, [[PARAM_1_:%.+]]: memref<?x1x96x8xf32>) -> memref<?x2x96x8xf32> {
 // CHECK-DAG:       [[CST_768_:%.+]] = arith.constant 768 : index
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
@@ -683,7 +683,7 @@ func.func @roberta_partial_simd_2dim_v3(%arg0: tensor<?x2x96x8xf32>, %arg1: tens
 // -----
 
 // Currently does partial simd only when partial simd static size is a mutiple of VL.
-func.func @roberta_partial_simd_2dim_not_0_mod_vl(%arg0: tensor<?x?x95x7xf32>, %arg1: tensor<?x?x95x7xf32>) -> tensor<?x?x95x7xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @roberta_partial_simd_2dim_not_0_mod_vl(%arg0: tensor<?x?x95x7xf32>, %arg1: tensor<?x?x95x7xf32>) -> tensor<?x?x95x7xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?x95x7xf32>, tensor<?x?x95x7xf32>) -> tensor<?x?x95x7xf32>
     return %0 : tensor<?x?x95x7xf32>
 
@@ -692,7 +692,7 @@ func.func @roberta_partial_simd_2dim_not_0_mod_vl(%arg0: tensor<?x?x95x7xf32>, %
 // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4)>
 // CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d5)>
 // CHECK-LABEL:  func.func @roberta_partial_simd_2dim_not_0_mod_vl
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x95x7xf32>, [[PARAM_1_:%.+]]: memref<?x?x95x7xf32>) -> memref<?x?x95x7xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x95x7xf32>, [[PARAM_1_:%.+]]: memref<?x?x95x7xf32>) -> memref<?x?x95x7xf32> {
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -1172,13 +1172,13 @@ func.func @test_prelu_broadcast2(%arg0: tensor<3x4x5xf32>, %arg1: tensor<1x5xf32
 // -----
 
 // case where only the lowest 2 dims are splatted.
-func.func @add_partial_splat(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3x1x1xf32>) -> tensor<*xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @add_partial_splat(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3x1x1xf32>) -> tensor<*xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<2x3x4x5xf32>, tensor<3x1x1xf32>) -> tensor<*xf32>
     return %0 : tensor<*xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @add_partial_splat
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3x4x5xf32>, [[PARAM_1_:%.+]]: memref<3x1x1xf32>) -> memref<2x3x4x5xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3x4x5xf32>, [[PARAM_1_:%.+]]: memref<3x1x1xf32>) -> memref<2x3x4x5xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_20_:%.+]] = arith.constant 20 : index
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
@@ -2141,13 +2141,13 @@ func.func private @test_ceil(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
 // -----
 
-func.func private @test_clip(%arg0: tensor<128xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<128xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func private @test_clip(%arg0: tensor<128xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<128xf32> {
   %0 = "onnx.Clip"(%arg0, %arg1, %arg2) : (tensor<128xf32>, tensor<f32>, tensor<f32>) -> tensor<128xf32>
   return %0 : tensor<128xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func private @test_clip
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<128xf32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<f32>) -> memref<128xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<128xf32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<f32>) -> memref<128xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<128xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
@@ -2172,14 +2172,14 @@ func.func private @test_clip(%arg0: tensor<128xf32>, %arg1: tensor<f32>, %arg2: 
 
 // -----
 
-func.func private @test_clip_default_min(%arg0: tensor<128xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<128xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func private @test_clip_default_min(%arg0: tensor<128xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<128xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %cst, %arg2) : (tensor<128xf32>, none, tensor<f32>) -> tensor<128xf32>
   return %0 : tensor<128xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func private @test_clip_default_min
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<128xf32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<f32>) -> memref<128xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<128xf32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<f32>) -> memref<128xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<128xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
@@ -2198,14 +2198,14 @@ func.func private @test_clip_default_min(%arg0: tensor<128xf32>, %arg1: tensor<f
 
 // -----
 
-func.func private @test_clip_default_min_int(%arg0: tensor<128xi32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<128xi32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func private @test_clip_default_min_int(%arg0: tensor<128xi32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<128xi32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %cst, %arg2) : (tensor<128xi32>, none, tensor<i32>) -> tensor<128xi32>
   return %0 : tensor<128xi32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func private @test_clip_default_min_int
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<128xi32>, [[PARAM_1_:%.+]]: memref<i32>, [[PARAM_2_:%.+]]: memref<i32>) -> memref<128xi32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<128xi32>, [[PARAM_1_:%.+]]: memref<i32>, [[PARAM_2_:%.+]]: memref<i32>) -> memref<128xi32> {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<128xi32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)

--- a/test/mlir/conversion/onnx_to_krnl/NN/Normalization_O3_SIMD_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/NN/Normalization_O3_SIMD_canonicalize.mlir
@@ -6,14 +6,14 @@
 // -----
 
 // It should make the substitution with the fast algo
-func.func @layernorm_4D_with_scale_bias(%arg0: tensor<2x64x32x8xf32>, %arg1: tensor<32x8xf32>, %arg2: tensor<32x8xf32>) -> tensor<*xf32> attributes {input_names = ["X", "S", "B"], output_names = ["LN"]} {
+func.func @layernorm_4D_with_scale_bias(%arg0: tensor<2x64x32x8xf32>, %arg1: tensor<32x8xf32>, %arg2: tensor<32x8xf32>) -> tensor<*xf32> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %arg1, %arg2) {axis = -2 : si64, epsilon = 9.99999974E-6 : f32, stash_type = 1 : si64} : (tensor<2x64x32x8xf32>, tensor<32x8xf32>, tensor<32x8xf32>) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
   onnx.Return %Y : tensor<*xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @layernorm_4D_with_scale_bias
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x64x32x8xf32>, [[PARAM_1_:%.+]]: memref<32x8xf32>, [[PARAM_2_:%.+]]: memref<32x8xf32>) -> memref<2x64x32x8xf32> attributes {input_names = ["X", "S", "B"], output_names = ["LN"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x64x32x8xf32>, [[PARAM_1_:%.+]]: memref<32x8xf32>, [[PARAM_2_:%.+]]: memref<32x8xf32>) -> memref<2x64x32x8xf32> {
 // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_:%.+]] 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
 // CHECK:           krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 128){
 // CHECK:             affine.for [[I_1_:%.+]] = 0 to 256 step 16 {
@@ -24,14 +24,14 @@ func.func @layernorm_4D_with_scale_bias(%arg0: tensor<2x64x32x8xf32>, %arg1: ten
 // -----
 
 // collapsed range is not a multiple of 4, cannot do simd
-func.func @layernorm_4D_with_scale_bias_no_SIMD(%arg0: tensor<2x64x31x3xf32>, %arg1: tensor<31x3xf32>, %arg2: tensor<31x3xf32>) -> tensor<*xf32> attributes {input_names = ["X", "S", "B"], output_names = ["LN"]} {
+func.func @layernorm_4D_with_scale_bias_no_SIMD(%arg0: tensor<2x64x31x3xf32>, %arg1: tensor<31x3xf32>, %arg2: tensor<31x3xf32>) -> tensor<*xf32> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %arg1, %arg2) {axis = -2 : si64, epsilon = 9.99999974E-6 : f32, stash_type = 1 : si64} : (tensor<2x64x31x3xf32>, tensor<31x3xf32>, tensor<31x3xf32>) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
   onnx.Return %Y : tensor<*xf32>
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @layernorm_4D_with_scale_bias_no_SIMD
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x64x31x3xf32>, [[PARAM_1_:%.+]]: memref<31x3xf32>, [[PARAM_2_:%.+]]: memref<31x3xf32>) -> memref<2x64x31x3xf32> attributes {input_names = ["X", "S", "B"], output_names = ["LN"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x64x31x3xf32>, [[PARAM_1_:%.+]]: memref<31x3xf32>, [[PARAM_2_:%.+]]: memref<31x3xf32>) -> memref<2x64x31x3xf32> {
 // CHECK:           [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 64, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 1, [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 1){
 // CHECK:           [[LOOP_1_:%.+]]:4 = krnl.define_loops 4
@@ -43,13 +43,13 @@ func.func @layernorm_4D_with_scale_bias_no_SIMD(%arg0: tensor<2x64x31x3xf32>, %a
 // -----
 
 // arg1 is defined for every outer loop, arg2 is defined for 64 of the 128 outer loops.
-func.func @layernorm_4D_with_scale_bias_with_high_dims(%arg0: tensor<2x64x32x8xf32>, %arg1: tensor<2x64x32x8xf32>, %arg2: tensor<64x32x8xf32>) -> tensor<*xf32> attributes {input_names = ["X", "S", "B"], output_names = ["LN"]} {
+func.func @layernorm_4D_with_scale_bias_with_high_dims(%arg0: tensor<2x64x32x8xf32>, %arg1: tensor<2x64x32x8xf32>, %arg2: tensor<64x32x8xf32>) -> tensor<*xf32> {
   %0 = "onnx.NoValue"() {value} : () -> none
   %Y, %Mean, %InvStdDev = "onnx.LayerNormalization"(%arg0, %arg1, %arg2) {axis = -2 : si64, epsilon = 9.99999974E-6 : f32, stash_type = 1 : si64} : (tensor<2x64x32x8xf32>, tensor<2x64x32x8xf32>, tensor<64x32x8xf32>) -> (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>)
   onnx.Return %Y : tensor<*xf32>
 
 // CHECK-LABEL:  func.func @layernorm_4D_with_scale_bias_with_high_dims
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x64x32x8xf32>, [[PARAM_1_:%.+]]: memref<2x64x32x8xf32>, [[PARAM_2_:%.+]]: memref<64x32x8xf32>) -> memref<2x64x32x8xf32> attributes {input_names = ["X", "S", "B"], output_names = ["LN"]} 
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x64x32x8xf32>, [[PARAM_1_:%.+]]: memref<2x64x32x8xf32>, [[PARAM_2_:%.+]]: memref<64x32x8xf32>) -> memref<2x64x32x8xf32> {  
 // CHECK-DAG:       [[VAR_reshape_4_:%.+]] = memref.reshape [[PARAM_1_]]([[RES_1_:%.+]]) : (memref<2x64x32x8xf32>, memref<2xindex>) -> memref<128x256xf32>
 // CHECK-DAG:       [[VAR_reshape_6_:%.+]] = memref.reshape [[PARAM_2_]]([[RES_2_:%.+]]) : (memref<64x32x8xf32>, memref<2xindex>) -> memref<64x256xf32>
 // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_:%.+]] 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)

--- a/test/mlir/conversion/onnx_to_krnl/NN/Normalization_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/NN/Normalization_with_canonicalize.mlir
@@ -3,13 +3,13 @@
 // Adding canonicalize is important here as this is the only way to check the values of the map,
 // which are otherwise before the function, and thus are hard to test.
 
-func.func @instance_norm(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>) -> tensor<2x3x4x5xf32> attributes {input_names = ["x", "s", "bias"], output_names = ["y"]} {
+func.func @instance_norm(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>) -> tensor<2x3x4x5xf32> {
   %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32} : (tensor<2x3x4x5xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x4x5xf32>
   return %0 : tensor<2x3x4x5xf32>
 
 // mlir2FileCheck.py -a'["input", "scale", "bias"]'
 // CHECK-LABEL:  func @instance_norm
-// CHECK-SAME:   ([[INPUT_:%.+]]: memref<2x3x4x5xf32>, [[SCALE_:%.+]]: memref<3xf32>, [[BIAS_:%.+]]: memref<3xf32>) -> memref<2x3x4x5xf32> attributes {input_names = ["x", "s", "bias"], output_names = ["y"]} {
+// CHECK-SAME:   ([[INPUT_:%.+]]: memref<2x3x4x5xf32>, [[SCALE_:%.+]]: memref<3xf32>, [[BIAS_:%.+]]: memref<3xf32>) -> memref<2x3x4x5xf32> {
 // CHECK-DAG:       [[CST_20_:%.+]] = arith.constant 2.000000e+01 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_0_dot_00999999977_:%.+]] = arith.constant 0.00999999977 : f32

--- a/test/mlir/conversion/onnx_to_krnl/ObjectDetection/onnx_lowering_nonmaxsuppression_op.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/ObjectDetection/onnx_lowering_nonmaxsuppression_op.mlir
@@ -177,12 +177,12 @@ func.func @test_nonmaxsuppression_center_point_box_format(%arg0: tensor<1x6x4xf3
 
 // -----
 
-func.func @test_nonmaxsuppression_flipped_coordinates(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+func.func @test_nonmaxsuppression_flipped_coordinates(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> {
   %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<1x6x4xf32>, tensor<1x1x6xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
   return %0 : tensor<?x3xi64>
 
 // CHECK-LABEL:  func @test_nonmaxsuppression_flipped_coordinates
-// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> {
 // CHECK-DAG:       [[CST_9_dot_99999993_:%.+]] = arith.constant 9.99999993E-9 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index
@@ -353,12 +353,12 @@ func.func @test_nonmaxsuppression_flipped_coordinates(%arg0: tensor<1x6x4xf32>, 
 
 // -----
 
-func.func @test_nonmaxsuppression_identical_boxes(%arg0: tensor<1x10x4xf32>, %arg1: tensor<1x1x10xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+func.func @test_nonmaxsuppression_identical_boxes(%arg0: tensor<1x10x4xf32>, %arg1: tensor<1x1x10xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> {
   %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<1x10x4xf32>, tensor<1x1x10xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
   return %0 : tensor<?x3xi64>
 
 // CHECK-LABEL:  func @test_nonmaxsuppression_identical_boxes
-// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x10x4xf32>, [[SCORES_:%.+]]: memref<1x1x10xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x10x4xf32>, [[SCORES_:%.+]]: memref<1x1x10xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> {
 // CHECK-DAG:       [[CST_9_dot_99999993_:%.+]] = arith.constant 9.99999993E-9 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index
@@ -529,12 +529,12 @@ func.func @test_nonmaxsuppression_identical_boxes(%arg0: tensor<1x10x4xf32>, %ar
 
 // -----
 
-func.func @test_nonmaxsuppression_limit_output_size(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+func.func @test_nonmaxsuppression_limit_output_size(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> {
   %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<1x6x4xf32>, tensor<1x1x6xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
   return %0 : tensor<?x3xi64>
 
 // CHECK-LABEL:  func @test_nonmaxsuppression_limit_output_size
-// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> {
 // CHECK-DAG:       [[CST_9_dot_99999993_:%.+]] = arith.constant 9.99999993E-9 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index
@@ -705,12 +705,12 @@ func.func @test_nonmaxsuppression_limit_output_size(%arg0: tensor<1x6x4xf32>, %a
 
 // -----
 
-func.func @test_nonmaxsuppression_single_box(%arg0: tensor<1x1x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+func.func @test_nonmaxsuppression_single_box(%arg0: tensor<1x1x4xf32>, %arg1: tensor<1x1x1xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> {
   %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<1x1x4xf32>, tensor<1x1x1xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
   return %0 : tensor<?x3xi64>
 
 // CHECK-LABEL:  func @test_nonmaxsuppression_single_box
-// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x1x4xf32>, [[SCORES_:%.+]]: memref<1x1x1xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x1x4xf32>, [[SCORES_:%.+]]: memref<1x1x1xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> {
 // CHECK-DAG:       [[CST_9_dot_99999993_:%.+]] = arith.constant 9.99999993E-9 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index
@@ -880,12 +880,12 @@ func.func @test_nonmaxsuppression_single_box(%arg0: tensor<1x1x4xf32>, %arg1: te
 
 // -----
 
-func.func @test_nonmaxsuppression_suppress_by_IOU(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+func.func @test_nonmaxsuppression_suppress_by_IOU(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> {
   %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<1x6x4xf32>, tensor<1x1x6xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
   return %0 : tensor<?x3xi64>
 
 // CHECK-LABEL:  func @test_nonmaxsuppression_suppress_by_IOU
-// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> {
 // CHECK-DAG:       [[CST_9_dot_99999993_:%.+]] = arith.constant 9.99999993E-9 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index
@@ -1056,12 +1056,12 @@ func.func @test_nonmaxsuppression_suppress_by_IOU(%arg0: tensor<1x6x4xf32>, %arg
 
 // -----
 
-func.func @test_nonmaxsuppression_suppress_by_IOU_and_scores(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+func.func @test_nonmaxsuppression_suppress_by_IOU_and_scores(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> {
   %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<1x6x4xf32>, tensor<1x1x6xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
   return %0 : tensor<?x3xi64>
 
 // CHECK-LABEL:  func @test_nonmaxsuppression_suppress_by_IOU_and_scores
-// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> {
 // CHECK-DAG:       [[CST_9_dot_99999993_:%.+]] = arith.constant 9.99999993E-9 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index
@@ -1232,13 +1232,13 @@ func.func @test_nonmaxsuppression_suppress_by_IOU_and_scores(%arg0: tensor<1x6x4
 
 // -----
 
-func.func @test_nonmaxsuppression_two_batches(%arg0: tensor<2x6x4xf32>, %arg1: tensor<2x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+func.func @test_nonmaxsuppression_two_batches(%arg0: tensor<2x6x4xf32>, %arg1: tensor<2x1x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> {
   %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<2x6x4xf32>, tensor<2x1x6xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
   return %0 : tensor<?x3xi64>
 
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0] -> (s0 * 2)>
 // CHECK-LABEL:  func @test_nonmaxsuppression_two_batches
-// CHECK-SAME:   ([[BOXES_:%.+]]: memref<2x6x4xf32>, [[SCORES_:%.+]]: memref<2x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+// CHECK-SAME:   ([[BOXES_:%.+]]: memref<2x6x4xf32>, [[SCORES_:%.+]]: memref<2x1x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> {
 // CHECK-DAG:       [[CST_9_dot_99999993_:%.+]] = arith.constant 9.99999993E-9 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index
@@ -1410,13 +1410,13 @@ func.func @test_nonmaxsuppression_two_batches(%arg0: tensor<2x6x4xf32>, %arg1: t
 
 // -----
 
-func.func @test_nonmaxsuppression_two_classes(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x2x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+func.func @test_nonmaxsuppression_two_classes(%arg0: tensor<1x6x4xf32>, %arg1: tensor<1x2x6xf32>, %arg2: tensor<1xi64>, %arg3: tensor<1xf32>, %arg4: tensor<1xf32>) -> tensor<?x3xi64> {
   %0 = "onnx.NonMaxSuppression"(%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<1x6x4xf32>, tensor<1x2x6xf32>, tensor<1xi64>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x3xi64>
   return %0 : tensor<?x3xi64>
 
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0] -> (s0 * 2)>
 // CHECK-LABEL:  func.func @test_nonmaxsuppression_two_classes
-// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x2x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> attributes {input_names = ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold", "score_threshold"], output_names = ["selected_indices"]} {
+// CHECK-SAME:   ([[BOXES_:%.+]]: memref<1x6x4xf32>, [[SCORES_:%.+]]: memref<1x2x6xf32>, [[MAX_OUTPUT_BOXES_PER_CLASS_:%.+]]: memref<1xi64>, [[IOU_THRESHOLD_:%.+]]: memref<1xf32>, [[SCORE_THRESHOLD_:%.+]]: memref<1xf32>) -> memref<?x3xi64> {
 // CHECK-DAG:       [[CST_9_dot_99999993_:%.+]] = arith.constant 9.99999993E-9 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : index

--- a/test/mlir/conversion/onnx_to_krnl/onnx_lowering_fuse.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/onnx_lowering_fuse.mlir
@@ -4,7 +4,7 @@
 
 // Fuse both Sqrt to Add
 
-func.func @test_fuse_element3(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @test_fuse_element3(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<1024xf32>, tensor<1024xf32>) -> tensor<1024xf32>
     %1 = "onnx.Sqrt"(%0) : (tensor<1024xf32>) -> tensor<1024xf32>
     %2 = "onnx.Sqrt"(%1) : (tensor<1024xf32>) -> tensor<1024xf32>
@@ -12,7 +12,7 @@ func.func @test_fuse_element3(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) 
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_fuse_element3
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1024xf32>, [[PARAM_1_:%.+]]: memref<1024xf32>) -> memref<1024xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1024xf32>, [[PARAM_1_:%.+]]: memref<1024xf32>) -> memref<1024xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1024xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 1024){
@@ -32,7 +32,7 @@ func.func @test_fuse_element3(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) 
 
 // Stop fusion after the first Sqrt because it has more one user
 
-func.func @test_fuse_element4(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @test_fuse_element4(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
     %0 = "onnx.Add"(%arg0, %arg1) : (tensor<1024xf32>, tensor<1024xf32>) -> tensor<1024xf32>
     %1 = "onnx.Sqrt"(%0) : (tensor<1024xf32>) -> tensor<1024xf32>
     %2 = "onnx.Sqrt"(%1) : (tensor<1024xf32>) -> tensor<1024xf32>
@@ -41,7 +41,7 @@ func.func @test_fuse_element4(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) 
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_fuse_element4
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1024xf32>, [[PARAM_1_:%.+]]: memref<1024xf32>) -> memref<1024xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1024xf32>, [[PARAM_1_:%.+]]: memref<1024xf32>) -> memref<1024xf32> {
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1024xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 1024){
@@ -77,7 +77,7 @@ func.func @test_fuse_element4(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) 
 
 // Start from unary op and dynamic
 
-func.func @test_fuse_element7(%arg0: tensor<?xf32>, %arg1: tensor<1xf32>) -> tensor<?xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+func.func @test_fuse_element7(%arg0: tensor<?xf32>, %arg1: tensor<1xf32>) -> tensor<?xf32> {
   %0 = "onnx.Pow"(%arg0, %arg1) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>
   %1 = "onnx.Sqrt"(%0) : (tensor<?xf32>) -> tensor<?xf32>
   return %1 : tensor<?xf32>
@@ -85,7 +85,7 @@ func.func @test_fuse_element7(%arg0: tensor<?xf32>, %arg1: tensor<1xf32>) -> ten
 // mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func @test_fuse_element7
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?xf32>, [[PARAM_1_:%.+]]: memref<1xf32>) -> memref<?xf32> attributes {input_names = ["x", "y"], output_names = ["sum"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?xf32>, [[PARAM_1_:%.+]]: memref<1xf32>) -> memref<?xf32> {
 // CHECK:           [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK:           [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?xf32>
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_dim_]]) {{.*}}: memref<?xf32>

--- a/test/mlir/conversion/onnx_to_stablehlo/Math/Clip.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Math/Clip.mlir
@@ -1,11 +1,10 @@
 // RUN: onnx-mlir-opt --convert-onnx-to-stablehlo --canonicalize %s -split-input-file | FileCheck %s
 
-func.func @test_clip(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func @test_clip(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> {
   %0 = "onnx.Clip"(%arg0, %arg1, %arg2) : (tensor<3xf32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 // CHECK-LABEL:  func @test_clip
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<f32>) -> tensor<3xf32>
-// CHECK-SAME:   attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<f32>) -> tensor<3xf32> {
 // CHECK-NEXT:     [[VAR_0_:%.+]] = stablehlo.clamp [[PARAM_1_]], [[PARAM_0_]], [[PARAM_2_]] : (tensor<f32>, tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
 // CHECK-NEXT:     return [[VAR_0_]] : tensor<3xf32>
 // CHECK-NEXT:   }
@@ -14,13 +13,12 @@ func.func @test_clip(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32
 // -----
 
 // Test when min is none
-func.func @test_clip_default_min_f32(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func @test_clip_default_min_f32(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %cst, %arg2) : (tensor<3xf32>, none, tensor<f32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 // CHECK-LABEL:  func @test_clip_default_min_f32
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<f32>) -> tensor<3xf32>
-// CHECK-SAME:   attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<f32>) -> tensor<3xf32> {
 // CHECK-NEXT:     [[VAR_0_:%.+]] = stablehlo.constant dense<0xFF800000> : tensor<f32>
 // CHECK-NEXT:     [[VAR_1_:%.+]] = stablehlo.clamp [[VAR_0_]], [[PARAM_0_]], [[PARAM_2_]] : (tensor<f32>, tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
 // CHECK-NEXT:     return [[VAR_1_]] : tensor<3xf32>
@@ -28,13 +26,12 @@ func.func @test_clip_default_min_f32(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %
 }
 
 // Test when min is none
-func.func @test_clip_default_min_f64(%arg0: tensor<3xf64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<3xf64> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func @test_clip_default_min_f64(%arg0: tensor<3xf64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<3xf64> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %cst, %arg2) : (tensor<3xf64>, none, tensor<f64>) -> tensor<3xf64>
   return %0 : tensor<3xf64>
 // CHECK-LABEL:  func @test_clip_default_min_f64
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf64>, [[PARAM_1_:%.+]]: tensor<f64>, [[PARAM_2_:%.+]]: tensor<f64>) -> tensor<3xf64>
-// CHECK-SAME:   attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf64>, [[PARAM_1_:%.+]]: tensor<f64>, [[PARAM_2_:%.+]]: tensor<f64>) -> tensor<3xf64> {
 // CHECK-NEXT:     [[VAR_0_:%.+]] = stablehlo.constant dense<0xFFF0000000000000> : tensor<f64>
 // CHECK-NEXT:     [[VAR_1_:%.+]] = stablehlo.clamp [[VAR_0_]], [[PARAM_0_]], [[PARAM_2_]] : (tensor<f64>, tensor<3xf64>, tensor<f64>) -> tensor<3xf64>
 // CHECK-NEXT:     return [[VAR_1_]] : tensor<3xf64>
@@ -42,13 +39,12 @@ func.func @test_clip_default_min_f64(%arg0: tensor<3xf64>, %arg1: tensor<f64>, %
 }
 
 // Test when min is none
-func.func @test_clip_default_min_i32(%arg0: tensor<3xi32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<3xi32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func @test_clip_default_min_i32(%arg0: tensor<3xi32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<3xi32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %cst, %arg2) : (tensor<3xi32>, none, tensor<i32>) -> tensor<3xi32>
   return %0 : tensor<3xi32>
 // CHECK-LABEL:  func @test_clip_default_min_i32
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xi32>, [[PARAM_1_:%.+]]: tensor<i32>, [[PARAM_2_:%.+]]: tensor<i32>) -> tensor<3xi32>
-// CHECK-SAME:   attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xi32>, [[PARAM_1_:%.+]]: tensor<i32>, [[PARAM_2_:%.+]]: tensor<i32>) -> tensor<3xi32> {
 // CHECK-NEXT:     [[VAR_0_:%.+]] = stablehlo.constant dense<-2147483648> : tensor<i32>
 // CHECK-NEXT:     [[VAR_1_:%.+]] = stablehlo.clamp [[VAR_0_]], [[PARAM_0_]], [[PARAM_2_]] : (tensor<i32>, tensor<3xi32>, tensor<i32>) -> tensor<3xi32>
 // CHECK-NEXT:     return [[VAR_1_]] : tensor<3xi32>
@@ -58,13 +54,12 @@ func.func @test_clip_default_min_i32(%arg0: tensor<3xi32>, %arg1: tensor<i32>, %
 // -----
 
 // Test when max is none
-func.func @test_clip_default_max_f32(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func @test_clip_default_max_f32(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %arg1, %cst) : (tensor<3xf32>, tensor<f32>, none) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 // CHECK-LABEL:  func @test_clip_default_max_f32
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<f32>) -> tensor<3xf32>
-// CHECK-SAME:   attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf32>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<f32>) -> tensor<3xf32> {
 // CHECK-NEXT:     [[VAR_0_:%.+]] = stablehlo.constant dense<0x7F800000> : tensor<f32>
 // CHECK-NEXT:     [[VAR_1_:%.+]] = stablehlo.clamp [[PARAM_1_]], [[PARAM_0_]], [[VAR_0_]] : (tensor<f32>, tensor<3xf32>, tensor<f32>) -> tensor<3xf32>
 // CHECK-NEXT:     return [[VAR_1_]] : tensor<3xf32>
@@ -72,13 +67,12 @@ func.func @test_clip_default_max_f32(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %
 }
 
 // Test when max is none
-func.func @test_clip_default_max_f64(%arg0: tensor<3xf64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<3xf64> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func @test_clip_default_max_f64(%arg0: tensor<3xf64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<3xf64> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %arg1, %cst) : (tensor<3xf64>, tensor<f64>, none) -> tensor<3xf64>
   return %0 : tensor<3xf64>
 // CHECK-LABEL:  func @test_clip_default_max_f64
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf64>, [[PARAM_1_:%.+]]: tensor<f64>, [[PARAM_2_:%.+]]: tensor<f64>) -> tensor<3xf64>
-// CHECK-SAME:   attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xf64>, [[PARAM_1_:%.+]]: tensor<f64>, [[PARAM_2_:%.+]]: tensor<f64>) -> tensor<3xf64> {
 // CHECK-NEXT:     [[VAR_0_:%.+]] = stablehlo.constant dense<0x7FF0000000000000> : tensor<f64>
 // CHECK-NEXT:     [[VAR_1_:%.+]] = stablehlo.clamp [[PARAM_1_]], [[PARAM_0_]], [[VAR_0_]] : (tensor<f64>, tensor<3xf64>, tensor<f64>) -> tensor<3xf64>
 // CHECK-NEXT:     return [[VAR_1_]] : tensor<3xf64>
@@ -86,13 +80,12 @@ func.func @test_clip_default_max_f64(%arg0: tensor<3xf64>, %arg1: tensor<f64>, %
 }
 
 // Test when max is none
-func.func @test_clip_default_max_i32(%arg0: tensor<3xi32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<3xi32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func @test_clip_default_max_i32(%arg0: tensor<3xi32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<3xi32> {
   %cst = "onnx.NoValue"() {value} : () -> none
   %0 = "onnx.Clip"(%arg0, %arg1, %cst) : (tensor<3xi32>, tensor<i32>, none) -> tensor<3xi32>
   return %0 : tensor<3xi32>
 // CHECK-LABEL:  func @test_clip_default_max_i32
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xi32>, [[PARAM_1_:%.+]]: tensor<i32>, [[PARAM_2_:%.+]]: tensor<i32>) -> tensor<3xi32>
-// CHECK-SAME:   attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3xi32>, [[PARAM_1_:%.+]]: tensor<i32>, [[PARAM_2_:%.+]]: tensor<i32>) -> tensor<3xi32> {
 // CHECK-NEXT:     [[VAR_0_:%.+]] = stablehlo.constant dense<2147483647> : tensor<i32>
 // CHECK-NEXT:     [[VAR_1_:%.+]] = stablehlo.clamp [[PARAM_1_]], [[PARAM_0_]], [[VAR_0_]] : (tensor<i32>, tensor<3xi32>, tensor<i32>) -> tensor<3xi32>
 // CHECK-NEXT:     return [[VAR_1_]] : tensor<3xi32>

--- a/test/mlir/onnx/functions/test_castlike_decomp.json
+++ b/test/mlir/onnx/functions/test_castlike_decomp.json
@@ -86,6 +86,9 @@
     }
   ]
 }
-// CHECK: func.func @main_graph(%arg0: tensor<3x4xf16>, %arg1: tensor<1xf32>) -> tensor<3x4xf32> attributes {input_dim_params = {{.*}}, input_names = ["input", "like"], output_dim_params = {{.*}}, output_names = ["output"]} {
-// CHECK:     %0 = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = f32} : (tensor<3x4xf16>) -> tensor<3x4xf32>
-// CHECK:     onnx.Return %0 : tensor<3x4xf32>
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf16> {onnx.names = "input"}, [[PARAM_1_:%.+]]: tensor<1xf32> {onnx.names = "like"}) -> (tensor<3x4xf32> {onnx.names = "output"}) {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 1 : si64, to = f32} : (tensor<3x4xf16>) -> tensor<3x4xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4xf32>
+// CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/functions/test_castlike_decomp.json
+++ b/test/mlir/onnx/functions/test_castlike_decomp.json
@@ -86,6 +86,6 @@
     }
   ]
 }
-// CHECK: func.func @main_graph(%arg0: tensor<3x4xf16>, %arg1: tensor<1xf32>) -> tensor<3x4xf32> attributes {input_names = ["input", "like"], output_names = ["output"]} {
+// CHECK: func.func @main_graph(%arg0: tensor<3x4xf16>, %arg1: tensor<1xf32>) -> tensor<3x4xf32> attributes {input_dim_params = {{.*}}, input_names = ["input", "like"], output_dim_params = {{.*}}, output_names = ["output"]} {
 // CHECK:     %0 = "onnx.Cast"(%arg0) {saturate = 1 : si64, to = f32} : (tensor<3x4xf16>) -> tensor<3x4xf32>
 // CHECK:     onnx.Return %0 : tensor<3x4xf32>

--- a/test/mlir/onnx/functions/test_castlike_decomp.json
+++ b/test/mlir/onnx/functions/test_castlike_decomp.json
@@ -87,7 +87,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf16> {onnx.names = "input"}, [[PARAM_1_:%.+]]: tensor<1xf32> {onnx.names = "like"}) -> (tensor<3x4xf32> {onnx.names = "output"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4xf16> {onnx.name = "input"}, [[PARAM_1_:%.+]]: tensor<1xf32> {onnx.name = "like"}) -> (tensor<3x4xf32> {onnx.name = "output"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 1 : si64, to = f32} : (tensor<3x4xf16>) -> tensor<3x4xf32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4xf32>
 // CHECK:         }

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -495,12 +495,12 @@ func.func @test_constantofshape(%arg0: tensor<?xi64>) -> tensor<*xi32> {
 
 // -----
 
-func.func @test_groupnorm(%arg0: tensor<3x4x2x2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>) -> tensor<3x4x2x2xf32> attributes {input_names = ["x", "scale", "bias"], output_names = ["y"]} {
+func.func @test_groupnorm(%arg0: tensor<3x4x2x2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>) -> tensor<3x4x2x2xf32> {
   %0 = "onnx.GroupNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32, num_groups = 2 : si64} : (tensor<3x4x2x2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<3x4x2x2xf32>
   onnx.Return %0 : tensor<3x4x2x2xf32>
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_groupnorm
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x2x2xf32>, [[PARAM_1_:%.+]]: tensor<2xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<3x4x2x2xf32> attributes {input_names = ["x", "scale", "bias"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x2x2xf32>, [[PARAM_1_:%.+]]: tensor<2xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<3x4x2x2xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[PARAM_1_]], [[VAR_0_]]) : (tensor<2xf32>, tensor<3xi64>) -> tensor<2x1x1x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Unsqueeze"([[PARAM_2_]], [[VAR_0_]]) : (tensor<2xf32>, tensor<3xi64>) -> tensor<2x1x1x1xf32>
@@ -518,11 +518,11 @@ func.func @test_groupnorm(%arg0: tensor<3x4x2x2xf32>, %arg1: tensor<2xf32>, %arg
 }
 // -----
 
-func.func @group_norm5d(%arg0: tensor<3x4x6x8x16xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>) -> tensor<3x4x6x8x16xf32> attributes {input_names = ["x", "scale", "bias"], output_names = ["y"]} {
+func.func @group_norm5d(%arg0: tensor<3x4x6x8x16xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>) -> tensor<3x4x6x8x16xf32> {
   %0 = "onnx.GroupNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32, num_groups = 2 : si64} : (tensor<3x4x6x8x16xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<3x4x6x8x16xf32>
   onnx.Return %0 : tensor<3x4x6x8x16xf32>
 // CHECK-LABEL:  func.func @group_norm5d
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x6x8x16xf32>, [[PARAM_1_:%.+]]: tensor<2xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<3x4x6x8x16xf32> attributes {input_names = ["x", "scale", "bias"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x6x8x16xf32>, [[PARAM_1_:%.+]]: tensor<2xf32>, [[PARAM_2_:%.+]]: tensor<2xf32>) -> tensor<3x4x6x8x16xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2, 3, 4]> : tensor<4xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[PARAM_1_]], [[VAR_0_]]) : (tensor<2xf32>, tensor<4xi64>) -> tensor<2x1x1x1x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Unsqueeze"([[PARAM_2_]], [[VAR_0_]]) : (tensor<2xf32>, tensor<4xi64>) -> tensor<2x1x1x1x1xf32>
@@ -541,12 +541,12 @@ func.func @group_norm5d(%arg0: tensor<3x4x6x8x16xf32>, %arg1: tensor<2xf32>, %ar
 
 // -----
 
-func.func @test_instancenorm(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> attributes {input_names = ["x", "s", "bias"], output_names = ["y"]} {
+func.func @test_instancenorm(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<3xf32>, %arg2: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> {
   %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 0.00999999977 : f32} : (tensor<2x3x4x5x6xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x4x5x6xf32>
   onnx.Return %0 : tensor<2x3x4x5x6xf32>
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_instancenorm
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5x6xf32>, [[PARAM_1_:%.+]]: tensor<3xf32>, [[PARAM_2_:%.+]]: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> attributes {input_names = ["x", "s", "bias"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5x6xf32>, [[PARAM_1_:%.+]]: tensor<3xf32>, [[PARAM_2_:%.+]]: tensor<3xf32>) -> tensor<2x3x4x5x6xf32> {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[1, 2, 3]> : tensor<3xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Unsqueeze"([[PARAM_1_]], [[VAR_0_]]) : (tensor<3xf32>, tensor<3xi64>) -> tensor<3x1x1x1xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Unsqueeze"([[PARAM_2_]], [[VAR_0_]]) : (tensor<3xf32>, tensor<3xi64>) -> tensor<3x1x1x1xf32>

--- a/test/mlir/onnx/onnx_decompose_convtranspose.mlir
+++ b/test/mlir/onnx/onnx_decompose_convtranspose.mlir
@@ -4,7 +4,7 @@
 
 // Test unit strides. Only convert weight tensor
 
-  func.func @test_convtrans_unitstrides(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3x3xf32>) -> tensor<1x2x5x5xf32> attributes {input_names = ["X", "W"], output_names = ["Y"]} {
+  func.func @test_convtrans_unitstrides(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3x3xf32>) -> tensor<1x2x5x5xf32> {
 // CHECK-LABEL:  func.func @test_convtrans_unitstrides
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x3x3xf32>, [[PARAM_1_:%.+]]: tensor<1x2x3x3xf32>)
 
@@ -39,7 +39,7 @@
 
 // Test 1d input
 
-  func.func @test_convtrans1d_unitstrides(%arg0: tensor<1x1x3xf32>, %arg1: tensor<1x2x3xf32>) -> tensor<1x2x5xf32> attributes {input_names = ["X", "W"], output_names = ["Y"]} {
+  func.func @test_convtrans1d_unitstrides(%arg0: tensor<1x1x3xf32>, %arg1: tensor<1x2x3xf32>) -> tensor<1x2x5xf32> {
 // CHECK-LABEL:  func.func @test_convtrans1d_unitstrides
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x3xf32>, [[PARAM_1_:%.+]]: tensor<1x2x3xf32>)
 
@@ -65,7 +65,7 @@
 
 // Test 3d input
 
-  func.func @test_convtrans3d_unitstrides(%arg0: tensor<1x1x3x4x5xf32>, %arg1: tensor<1x2x3x3x3xf32>) -> tensor<1x2x5x6x7xf32> attributes {input_names = ["X", "W"], output_names = ["Y"]} {
+  func.func @test_convtrans3d_unitstrides(%arg0: tensor<1x1x3x4x5xf32>, %arg1: tensor<1x2x3x3x3xf32>) -> tensor<1x2x5x6x7xf32> {
 // CHECK-LABEL:  func.func @test_convtrans3d_unitstrides
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x3x4x5xf32>, [[PARAM_1_:%.+]]: tensor<1x2x3x3x3xf32>)
 
@@ -107,7 +107,7 @@
 
 // Test non unit strides. Added pads between elements  in input data.
 
-  func.func @test_convtrans_strides(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3x3xf32>) -> tensor<1x2x7x3xf32> attributes {input_names = ["X", "W"], output_names = ["Y"]} {
+  func.func @test_convtrans_strides(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3x3xf32>) -> tensor<1x2x7x3xf32> {
 // CHECK-LABEL:  func.func @test_convtrans_strides
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x3x3xf32>, [[PARAM_1_:%.+]]: tensor<1x2x3x3xf32>)
 
@@ -167,7 +167,7 @@
 
 // Test output_padding. Additional pads are inserted after Conv op
 
-  func.func @test_convtrans_outputpadding(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3x3xf32>) -> tensor<1x2x10x8xf32> attributes {input_names = ["X", "W"], output_names = ["Y"]} {
+  func.func @test_convtrans_outputpadding(%arg0: tensor<1x1x3x3xf32>, %arg1: tensor<1x2x3x3xf32>) -> tensor<1x2x10x8xf32> {
 // CHECK-LABEL:  func.func @test_convtrans_outputpadding
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x3x3xf32>, [[PARAM_1_:%.+]]: tensor<1x2x3x3xf32>)
 
@@ -227,7 +227,7 @@
 
 // Test for unknown dimension in spatial dimensions
 
-  func.func @test_convtranspose_unknown_spatial_dim(%arg0: tensor<?x?x3x3xf32>, %arg1: tensor<?x?x3x3xf32>) -> tensor<?x?x10x8xf32> attributes {input_names = ["X", "W"], output_names = ["Y"]} {
+  func.func @test_convtranspose_unknown_spatial_dim(%arg0: tensor<?x?x3x3xf32>, %arg1: tensor<?x?x3x3xf32>) -> tensor<?x?x10x8xf32> {
 // CHECK-LABEL:  func.func @test_convtranspose_unknown_spatial_dim
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x3x3xf32>, [[PARAM_1_:%.+]]: tensor<?x?x3x3xf32>)
     %0 = "onnx.NoValue"() {value} : () -> none

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -2534,12 +2534,12 @@ func.func @test_less_unknown_dims_2(%arg0: tensor<?x?x5xf32>, %arg1: tensor<?x4x
 
 // -----
 
-func.func @test_clip2(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+func.func @test_clip2(%arg0: tensor<3xf32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<3xf32> {
   %0 = "onnx.Clip"(%arg0, %arg1, %arg2) : (tensor<3xf32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
   onnx.Return %0 : tensor<3xf32>
 
 // CHECK-LABEL:  func @test_clip2
-// CHECK-SAME:   ([[INPUT_:%.+]]: tensor<3xf32>, [[MIN_:%.+]]: tensor<f32>, [[MAX_:%.+]]: tensor<f32>) -> tensor<3xf32> attributes {input_names = ["x", "min", "max"], output_names = ["y"]} {
+// CHECK-SAME:   ([[INPUT_:%.+]]: tensor<3xf32>, [[MIN_:%.+]]: tensor<f32>, [[MAX_:%.+]]: tensor<f32>) -> tensor<3xf32> {
 // CHECK:           [[RES_:%.+]] = "onnx.Clip"([[INPUT_]], [[MIN_]], [[MAX_]]) : (tensor<3xf32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
 // CHECK:           onnx.Return [[RES_]] : tensor<3xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/dim_param.json
+++ b/test/mlir/onnx/parse/dim_param.json
@@ -1,0 +1,96 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+// dim_param.json is an onnx model that has a a single Add operations whose
+// operands and outputs use dim_param to represent unknown dimensions.
+
+// this json input is generated with utils/testing/dim_param.py
+
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32>, [[PARAM_1_:%.+]]: tensor<1x?xi64>) -> tensor<?x?xf32> attributes {input_dim_params = ["0:batch_size,1:sequence_len", "1:sequence_len"], input_names = ["X", "Y"], output_dim_params = ["0:batch_size,1:sequence_len"], output_names = ["Z"]} {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x?xf32>, tensor<1x?xi64>) -> tensor<?x?xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<?x?xf32>
+// CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+
+{
+  "irVersion": "9",
+  "producerName": "onnx-mlir",
+  "graph": {
+    "node": [
+      {
+        "input": [
+          "X",
+          "Y"
+        ],
+        "output": [
+          "Z"
+        ],
+        "opType": "Add"
+      }
+    ],
+    "name": "test-dim-param",
+    "input": [
+      {
+        "name": "X",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimParam": "batch_size"
+                },
+                {
+                  "dimParam": "sequence_len"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "Y",
+        "type": {
+          "tensorType": {
+            "elemType": 7,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "1"
+                },
+                {
+                  "dimParam": "sequence_len"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "output": [
+      {
+        "name": "Z",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimParam": "batch_size"
+                },
+                {
+                  "dimParam": "sequence_len"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "opsetImport": [
+    {
+      "version": "19"
+    }
+  ]
+}

--- a/test/mlir/onnx/parse/dim_param.json
+++ b/test/mlir/onnx/parse/dim_param.json
@@ -6,7 +6,7 @@
 // this json input is generated with utils/testing/dim_param.py
 
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32> {onnx.dim_params = "0:batch_size,1:sequence_len", onnx.names = "X"}, [[PARAM_1_:%.+]]: tensor<1x?xf32> {onnx.dim_params = "1:sequence_len", onnx.names = "Y"}) -> (tensor<?x?xf32> {onnx.dim_params = "0:batch_size,1:sequence_len", onnx.names = "Z"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32> {onnx.dim_params = "0:batch_size,1:sequence_len", onnx.name = "X"}, [[PARAM_1_:%.+]]: tensor<1x?xf32> {onnx.dim_params = "1:sequence_len", onnx.name = "Y"}) -> (tensor<?x?xf32> {onnx.dim_params = "0:batch_size,1:sequence_len", onnx.name = "Z"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x?xf32>, tensor<1x?xf32>) -> tensor<?x?xf32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<?x?xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/dim_param.json
+++ b/test/mlir/onnx/parse/dim_param.json
@@ -6,7 +6,7 @@
 // this json input is generated with utils/testing/dim_param.py
 
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32>, [[PARAM_1_:%.+]]: tensor<1x?xf32>) -> tensor<?x?xf32> attributes {input_dim_params = ["0:batch_size,1:sequence_len", "1:sequence_len"], input_names = ["X", "Y"], output_dim_params = ["0:batch_size,1:sequence_len"], output_names = ["Z"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32> {onnx.dim_params = "0:batch_size,1:sequence_len", onnx.names = "X"}, [[PARAM_1_:%.+]]: tensor<1x?xf32> {onnx.dim_params = "1:sequence_len", onnx.names = "Y"}) -> (tensor<?x?xf32> {onnx.dim_params = "0:batch_size,1:sequence_len", onnx.names = "Z"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x?xf32>, tensor<1x?xf32>) -> tensor<?x?xf32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<?x?xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/dim_param.json
+++ b/test/mlir/onnx/parse/dim_param.json
@@ -6,8 +6,8 @@
 // this json input is generated with utils/testing/dim_param.py
 
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32>, [[PARAM_1_:%.+]]: tensor<1x?xi64>) -> tensor<?x?xf32> attributes {input_dim_params = ["0:batch_size,1:sequence_len", "1:sequence_len"], input_names = ["X", "Y"], output_dim_params = ["0:batch_size,1:sequence_len"], output_names = ["Z"]} {
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x?xf32>, tensor<1x?xi64>) -> tensor<?x?xf32>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xf32>, [[PARAM_1_:%.+]]: tensor<1x?xf32>) -> tensor<?x?xf32> attributes {input_dim_params = ["0:batch_size,1:sequence_len", "1:sequence_len"], input_names = ["X", "Y"], output_dim_params = ["0:batch_size,1:sequence_len"], output_names = ["Z"]} {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x?xf32>, tensor<1x?xf32>) -> tensor<?x?xf32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<?x?xf32>
 // CHECK:         }
 // CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()
@@ -52,7 +52,7 @@
         "name": "Y",
         "type": {
           "tensorType": {
-            "elemType": 7,
+            "elemType": 1,
             "shape": {
               "dim": [
                 {

--- a/test/mlir/onnx/parse/external_data.json
+++ b/test/mlir/onnx/parse/external_data.json
@@ -608,7 +608,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
+// CHECK-SAME:   () -> (tensor<3xf32> {onnx.names = "output0"}, tensor<3xui8> {onnx.names = "output1"}, tensor<3xi8> {onnx.names = "output2"}, tensor<3xui16> {onnx.names = "output3"}, tensor<3xi16> {onnx.names = "output4"}, tensor<3xi32> {onnx.names = "output5"}, tensor<3xi64> {onnx.names = "output6"}, tensor<3xi1> {onnx.names = "output7"}, tensor<3xf16> {onnx.names = "output8"}, tensor<3xf64> {onnx.names = "output9"}, tensor<3xui32> {onnx.names = "output10"}, tensor<3xui64> {onnx.names = "output11"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>
@@ -623,3 +623,4 @@
 // CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui64>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/external_data.json
+++ b/test/mlir/onnx/parse/external_data.json
@@ -608,7 +608,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32> {onnx.names = "output0"}, tensor<3xui8> {onnx.names = "output1"}, tensor<3xi8> {onnx.names = "output2"}, tensor<3xui16> {onnx.names = "output3"}, tensor<3xi16> {onnx.names = "output4"}, tensor<3xi32> {onnx.names = "output5"}, tensor<3xi64> {onnx.names = "output6"}, tensor<3xi1> {onnx.names = "output7"}, tensor<3xf16> {onnx.names = "output8"}, tensor<3xf64> {onnx.names = "output9"}, tensor<3xui32> {onnx.names = "output10"}, tensor<3xui64> {onnx.names = "output11"}) {
+// CHECK-SAME:   () -> (tensor<3xf32> {onnx.name = "output0"}, tensor<3xui8> {onnx.name = "output1"}, tensor<3xi8> {onnx.name = "output2"}, tensor<3xui16> {onnx.name = "output3"}, tensor<3xi16> {onnx.name = "output4"}, tensor<3xi32> {onnx.name = "output5"}, tensor<3xi64> {onnx.name = "output6"}, tensor<3xi1> {onnx.name = "output7"}, tensor<3xf16> {onnx.name = "output8"}, tensor<3xf64> {onnx.name = "output9"}, tensor<3xui32> {onnx.name = "output10"}, tensor<3xui64> {onnx.name = "output11"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>

--- a/test/mlir/onnx/parse/external_data.json
+++ b/test/mlir/onnx/parse/external_data.json
@@ -608,7 +608,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_names = [], output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
+// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>

--- a/test/mlir/onnx/parse/fp16_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp16_nonraw_data.json
@@ -96,7 +96,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf16> {onnx.names = "output_f16"}, tensor<2xbf16> {onnx.names = "output_bf16"}) {
+// CHECK-SAME:   () -> (tensor<2xf16> {onnx.name = "output_f16"}, tensor<2xbf16> {onnx.name = "output_bf16"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xbf16>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>

--- a/test/mlir/onnx/parse/fp16_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp16_nonraw_data.json
@@ -96,8 +96,9 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output_f16", "output_bf16"]} {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xf16>
-// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xbf16>
+// CHECK-SAME:   () -> (tensor<2xf16> {onnx.names = "output_f16"}, tensor<2xbf16> {onnx.names = "output_bf16"}) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xbf16>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/fp16_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp16_nonraw_data.json
@@ -96,7 +96,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_names = [], output_names = ["output_f16", "output_bf16"]} {
+// CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output_f16", "output_bf16"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]>  : tensor<2xbf16>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>

--- a/test/mlir/onnx/parse/fp16_raw_data.json
+++ b/test/mlir/onnx/parse/fp16_raw_data.json
@@ -91,8 +91,9 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output_f16", "output_bf16"]} {
+// CHECK-SAME:   () -> (tensor<2xf16> {onnx.names = "output_f16"}, tensor<2xbf16> {onnx.names = "output_bf16"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xbf16>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/fp16_raw_data.json
+++ b/test/mlir/onnx/parse/fp16_raw_data.json
@@ -91,7 +91,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf16> {onnx.names = "output_f16"}, tensor<2xbf16> {onnx.names = "output_bf16"}) {
+// CHECK-SAME:   () -> (tensor<2xf16> {onnx.name = "output_f16"}, tensor<2xbf16> {onnx.name = "output_bf16"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xbf16>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>

--- a/test/mlir/onnx/parse/fp16_raw_data.json
+++ b/test/mlir/onnx/parse/fp16_raw_data.json
@@ -91,7 +91,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_names = [], output_names = ["output_f16", "output_bf16"]} {
+// CHECK-SAME:   () -> (tensor<2xf16>, tensor<2xbf16>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output_f16", "output_bf16"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xf16>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 9.984000e+03]> : tensor<2xbf16>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]] : tensor<2xf16>, tensor<2xbf16>

--- a/test/mlir/onnx/parse/fp8_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp8_nonraw_data.json
@@ -172,10 +172,11 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf8E4M3FN>, tensor<2xf8E4M3FNUZ>, tensor<2xf8E5M2>, tensor<2xf8E5M2FNUZ>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output_f8e4m3fn", "output_f8e4m3fnuz", "output_f8e5m2", "output_f8e5m2fnuz"]} {
+// CHECK-SAME:   () -> (tensor<2xf8E4M3FN> {onnx.names = "output_f8e4m3fn"}, tensor<2xf8E4M3FNUZ> {onnx.names = "output_f8e4m3fnuz"}, tensor<2xf8E5M2> {onnx.names = "output_f8e5m2"}, tensor<2xf8E5M2FNUZ> {onnx.names = "output_f8e5m2fnuz"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FN>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FNUZ>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E5M2>
 // CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E5M2FNUZ>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : tensor<2xf8E4M3FN>, tensor<2xf8E4M3FNUZ>, tensor<2xf8E5M2>, tensor<2xf8E5M2FNUZ>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/fp8_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp8_nonraw_data.json
@@ -172,7 +172,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf8E4M3FN> {onnx.names = "output_f8e4m3fn"}, tensor<2xf8E4M3FNUZ> {onnx.names = "output_f8e4m3fnuz"}, tensor<2xf8E5M2> {onnx.names = "output_f8e5m2"}, tensor<2xf8E5M2FNUZ> {onnx.names = "output_f8e5m2fnuz"}) {
+// CHECK-SAME:   () -> (tensor<2xf8E4M3FN> {onnx.name = "output_f8e4m3fn"}, tensor<2xf8E4M3FNUZ> {onnx.name = "output_f8e4m3fnuz"}, tensor<2xf8E5M2> {onnx.name = "output_f8e5m2"}, tensor<2xf8E5M2FNUZ> {onnx.name = "output_f8e5m2fnuz"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FN>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FNUZ>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E5M2>

--- a/test/mlir/onnx/parse/fp8_nonraw_data.json
+++ b/test/mlir/onnx/parse/fp8_nonraw_data.json
@@ -172,7 +172,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf8E4M3FN>, tensor<2xf8E4M3FNUZ>, tensor<2xf8E5M2>, tensor<2xf8E5M2FNUZ>) attributes {input_names = [], output_names = ["output_f8e4m3fn", "output_f8e4m3fnuz", "output_f8e5m2", "output_f8e5m2fnuz"]} {
+// CHECK-SAME:   () -> (tensor<2xf8E4M3FN>, tensor<2xf8E4M3FNUZ>, tensor<2xf8E5M2>, tensor<2xf8E5M2FNUZ>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output_f8e4m3fn", "output_f8e4m3fnuz", "output_f8e5m2", "output_f8e5m2fnuz"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FN>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FNUZ>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E5M2>

--- a/test/mlir/onnx/parse/fp8_raw_data.json
+++ b/test/mlir/onnx/parse/fp8_raw_data.json
@@ -161,7 +161,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf8E4M3FN>, tensor<2xf8E4M3FNUZ>, tensor<2xf8E5M2>, tensor<2xf8E5M2FNUZ>) attributes {input_names = [], output_names = ["output_f8e4m3fn", "output_f8e4m3fnuz", "output_f8e5m2", "output_f8e5m2fnuz"]} {
+// CHECK-SAME:   () -> (tensor<2xf8E4M3FN>, tensor<2xf8E4M3FNUZ>, tensor<2xf8E5M2>, tensor<2xf8E5M2FNUZ>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output_f8e4m3fn", "output_f8e4m3fnuz", "output_f8e5m2", "output_f8e5m2fnuz"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FN>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FNUZ>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E5M2>

--- a/test/mlir/onnx/parse/fp8_raw_data.json
+++ b/test/mlir/onnx/parse/fp8_raw_data.json
@@ -161,10 +161,11 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf8E4M3FN>, tensor<2xf8E4M3FNUZ>, tensor<2xf8E5M2>, tensor<2xf8E5M2FNUZ>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output_f8e4m3fn", "output_f8e4m3fnuz", "output_f8e5m2", "output_f8e5m2fnuz"]} {
+// CHECK-SAME:   () -> (tensor<2xf8E4M3FN> {onnx.names = "output_f8e4m3fn"}, tensor<2xf8E4M3FNUZ> {onnx.names = "output_f8e4m3fnuz"}, tensor<2xf8E5M2> {onnx.names = "output_f8e5m2"}, tensor<2xf8E5M2FNUZ> {onnx.names = "output_f8e5m2fnuz"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FN>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FNUZ>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E5M2>
 // CHECK-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E5M2FNUZ>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]] : tensor<2xf8E4M3FN>, tensor<2xf8E4M3FNUZ>, tensor<2xf8E5M2>, tensor<2xf8E5M2FNUZ>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/fp8_raw_data.json
+++ b/test/mlir/onnx/parse/fp8_raw_data.json
@@ -161,7 +161,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2xf8E4M3FN> {onnx.names = "output_f8e4m3fn"}, tensor<2xf8E4M3FNUZ> {onnx.names = "output_f8e4m3fnuz"}, tensor<2xf8E5M2> {onnx.names = "output_f8e5m2"}, tensor<2xf8E5M2FNUZ> {onnx.names = "output_f8e5m2fnuz"}) {
+// CHECK-SAME:   () -> (tensor<2xf8E4M3FN> {onnx.name = "output_f8e4m3fn"}, tensor<2xf8E4M3FNUZ> {onnx.name = "output_f8e4m3fnuz"}, tensor<2xf8E5M2> {onnx.name = "output_f8e5m2"}, tensor<2xf8E5M2FNUZ> {onnx.name = "output_f8e5m2fnuz"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FN>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E4M3FNUZ>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[-1.000000e+00, 1.920000e+02]> : tensor<2xf8E5M2>

--- a/test/mlir/onnx/parse/fun_model_test.onnxtext
+++ b/test/mlir/onnx/parse/fun_model_test.onnxtext
@@ -32,7 +32,7 @@ square (x) => (y) {
   y = Mul (x, x)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x128xf32> {onnx.dim_params = "0:N", onnx.names = "X"}, [[PARAM_1_:%.+]]: tensor<128x10xf32> {onnx.names = "W"}, [[PARAM_2_:%.+]]: tensor<10xf32> {onnx.names = "B"}) -> (tensor<?x10xf32> {onnx.dim_params = "0:N", onnx.names = "C"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x128xf32> {onnx.dim_params = "0:N", onnx.name = "X"}, [[PARAM_1_:%.+]]: tensor<128x10xf32> {onnx.name = "W"}, [[PARAM_2_:%.+]]: tensor<10xf32> {onnx.name = "B"}) -> (tensor<?x10xf32> {onnx.dim_params = "0:N", onnx.name = "C"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x128xf32>, tensor<128x10xf32>) -> tensor<?x10xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[VAR_0_]], [[PARAM_2_]]) : (tensor<?x10xf32>, tensor<10xf32>) -> tensor<?x10xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.SoftmaxV11"([[VAR_1_]]) {axis = 1 : si64} : (tensor<?x10xf32>) -> tensor<?x10xf32>

--- a/test/mlir/onnx/parse/fun_model_test.onnxtext
+++ b/test/mlir/onnx/parse/fun_model_test.onnxtext
@@ -32,10 +32,11 @@ square (x) => (y) {
   y = Mul (x, x)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x128xf32>, [[PARAM_1_:%.+]]: tensor<128x10xf32>, [[PARAM_2_:%.+]]: tensor<10xf32>) -> tensor<?x10xf32> attributes {input_dim_params = {{.*}}, input_names = ["X", "W", "B"], output_dim_params = {{.*}}, output_names = ["C"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x128xf32> {onnx.dim_params = "0:N", onnx.names = "X"}, [[PARAM_1_:%.+]]: tensor<128x10xf32> {onnx.names = "W"}, [[PARAM_2_:%.+]]: tensor<10xf32> {onnx.names = "B"}) -> (tensor<?x10xf32> {onnx.dim_params = "0:N", onnx.names = "C"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x128xf32>, tensor<128x10xf32>) -> tensor<?x10xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[VAR_0_]], [[PARAM_2_]]) : (tensor<?x10xf32>, tensor<10xf32>) -> tensor<?x10xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.SoftmaxV11"([[VAR_1_]]) {axis = 1 : si64} : (tensor<?x10xf32>) -> tensor<?x10xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[VAR_2_]], [[VAR_2_]]) : (tensor<?x10xf32>, tensor<?x10xf32>) -> tensor<?x10xf32>
 // CHECK:           onnx.Return [[VAR_3_]] : tensor<?x10xf32>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/fun_model_test.onnxtext
+++ b/test/mlir/onnx/parse/fun_model_test.onnxtext
@@ -32,7 +32,7 @@ square (x) => (y) {
   y = Mul (x, x)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x128xf32>, [[PARAM_1_:%.+]]: tensor<128x10xf32>, [[PARAM_2_:%.+]]: tensor<10xf32>) -> tensor<?x10xf32> attributes {input_names = ["X", "W", "B"], output_names = ["C"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x128xf32>, [[PARAM_1_:%.+]]: tensor<128x10xf32>, [[PARAM_2_:%.+]]: tensor<10xf32>) -> tensor<?x10xf32> attributes {input_dim_params = {{.*}}, input_names = ["X", "W", "B"], output_dim_params = {{.*}}, output_names = ["C"]} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x128xf32>, tensor<128x10xf32>) -> tensor<?x10xf32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[VAR_0_]], [[PARAM_2_]]) : (tensor<?x10xf32>, tensor<10xf32>) -> tensor<?x10xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.SoftmaxV11"([[VAR_1_]]) {axis = 1 : si64} : (tensor<?x10xf32>) -> tensor<?x10xf32>

--- a/test/mlir/onnx/parse/functiontest_attrname.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_attrname.onnxtext
@@ -20,7 +20,7 @@ myfun <s> (lx) => (ly) {
     ly = Mul (lx, df)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_dim_params = {{.*}}, input_names = ["x"], output_dim_params = {{.*}}, output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "y"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Shape"([[PARAM_0_]]) {start = 0 : si64} : (tensor<?xf32>) -> tensor<1xi64>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Cast"([[VAR_0_]]) {saturate = 1 : si64, to = f32} : (tensor<1xi64>) -> tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>

--- a/test/mlir/onnx/parse/functiontest_attrname.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_attrname.onnxtext
@@ -20,7 +20,7 @@ myfun <s> (lx) => (ly) {
     ly = Mul (lx, df)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_names = ["x"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_dim_params = {{.*}}, input_names = ["x"], output_dim_params = {{.*}}, output_names = ["y"]} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Shape"([[PARAM_0_]]) {start = 0 : si64} : (tensor<?xf32>) -> tensor<1xi64>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Cast"([[VAR_0_]]) {saturate = 1 : si64, to = f32} : (tensor<1xi64>) -> tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>

--- a/test/mlir/onnx/parse/functiontest_attrname.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_attrname.onnxtext
@@ -20,7 +20,7 @@ myfun <s> (lx) => (ly) {
     ly = Mul (lx, df)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "y"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.name = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.name = "y"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Shape"([[PARAM_0_]]) {start = 0 : si64} : (tensor<?xf32>) -> tensor<1xi64>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Cast"([[VAR_0_]]) {saturate = 1 : si64, to = f32} : (tensor<1xi64>) -> tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>

--- a/test/mlir/onnx/parse/functiontest_attrwithdefault.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_attrwithdefault.onnxtext
@@ -22,7 +22,7 @@ myfun <a: float=1.0> (x) => (y) {
     y = Add (x, x3)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_dim_params = {{.*}}, input_names = ["x"], output_dim_params = {{.*}}, output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "y"}) {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant {value_float = 2.000000e+00 : f32} : tensor<f32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.CastLike"([[VAR_0_]], [[PARAM_0_]]) {saturate = 1 : si64} : (tensor<f32>, tensor<?xf32>) -> tensor<f32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Add"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<f32>) -> tensor<?xf32>
@@ -32,3 +32,4 @@ myfun <a: float=1.0> (x) => (y) {
 // CHECK:           [[VAR_6_:%.+]] = "onnx.Add"([[VAR_2_]], [[VAR_5_]]) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
 // CHECK:           onnx.Return [[VAR_6_]] : tensor<?xf32>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/functiontest_attrwithdefault.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_attrwithdefault.onnxtext
@@ -22,7 +22,7 @@ myfun <a: float=1.0> (x) => (y) {
     y = Add (x, x3)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_names = ["x"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_dim_params = {{.*}}, input_names = ["x"], output_dim_params = {{.*}}, output_names = ["y"]} {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant {value_float = 2.000000e+00 : f32} : tensor<f32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.CastLike"([[VAR_0_]], [[PARAM_0_]]) {saturate = 1 : si64} : (tensor<f32>, tensor<?xf32>) -> tensor<f32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Add"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<f32>) -> tensor<?xf32>

--- a/test/mlir/onnx/parse/functiontest_attrwithdefault.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_attrwithdefault.onnxtext
@@ -22,7 +22,7 @@ myfun <a: float=1.0> (x) => (y) {
     y = Add (x, x3)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "y"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.name = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.name = "y"}) {
 // CHECK:           [[VAR_0_:%.+]] = onnx.Constant {value_float = 2.000000e+00 : f32} : tensor<f32>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.CastLike"([[VAR_0_]], [[PARAM_0_]]) {saturate = 1 : si64} : (tensor<f32>, tensor<?xf32>) -> tensor<f32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Add"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<f32>) -> tensor<?xf32>

--- a/test/mlir/onnx/parse/functiontest_nestedcall.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_nestedcall.onnxtext
@@ -29,10 +29,11 @@ twice (lx) => (ly) {
     ly = Mul (lx, two)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_dim_params = {{.*}}, input_names = ["x"], output_dim_params = {{.*}}, output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "y"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>
 // CHECK:           [[VAR_3_:%.+]] = "onnx.Add"([[VAR_2_]], [[VAR_0_]]) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>
 // CHECK:           onnx.Return [[VAR_3_]] : tensor<?xf32>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/functiontest_nestedcall.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_nestedcall.onnxtext
@@ -29,7 +29,7 @@ twice (lx) => (ly) {
     ly = Mul (lx, two)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.names = "y"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32> {onnx.dim_params = "0:N", onnx.name = "x"}) -> (tensor<?xf32> {onnx.dim_params = "0:N", onnx.name = "y"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>

--- a/test/mlir/onnx/parse/functiontest_nestedcall.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_nestedcall.onnxtext
@@ -29,7 +29,7 @@ twice (lx) => (ly) {
     ly = Mul (lx, two)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_names = ["x"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?xf32>) -> tensor<?xf32> attributes {input_dim_params = {{.*}}, input_names = ["x"], output_dim_params = {{.*}}, output_names = ["y"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<2.000000e+00> : tensor<1xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>

--- a/test/mlir/onnx/parse/fusedmatmul.onnxtext
+++ b/test/mlir/onnx/parse/fusedmatmul.onnxtext
@@ -19,11 +19,12 @@
 fusedmatmuller (float[2,3] lhs, float[4,3] rhs) => (float[2,4] output) {
    output = com.microsoft.FusedMatMul <alpha = 0.125, transA = 0, transB = 1> (lhs, rhs)
 }
-// CHECK-LABEL: func.func @main_graph
-// CHECK-SAME:  ([[PARAM_0_:%.+]]: tensor<2x3xf32>, [[PARAM_1_:%.+]]: tensor<4x3xf32>) -> tensor<2x4xf32> {{.*}} {
-// CHECK:         [[VAR_0_:%.+]] = onnx.Constant dense<1.250000e-01> : tensor<1xf32>
-// CHECK:         [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {onnx_node_name = {{.*}}, perm = [1, 0]} : (tensor<4x3xf32>) -> tensor<3x4xf32>
-// CHECK:         [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) {onnx_node_name = {{.*}}} : (tensor<2x3xf32>, tensor<3x4xf32>) -> tensor<2x4xf32>
-// CHECK:         [[VAR_3_:%.+]] = "onnx.Mul"([[VAR_2_]], [[VAR_0_]]) {onnx_node_name = {{.*}}} : (tensor<2x4xf32>, tensor<1xf32>) -> tensor<2x4xf32>
-// CHECK:         return [[VAR_3_]] : tensor<2x4xf32>
-// CHECK:       }
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3xf32> {onnx.names = "lhs"}, [[PARAM_1_:%.+]]: tensor<4x3xf32> {onnx.names = "rhs"}) -> (tensor<2x4xf32> {onnx.names = "output"}) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.250000e-01> : tensor<1xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {onnx_node_name = "onnx.Transpose_0", perm = [1, 0]} : (tensor<4x3xf32>) -> tensor<3x4xf32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) {onnx_node_name = "onnx.MatMul_1"} : (tensor<2x3xf32>, tensor<3x4xf32>) -> tensor<2x4xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.Mul"([[VAR_2_]], [[VAR_0_]]) {onnx_node_name = "onnx.Mul_2"} : (tensor<2x4xf32>, tensor<1xf32>) -> tensor<2x4xf32>
+// CHECK:           return [[VAR_3_]] : tensor<2x4xf32>
+// CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/fusedmatmul.onnxtext
+++ b/test/mlir/onnx/parse/fusedmatmul.onnxtext
@@ -20,7 +20,7 @@ fusedmatmuller (float[2,3] lhs, float[4,3] rhs) => (float[2,4] output) {
    output = com.microsoft.FusedMatMul <alpha = 0.125, transA = 0, transB = 1> (lhs, rhs)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3xf32> {onnx.names = "lhs"}, [[PARAM_1_:%.+]]: tensor<4x3xf32> {onnx.names = "rhs"}) -> (tensor<2x4xf32> {onnx.names = "output"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3xf32> {onnx.name = "lhs"}, [[PARAM_1_:%.+]]: tensor<4x3xf32> {onnx.name = "rhs"}) -> (tensor<2x4xf32> {onnx.name = "output"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1.250000e-01> : tensor<1xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Transpose"([[PARAM_1_]]) {onnx_node_name = "onnx.Transpose_0", perm = [1, 0]} : (tensor<4x3xf32>) -> tensor<3x4xf32>
 // CHECK:           [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) {onnx_node_name = "onnx.MatMul_1"} : (tensor<2x3xf32>, tensor<3x4xf32>) -> tensor<2x4xf32>

--- a/test/mlir/onnx/parse/layer_normalization_function_decomposition.onnxtext
+++ b/test/mlir/onnx/parse/layer_normalization_function_decomposition.onnxtext
@@ -9,7 +9,7 @@ agraph (float[12,3,5] X, float[5] S) => (float[12,3,5] LN) {
    LN = LayerNormalization (X, S)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<12x3x5xf32> {onnx.names = "X"}, [[PARAM_1_:%.+]]: tensor<5xf32> {onnx.names = "S"}) -> (tensor<12x3x5xf32> {onnx.names = "LN"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<12x3x5xf32> {onnx.name = "X"}, [[PARAM_1_:%.+]]: tensor<5xf32> {onnx.name = "S"}) -> (tensor<12x3x5xf32> {onnx.name = "LN"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<9.99999974E-6> : tensor<f32>
 // CHECK-NOT: separator of consecutive DAGs

--- a/test/mlir/onnx/parse/layer_normalization_function_decomposition.onnxtext
+++ b/test/mlir/onnx/parse/layer_normalization_function_decomposition.onnxtext
@@ -9,7 +9,7 @@ agraph (float[12,3,5] X, float[5] S) => (float[12,3,5] LN) {
    LN = LayerNormalization (X, S)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<12x3x5xf32>, [[PARAM_1_:%.+]]: tensor<5xf32>) -> tensor<12x3x5xf32> attributes {input_names = ["X", "S"], output_names = ["LN"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<12x3x5xf32>, [[PARAM_1_:%.+]]: tensor<5xf32>) -> tensor<12x3x5xf32> attributes {input_dim_params = {{.*}}, input_names = ["X", "S"], output_dim_params = {{.*}}, output_names = ["LN"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<9.99999974E-6> : tensor<f32>
 // CHECK-NOT: separator of consecutive DAGs

--- a/test/mlir/onnx/parse/layer_normalization_function_decomposition.onnxtext
+++ b/test/mlir/onnx/parse/layer_normalization_function_decomposition.onnxtext
@@ -9,7 +9,7 @@ agraph (float[12,3,5] X, float[5] S) => (float[12,3,5] LN) {
    LN = LayerNormalization (X, S)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<12x3x5xf32>, [[PARAM_1_:%.+]]: tensor<5xf32>) -> tensor<12x3x5xf32> attributes {input_dim_params = {{.*}}, input_names = ["X", "S"], output_dim_params = {{.*}}, output_names = ["LN"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<12x3x5xf32> {onnx.names = "X"}, [[PARAM_1_:%.+]]: tensor<5xf32> {onnx.names = "S"}) -> (tensor<12x3x5xf32> {onnx.names = "LN"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<9.99999974E-6> : tensor<f32>
 // CHECK-NOT: separator of consecutive DAGs

--- a/test/mlir/onnx/parse/nonraw_data.json
+++ b/test/mlir/onnx/parse/nonraw_data.json
@@ -487,7 +487,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
+// CHECK-SAME:   () -> (tensor<3xf32> {onnx.names = "output0"}, tensor<3xui8> {onnx.names = "output1"}, tensor<3xi8> {onnx.names = "output2"}, tensor<3xui16> {onnx.names = "output3"}, tensor<3xi16> {onnx.names = "output4"}, tensor<3xi32> {onnx.names = "output5"}, tensor<3xi64> {onnx.names = "output6"}, tensor<3xi1> {onnx.names = "output7"}, tensor<3xf16> {onnx.names = "output8"}, tensor<3xf64> {onnx.names = "output9"}, tensor<3xui32> {onnx.names = "output10"}, tensor<3xui64> {onnx.names = "output11"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>
@@ -502,3 +502,4 @@
 // CHECK-DAG:       [[VAR_11_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui64>
 // CHECK:           onnx.Return [[VAR_0_]], [[VAR_1_]], [[VAR_2_]], [[VAR_3_]], [[VAR_4_]], [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0, [[VAR_1_]]1 : tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/nonraw_data.json
+++ b/test/mlir/onnx/parse/nonraw_data.json
@@ -487,7 +487,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_names = [], output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
+// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>

--- a/test/mlir/onnx/parse/nonraw_data.json
+++ b/test/mlir/onnx/parse/nonraw_data.json
@@ -487,7 +487,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32> {onnx.names = "output0"}, tensor<3xui8> {onnx.names = "output1"}, tensor<3xi8> {onnx.names = "output2"}, tensor<3xui16> {onnx.names = "output3"}, tensor<3xi16> {onnx.names = "output4"}, tensor<3xi32> {onnx.names = "output5"}, tensor<3xi64> {onnx.names = "output6"}, tensor<3xi1> {onnx.names = "output7"}, tensor<3xf16> {onnx.names = "output8"}, tensor<3xf64> {onnx.names = "output9"}, tensor<3xui32> {onnx.names = "output10"}, tensor<3xui64> {onnx.names = "output11"}) {
+// CHECK-SAME:   () -> (tensor<3xf32> {onnx.name = "output0"}, tensor<3xui8> {onnx.name = "output1"}, tensor<3xi8> {onnx.name = "output2"}, tensor<3xui16> {onnx.name = "output3"}, tensor<3xi16> {onnx.name = "output4"}, tensor<3xi32> {onnx.name = "output5"}, tensor<3xi64> {onnx.name = "output6"}, tensor<3xi1> {onnx.name = "output7"}, tensor<3xf16> {onnx.name = "output8"}, tensor<3xf64> {onnx.name = "output9"}, tensor<3xui32> {onnx.name = "output10"}, tensor<3xui64> {onnx.name = "output11"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>

--- a/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
+++ b/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
@@ -21,7 +21,7 @@ prims_convert_element_type <dtype>(tensor) => (return_val)
    return_val = Cast <to: int = @dtype> (tensor)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64> {onnx.names = "slice_2"}) -> (tensor<f32> {onnx.names = "convert_element_type"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64> {onnx.name = "slice_2"}) -> (tensor<f32> {onnx.name = "convert_element_type"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 1 : si64, to = f32} : (tensor<i64>) -> tensor<f32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<f32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
+++ b/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
@@ -21,7 +21,7 @@ prims_convert_element_type <dtype>(tensor) => (return_val)
    return_val = Cast <to: int = @dtype> (tensor)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64>) -> tensor<f32> attributes {input_dim_params = {{.*}}, input_names = ["slice_2"], output_dim_params = {{.*}}, output_names = ["convert_element_type"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64> {onnx.names = "slice_2"}) -> (tensor<f32> {onnx.names = "convert_element_type"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 1 : si64, to = f32} : (tensor<i64>) -> tensor<f32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<f32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
+++ b/test/mlir/onnx/parse/prims_convert_element_type.onnxtext
@@ -21,7 +21,7 @@ prims_convert_element_type <dtype>(tensor) => (return_val)
    return_val = Cast <to: int = @dtype> (tensor)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64>) -> tensor<f32> attributes {input_names = ["slice_2"], output_names = ["convert_element_type"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<i64>) -> tensor<f32> attributes {input_dim_params = {{.*}}, input_names = ["slice_2"], output_dim_params = {{.*}}, output_names = ["convert_element_type"]} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 1 : si64, to = f32} : (tensor<i64>) -> tensor<f32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<f32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/raw_data.json
+++ b/test/mlir/onnx/parse/raw_data.json
@@ -440,7 +440,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32> {onnx.names = "output0"}, tensor<3xui8> {onnx.names = "output1"}, tensor<3xi8> {onnx.names = "output2"}, tensor<3xui16> {onnx.names = "output3"}, tensor<3xi16> {onnx.names = "output4"}, tensor<3xi32> {onnx.names = "output5"}, tensor<3xi64> {onnx.names = "output6"}, tensor<3xi1> {onnx.names = "output7"}, tensor<3xf16> {onnx.names = "output8"}, tensor<3xf64> {onnx.names = "output9"}, tensor<3xui32> {onnx.names = "output10"}, tensor<3xui64> {onnx.names = "output11"}) {
+// CHECK-SAME:   () -> (tensor<3xf32> {onnx.name = "output0"}, tensor<3xui8> {onnx.name = "output1"}, tensor<3xi8> {onnx.name = "output2"}, tensor<3xui16> {onnx.name = "output3"}, tensor<3xi16> {onnx.name = "output4"}, tensor<3xi32> {onnx.name = "output5"}, tensor<3xi64> {onnx.name = "output6"}, tensor<3xi1> {onnx.name = "output7"}, tensor<3xf16> {onnx.name = "output8"}, tensor<3xf64> {onnx.name = "output9"}, tensor<3xui32> {onnx.name = "output10"}, tensor<3xui64> {onnx.name = "output11"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>

--- a/test/mlir/onnx/parse/raw_data.json
+++ b/test/mlir/onnx/parse/raw_data.json
@@ -440,7 +440,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
+// CHECK-SAME:   () -> (tensor<3xf32> {onnx.names = "output0"}, tensor<3xui8> {onnx.names = "output1"}, tensor<3xi8> {onnx.names = "output2"}, tensor<3xui16> {onnx.names = "output3"}, tensor<3xi16> {onnx.names = "output4"}, tensor<3xi32> {onnx.names = "output5"}, tensor<3xi64> {onnx.names = "output6"}, tensor<3xi1> {onnx.names = "output7"}, tensor<3xf16> {onnx.names = "output8"}, tensor<3xf64> {onnx.names = "output9"}, tensor<3xui32> {onnx.names = "output10"}, tensor<3xui64> {onnx.names = "output11"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>

--- a/test/mlir/onnx/parse/raw_data.json
+++ b/test/mlir/onnx/parse/raw_data.json
@@ -440,7 +440,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_names = [], output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
+// CHECK-SAME:   () -> (tensor<3xf32>, tensor<3xui8>, tensor<3xi8>, tensor<3xui16>, tensor<3xi16>, tensor<3xi32>, tensor<3xi64>, tensor<3xi1>, tensor<3xf16>, tensor<3xf64>, tensor<3xui32>, tensor<3xui64>) attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output0", "output1", "output2", "output3", "output4", "output5", "output6", "output7", "output8", "output9", "output10", "output11"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[1.000000e+00, 0.000000e+00, 1.000000e+00]> : tensor<3xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xui8>
 // CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[1, 0, 1]> : tensor<3xi8>

--- a/test/mlir/onnx/parse/sequence_map_resize.onnxtext
+++ b/test/mlir/onnx/parse/sequence_map_resize.onnxtext
@@ -30,7 +30,7 @@ preprocess (input_batch) => (output_tensor)
    output_tensor = ConcatFromSequence <axis = 0, new_axis = 1> (tmp_seq)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<?x?x3xui8>> {onnx.names = "images"}) -> (tensor<?x3x224x224xf32> {onnx.dim_params = "0:B", onnx.names = "preproc_data"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<?x?x3xui8>> {onnx.name = "images"}) -> (tensor<?x3x224x224xf32> {onnx.dim_params = "0:B", onnx.name = "preproc_data"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceMap"([[PARAM_0_]]) ({
 // CHECK:           ^bb0([[PARAM_1_:%.+]]: tensor<?x?x3xui8>):
 // CHECK-DAG:         [[VAR_2_:%.+]] = onnx.Constant dense<256> : tensor<2xi64>

--- a/test/mlir/onnx/parse/sequence_map_resize.onnxtext
+++ b/test/mlir/onnx/parse/sequence_map_resize.onnxtext
@@ -30,7 +30,7 @@ preprocess (input_batch) => (output_tensor)
    output_tensor = ConcatFromSequence <axis = 0, new_axis = 1> (tmp_seq)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<?x?x3xui8>>) -> tensor<?x3x224x224xf32> attributes {input_names = ["images"], output_names = ["preproc_data"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<?x?x3xui8>>) -> tensor<?x3x224x224xf32> attributes {input_dim_params = {{.*}}, input_names = ["images"], output_dim_params = {{.*}}, output_names = ["preproc_data"]} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceMap"([[PARAM_0_]]) ({
 // CHECK:           ^bb0([[ARG_1_:%.+]]: tensor<?x?x3xui8>):
 // CHECK-DAG:         [[VAR_2_:%.+]] = onnx.Constant dense<256> : tensor<2xi64>
@@ -48,7 +48,7 @@ preprocess (input_batch) => (output_tensor)
 // CHECK:             [[VAR_12_:%.+]] = "onnx.Div"([[VAR_11_]], [[VAR_9_]]) : (tensor<224x224x3xf32>, tensor<3xf32>) -> tensor<224x224x3xf32>
 // CHECK:             [[VAR_13_:%.+]] = "onnx.Transpose"([[VAR_12_]]) {perm = [2, 0, 1]} : (tensor<224x224x3xf32>) -> tensor<3x224x224xf32>
 // CHECK:             onnx.Yield [[VAR_13_]] : tensor<3x224x224xf32>
-// CHECK:           }) {input_names = ["sample_in"], output_names = ["sample_out"]} : (!onnx.Seq<tensor<?x?x3xui8>>) -> !onnx.Seq<tensor<3x224x224xf32>>
+// CHECK:           }) {input_dim_params = {{.*}}, input_names = ["sample_in"], output_dim_params = {{.*}}, output_names = ["sample_out"]} : (!onnx.Seq<tensor<?x?x3xui8>>) -> !onnx.Seq<tensor<3x224x224xf32>>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.ConcatFromSequence"([[VAR_0_]]) {axis = 0 : si64, new_axis = 1 : si64} : (!onnx.Seq<tensor<3x224x224xf32>>) -> tensor<?x3x224x224xf32>
 // CHECK:           onnx.Return [[VAR_1_]] : tensor<?x3x224x224xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/sequence_map_resize.onnxtext
+++ b/test/mlir/onnx/parse/sequence_map_resize.onnxtext
@@ -30,14 +30,14 @@ preprocess (input_batch) => (output_tensor)
    output_tensor = ConcatFromSequence <axis = 0, new_axis = 1> (tmp_seq)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<?x?x3xui8>>) -> tensor<?x3x224x224xf32> attributes {input_dim_params = {{.*}}, input_names = ["images"], output_dim_params = {{.*}}, output_names = ["preproc_data"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: !onnx.Seq<tensor<?x?x3xui8>> {onnx.names = "images"}) -> (tensor<?x3x224x224xf32> {onnx.dim_params = "0:B", onnx.names = "preproc_data"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.SequenceMap"([[PARAM_0_]]) ({
-// CHECK:           ^bb0([[ARG_1_:%.+]]: tensor<?x?x3xui8>):
+// CHECK:           ^bb0([[PARAM_1_:%.+]]: tensor<?x?x3xui8>):
 // CHECK-DAG:         [[VAR_2_:%.+]] = onnx.Constant dense<256> : tensor<2xi64>
 // CHECK-DAG:         [[VAR_3_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-DAG:         [[VAR_4_:%.+]] = "onnx.NoValue"() {value} : () -> none
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_5_:%.+]] = "onnx.ResizeV18"([[ARG_1_]], [[VAR_3_]], [[VAR_4_]], [[VAR_2_]]) {antialias = 1 : si64, axes = [0, 1], coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "not_smaller", mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<?x?x3xui8>, none, none, tensor<2xi64>) -> tensor<?x?x3xui8>
+// CHECK-DAG:         [[VAR_5_:%.+]] = "onnx.ResizeV18"([[PARAM_1_]], [[VAR_3_]], [[VAR_4_]], [[VAR_2_]]) {antialias = 1 : si64, axes = [0, 1], coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "not_smaller", mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<?x?x3xui8>, none, none, tensor<2xi64>) -> tensor<?x?x3xui8>
 // CHECK-DAG:         [[VAR_6_:%.+]] = onnx.Constant dense<224> : tensor<2xi64>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_7_:%.+]] = "onnx.CenterCropPad"([[VAR_5_]], [[VAR_6_]]) {axes = [0, 1]} : (tensor<?x?x3xui8>, tensor<2xi64>) -> tensor<224x224x3xui8>
@@ -48,7 +48,8 @@ preprocess (input_batch) => (output_tensor)
 // CHECK:             [[VAR_12_:%.+]] = "onnx.Div"([[VAR_11_]], [[VAR_9_]]) : (tensor<224x224x3xf32>, tensor<3xf32>) -> tensor<224x224x3xf32>
 // CHECK:             [[VAR_13_:%.+]] = "onnx.Transpose"([[VAR_12_]]) {perm = [2, 0, 1]} : (tensor<224x224x3xf32>) -> tensor<3x224x224xf32>
 // CHECK:             onnx.Yield [[VAR_13_]] : tensor<3x224x224xf32>
-// CHECK:           }) {input_dim_params = {{.*}}, input_names = ["sample_in"], output_dim_params = {{.*}}, output_names = ["sample_out"]} : (!onnx.Seq<tensor<?x?x3xui8>>) -> !onnx.Seq<tensor<3x224x224xf32>>
+// CHECK:           }) {input_dim_params = ["0:unk__0,1:unk__1"], input_names = ["sample_in"], output_names = ["sample_out"]} : (!onnx.Seq<tensor<?x?x3xui8>>) -> !onnx.Seq<tensor<3x224x224xf32>>
 // CHECK:           [[VAR_1_:%.+]] = "onnx.ConcatFromSequence"([[VAR_0_]]) {axis = 0 : si64, new_axis = 1 : si64} : (!onnx.Seq<tensor<3x224x224xf32>>) -> tensor<?x3x224x224xf32>
 // CHECK:           onnx.Return [[VAR_1_]] : tensor<?x3x224x224xf32>
 // CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()

--- a/test/mlir/onnx/parse/string_data.json
+++ b/test/mlir/onnx/parse/string_data.json
@@ -57,7 +57,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> tensor<2x!onnx.String> attributes {input_names = [], output_names = ["output"]} {
+// CHECK-SAME:   () -> tensor<2x!onnx.String> attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output"]} {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<["hello", "world"]> : tensor<2x!onnx.String>
 // CHECK:           onnx.Return %0 : tensor<2x!onnx.String>
 // CHECK:         }

--- a/test/mlir/onnx/parse/string_data.json
+++ b/test/mlir/onnx/parse/string_data.json
@@ -57,7 +57,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> tensor<2x!onnx.String> attributes {input_dim_params = {{.*}}, input_names = [], output_dim_params = {{.*}}, output_names = ["output"]} {
+// CHECK-SAME:   () -> (tensor<2x!onnx.String> {onnx.names = "output"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<["hello", "world"]> : tensor<2x!onnx.String>
 // CHECK:           onnx.Return %0 : tensor<2x!onnx.String>
 // CHECK:         }

--- a/test/mlir/onnx/parse/string_data.json
+++ b/test/mlir/onnx/parse/string_data.json
@@ -57,7 +57,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   () -> (tensor<2x!onnx.String> {onnx.names = "output"}) {
+// CHECK-SAME:   () -> (tensor<2x!onnx.String> {onnx.name = "output"}) {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<["hello", "world"]> : tensor<2x!onnx.String>
 // CHECK:           onnx.Return %0 : tensor<2x!onnx.String>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_abs.onnxtext
+++ b/test/mlir/onnx/parse/test_abs.onnxtext
@@ -14,7 +14,7 @@ test_abs (float[3,4,5] x) => (float[3,4,5] y) {
    y = Abs (x)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {{.*}} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32> {onnx.names = "x"}) -> (tensor<3x4x5xf32> {onnx.names = "y"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Abs"([[PARAM_0_]]) : (tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4x5xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_abs.onnxtext
+++ b/test/mlir/onnx/parse/test_abs.onnxtext
@@ -14,7 +14,7 @@ test_abs (float[3,4,5] x) => (float[3,4,5] y) {
    y = Abs (x)
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32> {onnx.names = "x"}) -> (tensor<3x4x5xf32> {onnx.names = "y"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x4x5xf32> {onnx.name = "x"}) -> (tensor<3x4x5xf32> {onnx.name = "y"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Abs"([[PARAM_0_]]) : (tensor<3x4x5xf32>) -> tensor<3x4x5xf32>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x4x5xf32>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
+++ b/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
@@ -258,7 +258,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<f32>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<f32>) -> tensor<2xf32> {{.*}} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<f32> {onnx.names = "start"}, [[PARAM_1_:%.+]]: tensor<f32> {onnx.names = "limit"}, [[PARAM_2_:%.+]]: tensor<f32> {onnx.names = "delta"}) -> (tensor<2xf32> {onnx.names = "output"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Sub"([[PARAM_1_]], [[PARAM_0_]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Cast"([[VAR_0_]]) {saturate = 1 : si64, to = f32} : (tensor<f32>) -> tensor<f32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Cast"([[PARAM_2_]]) {saturate = 1 : si64, to = f32} : (tensor<f32>) -> tensor<f32>

--- a/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
+++ b/test/mlir/onnx/parse/test_range_float_type_positive_delta_expanded.json
@@ -258,7 +258,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<f32> {onnx.names = "start"}, [[PARAM_1_:%.+]]: tensor<f32> {onnx.names = "limit"}, [[PARAM_2_:%.+]]: tensor<f32> {onnx.names = "delta"}) -> (tensor<2xf32> {onnx.names = "output"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<f32> {onnx.name = "start"}, [[PARAM_1_:%.+]]: tensor<f32> {onnx.name = "limit"}, [[PARAM_2_:%.+]]: tensor<f32> {onnx.name = "delta"}) -> (tensor<2xf32> {onnx.name = "output"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.Sub"([[PARAM_1_]], [[PARAM_0_]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.Cast"([[VAR_0_]]) {saturate = 1 : si64, to = f32} : (tensor<f32>) -> tensor<f32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = "onnx.Cast"([[PARAM_2_]]) {saturate = 1 : si64, to = f32} : (tensor<f32>) -> tensor<f32>

--- a/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
+++ b/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
@@ -81,7 +81,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x!onnx.String>) -> tensor<3x!onnx.String> attributes {input_dim_params = {{.*}}, input_names = ["x"], output_dim_params = {{.*}}, output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x!onnx.String> {onnx.names = "x"}) -> (tensor<3x!onnx.String> {onnx.names = "y"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.StringNormalizer"([[PARAM_0_]]) {case_change_action = "NONE", is_case_sensitive = 1 : si64, stopwords = ["monday"]} : (tensor<4x!onnx.String>) -> tensor<3x!onnx.String>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x!onnx.String>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
+++ b/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
@@ -81,7 +81,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x!onnx.String> {onnx.names = "x"}) -> (tensor<3x!onnx.String> {onnx.names = "y"}) {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x!onnx.String> {onnx.name = "x"}) -> (tensor<3x!onnx.String> {onnx.name = "y"}) {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.StringNormalizer"([[PARAM_0_]]) {case_change_action = "NONE", is_case_sensitive = 1 : si64, stopwords = ["monday"]} : (tensor<4x!onnx.String>) -> tensor<3x!onnx.String>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x!onnx.String>
 // CHECK:         }

--- a/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
+++ b/test/mlir/onnx/parse/test_strnormalizer_export_monday_casesensintive_nochangecase.json
@@ -81,7 +81,7 @@
   ]
 }
 // CHECK-LABEL:  func.func @main_graph
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x!onnx.String>) -> tensor<3x!onnx.String> attributes {input_names = ["x"], output_names = ["y"]} {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x!onnx.String>) -> tensor<3x!onnx.String> attributes {input_dim_params = {{.*}}, input_names = ["x"], output_dim_params = {{.*}}, output_names = ["y"]} {
 // CHECK:           [[VAR_0_:%.+]] = "onnx.StringNormalizer"([[PARAM_0_]]) {case_change_action = "NONE", is_case_sensitive = 1 : si64, stopwords = ["monday"]} : (tensor<4x!onnx.String>) -> tensor<3x!onnx.String>
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<3x!onnx.String>
 // CHECK:         }

--- a/test/numerical/TestLoop.cpp
+++ b/test/numerical/TestLoop.cpp
@@ -46,7 +46,7 @@ module {
 // Save this model for future
 std::string testLoopWithEarlyTermination_Orig = R"(
 module {
-  func.func @main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<1xi64>) -> (tensor<1xi64>, tensor<?x1xi64>) attributes {input_names = ["trip_count", "cond", "y"], output_names = ["res_y", "res_scan"]} {
+  func.func @main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<1xi64>) -> (tensor<1xi64>, tensor<?x1xi64>) {
     %0:2 = "onnx.Loop"(%arg0, %arg1, %arg2) ({
     ^bb0(%body_arg0: tensor<i64>, %body_arg1: tensor<i1>, %body_arg2: tensor<1xi64>):
       %0 = "onnx.Constant"() {value = dense<3> : tensor<i64>} : () -> tensor<i64>
@@ -61,7 +61,7 @@ module {
 
 std::string testLoopWithEarlyTermination = R"(
 module {
-  func.func @main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<1xi64>) -> tensor<1xi64> attributes {input_names = ["trip_count", "cond", "y"], output_names = ["res_y"]} {
+  func.func @main_graph(%arg0: tensor<i64>, %arg1: tensor<i1>, %arg2: tensor<1xi64>) -> tensor<1xi64> {
     %0 = "onnx.Loop"(%arg0, %arg1, %arg2) ({
     ^bb0(%body_arg0: tensor<i64>, %body_arg1: tensor<i1>, %body_arg2: tensor<1xi64>):
       %0 = "onnx.Constant"() {value = dense<3> : tensor<i64>} : () -> tensor<i64>

--- a/utils/testing/dim_param.py
+++ b/utils/testing/dim_param.py
@@ -26,7 +26,7 @@ X = helper.make_tensor_value_info(
 )
 
 # Create second input (ValueInfoProto)
-Y = helper.make_tensor_value_info("Y", TensorProto.INT64, [1, "sequence_len"])
+Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, "sequence_len"])
 
 # Create one output (ValueInfoProto)
 Z = helper.make_tensor_value_info(

--- a/utils/testing/dim_param.py
+++ b/utils/testing/dim_param.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+################################# dim_param.py #################################
+#
+# Generates dim_param.json in test/mlir/onnx/parse/
+#
+# The model has a single Add operations whose operands and outputs use
+# dim_param to represent unknown dimensions.
+#
+################################################################################
+
+import onnx
+from onnx import helper
+from onnx import AttributeProto, TensorProto, GraphProto
+from google.protobuf.json_format import MessageToJson
+
+
+# The protobuf definition can be found here:
+# https://github.com/onnx/onnx/blob/main/onnx/onnx.proto
+
+
+# Create one input (ValueInfoProto)
+X = helper.make_tensor_value_info("X", TensorProto.FLOAT, ["batch_size", "sequence_len"])
+
+# Create second input (ValueInfoProto)
+Y = helper.make_tensor_value_info("Y", TensorProto.INT64, [1, "sequence_len"])
+
+# Create one output (ValueInfoProto)
+Z = helper.make_tensor_value_info("Z", TensorProto.FLOAT, ["batch_size", "sequence_len"])
+
+# Create a node (NodeProto)
+node_def = helper.make_node(
+    "Add", # node name
+    ["X", "Y"], # inputs
+    ["Z"], # outputs
+)
+
+# Create the graph (GraphProto)
+graph_def = helper.make_graph(
+    [node_def],
+    "test-dim-param",
+    [X, Y],
+    [Z],
+)
+
+# Create the model (ModelProto)
+model_def = helper.make_model(graph_def, producer_name="onnx-mlir")
+
+onnx.checker.check_model(model_def)
+print(MessageToJson(model_def))

--- a/utils/testing/dim_param.py
+++ b/utils/testing/dim_param.py
@@ -21,19 +21,23 @@ from google.protobuf.json_format import MessageToJson
 
 
 # Create one input (ValueInfoProto)
-X = helper.make_tensor_value_info("X", TensorProto.FLOAT, ["batch_size", "sequence_len"])
+X = helper.make_tensor_value_info(
+    "X", TensorProto.FLOAT, ["batch_size", "sequence_len"]
+)
 
 # Create second input (ValueInfoProto)
 Y = helper.make_tensor_value_info("Y", TensorProto.INT64, [1, "sequence_len"])
 
 # Create one output (ValueInfoProto)
-Z = helper.make_tensor_value_info("Z", TensorProto.FLOAT, ["batch_size", "sequence_len"])
+Z = helper.make_tensor_value_info(
+    "Z", TensorProto.FLOAT, ["batch_size", "sequence_len"]
+)
 
 # Create a node (NodeProto)
 node_def = helper.make_node(
-    "Add", # node name
-    ["X", "Y"], # inputs
-    ["Z"], # outputs
+    "Add",  # node name
+    ["X", "Y"],  # inputs
+    ["Z"],  # outputs
 )
 
 # Create the graph (GraphProto)


### PR DESCRIPTION
In ONNX specification, a dimension can be `dim_value` (static) or `dim_param` (a named dynamic dimension).
If two dynamic dimensions has the same `dim_param`, they must have the same value at runtime.

This patch will import `dim_param` of the inputs and outputs of a model, and embed such `dim_param` in argument and result attributes. This patch also moves `input_names` and `output_names` into argument and result attributes `onnx.names`. for example
```
func.func @main_graph(
         %arg0: tensor<?x?xf32> {onnx.dim_params = "0:batch_size,1:sequence_len", onnx.name = "X"}, 
         %arg1: tensor<1x?xf32> {onnx.dim_params = "1:sequence_len", onnx.name = "Y"}) 
    -> (tensor<?x?xf32> {onnx.dim_params = "0:batch_size,1:sequence_len", onnx.name = "Z"})
```

`input_dim_params` and `output_dim_params` are a list of `"dim_index:dim_param"`

`input_dim_params = ["0:batch_size,1:sequence_len", "1:sequence_len"]` so the second unknown dim of input 0 is the same as the second unknown dim of input 1 because they have the same dim_param.

`output_dim_params = ["0:batch_size,1:sequence_len", "1:sequence_len"]` so the output has the same shape as the input.

In a practical model, e.g. t5-decoder with KV cache, dim_param is like the following, and we know that all the first dimensions (batch_size) must be the same.
<img width="482" alt="Screenshot 2023-11-10 at 22 19 38" src="https://github.com/onnx/onnx-mlir/assets/1230113/7344ed32-4634-427a-8603-8b12c49ae029">

These dim_param information will be used later by the dynamic dimension analysis to make the analysis stronger. Also we can check if users' inputs to the model are consistent or not.