### PR TITLE
Fix link error on z/OS

### DIFF
--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
@@ -125,10 +125,12 @@ inline void omUnreachable() {
 // Uses compiler specific extensions if possible.
 // Even if no extension is used, undefined behavior is still raised by
 // an empty function body and the noreturn attribute.
-#if defined(_MSC_VER) && !defined(__clang__) // MSVC
-  __assume(false);
-#else // GCC, Clang
+#if defined(__GNUC__) || defined(__clang__) // GCC, Clang
   __builtin_unreachable();
+#elif defined(_MSC_VER) // MSVC
+  __assume(false);
+#else
+  ((void)0);
 #endif
 }
 


### PR DESCRIPTION
The link of the runtime fails on z/OS with recent changes in zDNNExtension.

 ```
IEW2456E 9207 SYMBOL __builtin_unreachable UNRESOLVED. MEMBER COULD NOT BE
INCLUDED FROM THE DESIGNATED CALL LIBRARY.
FSUM3065 The LINKEDIT step ended with return code 8.
```

Update the` omUnreachable()` to account for `__builtin_unreachable` and `__assume(false)` not being available on z/OS.