### PR TITLE
Fix position of registry for OpenMP dialect 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,6 @@ add_onnx_mlir_executable(onnx-mlir
   onnx-mlir.cpp
 
   LINK_LIBS PRIVATE
-  MLIROpenMPToLLVMIRTranslation
   OMCompilerOptions
   OMCompilerUtils
   OMOptionUtils

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -68,7 +68,7 @@ add_onnx_mlir_library(OMCompilerDialects
   OMKrnlOps
   OMONNXOps
   MLIRIR
-  MLIROpenMPDialect
+  MLIROpenMPToLLVMIRTranslation
   )
 
 add_onnx_mlir_library(OMCompilerPasses

--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -11,6 +11,7 @@
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 
 #include "mlir/InitAllDialects.h"
+#include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
 
 using namespace mlir;
 
@@ -35,7 +36,7 @@ DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
   registry.insert<ONNXDialect>();
   registry.insert<KrnlDialect>();
   registry.insert<cf::ControlFlowDialect>();
-  registry.insert<mlir::omp::OpenMPDialect>();
+  registerOpenMPDialectTranslation(registry);
 
   // Initialize accelerator(s) if required.
   accel::initAccelerators(accels);

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -14,7 +14,6 @@
 #include <iostream>
 #include <regex>
 
-#include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
 #include "src/Compiler/CompilerOptions.hpp"
 #include "src/Compiler/CompilerUtils.hpp"
 #include "src/Version/Version.hpp"
@@ -67,7 +66,6 @@ int main(int argc, char *argv[]) {
 
   // Create context after MLIRContextCLOptions are registered and parsed.
   mlir::MLIRContext context;
-  mlir::registerOpenMPDialectTranslation(context);
   if (!context.isMultithreadingEnabled()) {
     assert(context.getNumThreads() == 1 && "1 thread if no multithreading");
     LLVM_DEBUG(llvm::dbgs() << "multithreading is disabled\n");


### PR DESCRIPTION
This PR moves `registerOpenMPDialectTranslation()` into `registerDialects()`. This should be better position. The `registry.insert<mlir::omp::OpenMPDialect>()` removed in this PR is done in `mlir::registerOpenMPDialectTranslation()`.

Without this PR, I got following errors when specifying `-parallel` option in numerical tests as shown below.

Example:
```
$ export OMP_NUM_THREADS=4
$ TestMatMul2D  -O3 -mcpu=z16 --mtriple=s390x-ibm-loz -parallel

error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: omp.parallel
```

