### PR TITLE
Remove warning message when compiling runtime for z/OS

### DIFF
--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.c
@@ -492,7 +492,7 @@ bool initSplitInfo(SplitInfo *splitInfo, bool initTiles, const char *tag) {
     // No split benefit.
     splitInfo->reuseFullZTensor = true;
     splitInfo->reuseFullBuffer = true;
-    splitInfo->tiles = (zdnn_ztensor*) fullZTensor;
+    splitInfo->tiles = (zdnn_ztensor *) fullZTensor;
     if (OMZTensorSplitDebug)
       printSplitInfo(splitInfo, tag);
     return false;

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.c
@@ -492,7 +492,7 @@ bool initSplitInfo(SplitInfo *splitInfo, bool initTiles, const char *tag) {
     // No split benefit.
     splitInfo->reuseFullZTensor = true;
     splitInfo->reuseFullBuffer = true;
-    splitInfo->tiles = fullZTensor;
+    splitInfo->tiles = (zdnn_ztensor*) fullZTensor;
     if (OMZTensorSplitDebug)
       printSplitInfo(splitInfo, tag);
     return false;

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.c
@@ -492,7 +492,7 @@ bool initSplitInfo(SplitInfo *splitInfo, bool initTiles, const char *tag) {
     // No split benefit.
     splitInfo->reuseFullZTensor = true;
     splitInfo->reuseFullBuffer = true;
-    splitInfo->tiles = (zdnn_ztensor *) fullZTensor;
+    splitInfo->tiles = (zdnn_ztensor *)fullZTensor;
     if (OMZTensorSplitDebug)
       printSplitInfo(splitInfo, tag);
     return false;


### PR DESCRIPTION
This PR fixes a warning message when compiling the runtime on z/OS.

```
WARNING CCN3068 /tmp/zdlc-zos-src-tmp-27956/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.c:495   Operation between types "struct zdnn_ztensor*" and "const struct zdnn_ztensor*" is not allowed.
```