### PR TITLE
[mlir][ONNX] Implement `TileOp` canonicalizer

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -15,7 +15,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout e899641df2391179e8ec29ca14c53b09ae7ce85c && cd ..
+cd llvm-project && git checkout a4ca07f13b560b4f6fa5459eef7159e4f9ee9a6b && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -15,7 +15,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b2cdf3cc4c08729d0ff582d55e40793a20bbcdcc && cd ..
+cd llvm-project && git checkout e899641df2391179e8ec29ca14c53b09ae7ce85c && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout e899641df2391179e8ec29ca14c53b09ae7ce85c && cd ..
+cd llvm-project && git checkout a4ca07f13b560b4f6fa5459eef7159e4f9ee9a6b && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b2cdf3cc4c08729d0ff582d55e40793a20bbcdcc && cd ..
+cd llvm-project && git checkout e899641df2391179e8ec29ca14c53b09ae7ce85c && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)
@@ -100,6 +100,7 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
    -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir ^
+   -DONNX_MLIR_ENABLE_STABLEHLO=OFF ^
    -DONNX_MLIR_ENABLE_WERROR=ON
 
 call cmake --build . --config Release

--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -49,7 +49,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 20. Limitatio
 | **Concat** |6 - * | | |
 | **ConcatFromSequence** |none | | | |
 | **Constant** |6 - * | | |
-| **ConstantOfShape** |20 - * | | |
+| **ConstantOfShape** |9 - * | | |
 | **Conv** |6 - * | | |
 | **ConvInteger** |none | | | |
 | **ConvTranspose** |6 - * |Unknown dimension in spatial dimensions (such as H and W) not supported. | |

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/DevicePlacement.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/DevicePlacement.cpp
@@ -190,22 +190,22 @@ void DevicePlacementPass::runOnOperation() {
   RewritePatternSet Patterns1(context);
   getRewriteONNXForZHighPatterns(Patterns1, &dimAnalysis);
   getRewriteONNXForZHighDynamicallyLegal(&target, &dimAnalysis);
-  (void)applyAnalysisConversion(
-      module, target, std::move(Patterns1), legalizedOps1);
+  (void)applyAnalysisConversion(module, target, std::move(Patterns1),
+      ConversionConfig{.legalizableOps = &legalizedOps1});
 
   // Call ONNXToZHigh pass for lowering multiple ONNX ops at once to ZHigh.
   // E.g. `onnx.ReLu (onnx.Conv)` to zhigh.Conv.
   RewritePatternSet Patterns2(context);
   getONNXToZHighOneOpPatterns(Patterns2);
-  (void)applyAnalysisConversion(
-      module, target, std::move(Patterns2), legalizedOps2);
+  (void)applyAnalysisConversion(module, target, std::move(Patterns2),
+      ConversionConfig{.legalizableOps = &legalizedOps2});
 
   // Call ONNXToZHigh pass for lowering a single ONNX op to ZHigh.
   RewritePatternSet Patterns3(context);
   getONNXToZHighOneOpPatterns(Patterns3);
   getONNXToZHighOneOpDynamicallyLegal(&target, &dimAnalysis);
-  (void)applyAnalysisConversion(
-      module, target, std::move(Patterns3), legalizedOps3);
+  (void)applyAnalysisConversion(module, target, std::move(Patterns3),
+      ConversionConfig{.legalizableOps = &legalizedOps3});
 
   // Get the legalized ops that will run on the host.
   OpSetType cpuOps = llvm::set_intersection(

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1543,7 +1543,7 @@ int readAndStripComments(
   // but appear in lit tests in test/mlir/onnx/parse.
   for (llvm::line_iterator line(*buf, /*SkipBlanks=*/false), end; line != end;
        ++line) {
-    if (line->ltrim(" \t").startswith("//"))
+    if (line->ltrim(" \t").starts_with("//"))
       continue; // omit comment lines beginning with (whitespace and) //
     if (line->contains("//")) {
       // Not stripping end-of-line comments because there's no robust way to
@@ -1563,7 +1563,7 @@ int ImportFrontendModelFile(StringRef model_fname, MLIRContext &context,
     OwningOpRef<ModuleOp> &module, std::string *errorMessage,
     ImportOptions options) {
   onnx::ModelProto model;
-  if (model_fname.endswith(".onnxtext")) {
+  if (model_fname.ends_with(".onnxtext")) {
     std::string text;
     int ret = readAndStripComments(model_fname, errorMessage, text);
     if (ret != CompilerSuccess)
@@ -1576,7 +1576,7 @@ int ImportFrontendModelFile(StringRef model_fname, MLIRContext &context,
                       " with error '" + status.ErrorMessage() + "'";
       return InvalidOnnxFormat;
     }
-  } else if (model_fname.endswith(".json")) {
+  } else if (model_fname.ends_with(".json")) {
     std::string json;
     int ret = readAndStripComments(model_fname, errorMessage, json);
     if (ret != CompilerSuccess)

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -209,8 +209,7 @@ static void loadMLIR(std::string inputFilename, mlir::MLIRContext &context,
     // Update the function type.
     FunctionType newType =
         FunctionType::get(&context, newArgTypes, funcType.getResults());
-    ConversionPatternRewriter rewriter(&context);
-    rewriter.updateRootInPlace(funcOp, [&] { funcOp.setType(newType); });
+    funcOp.setType(newType);
   }
 }
 
@@ -605,10 +604,10 @@ int processInputFile(StringRef inputFilename, mlir::MLIRContext &context,
   // or JSON) or a model specified in MLIR.
   // The extension of the file is the decider.
   bool inputIsSTDIN = (inputFilename == "-");
-  bool inputIsONNX = inputFilename.endswith(".onnx");
-  bool inputIsONNXText = inputFilename.endswith(".onnxtext");
-  bool inputIsJSON = inputFilename.endswith(".json");
-  bool inputIsMLIR = inputFilename.endswith(".mlir");
+  bool inputIsONNX = inputFilename.ends_with(".onnx");
+  bool inputIsONNXText = inputFilename.ends_with(".onnxtext");
+  bool inputIsJSON = inputFilename.ends_with(".json");
+  bool inputIsMLIR = inputFilename.ends_with(".mlir");
 
   if (!inputIsSTDIN && !inputIsONNX && !inputIsONNXText && !inputIsJSON &&
       !inputIsMLIR) {

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -799,10 +799,8 @@ void ConvertKrnlToAffinePass::runOnOperation() {
     const std::lock_guard<std::mutex> lock(unrollAndJamMutex);
     unrollAndJamMap[currFuncOp] = currUnrollAndJamList;
   }
-
-  DenseSet<Operation *> unconverted;
   if (failed(applyPartialConversion(
-          getOperation(), target, std::move(patterns), &unconverted))) {
+          getOperation(), target, std::move(patterns)))) {
     {
       const std::lock_guard<std::mutex> lock(unrollAndJamMutex);
       unrollAndJamMap.erase(currFuncOp);

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -695,7 +695,7 @@ void loadConstantsFromFile(ModuleOp &module,
     // Get the global op for data.
     StringRef dataSymbol = dataGlobalOp.getSymName();
     std::string prefixData = EXTERNAL_CONSTANT_PREFIX + "data";
-    if (!dataSymbol.startswith(prefixData))
+    if (!dataSymbol.starts_with(prefixData))
       return WalkResult::advance();
     std::string constantName = dataSymbol.drop_front(prefixData.size()).str();
 

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -361,7 +361,7 @@ void genSignatureFunction(ModuleOp &module,
     LLVM::LLVMFuncOp funcOp = create.llvm.func(
         "omQueryEntryPoints", llvmFnType, /*createUniqueFunc=*/true);
     // Emit the body of the function.
-    Block *entryBlock = funcOp.addEntryBlock();
+    Block *entryBlock = funcOp.addEntryBlock(b);
     OpBuilder::InsertionGuard bodyGuard(b);
     b.setInsertionPointToStart(entryBlock);
     Value numOfEntryPoints = entryBlock->getArgument(0);
@@ -399,7 +399,7 @@ void genSignatureFunction(ModuleOp &module,
         create.llvm.func(funcNames[i], llvmFnType, /*createUniqueFunc=*/true);
 
     // 2. Emit the body of the function.
-    Block *entryBlock = funcOp.addEntryBlock();
+    Block *entryBlock = funcOp.addEntryBlock(b);
     OpBuilder::InsertionGuard bodyGuard(b);
     b.setInsertionPointToStart(entryBlock);
 
@@ -648,7 +648,7 @@ void loadConstantsFromFile(ModuleOp &module,
   }
 
   // Emit the body of the function.
-  Block *entryBlock = funcOp.addEntryBlock();
+  Block *entryBlock = funcOp.addEntryBlock(b);
   OpBuilder::InsertionGuard guard(b);
   b.setInsertionPointToStart(entryBlock);
 

--- a/src/Conversion/ONNXToStablehlo/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToStablehlo/Math/Gemm.cpp
@@ -72,7 +72,7 @@ struct ONNXGemmOpLoweringToStablehlo : public ConversionPattern {
         Value shape = rewriter.create<shape::ShapeOfOp>(loc, dot);
         Value broadcastedAlpha =
             rewriter.create<stablehlo::DynamicBroadcastInDimOp>(loc, resultType,
-                alphaVal, shape, rewriter.getI64TensorAttr({}));
+                alphaVal, shape, rewriter.getDenseI64ArrayAttr({}));
         dotResult =
             rewriter.create<stablehlo::MulOp>(loc, dot, broadcastedAlpha);
       }
@@ -108,10 +108,10 @@ struct ONNXGemmOpLoweringToStablehlo : public ConversionPattern {
         Value shape = rewriter.create<shape::ShapeOfOp>(loc, dot);
         if (cRank == 1)
           broadcastedC = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(
-              loc, resultType, C, shape, rewriter.getI64TensorAttr({1}));
+              loc, resultType, C, shape, rewriter.getDenseI64ArrayAttr({1}));
         else if (cRank == 0)
           broadcastedC = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(
-              loc, resultType, C, shape, rewriter.getI64TensorAttr({}));
+              loc, resultType, C, shape, rewriter.getDenseI64ArrayAttr({}));
         else
           broadcastedC = C;
         if (!closeTo(betaLit, 1.0f)) {
@@ -119,7 +119,8 @@ struct ONNXGemmOpLoweringToStablehlo : public ConversionPattern {
               loc, rewriter.getFloatAttr(elemType, gemmOp.getBeta()));
           Value broadcastedBeta =
               rewriter.create<stablehlo::DynamicBroadcastInDimOp>(loc,
-                  resultType, betaVal, shape, rewriter.getI64TensorAttr({}));
+                  resultType, betaVal, shape,
+                  rewriter.getDenseI64ArrayAttr({}));
           finalC = rewriter.create<stablehlo::MulOp>(
               loc, broadcastedC, broadcastedBeta);
         } else

--- a/src/Conversion/ONNXToStablehlo/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToStablehlo/Math/MatMul.cpp
@@ -114,11 +114,11 @@ struct ONNXMatMulOpLoweringToStablehlo : public ConversionPattern {
             dimTensors, rewriter.getI64IntegerAttr(0));
         broadcasted = rewriter.createOrFold<stablehlo::DynamicBroadcastInDimOp>(
             loc, broadCastedType, operandToBroadcast, fullShape,
-            rewriter.getI64VectorAttr(broadcastDimensions));
+            rewriter.getDenseI64ArrayAttr(broadcastDimensions));
       } else {
         broadcasted = rewriter.createOrFold<stablehlo::BroadcastInDimOp>(loc,
             broadCastedType, operandToBroadcast,
-            rewriter.getI64VectorAttr(broadcastDimensions));
+            rewriter.getDenseI64ArrayAttr(broadcastDimensions));
       }
       return broadcasted;
     };

--- a/src/Conversion/ONNXToStablehlo/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToStablehlo/Math/Reduction.cpp
@@ -367,7 +367,7 @@ Value createReduce(Location loc, Value operand, Value identity,
   Type reduceResultType =
       RankedTensorType::get(reduceShape, operandType.getElementType());
   stablehlo::ReduceOp reduce = rewriter.create<stablehlo::ReduceOp>(loc,
-      reduceResultType, operand, identity, rewriter.getI64TensorAttr(axes));
+      reduceResultType, operand, identity, rewriter.getDenseI64ArrayAttr(axes));
 
   // setup "stablehlo.reduce"'s body
   Region &region = reduce.getBody();

--- a/src/Conversion/ONNXToStablehlo/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToStablehlo/NN/Pooling.cpp
@@ -73,16 +73,8 @@ void buildReduceBodyFor<ONNXAveragePoolOp>(
   buildReduceBody<stablehlo::AddOp>(elementType, body, builder);
 }
 
-static DenseIntElementsAttr getDenseIntElementsAttr(
-    SmallVectorImpl<int64_t> &values, Builder *builder) {
-  return DenseIntElementsAttr::get(
-      RankedTensorType::get(
-          {static_cast<int64_t>(values.size())}, builder->getI64Type()),
-      values);
-}
-
 // Returns 1D 64-bit dense elements attribute padded with the given values.
-static DenseIntElementsAttr getKernelAttr(ArrayRef<IndexExpr> values,
+static DenseI64ArrayAttr getKernelAttr(ArrayRef<IndexExpr> values,
     Builder *builder, int64_t spatialOffset, int64_t defaultValue = 1) {
   SmallVector<int64_t> vectorValues(spatialOffset, defaultValue);
   int64_t size = values.size();
@@ -90,7 +82,7 @@ static DenseIntElementsAttr getKernelAttr(ArrayRef<IndexExpr> values,
     assert(values[i].isLiteral() && "kernel dim is not literal");
     vectorValues.push_back(values[i].getLiteral());
   }
-  return getDenseIntElementsAttr(vectorValues, builder);
+  return builder->getDenseI64ArrayAttr(vectorValues);
 }
 
 void padVector(
@@ -168,9 +160,9 @@ struct ONNXPoolOpLoweringToStablehlo : public ConversionPattern {
         rewriter.create<stablehlo::ReduceWindowOp>(loc, outputType,
             inputOperand, initVal,
             getKernelAttr(kernelShape, &rewriter, spatialOffset),
-            getDenseIntElementsAttr(strides, &rewriter),
-            /*base_dilations=*/DenseIntElementsAttr(),
-            /*window_dilations=*/getDenseIntElementsAttr(dilations, &rewriter),
+            rewriter.getDenseI64ArrayAttr(strides),
+            /*base_dilations=*/DenseI64ArrayAttr(),
+            /*window_dilations=*/rewriter.getDenseI64ArrayAttr(dilations),
             DenseIntElementsAttr::get(
                 RankedTensorType::get({rank, 2}, rewriter.getI64Type()),
                 flattenPaddings));
@@ -193,15 +185,15 @@ struct ONNXPoolOpLoweringToStablehlo : public ConversionPattern {
       } else {
         // Use another stablehlo.ReduceWindowOp to get the divisor
         Value one = getShapedFloat(loc, rewriter, 1.0, inputOperand);
-        stablehlo::ReduceWindowOp reduceDivisor = rewriter.create<
-            stablehlo::ReduceWindowOp>(loc, outputType, one, initVal,
-            getKernelAttr(kernelShape, &rewriter, spatialOffset),
-            getDenseIntElementsAttr(strides, &rewriter),
-            /*base_dilations=*/DenseIntElementsAttr(),
-            /*window_dilations=*/getDenseIntElementsAttr(dilations, &rewriter),
-            DenseIntElementsAttr::get(
-                RankedTensorType::get({rank, 2}, rewriter.getI64Type()),
-                flattenPaddings));
+        stablehlo::ReduceWindowOp reduceDivisor =
+            rewriter.create<stablehlo::ReduceWindowOp>(loc, outputType, one,
+                initVal, getKernelAttr(kernelShape, &rewriter, spatialOffset),
+                rewriter.getDenseI64ArrayAttr(strides),
+                /*base_dilations=*/DenseI64ArrayAttr(),
+                /*window_dilations=*/rewriter.getDenseI64ArrayAttr(dilations),
+                DenseIntElementsAttr::get(
+                    RankedTensorType::get({rank, 2}, rewriter.getI64Type()),
+                    flattenPaddings));
         buildReduceBodyFor<ONNXAveragePoolOp>(
             elemType, &reduceDivisor.getBody(), &rewriter);
         Value divResult = rewriter.create<stablehlo::DivOp>(

--- a/src/Conversion/ONNXToStablehlo/ONNXToStablehloCommon.cpp
+++ b/src/Conversion/ONNXToStablehlo/ONNXToStablehloCommon.cpp
@@ -36,7 +36,7 @@ Value getShapedZero(
         loc, rewriter.getZeroAttr(elemType));
     Value shape = rewriter.create<shape::ShapeOfOp>(loc, inp);
     broadcastedZero = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(
-        loc, inpType, zero, shape, rewriter.getI64TensorAttr({}));
+        loc, inpType, zero, shape, rewriter.getDenseI64ArrayAttr({}));
   }
   return broadcastedZero;
 }
@@ -62,7 +62,7 @@ llvm::SmallVector<Value, 4> getBroadcastedOperands(Operation *op,
         RankedTensorType::get(outputShapedType.getShape(), elementType);
     Value broadcast = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(loc,
         broadcastedOutputType, operand, resultExtents,
-        rewriter.getI64TensorAttr(broadcastDimensions));
+        rewriter.getDenseI64ArrayAttr(broadcastDimensions));
     broadcastedOperands.push_back(broadcast);
   }
   return broadcastedOperands;
@@ -89,7 +89,7 @@ llvm::SmallVector<Value, 4> getBroadcastedOperands(
         RankedTensorType::get(outputShapedType.getShape(), elementType);
     Value broadcast = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(loc,
         broadcastedOutputType, operand, resultExtents,
-        rewriter.getI64TensorAttr(broadcastDimensions));
+        rewriter.getDenseI64ArrayAttr(broadcastDimensions));
     broadcastedOperands.push_back(broadcast);
   }
   return broadcastedOperands;

--- a/src/Conversion/ONNXToStablehlo/ONNXToStablehloCommon.hpp
+++ b/src/Conversion/ONNXToStablehlo/ONNXToStablehloCommon.hpp
@@ -81,7 +81,7 @@ Value getShapedFloat(Location loc, ConversionPatternRewriter &rewriter,
         loc, rewriter.getFloatAttr(elemType, value));
     Value shape = rewriter.create<shape::ShapeOfOp>(loc, inp);
     broadcastedValue = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(
-        loc, inpType, floatValue, shape, rewriter.getI64TensorAttr({}));
+        loc, inpType, floatValue, shape, rewriter.getDenseI64ArrayAttr({}));
   }
   return broadcastedValue;
 }
@@ -103,7 +103,7 @@ Value getShapedInt(Location loc, ConversionPatternRewriter &rewriter,
         loc, rewriter.getIntegerAttr(elemType, value));
     Value shape = rewriter.create<shape::ShapeOfOp>(loc, inp);
     broadcastedValue = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(
-        loc, inpType, intValue, shape, rewriter.getI64TensorAttr({}));
+        loc, inpType, intValue, shape, rewriter.getDenseI64ArrayAttr({}));
   }
   return broadcastedValue;
 }

--- a/src/Conversion/ONNXToStablehlo/Tensor/ArgMax.cpp
+++ b/src/Conversion/ONNXToStablehlo/Tensor/ArgMax.cpp
@@ -104,14 +104,19 @@ struct ONNXArgMaxOpLoweringToStablehlo : public ConversionPattern {
         RankedTensorType::get(dataType.getShape(), indexElementType);
 
     IntegerAttr iotaDimension = IntegerAttr::get(rewriter.getI64Type(), axis);
-    Value inputShape = rewriter.create<shape::ShapeOfOp>(loc, data);
+    Value inputShapeOp = rewriter.create<shape::ShapeOfOp>(loc, data);
     Value indexValues = rewriter.create<stablehlo::DynamicIotaOp>(
-        loc, indexType, inputShape, iotaDimension);
+        loc, indexType, inputShapeOp, iotaDimension);
 
+    ArrayRef<int64_t> inputShape = dataType.getShape();
+    SmallVector<int64_t> resultShape;
+    for (int64_t i = 0; i < dataRank; i++)
+      if (i != axis)
+        resultShape.push_back(inputShape[i]);
     stablehlo::ReduceOp reduction = rewriter.create<stablehlo::ReduceOp>(loc,
         /*resultType0*/
-        TypeRange{UnrankedTensorType::get(elementType),
-            UnrankedTensorType::get(indexElementType)},
+        TypeRange{RankedTensorType::get(resultShape, elementType),
+            RankedTensorType::get(resultShape, indexElementType)},
         /*inputs*/ ValueRange{data, indexValues},
         /*init_values*/ ValueRange{initValue, indexInitValue},
         /*dimensions*/ rewriter.getDenseI64ArrayAttr({axis}));
@@ -127,7 +132,8 @@ struct ONNXArgMaxOpLoweringToStablehlo : public ConversionPattern {
         SmallVector<Value> dims;
         for (int64_t i = 0; i < dataRank; i++) {
           if (i != axis) {
-            Value dim = rewriter.create<shape::GetExtentOp>(loc, inputShape, i);
+            Value dim =
+                rewriter.create<shape::GetExtentOp>(loc, inputShapeOp, i);
             dims.push_back(dim);
           } else {
             Value dim = rewriter.create<arith::ConstantIndexOp>(loc, 1);

--- a/src/Conversion/ONNXToStablehlo/Tensor/ArgMax.cpp
+++ b/src/Conversion/ONNXToStablehlo/Tensor/ArgMax.cpp
@@ -108,14 +108,14 @@ struct ONNXArgMaxOpLoweringToStablehlo : public ConversionPattern {
     Value indexValues = rewriter.create<stablehlo::DynamicIotaOp>(
         loc, indexType, inputShape, iotaDimension);
 
-    Value dataOperands[] = {data, indexValues};
-    Value initValues[] = {initValue, indexInitValue};
-    DenseIntElementsAttr reductionDimensions =
-        rewriter.getI64VectorAttr({axis});
-
     stablehlo::ReduceOp reduction = rewriter.create<stablehlo::ReduceOp>(loc,
-        llvm::ArrayRef<Value>(dataOperands), llvm::ArrayRef<Value>(initValues),
-        reductionDimensions);
+        /*resultType0*/
+        TypeRange{UnrankedTensorType::get(elementType),
+            UnrankedTensorType::get(indexElementType)},
+        /*inputs*/ ValueRange{data, indexValues},
+        /*init_values*/ ValueRange{initValue, indexInitValue},
+        /*dimensions*/ rewriter.getDenseI64ArrayAttr({axis}));
+
     BuildArgmaxReductionBody(
         elementType, indexElementType, &reduction.getBody(), &rewriter);
 

--- a/src/Conversion/ONNXToStablehlo/Tensor/Expand.cpp
+++ b/src/Conversion/ONNXToStablehlo/Tensor/Expand.cpp
@@ -67,7 +67,7 @@ struct ONNXExpandOpLoweringToStablehlo : public ConversionPattern {
       RankedTensorType broadcastedType =
           RankedTensorType::get(shapeValues, elementType);
       broadcastedOnes = rewriter.create<stablehlo::BroadcastInDimOp>(
-          loc, broadcastedType, ones, rewriter.getI64TensorAttr({}));
+          loc, broadcastedType, ones, rewriter.getDenseI64ArrayAttr({}));
     } else {
       ShapedType shapeType = shape.getType().cast<ShapedType>();
       assert(shapeType.getRank() == 1 && shapeType.hasStaticShape() &&
@@ -76,7 +76,7 @@ struct ONNXExpandOpLoweringToStablehlo : public ConversionPattern {
       SmallVector<int64_t, 4> onesShape(shapeRank, ShapedType::kDynamic);
       RankedTensorType onesType = RankedTensorType::get(onesShape, elementType);
       broadcastedOnes = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(
-          loc, onesType, ones, shape, rewriter.getI64TensorAttr({}));
+          loc, onesType, ones, shape, rewriter.getDenseI64ArrayAttr({}));
     }
     llvm::SmallVector<Value, 4> newOperands = {input, broadcastedOnes};
     llvm::SmallVector<Value, 4> broadcastedOperands = getBroadcastedOperands(

--- a/src/Conversion/ONNXToStablehlo/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToStablehlo/Tensor/Gather.cpp
@@ -70,9 +70,9 @@ struct ONNXGatherOpLoweringToStablehlo : public ConversionPattern {
       axisDimSizeValue = rewriter.create<tensor::FromElementsOp>(loc,
           RankedTensorType::get({}, indicesType.getElementType()),
           axisDimSizeValue);
-      axisDimSize =
-          rewriter.create<stablehlo::DynamicBroadcastInDimOp>(loc, indicesType,
-              axisDimSizeValue, indicesShape, rewriter.getI64TensorAttr({}));
+      axisDimSize = rewriter.create<stablehlo::DynamicBroadcastInDimOp>(loc,
+          indicesType, axisDimSizeValue, indicesShape,
+          rewriter.getDenseI64ArrayAttr({}));
     }
     Value greaterOp = rewriter.create<stablehlo::CompareOp>(
         loc, indices, zero, stablehlo::ComparisonDirection::LT);

--- a/src/Conversion/ONNXToStablehlo/Tensor/GatherElements.cpp
+++ b/src/Conversion/ONNXToStablehlo/Tensor/GatherElements.cpp
@@ -76,11 +76,11 @@ struct ONNXGatherElementsOpLoweringToStablehlo : public ConversionPattern {
     }
     if (indicesType.hasStaticShape()) {
       broadcastedAxisDimSize = rewriter.create<stablehlo::BroadcastInDimOp>(
-          loc, indicesType, axisDimSize, rewriter.getI64TensorAttr({}));
+          loc, indicesType, axisDimSize, rewriter.getDenseI64ArrayAttr({}));
     } else {
       broadcastedAxisDimSize =
           rewriter.create<stablehlo::DynamicBroadcastInDimOp>(loc, indicesType,
-              axisDimSize, indicesShape, rewriter.getI64TensorAttr({}));
+              axisDimSize, indicesShape, rewriter.getDenseI64ArrayAttr({}));
     }
     Value isNegative = rewriter.create<stablehlo::CompareOp>(
         loc, indices, zero, stablehlo::ComparisonDirection::LT);
@@ -138,7 +138,8 @@ struct ONNXGatherElementsOpLoweringToStablehlo : public ConversionPattern {
     SmallVector<int64_t> sliceSizes(inputType.getRank(), 1);
 
     Value gatherValue = rewriter.create<stablehlo::GatherOp>(loc, outputType,
-        data, gatherIndicies, dimsAttr, rewriter.getI64TensorAttr(sliceSizes));
+        data, gatherIndicies, dimsAttr,
+        rewriter.getDenseI64ArrayAttr(sliceSizes));
     rewriter.replaceOp(op, gatherValue);
     return success();
   }

--- a/src/Conversion/ONNXToStablehlo/Tensor/OneHot.cpp
+++ b/src/Conversion/ONNXToStablehlo/Tensor/OneHot.cpp
@@ -73,20 +73,20 @@ struct ONNXOneHotOpLoweringToStablehlo
     Value iota = rewriter.create<stablehlo::IotaOp>(
         loc, indexType, IntegerAttr::get(rewriter.getIntegerType(64), axis));
     Value broadcastIndices = rewriter.create<stablehlo::BroadcastInDimOp>(
-        loc, indexType, indices, GetI64ElementsAttr(broadcastDims, &rewriter));
+        loc, indexType, indices, rewriter.getDenseI64ArrayAttr(broadcastDims));
     Value zero = rewriter.create<stablehlo::ConstantOp>(loc,
         DenseIntElementsAttr::get(RankedTensorType::get({}, indicesElementType),
             ArrayRef<int64_t>{0}));
     Value broadcastZero = rewriter.create<stablehlo::BroadcastInDimOp>(
-        loc, indexType, zero, rewriter.getI64TensorAttr({}));
+        loc, indexType, zero, rewriter.getDenseI64ArrayAttr({}));
     Value broadcastDepth;
     int64_t depthRank = depthValue.getType().cast<RankedTensorType>().getRank();
     if (depthRank == 1)
       broadcastDepth = rewriter.create<stablehlo::BroadcastInDimOp>(
-          loc, indexType, depthValue, rewriter.getI64TensorAttr({0}));
+          loc, indexType, depthValue, rewriter.getDenseI64ArrayAttr({0}));
     else
       broadcastDepth = rewriter.create<stablehlo::BroadcastInDimOp>(
-          loc, indexType, depthValue, rewriter.getI64TensorAttr({}));
+          loc, indexType, depthValue, rewriter.getDenseI64ArrayAttr({}));
     Value compareGeZero = rewriter.create<stablehlo::CompareOp>(loc,
         broadcastIndices, broadcastZero, stablehlo::ComparisonDirection::GE);
     Value positiveIndices = rewriter.create<stablehlo::AddOp>(
@@ -107,9 +107,9 @@ struct ONNXOneHotOpLoweringToStablehlo
         DenseI64ArrayAttr::get(context, ArrayRef<int64_t>{2}),
         DenseI64ArrayAttr::get(context, ArrayRef<int64_t>{1}));
     Value offValueBroadcast = rewriter.create<stablehlo::BroadcastInDimOp>(
-        loc, outputType, offValue, rewriter.getI64TensorAttr({0}));
+        loc, outputType, offValue, rewriter.getDenseI64ArrayAttr({0}));
     Value onValueBroadcast = rewriter.create<stablehlo::BroadcastInDimOp>(
-        loc, outputType, onValue, rewriter.getI64TensorAttr({0}));
+        loc, outputType, onValue, rewriter.getDenseI64ArrayAttr({0}));
     Value result = rewriter.create<stablehlo::SelectOp>(
         loc, outputType, compare, onValueBroadcast, offValueBroadcast);
     rewriter.replaceOp(op, {result});

--- a/src/Conversion/ONNXToStablehlo/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToStablehlo/Tensor/Slice.cpp
@@ -128,7 +128,7 @@ struct ONNXSliceOpLoweringToStablehlo : public ConversionPattern {
                 RankedTensorType::get(
                     dataType.getShape(), rewriter.getI1Type()),
                 isNegativeStepValue, inputShape,
-                rewriter.getI64TensorAttr({0}));
+                rewriter.getDenseI64ArrayAttr({0}));
         Value negatedStepValue =
             rewriter.create<stablehlo::NegOp>(loc, stepValue);
         Value negatedStartValue =

--- a/src/Conversion/ONNXToStablehlo/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToStablehlo/Tensor/Tile.cpp
@@ -94,8 +94,8 @@ struct ONNXTileOpLoweringToStablehlo : public ConversionPattern {
     for (int64_t dim_idx = 0; dim_idx < inputRank; ++dim_idx) {
       broadcastDimensions.push_back(1 + 2 * dim_idx);
     }
-    DenseIntElementsAttr broadcast_dims_attr =
-        rewriter.getI64VectorAttr(broadcastDimensions);
+    DenseI64ArrayAttr broadcast_dims_attr =
+        rewriter.getDenseI64ArrayAttr(broadcastDimensions);
 
     Value out_dim_size_tensor = rewriter.create<stablehlo::ConcatenateOp>(loc,
         RankedTensorType::get(

--- a/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
@@ -58,8 +58,8 @@ void handleIncludePadAttr(
 
   // In-place update of AveragePool by setting operand to PadOp
   // and pads attribute to {0, 0, 0, 0}.
-  rewriter.updateRootInPlace(op, [&]() { op->setOperand(0, padOp); });
-  rewriter.updateRootInPlace(op, [&]() {
+  rewriter.modifyOpInPlace(op, [&]() { op->setOperand(0, padOp); });
+  rewriter.modifyOpInPlace(op, [&]() {
     op->setAttr("pads", rewriter.getI32ArrayAttr({0, 0, 0, 0}));
   });
 }

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -101,7 +101,7 @@ def KrnlCallOp : Op<Krnl_Dialect, "call",
       OpBuilder<(ins "std::string":$funcNameStr, "mlir::ValueRange":$results, "mlir::Operation *":$op, "mlir::ValueRange":$operands, "bool":$copyAttrs)>];
 }
 
-def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
+def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops", [NoMemoryEffect]> {
   let summary = "define_loops operation";
   let description = [{
     The "krnl.define_loops" operation is used to define input loops,
@@ -129,7 +129,7 @@ def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
   }];
 }
 
-def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [ImplicitKrnlTerminator,
+def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [RecursiveMemoryEffects, ImplicitKrnlTerminator,
     DeclareOpInterfaceMethods<LoopLikeOpInterface>]> {
   let summary = "iterate operation";
   let description = [{
@@ -270,8 +270,9 @@ def KrnlSeqExtractOp : Op<Krnl_Dialect, "seqextract", [MemRefsNormalizable,
 
   let results = (outs AnyType:$output);
 }
-
-def KrnlSeqStoreOp : Op<Krnl_Dialect, "seqstore", [MemRefsNormalizable]> {
+def KrnlSeqStoreOp : Op<Krnl_Dialect, "seqstore",
+    [MemRefsNormalizable, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]
+  > {
   let summary = "Krnl store into a seq";
   let description = [{
     This op is similar to KrnSeqInsertOp but assumes that the input seq has
@@ -286,7 +287,7 @@ def KrnlSeqStoreOp : Op<Krnl_Dialect, "seqstore", [MemRefsNormalizable]> {
                        Index:$index);
 }
 
-def KrnlTerminatorOp : Op<Krnl_Dialect, "terminate", [ReturnLike, Terminator]> {
+def KrnlTerminatorOp : Op<Krnl_Dialect, "terminate", [ReturnLike, Terminator, NoMemoryEffect]> {
   let summary = "Krnl terminator operation";
   let description = [{
     Krnl terminator is a special terminator operation for blocks inside krnl
@@ -687,7 +688,7 @@ def KrnlMovableOp : Op<Krnl_Dialect, "movable", [ImplicitKrnlTerminator]> {
 
 }
 
-def KrnlGetInductionVariableValueOp : Op<Krnl_Dialect, "get_induction_var_value"> {
+def KrnlGetInductionVariableValueOp : Op<Krnl_Dialect, "get_induction_var_value", [NoMemoryEffect]> {
   let summary = "Krnl ";
   let description = [{
      Krnl operation to convert loop references to corresponding induction

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -915,6 +915,15 @@ void KrnlSeqExtractOp::getEffects(
       SideEffects::DefaultResource::get());
 }
 
+void KrnlSeqStoreOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getSeq(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInput(),
+      SideEffects::DefaultResource::get());
+}
+
 std::optional<Operation *> KrnlSeqExtractOp::buildDealloc(
     OpBuilder &builder, Value alloc) {
   Location loc = alloc.getLoc();

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1897,7 +1897,7 @@ LLVM::LLVMFuncOp LLVMBuilder::func(
       b().create<LLVM::LLVMFuncOp>(loc(), uniqueFuncName, uniqueFuncType);
 
   // Call uniqueFuncOp inside funcOp.
-  Block *entryBlock = funcOp.addEntryBlock();
+  Block *entryBlock = funcOp.addEntryBlock(b());
   OpBuilder::InsertionGuard bodyGuard(b());
   b().setInsertionPointToStart(entryBlock);
   ValueRange args = entryBlock->getArguments();

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1603,7 +1603,7 @@ Value VectorBuilder::reduction(
           loc(), vector::CombiningKind::MAXSI, value);
     if (MathBuilder::isFloatWithVector(type))
       return b().create<vector::ReductionOp>(
-          loc(), vector::CombiningKind::MAXF, value);
+          loc(), vector::CombiningKind::MAXNUMF, value);
     llvm_unreachable("unknown type in max");
   }
   case CombiningKind::MIN: {
@@ -1615,7 +1615,7 @@ Value VectorBuilder::reduction(
           loc(), vector::CombiningKind::MINSI, value);
     if (MathBuilder::isFloatWithVector(type))
       return b().create<vector::ReductionOp>(
-          loc(), vector::CombiningKind::MINF, value);
+          loc(), vector::CombiningKind::MINNUMF, value);
     llvm_unreachable("unknown type in min");
   }
   case CombiningKind::AND: {

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -9523,6 +9523,7 @@ def ONNXThresholdedReluOp:ONNX_Op<"ThresholdedRelu",
 
 def ONNXTileOp:ONNX_Op<"Tile",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Tile operation";
   let description = [{
   Constructs a tensor by tiling a given tensor.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -322,7 +322,7 @@ public:
              << rhsType;
     }
 
-    rewriter.updateRootInPlace(op, [&] {
+    rewriter.modifyOpInPlace(op, [&] {
       if (rhsRank < lhsRank - axis) {
         OnnxBuilder createONNX(rewriter, op->getLoc());
         SmallVector<int64_t> axesArray;
@@ -530,7 +530,7 @@ struct PropagateConstantScalingInAttentionLayerPattern
     if (isGemm) {
       auto onnxGemmOp = cast<ONNXGemmOp>(matmulOrGemmOp);
       // Update in place B and C of Gemm.
-      rewriter.updateRootInPlace(onnxGemmOp, [&] {
+      rewriter.modifyOpInPlace(onnxGemmOp, [&] {
         rewriter.setInsertionPoint(onnxGemmOp);
         onnxGemmOp.getBMutable().assign(rewriter.create<ONNXOp>(
             onnxGemmOp.getLoc(), onnxGemmOp.getB().getType(), A, K));
@@ -542,12 +542,12 @@ struct PropagateConstantScalingInAttentionLayerPattern
       auto onnxSubMatOp = cast<ONNXMatMulOp>(matmulOrGemmOp);
       auto onnxAddOp = cast<ONNXAddOp>(addOp);
       // Update in place MatMul and Add.
-      rewriter.updateRootInPlace(onnxSubMatOp, [&] {
+      rewriter.modifyOpInPlace(onnxSubMatOp, [&] {
         rewriter.setInsertionPoint(onnxSubMatOp);
         onnxSubMatOp.getBMutable().assign(rewriter.create<ONNXOp>(
             onnxSubMatOp.getLoc(), onnxSubMatOp.getB().getType(), A, K));
       });
-      rewriter.updateRootInPlace(onnxAddOp, [&] {
+      rewriter.modifyOpInPlace(onnxAddOp, [&] {
         OnnxBuilder createONNX(rewriter, onnxAddOp.getLoc());
         rewriter.setInsertionPoint(onnxAddOp);
         onnxAddOp.getBMutable().assign(rewriter.create<ONNXOp>(
@@ -581,7 +581,7 @@ public:
     bool emptyScales = isEmptyTensor(onnxResizeOp.getScales());
     bool emptySizes = isEmptyTensor(onnxResizeOp.getSizes());
     if (emptyRoi || emptyScales || emptySizes) {
-      rewriter.updateRootInPlace(onnxResizeOp, [&] {
+      rewriter.modifyOpInPlace(onnxResizeOp, [&] {
         OnnxBuilder createONNX(rewriter, onnxResizeOp.getLoc());
         if (emptyRoi)
           onnxResizeOp.getRoiMutable().assign(createONNX.none());
@@ -986,7 +986,7 @@ public:
 
     // Rewrite in-place because there are so many attributes, inputs, outputs.
     // Constructing a new op would be lengthy and hard to maintain.
-    rewriter.updateRootInPlace(onnxOp, [&]() {
+    rewriter.modifyOpInPlace(onnxOp, [&]() {
       // Transpose the X and initial_h inputs by inserting an ONNXTransposeOp
       // before each and replacing the each input with the transpose output.
       rewriter.setInsertionPoint(onnxOp); // insert before (redundant)

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -1726,6 +1726,12 @@ void ONNXSqueezeV11Op::getCanonicalizationPatterns(
   result.insert<RemoveSqueezeV11CastUnsqueezeV11Pattern>(context);
 }
 
+/// on the ONNXTileOp.
+void ONNXTileOp::getCanonicalizationPatterns(
+    RewritePatternSet &result, MLIRContext *context) {
+  result.insert<RemoveIdentityTilePattern>(context);
+}
+
 /// on the ONNXTransposeOp.
 void ONNXTransposeOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -135,8 +135,9 @@ class HaveSameDim<int dim>: Constraint<
   "Two tensors have the same specified dimension">;
 
 def HaveSameShapedType: Constraint<
-    CPred<"($0.getType().dyn_cast<ShapedType>() == "
-          "$1.getType().dyn_cast<ShapedType>())">,
+    CPred<"(isa<ShapedType>($0.getType()) &&"
+          "dyn_cast<ShapedType>($0.getType()) == "
+          "dyn_cast<ShapedType>($1.getType()))">,
     "has same shaped type">;
 
 def HaveSameStaticShape: Constraint<
@@ -456,7 +457,7 @@ def SwapCastSlicePattern: Pat<
 >;
 
 //===----------------------------------------------------------------------===//
-// Canonicalization for ONNXTransposeOp
+// Canonicalization for ONNXTileOp
 //===----------------------------------------------------------------------===//
 
 def IsFromONNXConstantOpWithOnesDenseElementsAttr: Constraint<

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -134,6 +134,11 @@ class HaveSameDim<int dim>: Constraint<
         "$1.getType().cast<RankedTensorType>().getShape()[" # dim # "])">,
   "Two tensors have the same specified dimension">;
 
+def HaveSameShapedType: Constraint<
+    CPred<"($0.getType().dyn_cast<ShapedType>() == "
+          "$1.getType().dyn_cast<ShapedType>())">,
+    "has same shaped type">;
+
 def HaveSameStaticShape: Constraint<
   CPred<"onnx_mlir::haveSameStaticShape($0, $1)">,
   "Two tensors have the same static shape">;
@@ -195,8 +200,8 @@ def IsNotFromONNXConstantOp: Constraint<
     "Is a value not from ONNXConstantOp">;
 
 def IsFromONNXConstantOpWithDenseElementsAttr: Constraint<
-    And<[CPred<" isa<ONNXConstantOp>($_self.getDefiningOp()) ">,
-         CPred<" onnx_mlir::getONNXConstantOp($_self).getValueAttr().isa<DenseElementsAttr>() ">
+    And<[CPred<" onnx_mlir::getONNXConstantOp($_self) ">,
+         CPred<" isa<DenseElementsAttr>(onnx_mlir::getONNXConstantOp($_self).getValueAttr()) ">
         ]>, "Value is not a ONNXConstantOp with a DenseElementsAttr">;
 
 def AreTheSameAxesConstant: Constraint<
@@ -449,6 +454,26 @@ def SwapCastSlicePattern: Pat<
   (ONNXCastOp (ONNXSliceOp $data, $starts, $ends, $axes, $steps), $saturate, $to),
   (ONNXSliceOp (ONNXCastOp $data, $saturate, $to), $starts, $ends, $axes, $steps)
 >;
+
+//===----------------------------------------------------------------------===//
+// Canonicalization for ONNXTransposeOp
+//===----------------------------------------------------------------------===//
+
+def IsFromONNXConstantOpWithOnesDenseElementsAttr: Constraint<
+    And<[IsFromONNXConstantOpWithDenseElementsAttr.predicate,
+         CPred<"::llvm::all_of("
+               "               onnx_mlir::getONNXConstantOp($_self).getValueAttr()"
+               "                .dyn_cast<DenseElementsAttr>().getValues<int64_t>(), "
+               "[](int64_t repeat) { return repeat == 1;})">
+        ]>, "Value is not a ONNXConstantOp with a DenseElementsAttr of ones">;
+
+def RemoveIdentityTilePattern:  Pat<
+  // Tile with `repeats` of all constant 1's
+  (ONNXTileOp:$result $val, $r),
+  // Remove the tile.
+  (replaceWithValue $val),
+  // Check that we have indeed a identity tile pattern.
+  [(IsFromONNXConstantOpWithOnesDenseElementsAttr:$r), (HaveSameShapedType $val,$result)]>;
 
 //===----------------------------------------------------------------------===//
 // Canonicalization for ONNXLayoutTransformOp

--- a/src/Dialect/ONNX/Transforms/ShapeInference.cpp
+++ b/src/Dialect/ONNX/Transforms/ShapeInference.cpp
@@ -54,12 +54,12 @@ LogicalResult verifyOp(Operation *op) {
 template <typename Callback = std::function<LogicalResult()>>
 LogicalResult tryUpdateRootInPlace(
     Operation *op, PatternRewriter &rewriter, Callback &&callback) {
-  rewriter.startRootUpdate(op);
+  rewriter.startOpModification(op);
   if (failed(callback())) {
-    rewriter.cancelRootUpdate(op);
+    rewriter.cancelOpModification(op);
     return failure();
   } else {
-    rewriter.finalizeRootUpdate(op);
+    rewriter.finalizeOpModification(op);
     return success();
   }
 }

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -29,6 +29,7 @@
 #include <mlir/Pass/Pass.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/FileUtilities.h>
+#include <mlir/Support/ToolUtilities.h>
 #include <mlir/Tools/mlir-opt/MlirOptMain.h>
 
 #include "RegisterPasses.hpp"
@@ -176,7 +177,7 @@ int main(int argc, char **argv) {
 
   MlirOptMainConfig config;
   config.setPassPipelineSetupFn(passManagerSetupFn)
-      .splitInputFile(split_input_file)
+      .splitInputFile(split_input_file ? kDefaultSplitMarker : "")
       .verifyDiagnostics(verify_diagnostics)
       .verifyPasses(verify_passes)
       .allowUnregisteredDialects(allowUnregisteredDialects)

--- a/src/Transform/ProcessScfParallelPrivate.cpp
+++ b/src/Transform/ProcessScfParallelPrivate.cpp
@@ -81,12 +81,12 @@ struct ProcessScfParallelWithoutScopePattern
       // Create a block containing the ops in the loop body.
       Block *ops = rewriter.splitBlock(&*newParForOp.getRegion().begin(),
           newParForOp.getRegion().begin()->begin());
-      auto oldYield = cast<scf::YieldOp>(ops->getTerminator());
+      auto oldYield = cast<scf::ReduceOp>(ops->getTerminator());
       // Insertion point at the top of the loop.
       rewriter.setInsertionPointToStart(&*newParForOp.getRegion().begin());
       // Create scope and scf yield.
       auto scope = rewriter.create<memref::AllocaScopeOp>(loc, TypeRange());
-      rewriter.create<scf::YieldOp>(loc, oldYield.getOperands());
+      rewriter.create<scf::ReduceOp>(loc, oldYield.getOperands());
       // Move the ops of the loop body into the alloca scope.
       Block *scopeBlock = rewriter.createBlock(&scope.getBodyRegion());
       rewriter.mergeBlocks(ops, scopeBlock);

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -436,41 +436,35 @@ def get_test_models():
         # ==LIM== CastLike only between float and double types. Only ppc64le and MacOS platforms support float16.
         "test_castlike_FLOAT_to_DOUBLE_cpu": {
             STATIC_SHAPE: {},
-            # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {2}},
             CONSTANT_INPUT: {-1},
         },
         "test_castlike_DOUBLE_to_FLOAT_cpu": {
             STATIC_SHAPE: {},
-            # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {2}},
             CONSTANT_INPUT: {-1},
         },
         "test_castlike_FLOAT_to_FLOAT16_cpu": {
             STATIC_SHAPE: {},
-            # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {2}},
             CONSTANT_INPUT: {-1},
             FLOAT16: {},
         },
         "test_castlike_FLOAT16_to_FLOAT_cpu": {
             STATIC_SHAPE: {},
-            # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {2}},
             CONSTANT_INPUT: {-1},
             FLOAT16: {},
         },
         "test_castlike_FLOAT16_to_DOUBLE_cpu": {
             STATIC_SHAPE: {},
-            # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {2}},
             CONSTANT_INPUT: {-1},
             FLOAT16: {},
         },
         "test_castlike_DOUBLE_to_FLOAT16_cpu": {
             STATIC_SHAPE: {},
-            # Issue #2639: Dynamic test fails. Need to be fixed.
-            # DYNAMIC_SHAPE: {-1: {-1}},
+            DYNAMIC_SHAPE: {0: {2}},
             CONSTANT_INPUT: {-1},
             FLOAT16: {},
         },

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -390,8 +390,8 @@ func.func @test_matmul_broadcast_2(%arg0: tensor<256x256xf32>, %arg1: tensor<4x1
 
 // CONSTPROP-LABEL:  func.func @test_matmul_broadcast_2
 // CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<256x256xf32>, [[PARAM_1_:%.+]]: tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32> {
-// CONSTPROP:           [[VAR_0_:%.+]] = onnx.Constant dense<[-1, 256, 64]> : tensor<3xi64>
 // CONSTPROP-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[4, 12, 256, 64]> : tensor<4xi64>
+// CONSTPROP:           [[VAR_0_:%.+]] = onnx.Constant dense<[-1, 256, 64]> : tensor<3xi64>
 // CONSTPROP:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
 // CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<256x256xf32>, tensor<48x256x64xf32>) -> tensor<48x256x64xf32>
 // CONSTPROP:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
@@ -556,8 +556,8 @@ func.func @softmax_nd_to_2d(%arg0: tensor<4x12x256x256xf32>) -> (tensor<4x12x256
 
 // CONSTPROP-LABEL:  func.func @softmax_nd_to_2d
 // CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>) -> tensor<4x12x256x256xf32> {
-// CONSTPROP:           [[VAR_0_:%.+]] = onnx.Constant dense<[-1, 256, 256]> : tensor<3xi64>
 // CONSTPROP-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[4, 12, 256, 256]> : tensor<4xi64>
+// CONSTPROP:           [[VAR_0_:%.+]] = onnx.Constant dense<[-1, 256, 256]> : tensor<3xi64>
 // CONSTPROP:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
 // CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.Softmax"([[VAR_1_]]) {axis = -1 : si64} : (tensor<48x256x256xf32>) -> tensor<48x256x256xf32>
 // CONSTPROP:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<48x256x256xf32>, tensor<4xi64>) -> tensor<4x12x256x256xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_canonicalize.mlir
@@ -228,7 +228,6 @@ func.func private @test_matmul7(%arg0 : tensor<5xf32>, %arg1 : tensor<5xf32>) ->
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<f32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate() with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 5){
-// CHECK:             krnl.get_induction_var_value() : () -> ()
 // CHECK:             [[RES_1_:%.+]] = memref.alloca() : memref<f32>
 // CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
 // CHECK:             krnl.iterate([[LOOP_0_]]) with (){

--- a/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_canonicalize_O3.mlir
@@ -230,7 +230,6 @@ func.func private @test_matmul7(%arg0 : tensor<5xf32>, %arg1 : tensor<5xf32>) ->
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<f32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate() with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 5){
-// CHECK:             krnl.get_induction_var_value() : () -> ()
 // CHECK:             [[RES_1_:%.+]] = memref.alloca() : memref<f32>
 // CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
 // CHECK:             krnl.iterate([[LOOP_0_]]) with (){

--- a/test/mlir/conversion/onnx_to_krnl/Quantization/DynamicQuantizeLinear_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Quantization/DynamicQuantizeLinear_with_canonicalize.mlir
@@ -27,9 +27,7 @@ func.func @test_dynamic_quantize_linear(%arg0: tensor<?x2xf32>) -> (tensor<?x2xu
 // CHECK:           [[RES_4_:%.+]] = memref.alloc() : memref<f32>
 // CHECK:           krnl.store [[CST_0_dot_000000_]], [[RES_4_]][] : memref<f32>
 // CHECK:           [[RES_5_:%.+]] = memref.alloc() : memref<f32>
-// CHECK:           krnl.define_loops 0
 // CHECK:           krnl.iterate() with (){
-// CHECK:             krnl.get_induction_var_value() : () -> ()
 // CHECK:             krnl.store [[CST_0_1_]], [[RES_5_]][] : memref<f32>
 // CHECK:           }
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
@@ -43,9 +41,7 @@ func.func @test_dynamic_quantize_linear(%arg0: tensor<?x2xf32>) -> (tensor<?x2xu
 // CHECK:             krnl.store [[VAR_37_]], [[RES_5_]][] : memref<f32>
 // CHECK:           }
 // CHECK:           [[RES_6_:%.+]] = memref.alloc() : memref<f32>
-// CHECK:           krnl.define_loops 0
 // CHECK:           krnl.iterate() with (){
-// CHECK:             krnl.get_induction_var_value() : () -> ()
 // CHECK:             krnl.store [[CST_0_]], [[RES_6_]][] : memref<f32>
 // CHECK:           }
 // CHECK-DAG:       [[LOOP_1_:%.+]]:2 = krnl.define_loops 2

--- a/test/mlir/conversion/onnx_to_krnl/Sequence/Sequence_with_dealloc.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Sequence/Sequence_with_dealloc.mlir
@@ -38,12 +38,11 @@ func.func @test_sequence_erase(%arg0: !onnx.Seq<tensor<?x4x5xf32>>) -> tensor<3x
 // CHECK:             "krnl.seqstore"([[LOAD_PARAM_0_MEM_]], [[VAR_2_]], [[VAR_7_]]) : (memref<?x4x5xf32>, memref<?xmemref<?x4x5xf32>>, index) -> ()
 // CHECK:           }
 // CHECK-DAG:       [[VAR_9_:%.+]] = arith.addi [[VAR_7_]], [[CST_1_]] : index
-// CHECK-DAG:       [[LOOP_1_:%.+]] = krnl.define_loops 1
-// CHECK:           krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_1_:%.+]] = [[VAR_9_]] to [[MAP_2_]](){{.}}[[VAR_dim_]], [[VAR_4_]]{{.}}){
-// CHECK:             [[VAR_18_1_:%.+]] = krnl.get_induction_var_value([[LOOP_1_]]) : (!krnl.loop) -> index
+// CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_1_:%.+]] = [[VAR_9_]] to [[MAP_2_]](){{.}}[[VAR_dim_]], [[VAR_4_]]{{.}}){
+// CHECK:             [[VAR_18_1_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
 // CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_18_1_]]{{.}} : memref<?xmemref<?x4x5xf32>>
 // CHECK-DAG:         [[VAR_20_:%.+]] = arith.subi [[VAR_18_1_]], [[CST_1_]] : index
-// CHECK:             "krnl.seqstore"([[LOAD_PARAM_0_MEM_1_]], [[VAR_2_]], [[VAR_2_]]0) : (memref<?x4x5xf32>, memref<?xmemref<?x4x5xf32>>, index) -> ()
+// CHECK:             "krnl.seqstore"([[LOAD_PARAM_0_MEM_1_]], [[VAR_2_]], [[VAR_20_]]) : (memref<?x4x5xf32>, memref<?xmemref<?x4x5xf32>>, index) -> ()
 // CHECK:           }
 // CHECK-DAG:       [[VAR_dim_0_:%.+]] = memref.dim [[VAR_2_]], [[CST_0_]] : memref<?xmemref<?x4x5xf32>>
 // CHECK-DAG:       [[LOAD_VAR_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]][] : memref<i64>

--- a/test/mlir/conversion/onnx_to_krnl/Tensor/Pad_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Tensor/Pad_with_canonicalize.mlir
@@ -123,24 +123,23 @@ func.func @pad_edge_mode(%arg0: tensor<1x3x4x5xf32>, %arg1: tensor<8xi64>, %arg2
 // CHECK-DAG:         [[VAR_23_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#0){{.}}[[VAR_1_]]{{.}}
 // CHECK:             [[VAR_24_:%.+]] = arith.select [[VAR_22_]], [[CST_0_]], [[VAR_23_]] : index
 // CHECK:             [[VAR_25_:%.+]] = arith.cmpi sge, [[VAR_24_]], [[CST_1_]] : index
-// CHECK:             [[VAR_26_:%.+]] = arith.ori [[VAR_25_]], [[VAR_22_]] : i1
-// CHECK-DAG:         [[VAR_27_:%.+]] = arith.select [[VAR_26_]], [[CST_0_]], [[VAR_23_]] : index
-// CHECK-DAG:         [[VAR_28_:%.+]] = arith.cmpi sle, [[VAR_21_]]#1, [[VAR_6_]] : index
-// CHECK-DAG:         [[VAR_29_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#1){{.}}[[VAR_6_]]{{.}}
-// CHECK:             [[VAR_30_:%.+]] = arith.select [[VAR_28_]], [[CST_0_]], [[VAR_29_]] : index
-// CHECK:             [[VAR_31_:%.+]] = arith.cmpi sge, [[VAR_30_]], [[CST_3_]] : index
-// CHECK-DAG:         [[VAR_32_:%.+]] = arith.select [[VAR_31_]], [[CST_2_]], [[VAR_30_]] : index
-// CHECK-DAG:         [[VAR_33_:%.+]] = arith.cmpi sle, [[VAR_21_]]#2, [[VAR_11_]] : index
-// CHECK-DAG:         [[VAR_34_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#2){{.}}[[VAR_11_]]{{.}}
-// CHECK:             [[VAR_35_:%.+]] = arith.select [[VAR_33_]], [[CST_0_]], [[VAR_34_]] : index
-// CHECK:             [[VAR_36_:%.+]] = arith.cmpi sge, [[VAR_35_]], [[CST_4_]] : index
-// CHECK-DAG:         [[VAR_37_:%.+]] = arith.select [[VAR_36_]], [[CST_3_]], [[VAR_35_]] : index
-// CHECK-DAG:         [[VAR_38_:%.+]] = arith.cmpi sle, [[VAR_21_]]#3, [[VAR_16_]] : index
-// CHECK-DAG:         [[VAR_39_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#3){{.}}[[VAR_16_]]{{.}}
-// CHECK:             [[VAR_40_:%.+]] = arith.select [[VAR_38_]], [[CST_0_]], [[VAR_39_]] : index
-// CHECK:             [[VAR_41_:%.+]] = arith.cmpi sge, [[VAR_40_]], [[CST_5_]] : index
-// CHECK:             [[VAR_42_:%.+]] = arith.select [[VAR_41_]], [[CST_4_]], [[VAR_40_]] : index
-// CHECK:             [[LOAD_DATA_MEM_:%.+]] = krnl.load [[DATA_]]{{.}}[[VAR_27_]], [[VAR_32_]], [[VAR_37_]], [[VAR_42_]]{{.}} : memref<1x3x4x5xf32>
+// CHECK:             [[VAR_26_:%.+]] = arith.select [[VAR_25_]], [[CST_0_]], [[VAR_24_]] : index
+// CHECK-DAG:         [[VAR_27_:%.+]] = arith.cmpi sle, [[VAR_21_]]#1, [[VAR_6_]] : index
+// CHECK-DAG:         [[VAR_28_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#1){{.}}[[VAR_6_]]{{.}}
+// CHECK-DAG:         [[VAR_29_:%.+]] = arith.select [[VAR_27_]], [[CST_0_]], [[VAR_28_]] : index
+// CHECK-DAG:         [[VAR_30_:%.+]] = arith.cmpi sge, [[VAR_29_]], [[CST_3_]] : index
+// CHECK:             [[VAR_31_:%.+]] = arith.select [[VAR_30_]], [[CST_2_]], [[VAR_29_]] : index
+// CHECK-DAG:         [[VAR_32_:%.+]] = arith.cmpi sle, [[VAR_21_]]#2, [[VAR_11_]] : index
+// CHECK-DAG:         [[VAR_33_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#2){{.}}[[VAR_11_]]{{.}}
+// CHECK:             [[VAR_34_:%.+]] = arith.select [[VAR_32_]], [[CST_0_]], [[VAR_33_]] : index
+// CHECK:             [[VAR_35_:%.+]] = arith.cmpi sge, [[VAR_34_]], [[CST_4_]] : index
+// CHECK:             [[VAR_36_:%.+]] = arith.select [[VAR_35_]], [[CST_3_]], [[VAR_34_]] : index
+// CHECK-DAG:         [[VAR_37_:%.+]] = arith.cmpi sle, [[VAR_21_]]#3, [[VAR_16_]] : index
+// CHECK-DAG:         [[VAR_38_:%.+]] = affine.apply [[MAP_8_]]([[VAR_21_]]#3){{.}}[[VAR_16_]]{{.}}
+// CHECK:             [[VAR_39_:%.+]] = arith.select [[VAR_37_]], [[CST_0_]], [[VAR_38_]] : index
+// CHECK:             [[VAR_40_:%.+]] = arith.cmpi sge, [[VAR_39_]], [[CST_5_]] : index
+// CHECK:             [[VAR_41_:%.+]] = arith.select [[VAR_40_]], [[CST_4_]], [[VAR_39_]] : index
+// CHECK:             [[LOAD_DATA_MEM_:%.+]] = krnl.load [[DATA_]]{{.}}[[VAR_26_]], [[VAR_31_]], [[VAR_36_]], [[VAR_41_]]{{.}} : memref<1x3x4x5xf32>
 // CHECK:             krnl.store [[LOAD_DATA_MEM_]], [[RES_]]{{.}}[[VAR_21_]]#0, [[VAR_21_]]#1, [[VAR_21_]]#2, [[VAR_21_]]#3] : memref<?x?x?x?xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x?x?x?xf32>

--- a/test/mlir/conversion/onnx_to_stablehlo/NN/Pooling.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/NN/Pooling.mlir
@@ -13,7 +13,7 @@ func.func @test_default_maxpoolsingleout(%arg0 : tensor<5x5x32x32xf32>) -> tenso
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
+// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x30x30xf32>
 // CHECK:         }
 
@@ -32,7 +32,7 @@ func.func @test_default_maxpoolsingleout_defpad(%arg0 : tensor<5x5x32x32xf32>) -
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
+// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x30x30xf32>
 // CHECK:         }
 
@@ -51,7 +51,7 @@ func.func @test_default_maxpoolsingleout_pad(%arg0 : tensor<5x5x32x32xf32>) -> t
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [1, 1]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x32x32xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [1, 1]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x32x32xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x32x32xf32>
 // CHECK:         }
 
@@ -70,7 +70,7 @@ func.func @test_default_maxpoolsingleout_pad_nonunif(%arg0 : tensor<5x5x32x32xf3
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [2, 1], [1, 0]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 5, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x31x31xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [2, 1], [1, 0]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 5, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x31x31xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x31x31xf32>
 // CHECK:         }
 
@@ -89,7 +89,7 @@ func.func @test_default_maxpoolsingleout_strides(%arg0 : tensor<5x5x32x32xf32>) 
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [1, 1]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<[1, 1, 2, 2]> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x16x16xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [1, 1]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 2, 2>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x16x16xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x16x16xf32>
 // CHECK:         }
 
@@ -108,7 +108,7 @@ func.func @test_default_maxpoolsingleout_strides_nonunifpad(%arg0 : tensor<5x5x3
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 0], [0, 0]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 2, 2]> : tensor<4xi64>, window_strides = dense<[1, 1, 2, 2]> : tensor<4xi64>} : (tensor<5x5x30x32xf32>, tensor<f32>) -> tensor<5x5x15x16xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 0], [0, 0]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 2, 2>, window_strides = array<i64: 1, 1, 2, 2>} : (tensor<5x5x30x32xf32>, tensor<f32>) -> tensor<5x5x15x16xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x15x16xf32>
 // CHECK:         }
 
@@ -127,7 +127,7 @@ func.func @test_default_maxpoolsingleout_strides_nonunifpad_ceil(%arg0 : tensor<
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [0, 0]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 2, 2]> : tensor<4xi64>, window_strides = dense<[1, 1, 2, 2]> : tensor<4xi64>} : (tensor<5x5x30x32xf32>, tensor<f32>) -> tensor<5x5x16x16xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [0, 0]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 2, 2>, window_strides = array<i64: 1, 1, 2, 2>} : (tensor<5x5x30x32xf32>, tensor<f32>) -> tensor<5x5x16x16xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x16x16xf32>
 // CHECK:         }
 
@@ -146,7 +146,7 @@ func.func @test_default_maxpoolsingleout_strides_dilatation(%arg0 : tensor<5x5x8
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<[1, 1, 2, 2]> : tensor<4xi64>, window_dimensions = dense<[1, 1, 2, 2]> : tensor<4xi64>, window_strides = dense<[1, 1, 3, 3]> : tensor<4xi64>} : (tensor<5x5x8x8xf32>, tensor<f32>) -> tensor<5x5x2x2xf32>
+// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 2, 2>, window_dimensions = array<i64: 1, 1, 2, 2>, window_strides = array<i64: 1, 1, 3, 3>} : (tensor<5x5x8x8xf32>, tensor<f32>) -> tensor<5x5x2x2xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x2x2xf32>
 // CHECK:         }
 
@@ -165,7 +165,7 @@ func.func @test_default_maxpoolsingleout_upper(%arg0 : tensor<5x5x16x13xf32>) ->
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [0, 0], [1, 2]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 4, 4]> : tensor<4xi64>, window_strides = dense<[1, 1, 4, 4]> : tensor<4xi64>} : (tensor<5x5x16x13xf32>, tensor<f32>) -> tensor<5x5x4x4xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [0, 0], [1, 2]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 4, 4>, window_strides = array<i64: 1, 1, 4, 4>} : (tensor<5x5x16x13xf32>, tensor<f32>) -> tensor<5x5x4x4xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x4x4xf32>
 // CHECK:         }
 
@@ -184,7 +184,7 @@ func.func @test_default_maxpoolsingleout_lower(%arg0 : tensor<5x5x16x13xf32>) ->
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_2_:%.+]] = stablehlo.maximum %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_2_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [0, 0], [2, 1]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 4, 4]> : tensor<4xi64>, window_strides = dense<[1, 1, 4, 4]> : tensor<4xi64>} : (tensor<5x5x16x13xf32>, tensor<f32>) -> tensor<5x5x4x4xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [0, 0], [2, 1]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 4, 4>, window_strides = array<i64: 1, 1, 4, 4>} : (tensor<5x5x16x13xf32>, tensor<f32>) -> tensor<5x5x4x4xf32>
 // CHECK:           return [[VAR_1_]] : tensor<5x5x4x4xf32>
 // CHECK:         }
 
@@ -204,12 +204,12 @@ func.func @test_averagepool_default(%arg0 : tensor<5x5x32x32xf32>) -> tensor<5x5
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_5_:%.+]] = stablehlo.add %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_5_]] : tensor<f32>
-// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
+// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
 // CHECK:           [[VAR_3_:%.+]] = "stablehlo.reduce_window"([[VAR_0_]], [[VAR_1_]]) ({
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_5_1_:%.+]] = stablehlo.add %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_5_1_]] : tensor<f32>
-// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
+// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
 // CHECK:           [[VAR_4_:%.+]] = stablehlo.divide [[VAR_2_]], [[VAR_3_]] : tensor<5x5x30x30xf32>
 // CHECK:           return [[VAR_4_]] : tensor<5x5x30x30xf32>
 // CHECK:         }
@@ -230,12 +230,12 @@ func.func @test_averagepool_pad(%arg0 : tensor<5x5x32x32xf32>) -> tensor<5x5x32x
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_5_:%.+]] = stablehlo.add %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_5_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [1, 1]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x32x32xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [1, 1]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x32x32xf32>
 // CHECK:           [[VAR_3_:%.+]] = "stablehlo.reduce_window"([[VAR_0_]], [[VAR_1_]]) ({
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_5_1_:%.+]] = stablehlo.add %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_5_1_]] : tensor<f32>
-// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [1, 1]{{.}}> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x32x32xf32>
+// CHECK:           }) {padding = dense<{{.}}[0, 0], [0, 0], [1, 1], [1, 1]]> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x32x32xf32>
 // CHECK:           [[VAR_4_:%.+]] = stablehlo.divide [[VAR_2_]], [[VAR_3_]] : tensor<5x5x32x32xf32>
 // CHECK:           return [[VAR_4_]] : tensor<5x5x32x32xf32>
 // CHECK:         }
@@ -256,7 +256,7 @@ func.func @test_averagepool_count_include_pad(%arg0 : tensor<5x5x32x32xf32>) -> 
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_4_:%.+]] = stablehlo.add %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_4_]] : tensor<f32>
-// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
+// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<5x5x32x32xf32>, tensor<f32>) -> tensor<5x5x30x30xf32>
 // CHECK:           [[VAR_3_:%.+]] = stablehlo.divide [[VAR_2_]], [[VAR_0_]] : tensor<5x5x30x30xf32>
 // CHECK:           return [[VAR_3_]] : tensor<5x5x30x30xf32>
 // CHECK:         }
@@ -277,14 +277,14 @@ func.func @test_averagepool_dynamic_shape(%arg0 : tensor<?x5x32x32xf32>) -> tens
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_7_:%.+]] = stablehlo.add %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_7_]] : tensor<f32>
-// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<?x5x32x32xf32>, tensor<f32>) -> tensor<?x5x30x30xf32>
+// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<?x5x32x32xf32>, tensor<f32>) -> tensor<?x5x30x30xf32>
 // CHECK:           [[VAR_3_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<?x5x32x32xf32> -> tensor<4xindex>
 // CHECK:           [[VAR_4_:%.+]] = stablehlo.dynamic_broadcast_in_dim [[VAR_0_]], [[VAR_3_]], dims = [] : (tensor<f32>, tensor<4xindex>) -> tensor<?x5x32x32xf32>
 // CHECK:           [[VAR_5_:%.+]] = "stablehlo.reduce_window"([[VAR_4_]], [[VAR_1_]]) ({
 // CHECK:           ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK:             [[VAR_7_1_:%.+]] = stablehlo.add %arg1, %arg2 : tensor<f32>
 // CHECK:             stablehlo.return [[VAR_7_1_]] : tensor<f32>
-// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = dense<1> : tensor<4xi64>, window_dimensions = dense<[1, 1, 3, 3]> : tensor<4xi64>, window_strides = dense<1> : tensor<4xi64>} : (tensor<?x5x32x32xf32>, tensor<f32>) -> tensor<?x5x30x30xf32>
+// CHECK:           }) {padding = dense<0> : tensor<4x2xi64>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 1, 1>} : (tensor<?x5x32x32xf32>, tensor<f32>) -> tensor<?x5x30x30xf32>
 // CHECK:           [[VAR_6_:%.+]] = stablehlo.divide [[VAR_2_]], [[VAR_5_]] : tensor<?x5x30x30xf32>
 // CHECK:           return [[VAR_6_]] : tensor<?x5x30x30xf32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/ArgMax.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/ArgMax.mlir
@@ -11,7 +11,7 @@ func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-DAG:       [[VAR_2_:%.+]] = stablehlo.constant dense<0xFF800000> : tensor<f32>
 // CHECK:           [[VAR_3_:%.+]] = stablehlo.dynamic_iota [[VAR_0_]], dim = 3 : (tensor<4xindex>) -> tensor<5x5x1x32xi64>
-// CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce(%arg0 init: %1), (%3 init: %0) across dimensions = [3] : (tensor<5x5x1x32xf32>, tensor<5x5x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<*xf32>, tensor<*xi64>)
+// CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce(%arg0 init: %1), (%3 init: %0) across dimensions = [3] : (tensor<5x5x1x32xf32>, tensor<5x5x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<5x5x1xf32>, tensor<5x5x1xi64>)
 // CHECK:            reducer(%arg1: tensor<f32>, %arg3: tensor<f32>) (%arg2: tensor<i64>, %arg4: tensor<i64>)  {
 // CHECK:             [[VAR_6_:%.+]] = stablehlo.compare  GE, %arg1, %arg3,  NOTYPE : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_7_:%.+]] = stablehlo.select [[VAR_6_]], %arg1, %arg3 : tensor<i1>, tensor<f32>
@@ -21,7 +21,7 @@ func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64>
 // CHECK:             [[VAR_11_:%.+]] = stablehlo.select [[VAR_8_]], [[VAR_9_]], [[VAR_10_]] : tensor<i1>, tensor<i64>
 // CHECK:             stablehlo.return [[VAR_7_]], [[VAR_11_]] : tensor<f32>, tensor<i64>
 // CHECK:           }
-// CHECK:           [[VAR_5_:%.+]] = stablehlo.reshape [[VAR_4_]]#1 : (tensor<*xi64>) -> tensor<5x5x1x1xi64>
+// CHECK:           [[VAR_5_:%.+]] = stablehlo.reshape [[VAR_4_]]#1 : (tensor<5x5x1xi64>) -> tensor<5x5x1x1xi64>
 // CHECK:           return [[VAR_5_]] : tensor<5x5x1x1xi64>
 // CHECK:         }
 
@@ -41,7 +41,7 @@ func.func @test_argmax_verifier_2(%arg0 : tensor<5x?x1x32xf32>) -> tensor<*xi64>
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[VAR_2_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<5x?x1x32xf32> -> tensor<4xindex>
 // CHECK:           [[VAR_3_:%.+]] = stablehlo.dynamic_iota [[VAR_2_]], dim = 3 : (tensor<4xindex>) -> tensor<5x?x1x32xi64>
-// CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce([[PARAM_0_]] init: [[VAR_0_]]), ([[VAR_3_]] init: [[VAR_1_]]) across dimensions = [3] : (tensor<5x?x1x32xf32>, tensor<5x?x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<*xf32>, tensor<*xi64>)
+// CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce([[PARAM_0_]] init: [[VAR_0_]]), ([[VAR_3_]] init: [[VAR_1_]]) across dimensions = [3] : (tensor<5x?x1x32xf32>, tensor<5x?x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<5x?x1xf32>, tensor<5x?x1xi64>)
 // CHECK:            reducer(%arg1: tensor<f32>, %arg3: tensor<f32>) (%arg2: tensor<i64>, %arg4: tensor<i64>)  {
 // CHECK:             [[VAR_11_:%.+]] = stablehlo.compare  GE, %arg1, %arg3,  NOTYPE : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_12_:%.+]] = stablehlo.select [[VAR_11_]], %arg1, %arg3 : tensor<i1>, tensor<f32>
@@ -56,6 +56,6 @@ func.func @test_argmax_verifier_2(%arg0 : tensor<5x?x1x32xf32>) -> tensor<*xi64>
 // CHECK-DAG:       [[VAR_7_:%.+]] = shape.get_extent [[VAR_2_]], [[CST_2_]] : tensor<4xindex>, index -> index
 // CHECK:           [[VAR_8_:%.+]] = shape.from_extents [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[CST_1_]] : index, index, index, index
 // CHECK:           [[VAR_9_:%.+]] = shape.to_extent_tensor [[VAR_8_]] : !shape.shape -> tensor<4xindex>
-// CHECK:           [[VAR_10_:%.+]] = stablehlo.dynamic_reshape [[VAR_4_]]#1, [[VAR_9_]] : (tensor<*xi64>, tensor<4xindex>) -> tensor<5x?x1x1xi64>
+// CHECK:           [[VAR_10_:%.+]] = stablehlo.dynamic_reshape [[VAR_4_]]#1, [[VAR_9_]] : (tensor<5x?x1xi64>, tensor<4xindex>) -> tensor<5x?x1x1xi64>
 // CHECK:           return [[VAR_10_]] : tensor<5x?x1x1xi64>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/ArgMax.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/ArgMax.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-stablehlo %s --canonicalize -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-stablehlo %s --canonicalize -cse -split-input-file | FileCheck %s
 
 func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64> {
   %1 = "onnx.ArgMax"(%arg0) { axis = -1 : si64} : (tensor<5x5x1x32xf32>)  -> tensor<*xi64>
@@ -11,7 +11,7 @@ func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64>
 // CHECK-DAG:       [[VAR_1_:%.+]] = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-DAG:       [[VAR_2_:%.+]] = stablehlo.constant dense<0xFF800000> : tensor<f32>
 // CHECK:           [[VAR_3_:%.+]] = stablehlo.dynamic_iota [[VAR_0_]], dim = 3 : (tensor<4xindex>) -> tensor<5x5x1x32xi64>
-// CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce([[PARAM_0_]] init: [[VAR_2_]]), ([[VAR_3_]] init: [[VAR_1_]]) across dimensions = [3] : (tensor<5x5x1x32xf32>, tensor<5x5x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<5x5x1xf32>, tensor<5x5x1xi64>)
+// CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce(%arg0 init: %1), (%3 init: %0) across dimensions = [3] : (tensor<5x5x1x32xf32>, tensor<5x5x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<*xf32>, tensor<*xi64>)
 // CHECK:            reducer(%arg1: tensor<f32>, %arg3: tensor<f32>) (%arg2: tensor<i64>, %arg4: tensor<i64>)  {
 // CHECK:             [[VAR_6_:%.+]] = stablehlo.compare  GE, %arg1, %arg3,  NOTYPE : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_7_:%.+]] = stablehlo.select [[VAR_6_]], %arg1, %arg3 : tensor<i1>, tensor<f32>
@@ -21,7 +21,7 @@ func.func @test_argmax_verifier_1(%arg0 : tensor<5x5x1x32xf32>) -> tensor<*xi64>
 // CHECK:             [[VAR_11_:%.+]] = stablehlo.select [[VAR_8_]], [[VAR_9_]], [[VAR_10_]] : tensor<i1>, tensor<i64>
 // CHECK:             stablehlo.return [[VAR_7_]], [[VAR_11_]] : tensor<f32>, tensor<i64>
 // CHECK:           }
-// CHECK:           [[VAR_5_:%.+]] = stablehlo.reshape [[VAR_4_]]#1 : (tensor<5x5x1xi64>) -> tensor<5x5x1x1xi64>
+// CHECK:           [[VAR_5_:%.+]] = stablehlo.reshape [[VAR_4_]]#1 : (tensor<*xi64>) -> tensor<5x5x1x1xi64>
 // CHECK:           return [[VAR_5_]] : tensor<5x5x1x1xi64>
 // CHECK:         }
 
@@ -41,7 +41,7 @@ func.func @test_argmax_verifier_2(%arg0 : tensor<5x?x1x32xf32>) -> tensor<*xi64>
 // CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
 // CHECK-DAG:       [[VAR_2_:%.+]] = shape.shape_of [[PARAM_0_]] : tensor<5x?x1x32xf32> -> tensor<4xindex>
 // CHECK:           [[VAR_3_:%.+]] = stablehlo.dynamic_iota [[VAR_2_]], dim = 3 : (tensor<4xindex>) -> tensor<5x?x1x32xi64>
-// CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce([[PARAM_0_]] init: [[VAR_0_]]), ([[VAR_3_]] init: [[VAR_1_]]) across dimensions = [3] : (tensor<5x?x1x32xf32>, tensor<5x?x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<5x?x1xf32>, tensor<5x?x1xi64>)
+// CHECK:           [[VAR_4_:%.+]]:2 = stablehlo.reduce([[PARAM_0_]] init: [[VAR_0_]]), ([[VAR_3_]] init: [[VAR_1_]]) across dimensions = [3] : (tensor<5x?x1x32xf32>, tensor<5x?x1x32xi64>, tensor<f32>, tensor<i64>) -> (tensor<*xf32>, tensor<*xi64>)
 // CHECK:            reducer(%arg1: tensor<f32>, %arg3: tensor<f32>) (%arg2: tensor<i64>, %arg4: tensor<i64>)  {
 // CHECK:             [[VAR_11_:%.+]] = stablehlo.compare  GE, %arg1, %arg3,  NOTYPE : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK-DAG:         [[VAR_12_:%.+]] = stablehlo.select [[VAR_11_]], %arg1, %arg3 : tensor<i1>, tensor<f32>
@@ -56,6 +56,6 @@ func.func @test_argmax_verifier_2(%arg0 : tensor<5x?x1x32xf32>) -> tensor<*xi64>
 // CHECK-DAG:       [[VAR_7_:%.+]] = shape.get_extent [[VAR_2_]], [[CST_2_]] : tensor<4xindex>, index -> index
 // CHECK:           [[VAR_8_:%.+]] = shape.from_extents [[VAR_5_]], [[VAR_6_]], [[VAR_7_]], [[CST_1_]] : index, index, index, index
 // CHECK:           [[VAR_9_:%.+]] = shape.to_extent_tensor [[VAR_8_]] : !shape.shape -> tensor<4xindex>
-// CHECK:           [[VAR_10_:%.+]] = stablehlo.dynamic_reshape [[VAR_4_]]#1, [[VAR_9_]] : (tensor<5x?x1xi64>, tensor<4xindex>) -> tensor<5x?x1x1xi64>
+// CHECK:           [[VAR_10_:%.+]] = stablehlo.dynamic_reshape [[VAR_4_]]#1, [[VAR_9_]] : (tensor<*xi64>, tensor<4xindex>) -> tensor<5x?x1x1xi64>
 // CHECK:           return [[VAR_10_]] : tensor<5x?x1x1xi64>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/GatherElements.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/GatherElements.mlir
@@ -14,6 +14,6 @@ func.func @main_gather_elements(%arg0: tensor<3x2xf32>, %arg1: tensor<2x2xi64>) 
 // CHECK-DAG:    [[VAR_6_:%.+]] = stablehlo.dynamic_reshape [[VAR_5_]], [[CST_]] : (tensor<2x2xi64>, tensor<3xindex>) -> tensor<2x2x1xi64>
 // CHECK-DAG:    [[VAR_7_:%.+]] = stablehlo.dynamic_iota [[CST_]], dim = 1 : (tensor<3xindex>) -> tensor<2x2x1xi64>
 // CHECK-NEXT:   [[VAR_8_:%.+]] = stablehlo.concatenate [[VAR_6_]], [[VAR_7_]], dim = 2 : (tensor<2x2x1xi64>, tensor<2x2x1xi64>) -> tensor<2x2x2xi64>
-// CHECK-NEXT:   [[VAR_9_:%.+]] = "stablehlo.gather"([[PARAM_0_]], [[VAR_8_]]) {dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = dense<1> : tensor<2xi64>} : (tensor<3x2xf32>, tensor<2x2x2xi64>) -> tensor<2x2xf32>
+// CHECK-NEXT:   [[VAR_9_:%.+]] = "stablehlo.gather"([[PARAM_0_]], [[VAR_8_]]) {dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>} : (tensor<3x2xf32>, tensor<2x2x2xi64>) -> tensor<2x2xf32>
 // CHECK-NEXT:   return [[VAR_9_]] : tensor<2x2xf32>
 }

--- a/test/mlir/conversion/onnx_to_stablehlo/Tensor/Reshape.mlir
+++ b/test/mlir/conversion/onnx_to_stablehlo/Tensor/Reshape.mlir
@@ -38,24 +38,23 @@ func.func @test_reshape_dynamic(%arg0 : tensor<5x5x1x32xf32>, %arg1 : tensor<4xi
 // CHECK:           [[VAR_13_:%.+]] = arith.cmpi eq, [[VAR_12_]], [[CST_0_]] : index
 // CHECK:           [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[CST_1_]], [[VAR_12_]] : index
 // CHECK:           [[VAR_15_:%.+]] = arith.cmpi eq, [[VAR_14_]], [[CST_minus_1_]] : index
-// CHECK:           [[VAR_16_:%.+]] = arith.ori [[VAR_15_]], [[VAR_13_]] : i1
-// CHECK:           [[VAR_17_:%.+]] = arith.select [[VAR_16_]], [[CST_1_]], [[VAR_12_]] : index
-// CHECK-DAG:       [[VAR_18_:%.+]] = arith.muli [[VAR_11_]], [[VAR_17_]] : index
-// CHECK-DAG:       [[VAR_19_:%.+]] = shape.get_extent [[VAR_0_]], [[CST_3_]] : tensor<4xindex>, index -> index
-// CHECK:           [[VAR_20_:%.+]] = arith.cmpi eq, [[VAR_19_]], [[CST_0_]] : index
-// CHECK:           [[VAR_21_:%.+]] = arith.select [[VAR_20_]], [[CST_32_]], [[VAR_19_]] : index
-// CHECK:           [[VAR_22_:%.+]] = arith.cmpi eq, [[VAR_21_]], [[CST_minus_1_]] : index
-// CHECK:           [[VAR_23_:%.+]] = arith.select [[VAR_22_]], [[CST_1_]], [[VAR_21_]] : index
-// CHECK:           [[VAR_24_:%.+]] = arith.muli [[VAR_18_]], [[VAR_23_]] : index
-// CHECK:           [[VAR_25_:%.+]] = arith.floordivsi [[CST_800_]], [[VAR_24_]] : index
-// CHECK-DAG:       [[VAR_26_:%.+]] = arith.select [[VAR_4_]], [[VAR_25_]], [[VAR_3_]] : index
-// CHECK-DAG:       [[VAR_27_:%.+]] = arith.select [[VAR_9_]], [[VAR_25_]], [[VAR_8_]] : index
-// CHECK-DAG:       [[VAR_28_:%.+]] = arith.select [[VAR_15_]], [[VAR_25_]], [[VAR_14_]] : index
-// CHECK-DAG:       [[VAR_29_:%.+]] = arith.select [[VAR_22_]], [[VAR_25_]], [[VAR_21_]] : index
-// CHECK:           [[VAR_30_:%.+]] = shape.from_extents [[VAR_26_]], [[VAR_27_]], [[VAR_28_]], [[VAR_29_]] : index, index, index, index
-// CHECK:           [[VAR_31_:%.+]] = shape.to_extent_tensor [[VAR_30_]] : !shape.shape -> tensor<4xindex>
-// CHECK:           [[VAR_32_:%.+]] = stablehlo.dynamic_reshape [[PARAM_0_]], [[VAR_31_]] : (tensor<5x5x1x32xf32>, tensor<4xindex>) -> tensor<?x?x?x?xf32>
-// CHECK:           return [[VAR_32_]] : tensor<?x?x?x?xf32>
+// CHECK:           [[VAR_16_:%.+]] = arith.select [[VAR_15_]], [[CST_1_]], [[VAR_14_]] : index
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.muli [[VAR_11_]], [[VAR_16_]] : index
+// CHECK-DAG:       [[VAR_18_:%.+]] = shape.get_extent [[VAR_0_]], [[CST_3_]] : tensor<4xindex>, index -> index
+// CHECK:           [[VAR_19_:%.+]] = arith.cmpi eq, [[VAR_18_]], [[CST_0_]] : index
+// CHECK:           [[VAR_20_:%.+]] = arith.select [[VAR_19_]], [[CST_32_]], [[VAR_18_]] : index
+// CHECK:           [[VAR_21_:%.+]] = arith.cmpi eq, [[VAR_20_]], [[CST_minus_1_]] : index
+// CHECK:           [[VAR_22_:%.+]] = arith.select [[VAR_21_]], [[CST_1_]], [[VAR_20_]] : index
+// CHECK:           [[VAR_23_:%.+]] = arith.muli [[VAR_17_]], [[VAR_22_]] : index
+// CHECK:           [[VAR_24_:%.+]] = arith.floordivsi [[CST_800_]], [[VAR_23_]] : index
+// CHECK-DAG:       [[VAR_25_:%.+]] = arith.select [[VAR_4_]], [[VAR_24_]], [[VAR_3_]] : index
+// CHECK-DAG:       [[VAR_26_:%.+]] = arith.select [[VAR_9_]], [[VAR_24_]], [[VAR_8_]] : index
+// CHECK-DAG:       [[VAR_27_:%.+]] = arith.select [[VAR_15_]], [[VAR_24_]], [[VAR_14_]] : index
+// CHECK-DAG:       [[VAR_28_:%.+]] = arith.select [[VAR_21_]], [[VAR_24_]], [[VAR_20_]] : index
+// CHECK:           [[VAR_29_:%.+]] = shape.from_extents [[VAR_25_]], [[VAR_26_]], [[VAR_27_]], [[VAR_28_]] : index, index, index, index
+// CHECK:           [[VAR_30_:%.+]] = shape.to_extent_tensor [[VAR_29_]] : !shape.shape -> tensor<4xindex>
+// CHECK:           [[VAR_31_:%.+]] = stablehlo.dynamic_reshape [[PARAM_0_]], [[VAR_30_]] : (tensor<5x5x1x32xf32>, tensor<4xindex>) -> tensor<?x?x?x?xf32>
+// CHECK:           return [[VAR_31_]] : tensor<?x?x?x?xf32>
 // CHECK:         }
 }
 

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -213,6 +213,18 @@ func.func @test_transpose_concat_reversed(%arg0: tensor<?x5x5x1xf32>, %arg1: ten
 
 // -----
 
+// CHECK-LABEL: func @identity_tile
+func.func @identity_tile(%arg0: tensor<32x64xf32>) -> tensor<32x64xf32> {
+    %0 = onnx.Constant dense<1> : tensor<2xi64>
+    %1 = "onnx.Tile"(%arg0, %0) : (tensor<32x64xf32>, tensor<2xi64>) -> tensor<32x64xf32>
+    onnx.Return %1 : tensor<32x64xf32>
+
+    // CHECK-NEXT: onnx.Return %arg0
+    // CHECK-NOT: "onnx.Tile"
+}
+
+// -----
+
 // Check the removal of identity reshapes.
 // CHECK-LABEL: func @test_reshape_removal_1(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
 func.func @test_reshape_removal_1(%arg0: tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {

--- a/test/mlir/onnx/onnx_hybrid_transform.mlir
+++ b/test/mlir/onnx/onnx_hybrid_transform.mlir
@@ -134,7 +134,7 @@ func.func @test_inception_v2_6_snippet(%arg0: tensor<1x3x224x224xf32>, %arg1: te
 // CHECK-DAG:       [[VAR_29_:%.+]] = onnx.Constant dense<4.800000e+00> : tensor<64xf32>
 // CHECK:           [[VAR_30_:%.+]] = "onnx.Add"([[VAR_6_]], [[VAR_1_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
 // CHECK:           [[VAR_31_:%.+]] = "onnx.Sqrt"([[VAR_30_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// CHECK:           [[VAR_32_:%.+]] = "onnx.Div"([[VAR_3_]], [[VAR_3_]]1) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// CHECK:           [[VAR_32_:%.+]] = "onnx.Div"([[VAR_3_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
 // CHECK:           [[VAR_33_:%.+]] = "onnx.Unsqueeze"([[VAR_32_]], [[VAR_2_]]) : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1x1xf32>
 // CHECK-DAG:       [[VAR_34_:%.+]] = "onnx.Mul"([[PARAM_1_]], [[VAR_33_]]) : (tensor<64x3x7x7xf32>, tensor<64x1x1x1xf32>) -> tensor<64x3x7x7xf32>
 // CHECK-DAG:       [[VAR_35_:%.+]] = "onnx.Neg"([[VAR_5_]]) : (tensor<64xf32>) -> tensor<64xf32>
@@ -231,7 +231,7 @@ func.func @test_inception_v2_6_snippet(%arg0: tensor<1x3x224x224xf32>, %arg1: te
 // DECOMPOSE-DAG:       [[VAR_29_:%.+]] = onnx.Constant dense<4.800000e+00> : tensor<64xf32>
 // DECOMPOSE:           [[VAR_30_:%.+]] = "onnx.Add"([[VAR_6_]], [[VAR_1_]]) : (tensor<64xf32>, tensor<1xf32>) -> tensor<64xf32>
 // DECOMPOSE:           [[VAR_31_:%.+]] = "onnx.Sqrt"([[VAR_30_]]) : (tensor<64xf32>) -> tensor<64xf32>
-// DECOMPOSE:           [[VAR_32_:%.+]] = "onnx.Div"([[VAR_3_]], [[VAR_3_]]1) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
+// DECOMPOSE:           [[VAR_32_:%.+]] = "onnx.Div"([[VAR_3_]], [[VAR_31_]]) : (tensor<64xf32>, tensor<64xf32>) -> tensor<64xf32>
 // DECOMPOSE:           [[VAR_33_:%.+]] = "onnx.Unsqueeze"([[VAR_32_]], [[VAR_2_]]) : (tensor<64xf32>, tensor<3xi64>) -> tensor<64x1x1x1xf32>
 // DECOMPOSE-DAG:       [[VAR_34_:%.+]] = "onnx.Mul"([[PARAM_1_]], [[VAR_33_]]) : (tensor<64x3x7x7xf32>, tensor<64x1x1x1xf32>) -> tensor<64x3x7x7xf32>
 // DECOMPOSE-DAG:       [[VAR_35_:%.+]] = "onnx.Neg"([[VAR_5_]]) : (tensor<64xf32>) -> tensor<64xf32>

--- a/test/mlir/parallel/scf_parallel_private.mlir
+++ b/test/mlir/parallel/scf_parallel_private.mlir
@@ -22,7 +22,7 @@ func.func @add_with_par(%arg0: memref<16x8x128xf32>) -> (memref<16x8x128xf32>)  
     %1 = vector.load %reshape_2[%arg1] : memref<16384xf32>, vector<32xf32>
     %2 = arith.addf %0, %1 : vector<32xf32>
     vector.store %2, %reshape_4[%arg1] : memref<16384xf32>, vector<32xf32>
-    scf.yield
+    scf.reduce
   }
   return %alloc : memref<16x8x128xf32>
 
@@ -49,7 +49,7 @@ func.func @add_with_par(%arg0: memref<16x8x128xf32>) -> (memref<16x8x128xf32>)  
 // CHECK:               [[VAR_2_:%.+]] = arith.addf [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xf32>
 // CHECK:               vector.store [[VAR_2_]], [[VAR_reshape_4_]]{{.}}[[arg1_]]{{.}} : memref<16384xf32>, vector<32xf32>
 // CHECK:             }
-// CHECK:             scf.yield
+// CHECK:             scf.reduce
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<16x8x128xf32>
 // CHECK:         }

--- a/utils/build-onnx-mlir.cmd
+++ b/utils/build-onnx-mlir.cmd
@@ -8,6 +8,7 @@ call cmake %root_dir%\onnx-mlir -G "Ninja" ^
    -DLLVM_EXTERNAL_LIT=%lit_path% ^
    -DLLVM_LIT_ARGS=-v ^
    -DMLIR_DIR=%root_dir%\llvm-project\build\lib\cmake\mlir ^
+   -DONNX_MLIR_ENABLE_STABLEHLO=OFF ^
    -DONNX_MLIR_ENABLE_WERROR=ON
 
 call cmake --build . --config Release

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout e899641df2391179e8ec29ca14c53b09ae7ce85c && cd ..
+cd llvm-project && git checkout a4ca07f13b560b4f6fa5459eef7159e4f9ee9a6b && cd ..

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout b2cdf3cc4c08729d0ff582d55e40793a20bbcdcc && cd ..
+cd llvm-project && git checkout e899641df2391179e8ec29ca14c53b09ae7ce85c && cd ..

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -356,6 +356,7 @@ OpsWithCanonicalizer = [
     "Squeeze",
     "SqueezeV11",
     "Sub",
+    "Tile",
     "Transpose",
     "Unsqueeze",
     "UnsqueezeV11",


### PR DESCRIPTION
Canonicalize `TileOp` when it is identity, i.e. when the input/result shape is same and all `repeat` values are constantly known to be 1.