### PR TITLE
Allow onnx.unique with no data

### DIFF
--- a/src/Runtime/OMUnique.inc
+++ b/src/Runtime/OMUnique.inc
@@ -268,7 +268,8 @@ void produceY(const OMTensor *inputTensor, OMTensor *indices, int64_t sliceAxis,
   const int64_t *indicesShape = omTensorGetShape(indices);
   const int64_t count = indicesShape[0];
   int64_t *indicesPtr = (int64_t *)omTensorGetDataPtr(indices);
-  assert(count > 0 && "count should be greater than 0");
+  if (count == 0)
+    return;
   void *YPtr = omTensorGetDataPtr(Y);
 
   const OM_DATA_TYPE dataType = omTensorGetDataType(inputTensor);


### PR DESCRIPTION
Current onnx.Unique op implementation causes the following runtime error with a Tensor with no data.
This case should be handled as a normal case without causing errors.

```
.../src/Runtime/OMUnique.inc:271: produceY: Assertion `count > 0 && "count should be greater than 0"' failed.
```

