### PR TITLE
ONNX-to-TOSA: Add ResizeOp Conversion

### DIFF
--- a/src/Conversion/ONNXToTOSA/CMakeLists.txt
+++ b/src/Conversion/ONNXToTOSA/CMakeLists.txt
@@ -14,6 +14,7 @@ add_onnx_mlir_library(OMONNXToTOSA
   NN/AveragePool.cpp
   Tensor/Constant.cpp
   Tensor/Reshape.cpp
+  Tensor/Resize.cpp
 
   LINK_LIBS PUBLIC
   OMONNXOps

--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -41,6 +41,8 @@ void populateONNXToTOSAConversionPattern(ConversionTarget &target,
       target, patterns, typeConverter, ctx);
   populateLoweringONNXReshapeOpToTOSAPattern(
       target, patterns, typeConverter, ctx);
+  populateLoweringONNXResizeOpToTOSAPattern(
+      target, patterns, typeConverter, ctx);
 }
 
 // Performs lowering to TOSA dialect

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -120,4 +120,6 @@ void populateLoweringONNXConstOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXReshapeOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXResizeOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -35,6 +35,17 @@ using namespace mlir;
 namespace onnx_mlir {
 namespace tosa {
 
+int64_t convertNegativeAxis(int64_t axis, int64_t inputRank) {
+  if (axis < 0)
+    axis += inputRank;
+
+  // Check if axis is in correct range.
+  assert(
+      (axis >= 0 && axis < inputRank) && "axis attribute not in correct range");
+
+  return axis;
+}
+
 mlir::RankedTensorType reduceAxisToOne(llvm::ArrayRef<int64_t> shape,
     mlir::Type elementType, mlir::Attribute encoding) {
   return mlir::RankedTensorType::get(

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -30,6 +30,10 @@
 namespace onnx_mlir {
 namespace tosa {
 
+// ONNX can use negative indices for axis while TOSA cannot. This functions
+// makes sure the axis is in the right range for TOSA.
+int64_t convertNegativeAxis(int64_t axis, int64_t inputRank);
+
 // Create a RankedTensorType with shape and all elements being 1
 mlir::RankedTensorType reduceAxisToOne(llvm::ArrayRef<int64_t> shape,
     mlir::Type elementType, mlir::Attribute encoding = {});

--- a/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
@@ -1,0 +1,332 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------------- Resize.cpp - Resize Op-------------------------------===//
+//
+// Copyright (c) 2023 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file lowers the ONNX Resize operator to TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+
+#include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+
+#include <cstdint>
+#include <numeric>
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+namespace {
+struct ScaleHelper {
+  ScaleHelper(
+      int64_t numerator, int64_t denominator, int64_t offset, int64_t border)
+      : numerator(numerator), denominator(denominator), offset(offset),
+        border(border){};
+  int64_t numerator, denominator, offset, border;
+};
+
+// Adapted from TFL to TOSA.
+ScaleHelper normalize(int64_t output, int64_t input, bool pytorchHalfPixel,
+    bool alignCorners, bool halfPixel, bool isNearest,
+    bool isNearestModeFloor) {
+  int64_t numerator, denominator, offset, border;
+  // Test if pytorch_half_pixel needs special handling
+  if (pytorchHalfPixel && output == 1) {
+    numerator = 1;
+    denominator = 1;
+    offset = -1;
+    border = denominator * (output - 1) - numerator * (input - 1) + offset;
+    return ScaleHelper(numerator, denominator, offset, border);
+  }
+
+  // Apply if aligned and capable to be aligned.
+  bool applyAligned = alignCorners && (output > 1);
+  numerator = applyAligned ? (output - 1) : output;
+  denominator = applyAligned ? (input - 1) : input;
+
+  // Simplify the scalers, make sure they are even values.
+  int gcd = std::gcd(numerator, denominator);
+  numerator = 2 * numerator / gcd;
+  denominator = 2 * denominator / gcd;
+
+  // If half pixel centers we need to sample half a pixel inward.
+  offset = halfPixel || pytorchHalfPixel ? (denominator - numerator) / 2 : 0;
+
+  // If round_half_up we need to adjust the offset
+  if (isNearest && isNearestModeFloor) {
+    offset -= numerator / 2;
+  }
+
+  // We can compute this directly based on previous values.
+  border = denominator * (output - 1) - numerator * (input - 1) + offset;
+  return ScaleHelper(numerator, denominator, offset, border);
+};
+
+void valuesFromAxis(ArrayAttr *axis, llvm::SmallVectorImpl<int64_t> &axisVec) {
+  auto axisRange = axis->getAsRange<IntegerAttr>();
+  llvm::transform(axisRange, std::back_inserter(axisVec), [](IntegerAttr attr) {
+    return tosa::convertNegativeAxis(attr.getInt(), 4);
+  });
+}
+
+LogicalResult getScaleValue(ConversionPatternRewriter &rewriter, Operation *op,
+    llvm::SmallVectorImpl<int64_t> &axisVec,
+    llvm::SmallVectorImpl<float> &scaleVec, Value scaleValue) {
+  mlir::ElementsAttr elementsAttr =
+      getElementAttributeFromONNXValue(scaleValue);
+  if (!elementsAttr)
+    return rewriter.notifyMatchFailure(
+        op, "Scale cannot come from a block argument.");
+
+  // The axis attribute might permute and/or reduce the number of elements
+  // in scaleValue. This reorders the scales to account for that.
+  for (auto [index, value] : llvm::enumerate(axisVec))
+    scaleVec[value] =
+        elementsAttr.getValues<FloatAttr>()[index].getValueAsDouble();
+
+  // Even if the shapes are identical, a scale value other than 1 is
+  // possible. TOSA does not allow that for non-spatial dimensions.
+  for (int64_t nonSpatialDimensions : {0, 1}) {
+    if (scaleVec[nonSpatialDimensions] != 1)
+      return rewriter.notifyMatchFailure(
+          op, "Axis Attr if present must contain both output dimensions.");
+  }
+  return success();
+}
+
+class ONNXResizeOpLoweringToTOSA : public ConversionPattern {
+public:
+  ONNXResizeOpLoweringToTOSA(MLIRContext *ctx)
+      : ConversionPattern(ONNXResizeOp::getOperationName(), 1, ctx) {}
+  using OpAdaptor = typename ONNXResizeOp::Adaptor;
+
+  struct FractionNumber {
+    FractionNumber(float number) {
+      double integral = std::floor(number);
+      double frac = number - integral;
+
+      const long precision = 1000000000; // This is the accuracy.
+
+      long gcd_ = std::gcd((int)round(frac * precision), precision);
+
+      long denominator = precision / gcd_;
+      long numerator = round(frac * precision) / gcd_;
+
+      this->numerator = numerator + denominator * integral;
+      this->denominator = denominator;
+    }
+    int64_t numerator;
+    int64_t denominator;
+  };
+
+  /// ## coordinateTransformationMode ##
+  /// TOSA uses the formula ix = (ox * scale_x_d + offset_x) / scale_x_n
+  /// to find the input coordinates. In order to lower ONNX one needs to
+  /// express the modes in this context. Border is only used to check if certain
+  /// conditions in the dimensions are met, but has no actual use in calculating
+  /// something. It is probably an error in the TOSA specification. In order to
+  /// fulfill the conditions, border is always
+  /// border = d * (output - 1) - n *(input - 1) + offset
+  ///
+  /// ### half_pixel ###
+  /// ONNX formula: ix = (ox + 0.5) / scale - 0.5
+  /// gcd = greatest common divisor
+  /// To meet TOSA requirements:
+  /// - scale_x_d = input_size * 2 / gcd
+  /// - scale_x_n = output_size * 2 / gcd
+  /// - offset_x =  (scale_x_d - scale_x_n) / 2
+  ///
+  /// ### pytorch_half_pixel ###
+  /// Same as half_pixel, but if output == 1:
+  /// - scale_x_d = scale_x_n = 1
+  /// - offset = -1
+  ///
+  /// ### half_pixel_symmetric ###
+  /// NOT SUPPORTED BY TOSA, BECAUSE OF INT OFFSET
+  /// Same as half_pixel, but with another offset
+  /// - offset_x += symmetric_offset_x
+  ///
+  /// ### align_corners ###
+  /// - scale_x_d = (input_size - 1)
+  /// - scale_x_n = (output_size - 1)
+  /// - offset = 0
+  ///
+  /// ### asymmetric ###
+  /// - scale_x_d = input_size
+  /// - scale_x_n = output_size
+  /// - offset = 0
+  ///
+  /// ## nearest_mode ##
+  /// If mode == nearest, then ONNX can set the nearest_mode attribute.
+  /// The standard case for TOSA of round_half_up. Support for floor can
+  /// be achieved with:
+  /// offset_x -= n/2
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const final {
+    auto resizeOp = llvm::cast<ONNXResizeOp>(op);
+    Location loc = op->getLoc();
+    OpAdaptor adaptor(operands, op->getAttrDictionary());
+
+    TosaBuilder tosaBuilder(rewriter, loc);
+
+    Value input = adaptor.getX();
+    auto inputType = input.getType().dyn_cast<RankedTensorType>();
+
+    auto resultType =
+        resizeOp.getResult().getType().dyn_cast<RankedTensorType>();
+
+    StringRef mode = adaptor.getMode();
+    StringRef nearestMode = adaptor.getNearestMode();
+    StringRef coordinateTransformationMode =
+        adaptor.getCoordinateTransformationMode();
+    std::optional<ArrayAttr> axis = adaptor.getAxes();
+    int64_t antialias = adaptor.getAntialias();
+
+    if (!inputType || inputType.getRank() != 4) {
+      return rewriter.notifyMatchFailure(
+          resizeOp, "TOSA only support 4D tensors as input of resize.");
+    }
+
+    // With only static dimensions, scales and sizes as inputs are not relevant
+    // anymore.
+    if (inputType.isDynamicDim(2) || inputType.isDynamicDim(3)) {
+      return rewriter.notifyMatchFailure(
+          resizeOp, "Only static sized tensors are supported.");
+    }
+
+    auto elementType = inputType.getElementType();
+    if (!(isTOSAFloat(elementType) || isTOSASignedInt(elementType))) {
+      return rewriter.notifyMatchFailure(
+          resizeOp, "Element type is not supported by TOSA.");
+    }
+
+    if (mode == "cubic") {
+      return rewriter.notifyMatchFailure(
+          resizeOp, "TOSA does not support cubic interpolation.");
+    }
+
+    if (mode == "nearest" &&
+        (nearestMode == "ceil" || nearestMode == "round_prefer_floor")) {
+      return rewriter.notifyMatchFailure(resizeOp,
+          "TOSA does not support ceil and round_prefer_floor as nearestMode.");
+    }
+
+    // This also makes roi as an input irrelevant.
+    if (coordinateTransformationMode == "tf_crop_and_resize") {
+      return rewriter.notifyMatchFailure(
+          resizeOp, "TOSA does not support tf_crop_and_resize.");
+    }
+
+    if (antialias != 0)
+      return rewriter.notifyMatchFailure(
+          op, "TOSA does not support antialiasing.");
+
+    auto inputShape = inputType.getShape();
+    auto outputShape = resultType.getShape();
+
+    if (inputShape[0] != outputShape[0] || inputShape[1] != outputShape[1])
+      return rewriter.notifyMatchFailure(
+          op, "Cannot resize non spatial dimensions.");
+
+    // Get axis values if set. Default is all axis in normal order.
+    llvm::SmallVector<int64_t> axisVec;
+    if (axis.has_value()) {
+      valuesFromAxis(&axis.value(), axisVec);
+    } else {
+      axisVec.append({0, 1, 2, 3});
+    }
+
+    // Set these explicitly just out of convenience.
+    int64_t inputHeight = inputShape[2];
+    int64_t inputWidth = inputShape[3];
+    int64_t outputHeight = outputShape[2];
+    int64_t outputWidth = outputShape[3];
+
+    // Check if scales are set. We need to get those float values, because they
+    // make a difference in linear interpolation.
+    Value scaleValue = resizeOp.getScales();
+    llvm::SmallVector<float, 4> scales{1, 1, 1, 1};
+    if (!isNoneValue(scaleValue)) {
+      if (getScaleValue(rewriter, op, axisVec, scales, scaleValue).failed())
+        return rewriter.notifyMatchFailure(
+            op, "Could not retrieve scale values.");
+
+      // In TOSA the scale is a fraction of two integer numbers.
+      FractionNumber height(scales[2]);
+      FractionNumber width(scales[3]);
+      outputHeight = height.numerator;
+      inputHeight = height.denominator;
+      outputWidth = width.numerator;
+      inputWidth = width.denominator;
+    }
+
+    bool alignCorners = coordinateTransformationMode == "align_corners";
+    bool halfPixel = coordinateTransformationMode == "half_pixel";
+    bool pytorchHalfPixel =
+        coordinateTransformationMode == "pytorch_half_pixel";
+    bool halfPixelSymmetric =
+        coordinateTransformationMode == "half_pixel_symmetric";
+    bool isBilinear = mode == "linear";
+    bool isNearest = mode == "nearest";
+    bool isNearestModeFloor = nearestMode == "floor";
+    StringRef resizeMode = isBilinear ? "BILINEAR" : "NEAREST_NEIGHBOR";
+
+    if (halfPixelSymmetric)
+      return rewriter.notifyMatchFailure(op,
+          "TOSA does not support float offsets which are required "
+          "for symmetric mode.");
+
+    ScaleHelper yDimension =
+        normalize(outputHeight, inputHeight, pytorchHalfPixel, alignCorners,
+            halfPixel, isNearest, isNearestModeFloor);
+    ScaleHelper xDimension =
+        normalize(outputWidth, inputWidth, pytorchHalfPixel, alignCorners,
+            halfPixel, isNearest, isNearestModeFloor);
+
+    // Convert input [N,IC,IH,IW] -> [N,IH,IW,IC]
+    Value newInput = tosaBuilder.transpose(input, {0, 2, 3, 1});
+
+    // Create resizeOp
+    auto scale = rewriter.getDenseI64ArrayAttr({yDimension.numerator,
+        yDimension.denominator, xDimension.numerator, xDimension.denominator});
+    auto offset =
+        rewriter.getDenseI64ArrayAttr({yDimension.offset, xDimension.offset});
+    auto border =
+        rewriter.getDenseI64ArrayAttr({yDimension.border, xDimension.border});
+    auto resizeModeAttr = rewriter.getStringAttr(resizeMode);
+    Type newOutputType =
+        RankedTensorType::get(llvm::SmallVector<int64_t, 4>(
+                                  inputType.getRank(), ShapedType::kDynamic),
+            resultType.cast<ShapedType>().getElementType());
+
+    Value resize = tosa::CreateOpAndInfer<mlir::tosa::ResizeOp>(rewriter, loc,
+        newOutputType, newInput, scale, offset, border, resizeModeAttr);
+
+    // Convert output [N,OH,OW,OC] -> [N,OC,OH,OW]
+    Value newOutput = tosaBuilder.transpose(resize, {0, 3, 1, 2});
+
+    rewriter.replaceOp(resizeOp, newOutput);
+
+    return success();
+  }
+};
+
+} // namespace
+
+void populateLoweringONNXResizeOpToTOSAPattern(ConversionTarget &target,
+    RewritePatternSet &patterns, TypeConverter &typeConverter,
+    MLIRContext *ctx) {
+  patterns.insert<ONNXResizeOpLoweringToTOSA>(ctx);
+}
+
+} // namespace onnx_mlir

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Resize.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Resize.mlir
@@ -1,0 +1,225 @@
+// RUN: onnx-mlir-opt --convert-onnx-to-tosa -cse %s -split-input-file | FileCheck %s
+
+func.func @test_resize_pytorch_half_pixel_linear(%arg0: tensor<1x1x2x4xf32>) -> tensor<1x1x4x8xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x4xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x8xf32>
+    return %2 : tensor<1x1x4x8xf32>
+// CHECK-LABEL:  func.func @test_resize_pytorch_half_pixel_linear
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x2x4xf32>) -> tensor<1x1x4x8xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x2x4xf32>, tensor<4xi32>) -> tensor<1x2x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: 1, 1>, mode = "BILINEAR", offset = array<i64: -1, -1>, scale = array<i64: 4, 2, 4, 2>} : (tensor<1x2x4x1xf32>) -> tensor<1x4x8x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x4x8x1xf32>, tensor<4xi32>) -> tensor<1x1x4x8xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x4x8xf32>
+}
+
+// -----
+
+func.func @test_resize_half_pixel_nearest_floor(%arg0: tensor<1x1x1x4xf32>) -> tensor<1x1x1x12xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 1, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x1x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x1x12xf32>
+    return %2 : tensor<1x1x1x12xf32>
+// CHECK-LABEL:  func.func @test_resize_half_pixel_nearest_floor
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x1x4xf32>) -> tensor<1x1x1x12xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x1x4xf32>, tensor<4xi32>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: -1, -1>, mode = "NEAREST_NEIGHBOR", offset = array<i64: -1, -5>, scale = array<i64: 2, 2, 6, 2>} : (tensor<1x1x4x1xf32>) -> tensor<1x1x12x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x1x12x1xf32>, tensor<4xi32>) -> tensor<1x1x1x12xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x1x12xf32>
+}
+
+// -----
+
+func.func @test_resize_half_pixel_nearest_round_prefer_ceil(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_ceil"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+    return %2 : tensor<1x1x3x12xf32>
+// CHECK-LABEL:  func.func @test_resize_half_pixel_nearest_round_prefer_ceil
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x3x4xf32>, tensor<4xi32>) -> tensor<1x3x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: 0, 2>, mode = "NEAREST_NEIGHBOR", offset = array<i64: 0, -2>, scale = array<i64: 2, 2, 6, 2>} : (tensor<1x3x4x1xf32>) -> tensor<1x3x12x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x3x12x1xf32>, tensor<4xi32>) -> tensor<1x1x3x12xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x3x12xf32>
+}
+
+// -----
+
+func.func @test_resize_align_corners(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "align_corners", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_ceil"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+    return %2 : tensor<1x1x3x12xf32>
+// CHECK-LABEL:  func.func @test_resize_align_corners
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x3x4xf32>, tensor<4xi32>) -> tensor<1x3x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: 0, 0>, mode = "NEAREST_NEIGHBOR", offset = array<i64: 0, 0>, scale = array<i64: 2, 2, 22, 6>} : (tensor<1x3x4x1xf32>) -> tensor<1x3x12x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x3x12x1xf32>, tensor<4xi32>) -> tensor<1x1x3x12xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x3x12xf32>
+}
+
+// -----
+
+func.func @test_resize_asymmetric(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_ceil"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+    return %2 : tensor<1x1x3x12xf32>
+// CHECK-LABEL:  func.func @test_resize_asymmetric
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x3x4xf32>, tensor<4xi32>) -> tensor<1x3x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: 0, 4>, mode = "NEAREST_NEIGHBOR", offset = array<i64: 0, 0>, scale = array<i64: 2, 2, 6, 2>} : (tensor<1x3x4x1xf32>) -> tensor<1x3x12x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x3x12x1xf32>, tensor<4xi32>) -> tensor<1x1x3x12xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x3x12xf32>
+}
+
+// -----
+
+func.func @test_resize_half_pixel_nearest_floor_downsample(%arg0: tensor<1x1x1x12xf32>) -> tensor<1x1x1x4xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 1, 4]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x1x12xf32>, none, none, tensor<4xi64>) -> tensor<1x1x1x4xf32>
+    return %2 : tensor<1x1x1x4xf32>
+// CHECK-LABEL:  func.func @test_resize_half_pixel_nearest_floor_downsample
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x1x12xf32>) -> tensor<1x1x1x4xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x1x12xf32>, tensor<4xi32>) -> tensor<1x1x12x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: -1, -3>, mode = "NEAREST_NEIGHBOR", offset = array<i64: -1, 1>, scale = array<i64: 2, 2, 2, 6>} : (tensor<1x1x12x1xf32>) -> tensor<1x1x4x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x1x4x1xf32>, tensor<4xi32>) -> tensor<1x1x1x4xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x1x4xf32>
+}
+
+// -----
+
+func.func @test_resize_input_one(%arg0: tensor<1x1x1x1xf32>) -> tensor<1x1x4x4xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 4, 4]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "floor"} : (tensor<1x1x1x1xf32>, none, none, tensor<4xi64>) -> tensor<1x1x4x4xf32>
+    return %2 : tensor<1x1x4x4xf32>
+// CHECK-LABEL:  func.func @test_resize_input_one
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x1x1xf32>) -> tensor<1x1x4x4xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x1x1xf32>, tensor<4xi32>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: 3, 3>, mode = "BILINEAR", offset = array<i64: -3, -3>, scale = array<i64: 8, 2, 8, 2>} : (tensor<1x1x1x1xf32>) -> tensor<1x4x4x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x4x4x1xf32>, tensor<4xi32>) -> tensor<1x1x4x4xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x4x4xf32>
+}
+
+// -----
+
+func.func @test_resize_pytorch_half_pixel_linear_float_scale_upsample(%arg0: tensor<1x1x2x4xf32>) -> tensor<1x1x4x8xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 2.001000e+00, 2.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x4xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x8xf32>
+    return %2 : tensor<1x1x4x8xf32>
+// CHECK-LABEL:  func.func @test_resize_pytorch_half_pixel_linear_float_scale_upsample
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x2x4xf32>) -> tensor<1x1x4x8xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x2x4xf32>, tensor<4xi32>) -> tensor<1x2x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: 125124991, 1>, mode = "BILINEAR", offset = array<i64: -125124991, -1>, scale = array<i64: 500249982, 250000000, 4, 2>} : (tensor<1x2x4x1xf32>) -> tensor<1x4x8x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x4x8x1xf32>, tensor<4xi32>) -> tensor<1x1x4x8xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x4x8xf32>
+}
+
+// -----
+
+func.func @test_resize_pytorch_half_pixel_linear_float_scale_downsample(%arg0: tensor<1x1x2x4xf32>) -> tensor<1x1x1x2xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 0.6000e+00, 0.600000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x4xf32>, none, tensor<4xf32>, none) -> tensor<1x1x1x2xf32>
+    return %2 : tensor<1x1x1x2xf32>
+// CHECK-LABEL:  func.func @test_resize_pytorch_half_pixel_linear_float_scale_downsample
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x2x4xf32>) -> tensor<1x1x1x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x2x4xf32>, tensor<4xi32>) -> tensor<1x2x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: -49999997, -49999997>, mode = "BILINEAR", offset = array<i64: 49999997, 49999997>, scale = array<i64: 150000006, 250000000, 150000006, 250000000>} : (tensor<1x2x4x1xf32>) -> tensor<1x1x2x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x1x2x1xf32>, tensor<4xi32>) -> tensor<1x1x1x2xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x1x2xf32>
+}
+
+// -----
+
+func.func @test_resize_half_pixel_nearest_floor_downsample_axis_both(%arg0: tensor<1x1x1x12xf32>) -> tensor<1x1x1x6xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 6]> : tensor<2xi64>} : () -> tensor<2xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {axes = [2, 3], coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x1x12xf32>, none, none, tensor<2xi64>) -> tensor<1x1x1x6xf32>
+    return %2 : tensor<1x1x1x6xf32>
+// CHECK-LABEL:  func.func @test_resize_half_pixel_nearest_floor_downsample_axis_both
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x1x12xf32>) -> tensor<1x1x1x6xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x1x12xf32>, tensor<4xi32>) -> tensor<1x1x12x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: -1, -2>, mode = "NEAREST_NEIGHBOR", offset = array<i64: -1, 0>, scale = array<i64: 2, 2, 2, 4>} : (tensor<1x1x12x1xf32>) -> tensor<1x1x6x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x1x6x1xf32>, tensor<4xi32>) -> tensor<1x1x1x6xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x1x6xf32>
+}
+
+// -----
+
+func.func @test_resize_half_pixel_nearest_floor_downsample_axis_one(%arg0: tensor<1x1x1x12xf32>) -> tensor<1x1x1x6xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[6]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {axes = [3], coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x1x12xf32>, none, none, tensor<1xi64>) -> tensor<1x1x1x6xf32>
+    return %2 : tensor<1x1x1x6xf32>
+// CHECK-LABEL:  func.func @test_resize_half_pixel_nearest_floor_downsample_axis_one
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x1x12xf32>) -> tensor<1x1x1x6xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x1x12xf32>, tensor<4xi32>) -> tensor<1x1x12x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: -1, -2>, mode = "NEAREST_NEIGHBOR", offset = array<i64: -1, 0>, scale = array<i64: 2, 2, 2, 4>} : (tensor<1x1x12x1xf32>) -> tensor<1x1x6x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x1x6x1xf32>, tensor<4xi32>) -> tensor<1x1x1x6xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x1x6xf32>
+}
+
+// -----
+
+func.func @test_resize_pytorch_half_pixel_linear_other_axis_allowed(%arg0: tensor<1x1x2x4xf32>) -> tensor<1x1x2x8xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {axes = [1, 3], coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x4xf32>, none, tensor<2xf32>, none) -> tensor<1x1x2x8xf32>
+    return %2 : tensor<1x1x2x8xf32>
+// CHECK-LABEL:  func.func @test_resize_pytorch_half_pixel_linear_other_axis_allowed
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x2x4xf32>) -> tensor<1x1x2x8xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "tosa.const"() <{value = dense<[0, 2, 3, 1]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.transpose [[PARAM_0_]], [[VAR_0_]] : (tensor<1x1x2x4xf32>, tensor<4xi32>) -> tensor<1x2x4x1xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.resize [[VAR_1_]] {border = array<i64: -1, 1>, mode = "BILINEAR", offset = array<i64: -1, -1>, scale = array<i64: 1, 1, 4, 2>} : (tensor<1x2x4x1xf32>) -> tensor<1x2x8x1xf32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "tosa.const"() <{value = dense<[0, 3, 1, 2]> : tensor<4xi32>}> : () -> tensor<4xi32>
+// CHECK:           [[VAR_4_:%.+]] = tosa.transpose [[VAR_2_]], [[VAR_3_]] : (tensor<1x2x8x1xf32>, tensor<4xi32>) -> tensor<1x1x2x8xf32>
+// CHECK:           return [[VAR_4_]] : tensor<1x1x2x8xf32>
+}
+
+// -----
+
+func.func @test_resize_pytorch_half_pixel_linearother_axis_disallowed(%arg0: tensor<1x1x2x4xf32>) -> tensor<1x1x2x8xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {axes = [1, 0], coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x4xf32>, none, tensor<2xf32>, none) -> tensor<1x1x2x8xf32>
+    return %2 : tensor<1x1x2x8xf32>
+// CHECK-LABEL:  func.func @test_resize_pytorch_half_pixel_linearother_axis_disallowed
+// CHECK-LABEL:  onnx.Resize
+}
+
+// -----
+
+func.func @test_resize_cubic_disallowed(%arg0: tensor<1x1x2x4xf32>) -> tensor<1x1x2x8xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>} : () -> tensor<2xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {axes = [1, 3], coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "cubic", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x4xf32>, none, tensor<2xf32>, none) -> tensor<1x1x2x8xf32>
+    return %2 : tensor<1x1x2x8xf32>
+// CHECK-LABEL:  func.func @test_resize_cubic_disallowed
+// CHECK-LABEL:  onnx.Resize
+}


### PR DESCRIPTION
This introduces the conversion of the `ResizeOp` from ONNX to TOSA.
The different modes of the op would all probably deserve their own operation instead of just an `Attribute`, so be extra careful when reviewing please. Also TOSA has the concept of using a fraction instead a float for the scale. You can look it up here: https://www.mlplatform.org/tosa/tosa_spec.html#_resize. I tried to give as much information as possible on how I arrived at the different formulas. Please let me know if something is not clear.

We also have to disallow a lot of cases because the onnx op is more powerful than the TOSA one.