### PR TITLE
[Non-functional change] Added analyze-simd functionality for stick/unstick simd instructions

### DIFF
--- a/utils/analyze-simd.py
+++ b/utils/analyze-simd.py
@@ -86,6 +86,8 @@ def define_arch_op_names(arch):
         op_name["vfma"] = "vfma"
         op_name["vmul"] = "vfm.b"
         op_name["vdiv"] = "vfd"
+        # vector conversion between formats (NNPA <-> fp)
+        op_name["vconv"] = "(vclfnh|vclfnl|vcfn|vcrnf|vcnf)"
         # add | sub| max | min | compare
         op_name["vadd"] = "([vw]fa|[vw]fs|[vw]fmax|[vw]fmin|[vw]f[ck][eh])"
         op_name["load"] = "lg"
@@ -101,6 +103,7 @@ def define_arch_op_names(arch):
         op_name["vfma"] = "v?fmadd[123]+p[ds]"
         op_name["vmul"] = "v?mulp[ds]"
         op_name["vdiv"] = "v?divp[sd]"
+        op_name["vconv"] = ""
         # add | sub| max | min | compare | and
         op_name["vadd"] = (
             "(v?addp[ds]|v?subp[ds]|v?maxp[ds]|v?min[dp]|cmp..p[sd]|andp|andnp|orp|xorp|pand|pandn|por|pxor)"
@@ -191,6 +194,10 @@ def characterize_op(line):
         inc_aggr_dict("vcompute")
         inc_aggr_dict("vec")
         return "vfma"
+    if re.match(r".*\s" + op_name["vconv"], line):
+        inc_op_dict("vconv")
+        inc_aggr_dict("vec")
+        return "vconv"
     # Scalar
     if re.match(r".*\s" + op_name["load"], line):
         inc_op_dict("load")
@@ -237,6 +244,8 @@ def print_characterization(details=False):
         + get_aggr_dict("vec")
         + ", compute, "
         + get_aggr_dict("vcompute")
+        + ", conversion, "
+        + get_op_dict("vconv")
         + ", mem, "
         + get_aggr_dict("vmem")
         + ", overhead, "
@@ -440,6 +449,7 @@ def main(argv):
             pattern = add_pattern(pattern, op_name["vadd"])
             pattern = add_pattern(pattern, op_name["vmul"])
             pattern = add_pattern(pattern, op_name["vdiv"])
+            pattern = add_pattern(pattern, op_name["vconv"])
             # Mem
             pattern = add_pattern(pattern, op_name["vload"])
             pattern = add_pattern(pattern, op_name["vload-splat"])
@@ -453,6 +463,7 @@ def main(argv):
             pattern = add_pattern(pattern, op_name["vadd"])
             pattern = add_pattern(pattern, op_name["vmul"])
             pattern = add_pattern(pattern, op_name["vdiv"])
+            pattern = add_pattern(pattern, op_name["vconv"])
         elif opt in ("-m", "--mem"):
             if not pattern:
                 define_arch_op_names(arch)


### PR DESCRIPTION
Useful to detect SIMD instructions for stick and unstick operations.

Example from compiler generated code:
```
analyze-simd.py -t z -a -p add.so
[...]
# Block #1 with SIMD
    8c02:	41 10 10 08       	la	%r1,8(%r1)
    8c06:	e7 00 30 00 40 06 	vl	%v0,0(%r3),4                         <<<<==== vload
    8c0c:	e6 10 00 00 20 56 	vclfnh	%v1,%v0,2,0                      <<<<==== vconv
    8c12:	e6 00 00 00 20 5e 	vclfnl	%v0,%v0,2,0                      <<<<==== vconv
    8c18:	e7 10 20 00 40 0e 	vst	%v1,0(%r2),4                        <<<<==== vstore
    8c1e:	e7 00 20 10 40 0e 	vst	%v0,16(%r2),4                       <<<<==== vstore
    8c24:	41 20 20 20       	la	%r2,32(%r2)
    8c28:	41 30 30 10       	la	%r3,16(%r3)
    8c2c:	c2 1e 00 00 3f f8 	clgfi	%r1,16376
    8c32:	a7 44 ff e8       	jl	8c02 <main_graph_add+0xf12>
# vector ops, 5, compute, 0, conversion, 2, mem, 3, overhead, 0, vcompute/vec, 0.00
# scalar, 0, mem, 0
# others, 5, vec/tot, 0.50
# Block #2 with SIMD
```
