### PR TITLE
Add omp parallel for in MatMul lib (NNPA)

### DIFF
--- a/src/Accelerators/NNPA/Runtime/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Runtime/CMakeLists.txt
@@ -21,6 +21,6 @@ set_target_properties(RuntimeNNPA
   PROPERTIES
   LANGUAGE C
   POSITION_INDEPENDENT_CODE TRUE
-  COMPILE_OPTIONS -O3
+  COMPILE_OPTIONS "-O3;-fopenmp"
   )
 

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/MatMul.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/MatMul.c
@@ -17,6 +17,7 @@
 #define _OPEN_THREADS
 #endif
 #include <pthread.h>
+#include <sched.h>
 
 #include <assert.h>
 #include <math.h>
@@ -96,7 +97,9 @@ static zdnn_status zdnn_matmul_op_common(const zdnn_ztensor *inputA,
   // Call zdnn_matmul_op on each chunk.
   if (OMZTensorSplitDebug)
     start_time = clock();
+#pragma omp parallel for
   for (uint32_t i = 0; i < splitInfoA.numOfChunks; ++i) {
+    //printf("====cpu id %d=======\n", sched_getcpu());
     zdnn_ztensor *zaTensor = (splitInfoA.chunks + i)->ztensor;
     zdnn_ztensor *zyTensor = (splitInfoY.chunks + i)->ztensor;
     zdnn_status status = call_zdnn_matmul_op(


### PR DESCRIPTION
I first build llvm-project with targets of clang and omp. Then use the built clang to configure onnx-mlir, so that the omp pragma can be interpreted. 

To compile a model, I added `-lgomp` to avoid undefined symbol at runtime. `--parallel` can not solve this issue. Will look into a more elegant solution. 