### PR TITLE
Enable krnl.parallel to have multiple loops

### DIFF
--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -619,8 +619,9 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     // affine.parallel
     LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << " interpret parallel op "
                             << parallelOp << "\n");
+    // ToFix handle multiple parallel loop
     // Obtain the the reference the loop that needs to be parallelized
-    Value loopRef = parallelOp.getLoop();
+    Value loopRef = parallelOp.getLoops()[0];
     // Obtain the lowered affine.forOp
     AffineForOp loopToParallel = llvm::cast<AffineForOp>(loopRefToOp[loopRef]);
     OpBuilder opBuilder(loopToParallel);

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -624,40 +624,43 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
 
     // Obtain the the reference the loop that needs to be parallelized
     for (Value loopRef : loopRefs) {
-    //Value loopRef = parallelOp.getLoops()[0];
-    // Obtain the lowered affine.forOp
-    AffineForOp loopToParallel = llvm::cast<AffineForOp>(loopRefToOp[loopRef]);
-    OpBuilder opBuilder(loopToParallel);
+      // Value loopRef = parallelOp.getLoops()[0];
+      //  Obtain the lowered affine.forOp
+      AffineForOp loopToParallel =
+          llvm::cast<AffineForOp>(loopRefToOp[loopRef]);
+      OpBuilder opBuilder(loopToParallel);
 
-    // Extract the metadata from the original affine.forOp and then create a
-    // affine.parallelOp
-    Location loc = loopToParallel.getLoc();
-    AffineMap lbsMap = loopToParallel.getLowerBoundMap();
-    ValueRange lbsOperands = loopToParallel.getLowerBoundOperands();
-    AffineMap ubsMap = loopToParallel.getUpperBoundMap();
-    ValueRange ubsOperands = loopToParallel.getUpperBoundOperands();
+      // Extract the metadata from the original affine.forOp and then create a
+      // affine.parallelOp
+      Location loc = loopToParallel.getLoc();
+      AffineMap lbsMap = loopToParallel.getLowerBoundMap();
+      ValueRange lbsOperands = loopToParallel.getLowerBoundOperands();
+      AffineMap ubsMap = loopToParallel.getUpperBoundMap();
+      ValueRange ubsOperands = loopToParallel.getUpperBoundOperands();
 
-    // Current: parallel reduction is not used. Parallel reduction can be
-    // enabled after the Ops have been lowered to Affine. Please check
-    // Dialect/Affine/Transforms/AffineParallelize.cpp in MLIR repo to see how
-    // to enable parallel reduction.
-    SmallVector<LoopReduction> parallelReductions;
-    auto reducedValues = llvm::to_vector<4>(llvm::map_range(parallelReductions,
-        [](const LoopReduction &red) { return red.value; }));
-    auto reductionKinds = llvm::to_vector<4>(llvm::map_range(
-        parallelReductions, [](const LoopReduction &red) { return red.kind; }));
+      // Current: parallel reduction is not used. Parallel reduction can be
+      // enabled after the Ops have been lowered to Affine. Please check
+      // Dialect/Affine/Transforms/AffineParallelize.cpp in MLIR repo to see how
+      // to enable parallel reduction.
+      SmallVector<LoopReduction> parallelReductions;
+      auto reducedValues =
+          llvm::to_vector<4>(llvm::map_range(parallelReductions,
+              [](const LoopReduction &red) { return red.value; }));
+      auto reductionKinds =
+          llvm::to_vector<4>(llvm::map_range(parallelReductions,
+              [](const LoopReduction &red) { return red.kind; }));
 
-    AffineParallelOp parallelLoop = opBuilder.create<AffineParallelOp>(loc,
-        ValueRange(reducedValues).getTypes(), reductionKinds, ArrayRef(lbsMap),
-        lbsOperands, ArrayRef(ubsMap), ubsOperands,
-        ArrayRef(loopToParallel.getStepAsInt()));
-    parallelLoop.getRegion().takeBody(loopToParallel.getRegion());
-    Operation *yieldOp = &parallelLoop.getBody()->back();
+      AffineParallelOp parallelLoop = opBuilder.create<AffineParallelOp>(loc,
+          ValueRange(reducedValues).getTypes(), reductionKinds,
+          ArrayRef(lbsMap), lbsOperands, ArrayRef(ubsMap), ubsOperands,
+          ArrayRef(loopToParallel.getStepAsInt()));
+      parallelLoop.getRegion().takeBody(loopToParallel.getRegion());
+      Operation *yieldOp = &parallelLoop.getBody()->back();
 
-    yieldOp->setOperands(reducedValues);
-    // Replace the affine.forOp with affine.parallelOp in loopRefToTop
-    loopRefToOp[loopRef] = parallelLoop;
-    loopToParallel.erase();
+      yieldOp->setOperands(reducedValues);
+      // Replace the affine.forOp with affine.parallelOp in loopRefToTop
+      loopRefToOp[loopRef] = parallelLoop;
+      loopToParallel.erase();
     }
     opsToErase.insert(parallelOp);
     return success();

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -620,8 +620,11 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << " interpret parallel op "
                             << parallelOp << "\n");
     // ToFix handle multiple parallel loop
+    ValueRange loopRefs = parallelOp.getLoops();
+
     // Obtain the the reference the loop that needs to be parallelized
-    Value loopRef = parallelOp.getLoops()[0];
+    for (Value loopRef : loopRefs) {
+    //Value loopRef = parallelOp.getLoops()[0];
     // Obtain the lowered affine.forOp
     AffineForOp loopToParallel = llvm::cast<AffineForOp>(loopRefToOp[loopRef]);
     OpBuilder opBuilder(loopToParallel);
@@ -654,8 +657,9 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
     yieldOp->setOperands(reducedValues);
     // Replace the affine.forOp with affine.parallelOp in loopRefToTop
     loopRefToOp[loopRef] = parallelLoop;
-    opsToErase.insert(parallelOp);
     loopToParallel.erase();
+    }
+    opsToErase.insert(parallelOp);
     return success();
   }
   return success();

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2210,7 +2210,7 @@ struct ONNXElementwiseBinaryOpLowering
       create.krnlIE.getShapeAsDims(alloc, ubs);
       // TODO adjust in the future
       if (enableParallel) {
-        create.krnl.parallel(loopDef[0]);
+        create.krnl.parallel(loopDef);
         LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
       }
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
@@ -2373,7 +2373,7 @@ struct ONNXElementwiseVariadicOpLowering
       create.krnlIE.getShapeAsDims(alloc, ubs);
 
       if (enableParallel) {
-        create.krnl.parallel(loopDef[0]);
+        create.krnl.parallel(loopDef);
         LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
       }
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2210,7 +2210,7 @@ struct ONNXElementwiseBinaryOpLowering
       create.krnlIE.getShapeAsDims(alloc, ubs);
       // TODO adjust in the future
       if (enableParallel) {
-        create.krnl.parallel(loopDef);
+        create.krnl.parallel(loopDef[0]);
         LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
       }
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
@@ -2373,7 +2373,7 @@ struct ONNXElementwiseVariadicOpLowering
       create.krnlIE.getShapeAsDims(alloc, ubs);
 
       if (enableParallel) {
-        create.krnl.parallel(loopDef);
+        create.krnl.parallel(loopDef[0]);
         LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: " << op->getName() << "\n");
       }
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -126,8 +126,8 @@ ValueRange KrnlBuilder::getInductionVarValue(ValueRange loops) const {
       .getResults();
 }
 
-void KrnlBuilder::parallel(Value loop) const {
-  b().template create<KrnlParallelOp>(loc(), loop);
+void KrnlBuilder::parallel(ValueRange loops) const {
+  b().template create<KrnlParallelOp>(loc(), loops);
 }
 
 void KrnlBuilder::iterate(ValueRange originalLoops, ValueRange optimizedLoops,

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -52,7 +52,7 @@ struct KrnlBuilder : public DialectBuilder {
   mlir::ValueRange block(mlir::Value loop, int64_t blockSize) const;
   void permute(mlir::ValueRange loops, mlir::ArrayRef<int64_t> map) const;
   mlir::ValueRange getInductionVarValue(mlir::ValueRange loops) const;
-  void parallel(mlir::Value loop) const;
+  void parallel(mlir::ValueRange loops) const;
 
   // Lambda passes loop indices as 2nd parameter.
   void iterate(mlir::ValueRange originalLoops, mlir::ValueRange optimizedLoops,

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -513,10 +513,10 @@ def KrnlParallelOp : Op<Krnl_Dialect, "parallel"> {
     ```
   }];
 
-  let arguments = (ins AnyType:$loop);
+  let arguments = (ins Variadic<AnyType>:$loops);
 
   let assemblyFormat = [{
-      $loop attr-dict `:` type($loop)
+      $loops attr-dict `:` type($loops)
   }];
 }
 

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -509,14 +509,14 @@ def KrnlParallelOp : Op<Krnl_Dialect, "parallel"> {
     operator before krnl.iterate. Since we do not want to parallelize the loop
     until we interpret krnl.block, krnl.permute and krnl.unroll.
     ```
-    krnl.parallel %i
+    krnl.parallel (%i0, %i1)
     ```
   }];
 
   let arguments = (ins Variadic<AnyType>:$loops);
 
   let assemblyFormat = [{
-      $loops attr-dict `:` type($loops)
+      `(` $loops `)` attr-dict `:` type($loops)
   }];
 }
 

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -503,13 +503,15 @@ def KrnlUnrollOp : Op<Krnl_Dialect, "unroll"> {
 }
 
 def KrnlParallelOp : Op<Krnl_Dialect, "parallel"> {
-  let summary = "Krnl parallel operation";
+  let summary = "Mark Krnl loops as parallel loops";
   let description = [{
-    Parallelize the specified loops. krnl.parallel should be placed as the last
-    operator before krnl.iterate. Since we do not want to parallelize the loop
-    until we interpret krnl.block, krnl.permute and krnl.unroll.
+    Parallelize the specified loops. When multiple loop specifiers are passed
+    as parameters, there loops can be parallelized as a collapsed loop.
+    krnl.parallel should be placed as the last operator before krnl.iterate,
+    Since we do not want to parallelize the loop until we interpret krnl.block,
+    krnl.permute and krnl.unroll.
     ```
-    krnl.parallel (%i0, %i1)
+    krnl.parallel (%i0, %i1) : !Krnl.loop, !Krnl.loop
     ```
   }];
 

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_parallel_canonicalize_O3.mlir
@@ -33,7 +33,7 @@ func.func @test_relu_parallel(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   // CHECK-DAG:       [[VAR_reshape_3_:%.+]] = memref.reshape [[VAR_view_]]([[RES_2_]]) : (memref<?x10xf32>, memref<1xindex>) -> memref<?xf32>
   // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
   // CHECK:           [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
-  // CHECK:           krnl.parallel [[BLOCK_TILE__0_]] : !krnl.loop
+  // CHECK:           krnl.parallel([[BLOCK_TILE__0_]]) : !krnl.loop
   // CHECK:           krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to [[MAP_2_]](){{.}}[[VAR_dim_]], [[VAR_dim_]]_0]){
   // CHECK:             [[VAR_4_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
   // CHECK:             [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_4_]]{{.}} : memref<?xf32>, vector<32xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Math/Gemm_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Gemm_with_parallel_canonicalize_O3.mlir
@@ -28,7 +28,7 @@ func.func @test_gemm_parallel(%arg0 : tensor<5x10xf32>, %arg1 : tensor<5x10xf32>
   // CHECK:           [[BLOCK_TILE__3_:%.+]], [[BLOCK_IN__3_:%.+]] = krnl.block [[BLOCK_IN__2_]] 16 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
   // CHECK:           [[BLOCK_TILE__4_:%.+]], [[BLOCK_IN__4_:%.+]] = krnl.block [[LOOP_0_]]#2 256 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
   // CHECK:           krnl.permute([[BLOCK_TILE__2_]], [[BLOCK_TILE__3_]], [[BLOCK_IN__3_]], [[BLOCK_TILE__4_]], [[BLOCK_IN__4_]], [[BLOCK_TILE__0_]], [[BLOCK_TILE__0_]]_3, [[BLOCK_IN__1_]]) [0, 3, 5, 1, 6, 2, 4, 7] : !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop
-  // CHECK:           krnl.parallel [[BLOCK_TILE__2_]] : !krnl.loop
+  // CHECK:           krnl.parallel([[BLOCK_TILE__2_]]) : !krnl.loop
   // CHECK:           krnl.iterate([[BLOCK_TILE__2_]], [[BLOCK_TILE__4_]]) with ([[LOOP_0_]]#1 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#2 -> [[I_1_:%.+]] = 0 to 5, [[LOOP_0_]]#0 -> [[I_2_:%.+]] = 0 to 10){
   // CHECK:             [[VAR_2_:%.+]]:2 = krnl.get_induction_var_value([[BLOCK_TILE__2_]], [[BLOCK_TILE__4_]]) : (!krnl.loop, !krnl.loop) -> (index, index)
   // CHECK:             krnl.copy_to_tile_buffer [[RES_2_]], [[PARAM_1_]]{{.}}[[VAR_2_]]#1, [[VAR_2_]]#0], [[CST_0_dot_000000_]] {padToNext = [], tileSize = []} : memref<256x64xf32>, memref<5x10xf32>
@@ -42,7 +42,7 @@ func.func @test_gemm_parallel(%arg0 : tensor<5x10xf32>, %arg1 : tensor<5x10xf32>
   // CHECK:             }
   // CHECK:           }
   // CHECK:           [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
-  // CHECK:           krnl.parallel [[LOOP_1_]]#0 : !krnl.loop
+  // CHECK:           krnl.parallel([[LOOP_1_]]#0) : !krnl.loop
   // CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_3_:%.+]] = 0 to 10, [[LOOP_1_]]#1 -> [[I_4_:%.+]] = 0 to 10){
   // CHECK:             [[VAR_2_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
   // CHECK-DAG:         [[VAR_3_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#1] : memref<10x10xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_parallel_canonicalize_O3.mlir
@@ -24,7 +24,7 @@ func.func @test_matmul_parallel(%arg0 : tensor<4x8xf32>, %arg1 : tensor<8x16xf32
   // CHECK:           [[BLOCK_TILE__1_:%.+]], [[BLOCK_IN__1_:%.+]] = krnl.block [[LOOP_0_]]#1 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
   // CHECK:           [[BLOCK_TILE__2_:%.+]], [[BLOCK_IN__2_:%.+]] = krnl.block [[LOOP_0_]]#2 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
   // CHECK:           krnl.permute([[BLOCK_TILE__0_]], [[BLOCK_IN__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_IN__0_]]_1, [[BLOCK_TILE__0_]]_2, [[BLOCK_IN__0_]]_3) [0, 3, 1, 4, 2, 5] : !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop
-  // CHECK:           krnl.parallel [[BLOCK_TILE__0_]] : !krnl.loop
+  // CHECK:           krnl.parallel([[BLOCK_TILE__0_]]) : !krnl.loop
   // CHECK:           krnl.iterate([[BLOCK_TILE__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_TILE__0_]]_2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = [[CST_0_]] to [[CST_4_]], [[LOOP_0_]]#1 -> [[I_1_:%.+]] = [[CST_0_]] to [[CST_16_]], [[LOOP_0_]]#2 -> [[I_2_:%.+]] = [[CST_0_]] to [[CST_8_]]){
   // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[BLOCK_TILE__0_]], [[BLOCK_TILE__0_]]_0, [[BLOCK_TILE__0_]]_2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
   // CHECK:             krnl.matmul [[PARAM_0_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, [[PARAM_1_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, [[RES_]]{{.}}[[CST_0_]], [[CST_0_]]{{.}}, ([[BLOCK_IN__0_]], [[BLOCK_IN__0_]]_1, [[BLOCK_IN__0_]]_3), ([[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2), ([[CST_4_]], [[CST_16_]], [[CST_8_]]) {aTileSize = [], bTileSize = [], cTileSize = [], computeTileSize = [4, 8, 8]} : memref<4x8xf32>, memref<8x16xf32>, memref<4x16xf32>, (!krnl.loop, !krnl.loop, !krnl.loop)

--- a/test/mlir/conversion/onnx_to_krnl/Math/Reduction_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Reduction_with_parallel_canonicalize_O3.mlir
@@ -15,7 +15,7 @@ func.func private @test_reducemean_v13_f32(%arg0 : tensor<3x2x2xf32>) -> tensor<
   // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
   // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<3x2xf32>
   // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
-  // CHECK:           krnl.parallel [[LOOP_0_]]#0 : !krnl.loop
+  // CHECK:           krnl.parallel([[LOOP_0_]]#0) : !krnl.loop
   // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 2){
   // CHECK:             [[VAR_3_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
   // CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1] : memref<3x2xf32>
@@ -29,7 +29,7 @@ func.func private @test_reducemean_v13_f32(%arg0 : tensor<3x2x2xf32>) -> tensor<
   // CHECK:             krnl.store [[VAR_6_]], [[RES_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#2] : memref<3x2xf32>
   // CHECK:           }
   // CHECK:           [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-  // CHECK:           krnl.parallel [[LOOP_2_]]#0 : !krnl.loop
+  // CHECK:           krnl.parallel([[LOOP_2_]]#0) : !krnl.loop
   // CHECK:           krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_5_:%.+]] = 0 to 3, [[LOOP_2_]]#1 -> [[I_6_:%.+]] = 0 to 2){
   // CHECK:             [[VAR_3_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
   // CHECK:             [[LOAD_RES_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_3_2_]]#0, [[VAR_3_2_]]#1] : memref<3x2xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_parallel_canonicalize_O3.mlir
@@ -17,7 +17,7 @@ func.func @test_softmax_v13_parallel(%arg0 : tensor<10x20x30xf32>) -> tensor<*xf
   // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<f32>
   // CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() : memref<f32>
   // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
-  // CHECK:           krnl.parallel [[LOOP_0_]]#0 : !krnl.loop
+  // CHECK:           krnl.parallel([[LOOP_0_]]#0) : !krnl.loop
   // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 30){
   // CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
   // CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>

--- a/test/mlir/conversion/onnx_to_krnl/Tensor/Concat_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Tensor/Concat_with_parallel_canonicalize_O3.mlir
@@ -15,14 +15,14 @@ func.func @test_concat_parallel(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5
   // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<5x5x1x32xf32>, [[PARAM_1_:%.+]]: memref<5x5x3x32xf32>, [[PARAM_2_:%.+]]: memref<5x5x5x32xf32>) -> memref<5x5x9x32xf32> {
   // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<5x5x9x32xf32>
   // CHECK-DAG:       [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
-  // CHECK:           krnl.parallel [[LOOP_0_]]#0 : !krnl.loop
+  // CHECK:           krnl.parallel([[LOOP_0_]]#0) : !krnl.loop
   // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 5, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 5, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 1, [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 32){
   // CHECK:             [[VAR_3_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
   // CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1, [[VAR_3_]]#2, [[VAR_3_]]#3] : memref<5x5x1x32xf32>
   // CHECK:             krnl.store [[LOAD_PARAM_0_MEM_]], [[RES_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1, [[VAR_3_]]#2, [[VAR_3_]]#3] : memref<5x5x9x32xf32>
   // CHECK:           }
   // CHECK:           [[LOOP_1_:%.+]]:4 = krnl.define_loops 4
-  // CHECK:           krnl.parallel [[LOOP_1_]]#0 : !krnl.loop
+  // CHECK:           krnl.parallel([[LOOP_1_]]#0) : !krnl.loop
   // CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) with ([[LOOP_1_]]#0 -> [[I_4_:%.+]] = 0 to 5, [[LOOP_1_]]#1 -> [[I_5_:%.+]] = 0 to 5, [[LOOP_1_]]#2 -> [[I_6_:%.+]] = 0 to 3, [[LOOP_1_]]#3 -> [[I_7_:%.+]] = 0 to 32){
   // CHECK:             [[VAR_3_1_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
   // CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = affine.apply [[MAP_0_]]([[VAR_3_1_]]#2)
@@ -30,7 +30,7 @@ func.func @test_concat_parallel(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<5x5
   // CHECK:             krnl.store [[LOAD_PARAM_1_MEM_]], [[RES_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[LOAD_PARAM_0_MEM_1_]], [[VAR_3_1_]]#3] : memref<5x5x9x32xf32>
   // CHECK:           }
   // CHECK:           [[LOOP_2_:%.+]]:4 = krnl.define_loops 4
-  // CHECK:           krnl.parallel [[LOOP_2_]]#0 : !krnl.loop
+  // CHECK:           krnl.parallel([[LOOP_2_]]#0) : !krnl.loop
   // CHECK:           krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2, [[LOOP_2_]]#3) with ([[LOOP_2_]]#0 -> [[I_8_:%.+]] = 0 to 5, [[LOOP_2_]]#1 -> [[I_9_:%.+]] = 0 to 5, [[LOOP_2_]]#2 -> [[I_10_:%.+]] = 0 to 5, [[LOOP_2_]]#3 -> [[I_11_:%.+]] = 0 to 32){
   // CHECK:             [[VAR_3_2_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2, [[LOOP_2_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
   // CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = affine.apply [[MAP_1_]]([[VAR_3_2_]]#2)

--- a/test/mlir/conversion/onnx_to_krnl/Tensor/Transpose_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Tensor/Transpose_with_parallel_canonicalize_O3.mlir
@@ -13,7 +13,7 @@ func.func @test_transpose_block_1_last_dim_parallel(%arg0: tensor<?x256x12x64xf3
     // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
     // CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1, d2) -> (d0 * 196608 + d1 * 768 + d2 * 64)>
     // CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1, d2) -> (d0 * 196608 + d1 * 64 + d2 * 16384)>
-    // CHECK-LABEL:  func.func @test_transpose_block_1_last_dim
+    // CHECK-LABEL:  func.func @test_transpose_block_1_last_dim_parallel
     // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x256x12x64xf32>) -> memref<?x12x256x64xf32> {
     // CHECK-DAG:       [[CST_64_:%.+]] = arith.constant 64 : i64
     // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
@@ -21,7 +21,7 @@ func.func @test_transpose_block_1_last_dim_parallel(%arg0: tensor<?x256x12x64xf3
     // CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_dim_]]) {{.*}}: memref<?x12x256x64xf32>
     // CHECK-DAG:       [[VAR_dim_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x256x12x64xf32>
     // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
-    // CHECK:           krnl.parallel [[LOOP_0_]]#0 : !krnl.loop
+    // CHECK:           krnl.parallel([[LOOP_0_]]#0) : !krnl.loop
     // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_0_]]([[VAR_dim_0_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 256, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 12){
     // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
     // CHECK-DAG:         [[VAR_2_:%.+]] = affine.apply [[MAP_1_]]([[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2)


### PR DESCRIPTION
Previously, only one loop ref is allowed by krnl.parallel.
This PR allows a variadic input of loop refs for krnl.prallel. For example, the krnl for an element wise op on three dimension tensor could be (if our parallelization had been modified):
```
    %0:3 = krnl.define_loops 3
    krnl.parallel %0#0, %0#1, %0#2 : !krnl.loop, !krnl.loop, !krnl.loop
    krnl.iterate(%0#0, %0#1, %0#2) with (%0#0 -> %arg2 = 0 to 3, %0#1 -> %arg3 = 0 to 4, %0#2 -> %arg4 = 0 to 5){
      %1:3 = krnl.get_induction_var_value(%0#0, %0#1, %0#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
      %2 = krnl.load %arg0[%1#0, %1#1, %1#2] : memref<3x4x5xf32>
      %3 = krnl.load %arg1[%1#0, %1#1, %1#2] : memref<3x4x5xf32>
      %4 = arith.addf %2, %3 : f32
      krnl.store %4, %alloc[%1#0, %1#1, %1#2] : memref<3x4x5xf32>
    } 
```
In the Krnl to affine, each loop in the krnl.parallel will be converted into a affine.parallel. 
```
    affine.parallel (%arg2) = (0) to (3) {
      affine.parallel (%arg3) = (0) to (4) {
        affine.parallel (%arg4) = (0) to (5) {
          %0 = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
          %1 = affine.load %arg1[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
          %2 = arith.addf %0, %1 : f32
          affine.store %2, %alloc[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
        }
      }
    }
```
and the omp loops will have three nested parallel, which is not we want.

This is not the final result yet. At least two PRs will be needed:
1. Create krnl.parallel with multiple loops
2. Create affine.parallel with multiple loops so that we can have multiple loops for the amp.wsloop. 
```
    affine.parallel (%arg2, %arg3, %arg4) = (0, 0, 0) to (3, 4, 5) {
          %0 = affine.load %arg0[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
          %1 = affine.load %arg1[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
          %2 = arith.addf %0, %1 : f32
          affine.store %2, %alloc[%arg2, %arg3, %arg4] : memref<3x4x5xf32>
    }
```