### PR TITLE
Update to LLVM 28b27c1b10ae8d1f5b4fb9df691e8cf0da9be3f6

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -15,7 +15,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b44b3494f60296db6aca38a14cab061d9b747a0a && cd ..
+cd llvm-project && git checkout 28b27c1b10ae8d1f5b4fb9df691e8cf0da9be3f6 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b44b3494f60296db6aca38a14cab061d9b747a0a && cd ..
+cd llvm-project && git checkout 28b27c1b10ae8d1f5b4fb9df691e8cf0da9be3f6 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/test/mlir/conversion/onnx_to_krnl/Tensor/Pad_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Tensor/Pad_with_canonicalize.mlir
@@ -123,8 +123,7 @@ func.func @pad_edge_mode(%arg0: tensor<1x3x4x5xf32>, %arg1: tensor<8xi64>, %arg2
 // CHECK-DAG:         [[VAR_23_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#0){{.}}[[VAR_1_]]{{.}}
 // CHECK:             [[VAR_24_:%.+]] = arith.select [[VAR_22_]], [[CST_0_]], [[VAR_23_]] : index
 // CHECK:             [[VAR_25_:%.+]] = arith.cmpi sge, [[VAR_24_]], [[CST_1_]] : index
-// CHECK:             [[VAR_26_:%.+]] = arith.ori [[VAR_25_]], [[VAR_22_]] : i1
-// CHECK-DAG:         [[VAR_27_:%.+]] = arith.select [[VAR_26_]], [[CST_0_]], [[VAR_23_]] : index
+// CHECK-DAG:         [[VAR_27_:%.+]] = arith.select [[VAR_25_]], [[CST_0_]], [[VAR_24_]] : index
 // CHECK-DAG:         [[VAR_28_:%.+]] = arith.cmpi sle, [[VAR_21_]]#1, [[VAR_6_]] : index
 // CHECK-DAG:         [[VAR_29_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#1){{.}}[[VAR_6_]]{{.}}
 // CHECK:             [[VAR_30_:%.+]] = arith.select [[VAR_28_]], [[CST_0_]], [[VAR_29_]] : index

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/Reshape.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/Reshape.mlir
@@ -37,24 +37,23 @@ func.func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi
 // CHECK:           [[VAR_13_:%.+]] = arith.cmpi eq, [[VAR_12_]], [[CST_0_]] : index
 // CHECK:           [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[CST_1_]], [[VAR_12_]] : index
 // CHECK:           [[VAR_15_:%.+]] = arith.cmpi eq, [[VAR_14_]], [[CST_minus_1_]] : index
-// CHECK:           [[VAR_16_:%.+]] = arith.ori [[VAR_15_]], [[VAR_13_]] : i1
-// CHECK:           [[VAR_17_:%.+]] = arith.select [[VAR_16_]], [[CST_1_]], [[VAR_12_]] : index
-// CHECK-DAG:       [[VAR_18_:%.+]] = arith.muli [[VAR_11_]], [[VAR_17_]] : index
-// CHECK-DAG:       [[VAR_19_:%.+]] = shape.get_extent [[VAR_0_]], [[CST_3_]] : tensor<4xindex>, index -> index
-// CHECK:           [[VAR_20_:%.+]] = arith.cmpi eq, [[VAR_19_]], [[CST_0_]] : index
-// CHECK:           [[VAR_21_:%.+]] = arith.select [[VAR_20_]], [[CST_32_]], [[VAR_19_]] : index
-// CHECK:           [[VAR_22_:%.+]] = arith.cmpi eq, [[VAR_21_]], [[CST_minus_1_]] : index
-// CHECK:           [[VAR_23_:%.+]] = arith.select [[VAR_22_]], [[CST_1_]], [[VAR_21_]] : index
-// CHECK:           [[VAR_24_:%.+]] = arith.muli [[VAR_18_]], [[VAR_23_]] : index
-// CHECK:           [[VAR_25_:%.+]] = arith.floordivsi [[CST_800_]], [[VAR_24_]] : index
-// CHECK-DAG:       [[VAR_26_:%.+]] = arith.select [[VAR_4_]], [[VAR_25_]], [[VAR_3_]] : index
-// CHECK-DAG:       [[VAR_27_:%.+]] = arith.select [[VAR_9_]], [[VAR_25_]], [[VAR_8_]] : index
-// CHECK-DAG:       [[VAR_28_:%.+]] = arith.select [[VAR_15_]], [[VAR_25_]], [[VAR_14_]] : index
-// CHECK-DAG:       [[VAR_29_:%.+]] = arith.select [[VAR_22_]], [[VAR_25_]], [[VAR_21_]] : index
-// CHECK:           [[VAR_30_:%.+]] = shape.from_extents [[VAR_26_]], [[VAR_27_]], [[VAR_28_]], [[VAR_29_]] : index, index, index, index
-// CHECK:           [[VAR_31_:%.+]] = shape.to_extent_tensor [[VAR_30_]] : !shape.shape -> tensor<4xindex>
-// CHECK:           [[VAR_32_:%.+]] = stablehlo.dynamic_reshape [[PARAM_0_]], [[VAR_31_]] : (tensor<5x5x1x32xf32>, tensor<4xindex>) -> tensor<?x?x?x?xf32>
-// CHECK:           return [[VAR_32_]] : tensor<?x?x?x?xf32>
+// CHECK:           [[VAR_16_:%.+]] = arith.select [[VAR_15_]], [[CST_1_]], [[VAR_14_]] : index
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.muli [[VAR_11_]], [[VAR_16_]] : index
+// CHECK-DAG:       [[VAR_18_:%.+]] = shape.get_extent [[VAR_0_]], [[CST_3_]] : tensor<4xindex>, index -> index
+// CHECK:           [[VAR_19_:%.+]] = arith.cmpi eq, [[VAR_18_]], [[CST_0_]] : index
+// CHECK:           [[VAR_20_:%.+]] = arith.select [[VAR_19_]], [[CST_32_]], [[VAR_18_]] : index
+// CHECK:           [[VAR_21_:%.+]] = arith.cmpi eq, [[VAR_20_]], [[CST_minus_1_]] : index
+// CHECK:           [[VAR_22_:%.+]] = arith.select [[VAR_21_]], [[CST_1_]], [[VAR_20_]] : index
+// CHECK:           [[VAR_23_:%.+]] = arith.muli [[VAR_17_]], [[VAR_22_]] : index
+// CHECK:           [[VAR_24_:%.+]] = arith.floordivsi [[CST_800_]], [[VAR_23_]] : index
+// CHECK-DAG:       [[VAR_25_:%.+]] = arith.select [[VAR_4_]], [[VAR_24_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_26_:%.+]] = arith.select [[VAR_9_]], [[VAR_24_]], [[VAR_8_]] : index
+// CHECK-DAG:       [[VAR_27_:%.+]] = arith.select [[VAR_15_]], [[VAR_24_]], [[VAR_14_]] : index
+// CHECK-DAG:       [[VAR_28_:%.+]] = arith.select [[VAR_21_]], [[VAR_24_]], [[VAR_20_]] : index
+// CHECK:           [[VAR_29_:%.+]] = shape.from_extents [[VAR_25_]], [[VAR_26_]], [[VAR_27_]], [[VAR_28_]] : index, index, index, index
+// CHECK:           [[VAR_30_:%.+]] = shape.to_extent_tensor [[VAR_29_]] : !shape.shape -> tensor<4xindex>
+// CHECK:           [[VAR_31_:%.+]] = stablehlo.dynamic_reshape [[PARAM_0_]], [[VAR_30_]] : (tensor<5x5x1x32xf32>, tensor<4xindex>) -> tensor<?x?x?x?xf32>
+// CHECK:           return [[VAR_31_]] : tensor<?x?x?x?xf32>
 // CHECK:         }
 
 // -----

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b44b3494f60296db6aca38a14cab061d9b747a0a && cd ..
+cd llvm-project && git checkout 28b27c1b10ae8d1f5b4fb9df691e8cf0da9be3f6 && cd ..


### PR DESCRIPTION
This PR updates onnx-mlir to LLVM commit `28b27c1b10ae8d1f5b4fb9df691e8cf0da9be3f6`.
This is the same LLVM commit level that torch-mlir is currently at.