### PR TITLE
Update test_constant_pad_cpu, test_edge_pad_cpu, and test_reflect_pad_cpu

### DIFF
--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -2278,20 +2278,18 @@ def get_test_models():
         # ==LIM== axes input not supported
         "test_constant_pad_cpu": {
             STATIC_SHAPE: {},
-            # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {-1}},
             CONSTANT_INPUT: {-1},
         },
         "test_edge_pad_cpu": {
             STATIC_SHAPE: {},
-            # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {-1}},
             CONSTANT_INPUT: {-1},
         },
         "test_reflect_pad_cpu": {
             STATIC_SHAPE: {},
             # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {-1}},
             CONSTANT_INPUT: {-1},
         },
         # ==OP== Pow


### PR DESCRIPTION
This PR uses "{0:{-1}}" for the dynamic shape for the backend dynamic test cases test_constant_pad_cpu, test_edge_pad_cpu, and test_reflect_pad_cpu.