### PR TITLE
Loop collapsing with fusion

### DIFF
--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1899,7 +1899,7 @@ void OpFusionHelper::decideCollapsibleLoops() {
   Type outputType = rootOp->getResultTypes()[0];
   int rank = (int)getRank(outputType);
 
-  llvm::dbgs() << "broadcast bits " << broadcastBits << "\n";
+  LLVM_DEBUG(llvm::dbgs() << "broadcast bits " << broadcastBits << "\n";);
 
   for (int i = 0; i < rank; i++) {
     if ((broadcastBits & (0x01 << i)) != 0) {
@@ -2113,8 +2113,8 @@ struct ONNXElementwiseUnaryOpLowering
     OpFusionHelper opFusionHelper(rewriter, op, dimAnalysis);
     opFusionHelper.findFusibleOps();
     opFusionHelper.decideCollapsibleLoops();
-    llvm::dbgs() << "loop collaping: " << opFusionHelper.collapsibleLoops
-                 << "\n";
+    LLVM_DEBUG(llvm::dbgs() << "loop collaping: " << opFusionHelper.collapsibleLoops
+                 << "\n");
     outputMemRefType = opFusionHelper.getOutputType(outputMemRefType);
 
     // Insert an allocation for the result of this operation.
@@ -2284,8 +2284,8 @@ struct ONNXElementwiseBinaryOpLowering
     OpFusionHelper opFusionHelper(rewriter, op, dimAnalysis);
     opFusionHelper.findFusibleOps();
     opFusionHelper.decideCollapsibleLoops();
-    llvm::dbgs() << "loop collaping: " << opFusionHelper.collapsibleLoops
-                 << "\n";
+    LLVM_DEBUG(llvm::dbgs() << "loop collaping: "
+                            << opFusionHelper.collapsibleLoops << "\n";);
     outputMemRefType = opFusionHelper.getOutputType(outputMemRefType);
 
     // Insert an allocation and deallocation for the result of this operation.
@@ -2450,8 +2450,8 @@ struct ONNXElementwiseVariadicOpLowering
     OpFusionHelper opFusionHelper(rewriter, op, dimAnalysis);
     opFusionHelper.findFusibleOps();
     opFusionHelper.decideCollapsibleLoops();
-    llvm::dbgs() << "loop collaping: " << opFusionHelper.collapsibleLoops
-                 << "\n";
+    LLVM_DEBUG(llvm::dbgs() << "loop collaping: "
+                            << opFusionHelper.collapsibleLoops << "\n");
     outputMemRefType = opFusionHelper.getOutputType(outputMemRefType);
 
     // Insert an allocation and deallocation for the result of this operation.


### PR DESCRIPTION
This PR handles loop collapsing in op fusion. There are two parts:
1. Decide which loops to be collapsed. When ops are fused, all its operands should be checked whether its dimensions are involved in broadcasting. Such information will be used to decide which loops should be collapsed.
2. Code generation when some loops are collapsed. 