### PR TITLE
Added an onnx-mlir option to select which operation to parallelize

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
@@ -4,7 +4,7 @@
 
 //====------ ZHighToZLow.cpp - ZHigh dialect to ZLow lowering -------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -1599,7 +1599,12 @@ struct ZHighToZLowDataConversionLowering
   ZHighToZLowDataConversionLowering(TypeConverter &typeConverter,
       MLIRContext *ctx, bool fromF32, bool enableParallel)
       : OpConversionPattern<CONVERT_OP>(typeConverter, ctx), fromF32(fromF32),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            CONVERT_OP::getOperationName());
+  }
 
   LogicalResult matchAndRewrite(CONVERT_OP convertOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
@@ -1598,8 +1598,7 @@ struct ZHighToZLowDataConversionLowering
 
   ZHighToZLowDataConversionLowering(TypeConverter &typeConverter,
       MLIRContext *ctx, bool fromF32, bool enableParallel)
-      : OpConversionPattern<CONVERT_OP>(typeConverter, ctx), fromF32(fromF32),
-        enableParallel(enableParallel) {
+      : OpConversionPattern<CONVERT_OP>(typeConverter, ctx), fromF32(fromF32) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,5 +19,6 @@ add_onnx_mlir_executable(onnx-mlir
   MLIROpenMPToLLVMIRTranslation
   OMCompilerOptions
   OMCompilerUtils
+  OMOptionUtils
   )
   

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -181,6 +181,23 @@ add_onnx_mlir_library(OMCompilerUtils
   MC
   )
 
+  add_onnx_mlir_library(OMOptionUtils
+  OptionUtils.cpp
+
+  EXCLUDE_FROM_OM_LIBS
+
+  DEPENDS
+
+  INCLUDE_DIRS PRIVATE
+  ${FILE_GENERATE_DIR}
+
+  INCLUDE_DIRS PUBLIC
+  ${ONNX_MLIR_SRC_ROOT}/include
+
+  LINK_LIBS PUBLIC
+  )
+
+
 # CompilerUtils does not require cruntime or jniruntime to build,
 # however, they are required for execution when using the EmitLib or EmitJNI
 # options

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -61,6 +61,7 @@ std::vector<std::string> Xllc;                         // onnx-mlir only
 std::string mllvm;                                     // onnx-mlir only
 std::string instrumentOps;                             // onnx-mlir only
 unsigned instrumentControlBits;                        // onnx-mlir only
+std::string parallelizeOps;                            // onnx-mlir only
 bool instrumentONNXSignature;                          // onnx-mlir only
 std::string ONNXOpStats;                               // onnx-mlir only
 int onnxOpTransformThreshold;                          // onnx-mlir only
@@ -364,7 +365,7 @@ static llvm::cl::opt<std::string, true> mllvmOpt("mllvm",
     llvm::cl::ValueRequired);
 
 static llvm::cl::opt<std::string, true> instrumentOpsOpt("instrument-ops",
-    llvm::cl::desc("Specify operations operations to be instrumented:\n"
+    llvm::cl::desc("Specify operations to be instrumented:\n"
                    "\"NONE\" or \"\" for no instrument,\n"
                    "\"ops1,ops2, ...\" for the multiple ops.\n"
                    "e.g. \"onnx.Conv,onnx.Add\" for Conv and Add ops.\n"
@@ -383,6 +384,16 @@ static llvm::cl::bits<InstrumentActions, unsigned> instrumentControlBitsOpt(
             InstrumentReportTime, "instrument runtime reports time usage,"),
         clEnumVal(InstrumentReportMemory,
             "instrument runtime reports memory usage.")),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<std::string, true> parallelizeOpsOpt("parallelize-ops",
+    llvm::cl::desc("Specify explicitly which operations to parallelize:\n"
+                   "\"\" for all available operations (default),\n"
+                   "\"ops1,ops2, ...\" for the multiple ops.\n"
+                   "e.g. \"onnx.MatMul,onnx.Add\" for MatMul and Add ops.\n"
+                   "Asterisk is also available.\n"
+                   "e.g. \"onnx.*\" for all onnx operations.\n"),
+    llvm::cl::location(parallelizeOps), llvm::cl::init(""),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> instrumentONNXSignatureOpt(

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -366,7 +366,8 @@ static llvm::cl::opt<std::string, true> mllvmOpt("mllvm",
 
 static llvm::cl::opt<std::string, true> instrumentOpsOpt("instrument-ops",
     llvm::cl::desc("Specify operations to be instrumented:\n"
-                   "\"NONE\" or \"\" for no instrument,\n"
+                   "\"NONE\" or \"\" for no instrument (default),\n"
+                   "\"ALL\" for instrument of all ops,\n"
                    "\"ops1,ops2, ...\" for the multiple ops.\n"
                    "e.g. \"onnx.Conv,onnx.Add\" for Conv and Add ops.\n"
                    "Asterisk is also available.\n"
@@ -388,7 +389,8 @@ static llvm::cl::bits<InstrumentActions, unsigned> instrumentControlBitsOpt(
 
 static llvm::cl::opt<std::string, true> parallelizeOpsOpt("parallelize-ops",
     llvm::cl::desc("Specify explicitly which operations to parallelize:\n"
-                   "\"\" for all available operations (default),\n"
+                   "\"ALL\" or \"\" for all available operations (default),\n"
+                   "\"NONE\" for no instrument,\n"
                    "\"ops1,ops2, ...\" for the multiple ops.\n"
                    "e.g. \"onnx.MatMul,onnx.Add\" for MatMul and Add ops.\n"
                    "Asterisk is also available.\n"

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -453,7 +453,7 @@ llvm::cl::opt<std::string, true> opsForCallOpt("ops-for-call",
                    "krnl loops. op name are used to check against this option."
                    "Names of opa are separated with space."
                    "Example: ops-for-call=Conv MatMul"
-                   "The regexp match will be used to check against op name"),
+                   "The regex match will be used to check against op name"),
     llvm::cl::location(opsForCall), llvm::cl::init(""),
     llvm::cl::cat(OnnxMlirOptions));
 

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -104,6 +104,7 @@ extern std::vector<std::string> Xllc;                         // onnx-mlir only
 extern std::string mllvm;                                     // onnx-mlir only
 extern std::string instrumentOps;                             // onnx-mlir only
 extern unsigned instrumentControlBits;                        // onnx-mlir only
+extern std::string parallelizeOps;                            // onnx-mlir only
 extern bool instrumentONNXSignature;                          // onnx-mlir only
 extern std::string ONNXOpStats;                               // onnx-mlir only
 extern int onnxOpTransformThreshold;                          // onnx-mlir only

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -4,7 +4,7 @@
 
 //===------------------------- CompilerPasses.cpp -------------------------===//
 //
-// Copyright 2022-2023 The IBM Research Authors.
+// Copyright 2022-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -50,7 +50,8 @@ void configurePasses() {
       onnxConstPropExpansionBound, onnxConstPropDisablePatterns,
       disableConstantProp);
   configureOnnxToKrnlLoweringPass(optReport == OptReport::Parallel,
-      enableParallel, optReport == OptReport::Simd, !disableSimdOption);
+      enableParallel, parallelizeOps, optReport == OptReport::Simd,
+      !disableSimdOption);
 }
 
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU) {

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -911,51 +911,51 @@ int compileModule(mlir::OwningOpRef<ModuleOp> &module,
 }
 
 // =============================================================================
-// Support for enabled ops by regexp option
+// Support for enabled ops by regex option
 // =============================================================================
 
-EnableByRegexpOption::EnableByRegexpOption(
-    bool emptyIsNone, std::string regexpString)
+EnableByRegexOption::EnableByRegexOption(
+    bool emptyIsNone, std::string regexString)
     : emptyIsNone(emptyIsNone) {
-  setRegexpString(regexpString);
+  setRegexString(regexString);
 }
 
-void EnableByRegexpOption::setRegexpString(std::string regexpString) {
-  assert(nameCache.empty() && "can set regexp string only before any queries");
+void EnableByRegexOption::setRegexString(std::string regexString) {
+  assert(nameCache.empty() && "can set regex string only before any queries");
   allEnabled = allDisabled = false;
-  if (regexpString.empty()) {
+  if (regexString.empty()) {
     if (emptyIsNone)
       allDisabled = true;
     else
       allEnabled = true;
   } else {
-    if (regexpString.find("NONE") != std::string::npos)
+    if (regexString.find("NONE") != std::string::npos)
       allDisabled = true;
-    if (regexpString.find("ALL") != std::string::npos)
+    if (regexString.find("ALL") != std::string::npos)
       allEnabled = true;
   }
   assert(!(allDisabled && allEnabled) && "cannot have both ALL and NONE");
   if (allDisabled || allEnabled)
-    // No need to scan regexps.
+    // No need to scan regexs.
     return;
 
-  // We have a finite list of regexp, preprocess them now. Lifted from the
+  // We have a finite list of regex, preprocess them now. Lifted from the
   // InstrumentPass.cpp original implementation.
   // Separate multiple expressions with space.
-  regexpString = std::regex_replace(regexpString, std::regex(","), " ");
-  // The '.' character in regexp string is recognized as normal character, not
+  regexString = std::regex_replace(regexString, std::regex(","), " ");
+  // The '.' character in regex string is recognized as normal character, not
   // regular expression.
-  regexpString = std::regex_replace(regexpString, std::regex("\\."), "\\.");
-  // The '*' character in regexp string is recognized as '.*' pattern.
-  regexpString = std::regex_replace(regexpString, std::regex("\\*"), ".*");
-  std::stringstream ss(regexpString);
+  regexString = std::regex_replace(regexString, std::regex("\\."), "\\.");
+  // The '*' character in regex string is recognized as '.*' pattern.
+  regexString = std::regex_replace(regexString, std::regex("\\*"), ".*");
+  std::stringstream ss(regexString);
   std::istream_iterator<std::string> begin(ss);
   std::istream_iterator<std::string> end;
-  // Create the set of regexp defined by the original regexpString.
-  regexpOfAllowedNames = std::set<std::string>(begin, end);
+  // Create the set of regex defined by the original regexString.
+  regexOfAllowedNames = std::set<std::string>(begin, end);
 }
 
-bool EnableByRegexpOption::isEnabled(const std::string &name) {
+bool EnableByRegexOption::isEnabled(const std::string &name) {
   if (allEnabled)
     return true;
   if (allDisabled)
@@ -966,9 +966,9 @@ bool EnableByRegexpOption::isEnabled(const std::string &name) {
     return it->second;
   }
 
-  // We have not seen this op, then test using the regexp and cache answer.
-  for (auto itr = regexpOfAllowedNames.begin();
-       itr != regexpOfAllowedNames.end(); ++itr) {
+  // We have not seen this op, then test using the regex and cache answer.
+  for (auto itr = regexOfAllowedNames.begin();
+       itr != regexOfAllowedNames.end(); ++itr) {
     std::regex re(*itr);
     if (std::regex_match(name, re)) {
       // We have a match, cache and return true.

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -967,8 +967,8 @@ bool EnableByRegexOption::isEnabled(const std::string &name) {
   }
 
   // We have not seen this op, then test using the regex and cache answer.
-  for (auto itr = regexOfAllowedNames.begin();
-       itr != regexOfAllowedNames.end(); ++itr) {
+  for (auto itr = regexOfAllowedNames.begin(); itr != regexOfAllowedNames.end();
+       ++itr) {
     std::regex re(*itr);
     if (std::regex_match(name, re)) {
       // We have a match, cache and return true.

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -914,6 +914,10 @@ int compileModule(mlir::OwningOpRef<ModuleOp> &module,
 // Support for enabled ops by regexp option
 // =============================================================================
 
+EnableByRegexpOption::EnableByRegexpOption(std::string regexpString) {
+  setRegexpString(regexpString);
+}
+
 void EnableByRegexpOption::setRegexpString(std::string regexpString) {
   // Empty string indicates that all ops are allowed (nothing was specified).
   if (regexpString.empty()) {
@@ -944,8 +948,9 @@ bool EnableByRegexpOption::isEnabled(const std::string &name) {
     return true;
   // Now check if we have already seen this op.
   std::map<std::string, bool>::iterator it = nameCache.find(name);
-  if (it != nameCache.end())
+  if (it != nameCache.end()) {
     return it->second;
+  }
 
   // We have not seen this op, then test using the regexp and cache answer.
   for (auto itr = regexpOfAllowedNames.begin();

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -14,6 +14,7 @@
 
 #include "CompilerUtils.hpp"
 
+#include <fstream>
 #include <regex>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -44,9 +45,6 @@
 #include "src/Compiler/CompilerPasses.hpp"
 #include "src/Compiler/HeapReporter.hpp"
 #include "src/Version/Version.hpp"
-
-#include <fstream>
-#include <regex>
 
 using namespace mlir;
 using namespace onnx_mlir;
@@ -908,77 +906,6 @@ int compileModule(mlir::OwningOpRef<ModuleOp> &module,
   if (mlir::failed(pm.run(*module)))
     return CompilerFailure;
   return emitOutput(module, context, outputNameNoExt, pm, emissionTarget);
-}
-
-// =============================================================================
-// Support for enabled ops by regex option
-// =============================================================================
-
-EnableByRegexOption::EnableByRegexOption(
-    bool emptyIsNone, std::string regexString)
-    : emptyIsNone(emptyIsNone) {
-  setRegexString(regexString);
-}
-
-void EnableByRegexOption::setRegexString(std::string regexString) {
-  assert(nameCache.empty() && "can set regex string only before any queries");
-  allEnabled = allDisabled = false;
-  if (regexString.empty()) {
-    if (emptyIsNone)
-      allDisabled = true;
-    else
-      allEnabled = true;
-  } else {
-    if (regexString.find("NONE") != std::string::npos)
-      allDisabled = true;
-    if (regexString.find("ALL") != std::string::npos)
-      allEnabled = true;
-  }
-  assert(!(allDisabled && allEnabled) && "cannot have both ALL and NONE");
-  if (allDisabled || allEnabled)
-    // No need to scan regexs.
-    return;
-
-  // We have a finite list of regex, preprocess them now. Lifted from the
-  // InstrumentPass.cpp original implementation.
-  // Separate multiple expressions with space.
-  regexString = std::regex_replace(regexString, std::regex(","), " ");
-  // The '.' character in regex string is recognized as normal character, not
-  // regular expression.
-  regexString = std::regex_replace(regexString, std::regex("\\."), "\\.");
-  // The '*' character in regex string is recognized as '.*' pattern.
-  regexString = std::regex_replace(regexString, std::regex("\\*"), ".*");
-  std::stringstream ss(regexString);
-  std::istream_iterator<std::string> begin(ss);
-  std::istream_iterator<std::string> end;
-  // Create the set of regex defined by the original regexString.
-  regexOfAllowedNames = std::set<std::string>(begin, end);
-}
-
-bool EnableByRegexOption::isEnabled(const std::string &name) {
-  if (allEnabled)
-    return true;
-  if (allDisabled)
-    return false;
-  // Now check if we have already seen this op.
-  std::map<std::string, bool>::iterator it = nameCache.find(name);
-  if (it != nameCache.end()) {
-    return it->second;
-  }
-
-  // We have not seen this op, then test using the regex and cache answer.
-  for (auto itr = regexOfAllowedNames.begin(); itr != regexOfAllowedNames.end();
-       ++itr) {
-    std::regex re(*itr);
-    if (std::regex_match(name, re)) {
-      // We have a match, cache and return true.
-      nameCache[name] = true;
-      return true;
-    }
-  }
-  // We did not find a match; cache and return false.
-  nameCache[name] = false;
-  return false;
 }
 
 } // namespace onnx_mlir

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -97,7 +97,7 @@ public:
   // Constructor provides a string that is a comma separated list of regex.
   // These regex will determine which names are enabled or disabled by the
   // option. The emptyIsNone defines what to do when the provided string is
-  // empty.
+  // empty. If true, empty string means NONE; if false, empty string means ALL.
   EnableByRegexOption(
       bool emptyIsNone, std::string regexString = std::string());
   // Delayed initialization of the list of regex, permissible prior to a first
@@ -114,7 +114,7 @@ private:
   bool allEnabled;  // Short-circuit test when all names are enabled.
   bool allDisabled; // Short-circuit test when all names are disabled.
   std::set<std::string> regexOfAllowedNames; // List of regex.
-  std::map<std::string, bool> nameCache; // Map of name -> enabled/disabled.
+  std::map<std::string, bool> nameCache;     // Map of name -> enabled/disabled.
 };
 
 } // namespace onnx_mlir

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -4,7 +4,7 @@
 
 //===-------------------------- CompilerUtils.hpp -------------------------===//
 //
-// Copyright 2019-2024 The IBM Research Authors.
+// Copyright 2019-2023 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -21,9 +21,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Path.h"
 
-#include <map>
 #include <optional>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -80,41 +78,5 @@ int compileModule(mlir::OwningOpRef<mlir::ModuleOp> &module,
 // depending on the underlying machine and/or operating system.
 std::string getTargetFilename(
     const std::string filenameNoExt, EmissionTargetType target);
-
-// Class that takes a list of comma separated regex expression to define a set
-// of names that are "enabled" or not by a given compiler option. The
-// "isEnabled(name)" function let a user determine if that name satisfies any of
-// the regex or not. Class uses caching to reduce overheads.
-//
-// List of regex have the following properties.
-// The presence of presence of "NONE" signifies that all names are disabled. The
-// presence of "ALL" signifies that all names are enabled. A '.' char is treated
-// as a regular char (aka "\."); and a '*' char is treated as a any string
-// sequence (aka ".*").
-class EnableByRegexOption {
-public:
-  EnableByRegexOption() = delete;
-  // Constructor provides a string that is a comma separated list of regex.
-  // These regex will determine which names are enabled or disabled by the
-  // option. The emptyIsNone defines what to do when the provided string is
-  // empty. If true, empty string means NONE; if false, empty string means ALL.
-  EnableByRegexOption(
-      bool emptyIsNone, std::string regexString = std::string());
-  // Delayed initialization of the list of regex, permissible prior to a first
-  // "isEnabled" query.
-  void setRegexString(std::string regexString);
-
-  // Returns true/false depending on wether that name matches any of the
-  // regex.
-  bool isEnabled(const std::string &name);
-  bool isEnabled(const llvm::StringRef &name) { return isEnabled(name.str()); }
-
-private:
-  bool emptyIsNone; // If true, empty string is NONE; otherwise empty is ALL.
-  bool allEnabled;  // Short-circuit test when all names are enabled.
-  bool allDisabled; // Short-circuit test when all names are disabled.
-  std::set<std::string> regexOfAllowedNames; // List of regex.
-  std::map<std::string, bool> nameCache;     // Map of name -> enabled/disabled.
-};
 
 } // namespace onnx_mlir

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -81,31 +81,31 @@ int compileModule(mlir::OwningOpRef<mlir::ModuleOp> &module,
 std::string getTargetFilename(
     const std::string filenameNoExt, EmissionTargetType target);
 
-// Class that takes a list of comma separated regexp expression to define a set
+// Class that takes a list of comma separated regex expression to define a set
 // of names that are "enabled" or not by a given compiler option. The
 // "isEnabled(name)" function let a user determine if that name satisfies any of
-// the regexps or not. Class uses caching to reduce overheads.
+// the regex or not. Class uses caching to reduce overheads.
 //
-// List of regexp have the following properties.
+// List of regex have the following properties.
 // The presence of presence of "NONE" signifies that all names are disabled. The
 // presence of "ALL" signifies that all names are enabled. A '.' char is treated
 // as a regular char (aka "\."); and a '*' char is treated as a any string
 // sequence (aka ".*").
-class EnableByRegexpOption {
+class EnableByRegexOption {
 public:
-  EnableByRegexpOption() = delete;
-  // Constructor provides a string that is a comma separated list of regexps.
-  // These regexps will determine which names are enabled or disabled by the
+  EnableByRegexOption() = delete;
+  // Constructor provides a string that is a comma separated list of regex.
+  // These regex will determine which names are enabled or disabled by the
   // option. The emptyIsNone defines what to do when the provided string is
   // empty.
-  EnableByRegexpOption(
-      bool emptyIsNone, std::string regexpString = std::string());
-  // Delayed initialization of the list of regexps, permissible prior to a first
+  EnableByRegexOption(
+      bool emptyIsNone, std::string regexString = std::string());
+  // Delayed initialization of the list of regex, permissible prior to a first
   // "isEnabled" query.
-  void setRegexpString(std::string regexpString);
+  void setRegexString(std::string regexString);
 
   // Returns true/false depending on wether that name matches any of the
-  // regexps.
+  // regex.
   bool isEnabled(const std::string &name);
   bool isEnabled(const llvm::StringRef &name) { return isEnabled(name.str()); }
 
@@ -113,7 +113,7 @@ private:
   bool emptyIsNone; // If true, empty string is NONE; otherwise empty is ALL.
   bool allEnabled;  // Short-circuit test when all names are enabled.
   bool allDisabled; // Short-circuit test when all names are disabled.
-  std::set<std::string> regexpOfAllowedNames; // List of regexps.
+  std::set<std::string> regexOfAllowedNames; // List of regex.
   std::map<std::string, bool> nameCache; // Map of name -> enabled/disabled.
 };
 

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -92,17 +92,18 @@ public:
   // option. Empty regexpString signify all names are enabled. The '.' char is
   // treated as a regular char (aka "\."); and the  '*' char is treated as a any
   // string sequence (aka ".*").
-  EnableByRegexpOption(std::string regexpString = std::string()) {
-    setRegexpString(regexpString);
-  }
-
-  // Delayed initialization of the list of regexps, permissible prior a first
+  EnableByRegexpOption(std::string regexpString = std::string());
+  // Delayed initialization of the list of regexps, permissible prior to a first
   // "isEnabled" query.
   void setRegexpString(std::string regexpString);
 
   // Returns true/false depending on wether that name matches any of the
   // regexps.
   bool isEnabled(const std::string &name);
+  bool isEnabled(const llvm::StringRef &name) {
+    // Use the actual name only when it is actually needed.
+    return allEnabled || isEnabled(name.str());
+  }
 
 private:
   bool allEnabled; // Short-circuit test when all names are enabled.

--- a/src/Compiler/OptionUtils.cpp
+++ b/src/Compiler/OptionUtils.cpp
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------------------------- OptionUtils.cpp -------------------------===//
+//
+// Copyright 2024 The IBM Research Authors.
+//
+// =============================================================================
+//
+// Functions for adding passes and processing options.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OptionUtils.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <regex>
+#include <sstream>
+#include <string>
+
+using namespace onnx_mlir;
+
+namespace onnx_mlir {
+
+// =============================================================================
+// Support for enabled ops by regex option
+// =============================================================================
+
+EnableByRegexOption::EnableByRegexOption(
+    bool emptyIsNone, std::string regexString)
+    : emptyIsNone(emptyIsNone) {
+  setRegexString(regexString);
+}
+
+void EnableByRegexOption::setRegexString(std::string regexString) {
+  assert(nameCache.empty() && "can set regex string only before any queries");
+  allEnabled = allDisabled = false;
+  if (regexString.empty()) {
+    if (emptyIsNone)
+      allDisabled = true;
+    else
+      allEnabled = true;
+  } else {
+    if (regexString.find("NONE") != std::string::npos)
+      allDisabled = true;
+    if (regexString.find("ALL") != std::string::npos)
+      allEnabled = true;
+  }
+  assert(!(allDisabled && allEnabled) && "cannot have both ALL and NONE");
+  if (allDisabled || allEnabled)
+    // No need to scan regexs.
+    return;
+
+  // We have a finite list of regex, preprocess them now. Lifted from the
+  // InstrumentPass.cpp original implementation.
+  // Separate multiple expressions with space.
+  regexString = std::regex_replace(regexString, std::regex(","), " ");
+  // The '.' character in regex string is recognized as normal character, not
+  // regular expression.
+  regexString = std::regex_replace(regexString, std::regex("\\."), "\\.");
+  // The '*' character in regex string is recognized as '.*' pattern.
+  regexString = std::regex_replace(regexString, std::regex("\\*"), ".*");
+  std::stringstream ss(regexString);
+  std::istream_iterator<std::string> begin(ss);
+  std::istream_iterator<std::string> end;
+  // Create the set of regex defined by the original regexString.
+  regexOfAllowedNames = std::set<std::string>(begin, end);
+}
+
+bool EnableByRegexOption::isEnabled(const std::string &name) {
+  if (allEnabled)
+    return true;
+  if (allDisabled)
+    return false;
+  // Now check if we have already seen this op.
+  std::map<std::string, bool>::iterator it = nameCache.find(name);
+  if (it != nameCache.end()) {
+    return it->second;
+  }
+
+  // We have not seen this op, then test using the regex and cache answer.
+  for (auto itr = regexOfAllowedNames.begin(); itr != regexOfAllowedNames.end();
+       ++itr) {
+    std::regex re(*itr);
+    if (std::regex_match(name, re)) {
+      // We have a match, cache and return true.
+      nameCache[name] = true;
+      return true;
+    }
+  }
+  // We did not find a match; cache and return false.
+  nameCache[name] = false;
+  return false;
+}
+
+} // namespace onnx_mlir

--- a/src/Compiler/OptionUtils.hpp
+++ b/src/Compiler/OptionUtils.hpp
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------------------------- OptionUtils.hpp -------------------------===//
+//
+// Copyright 2024 The IBM Research Authors.
+//
+// =============================================================================
+//
+// Functions for adding passes and processing options.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "onnx-mlir/Compiler/OMCompilerTypes.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include <map>
+#include <set>
+#include <string>
+
+namespace onnx_mlir {
+
+// Class that takes a list of comma separated regex expression to define a set
+// of names that are "enabled" or not by a given compiler option. The
+// "isEnabled(name)" function let a user determine if that name satisfies any of
+// the regex or not. Class uses caching to reduce overheads.
+//
+// List of regex have the following properties.
+// The presence of presence of "NONE" signifies that all names are disabled. The
+// presence of "ALL" signifies that all names are enabled. A '.' char is treated
+// as a regular char (aka "\."); and a '*' char is treated as a any string
+// sequence (aka ".*").
+class EnableByRegexOption {
+public:
+  EnableByRegexOption() = delete;
+  // Constructor provides a string that is a comma separated list of regex.
+  // These regex will determine which names are enabled or disabled by the
+  // option. The emptyIsNone defines what to do when the provided string is
+  // empty. If true, empty string means NONE; if false, empty string means ALL.
+  EnableByRegexOption(
+      bool emptyIsNone, std::string regexString = std::string());
+  // Delayed initialization of the list of regex, permissible prior to a first
+  // "isEnabled" query.
+  void setRegexString(std::string regexString);
+
+  // Returns true/false depending on wether that name matches any of the
+  // regex.
+  bool isEnabled(const std::string &name);
+  bool isEnabled(const llvm::StringRef &name) { return isEnabled(name.str()); }
+
+private:
+  bool emptyIsNone; // If true, empty string is NONE; otherwise empty is ALL.
+  bool allEnabled;  // Short-circuit test when all names are enabled.
+  bool allDisabled; // Short-circuit test when all names are disabled.
+  std::set<std::string> regexOfAllowedNames; // List of regex.
+  std::map<std::string, bool> nameCache;     // Map of name -> enabled/disabled.
+};
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
+++ b/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
@@ -30,8 +30,7 @@ struct ONNXLayoutTransformOpLowering
 
   ONNXLayoutTransformOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
-      : OpConversionPattern(typeConverter, ctx),
-        enableParallel(enableParallel) {
+      : OpConversionPattern(typeConverter, ctx) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
+++ b/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
@@ -31,7 +31,12 @@ struct ONNXLayoutTransformOpLowering
   ONNXLayoutTransformOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
       : OpConversionPattern(typeConverter, ctx),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXLayoutTransformOp::getOperationName());
+  }
 
   LogicalResult matchAndRewrite(ONNXLayoutTransformOp layoutOp,
       ONNXLayoutTransformOpAdaptor adaptor,

--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -82,6 +82,7 @@ add_onnx_mlir_library(OMONNXToKrnl
   OMONNXConversionCommon
   OMONNXOps
   OMSupport
+  OMOptionUtils
   MLIRFuncDialect
   MLIRFuncTransforms
   )

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -19,6 +19,7 @@
 
 #include "src/Accelerators/Accelerator.hpp"
 #include "src/Builder/ModelInputShaper.hpp"
+#include "src/Compiler/OptionUtils.hpp"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 #include "src/Dialect/Mlir/VectorMachineSupport.hpp"
 

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -477,7 +477,8 @@ int OnnxToKrnlLoweringConfiguration::reportOnParallel = 0; // 0: no reporting.
 int OnnxToKrnlLoweringConfiguration::reportOnSimd = 0;     // 0: no reporting.
 std::string OnnxToKrnlLoweringConfiguration::defaultParallelComment = "";
 std::string OnnxToKrnlLoweringConfiguration::defaultSimdComment = "";
-EnableByRegexpOption OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps;
+EnableByRegexpOption OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps(
+    /*emptyIsNone*/ false);
 
 // Function to set default reporting messages, if any.
 void configureOnnxToKrnlLoweringPass(bool reportOnParallel,

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -4,7 +4,7 @@
 
 //====------ ConvertONNXToKrnl.cpp - ONNX dialects to Krnl lowering -------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -477,10 +477,12 @@ int OnnxToKrnlLoweringConfiguration::reportOnParallel = 0; // 0: no reporting.
 int OnnxToKrnlLoweringConfiguration::reportOnSimd = 0;     // 0: no reporting.
 std::string OnnxToKrnlLoweringConfiguration::defaultParallelComment = "";
 std::string OnnxToKrnlLoweringConfiguration::defaultSimdComment = "";
+EnableByRegexpOption OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps;
 
 // Function to set default reporting messages, if any.
 void configureOnnxToKrnlLoweringPass(bool reportOnParallel,
-    bool parallelIsEnabled, bool reportOnSimd, bool simdIsEnabled) {
+    bool parallelIsEnabled, std::string specificParallelOps, bool reportOnSimd,
+    bool simdIsEnabled) {
   OnnxToKrnlLoweringConfiguration::reportOnParallel = reportOnParallel;
   OnnxToKrnlLoweringConfiguration::reportOnSimd = reportOnSimd;
   if (reportOnParallel && !parallelIsEnabled)
@@ -497,6 +499,10 @@ void configureOnnxToKrnlLoweringPass(bool reportOnParallel,
             "cpu with unspecified simd ISA";
     }
   }
+  if (parallelIsEnabled)
+    // We have parallelism, enable specific parallel ops if available.
+    OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.setRegexpString(
+        specificParallelOps);
 }
 
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -477,7 +477,7 @@ int OnnxToKrnlLoweringConfiguration::reportOnParallel = 0; // 0: no reporting.
 int OnnxToKrnlLoweringConfiguration::reportOnSimd = 0;     // 0: no reporting.
 std::string OnnxToKrnlLoweringConfiguration::defaultParallelComment = "";
 std::string OnnxToKrnlLoweringConfiguration::defaultSimdComment = "";
-EnableByRegexpOption OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps(
+EnableByRegexOption OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps(
     /*emptyIsNone*/ false);
 
 // Function to set default reporting messages, if any.
@@ -502,7 +502,7 @@ void configureOnnxToKrnlLoweringPass(bool reportOnParallel,
   }
   if (parallelIsEnabled)
     // We have parallelism, enable specific parallel ops if available.
-    OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.setRegexpString(
+    OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.setRegexString(
         specificParallelOps);
 }
 

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2035,7 +2035,12 @@ struct ONNXElementwiseUnaryOpLowering
       DimAnalysis *dimAnalysis, bool enableSIMD, bool enableParallel)
       : OpConversionPattern<ElementwiseUnaryOp>(typeConverter, ctx),
         dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ElementwiseUnaryOp::getOperationName());
+  }
 
   LogicalResult matchAndRewrite(ElementwiseUnaryOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
@@ -2212,7 +2217,12 @@ struct ONNXElementwiseBinaryOpLowering
       bool isUniBroadcasting = false, bool enableParallel = false)
       : OpConversionPattern<ElementwiseBinaryOp>(typeConverter, ctx),
         dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        isUniBroadcasting(isUniBroadcasting), enableParallel(enableParallel) {}
+        isUniBroadcasting(isUniBroadcasting), enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ElementwiseBinaryOp::getOperationName());
+  }
 
   LogicalResult matchAndRewrite(ElementwiseBinaryOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
@@ -2387,7 +2397,12 @@ struct ONNXElementwiseVariadicOpLowering
       bool enableParallel)
       : OpConversionPattern<ElementwiseVariadicOp>(typeConverter, ctx),
         dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ElementwiseVariadicOp::getOperationName());
+  }
 
   LogicalResult matchAndRewrite(ElementwiseVariadicOp elmsOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
@@ -2569,7 +2584,12 @@ struct ONNXWhereOpLowering : public ConversionPattern {
       : ConversionPattern(
             typeConverter, ONNXWhereOp::getOperationName(), 1, ctx),
         dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXWhereOp::getOperationName());
+  }
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -346,17 +346,16 @@ struct ScalarOp<ONNXGeluOp> {
 template <>
 double analyzeSimdFor<ONNXGeluOp>(
     Type t, Operation *op, int64_t &von, int64_t &son) {
-  double results;
   StringRef approximate = dyn_cast<ONNXGeluOp>(op).getApproximate();
   if (approximate.equals_insensitive("none"))
-    results = simdAnalysis(
+    return simdAnalysis(
         {GenericOps::ArithmeticGop, GenericOps::ErfGop, GenericOps::MulGop},
         {1, 1, 3}, t, von, son);
   if (approximate.equals_insensitive("tanh"))
-    results = simdAnalysis({GenericOps::ArithmeticGop, GenericOps::MulGop,
+    return simdAnalysis({GenericOps::ArithmeticGop, GenericOps::MulGop,
                                GenericOps::TrigHyperbolicGop},
         {2, 5, 1}, t, von, son);
-  return results;
+  llvm_unreachable("approximate should be only none or tanh");
 }
 
 template <>

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -353,7 +353,7 @@ double analyzeSimdFor<ONNXGeluOp>(
         {1, 1, 3}, t, von, son);
   if (approximate.equals_insensitive("tanh"))
     return simdAnalysis({GenericOps::ArithmeticGop, GenericOps::MulGop,
-                               GenericOps::TrigHyperbolicGop},
+                            GenericOps::TrigHyperbolicGop},
         {2, 5, 1}, t, von, son);
   llvm_unreachable("approximate should be only none or tanh");
 }

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2034,8 +2034,7 @@ struct ONNXElementwiseUnaryOpLowering
   ONNXElementwiseUnaryOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
       DimAnalysis *dimAnalysis, bool enableSIMD, bool enableParallel)
       : OpConversionPattern<ElementwiseUnaryOp>(typeConverter, ctx),
-        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {
+        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
@@ -2217,7 +2216,7 @@ struct ONNXElementwiseBinaryOpLowering
       bool isUniBroadcasting = false, bool enableParallel = false)
       : OpConversionPattern<ElementwiseBinaryOp>(typeConverter, ctx),
         dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        isUniBroadcasting(isUniBroadcasting), enableParallel(enableParallel) {
+        isUniBroadcasting(isUniBroadcasting) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
@@ -2396,8 +2395,7 @@ struct ONNXElementwiseVariadicOpLowering
       MLIRContext *ctx, DimAnalysis *dimAnalysis, bool enableSIMD,
       bool enableParallel)
       : OpConversionPattern<ElementwiseVariadicOp>(typeConverter, ctx),
-        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {
+        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
@@ -2583,8 +2581,7 @@ struct ONNXWhereOpLowering : public ConversionPattern {
       DimAnalysis *dimAnalysis, bool enableSIMD, bool enableParallel)
       : ConversionPattern(
             typeConverter, ONNXWhereOp::getOperationName(), 1, ctx),
-        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {
+        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -36,8 +36,7 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
   ONNXGemmOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
       bool enableTiling, bool enableSIMD, bool enableParallel)
       : OpConversionPattern<GemmOp>(typeConverter, ctx),
-        enableTiling(enableTiling), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {
+        enableTiling(enableTiling), enableSIMD(enableSIMD) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- Gemm.cpp - Lowering Gemm Op ------------------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -37,7 +37,12 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
       bool enableTiling, bool enableSIMD, bool enableParallel)
       : OpConversionPattern<GemmOp>(typeConverter, ctx),
         enableTiling(enableTiling), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXGemmOp::getOperationName());
+  }
 
   using OpAdaptor = typename GemmOp::Adaptor;
   bool enableTiling;

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -33,8 +33,7 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
       DimAnalysis *dimAnalysis, bool enableTiling, bool enableSIMD,
       bool enableParallel)
       : OpConversionPattern(typeConverter, ctx), dimAnalysis(dimAnalysis),
-        enableTiling(enableTiling), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {
+        enableTiling(enableTiling), enableSIMD(enableSIMD) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- Matmul.cpp - Lowering Matmul Op --------------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -34,7 +34,13 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
       bool enableParallel)
       : OpConversionPattern(typeConverter, ctx), dimAnalysis(dimAnalysis),
         enableTiling(enableTiling), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXMatMulOp::getOperationName());
+  }
+
   DimAnalysis *dimAnalysis;
   bool enableTiling;
   bool enableSIMD;

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -4,7 +4,7 @@
 
 //===-------------- Reduction.cpp - Lowering Reduction Ops ----------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -340,7 +340,12 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
       bool enableSIMD, bool enableParallel, bool computeMean = false)
       : OpConversionPattern<ONNXReductionOp>(typeConverter, ctx),
         enableSIMD(enableSIMD), computeMean(computeMean),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXReductionOp::getOperationName());
+  }
 
   LogicalResult matchAndRewrite(ONNXReductionOp reduceOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -339,8 +339,7 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
   ONNXReductionOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
       bool enableSIMD, bool enableParallel, bool computeMean = false)
       : OpConversionPattern<ONNXReductionOp>(typeConverter, ctx),
-        enableSIMD(enableSIMD), computeMean(computeMean),
-        enableParallel(enableParallel) {
+        enableSIMD(enableSIMD), computeMean(computeMean) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -126,7 +126,7 @@ template <typename T>
 void emitInstForSoftmax(ConversionPatternRewriter &rewriter, Operation *op,
     Location loc, Value alloc, Value input, MemRefType scalarMemRefType,
     Value sumOp, Value maxOp, Value zero, Value negInfinity, int64_t axis,
-    bool useParallel) = delete;
+    bool enableParallel) = delete;
 
 // For Softmax opset < 13, `axis` is the coerced point. All dimensions
 // after `axis` will be logically coerced into a single dimension.
@@ -134,7 +134,7 @@ template <>
 void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
     Operation *op, Location loc, Value alloc, Value input,
     MemRefType scalarMemRefType, Value sumOp, Value maxOp, Value zero,
-    Value negInfinity, int64_t axis, bool useParallel) {
+    Value negInfinity, int64_t axis, bool enableParallel) {
   int64_t rank = alloc.getType().cast<MemRefType>().getRank();
 
   MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl> create(
@@ -149,7 +149,7 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
   // dimensions. The outer loop is only created once `axis` is not
   // zero.
   if (axis == 0) {
-    assert(!useParallel && "only outer loop parallelism at this time");
+    assert(!enableParallel && "only outer loop parallelism at this time");
     // There is no need having outer loops.
     // Reset accumulators.
     create.krnl.store(zero, sumOp, ArrayRef<Value>{});
@@ -170,7 +170,7 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
     SmallVector<IndexExpr, 4> outerUbs;
     for (int i = 0; i < axis; ++i)
       outerUbs.emplace_back(create.krnlIE.getShapeAsDim(input, i));
-    if (useParallel) {
+    if (enableParallel) {
       assert(axis > 0 && "bad assumption");
       create.krnl.parallel(outerLoops[0]);
       onnxToKrnlParallelReport(
@@ -184,7 +184,7 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
               create(ck);
           IndexExprScope ieScope(ck);
 
-          if (useParallel) {
+          if (enableParallel) {
             // Temporary results must be private when parallel. Use alloca here
             // as scalars are small.
             sumOp = create.mem.alignedAlloca(scalarMemRefType);
@@ -215,7 +215,7 @@ template <>
 void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
     Operation *op, Location loc, Value alloc, Value input,
     MemRefType scalarMemRefType, Value sumOp, Value maxOp, Value zero,
-    Value negInfinity, int64_t axis, bool useParallel) {
+    Value negInfinity, int64_t axis, bool enableParallel) {
   int64_t rank = alloc.getType().cast<MemRefType>().getRank();
 
   MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl> create(
@@ -225,7 +225,7 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
 
   // Parallel only if output is not a scalar.
   if (rank - 1 == 0)
-    useParallel = false;
+    enableParallel = false;
 
   // Outer loops iterate over all dimensions except axis.
   ValueRange outerLoops = create.krnl.defineLoops(rank - 1);
@@ -235,7 +235,7 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
     if (i != axis)
       outerUbs.emplace_back(create.krnlIE.getShapeAsDim(input, i));
 
-  if (useParallel) {
+  if (enableParallel) {
     create.krnl.parallel(outerLoops[0]);
     onnxToKrnlParallelReport(op, true, 0, outerLbs[0], outerUbs[0], "softmax");
     LLVM_DEBUG(llvm::dbgs() << "[Parallel Op]: onnx.Softmax \n");
@@ -248,7 +248,7 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
             create(ck);
         IndexExprScope ieScope(ck);
 
-        if (useParallel) {
+        if (enableParallel) {
           // Temporary results must be private when parallel. Use alloca here as
           // scalars are small.
           sumOp = create.mem.alignedAlloca(scalarMemRefType);
@@ -304,7 +304,9 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
     assert(axis >= -rank && axis <= rank - 1);
     // Since we parallelize the outer loops only at this time, disable the case
     // where there is no outer loops at all.
-    bool useParallel = enableParallel && (axis > 0);
+    bool enableParallelLocal = enableParallel;
+    if (axis <= 0)
+      enableParallelLocal = false;
 
     // Insert an allocation and deallocation for the result of this operation.
     Type elementType = memRefType.getElementType();
@@ -314,7 +316,7 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
     // Insert allocations and deallocations for sum and max.
     MemRefType scalarMemRefType = MemRefType::get({}, elementType, {}, 0);
     Value sumOp, maxOp;
-    if (!useParallel) {
+    if (!enableParallelLocal) {
       // Temporary results must be private when parallel.
       sumOp = create.mem.alignedAlloc(scalarMemRefType);
       maxOp = create.mem.alignedAlloc(scalarMemRefType);
@@ -325,7 +327,8 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
         elementType, -std::numeric_limits<float>::infinity());
 
     emitInstForSoftmax<SoftmaxOp>(rewriter, op, loc, alloc, input,
-        scalarMemRefType, sumOp, maxOp, zero, negInfinity, axis, useParallel);
+        scalarMemRefType, sumOp, maxOp, zero, negInfinity, axis,
+        enableParallelLocal);
 
     rewriter.replaceOp(op, alloc);
     onnxToKrnlSimdReport(op);

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -275,8 +275,7 @@ template <typename SoftmaxOp>
 struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
   ONNXSoftmaxLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
-      : OpConversionPattern<SoftmaxOp>(typeConverter, ctx),
-        enableParallel(enableParallel) {
+      : OpConversionPattern<SoftmaxOp>(typeConverter, ctx) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -4,7 +4,7 @@
 
 //===----------------- Softmax.cpp - Softmax Op ---------------------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -276,7 +276,13 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
   ONNXSoftmaxLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
       : OpConversionPattern<SoftmaxOp>(typeConverter, ctx),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXSoftmaxOp::getOperationName());
+  }
+
   using OpAdaptor = typename SoftmaxOp::Adaptor;
   bool enableParallel = false;
 

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -4,7 +4,7 @@
 
 //===--------------- Conv.cpp - Lowering Convolution Op -------------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -23,7 +23,13 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
   ONNXConvOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
       : OpConversionPattern(typeConverter, ctx),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXConvOp::getOperationName());
+  }
+
   bool enableParallel;
 
   void convUnoptimized(ConversionPatternRewriter &rewriter, ONNXConvOp &convOp,

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -22,8 +22,7 @@ namespace onnx_mlir {
 struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
   ONNXConvOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
-      : OpConversionPattern(typeConverter, ctx),
-        enableParallel(enableParallel) {
+      : OpConversionPattern(typeConverter, ctx) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -403,7 +403,12 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
       DimAnalysis *dimAnalysis, bool enableSIMD, bool enableParallel)
       : OpConversionPattern<OP_TYPE>(typeConverter, ctx),
         dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            OP_TYPE::getOperationName());
+  }
 
   DimAnalysis *dimAnalysis;
   bool enableSIMD, enableParallel;

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -402,8 +402,7 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
   GenericLayerNormaOpLowering(TypeConverter &typeConverter, MLIRContext *ctx,
       DimAnalysis *dimAnalysis, bool enableSIMD, bool enableParallel)
       : OpConversionPattern<OP_TYPE>(typeConverter, ctx),
-        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD),
-        enableParallel(enableParallel) {
+        dimAnalysis(dimAnalysis), enableSIMD(enableSIMD) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -31,7 +31,7 @@
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/TypeSwitch.h"
 
-#include "src/Compiler/CompilerUtils.hpp"
+#include "src/Compiler/OptionUtils.hpp"
 #include "src/Dialect/Krnl/DialectBuilder.hpp"
 #include "src/Dialect/Krnl/KrnlHelper.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -4,7 +4,7 @@
 
 //====------ ONNXToKrnlCommon.hpp - ONNX dialects to Krnl lowering --------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -31,6 +31,7 @@
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/TypeSwitch.h"
 
+#include "src/Compiler/CompilerUtils.hpp"
 #include "src/Dialect/Krnl/DialectBuilder.hpp"
 #include "src/Dialect/Krnl/KrnlHelper.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
@@ -603,6 +604,7 @@ struct OnnxToKrnlLoweringConfiguration {
   static std::string defaultParallelComment;
   static int reportOnSimd;
   static std::string defaultSimdComment;
+  static EnableByRegexpOption enableSpecificParallelOps;
 };
 
 namespace impl {

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -604,7 +604,7 @@ struct OnnxToKrnlLoweringConfiguration {
   static std::string defaultParallelComment;
   static int reportOnSimd;
   static std::string defaultSimdComment;
-  static EnableByRegexpOption enableSpecificParallelOps;
+  static EnableByRegexOption enableSpecificParallelOps;
 };
 
 namespace impl {

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -25,8 +25,7 @@ namespace onnx_mlir {
 struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
   ONNXConcatOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
-      : OpConversionPattern(typeConverter, ctx),
-        enableParallel(enableParallel) {
+      : OpConversionPattern(typeConverter, ctx) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Concat.cpp - Lowering Concat Op -------------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -26,7 +26,13 @@ struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
   ONNXConcatOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
       : OpConversionPattern(typeConverter, ctx),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXConcatOp::getOperationName());
+  }
+
   bool enableParallel = false;
 
   LogicalResult matchAndRewrite(ONNXConcatOp concatOp,

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -4,7 +4,7 @@
 
 //===---------------- Transpose.cpp - Lowering Transpose Op ---------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -29,7 +29,12 @@ struct ONNXTransposeOpLowering : public OpConversionPattern<ONNXTransposeOp> {
   ONNXTransposeOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
       : OpConversionPattern(typeConverter, ctx),
-        enableParallel(enableParallel) {}
+        enableParallel(enableParallel) {
+    this->enableParallel =
+        enableParallel &&
+        OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(
+            ONNXTransposeOp::getOperationName());
+  }
 
   LogicalResult matchAndRewrite(ONNXTransposeOp transposeOp,
       ONNXTransposeOpAdaptor adaptor,

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -28,8 +28,7 @@ struct ONNXTransposeOpLowering : public OpConversionPattern<ONNXTransposeOp> {
 
   ONNXTransposeOpLowering(
       TypeConverter &typeConverter, MLIRContext *ctx, bool enableParallel)
-      : OpConversionPattern(typeConverter, ctx),
-        enableParallel(enableParallel) {
+      : OpConversionPattern(typeConverter, ctx) {
     this->enableParallel =
         enableParallel &&
         OnnxToKrnlLoweringConfiguration::enableSpecificParallelOps.isEnabled(

--- a/src/Dialect/ONNX/ONNXOps/NN/Normalization.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Normalization.cpp
@@ -229,9 +229,6 @@ mlir::LogicalResult ONNXLNOpShapeHelper<OP_TYPE>::computeShape() {
   int64_t XRank = X.getType().cast<ShapedType>().getRank();
   int64_t axis = getAxisInRange(lnOp.getAxis(), XRank);
 
-  // Get Scale
-  Value scale = operandAdaptor.getScale();
-
   // Check optional outputs, with specialization for ONNXLayerNormalizationOp
   // and ONNXRMSLayerNormalizationOp.
   bool hasMean, hasInvStdDev;

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -4,7 +4,7 @@
 
 //===---------- Passes.hpp - ONNX-MLIR Passes Definition ------------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -86,7 +86,8 @@ std::unique_ptr<mlir::Pass> createLowerToKrnlPass();
 std::unique_ptr<mlir::Pass> createLowerToKrnlPass(bool enableTiling,
     bool enableSIMD, bool enableParallel, std::string opsForCall);
 void configureOnnxToKrnlLoweringPass(bool reportOnParallel,
-    bool parallelIsEnabled, bool reportOnSimd, bool simdIsEnabled);
+    bool parallelIsEnabled, std::string specificParallelOps, bool reportOnSimd,
+    bool simdIsEnabled);
 std::unique_ptr<mlir::Pass> createProcessScfParallelPrivatePass();
 
 #ifdef ONNX_MLIR_ENABLE_STABLEHLO

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -54,6 +54,7 @@ add_onnx_mlir_library(OMInstrumentONNX
   OMONNXOps
   OMKrnlOps
   MLIRPass
+  OMCompilerUtils
   )
 
 add_onnx_mlir_library(OMOpTransform

--- a/src/Transform/ONNX/CMakeLists.txt
+++ b/src/Transform/ONNX/CMakeLists.txt
@@ -54,7 +54,7 @@ add_onnx_mlir_library(OMInstrumentONNX
   OMONNXOps
   OMKrnlOps
   MLIRPass
-  OMCompilerUtils
+  OMOptionUtils
   )
 
 add_onnx_mlir_library(OMOpTransform

--- a/src/Transform/ONNX/InstrumentPass.cpp
+++ b/src/Transform/ONNX/InstrumentPass.cpp
@@ -26,7 +26,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "src/Compiler/CompilerUtils.hpp"
+#include "src/Compiler/OptionUtils.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Interface/ShapeInferenceOpInterface.hpp"
 #include "src/Pass/Passes.hpp"

--- a/src/Transform/ONNX/InstrumentPass.cpp
+++ b/src/Transform/ONNX/InstrumentPass.cpp
@@ -82,7 +82,7 @@ public:
   }
 
 private:
-  EnableByRegexpOption allowedOps;
+  EnableByRegexOption allowedOps;
 
 public:
   StringRef getArgument() const override { return "instrument"; }
@@ -121,7 +121,7 @@ public:
   void runOnOperation() override {
     if (instrumentOps == "" || instrumentOps == "NONE")
       return;
-    allowedOps.setRegexpString(instrumentOps);
+    allowedOps.setRegexString(instrumentOps);
     bool hasInitializedRuntime = false;
 
     // Iterate on the operations nested in this function

--- a/src/Transform/ONNX/InstrumentPass.cpp
+++ b/src/Transform/ONNX/InstrumentPass.cpp
@@ -4,7 +4,7 @@
 
 //===------- InstrumentPass.cpp - Instrumentation ---------------------===//
 //
-// Copyright 2019-2020 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -26,6 +26,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "src/Compiler/CompilerUtils.hpp"
 #include "src/Dialect/Krnl/KrnlOps.hpp"
 #include "src/Interface/ShapeInferenceOpInterface.hpp"
 #include "src/Pass/Passes.hpp"
@@ -79,25 +80,12 @@ public:
   }
 
 private:
-  std::set<std::string> allowedOps;
+  EnableByRegexpOption allowedOps;
 
 public:
   StringRef getArgument() const override { return "instrument"; }
 
   StringRef getDescription() const override { return "instrument on ops."; }
-
-  void init(std::string allowedOps_) {
-    // Separate multiple expressions with space
-    allowedOps_ = std::regex_replace(allowedOps_, std::regex(","), " ");
-    // '.' in `--instrument-ops` is recognized as normal character, not regular
-    // expression
-    allowedOps_ = std::regex_replace(allowedOps_, std::regex("\\."), "\\.");
-    allowedOps_ = std::regex_replace(allowedOps_, std::regex("\\*"), ".*");
-    std::stringstream ss(allowedOps_);
-    std::istream_iterator<std::string> begin(ss);
-    std::istream_iterator<std::string> end;
-    allowedOps = std::set<std::string>(begin, end);
-  }
 
   // merge all action options into a bitset
   // used to create tags for instrumentation ops
@@ -131,7 +119,7 @@ public:
   void runOnOperation() override {
     if (instrumentOps == "" || instrumentOps == "NONE")
       return;
-    init(instrumentOps);
+    allowedOps.setRegexpString(instrumentOps);
     bool hasInitializedRuntime = false;
 
     // Iterate on the operations nested in this function
@@ -150,30 +138,27 @@ public:
       if (op->getNumResults() == 1 && isa<NoneType>(op->getResult(0).getType()))
         return WalkResult::advance();
       std::string opName = op->getName().getStringRef().str();
-      for (auto itr = allowedOps.begin(); itr != allowedOps.end(); ++itr) {
-        std::regex re(*itr);
-        if (std::regex_match(opName, re)) {
-          Location loc = op->getLoc();
-          OpBuilder opBuilder(op);
-          if (instrumentBefore) {
-            uint64_t tag = beforeTag();
-            if (!hasInitializedRuntime) {
-              SET_INSTRUMENT_INIT(tag);
-              hasInitializedRuntime = true;
-            }
-            opBuilder.create<mlir::KrnlInstrumentOp>(loc, op, tag);
+      if (allowedOps.isEnabled(opName)) {
+        Location loc = op->getLoc();
+        OpBuilder opBuilder(op);
+        if (instrumentBefore) {
+          uint64_t tag = beforeTag();
+          if (!hasInitializedRuntime) {
+            SET_INSTRUMENT_INIT(tag);
+            hasInitializedRuntime = true;
           }
+          opBuilder.create<mlir::KrnlInstrumentOp>(loc, op, tag);
+        }
 
-          // Can not insert after Op (e.g. ONNXYieldOP) with IsTerminator Trait
-          if (instrumentAfter && !op->hasTrait<OpTrait::IsTerminator>()) {
-            opBuilder.setInsertionPointAfter(op);
-            uint64_t tag = afterTag();
-            if (!hasInitializedRuntime) {
-              SET_INSTRUMENT_INIT(tag);
-              hasInitializedRuntime = true;
-            }
-            opBuilder.create<mlir::KrnlInstrumentOp>(loc, op, tag);
+        // Can not insert after Op (e.g. ONNXYieldOP) with IsTerminator Trait
+        if (instrumentAfter && !op->hasTrait<OpTrait::IsTerminator>()) {
+          opBuilder.setInsertionPointAfter(op);
+          uint64_t tag = afterTag();
+          if (!hasInitializedRuntime) {
+            SET_INSTRUMENT_INIT(tag);
+            hasInitializedRuntime = true;
           }
+          opBuilder.create<mlir::KrnlInstrumentOp>(loc, op, tag);
         }
       }
       return WalkResult::advance();

--- a/src/Transform/ONNX/InstrumentPass.cpp
+++ b/src/Transform/ONNX/InstrumentPass.cpp
@@ -67,10 +67,12 @@ public:
       llvm::cl::desc("instrument runtime reports memory usage"),
       llvm::cl::init(false)};
 
-  InstrumentPass() = default;
+  InstrumentPass() : allowedOps(/*emptyIsNone*/ true){};
   InstrumentPass(const InstrumentPass &pass)
-      : mlir::PassWrapper<InstrumentPass, OperationPass<func::FuncOp>>() {}
-  InstrumentPass(const std::string &ops, unsigned actions) {
+      : mlir::PassWrapper<InstrumentPass, OperationPass<func::FuncOp>>(),
+        allowedOps(/*emptyIsNone*/ true) {}
+  InstrumentPass(const std::string &ops, unsigned actions)
+      : allowedOps(/*emptyIsNone*/ true) {
     this->instrumentOps = ops;
     unsigned long long tag = actions;
     this->instrumentBefore = IS_INSTRUMENT_BEFORE_OP(tag);

--- a/utils/analyze-simd.py
+++ b/utils/analyze-simd.py
@@ -40,7 +40,7 @@ def print_usage(msg=""):
     dprint("  -o | --overhead: search for vector overhead patterns.")
     dprint("")
     dprint("  -f | --function pattern: investigate only functions whose name match")
-    dprint('                           the regexp pattern (default "^main_graph$").')
+    dprint('                           the regex pattern (default "^main_graph$").')
     dprint(
         "  -n | --num num:          investigate only that one occurrence num(default all)"
     )

--- a/utils/analyze-simd.py
+++ b/utils/analyze-simd.py
@@ -40,7 +40,7 @@ def print_usage(msg=""):
     dprint("  -o | --overhead: search for vector overhead patterns.")
     dprint("")
     dprint("  -f | --function pattern: investigate only functions whose name match")
-    dprint('                           the regex pattern (default "^main_graph$").')
+    dprint('                           the regexp pattern (default "^main_graph$").')
     dprint(
         "  -n | --num num:          investigate only that one occurrence num(default all)"
     )

--- a/utils/make-report.py
+++ b/utils/make-report.py
@@ -40,7 +40,7 @@ def print_usage(msg=""):
         """
 Usage: Report statistics on compiler and runtime characteristics of ONNX ops.
 make-report.py -[vh] [-c <compile_log>] [-r <run_log>] [-l <num>]
-      [-s <stats>] [--sort <val>] [--supported] [-u <val>] [-p <op regexp>]
+      [-s <stats>] [--sort <val>] [--supported] [-u <val>] [-p <op regex>]
       [-w <num>]
           
 Compile-time statistics are collected from a `onnx-mlir` compiler output
@@ -74,7 +74,7 @@ Parameters:
                        1: Also count reasons for success/failure.
                        2: Also list metrics.
                        3: Also list node name.
-  -f/--focus <regexp>: Focus only on ops that match the regexp pattern.
+  -f/--focus <regex>:  Focus only on ops that match the regex pattern.
   -m/--min <num>:      Focus on operations with at least <num>% of exec time.
   -supported:          Focus only on ops that are supported. Namely, the report
                        will skip ops for which compile-time statistics list

--- a/utils/make-report.py
+++ b/utils/make-report.py
@@ -40,7 +40,7 @@ def print_usage(msg=""):
         """
 Usage: Report statistics on compiler and runtime characteristics of ONNX ops.
 make-report.py -[vh] [-c <compile_log>] [-r <run_log>] [-l <num>]
-      [-s <stats>] [--sort <val>] [--supported] [-u <val>] [-p <op regex>]
+      [-s <stats>] [--sort <val>] [--supported] [-u <val>] [-p <op regexp>]
       [-w <num>]
           
 Compile-time statistics are collected from a `onnx-mlir` compiler output
@@ -74,7 +74,7 @@ Parameters:
                        1: Also count reasons for success/failure.
                        2: Also list metrics.
                        3: Also list node name.
-  -f/--focus <regex>:  Focus only on ops that match the regex pattern.
+  -f/--focus <regexp>: Focus only on ops that match the regexp pattern.
   -m/--min <num>:      Focus on operations with at least <num>% of exec time.
   -supported:          Focus only on ops that are supported. Namely, the report
                        will skip ops for which compile-time statistics list


### PR DESCRIPTION
Up to know, we either parallelized all operations (with `-parallel`) or none. This PR add the ability to define a `-parallelize-ops=regexp` to decide which operation should be parallelized. It must be used in conjunction with the `-parallel` flag.

As we already had some support for regex processing, I factorized the regex processing from InstrumentOps to compiler util so that it may be reused where ever needed.