### PR TITLE
Fix compile messages for z/OS

### DIFF
--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef ONNX_MLIR_ZDNNEXTENSION_H
+#define ONNX_MLIR_ZDNNEXTENSION_H
 
 #include "zdnn.h"
 
@@ -180,3 +181,5 @@ zdnn_status zdnn_tanh_ext(const zdnn_ztensor *input, zdnn_ztensor *output);
 #ifdef __cplusplus
 }
 #endif
+
+#endif // ONNX_MLIR_ZDNNEXTENSION_H

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -4,7 +4,7 @@
 
 //===------------- jniwrapper.c - JNI wrapper Implementation -------------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -620,19 +620,35 @@ jobject omtl_native_to_java(
     JNI_TYPE_VAR_CALL(env, jlongArray, jomt_shape,
         (*env)->NewLongArray(env, jomt_rank), jomt_shape != NULL,
         japi->jecpt_cls, "omt[%d]:jomt_shape=%p", i, jomt_shape);
+    /* On z/OS, remove const specification for jni_shape */
+#ifdef __MVS__
+    JNI_CALL(env,
+        (*env)->SetLongArrayRegion(
+            env, jomt_shape, 0, jomt_rank, (jlong *)jni_shape),
+        1, NULL, "");
+#else
     JNI_CALL(env,
         (*env)->SetLongArrayRegion(
             env, jomt_shape, 0, jomt_rank, (const jlong *)jni_shape),
         1, NULL, "");
+#endif
 
     /* Create data strides array Java object, fill in from native array */
     JNI_TYPE_VAR_CALL(env, jlongArray, jomt_strides,
         (*env)->NewLongArray(env, jomt_rank), jomt_strides != NULL,
         japi->jecpt_cls, "omt[%d]:jomt_strides=%p", i, jomt_strides);
+    /* On z/OS, remove const specification for jni_strides */
+#ifdef __MVS__
+    JNI_CALL(env,
+        (*env)->SetLongArrayRegion(
+            env, jomt_strides, 0, jomt_rank, (jlong *)jni_strides),
+        1, NULL, "");
+#else
     JNI_CALL(env,
         (*env)->SetLongArrayRegion(
             env, jomt_strides, 0, jomt_rank, (const jlong *)jni_strides),
         1, NULL, "");
+#endif
 
     /* Create the OMTensor Java object */
     JNI_TYPE_VAR_CALL(env, jobject, jobj_omt,


### PR DESCRIPTION
This PR adds a header guard for zDNNExtension.h instead of using `#pragma once`.  The `#pragma once` is not supported on z/OS and causes a warning during compile. This warning shows up when compiling the Runtime code to be used when linking a z/OS shared object model.

This PR also corrects a warning message issued when compiling jniwrapper.c on z/OS.