### PR TITLE
fix broken ONNX_MLIR_FLAGS

### DIFF
--- a/docs/doc_example/main.c
+++ b/docs/doc_example/main.c
@@ -55,7 +55,7 @@ int main() {
   }
   printf("\n");
 
-  // Destory the list and the tensors inside of it.
+  // Destroy the list and the tensors inside of it.
   // Use omTensorListDestroyShallow if only want to destroy the list themselves.
   omTensorListDestroy(input_list);
   omTensorListDestroy(output_list);

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -289,7 +289,7 @@ static llvm::cl::opt<std::string, true> customEnvFlagsOpt("customEnvFlags",
     llvm::cl::desc("Override default option env var OnnxMlirEnvOptionName: "
                    "ONNX_MLIR_FLAGS"),
     llvm::cl::value_desc("option env var"), llvm::cl::location(customEnvFlags),
-    lvm::cl::cat(OnnxMlirOptions));
+    llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<ModelSize, true> modelSizeOpt("modelSize",
     llvm::cl::desc("Model to generate code"),

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -21,6 +21,8 @@
 
 #define DEBUG_TYPE "compiler_options"
 
+const std::string OnnxMlirEnvOptionName = "ONNX_MLIR_FLAGS";
+
 namespace onnx_mlir {
 
 // Use external storage for the options so that they are globally accessible
@@ -281,7 +283,7 @@ static llvm::cl::opt<std::string, true> customEnvFlagsOpt("customEnvFlags",
     llvm::cl::desc("Override default option env var OnnxMlirEnvOptionName: "
                    "ONNX_MLIR_FLAGS"),
     llvm::cl::value_desc("option env var"), llvm::cl::location(customEnvFlags),
-    llvm::cl::init("ONNX_MLIR_FLAGS"), llvm::cl::cat(OnnxMlirOptions));
+    llvm::cl::init(OnnxMlirEnvOptionName), llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<ModelSize, true> modelSizeOpt("modelSize",
     llvm::cl::desc("Model to generate code"),
@@ -607,6 +609,10 @@ bool parseCustomEnvFlagsCommandLineOption(
     }
     // The envVar is verified, use it.
     setCustomEnvVar(envVar);
+  } else {
+    // It appears that the default value of this compiler options may be set too
+    // late for where its first used. So set it explicitly here.
+    setCustomEnvVar(OnnxMlirEnvOptionName);
   }
   return true;
 }

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -289,7 +289,7 @@ static llvm::cl::opt<std::string, true> customEnvFlagsOpt("customEnvFlags",
     llvm::cl::desc("Override default option env var OnnxMlirEnvOptionName: "
                    "ONNX_MLIR_FLAGS"),
     llvm::cl::value_desc("option env var"), llvm::cl::location(customEnvFlags),
-    llvm::cl::init(""), llvm::cl::cat(OnnxMlirOptions));
+    lvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<ModelSize, true> modelSizeOpt("modelSize",
     llvm::cl::desc("Model to generate code"),

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -21,6 +21,7 @@
 
 #define DEBUG_TYPE "compiler_options"
 
+// Default env var where to find default options, when defined.
 const std::string OnnxMlirEnvOptionName = "ONNX_MLIR_FLAGS";
 
 namespace onnx_mlir {

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -25,6 +25,10 @@
 
 #define DEFAULT_INSTRUMENTSTAGE_CL_ENUM clEnumVal(Onnx, "Profile for onnx ops.")
 
+// Variable contains the name of the default environment variable that is used
+// to find the default onnx-mlir options.
+// Its default value is ONNX_MLIR_FLAGS, as defined in CompilerOptions.cpp.
+// TODO: may want to do this constant set by a variable in CMakeFiles.
 extern const std::string OnnxMlirEnvOptionName;
 
 namespace onnx_mlir {

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -49,8 +49,6 @@
 using namespace mlir;
 using namespace onnx_mlir;
 
-const std::string OnnxMlirEnvOptionName = "ONNX_MLIR_FLAGS";
-
 namespace onnx_mlir {
 
 // Make a function that forces preserving all files using the runtime arguments


### PR DESCRIPTION
The default ONNX_MLIR_FLAGS env variable was not scanned in `onnx-mlir`. This opinion is useful and documented. This PR restore its proper usage.