### PR TITLE
Do not save LLVMIR to .ll file if not requested

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -146,8 +146,7 @@ int Command::exec(std::string wdir) const {
     llvm::errs() << llvm::join(argsRef, " ") << "\n"
                  << "Error message: " << errMsg << "\n"
                  << "Program path: " << _path << "\n"
-                 << "Command execution failed."
-                 << "\n";
+                 << "Command execution failed." << "\n";
     return rc;
   }
 
@@ -360,17 +359,19 @@ static int genLLVMBitcode(const mlir::OwningOpRef<ModuleOp> &module,
   tailorLLVMIR(*llvmModule);
 
   // Write LLVMIR to a file.
-  std::string llvmirNameWithExt = outputNameNoExt + ".ll";
-  llvm::FileRemover llvmirRemover(
-      llvmirNameWithExt, !keepFiles(KeepFilesOfType::LLVMIR));
-  llvm::raw_fd_ostream moduleLLVMIRStream(
-      llvmirNameWithExt, error, llvm::sys::fs::OF_None);
-  if (error) {
-    llvm::errs() << llvmirNameWithExt << ": " << error.message() << "\n";
-    return InvalidTemporaryFileAccess;
+  if (keepFiles(KeepFilesOfType::LLVMIR)) {
+    std::string llvmirNameWithExt = outputNameNoExt + ".ll";
+    llvm::FileRemover llvmirRemover(
+        llvmirNameWithExt, !keepFiles(KeepFilesOfType::LLVMIR));
+    llvm::raw_fd_ostream moduleLLVMIRStream(
+        llvmirNameWithExt, error, llvm::sys::fs::OF_None);
+    if (error) {
+      llvm::errs() << llvmirNameWithExt << ": " << error.message() << "\n";
+      return InvalidTemporaryFileAccess;
+    }
+    llvmModule->print(moduleLLVMIRStream, nullptr);
+    moduleLLVMIRStream.flush();
   }
-  llvmModule->print(moduleLLVMIRStream, nullptr);
-  moduleLLVMIRStream.flush();
 
   // Write unoptimized bitcode to a file.
   llvm::WriteBitcodeToFile(*llvmModule, moduleBitcodeStream);

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -146,7 +146,8 @@ int Command::exec(std::string wdir) const {
     llvm::errs() << llvm::join(argsRef, " ") << "\n"
                  << "Error message: " << errMsg << "\n"
                  << "Program path: " << _path << "\n"
-                 << "Command execution failed." << "\n";
+                 << "Command execution failed."
+                 << "\n";
     return rc;
   }
 


### PR DESCRIPTION
There is a bug in saving LLVMIR to `.ll`. It was always saving to a .ll file (which is slow) then deleting the file if not requested from users.
This patch adds a `if` statement so that the saving to .ll is done only when users request.