### PR TITLE
[NNPA] A rewrite pattern to get dim directly from a zTensor without unstickification.

### DIFF
--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.cpp
@@ -438,5 +438,27 @@ AffineMapAttr getTransposeMap(OpBuilder &b, ArrayAttr permAttr) {
   return AffineMapAttr::get(map);
 }
 
+IntegerAttr getAxisNHWC(IntegerAttr axisNCHWAttr) {
+  int64_t axisNCHW = axisNCHWAttr.getSInt();
+  int64_t axisNHWC;
+  switch (axisNCHW) {
+  case 0: // N
+    axisNHWC = 0;
+    break;
+  case 1: // C
+    axisNHWC = 3;
+    break;
+  case 2: // H
+    axisNHWC = 1;
+    break;
+  case 3: // W
+    axisNHWC = 2;
+    break;
+  default:
+    axisNHWC = axisNCHW;
+  }
+  return IntegerAttr::get(axisNCHWAttr.getType(), axisNHWC);
+}
+
 } // namespace zhigh
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp
@@ -78,5 +78,8 @@ mlir::AffineMapAttr getCollapsing4DTo2DMap(mlir::OpBuilder &b, mlir::Value val);
 mlir::AffineMapAttr getTransposeMap(
     mlir::OpBuilder &b, mlir::ArrayAttr permAttr);
 
+/// Get an axis for NHWC layout given an axis for NCHW layout.
+mlir::IntegerAttr getAxisNHWC(mlir::IntegerAttr axisNCHWAttr);
+
 } // namespace zhigh
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td
@@ -99,6 +99,20 @@ def TensorHas3DSLayout: Constraint<
   "ZTensor has 3DS layout"
 >;
 
+def TensorHasNHWCLayout: Constraint<
+  CPred<"::onnx_mlir::isNHWCLayout("
+        "::onnx_mlir::zhigh::convertZTensorDataLayoutToStringAttr($_builder, "
+        "::onnx_mlir::zhigh::getZTensorLayout($0.getType())))">,
+  "ZTensor has NHWC layout"
+>;
+
+def TensorHasNoNHWCLayout: Constraint<
+  CPred<"!::onnx_mlir::isNHWCLayout("
+        "::onnx_mlir::zhigh::convertZTensorDataLayoutToStringAttr($_builder, "
+        "::onnx_mlir::zhigh::getZTensorLayout($0.getType())))">,
+  "ZTensor has no NHWC layout"
+>;
+
 def Is2DLayout : Constraint<
   CPred<"::onnx_mlir::is2DLayout($0)">,
   "Is 2D layout"
@@ -165,6 +179,10 @@ def GetTransposeMap : NativeCodeCall<
 def IsIdentityAffineMap : Constraint<
   CPred<"$_self.isIdentity()">,
   "Is identity AffineMap"
+>;
+
+def GetAxisNHWC : NativeCodeCall<
+  "::onnx_mlir::zhigh::getAxisNHWC($0)"
 >;
 
 #endif // OP_HELPER 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Unstick/Unstick.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Unstick/Unstick.cpp
@@ -116,6 +116,8 @@ LogicalResult ZHighUnstickOp::inferShapes(
 void ZHighUnstickOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<UnstickStickRemovalPattern>(context);
+  results.insert<DimUnstickRemovalPattern>(context);
+  results.insert<DimUnstickNHWCRemovalPattern>(context);
 }
 
 } // namespace zhigh

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Unstick/ZHighUnstick.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Unstick/ZHighUnstick.td
@@ -40,4 +40,20 @@ def UnstickStickRemovalPattern : Pat<
   (replaceWithValue $arg)
 >;
 
+// onnx.Dim (zhigh.Unstick (%X)) = onnx.Dim %X
+// For NHWC layout.
+def DimUnstickNHWCRemovalPattern : Pat<
+  (ONNXDimOp (ZHighUnstickOp $arg), $axis),
+  (ONNXDimOp $arg, (GetAxisNHWC $axis)),
+  [(TensorHasNHWCLayout $arg)]
+>;
+
+// onnx.Dim (zhigh.Unstick (%X)) = onnx.Dim %X
+// For non-NHWC layout.
+def DimUnstickRemovalPattern : Pat<
+  (ONNXDimOp (ZHighUnstickOp $arg), $axis),
+  (ONNXDimOp $arg, $axis),
+  [(TensorHasNoNHWCLayout $arg)]
+>;
+
 #endif // UNSTICK_TD

--- a/test/mlir/accelerators/nnpa/transform/zhigh-combine.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zhigh-combine.mlir
@@ -232,3 +232,31 @@ func.func @reshape_transpose_reshape_3ds_to_2d(%arg0: tensor<48x256x64xf16, #zhi
 // CHECK:           return [[VAR_2_]] : tensor<1024x768xf16, #zhigh.layout<{dataLayout = "2D"}>>
 // CHECK:         }
 }
+
+// -----
+
+func.func @test_unstick_dim(%arg0: tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3D"}>>) -> tensor<1xi64> {
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3D"}>>) -> tensor<?x?x?xf32>
+  %1 = "onnx.Dim"(%0) {axis = 1 : si64}: (tensor<?x?x?xf32>) -> tensor<1xi64>
+  return %1 : tensor<1xi64>
+
+// CHECK-LABEL:  func.func @test_unstick_dim
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3D"}>>) -> tensor<1xi64> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 1 : si64} : (tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3D"}>>) -> tensor<1xi64>
+// CHECK:           return [[VAR_0_]] : tensor<1xi64>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_unstick_dim_nchw(%arg0: tensor<?x?x?x?xf16, #zhigh.layout<{dataLayout = "NHWC"}>>) -> tensor<1xi64> {
+  %0 = "zhigh.Unstick"(%arg0) : (tensor<?x?x?x?xf16, #zhigh.layout<{dataLayout = "NHWC"}>>) -> tensor<?x?x?x?xf32>
+  %1 = "onnx.Dim"(%0) {axis = 1 : si64}: (tensor<?x?x?x?xf32>) -> tensor<1xi64>
+  return %1 : tensor<1xi64>
+
+// CHECK-LABEL:  func.func @test_unstick_dim_nchw
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x?x?xf16, #zhigh.layout<{dataLayout = "NHWC"}>>) -> tensor<1xi64> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 3 : si64} : (tensor<?x?x?x?xf16, #zhigh.layout<{dataLayout = "NHWC"}>>) -> tensor<1xi64>
+// CHECK:           return [[VAR_0_]] : tensor<1xi64>
+// CHECK:         }
+}


### PR DESCRIPTION
This patch is to add a rewriting pattern that removes `zhigh.unstick` when getting dimensions.

For example, the following code
```mIir
%0 = "zhigh.Unstick"(%arg0) : (tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3D"}>>) -> tensor<?x?x?xf32>
%1 = "onnx.Dim"(%0) {axis = 1 : si64}: (tensor<?x?x?xf32>) -> tensor<1xi64>
```
will be replace by 
```mlir
"onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3D"}>>) 
```
where the dimension is obtained directly from a zTensor without unstickifying the zTensor.