### PR TITLE
Modelzoo restructure breaks verifying user docker image

### DIFF
--- a/.buildbot/jenkins-verify-user-image.py
+++ b/.buildbot/jenkins-verify-user-image.py
@@ -6,6 +6,7 @@ import logging
 import math
 import os
 import requests
+import shutil
 import subprocess
 import sys
 
@@ -14,14 +15,6 @@ logging.basicConfig(
     format="[%(asctime)s][%(lineno)03d] %(levelname)s: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-
-DOCKER_USR_IMAGE_WORKDIR = "/workdir"
-
-MNIST8_URL = (
-    "https://github.com/onnx/models/raw/main/vision/classification/mnist/model/"
-)
-MNIST8_ONNX = "mnist-8.onnx"
-MNIST8_DIR = "mnist-8"
 
 docker_daemon_socket = os.getenv("DOCKER_DAEMON_SOCKET")
 docker_registry_host_name = os.getenv("DOCKER_REGISTRY_HOST_NAME")
@@ -35,6 +28,7 @@ jenkins_home = os.getenv("JENKINS_HOME")
 job_name = os.getenv("JOB_NAME")
 workspace_dir = os.getenv("WORKSPACE")
 
+docker_usr_image_workdir = "/workdir"
 docker_usr_image_name = github_repo_name + (
     "." + github_pr_baseref2 if github_pr_baseref != "main" else ""
 )
@@ -47,21 +41,21 @@ docker_usr_image_full = (
     + docker_usr_image_tag
 )
 
-workspace_workdir = os.path.join(workspace_dir, MNIST8_DIR)
-container_workdir = os.path.join(DOCKER_USR_IMAGE_WORKDIR, MNIST8_DIR)
+MNIST_ONNX = "mnist.onnx"
+MNIST_DIR = "mnist"
 
-
-def urlretrieve(remote_url, local_file):
-    req = requests.get(remote_url)
-    with open(local_file, "wb") as f:
-        f.write(req.content)
+workspace_workdir = os.path.join(workspace_dir, MNIST_DIR)
+container_workdir = os.path.join(docker_usr_image_workdir, MNIST_DIR)
 
 
 def main():
     os.makedirs(workspace_workdir)
 
-    # Download mnist-8.onnx
-    urlretrieve(MNIST8_URL + MNIST8_ONNX, os.path.join(workspace_workdir, MNIST8_ONNX))
+    # Copy docs/mnist_example/mnist.onnx to workspace_workdir
+    shutil.copy(
+        os.path.join(workspace_dir, "docs", "mnist_example", MNIST_ONNX),
+        os.path.join(workspace_workdir, MNIST_ONNX),
+    )
 
     cmd = [
         "docker",
@@ -73,7 +67,7 @@ def main():
         workspace_workdir + ":" + container_workdir,
         docker_usr_image_full,
         "--EmitLib",
-        os.path.join(container_workdir, MNIST8_ONNX),
+        os.path.join(container_workdir, MNIST_ONNX),
     ]
 
     logging.info(" ".join(cmd))


### PR DESCRIPTION
Use docs/mnist_example/mnist.onnx for verifying user docker image so we don't depend on modelzoo, which has just been completely restructured.

This is a blocking issue for Jenkins CI so we should merge asap.