### PR TITLE
make the OMP parallel runtime included with the `-parallel` flag

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -1073,6 +1073,10 @@ void initCompilerConfig() {
             : std::vector<std::string>{"jniruntime", "cruntime"});
     addCompilerConfig(CCM_SHARED_LIB_PATH_DEPS, {getLibraryPath()});
 
+    // Add OpenMP LLVM library if parallel is enabled.
+    if (enableParallel)
+      addCompilerConfig(CCM_SHARED_LIB_DEPS, {"ompruntime"});
+
     // Add user specified libs and their path
     // Multiple lib or directory can be specified with multiple options.
     // For example, -lextra1, -lextra2, -Lpath1, -Lpath2

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -211,10 +211,9 @@ void addKrnlToLLVMPasses(
     pm.addPass(mlir::createCSEPass());
   pm.addNestedPass<func::FuncOp>(mlir::createConvertVectorToSCFPass());
   pm.addPass(mlir::createLowerAffinePass());
-  if (enableParallel) {
-    pm.addPass(mlir::createConvertSCFToOpenMPPass());
-    pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
-  }
+
+  // Early introduction of omp causes problems with bufferization, delay for
+  // now. May revise this decision later.
 
   // After affine is lowered, KrnlRegion for affine scope can be removed.
   pm.addNestedPass<func::FuncOp>(krnl::createLowerKrnlRegionPass());
@@ -231,6 +230,12 @@ void addKrnlToLLVMPasses(
       pm, bufferDeallocOptions);
 
   pm.addPass(mlir::createBufferizationToMemRefPass());
+
+  // Late introduction of OpenMP, after bufferization.
+  if (enableParallel) {
+    pm.addPass(mlir::createConvertSCFToOpenMPPass());
+    pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
+  }
 
   // The pass below is needed for subview and collapseShape.. Unfortunately,
   // MLIR supports only collapse for scalar loaded by scalar memory at this

--- a/src/Runtime/omp/CMakeLists.txt
+++ b/src/Runtime/omp/CMakeLists.txt
@@ -27,7 +27,7 @@ if(TARGET omp)
 
   add_custom_target(libOMomp
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${OMP_TOPDIR}/lib/libomp.a ${ONNX_MLIR_LIBRARY_PATH}/libOMomp.a
+            ${OMP_TOPDIR}/lib/libomp.a ${ONNX_MLIR_LIBRARY_PATH}/libompruntime.a
     DEPENDS OMomp
     # BYPRODUCTS requires cmake 3.20+
     BYPRODUCTS ${OMP_TOPDIR}/lib/libomp.a


### PR DESCRIPTION
Using the '-parallel` flag, the OpenMP runtime is linked in the model so that no matter how the model is deployed, the OpenMP runtime will work.

Also moved the bufferization before OMP expansion as it seems to fail otherwise at this time. This may be reverted in the future.