### PR TITLE
Use dim_params in dynamic dimension analysis

### DIFF
--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -504,10 +504,13 @@ DimAnalysis::DimAnalysis(ArrayRef<Value> vals) {
 DimAnalysis::DimAnalysis(ModuleOp moduleOp) {
   moduleOp.walk([&](Operation *op) {
     if (auto funcOp = dyn_cast<func::FuncOp>(op)) {
+      // Build dimensions for function arguments and results.
       buildFunctionArgsRes(funcOp);
     } else {
+      // Build dimensions for normal operation results.
       for (Value output : op->getResults())
-        build(output);
+        if (!isNoneValue(output))
+          build(output);
     }
   });
   LLVM_DEBUG(llvm::dbgs() << "The number of dynamic dims in the IR: "

--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -503,15 +503,79 @@ DimAnalysis::DimAnalysis(ArrayRef<Value> vals) {
 
 DimAnalysis::DimAnalysis(ModuleOp moduleOp) {
   moduleOp.walk([&](Operation *op) {
-    if (auto funcOp = dyn_cast<func::FuncOp>(op)) {
-      for (Value arg : funcOp.getArguments())
-        build(arg);
-    }
+    if (auto funcOp = dyn_cast<func::FuncOp>(op))
+      buildFuncArguments(funcOp);
     for (Value output : op->getResults())
       build(output);
   });
   LLVM_DEBUG(llvm::dbgs() << "The number of dynamic dims in the IR: "
                           << numOfDynamicDims << "\n");
+}
+
+int64_t DimAnalysis::build(DimT d, int64_t setID) {
+  if (setID >= 0) {
+    if (dimSetMap.contains(setID)) {
+      dimSetMap[setID].insert(d);
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Build a new dim(" << d.first << ", " << d.second
+                 << ") and insert it into the existing set " << setID << "\n");
+    }
+  } else {
+    setID = setCounter;
+    DimSetT dimSet;
+    dimSet.insert(d);
+    dimSetMap[setID] = dimSet;
+    setCounter++;
+    LLVM_DEBUG(llvm::dbgs()
+               << "Build a new dim(" << d.first << ", " << d.second << ")\n");
+  }
+  if (setID >= 0)
+    numOfDynamicDims++;
+  return setID;
+}
+
+void DimAnalysis::buildFuncArguments(func::FuncOp funcOp) {
+  // If dim_params are available, try to group dims using dim_params because
+  // dimensions wih the same dim_param are supposed to be the same at runtime.
+  ArrayRef<BlockArgument> args = funcOp.getArguments();
+  ArrayAttr argAttrs = funcOp.getArgAttrsAttr();
+  // Keep dynamic dimensions with the same dim_param.
+  std::map<std::string, DimSetT> paramSetMap;
+  for (size_t argPos = 0; argPos < args.size(); ++argPos) {
+    Value arg = args[argPos];
+    auto tensorType = arg.getType().dyn_cast<RankedTensorType>();
+    if (!tensorType)
+      continue;
+    // Get dim_params if exists.
+    std::map<unsigned, std::string> indexParamMap;
+    getONNXDimParams(indexParamMap, argAttrs, argPos);
+    // Check and build each dynamic dimension.
+    for (int64_t dimPos = 0; dimPos < tensorType.getRank(); ++dimPos) {
+      if (!tensorType.isDynamicDim(dimPos))
+        continue;
+      DimT ti(arg, dimPos);
+      if (auto dp = indexParamMap.find(dimPos); dp != indexParamMap.end()) {
+        // This arg has dim_param, build it later with other args of the
+        // same dim_param
+        if (paramSetMap.find(dp->second) == paramSetMap.end()) {
+          DimSetT dimSet;
+          dimSet.insert(ti);
+          paramSetMap[dp->second] = dimSet;
+        } else {
+          paramSetMap[dp->second].insert(ti);
+        }
+      } else {
+        // This arg does not have dim_param, build it now.
+        build(ti);
+      }
+    }
+  }
+  // Build dynamic dimensions using dim_param.
+  for (const auto &[param, dimSet] : paramSetMap) {
+    int64_t setID = -1;
+    for (DimT d : dimSet)
+      setID = build(d, setID);
+  }
 }
 
 void DimAnalysis::build(Value val) {
@@ -635,6 +699,27 @@ void DimAnalysis::dump() const {
     llvm::outs() << "\n- Set " << i << " (size: " << dimSet.size() << "):\n";
     for (auto &ti : dimSet)
       llvm::outs() << "  - Dim " << ti.second << " of " << ti.first << "\n";
+  }
+}
+
+void DimAnalysis::getONNXDimParams(
+    std::map<unsigned, std::string> &indexParamMap, ArrayAttr argResAttr,
+    unsigned index) {
+  DictionaryAttr dictAttr = llvm::dyn_cast<DictionaryAttr>(argResAttr[index]);
+  if (dictAttr && dictAttr.contains("onnx.dim_params")) {
+    // onnx.dim_params = dimIndex:dimParam,dimIndex:dimParam,...
+    StringRef dimParams = dictAttr.getNamed("onnx.dim_params")
+                              .value()
+                              .getValue()
+                              .cast<StringAttr>()
+                              .getValue();
+    SmallVector<StringRef, 4> splittedDimParams;
+    dimParams.split(splittedDimParams, ',');
+    for (size_t k = 0; k < splittedDimParams.size(); ++k) {
+      StringRef s = splittedDimParams[k];
+      std::pair<StringRef, StringRef> indexParam = s.split(':');
+      indexParamMap[stoi(indexParam.first.str())] = indexParam.second.str();
+    }
   }
 }
 

--- a/src/Dialect/ONNX/ONNXDimAnalysis.hpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.hpp
@@ -97,8 +97,8 @@ private:
   /// This method returns the set ID that contains the dimension.
   int64_t build(DimT d, int64_t setID = -1);
 
-  /// Initializes the internal mappings for function arguments.
-  void buildFuncArguments(mlir::func::FuncOp funcOp);
+  /// Initializes the internal mappings for function arguments and resutls.
+  void buildFunctionArgsRes(mlir::func::FuncOp funcOp);
 
   // Create dims for function arguments.
   /// Update each set of dynamic dimensions to include the same dynamic

--- a/src/Dialect/ONNX/ONNXDimAnalysis.hpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Value.h"
 
@@ -90,6 +91,16 @@ private:
   /// Each dynamic dimension is initially assigned to a singleton set.
   void build(mlir::Value val);
 
+  /// Initializes the internal mappings for a single dynamic dimension.
+  /// The dynamic dimension is initially assigned to a newly-created set or an
+  /// existing set depending on `setID` is -1 or not.
+  /// This method returns the set ID that contains the dimension.
+  int64_t build(DimT d, int64_t setID = -1);
+
+  /// Initializes the internal mappings for function arguments.
+  void buildFuncArguments(mlir::func::FuncOp funcOp);
+
+  // Create dims for function arguments.
   /// Update each set of dynamic dimensions to include the same dynamic
   /// dimensions. This is a local update in the sense that the search space
   /// includes dynamic dimensions that directly link to the dimensions in the
@@ -102,6 +113,12 @@ private:
 
   /// Visit a dynamic dimension and find new same dynamic dimensions.
   void visitDim(DimT &dim, DimSetT &sameDims) const;
+
+  /// Get onnx.dim_params value from a function argument/result and put it into
+  /// a map.
+  /// TODO: find a new home for this function.
+  void getONNXDimParams(std::map<unsigned, std::string> &indexParamMap,
+      mlir::ArrayAttr argResAttr, unsigned index);
 
 private:
   int64_t setCounter = 0;


### PR DESCRIPTION
This patch improves the dynamic dimension analysis by getting the relationship between input and output dimensions via `onnx.dim_params` attribute.