### PR TITLE
[NNPA] Splitting the second input in zdnn matmul 

### DIFF
--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/Elementwise.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/Elementwise.c
@@ -198,6 +198,8 @@ static zdnn_status zdnn_binary_elementwise_common(const zdnn_ztensor *inputA,
       return zdnn_sub(inputA, inputB, output);
     else if (opType == ZDNN_MUL_EXT)
       return zdnn_mul(inputA, inputB, output);
+    else if (opType == ZDNN_DIV_EXT)
+      return zdnn_div(inputA, inputB, output);
     else if (opType == ZDNN_MAX_EXT)
       return zdnn_max(inputA, inputB, output);
     else if (opType == ZDNN_MIN_EXT)

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
@@ -86,6 +86,10 @@ typedef struct SplitInfo {
   uint32_t chunkSize;
   // The number of chunks.
   uint32_t numOfChunks;
+  // If reuse the original ztensor's buffer or not.
+  // If yes, there is no need to allocate buffers for chunks, and chunk ztensors
+  // will use the original ztensor's buffer.
+  bool reuseOrigBuffer;
   // Information for each chunk.
   ChunkInfo *chunks;
 } SplitInfo;


### PR DESCRIPTION
This patch supports splitting the second input B in zdnn matmul. So, for `A(BS, M, N) * B(N, P) + C(P)`, we split both M and/or P.
This patch supports reuse of the original buffer in some cases:
- When `BS = 1`, `N=64`, splitting and merging A need not copy data and the original ztensor is reused.
- When `BS=1`, splitting and merging B need not copy data and the original ztensor is reused.