### PR TITLE
Update Protobuf to v21.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,52 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Here we are installing the required dependency named "abseil" 
+# in order to upgrade protobuf version to >= 3.21.0
+if (Protobuf_FOUND)
+  find_package(absl REQUIRED)
+  find_package(utf8_range REQUIRED)
+  message(STATUS "absl_VERSION: ${absl_VERSION}")
+  set(protobuf_ABSL_USED_TARGETS
+    absl::absl_check
+    absl::absl_log
+    absl::algorithm
+    absl::base
+    absl::bind_front
+    absl::bits
+    absl::btree
+    absl::cleanup
+    absl::cord
+    absl::core_headers
+    absl::debugging
+    absl::die_if_null
+    absl::dynamic_annotations
+    absl::flags
+    absl::flat_hash_map
+    absl::flat_hash_set
+    absl::function_ref
+    absl::hash
+    absl::layout
+    absl::log_initialize
+    absl::log_severity
+    absl::memory
+    absl::node_hash_map
+    absl::node_hash_set
+    absl::optional
+    absl::span
+    absl::status
+    absl::statusor
+    absl::strings
+    absl::synchronization
+    absl::time
+    absl::type_traits
+    absl::utility
+    absl::variant
+    utf8_range::utf8_range
+    utf8_range::utf8_validity
+  )
+endif()
+
 # On systems that still have legacy lib64 directories (e.g., rhel/fedora,
 # etc.), by default some components (e.g., cmake) install into lib while
 # others (e.g., python) install into lib64.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,52 +17,6 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Here we are installing the required dependency named "abseil" 
-# in order to upgrade protobuf version to >= 3.21.0
-if (Protobuf_FOUND)
-  find_package(absl REQUIRED)
-  find_package(utf8_range REQUIRED)
-  message(STATUS "absl_VERSION: ${absl_VERSION}")
-  set(protobuf_ABSL_USED_TARGETS
-    absl::absl_check
-    absl::absl_log
-    absl::algorithm
-    absl::base
-    absl::bind_front
-    absl::bits
-    absl::btree
-    absl::cleanup
-    absl::cord
-    absl::core_headers
-    absl::debugging
-    absl::die_if_null
-    absl::dynamic_annotations
-    absl::flags
-    absl::flat_hash_map
-    absl::flat_hash_set
-    absl::function_ref
-    absl::hash
-    absl::layout
-    absl::log_initialize
-    absl::log_severity
-    absl::memory
-    absl::node_hash_map
-    absl::node_hash_set
-    absl::optional
-    absl::span
-    absl::status
-    absl::statusor
-    absl::strings
-    absl::synchronization
-    absl::time
-    absl::type_traits
-    absl::utility
-    absl::variant
-    utf8_range::utf8_range
-    utf8_range::utf8_validity
-  )
-endif()
-
 # On systems that still have legacy lib64 directories (e.g., rhel/fedora,
 # etc.), by default some components (e.g., cmake) install into lib while
 # others (e.g., python) install into lib64.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Detailed instructions are provided below.
 ```
 python >= 3.8
 gcc >= 6.4
-protobuf >= 3.20.3
+protobuf >= 4.21.12
 cmake >= 3.13.4
 make >= 4.2.1 or ninja >= 1.10.2
 java >= 1.11 (optional)

--- a/docker/Dockerfile.llvm-project
+++ b/docker/Dockerfile.llvm-project
@@ -64,7 +64,7 @@ RUN distro=$(cat /etc/os-release|grep -Po '(?<=^ID=").*(?=")|(?<=^ID=)[^"].*[^"]
     && ln -sf /usr/bin/python3 /usr/bin/python
 
 # Install protobuf
-ARG PROTOBUF_VERSION=3.20.3
+ARG PROTOBUF_VERSION=21.12
 RUN git clone -b v${PROTOBUF_VERSION} --recursive https://github.com/protocolbuffers/protobuf.git \
     && cd protobuf && ./autogen.sh \
     && ./configure --enable-static=no \

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -99,13 +99,13 @@ make: *** [Makefile:146: all] Error 2.
 
 The suggested workaround until jsoniter is fixed is as follows: install maven (e.g. `brew install maven`) and run `alias nproc="sysctl -n hw.logicalcpu"` in your shell.
 
-#### Protobuf issue (Mac M1, specific to protobuf 3.20.3 which is currently required)
+#### Protobuf issue (Mac M1, specific to protobuf 4.21.12 which is currently required)
 
 On Mac M1, you may have some issues building protobuf. In particular, you may fail to install onnx (via `pip install -e third_party/onnx`) or you may fail to compile `onnx-mlir` (no arm64 symbol for `InternalMetadata::~InternalMetadata`).
 
 The first failure is likely an issue with having multiple versions of protobuf.
-Installing a version with `brew` was not helpful (version 3.20.3 because of a known bug that can be corrected with a patch below).
-Uninstall the brew version, and make sure you install the right one with pip: `pip install protobuf==3.20.3`.
+Installing a version with `brew` was not helpful (version 4.21.12 because of a known bug that can be corrected with a patch below).
+Uninstall the brew version, and make sure you install the right one with pip: `pip install protobuf== 4.21.12`.
 
 The second failure can be remediated by downloading protobuf source code, applying a patch, and installing it on the local machine.
 See [Dockerfile.llvm-project](../docker/Dockerfile.llvm-project) on line 66 for cloning instructions. After cloning the right version, you should apply a patch [patch](https://github.com/protocolbuffers/protobuf/commit/0574167d92a232cb8f5a9107aabda0aefbc39e8b) by downloading from the link above and applying it.

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -15,8 +15,8 @@ Build protobuf as a static library.
 
 [same-as-file]: <> (utils/install-protobuf.cmd)
 ```shell
-REM Check out protobuf v3.20.3
-set protobuf_version=3.20.3
+REM Check out protobuf v21.12
+set protobuf_version=21.12
 git clone -b v%protobuf_version% --recursive https://github.com/protocolbuffers/protobuf.git
 
 set root_dir=%cd%
@@ -42,7 +42,7 @@ set PATH=%root_dir%\protobuf_install\bin;%PATH%
 
 If you wish to be able to run all the ONNX-MLIR tests, you will also need to install the matching version of protobuf through pip. Note that this is included in the requirements.txt file at the root of onnx-mlir, so if you plan on using it, you won't need to explicitly install protobuf.
 ```shell
-python3 -m pip install protobuf==3.20.3
+python3 -m pip install protobuf==4.21.12
 ```
 
 #### MLIR

--- a/docs/Prerequisite.md
+++ b/docs/Prerequisite.md
@@ -6,7 +6,7 @@
 ```
 python >= 3.8
 gcc >= 6.4
-protobuf >= 3.20.3
+protobuf >= 4.21.12
 cmake >= 3.13.4
 make >= 4.2.1 or ninja >= 1.10.2
 java >= 1.11 (optional)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ lit~=15.0
 # numpy 1.24 deprecates np.object, np.bool, np.float, np.complex, np.str,
 # and np.int which are used heavily in onnx-mlir.
 numpy~=1.22.2, <=1.23.5
-protobuf~=3.20
+protobuf==4.21.12
 pytest~=7.2
 pytest-xdist~=3.0

--- a/utils/install-protobuf.cmd
+++ b/utils/install-protobuf.cmd
@@ -1,5 +1,5 @@
-REM Check out protobuf v3.20.3
-set protobuf_version=3.20.3
+REM Check out protobuf v21.12
+set protobuf_version=21.12
 git clone -b v%protobuf_version% --recursive https://github.com/protocolbuffers/protobuf.git
 
 set root_dir=%cd%

--- a/utils/install-protobuf.sh
+++ b/utils/install-protobuf.sh
@@ -1,5 +1,5 @@
-# Check out protobuf (mac x86 seems to need an older version)
-PROTOBUF_VERSION=3.18.3
+# Check out protobuf
+PROTOBUF_VERSION=21.12
 git clone -b v${PROTOBUF_VERSION} --depth 1 --recursive https://github.com/protocolbuffers/protobuf.git
 
 cd protobuf


### PR DESCRIPTION
Upgrading Protobuf to match the onnx community. In order to upgrade Protobuf we have to include the abseil dependencies as well or else we will receive failures. I am hoping by upgrading Protobuf it will help us with ONNX 1.15.0 upgrade. 