### PR TITLE
Use old LLVM bufferization to avoid performance regression

### DIFF
--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -43,6 +43,7 @@ DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
   for (auto *accel : accel::Accelerator::getAccelerators())
     accel->registerDialects(registry);
 
+  memref::registerAllocationOpInterfaceExternalModels(registry);
   return registry;
 }
 

--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -6,6 +6,7 @@
 
 #include "CompilerDialects.hpp"
 
+#include "src/Compiler/CompilerOptions.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 
@@ -43,7 +44,9 @@ DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
   for (auto *accel : accel::Accelerator::getAccelerators())
     accel->registerDialects(registry);
 
-  memref::registerAllocationOpInterfaceExternalModels(registry);
+  if (useOldBufferization)
+    memref::registerAllocationOpInterfaceExternalModels(registry);
+
   return registry;
 }
 

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -77,6 +77,7 @@ std::vector<std::string> extraLibPaths;                // onnx-mlir only
 std::vector<std::string> extraLibs;                    // onnx-mlir only
 ProfileIRs profileIR;                                  // onnx-mlir only
 OptReport optReport;                                   // onnx-mlir only
+bool useOldBufferization;                              // onnx-mlir only
 bool split_input_file;                                 // onnx-mlir-opt only
 bool verify_diagnostics;                               // onnx-mlir-opt only
 bool verify_passes;                                    // onnx-mlir-opt only
@@ -548,6 +549,15 @@ static llvm::cl::opt<bool, true> allowUnregisteredDialectsOpt(
     llvm::cl::desc("Allow operation with no registered dialects"),
     llvm::cl::location(allowUnregisteredDialects), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptOptions));
+
+// Removed once the new LLVM bufferization works without performance regression.
+static llvm::cl::opt<bool, true> useOldBufferizationOpt("use-old-bufferization",
+    llvm::cl::desc(
+        "Enable the old LLVM bufferization mechanism (default=true)\n"
+        "This option should be removed once the new LLVM bufferization works "
+        "well in onnx-mlir"),
+    llvm::cl::location(useOldBufferization), llvm::cl::init(true),
+    llvm::cl::cat(OnnxMlirOptions));
 
 // Configuration states associated with certain options.
 // For example, when maccel is specified, NNPA can register

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -119,6 +119,7 @@ extern std::vector<std::string> extraLibPaths;                // onnx-mlir only
 extern std::vector<std::string> extraLibs;                    // onnx-mlir only
 extern ProfileIRs profileIR;                                  // onnx-mlir only
 extern OptReport optReport;                                   // onnx-mlir only
+extern bool useOldBufferization;                              // onnx-mlir only
 extern bool split_input_file;          // onnx-mlir-opt only
 extern bool verify_diagnostics;        // onnx-mlir-opt only
 extern bool verify_passes;             // onnx-mlir-opt only

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -225,11 +225,17 @@ void addKrnlToLLVMPasses(
   // Currently this has to be done *after* lowering the affine dialect because
   // operations in that dialect do not conform to the requirements explained
   // in https://mlir.llvm.org/docs/BufferDeallocationInternals.
-  bufferization::BufferDeallocationPipelineOptions bufferDeallocOptions;
-  mlir::bufferization::buildBufferDeallocationPipeline(
+  bool USE_NEW_BUFFER = false;
+  if (USE_NEW_BUFFER) {
+    bufferization::BufferDeallocationPipelineOptions bufferDeallocOptions;
+    mlir::bufferization::buildBufferDeallocationPipeline(
       pm, bufferDeallocOptions);
-
-  pm.addPass(mlir::createBufferizationToMemRefPass());
+    pm.addPass(mlir::createBufferizationToMemRefPass());
+  } else {
+    pm.addNestedPass<func::FuncOp>(
+            mlir::bufferization::createBufferDeallocationPass());
+    // pm.addPass(mlir::createBufferizationToMemRefPass());
+  }
 
   // Late introduction of OpenMP, after bufferization.
   if (enableParallel) {

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -225,16 +225,14 @@ void addKrnlToLLVMPasses(
   // Currently this has to be done *after* lowering the affine dialect because
   // operations in that dialect do not conform to the requirements explained
   // in https://mlir.llvm.org/docs/BufferDeallocationInternals.
-  bool USE_NEW_BUFFER = false;
-  if (USE_NEW_BUFFER) {
+  if (useOldBufferization) {
+    pm.addNestedPass<func::FuncOp>(
+        mlir::bufferization::createBufferDeallocationPass());
+  } else {
     bufferization::BufferDeallocationPipelineOptions bufferDeallocOptions;
     mlir::bufferization::buildBufferDeallocationPipeline(
-      pm, bufferDeallocOptions);
+        pm, bufferDeallocOptions);
     pm.addPass(mlir::createBufferizationToMemRefPass());
-  } else {
-    pm.addNestedPass<func::FuncOp>(
-            mlir::bufferization::createBufferDeallocationPass());
-    // pm.addPass(mlir::createBufferizationToMemRefPass());
   }
 
   // Late introduction of OpenMP, after bufferization.

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -671,7 +671,7 @@ def main():
         # Use the generated shared library to create an execution session.
         print("Loading the compiled model ...")
         start = time.perf_counter()
-        sess = OMExecutionSession(shared_lib_path, tag="None")
+        sess = OMExecutionSession(shared_lib_path)
         end = time.perf_counter()
         print("  took ", end - start, " seconds.\n")
 

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -671,7 +671,7 @@ def main():
         # Use the generated shared library to create an execution session.
         print("Loading the compiled model ...")
         start = time.perf_counter()
-        sess = OMExecutionSession(shared_lib_path)
+        sess = OMExecutionSession(shared_lib_path, tag="None")
         end = time.perf_counter()
         print("  took ", end - start, " seconds.\n")
 


### PR DESCRIPTION
The new LLVM bufferization mechanism causes the inference time very slow. While it may take time for the new bufferization to produce good performance, this patch adds a compile option `--use-old-bufferization` to enable the old LLVM bufferization mechanism.