### PR TITLE
Fix backed test issues with "force-dynamic" mode.

### DIFF
--- a/test/backend/common.py
+++ b/test/backend/common.py
@@ -63,7 +63,7 @@ def execute_commands(cmds, dynamic_inputs_dims):
                     first_dim = False
                 else:
                     env_string += "," + str(dim_index)
-        my_env["TEST_IMPORTER_FORCE_DYNAMIC"] = env_string
+        my_env["IMPORTER_FORCE_DYNAMIC"] = env_string
     subprocess.run(cmds, env=my_env, check=True)
 
 


### PR DESCRIPTION
It seems that backend tests with the "force-dynamic" mode are not executed by "cmake check-onnx-backend-dynamic", and the normal static mode is executed by "cmake check-onnx-backend-dynamic" now.

"test/backend/common.py" sets the "TEST_IMPORTER_FORCE_DYNAMIC" environment variable, but it is not referred by the onnx-mlir compiler, but the "IMPORTER_FORCE_DYNAMIC" environment variable is referred.
 
 This PR sets the "IMPORTER_FORCE_DYNAMIC" environment variable to execute backend tests with the "force-dynamic" mode.
 
 PR #2617 changes shapes of results as same as input shapes, and  will fix a part of this issue.