### PR TITLE
Add cmake optional switch for a additional unified shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.20.0)
 project(onnx-mlir)
 
 option(ONNX_MLIR_BUILD_TESTS "Build ONNX-MLIR test executables. If OFF, just generate build targets." ON)
+option(ONNX_MLIR_BUILD_SHARED "Enable ONNX-MLIR additional shared library object." OFF)
 option(ONNX_MLIR_CCACHE_BUILD "Set to ON for a ccache enabled build." OFF)
 option(ONNX_MLIR_ENABLE_STABLEHLO "Enable StableHLO support." ON)
 option(ONNX_MLIR_DECOMP_ONNX_CONVTRANSPOSE "Enable ONNXConvTransposeOp decomposition." ON)
@@ -21,9 +22,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # etc.), by default some components (e.g., cmake) install into lib while
 # others (e.g., python) install into lib64.
 # This causes trouble when we try to figure out the runtime directory in
-# CompilerUtils.cpp::getLibraryPath(). So we explicitly set CMAKE_INSTALL_LIBDIR
+# CompilerUtils.cpp::getLibraryPath(). So we set a default CMAKE_INSTALL_LIBDIR
 # to install into lib on all systems so we don't have to deal with lib64.
-set(CMAKE_INSTALL_LIBDIR lib)
+if(NOT CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR lib)
+endif()
 
 if (NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type selected, default to Debug")

--- a/MLIR.cmake
+++ b/MLIR.cmake
@@ -28,8 +28,9 @@ include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 
 add_definitions(${LLVM_DEFINITIONS})
-
-set(BUILD_SHARED_LIBS ${LLVM_ENABLE_SHARED_LIBS} CACHE BOOL "" FORCE)
+if (NOT BUILD_SHARED_LIBS)
+  set(BUILD_SHARED_LIBS ${LLVM_ENABLE_SHARED_LIBS} CACHE BOOL "" FORCE)
+endif()
 message(STATUS "BUILD_SHARED_LIBS        : " ${BUILD_SHARED_LIBS})
 
 # onnx uses exceptions, so we need to make sure that LLVM_REQUIRES_EH is set to ON, so that
@@ -203,8 +204,8 @@ function(add_onnx_mlir_library name)
 
   if (NOT ARG_NO_INSTALL)
     install(TARGETS ${name}
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       RUNTIME DESTINATION bin
       )
   endif()

--- a/src/Accelerators/NNPA/zdnn.cmake
+++ b/src/Accelerators/NNPA/zdnn.cmake
@@ -50,7 +50,7 @@ function(setup_zdnn version)
       # BYPRODUCTS ${NNPA_LIBRARY_PATH}/libzdnn.a ${NNPA_INCLUDE_PATH}/zdnn.h
       )
 
-    install(FILES ${NNPA_LIBRARY_PATH}/libzdnn.a DESTINATION lib)
+    install(FILES ${NNPA_LIBRARY_PATH}/libzdnn.a DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
   # On other archs, just copy zdnn.h so NNPA code can be compiled
   else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,29 @@ add_subdirectory(Tools)
 add_subdirectory(Version)
 add_subdirectory(Compiler)
 
+if (ONNX_MLIR_BUILD_SHARED)
+  # Gather all mlir library exports
+  get_property(_om_targets GLOBAL PROPERTY ONNX_MLIR_LIBS)
+  foreach(_target IN LISTS _om_targets)
+    list(APPEND _om_objects $<TARGET_OBJECTS:${_target}>)
+  endforeach()
+  # Append non mlir library exports
+  list(APPEND _om_objects $<TARGET_OBJECTS:OMAccelerator>)
+  list(APPEND _om_objects $<TARGET_OBJECTS:OMCompiler>)
+  list(APPEND _om_objects $<TARGET_OBJECTS:OMCompilerOptions>)
+  list(APPEND _om_objects $<TARGET_OBJECTS:OMCompilerPasses>)
+  list(APPEND _om_objects $<TARGET_OBJECTS:OMCompilerUtils>)
+  list(APPEND _om_objects $<TARGET_OBJECTS:OMInitAccelerators>)
+  list(APPEND _om_objects $<TARGET_OBJECTS:OMOptionUtils>)
+
+  # Single shared library
+  add_library(ONNXMLIR SHARED
+    ${_om_objects}
+  )
+  target_link_libraries(ONNXMLIR PUBLIC MLIR LLVM onnx onnx_proto)
+  install(TARGETS ONNXMLIR LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
 add_onnx_mlir_executable(onnx-mlir
   onnx-mlir.cpp
 
@@ -21,4 +44,3 @@ add_onnx_mlir_executable(onnx-mlir
   OMCompilerUtils
   OMOptionUtils
   )
-  

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -57,13 +57,15 @@ add_onnx_mlir_library(OMCompilerOptions
   MLIRIR
   OMAccelerator
   )
-
+list(APPEND DEFINITIONS "LIBDIR_PATH=\"${CMAKE_INSTALL_LIBDIR}\"")
+target_compile_definitions(OMCompilerOptions PUBLIC ${DEFINITIONS})
 
 add_onnx_mlir_library(OMCompilerDialects
   CompilerDialects.cpp
 
   LINK_LIBS PUBLIC
   OMAccelerator
+  OMCompilerOptions
   OMInitAccelerators
   OMKrnlOps
   OMONNXOps
@@ -252,5 +254,5 @@ target_link_libraries(PyCompile
   )
 
 install(TARGETS PyCompile
-  DESTINATION lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -1019,12 +1019,12 @@ std::string getLibraryPath() {
   std::string execDir = llvm::sys::path::parent_path(getExecPath()).str();
   if (llvm::sys::path::stem(execDir).str().compare("bin") == 0) {
     std::string p = execDir.substr(0, execDir.size() - 3);
-    if (llvm::sys::fs::exists(p + "lib"))
-      return p + "lib";
+    if (llvm::sys::fs::exists(p + LibPath))
+      return p + LibPath;
   }
 
   llvm::SmallString<8> instDir(kInstPath);
-  llvm::sys::path::append(instDir, "lib");
+  llvm::sys::path::append(instDir, LibPath);
   return llvm::StringRef(instDir).str();
 }
 

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -31,6 +31,17 @@
 // TODO: may want to do this constant set by a variable in CMakeFiles.
 extern const std::string OnnxMlirEnvOptionName;
 
+#ifndef _LIBDIR_DEFINED
+#define _LIBDIR_DEFINED
+#ifndef LIBDIR_PATH
+// default path
+const std::string LibPath = "lib";
+#else
+// pickup -DFSLIB_PATH=
+const std::string LibPath = LIBDIR_PATH;
+#endif
+#endif
+
 namespace onnx_mlir {
 
 typedef enum {

--- a/src/Conversion/ONNXToStablehlo/CMakeLists.txt
+++ b/src/Conversion/ONNXToStablehlo/CMakeLists.txt
@@ -33,7 +33,7 @@ set(STABLEHLO_LIBS
 
 install(TARGETS
   ${STABLEHLO_LIBS}
-  DESTINATION lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
 
 add_onnx_mlir_library(OMONNXToStablehlo

--- a/src/Runtime/jni/CMakeLists.txt
+++ b/src/Runtime/jni/CMakeLists.txt
@@ -26,7 +26,7 @@ if (ONNX_MLIR_ENABLE_JNI)
   if (TARGET jsoniter)
     add_dependencies(javaruntime jsoniter)
   endif()
-  install_jar(javaruntime DESTINATION lib)
+  install_jar(javaruntime DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
   # ONNX_MLIR_LIBRARY_PATH is a generator expression which is not supported by
   # add_jar as the output directory. Instead, we let add_jar place the jar file

--- a/src/Runtime/omp/CMakeLists.txt
+++ b/src/Runtime/omp/CMakeLists.txt
@@ -33,7 +33,7 @@ if(TARGET omp)
     BYPRODUCTS ${OMP_TOPDIR}/lib/libomp.a
     )
 
-  install(FILES ${ONNX_MLIR_LIBRARY_PATH}/libompruntime.a DESTINATION lib)
+  install(FILES ${ONNX_MLIR_LIBRARY_PATH}/libompruntime.a DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
   message(STATUS "OpenMP support           : ON")
 else()

--- a/src/Runtime/python/CMakeLists.txt
+++ b/src/Runtime/python/CMakeLists.txt
@@ -89,7 +89,7 @@ target_link_libraries(PyRuntimeC
 llvm_update_compile_flags(PyRuntimeC)
 
 install(TARGETS PyRuntimeC
-  DESTINATION lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
 
 pybind11_add_module(PyCompileAndRuntimeC PyOMCompileExecutionSession.cpp)
@@ -116,5 +116,5 @@ target_link_libraries(PyCompileAndRuntimeC
 llvm_update_compile_flags(PyCompileAndRuntimeC)
 
 install(TARGETS PyCompileAndRuntimeC
-  DESTINATION lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )


### PR DESCRIPTION
Hi folks,

For a better development usage this request allows to build (optionally) a single unified shared library object too.

---

Just like in MLIR or LLVM, beside the many static library components, there can be a single shared object too.
No prior behavior is changed for cmake here, it just optionally generates a additional single ```libONNXMLIR.so``` object.


* The shared object, having MLIR + LLVM linked in as shared too:
```
$ cmake {...} 
  -DONNX_MLIR_BUILD_SHARED=ON
  -DCMAKE_INSTALL_LIBDIR=lib64
{...}

$ readelf -a /usr/lib64/libONNXMLIR.so | grep NEED
  [ 7] .gnu.version_r    VERNEED          00000000001c9bf8  001c9bf8
 0x0000000000000001 (NEEDED)             Shared library: [libMLIR.so.18]
 0x0000000000000001 (NEEDED)             Shared library: [libLLVM-18.so]
 0x0000000000000001 (NEEDED)             Shared library: [libonnx.so]
 0x0000000000000001 (NEEDED)             Shared library: [libonnx_proto.so]
 0x0000000000000001 (NEEDED)             Shared library: [libprotobuf.so.32]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x000000006ffffffe (VERNEED)            0x1c9bf8
 0x000000006fffffff (VERNEEDNUM)         6

$ ls -lh /usr/lib64/libONNXMLIR.so 
-rwxr-xr-x 1 root root 13M Feb  1 02:00 /usr/lib64/libONNXMLIR.so
```

* Rel-eng point of view:
```
$ rpm -qa | grep onnx-mlir
onnx-mlir-0.4.2-20240201.0.git52e10941.fc40.x86_64
onnx-mlir-static-0.4.2-20240201.0.git52e10941.fc40.x86_64
onnx-mlir-devel-0.4.2-20240201.0.git52e10941.fc40.x86_64
onnx-mlir-python3-0.4.2-20240201.0.git52e10941.fc40.x86_64

$ rpm -ql onnx-mlir | grep ONN
/usr/lib64/libONNXMLIR.so

$ rpm -ql onnx-mlir-static
/usr/lib64/libOMAccelerator.a
/usr/lib64/libOMBuilder.a
/usr/lib64/libOMCompiler.a
/usr/lib64/libOMCompilerDialects.a
/usr/lib64/libOMCompilerOptions.a
/usr/lib64/libOMCompilerPasses.a
/usr/lib64/libOMCompilerUtils.a
{...}

```
---

Changes:
  
 * Add ```ONNX_MLIR_BUILD_SHARED``` cmake knob (default is ```OFF```) for this object generation.
 * Allow user to optionally override the ```CMAKE_INSTALL_LIBDIR``` path (distro friendliness).
 * Allow user to optionally enforce shared/static for all objects via ```BUILD_SHARED_LIBS``` (distro friendliness).
 * Little bugfix of OMCompilerDialects target to pickup the proper objects (matters for shared object cases).
 
This proposal is a continuation of #2698 towards a better rel-eng flexibility.

