### PR TITLE
[RFC] Introduce `krnl.yield` Operation for `krnl.iterate`

### DIFF
--- a/src/Conversion/KrnlToAffine/KrnlTerminator.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlTerminator.cpp
@@ -42,9 +42,23 @@ public:
   }
 };
 
+class KrnlYieldLowering : public ConversionPattern {
+public:
+  explicit KrnlYieldLowering(TypeConverter &typeConverter, MLIRContext *context)
+      : ConversionPattern(
+            typeConverter, KrnlYieldOp::getOperationName(), 1, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<affine::AffineYieldOp>(op, op->getOperands());
+    return success();
+  }
+};
+
 void populateLoweringKrnlTerminatorOpPattern(TypeConverter &typeConverter,
     RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.insert<KrnlTerminatorLowering>(typeConverter, ctx);
+  patterns.insert<KrnlTerminatorLowering, KrnlYieldLowering>(
+      typeConverter, ctx);
 }
 
 } // namespace krnl

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -88,10 +88,10 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
           ValueRange inits = ValueRange(fZero);
           // Inner loop for reduction.
           auto innerIterate = create.krnl.iterate({}, innerLoop, {}, {}, inits,
-              [&](KrnlBuilder &createKrnl, ValueRange innerIndex) {
-                Block *innerIterEntryBB = createKrnl.getBuilder().getBlock();
+              [&](KrnlBuilder &createKrnl, ValueRange innerIndex,
+                  ValueRange iterArgs) {
                 // Get last argument for the iterate body.
-                Value iterArg = innerIterEntryBB->getArguments().back();
+                Value iterArg = iterArgs.back();
 
                 MultiDialectBuilder<KrnlBuilder, MathBuilder> create(
                     createKrnl);

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -23,14 +23,19 @@ namespace onnx_mlir {
 
 static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
     SmallVectorImpl<IndexExpr> &Lbs, SmallVectorImpl<IndexExpr> &Ubs,
-    ValueRange outerIndices, Value input, Value alloc, Value sumOp, Value maxOp,
-    int64_t axis, bool coerced = true) {
+    ValueRange outerIndices, Value input, Value alloc, Value zero,
+    Value negInfinity, int64_t axis, bool coerced = true) {
   int64_t rank = alloc.getType().cast<MemRefType>().getRank();
 
+  ValueRange maxInits = ValueRange(negInfinity);
   // Compute the maximum value along axis.
   ValueRange maxLoops = createKrnl.defineLoops(numberOfLoops);
-  createKrnl.iterateIE(maxLoops, maxLoops, Lbs, Ubs,
+  auto maxLoop = createKrnl.iterateIE(maxLoops, maxLoops, Lbs, Ubs, maxInits,
       [&](KrnlBuilder &createKrnl, ValueRange maxIndices) {
+        Block *iterEntryBB = createKrnl.getBuilder().getBlock();
+        // Get last argument for the iterate body.
+        Value iterArg = iterEntryBB->getArguments().back();
+
         MultiDialectBuilder<KrnlBuilder, MathBuilder> create(createKrnl);
         IndexExprScope ieScope(createKrnl);
 
@@ -49,19 +54,25 @@ static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
             maxLoopIVs.push_back(outerIndices[i - 1]);
         }
 
-        Value max = create.krnl.load(maxOp, {});
+        Value max = iterArg;
         Value nextMax = create.krnl.load(input, maxLoopIVs);
         auto maxCond = create.math.sgt(max, nextMax);
         max = create.math.select(maxCond, max, nextMax);
-        create.krnl.store(max, maxOp, ArrayRef<Value>{});
-      });
-  // Load the maximum value.
-  Value max = createKrnl.load(maxOp, {});
 
+        create.krnl.yield(max);
+      });
+  // Get the maximum value.
+  Value max = maxLoop.getResult(0);
+
+  ValueRange sumInits = ValueRange(zero);
   // Compute the sum of all values along axis.
   ValueRange sumLoops = createKrnl.defineLoops(numberOfLoops);
-  createKrnl.iterateIE(sumLoops, sumLoops, Lbs, Ubs,
+  auto sumLoop = createKrnl.iterateIE(sumLoops, sumLoops, Lbs, Ubs, sumInits,
       [&](KrnlBuilder &createKrnl, ValueRange sumIndices) {
+        Block *iterEntryBB = createKrnl.getBuilder().getBlock();
+        // Get last argument for the iterate body.
+        Value iterArg = iterEntryBB->getArguments().back();
+
         MultiDialectBuilder<KrnlBuilder, MathBuilder> create(createKrnl);
         IndexExprScope ieScope(createKrnl);
 
@@ -80,19 +91,19 @@ static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
             sumLoopIVs.push_back(outerIndices[i - 1]);
         }
 
-        Value sum = create.krnl.load(sumOp, {});
+        Value sum = iterArg;
         Value next = create.krnl.load(input, sumLoopIVs);
         Value sub = create.math.sub(next, max);
         Value exp = create.math.exp(sub);
         sum = create.math.add(sum, exp);
-        create.krnl.store(sum, sumOp, ArrayRef<Value>{});
         // Store intermediate values in the result to avoid
         // recomputation.
         create.krnl.store(exp, alloc, sumLoopIVs);
+        create.krnl.yield(sum);
       });
 
   // Load the sum value.
-  Value sum = createKrnl.load(sumOp, {});
+  Value sum = sumLoop.getResult(0);
 
   // Compute the softmax.
   ValueRange softmaxLoops = createKrnl.defineLoops(numberOfLoops);
@@ -124,16 +135,14 @@ static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
 
 template <typename T>
 void emitInstForSoftmax(ConversionPatternRewriter &rewriter, Operation *op,
-    Location loc, Value alloc, Value input, MemRefType scalarMemRefType,
-    Value sumOp, Value maxOp, Value zero, Value negInfinity, int64_t axis,
-    bool enableParallel) = delete;
+    Location loc, Value alloc, Value input, Value zero, Value negInfinity,
+    int64_t axis, bool enableParallel) = delete;
 
 // For Softmax opset < 13, `axis` is the coerced point. All dimensions
 // after `axis` will be logically coerced into a single dimension.
 template <>
 void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
-    Operation *op, Location loc, Value alloc, Value input,
-    MemRefType scalarMemRefType, Value sumOp, Value maxOp, Value zero,
+    Operation *op, Location loc, Value alloc, Value input, Value zero,
     Value negInfinity, int64_t axis, bool enableParallel) {
   int64_t rank = alloc.getType().cast<MemRefType>().getRank();
 
@@ -151,9 +160,6 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
   if (axis == 0) {
     assert(!enableParallel && "only outer loop parallelism at this time");
     // There is no need having outer loops.
-    // Reset accumulators.
-    create.krnl.store(zero, sumOp, ArrayRef<Value>{});
-    create.krnl.store(negInfinity, maxOp, ArrayRef<Value>{});
 
     // Common information to create nested loops.
     int64_t numberOfLoops = rank;
@@ -161,8 +167,8 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
     SmallVector<IndexExpr, 4> Ubs;
     create.krnlIE.getShapeAsDims(input, Ubs);
 
-    emitInnerLoops(create.krnl, numberOfLoops, Lbs, Ubs, {}, input, alloc,
-        sumOp, maxOp, axis, /*coerced=*/true);
+    emitInnerLoops(create.krnl, numberOfLoops, Lbs, Ubs, {}, input, alloc, zero,
+        negInfinity, axis, /*coerced=*/true);
   } else {
     // Define outer loops.
     ValueRange outerLoops = create.krnl.defineLoops(axis);
@@ -183,16 +189,6 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
               create(ck);
           IndexExprScope ieScope(ck);
 
-          if (enableParallel) {
-            // Temporary results must be private when parallel. Use alloca here
-            // as scalars are small.
-            sumOp = create.mem.alignedAlloca(scalarMemRefType);
-            maxOp = create.mem.alignedAlloca(scalarMemRefType);
-          }
-          // Reset accumulators.
-          create.krnl.store(zero, sumOp, ArrayRef<Value>{});
-          create.krnl.store(negInfinity, maxOp, ArrayRef<Value>{});
-
           // Common information to create inner nested loops.
           int64_t numberOfLoops = rank - axis;
           SmallVector<IndexExpr, 4> Lbs(numberOfLoops, zeroIE);
@@ -202,7 +198,7 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
 
           // Emit the inner loops.
           emitInnerLoops(create.krnl, numberOfLoops, Lbs, Ubs, outerIndices,
-              input, alloc, sumOp, maxOp, axis, /*coerced=*/true);
+              input, alloc, zero, negInfinity, axis, /*coerced=*/true);
         });
   }
 }
@@ -212,8 +208,7 @@ void emitInstForSoftmax<ONNXSoftmaxV11Op>(ConversionPatternRewriter &rewriter,
 // `axis`.
 template <>
 void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
-    Operation *op, Location loc, Value alloc, Value input,
-    MemRefType scalarMemRefType, Value sumOp, Value maxOp, Value zero,
+    Operation *op, Location loc, Value alloc, Value input, Value zero,
     Value negInfinity, int64_t axis, bool enableParallel) {
   int64_t rank = alloc.getType().cast<MemRefType>().getRank();
 
@@ -246,17 +241,6 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
             create(ck);
         IndexExprScope ieScope(ck);
 
-        if (enableParallel) {
-          // Temporary results must be private when parallel. Use alloca here as
-          // scalars are small.
-          sumOp = create.mem.alignedAlloca(scalarMemRefType);
-          maxOp = create.mem.alignedAlloca(scalarMemRefType);
-        }
-
-        // Reset accumulators.
-        create.krnl.store(zero, sumOp, ArrayRef<Value>{});
-        create.krnl.store(negInfinity, maxOp, ArrayRef<Value>{});
-
         // Common information to create inner nested loops for axis only.
         int64_t numberOfLoops = 1;
         SmallVector<IndexExpr, 4> Lbs(numberOfLoops, zeroIE);
@@ -265,7 +249,7 @@ void emitInstForSoftmax<ONNXSoftmaxOp>(ConversionPatternRewriter &rewriter,
 
         // Emit the inner loops.
         emitInnerLoops(create.krnl, numberOfLoops, Lbs, Ubs, outerIndices,
-            input, alloc, sumOp, maxOp, axis, /*coerced=*/false);
+            input, alloc, zero, negInfinity, axis, /*coerced=*/false);
       });
 }
 
@@ -316,22 +300,12 @@ struct ONNXSoftmaxLowering : public OpConversionPattern<SoftmaxOp> {
     MultiDialectBuilder<MemRefBuilder, MathBuilder> create(rewriter, loc);
     Value alloc = create.mem.alignedAlloc(input, memRefType);
 
-    // Insert allocations and deallocations for sum and max.
-    MemRefType scalarMemRefType = MemRefType::get({}, elementType, {}, 0);
-    Value sumOp, maxOp;
-    if (!enableParallelLocal) {
-      // Temporary results must be private when parallel.
-      sumOp = create.mem.alignedAlloc(scalarMemRefType);
-      maxOp = create.mem.alignedAlloc(scalarMemRefType);
-    }
-
     Value zero = create.math.constant(elementType, 0);
     Value negInfinity = create.math.constant(
         elementType, -std::numeric_limits<float>::infinity());
 
-    emitInstForSoftmax<SoftmaxOp>(rewriter, op, loc, alloc, input,
-        scalarMemRefType, sumOp, maxOp, zero, negInfinity, axis,
-        enableParallelLocal);
+    emitInstForSoftmax<SoftmaxOp>(rewriter, op, loc, alloc, input, zero,
+        negInfinity, axis, enableParallelLocal);
 
     rewriter.replaceOp(op, alloc);
     onnxToKrnlSimdReport(op);

--- a/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Softmax.cpp
@@ -31,10 +31,9 @@ static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
   // Compute the maximum value along axis.
   ValueRange maxLoops = createKrnl.defineLoops(numberOfLoops);
   auto maxLoop = createKrnl.iterateIE(maxLoops, maxLoops, Lbs, Ubs, maxInits,
-      [&](KrnlBuilder &createKrnl, ValueRange maxIndices) {
-        Block *iterEntryBB = createKrnl.getBuilder().getBlock();
+      [&](KrnlBuilder &createKrnl, ValueRange maxIndices, ValueRange iterArgs) {
         // Get last argument for the iterate body.
-        Value iterArg = iterEntryBB->getArguments().back();
+        Value iterArg = iterArgs.back();
 
         MultiDialectBuilder<KrnlBuilder, MathBuilder> create(createKrnl);
         IndexExprScope ieScope(createKrnl);
@@ -68,10 +67,9 @@ static void emitInnerLoops(KrnlBuilder &createKrnl, int64_t numberOfLoops,
   // Compute the sum of all values along axis.
   ValueRange sumLoops = createKrnl.defineLoops(numberOfLoops);
   auto sumLoop = createKrnl.iterateIE(sumLoops, sumLoops, Lbs, Ubs, sumInits,
-      [&](KrnlBuilder &createKrnl, ValueRange sumIndices) {
-        Block *iterEntryBB = createKrnl.getBuilder().getBlock();
+      [&](KrnlBuilder &createKrnl, ValueRange sumIndices, ValueRange iterArgs) {
         // Get last argument for the iterate body.
-        Value iterArg = iterEntryBB->getArguments().back();
+        Value iterArg = iterArgs.back();
 
         MultiDialectBuilder<KrnlBuilder, MathBuilder> create(createKrnl);
         IndexExprScope ieScope(createKrnl);

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -156,10 +156,10 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
             //     for kw in lb .. ub:
             auto innerIterate =
                 create.krnl.iterateIE(redLoops, redLoops, redLbs, redUbs, inits,
-                    [&](KrnlBuilder &createKrnl, ValueRange redIndices) {
-                      Block *iterEntryBB = createKrnl.getBuilder().getBlock();
+                    [&](KrnlBuilder &createKrnl, ValueRange redIndices,
+                        ValueRange iterArgs) {
                       // Get last argument for the iterate body.
-                      Value iterArg = iterEntryBB->getArguments().back();
+                      Value iterArg = iterArgs.back();
                       IndexExprScope redScope(createKrnl);
                       MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl,
                           MathBuilder>

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -146,12 +146,18 @@ void KrnlBuilder::iterate(ValueRange originalLoops, ValueRange optimizedLoops,
     ValueRange lbs, ValueRange ubs,
     function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
         bodyBuilderFn) const {
+  iterate(originalLoops, optimizedLoops, lbs, ubs, {}, bodyBuilderFn);
+}
+
+mlir::KrnlIterateOp KrnlBuilder::iterate(ValueRange originalLoops,
+    ValueRange optimizedLoops, ValueRange lbs, ValueRange ubs, ValueRange inits,
+    function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
+        bodyBuilderFn) const {
   // Check that originalLoops, lbs, and ubs have the same rank.
   assert(originalLoops.size() == lbs.size() && "expected same rank");
   assert(originalLoops.size() == ubs.size() && "expected same rank");
-  ValueRange empty;
-  b().create<KrnlIterateOp>(loc(), originalLoops, optimizedLoops, lbs, ubs,
-      empty, [&](OpBuilder &builder, Location loc, ValueRange args) {
+  return b().create<KrnlIterateOp>(loc(), originalLoops, optimizedLoops, lbs,
+      ubs, inits, [&](OpBuilder &builder, Location loc, ValueRange args) {
         KrnlBuilder createKrnl(builder, loc);
         ValueRange indices = createKrnl.getInductionVarValue(optimizedLoops);
         bodyBuilderFn(createKrnl, indices);
@@ -167,16 +173,27 @@ void KrnlBuilder::iterateIE(ValueRange originalLoops, ValueRange optimizedLoops,
     ArrayRef<IndexExpr> lbs, ArrayRef<IndexExpr> ubs,
     function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
         bodyBuilderFn) const {
+  iterateIE(originalLoops, optimizedLoops, lbs, ubs, {}, bodyBuilderFn);
+}
+
+mlir::KrnlIterateOp KrnlBuilder::iterateIE(ValueRange originalLoops,
+    ValueRange optimizedLoops, ArrayRef<IndexExpr> lbs, ArrayRef<IndexExpr> ubs,
+    mlir::ValueRange inits,
+    function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
+        bodyBuilderFn) const {
   // Check that originalLoops, lbs, and ubs have the same rank.
   assert(originalLoops.size() == lbs.size() && "expected same rank");
   assert(originalLoops.size() == ubs.size() && "expected same rank");
-  ValueRange empty;
-  b().create<KrnlIterateOp>(loc(), originalLoops, optimizedLoops, lbs, ubs,
-      empty, [&](OpBuilder &builder, Location loc, ValueRange args) {
+  return b().create<KrnlIterateOp>(loc(), originalLoops, optimizedLoops, lbs,
+      ubs, inits, [&](OpBuilder &builder, Location loc, ValueRange args) {
         KrnlBuilder createKrnl(builder, loc);
         ValueRange indices = createKrnl.getInductionVarValue(optimizedLoops);
         bodyBuilderFn(createKrnl, indices);
       });
+}
+
+void KrnlBuilder::yield(mlir::ValueRange iterArgs) const {
+  b().create<KrnlYieldOp>(loc(), iterArgs);
 }
 
 void KrnlBuilder::copyToBuffer(Value bufferMemref, Value sourceMemref,

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -157,21 +157,28 @@ void KrnlBuilder::iterate(ValueRange originalLoops, ValueRange optimizedLoops,
     ValueRange lbs, ValueRange ubs,
     function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
         bodyBuilderFn) const {
-  iterate(originalLoops, optimizedLoops, lbs, ubs, {}, bodyBuilderFn);
+  auto bodyBuilderFnWrapper = [&](KrnlBuilder &createKrnl, ValueRange indices,
+                                  ValueRange iterArgs) {
+    bodyBuilderFn(createKrnl, indices);
+  };
+  iterate(originalLoops, optimizedLoops, lbs, ubs, {}, bodyBuilderFnWrapper);
 }
 
 mlir::KrnlIterateOp KrnlBuilder::iterate(ValueRange originalLoops,
     ValueRange optimizedLoops, ValueRange lbs, ValueRange ubs, ValueRange inits,
-    function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
+    function_ref<void(
+        KrnlBuilder &createKrnl, ValueRange indices, ValueRange iterArgs)>
         bodyBuilderFn) const {
   // Check that originalLoops, lbs, and ubs have the same rank.
   assert(originalLoops.size() == lbs.size() && "expected same rank");
   assert(originalLoops.size() == ubs.size() && "expected same rank");
   return b().create<KrnlIterateOp>(loc(), originalLoops, optimizedLoops, lbs,
-      ubs, inits, [&](OpBuilder &builder, Location loc, ValueRange args) {
+      ubs, inits,
+      [&](OpBuilder &builder, Location loc, ValueRange args,
+          ValueRange iterArgs) {
         KrnlBuilder createKrnl(builder, loc);
         ValueRange indices = createKrnl.getInductionVarValue(optimizedLoops);
-        bodyBuilderFn(createKrnl, indices);
+        bodyBuilderFn(createKrnl, indices, iterArgs);
       });
 }
 
@@ -184,22 +191,29 @@ void KrnlBuilder::iterateIE(ValueRange originalLoops, ValueRange optimizedLoops,
     ArrayRef<IndexExpr> lbs, ArrayRef<IndexExpr> ubs,
     function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
         bodyBuilderFn) const {
-  iterateIE(originalLoops, optimizedLoops, lbs, ubs, {}, bodyBuilderFn);
+  auto bodyBuilderFnWrapper = [&](KrnlBuilder &createKrnl, ValueRange indices,
+                                  ValueRange iterArgs) {
+    bodyBuilderFn(createKrnl, indices);
+  };
+  iterateIE(originalLoops, optimizedLoops, lbs, ubs, {}, bodyBuilderFnWrapper);
 }
 
 mlir::KrnlIterateOp KrnlBuilder::iterateIE(ValueRange originalLoops,
     ValueRange optimizedLoops, ArrayRef<IndexExpr> lbs, ArrayRef<IndexExpr> ubs,
     mlir::ValueRange inits,
-    function_ref<void(KrnlBuilder &createKrnl, ValueRange indices)>
+    function_ref<void(
+        KrnlBuilder &createKrnl, ValueRange indices, ValueRange iterArgs)>
         bodyBuilderFn) const {
   // Check that originalLoops, lbs, and ubs have the same rank.
   assert(originalLoops.size() == lbs.size() && "expected same rank");
   assert(originalLoops.size() == ubs.size() && "expected same rank");
   return b().create<KrnlIterateOp>(loc(), originalLoops, optimizedLoops, lbs,
-      ubs, inits, [&](OpBuilder &builder, Location loc, ValueRange args) {
+      ubs, inits,
+      [&](OpBuilder &builder, Location loc, ValueRange args,
+          ValueRange iterArgs) {
         KrnlBuilder createKrnl(builder, loc);
         ValueRange indices = createKrnl.getInductionVarValue(optimizedLoops);
-        bodyBuilderFn(createKrnl, indices);
+        bodyBuilderFn(createKrnl, indices, iterArgs);
       });
 }
 

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -71,8 +71,8 @@ struct KrnlBuilder : public DialectBuilder {
   mlir::KrnlIterateOp iterate(mlir::ValueRange originalLoops,
       mlir::ValueRange optimizedLoops, mlir::ValueRange lbs,
       mlir::ValueRange ubs, mlir::ValueRange inits,
-      mlir::function_ref<void(
-          KrnlBuilder &createKrnl, mlir::ValueRange indices)>
+      mlir::function_ref<void(KrnlBuilder &createKrnl, mlir::ValueRange indices,
+          mlir::ValueRange blockIters)>
           bodyBuilderFn) const;
   mlir::KrnlIterateOp iterate(
       const krnl::KrnlIterateOperandPack &operands) const;
@@ -87,8 +87,8 @@ struct KrnlBuilder : public DialectBuilder {
   mlir::KrnlIterateOp iterateIE(mlir::ValueRange originalLoops,
       mlir::ValueRange optimizedLoops, mlir::ArrayRef<IndexExpr> lbs,
       mlir::ArrayRef<IndexExpr> ubs, mlir::ValueRange inits,
-      mlir::function_ref<void(
-          KrnlBuilder &createKrnl, mlir::ValueRange indices)>
+      mlir::function_ref<void(KrnlBuilder &createKrnl, mlir::ValueRange indices,
+          mlir::ValueRange blockIters)>
           bodyBuilderFn) const;
 
   void yield(mlir::ValueRange iterArgs) const;

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -65,6 +65,12 @@ struct KrnlBuilder : public DialectBuilder {
       mlir::function_ref<void(
           KrnlBuilder &createKrnl, mlir::ValueRange indices)>
           bodyBuilderFn) const;
+  mlir::KrnlIterateOp iterate(mlir::ValueRange originalLoops,
+      mlir::ValueRange optimizedLoops, mlir::ValueRange lbs,
+      mlir::ValueRange ubs, mlir::ValueRange inits,
+      mlir::function_ref<void(
+          KrnlBuilder &createKrnl, mlir::ValueRange indices)>
+          bodyBuilderFn) const;
   mlir::KrnlIterateOp iterate(
       const krnl::KrnlIterateOperandPack &operands) const;
 
@@ -75,6 +81,14 @@ struct KrnlBuilder : public DialectBuilder {
       mlir::function_ref<void(
           KrnlBuilder &createKrnl, mlir::ValueRange indices)>
           bodyBuilderFn) const;
+  mlir::KrnlIterateOp iterateIE(mlir::ValueRange originalLoops,
+      mlir::ValueRange optimizedLoops, mlir::ArrayRef<IndexExpr> lbs,
+      mlir::ArrayRef<IndexExpr> ubs, mlir::ValueRange inits,
+      mlir::function_ref<void(
+          KrnlBuilder &createKrnl, mlir::ValueRange indices)>
+          bodyBuilderFn) const;
+
+  void yield(mlir::ValueRange iterArgs) const;
 
   void copyToBuffer(
       // Buffer and source memory. Source memref may have a higher rank than

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -130,8 +130,35 @@ def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops", [NoMemoryEffect]> {
   }];
 }
 
-def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [RecursiveMemoryEffects, ImplicitKrnlTerminator,
-    DeclareOpInterfaceMethods<LoopLikeOpInterface>]> {
+def KrnlYieldOp : Op<Krnl_Dialect, "yield", [Pure, Terminator, ReturnLike,
+    MemRefsNormalizable]> {
+  let summary = "Yield values to parent operation";
+  let description = [{
+    The `krnl.yield` yields zero or more SSA values from an krnl.iterate op region and
+    terminates the region. The semantics of how the values yielded are used
+    is defined by the parent operation.
+    If `krnl.yield` has any operands, the operands must match the parent
+    operation's results.
+    If the parent operation defines no values, then the `krnl.yield` may be
+    left out in the custom syntax and the builders will insert one implicitly.
+    Otherwise, it has to be present in the syntax to indicate which values are
+    yielded.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  let builders = [
+    OpBuilder<(ins), [{ build($_builder, $_state, std::nullopt); }]>
+  ];
+
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
+  let hasVerifier = 1;
+}
+
+def ImplicitKrnlYield : SingleBlockImplicitTerminator<"KrnlYieldOp">;
+
+def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [RecursiveMemoryEffects, ImplicitKrnlYield,
+    DeclareOpInterfaceMethods<LoopLikeOpInterface, ["getInitsMutable", "getYieldedValuesMutable"]>]> {
   let summary = "iterate operation";
   let description = [{
     The "krnl.iterate" operation is conceptually equivalent to a nested for loops.
@@ -161,7 +188,7 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [RecursiveMemoryEffects, Implici
   }];
 
   let arguments = (ins Variadic<AnyType>);
-
+  let results = (outs Variadic<AnyType>:$results);
   let regions = (region SizedRegion<1>:$bodyRegion);
 
   let skipDefaultBuilders = 1;
@@ -201,6 +228,19 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [RecursiveMemoryEffects, Implici
           .getValue()
           .getSExtValue();
       return num_optimized_loops;
+    }
+
+    int64_t getNumIterArgs() { return getNumResults(); }
+
+    Block::BlockArgListType getRegionIterArgs() {
+      return Block::BlockArgListType(getBody()->getArguments().begin() +
+                                         (getBody()->getArguments().size() - getNumIterArgs()),
+          getBody()->getArguments().end());
+    }
+    ValueRange getIterArgInits() {
+      return iterator_range(
+          operand_begin() + (getNumOperands() - getNumIterArgs()),
+          operand_end());
     }
 
     // Get name of the attribute for storing bound represented using affine maps.

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -196,18 +196,18 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [RecursiveMemoryEffects, Implici
     // Main builder.
     OpBuilder<(ins "onnx_mlir::krnl::KrnlIterateOperandPack":$operandPack,
       CArg<"ValueRange", "std::nullopt">:$iterArgs,
-      CArg<"function_ref<void(OpBuilder &, Location, ValueRange)>", "nullptr">:$bodyBuilderFn)>,
+      CArg<"function_ref<void(OpBuilder &, Location, ValueRange, ValueRange)>", "nullptr">:$bodyBuilderFn)>,
     // Builder for the optimized iterate op.
     OpBuilder<(ins
       CArg<"ValueRange">:$originalLoops, CArg<"ValueRange">:$optimizedLoops,
       CArg<"ValueRange">:$lbs, CArg<"ValueRange">:$ubs, CArg<"ValueRange">:$iterArgs,
-      CArg<"function_ref<void(OpBuilder &, Location, ValueRange)>">:$bodyBuilderFn)>,
+      CArg<"function_ref<void(OpBuilder &, Location, ValueRange, ValueRange)>">:$bodyBuilderFn)>,
     // Builder for the optimized iterate op with IndexExpr
     OpBuilder<(ins
       CArg<"ValueRange">:$originalLoops, CArg<"ValueRange">:$optimizedLoops,
       CArg<"ArrayRef<onnx_mlir::IndexExpr>">:$lbs, CArg<"ArrayRef<onnx_mlir::IndexExpr>">:$ubs,
       CArg<"ValueRange">:$iterArgs,
-      CArg<"function_ref<void(OpBuilder &, Location, ValueRange)>">:$bodyBuilderFn)>
+      CArg<"function_ref<void(OpBuilder &, Location, ValueRange, ValueRange)>">:$bodyBuilderFn)>
   ];
 
   let hasCustomAssemblyFormat = 1;

--- a/test/mlir/conversion/krnl_to_affine/yield_to_affine.mlir
+++ b/test/mlir/conversion/krnl_to_affine/yield_to_affine.mlir
@@ -1,0 +1,225 @@
+// RUN: onnx-mlir-opt -O3 --convert-krnl-to-affine %s -split-input-file | FileCheck %s
+
+// yield value on a loop with unroll.
+func.func @unroll() -> index {
+  %cst = arith.constant 0 : index
+  %ii = krnl.define_loops 1
+  %alloca = memref.alloca() : memref<index>
+  krnl.store %cst, %alloca[] : memref<index>
+  %ii1, %ii2 = krnl.block %ii 4 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+  krnl.unroll %ii2 : !krnl.loop
+  krnl.iterate(%ii1) with (%ii -> %i = 0 to 8) {
+    %0 = krnl.iterate(%ii2) with () iter_args(%arg1 = %cst) -> (index) {
+      %i2 = krnl.get_induction_var_value(%ii2) : (!krnl.loop) -> index
+      %foo = arith.addi %arg1, %i2 : index
+	  krnl.yield %foo : index
+    }
+	%ld = krnl.load %alloca[] : memref<index>
+	%add = arith.addi %0, %ld : index
+	krnl.store %add, %alloca[] : memref<index>
+  }
+  %ld1 = krnl.load %alloca[] : memref<index>
+  return %ld1 : index
+  // #map = affine_map<(d0) -> (d0 + 1)>
+  // #map1 = affine_map<(d0) -> (d0 + 2)>
+  // #map2 = affine_map<(d0) -> (d0 + 3)>
+  // CHECK-LABEL: unroll
+  // CHECK: [[Cst:%.+]] = arith.constant 0 : index
+  // CHECK: [[Alloca:%.+]] = memref.alloca() : memref<index>
+  // CHECK:   affine.store [[Cst]], %alloca[] : memref<index>
+  // CHECK:  affine.for %arg0 = 0 to 8 step 4 {
+  // CHECK: [[Add0:%.+]] = arith.addi %c0, %arg0 : index
+  // CHECK: [[CST:%.+]] = affine.apply #map(%arg0)
+  // CHECK: [[Add1:%.+]] = arith.addi %1, %2 : index
+  // CHECK: [[CST:%.+]] = affine.apply #map1(%arg0)
+  // CHECK: [[Add2:%.+]] = arith.addi %3, %4 : index
+  // CHECK: [[CST:%.+]] = affine.apply #map2(%arg0)
+  // CHECK: [[Add3:%.+]] = arith.addi %5, %6 : index
+  // CHECK: [[AllocaLd:%.+]] = affine.load %alloca[] : memref<index>
+  // CHECK: [[AllocaAdd:%.+]] = arith.addi %7, %8 : index
+  // CHECK:   affine.store [[AllocaAdd]], %alloca[] : memref<index>
+  // CHECK: [[AllocaLd2:%.+]] = affine.load %alloca[] : memref<index>
+  // CHECK: return [[AllocaLd2]] : index
+
+}
+
+// -----
+
+// yield value when iterate is not a loop.
+func.func @no_loop(%arg0: memref<f32>) -> memref<f32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = memref.alloc() : memref<f32>
+  %1 = krnl.iterate() with () iter_args(%arg1 = %cst) -> (f32) {
+    %2 = memref.load %arg0[] : memref<f32>
+    memref.store %2, %0[] : memref<f32>
+    %3 = arith.addf %arg1, %2 : f32
+    krnl.yield %3 : f32
+  }
+  %4 = memref.load %arg0[] : memref<f32>
+  %5 = arith.addf %4, %1 : f32
+  memref.store %5, %0[] : memref<f32>
+  return %0 : memref<f32>
+  // CHECK-LABEL: no_loop
+  // CHECK: [[CST:%.+]] = arith.constant 0.000000e+00 : f32
+  // CHECK-NEXT: [[ALLOC:%.+]] = memref.alloc() : memref<f32>
+  // CHECK-NEXT: [[ArgLD:%.+]] = memref.load %arg0[] : memref<f32>
+  // CHECK-NEXT: memref.store [[ArgLD]], [[ALLOC]][] : memref<f32>
+  // CHECK-NEXT: [[CstAdd:%.+]] = arith.addf [[CST]], [[ArgLD]] : f32
+  // CHECK-NEXT: [[ArgLD2:%.+]] = memref.load %arg0[] : memref<f32>
+  // CHECK-NEXT: [[Add:%.+]] = arith.addf [[ArgLD2]], [[CstAdd]] : f32
+  // CHECK-NEXT: memref.store [[Add]], [[ALLOC]][] : memref<f32>
+  // CHECK-NEXT: return [[ALLOC]] : memref<f32>
+
+}
+
+// -----
+
+// yield more than one value.
+func.func @yield2(%arg0: memref<10x10xf32>, %arg1: memref<10x?xf32>) -> memref<10x10xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = memref.alloc() : memref<10x10xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %1 = memref.dim %arg1, %c1 : memref<10x?xf32>
+  %2:2 = krnl.define_loops 2
+  %y0, %y1 = krnl.iterate(%2#0, %2#1) with (%2#0 -> %arg2 = 0 to 10, %2#1 -> %arg3 = 0 to 10) iter_args(%arg4 = %cst, %arg5 = %cst) -> (f32, f32) {
+    %3 = krnl.load %arg0[%arg2, %arg3] : memref<10x10xf32>
+    %4 = arith.cmpi sgt, %1, %c1 : index
+    %5 = arith.select %4, %arg3, %c0 : index
+    %6 = krnl.load %arg1[%arg2, %5] : memref<10x?xf32>
+    %7 = arith.addf %3, %6 : f32
+    krnl.store %7, %0[%arg2, %arg3] : memref<10x10xf32>
+    %8 = arith.addf %arg4, %7 : f32
+    %9 = arith.mulf %arg5, %7 : f32
+    krnl.yield %8, %9 : f32, f32
+  }
+  %10 = arith.addf %y0, %y1 : f32
+  memref.store %10, %arg0[%c0, %c0] : memref<10x10xf32>
+  return %0 : memref<10x10xf32>
+	// CHECK-LABEL: yield2
+	// CHECK: [[Dim:%.+]] = memref.dim %arg1, %c1 : memref<10x?xf32>
+	// CHECK: [[Cmp:%.+]] = arith.cmpi sgt, [[Dim]], %c1 : index
+	// CHECK: [[For0:%.+]]:2 = affine.for %arg2 = 0 to 10 iter_args(%arg3 = %cst, %arg4 = %cst) -> (f32, f32) {
+	// CHECK: [[For1:%.+]]:2 = affine.for %arg5 = 0 to 10 iter_args(%arg6 = %arg3, %arg7 = %arg4) -> (f32, f32) {
+	// CHECK: [[Arg0Ld:%.+]] = affine.load %arg0[%arg2, %arg5] : memref<10x10xf32>
+	// CHECK: [[Sel:%.+]] = arith.select [[Cmp]], %arg5, %c0 : index
+	// CHECK: [[Arg1Ld:%.+]] = memref.load %arg1[%arg2, [[Sel]]] : memref<10x?xf32>
+	// CHECK: [[Add:%.+]] = arith.addf [[Arg0Ld]], [[Arg1Ld]] : f32
+	// CHECK:       affine.store [[Add]], %alloc[%arg2, %arg5] : memref<10x10xf32>
+	// CHECK: [[Add2:%.+]] = arith.addf %arg6, [[Add]] : f32
+	// CHECK: [[Mul:%.+]] = arith.mulf %arg7, [[Add]] : f32
+	// CHECK:        affine.yield [[Add2]], [[Mul]] : f32, f32
+	// CHECK:      affine.yield [[For1]]#0, [[For1]]#1 : f32, f32
+	// CHECK:   [[Add3:%.+]] = arith.addf [[For0]]#0, [[For0]]#1 : f32
+	// CHECK:    memref.store [[Add3]], %arg0[%c0, %c0] : memref<10x10xf32>
+}
+
+
+
+// -----
+
+// yield in outer iterate only.
+func.func @outer(%arg0: memref<3x4xf32>, %arg1: memref<4x3xf32> ) -> (memref<3x3xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() : memref<3x3xf32>
+  %0:3 = krnl.define_loops 3
+  %i = krnl.iterate(%0#0, %0#1) with (%0#0 -> %arg2 = 0 to 3, %0#1 -> %arg3 = 0 to 3, %0#2 -> %arg4 = 0 to 4) iter_args(%arg5 = %cst) -> (f32){
+    %1:2 = krnl.get_induction_var_value(%0#0, %0#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+      krnl.iterate(%0#2) with () {
+      %3 = krnl.get_induction_var_value(%0#2) : (!krnl.loop) -> index
+      %4 = krnl.load %arg0[%1#0, %3] : memref<3x4xf32>
+      %5 = krnl.load %arg1[%3, %1#1] : memref<4x3xf32>
+      %6 = arith.mulf %4, %5 : f32
+      %7 = arith.addf %arg5, %6 : f32
+      krnl.store %7, %alloc[%1#0, %1#1] : memref<3x3xf32>
+      krnl.yield
+    }
+    %8 = krnl.load %alloc[%1#0, %1#1] : memref<3x3xf32>
+    %9 = arith.addf %arg5, %8 : f32
+    krnl.yield %9 : f32
+  }
+  return %alloc : memref<3x3xf32>
+	// CHECK-LABEL: outer
+	// CHECK: [[For0:%.+]] = affine.for %arg2 = 0 to 3 iter_args(%arg3 = %cst) -> (f32) {
+	// CHECK: [[For1:%.+]] = affine.for %arg4 = 0 to 3 iter_args(%arg5 = %arg3) -> (f32) {
+	// CHECK:        affine.for %arg6 = 0 to 4 {
+	// CHECK: [[Arg0Ld:%.+]] = affine.load %arg0[%arg2, %arg6] : memref<3x4xf32>
+	// CHECK: [[Arg1Ld:%.+]] = affine.load %arg1[%arg6, %arg4] : memref<4x3xf32>
+	// CHECK: [[Mul:%.+]] = arith.mulf %4, %5 : f32
+	// CHECK: [[Add:%.+]] = arith.addf %arg5, %6 : f32
+	// CHECK:          affine.store [[Add]], %alloc[%arg2, %arg4] : memref<3x3xf32>
+	// CHECK: [[AllocLd:%.+]] = affine.load %alloc[%arg2, %arg4] : memref<3x3xf32>
+	// CHECK: [[Add2:%.+]] = arith.addf %arg5, [[AllocLd]] : f32
+	// CHECK:        affine.yield [[Add2]] : f32
+	// CHECK:      affine.yield [[For1]] : f32
+}
+
+
+// -----
+
+// yield in inner iterate only.
+func.func @inner(%arg0: memref<3x4xf32>, %arg1: memref<4x3xf32> ) -> (memref<3x3xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() : memref<3x3xf32>
+  %0:3 = krnl.define_loops 3
+  krnl.iterate(%0#0, %0#1) with (%0#0 -> %arg2 = 0 to 3, %0#1 -> %arg3 = 0 to 3, %0#2 -> %arg4 = 0 to 4) {
+    %1:2 = krnl.get_induction_var_value(%0#0, %0#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+    %2 = krnl.iterate(%0#2) with () iter_args(%arg5 = %cst) -> (f32){
+      %3 = krnl.get_induction_var_value(%0#2) : (!krnl.loop) -> index
+      %4 = krnl.load %arg0[%1#0, %3] : memref<3x4xf32>
+      %5 = krnl.load %arg1[%3, %1#1] : memref<4x3xf32>
+      %6 = arith.mulf %4, %5 : f32
+      %7 = arith.addf %arg5, %6 : f32
+      krnl.yield %7 : f32
+    }
+    krnl.store %2, %alloc[%1#0, %1#1] : memref<3x3xf32>
+    krnl.yield
+  }
+  return %alloc : memref<3x3xf32>
+	// CHECK-LABEL: inner
+	// CHECK:    affine.for %arg2 = 0 to 3 {
+	// CHECK:      affine.for %arg3 = 0 to 3 {
+	// CHECK: [[For2:%.+]] = affine.for %arg4 = 0 to 4 iter_args(%arg5 = %cst) -> (f32) {
+	// CHECK: [[Arg0Ld:%.+]] = affine.load %arg0[%arg2, %arg4] : memref<3x4xf32>
+	// CHECK: [[Arg1Ld:%.+]] = affine.load %arg1[%arg4, %arg3] : memref<4x3xf32>
+	// CHECK: [[Mul:%.+]] = arith.mulf [[Arg0Ld]], [[Arg1Ld]] : f32
+	// CHECK: [[Add:%.+]] = arith.addf %arg5, [[Mul]] : f32
+	// CHECK:          affine.yield [[Add]] : f32
+	// CHECK:        affine.store [[For2]], %alloc[%arg2, %arg3] : memref<3x3xf32>
+}
+
+
+// -----
+
+// yield in both inner and outter iterate.
+func.func @both(%arg0: memref<3x4xf32>, %arg1: memref<4x3xf32> ) -> (memref<3x3xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() : memref<3x3xf32>
+  %0:3 = krnl.define_loops 3
+  %i = krnl.iterate(%0#0, %0#1) with (%0#0 -> %arg2 = 0 to 3, %0#1 -> %arg3 = 0 to 3, %0#2 -> %arg4 = 0 to 4) iter_args(%arg5 = %cst) -> (f32){
+    %1:2 = krnl.get_induction_var_value(%0#0, %0#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+    %2 = krnl.iterate(%0#2) with () iter_args(%arg6 = %arg5) -> (f32){
+      %3 = krnl.get_induction_var_value(%0#2) : (!krnl.loop) -> index
+      %4 = krnl.load %arg0[%1#0, %3] : memref<3x4xf32>
+      %5 = krnl.load %arg1[%3, %1#1] : memref<4x3xf32>
+      %6 = arith.mulf %4, %5 : f32
+      %7 = arith.addf %arg6, %6 : f32
+      krnl.yield %7 : f32
+    }
+    krnl.store %2, %alloc[%1#0, %1#1] : memref<3x3xf32>
+    krnl.yield %2 : f32
+  }
+  return %alloc : memref<3x3xf32>
+	// CHECK-LABEL: both
+	// CHECK: [[For0:%.+]] = affine.for %arg2 = 0 to 3 iter_args(%arg3 = %cst) -> (f32) {
+	// CHECK: [[For1:%.+]] = affine.for %arg4 = 0 to 3 iter_args(%arg5 = %arg3) -> (f32) {
+	// CHECK: [[For2:%.+]] = affine.for %arg6 = 0 to 4 iter_args(%arg7 = %arg5) -> (f32) {
+	// CHECK: [[Arg0Ld:%.+]] = affine.load %arg0[%arg2, %arg6] : memref<3x4xf32>
+	// CHECK: [[Arg1Ld:%.+]] = affine.load %arg1[%arg6, %arg4] : memref<4x3xf32>
+	// CHECK: [[Mul:%.+]] = arith.mulf [[Arg0Ld]], [[Arg1Ld]] : f32
+	// CHECK: [[Add:%.+]] = arith.addf %arg7, [[Mul]] : f32
+	// CHECK:        affine.yield [[Add]] : f32
+	// CHECK:      affine.store [[For2]], %alloc[%arg2, %arg4] : memref<3x3xf32>
+	// CHECK:      affine.yield [[For2]] : f32
+	// CHECK:   affine.yield [[For1]] : f32
+}

--- a/test/mlir/conversion/onnx_to_krnl/Math/MatMul.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/MatMul.mlir
@@ -16,19 +16,15 @@ func.func private @test_matmul1(%arg0 : tensor<16x16xf32>, %arg1 : tensor<16x16x
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 16, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 16, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 16){
 // CHECK-DAG:         [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.iterate([[LOOP_0_]]#2) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_0_]]#2) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]#2) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_1_]]#0, [[VAR_3_]]{{.}} : memref<16x16xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_3_]], [[VAR_1_]]#1] : memref<16x16xf32>
-// CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_1_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<16x16xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<16x16xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<16x16xf32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_krnl/Math/MatMulInteger_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/MatMulInteger_with_canonicalize.mlir
@@ -72,19 +72,15 @@ func.func @test_matmulinteger_per_tensor(%arg0: tensor<16x32xui8>, %arg1: tensor
 // CHECK-DAG:       [[LOOP_6_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_6_]]#0, [[LOOP_6_]]#1) with ([[LOOP_6_]]#0 -> [[I_10_:%.+]] = 0 to 16, [[LOOP_6_]]#1 -> [[I_11_:%.+]] = 0 to 64, [[LOOP_6_]]#2 -> [[I_12_:%.+]] = 0 to 32){
 // CHECK-DAG:         [[VAR_7_6_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_6_]]#0, [[LOOP_6_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_7_:%.+]] = memref.alloca() : memref<i32>
-// CHECK:             krnl.store [[CST_0_]], [[RES_7_]][] : memref<i32>
-// CHECK:             krnl.iterate([[LOOP_6_]]#2) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_6_]]#2) with () iter_args([[IterArg:%.+]] = [[CST_0_]]) -> (i32){
 // CHECK:               [[VAR_9_4_:%.+]] = krnl.get_induction_var_value([[LOOP_6_]]#2) : (!krnl.loop) -> index
 // CHECK-DAG:           [[VAR_10_5_:%.+]] = krnl.load [[RES_2_]]{{.}}[[VAR_7_6_]]#0, [[VAR_9_4_]]{{.}} : memref<16x32xi32>
 // CHECK-DAG:           [[LOAD_RES_5_MEM_:%.+]] = krnl.load [[RES_5_]]{{.}}[[VAR_9_4_]], [[VAR_7_6_]]#1] : memref<32x64xi32>
-// CHECK-DAG:           [[LOAD_RES_7_MEM_:%.+]] = krnl.load [[RES_7_]][] : memref<i32>
 // CHECK:               [[VAR_13_:%.+]] = arith.muli [[VAR_10_5_]], [[LOAD_RES_5_MEM_]] : i32
-// CHECK:               [[VAR_14_:%.+]] = arith.addi [[LOAD_RES_7_MEM_]], [[VAR_13_]] : i32
-// CHECK:               krnl.store [[VAR_14_]], [[RES_7_]][] : memref<i32>
+// CHECK:               [[VAR_14_:%.+]] = arith.addi [[IterArg]], [[VAR_13_]] : i32
+// CHECK:               krnl.yield [[VAR_14_]] : i32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_7_MEM_1_:%.+]] = krnl.load [[RES_7_]][] : memref<i32>
-// CHECK:             krnl.store [[LOAD_RES_7_MEM_1_]], [[RES_6_]]{{.}}[[VAR_7_6_]]#0, [[VAR_7_6_]]#1] : memref<16x64xi32>
+// CHECK:             krnl.store [[IterResult]], [[RES_6_]]{{.}}[[VAR_7_6_]]#0, [[VAR_7_6_]]#1] : memref<16x64xi32>
 // CHECK:           }
 // CHECK:           return [[RES_6_]] : memref<16x64xi32>
 // CHECK:         }
@@ -160,19 +156,15 @@ func.func @test_matmulinteger_per_row_a(%arg0: tensor<16x32xui8>, %arg1: tensor<
 // CHECK-DAG:       [[LOOP_6_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_6_]]#0, [[LOOP_6_]]#1) with ([[LOOP_6_]]#0 -> [[I_10_:%.+]] = 0 to 16, [[LOOP_6_]]#1 -> [[I_11_:%.+]] = 0 to 64, [[LOOP_6_]]#2 -> [[I_12_:%.+]] = 0 to 32){
 // CHECK-DAG:         [[VAR_7_6_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_6_]]#0, [[LOOP_6_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_7_:%.+]] = memref.alloca() : memref<i32>
-// CHECK:             krnl.store [[CST_0_]], [[RES_7_]][] : memref<i32>
-// CHECK:             krnl.iterate([[LOOP_6_]]#2) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_6_]]#2) with () iter_args([[IterArg:%.+]] = [[CST_0_]]) -> (i32){
 // CHECK:               [[VAR_9_4_:%.+]] = krnl.get_induction_var_value([[LOOP_6_]]#2) : (!krnl.loop) -> index
 // CHECK-DAG:           [[VAR_10_5_:%.+]] = krnl.load [[RES_2_]]{{.}}[[VAR_7_6_]]#0, [[VAR_9_4_]]{{.}} : memref<16x32xi32>
 // CHECK-DAG:           [[LOAD_RES_5_MEM_:%.+]] = krnl.load [[RES_5_]]{{.}}[[VAR_9_4_]], [[VAR_7_6_]]#1] : memref<32x64xi32>
-// CHECK-DAG:           [[LOAD_RES_7_MEM_:%.+]] = krnl.load [[RES_7_]][] : memref<i32>
 // CHECK:               [[VAR_13_:%.+]] = arith.muli [[VAR_10_5_]], [[LOAD_RES_5_MEM_]] : i32
-// CHECK:               [[VAR_14_:%.+]] = arith.addi [[LOAD_RES_7_MEM_]], [[VAR_13_]] : i32
-// CHECK:               krnl.store [[VAR_14_]], [[RES_7_]][] : memref<i32>
+// CHECK:               [[VAR_14_:%.+]] = arith.addi [[IterArg]], [[VAR_13_]] : i32
+// CHECK:               krnl.yield [[VAR_14_]] : i32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_7_MEM_1_:%.+]] = krnl.load [[RES_7_]][] : memref<i32>
-// CHECK:             krnl.store [[LOAD_RES_7_MEM_1_]], [[RES_6_]]{{.}}[[VAR_7_6_]]#0, [[VAR_7_6_]]#1] : memref<16x64xi32>
+// CHECK:             krnl.store [[IterResult]], [[RES_6_]]{{.}}[[VAR_7_6_]]#0, [[VAR_7_6_]]#1] : memref<16x64xi32>
 // CHECK:           }
 // CHECK:           return [[RES_6_]] : memref<16x64xi32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_canonicalize.mlir
@@ -19,19 +19,15 @@ func.func private @test_matmul1(%arg0 : tensor<16x16xf32>, %arg1 : tensor<16x16x
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 16, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 16, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 16){
 // CHECK-DAG:         [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.iterate([[LOOP_0_]]#2) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_0_]]#2) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]#2) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_1_]]#0, [[VAR_3_]]{{.}} : memref<16x16xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_3_]], [[VAR_1_]]#1] : memref<16x16xf32>
-// CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_1_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<16x16xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<16x16xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<16x16xf32>
 // CHECK:         }
@@ -53,19 +49,15 @@ func.func private @test_matmul2(%arg0 : tensor<10x5xf32>, %arg1 : tensor<2x3x5x1
 // CHECK-DAG:       [[RES_1_:%.+]]:5 = krnl.define_loops 5
 // CHECK:           krnl.iterate([[RES_1_]]#0, [[RES_1_]]#1, [[RES_1_]]#2, [[RES_1_]]#3) with ([[RES_1_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[RES_1_]]#1 -> [[I_1_:%.+]] = 0 to 3, [[RES_1_]]#2 -> [[I_2_:%.+]] = 0 to 10, [[RES_1_]]#3 -> [[I_3_:%.+]] = 0 to 10, [[RES_1_]]#4 -> [[I_4_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[VAR_1_:%.+]]:4 = krnl.get_induction_var_value([[RES_1_]]#0, [[RES_1_]]#1, [[RES_1_]]#2, [[RES_1_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.iterate([[RES_1_]]#4) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[RES_1_]]#4) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[RES_1_]]#4) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_1_]]#2, [[VAR_3_]]{{.}} : memref<10x5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_3_]], [[VAR_1_]]#3] : memref<2x3x5x10xf32>
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_2_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_2_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2, [[VAR_1_]]#3] : memref<2x3x10x10xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2, [[VAR_1_]]#3] : memref<2x3x10x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<2x3x10x10xf32>
 // CHECK:         }
@@ -87,19 +79,15 @@ func.func private @test_matmul3(%arg0 : tensor<2x3x10x5xf32>, %arg1 : tensor<2x3
 // CHECK-DAG:       [[RES_1_:%.+]]:5 = krnl.define_loops 5
 // CHECK:           krnl.iterate([[RES_1_]]#0, [[RES_1_]]#1, [[RES_1_]]#2, [[RES_1_]]#3) with ([[RES_1_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[RES_1_]]#1 -> [[I_1_:%.+]] = 0 to 3, [[RES_1_]]#2 -> [[I_2_:%.+]] = 0 to 10, [[RES_1_]]#3 -> [[I_3_:%.+]] = 0 to 10, [[RES_1_]]#4 -> [[I_4_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[VAR_1_:%.+]]:4 = krnl.get_induction_var_value([[RES_1_]]#0, [[RES_1_]]#1, [[RES_1_]]#2, [[RES_1_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.iterate([[RES_1_]]#4) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[RES_1_]]#4) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[RES_1_]]#4) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2, [[VAR_3_]]{{.}} : memref<2x3x10x5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_3_]], [[VAR_1_]]#3] : memref<2x3x5x10xf32>
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_2_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_2_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2, [[VAR_1_]]#3] : memref<2x3x10x10xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2, [[VAR_1_]]#3] : memref<2x3x10x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<2x3x10x10xf32>
 // CHECK:         }
@@ -121,19 +109,15 @@ func.func private @test_matmul4(%arg0 : tensor<5xf32>, %arg1 : tensor<5x10xf32>)
 // CHECK-DAG:       [[RES_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[RES_1_]]#0) with ([[RES_1_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[RES_1_]]#1 -> [[I_1_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[VAR_1_:%.+]] = krnl.get_induction_var_value([[RES_1_]]#0) : (!krnl.loop) -> index
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.iterate([[RES_1_]]#1) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[RES_1_]]#1) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[RES_1_]]#1) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_3_]]{{.}} : memref<5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_3_]], [[VAR_1_]]{{.}} : memref<5x10xf32>
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_2_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_2_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<10xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<10xf32>
 // CHECK:         }
@@ -158,19 +142,15 @@ func.func private @test_matmul5(%arg0 : tensor<5xf32>, %arg1 : tensor<?x5x10xf32
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_0_]]([[VAR_dim_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[RES_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.iterate([[LOOP_0_]]#2) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_0_]]#2) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]#2) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_3_]]{{.}} : memref<5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[RES_1_]]#0, [[VAR_3_]], [[RES_1_]]#1] : memref<?x5x10xf32>
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_2_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_2_MEM_1_]], [[RES_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1] : memref<?x10xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1] : memref<?x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x10xf32>
 // CHECK:         }
@@ -195,19 +175,15 @@ func.func private @test_matmul6(%arg0 : tensor<?x10x5xf32>, %arg1 : tensor<5xf32
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_0_]]([[VAR_dim_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[RES_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.iterate([[LOOP_0_]]#2) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_0_]]#2) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]#2) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1, [[VAR_3_]]{{.}} : memref<?x10x5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_3_]]{{.}} : memref<5xf32>
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_2_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_2_MEM_1_]], [[RES_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1] : memref<?x10xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1] : memref<?x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x10xf32>
 // CHECK:         }
@@ -228,19 +204,15 @@ func.func private @test_matmul7(%arg0 : tensor<5xf32>, %arg1 : tensor<5xf32>) ->
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<f32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate() with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 5){
-// CHECK:             [[RES_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.iterate([[LOOP_0_]]) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_0_]]) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_2_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_2_]]{{.}} : memref<5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_2_]]{{.}} : memref<5xf32>
-// CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:               [[VAR_6_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_7_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_6_]] : f32
-// CHECK:               krnl.store [[VAR_7_]], [[RES_1_]][] : memref<f32>
+// CHECK:               [[VAR_7_:%.+]] = arith.addf [[IterArg]], [[VAR_6_]] : f32
+// CHECK:               krnl.yield [[VAR_7_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]][] : memref<f32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]][] : memref<f32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<f32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/MatMul_with_canonicalize_O3.mlir
@@ -123,19 +123,15 @@ func.func private @test_matmul4(%arg0 : tensor<5xf32>, %arg1 : tensor<5x10xf32>)
 // CHECK-DAG:       [[RES_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[RES_1_]]#0) with ([[RES_1_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[RES_1_]]#1 -> [[I_1_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[VAR_1_:%.+]] = krnl.get_induction_var_value([[RES_1_]]#0) : (!krnl.loop) -> index
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.iterate([[RES_1_]]#1) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[RES_1_]]#1) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[RES_1_]]#1) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_3_]]{{.}} : memref<5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_3_]], [[VAR_1_]]{{.}} : memref<5x10xf32>
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_2_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_2_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<10xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]{{.}} : memref<10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<10xf32>
 // CHECK:         }
@@ -160,19 +156,15 @@ func.func private @test_matmul5(%arg0 : tensor<5xf32>, %arg1 : tensor<?x5x10xf32
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_0_]]([[VAR_dim_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[RES_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.iterate([[LOOP_0_]]#2) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_0_]]#2) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]#2) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_3_]]{{.}} : memref<5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[RES_1_]]#0, [[VAR_3_]], [[RES_1_]]#1] : memref<?x5x10xf32>
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_2_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_2_MEM_1_]], [[RES_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1] : memref<?x10xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1] : memref<?x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x10xf32>
 // CHECK:         }
@@ -197,19 +189,15 @@ func.func private @test_matmul6(%arg0 : tensor<?x10x5xf32>, %arg1 : tensor<5xf32
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_0_]]([[VAR_dim_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 10, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[RES_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.iterate([[LOOP_0_]]#2) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_0_]]#2) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]#2) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1, [[VAR_3_]]{{.}} : memref<?x10x5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_3_]]{{.}} : memref<5xf32>
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[VAR_7_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_2_MEM_]], [[VAR_7_]] : f32
-// CHECK:               krnl.store [[VAR_8_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterArg]], [[VAR_7_]] : f32
+// CHECK:               krnl.yield [[VAR_8_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_2_MEM_1_]], [[RES_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1] : memref<?x10xf32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]]{{.}}[[RES_1_]]#0, [[RES_1_]]#1] : memref<?x10xf32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<?x10xf32>
 // CHECK:         }
@@ -230,19 +218,15 @@ func.func private @test_matmul7(%arg0 : tensor<5xf32>, %arg1 : tensor<5xf32>) ->
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<f32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate() with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 5){
-// CHECK:             [[RES_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.iterate([[LOOP_0_]]) with (){
+// CHECK:             [[IterResult:%.+]] = krnl.iterate([[LOOP_0_]]) with () iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:               [[VAR_2_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
 // CHECK-DAG:           [[LOAD_A_MEM_:%.+]] = krnl.load [[A_]]{{.}}[[VAR_2_]]{{.}} : memref<5xf32>
 // CHECK-DAG:           [[LOAD_B_MEM_:%.+]] = krnl.load [[B_]]{{.}}[[VAR_2_]]{{.}} : memref<5xf32>
-// CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:               [[VAR_6_:%.+]] = arith.mulf [[LOAD_A_MEM_]], [[LOAD_B_MEM_]] : f32
-// CHECK:               [[VAR_7_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_6_]] : f32
-// CHECK:               krnl.store [[VAR_7_]], [[RES_1_]][] : memref<f32>
+// CHECK:               [[VAR_7_:%.+]] = arith.addf [[IterArg]], [[VAR_6_]] : f32
+// CHECK:               krnl.yield [[VAR_7_]] : f32
 // CHECK:             }
-// CHECK:             [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]][] : memref<f32>
+// CHECK:             krnl.store [[IterResult]], [[RES_]][] : memref<f32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<f32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_canonicalize.mlir
@@ -12,40 +12,32 @@ func.func private @test_softmax_v11(%arg0 : tensor<10x20x30xf32>) -> tensor<*xf3
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<10x20x30xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<f32>
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<f32>
 // CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 10){
 // CHECK:             [[VAR_4_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[VAR_1_]][] : memref<f32>
-// CHECK:             krnl.store [[CST_0_]], [[VAR_0_]][] : memref<f32>
 // CHECK:             [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_1_:%.+]] = 0 to 20, [[LOOP_1_]]#1 -> [[I_2_:%.+]] = 0 to 30){
+// CHECK:             [[Iter0Result:%.+]] = krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_1_:%.+]] = 0 to 20, [[LOOP_1_]]#1 -> [[I_2_:%.+]] = 0 to 30) iter_args([[Iter0Arg:%.+]] = [[CST_0_]]) -> (f32){
 // CHECK-DAG:           [[VAR_10_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[LOAD_VAR_0_MEM_:%.+]] = krnl.load [[VAR_0_]][] : memref<f32>
 // CHECK:               [[LOAD_arg0_MEM_:%.+]] = krnl.load [[arg0_]]{{.}}[[VAR_4_]], [[VAR_10_]]#0, [[VAR_10_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_13_:%.+]] = arith.cmpf ogt, [[LOAD_VAR_0_MEM_]], [[LOAD_arg0_MEM_]] : f32
-// CHECK:               [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[LOAD_VAR_0_MEM_]], [[LOAD_arg0_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_14_]], [[VAR_0_]][] : memref<f32>
+// CHECK:               [[VAR_13_:%.+]] = arith.cmpf ogt, [[Iter0Arg]], [[LOAD_arg0_MEM_]] : f32
+// CHECK:               [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[Iter0Arg]], [[LOAD_arg0_MEM_]] : f32
+// CHECK:               krnl.yield [[VAR_14_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOAD_VAR_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]][] : memref<f32>
 // CHECK-DAG:         [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = 0 to 20, [[LOOP_2_]]#1 -> [[I_4_:%.+]] = 0 to 30){
+// CHECK:             [[Iter1Result:%.+]] = krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_3_:%.+]] = 0 to 20, [[LOOP_2_]]#1 -> [[I_4_:%.+]] = 0 to 30) iter_args([[Iter1Arg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK-DAG:           [[VAR_10_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:           [[LOAD_VAR_0_MEM_2_:%.+]] = krnl.load [[VAR_1_]][] : memref<f32>
 // CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = krnl.load [[arg0_]]{{.}}[[VAR_4_]], [[VAR_10_1_]]#0, [[VAR_10_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_13_1_:%.+]] = arith.subf [[LOAD_arg0_MEM_1_]], [[LOAD_VAR_0_MEM_1_]] : f32
+// CHECK:               [[VAR_13_1_:%.+]] = arith.subf [[LOAD_arg0_MEM_1_]], [[Iter0Result]] : f32
 // CHECK:               [[VAR_14_1_:%.+]] = math.exp [[VAR_13_1_]] : f32
-// CHECK:               [[VAR_15_:%.+]] = arith.addf [[LOAD_VAR_0_MEM_2_]], [[VAR_14_1_]] : f32
-// CHECK:               krnl.store [[VAR_15_]], [[VAR_1_]][] : memref<f32>
+// CHECK:               [[VAR_15_:%.+]] = arith.addf [[Iter1Arg]], [[VAR_14_1_]] : f32
 // CHECK:               krnl.store [[VAR_14_1_]], [[VAR_2_]]{{.}}[[VAR_4_]], [[VAR_10_1_]]#0, [[VAR_10_1_]]#1] : memref<10x20x30xf32>
+// CHECK:               krnl.yield [[VAR_15_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOAD_VAR_1_MEM_:%.+]] = krnl.load [[VAR_1_]][] : memref<f32>
 // CHECK-DAG:         [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
 // CHECK:             krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_5_:%.+]] = 0 to 20, [[LOOP_3_]]#1 -> [[I_6_:%.+]] = 0 to 30){
 // CHECK:               [[VAR_10_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:               [[LOAD_VAR_0_MEM_2_:%.+]] = krnl.load [[VAR_2_]]{{.}}[[VAR_4_]], [[VAR_10_2_]]#0, [[VAR_10_2_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = arith.divf [[LOAD_VAR_0_MEM_2_]], [[LOAD_VAR_1_MEM_]] : f32
+// CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = arith.divf [[LOAD_VAR_0_MEM_2_]], [[Iter1Result]] : f32
 // CHECK:               krnl.store [[LOAD_arg0_MEM_1_]], [[VAR_2_]]{{.}}[[VAR_4_]], [[VAR_10_2_]]#0, [[VAR_10_2_]]#1] : memref<10x20x30xf32>
 // CHECK:             }
 // CHECK:           }
@@ -65,40 +57,32 @@ func.func private @test_softmax_v13(%arg0 : tensor<10x20x30xf32>) -> tensor<*xf3
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc() {{.*}}: memref<10x20x30xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = memref.alloc() {{.*}}: memref<f32>
-// CHECK-DAG:       [[VAR_0_:%.+]] = memref.alloc() {{.*}}: memref<f32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 30){
 // CHECK:             [[VAR_4_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[VAR_1_]][] : memref<f32>
-// CHECK:             krnl.store [[CST_0_]], [[VAR_0_]][] : memref<f32>
 // CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
-// CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 20){
+// CHECK:             [[Iter0Result:%.+]] = krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 20) iter_args([[Iter0Arg:%.+]] = [[CST_0_]]) -> (f32){
 // CHECK-DAG:           [[VAR_10_:%.+]] = krnl.get_induction_var_value([[LOOP_1_]]) : (!krnl.loop) -> index
-// CHECK-DAG:           [[LOAD_VAR_0_MEM_:%.+]] = krnl.load [[VAR_0_]][] : memref<f32>
 // CHECK:               [[LOAD_arg0_MEM_:%.+]] = krnl.load [[arg0_]]{{.}}[[VAR_4_]]#0, [[VAR_10_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_13_:%.+]] = arith.cmpf ogt, [[LOAD_VAR_0_MEM_]], [[LOAD_arg0_MEM_]] : f32
-// CHECK:               [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[LOAD_VAR_0_MEM_]], [[LOAD_arg0_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_14_]], [[VAR_0_]][] : memref<f32>
+// CHECK:               [[VAR_13_:%.+]] = arith.cmpf ogt, [[Iter0Arg]], [[LOAD_arg0_MEM_]] : f32
+// CHECK:               [[VAR_14_:%.+]] = arith.select [[VAR_13_]], [[Iter0Arg]], [[LOAD_arg0_MEM_]] : f32
+// CHECK:               krnl.yield [[VAR_14_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOAD_VAR_0_MEM_1_:%.+]] = krnl.load [[VAR_0_]][] : memref<f32>
 // CHECK-DAG:         [[LOOP_2_:%.+]] = krnl.define_loops 1
-// CHECK:             krnl.iterate([[LOOP_2_]]) with ([[LOOP_2_]] -> [[I_3_:%.+]] = 0 to 20){
+// CHECK:             [[Iter1Result:%.+]] = krnl.iterate([[LOOP_2_]]) with ([[LOOP_2_]] -> [[I_3_:%.+]] = 0 to 20) iter_args([[Iter1Arg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK-DAG:           [[VAR_10_1_:%.+]] = krnl.get_induction_var_value([[LOOP_2_]]) : (!krnl.loop) -> index
-// CHECK-DAG:           [[LOAD_VAR_0_MEM_2_:%.+]] = krnl.load [[VAR_1_]][] : memref<f32>
 // CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = krnl.load [[arg0_]]{{.}}[[VAR_4_]]#0, [[VAR_10_1_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_13_1_:%.+]] = arith.subf [[LOAD_arg0_MEM_1_]], [[LOAD_VAR_0_MEM_1_]] : f32
+// CHECK:               [[VAR_13_1_:%.+]] = arith.subf [[LOAD_arg0_MEM_1_]], [[Iter0Result]] : f32
 // CHECK:               [[VAR_14_1_:%.+]] = math.exp [[VAR_13_1_]] : f32
-// CHECK:               [[VAR_15_:%.+]] = arith.addf [[LOAD_VAR_0_MEM_2_]], [[VAR_14_1_]] : f32
-// CHECK:               krnl.store [[VAR_15_]], [[VAR_1_]][] : memref<f32>
+// CHECK:               [[VAR_15_:%.+]] = arith.addf [[Iter1Arg]], [[VAR_14_1_]] : f32
 // CHECK:               krnl.store [[VAR_14_1_]], [[VAR_2_]]{{.}}[[VAR_4_]]#0, [[VAR_10_1_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
+// CHECK:               krnl.yield [[VAR_15_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOAD_VAR_1_MEM_:%.+]] = krnl.load [[VAR_1_]][] : memref<f32>
 // CHECK-DAG:         [[LOOP_3_:%.+]] = krnl.define_loops 1
 // CHECK:             krnl.iterate([[LOOP_3_]]) with ([[LOOP_3_]] -> [[I_4_:%.+]] = 0 to 20){
 // CHECK:               [[VAR_10_2_:%.+]] = krnl.get_induction_var_value([[LOOP_3_]]) : (!krnl.loop) -> index
 // CHECK:               [[LOAD_VAR_0_MEM_2_:%.+]] = krnl.load [[VAR_2_]]{{.}}[[VAR_4_]]#0, [[VAR_10_2_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = arith.divf [[LOAD_VAR_0_MEM_2_]], [[LOAD_VAR_1_MEM_]] : f32
+// CHECK:               [[LOAD_arg0_MEM_1_:%.+]] = arith.divf [[LOAD_VAR_0_MEM_2_]], [[Iter1Result]] : f32
 // CHECK:               krnl.store [[LOAD_arg0_MEM_1_]], [[VAR_2_]]{{.}}[[VAR_4_]]#0, [[VAR_10_2_]], [[VAR_4_]]#1] : memref<10x20x30xf32>
 // CHECK:             }
 // CHECK:           }

--- a/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_parallel_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Softmax_with_parallel_canonicalize_O3.mlir
@@ -22,37 +22,28 @@ func.func @test_softmax_v13_parallel(%arg0 : tensor<10x20x30xf32>) -> tensor<*xf
 // CHECK:           krnl.parallel([[LOOP_0_]]#0) : !krnl.loop
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 30){
 // CHECK-DAG:         [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloca() : memref<f32>
-// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloca() : memref<f32>
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
-// CHECK:             krnl.store [[CST_0_]], [[RES_2_]][] : memref<f32>
 // CHECK:             [[LOOP_1_:%.+]] = krnl.define_loops 1
-// CHECK:             krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 20){
+// CHECK:             [[Iter0Result:%.+]] = krnl.iterate([[LOOP_1_]]) with ([[LOOP_1_]] -> [[I_2_:%.+]] = 0 to 20) iter_args([[Iter0Arg:%.+]] = [[CST_0_]]) -> (f32){
 // CHECK-DAG:           [[VAR_7_:%.+]] = krnl.get_induction_var_value([[LOOP_1_]]) : (!krnl.loop) -> index
-// CHECK-DAG:           [[LOAD_RES_2_MEM_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK:               [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_7_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_10_:%.+]] = arith.cmpf ogt, [[LOAD_RES_2_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:               [[VAR_11_:%.+]] = arith.select [[VAR_10_]], [[LOAD_RES_2_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_11_]], [[RES_2_]][] : memref<f32>
+// CHECK:               [[VAR_10_:%.+]] = arith.cmpf ogt, [[Iter0Arg]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:               [[VAR_11_:%.+]] = arith.select [[VAR_10_]], [[Iter0Arg]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:               krnl.yield [[VAR_11_]] : f32
 // CHECK:             }
-// CHECK-DAG:         [[LOAD_RES_2_MEM_1_:%.+]] = krnl.load [[RES_2_]][] : memref<f32>
 // CHECK-DAG:         [[LOOP_2_:%.+]] = krnl.define_loops 1
-// CHECK:             krnl.iterate([[LOOP_2_]]) with ([[LOOP_2_]] -> [[I_3_:%.+]] = 0 to 20){
+// CHECK:             [[Iter1Result:%.+]] = krnl.iterate([[LOOP_2_]]) with ([[LOOP_2_]] -> [[I_3_:%.+]] = 0 to 20) iter_args([[Iter1Arg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK-DAG:           [[VAR_7_1_:%.+]] = krnl.get_induction_var_value([[LOOP_2_]]) : (!krnl.loop) -> index
-// CHECK-DAG:           [[LOAD_RES_2_MEM_2_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_7_1_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[VAR_10_1_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_1_]], [[LOAD_RES_2_MEM_1_]] : f32
+// CHECK:               [[VAR_10_1_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_1_]], [[Iter0Result]] : f32
 // CHECK:               [[VAR_11_1_:%.+]] = math.exp [[VAR_10_1_]] : f32
-// CHECK:               [[VAR_12_:%.+]] = arith.addf [[LOAD_RES_2_MEM_2_]], [[VAR_11_1_]] : f32
-// CHECK:               krnl.store [[VAR_12_]], [[RES_1_]][] : memref<f32>
+// CHECK:               [[VAR_12_:%.+]] = arith.addf [[Iter1Arg]], [[VAR_11_1_]] : f32
 // CHECK:               krnl.store [[VAR_11_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_1_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
-// CHECK:             }
-// CHECK-DAG:         [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
+// CHECK:               krnl.yield [[VAR_12_]] : f32
 // CHECK-DAG:         [[LOOP_3_:%.+]] = krnl.define_loops 1
 // CHECK:             krnl.iterate([[LOOP_3_]]) with ([[LOOP_3_]] -> [[I_4_:%.+]] = 0 to 20){
 // CHECK:               [[VAR_7_2_:%.+]] = krnl.get_induction_var_value([[LOOP_3_]]) : (!krnl.loop) -> index
 // CHECK:               [[LOAD_RES_2_MEM_2_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_2_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
-// CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = arith.divf [[LOAD_RES_2_MEM_2_]], [[LOAD_RES_1_MEM_]] : f32
+// CHECK:               [[LOAD_PARAM_0_MEM_1_:%.+]] = arith.divf [[LOAD_RES_2_MEM_2_]], [[Iter1Result]] : f32
 // CHECK:               krnl.store [[LOAD_PARAM_0_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_7_2_]], [[VAR_1_]]#1] : memref<10x20x30xf32>
 // CHECK:             }
 // CHECK:           }

--- a/test/mlir/conversion/onnx_to_krnl/NN/Conv_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/NN/Conv_with_canonicalize.mlir
@@ -40,17 +40,15 @@ func.func private @test_conv_unknown_dimensions(%arg0 : tensor<?x?x?x?xf32>, %ar
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_2_]]([[VAR_dim_0_]], [[VAR_dim_1_]], [[VAR_dim_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 1, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[VAR_3_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloca() : memref<f32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_4_:%.+]] = affine.apply [[MAP_3_]]([[VAR_3_]]#1, [[VAR_3_]]#2)
 // CHECK-DAG:         [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_3_:%.+]] = 0 to [[MAP_4_]]([[VAR_3_]]#1, [[VAR_3_]]#2){{.}}[[VAR_0_]]{{.}}, [[LOOP_1_]]#1 -> [[I_4_:%.+]] = 0 to [[MAP_5_]]([[VAR_3_]]#1, [[VAR_3_]]#2){{.}}[[VAR_0_]], [[VAR_1_]]{{.}}){
 // CHECK:               [[VAR_6_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
 // CHECK-DAG:           [[LOOP_2_:%.+]]:3 = krnl.define_loops 3
 // CHECK-DAG:           [[VAR_dim_2_:%.+]] = memref.dim [[IMAGE_]], [[CST_2_]] : memref<?x?x?x?xf32>
 // CHECK-DAG:           [[VAR_dim_3_:%.+]] = memref.dim [[IMAGE_]], [[CST_3_]] : memref<?x?x?x?xf32>
-// CHECK:               krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_5_:%.+]] = 0 to 2, [[LOOP_2_]]#1 -> [[I_6_:%.+]] = max [[MAP_6_]]([[VAR_6_]]#0) to min [[MAP_7_]]([[VAR_6_]]#0){{.}}[[VAR_dim_2_]]{{.}}, [[LOOP_2_]]#2 -> [[I_7_:%.+]] = max [[MAP_8_]]([[VAR_6_]]#0, [[VAR_6_]]#1){{.}}[[VAR_dim_2_]]{{.}} to min [[MAP_9_]]([[VAR_6_]]#0, [[VAR_6_]]#1){{.}}[[VAR_dim_2_]], [[VAR_dim_3_]]{{.}}){
+// CHECK:               [[IterResult:%.+]] = krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_5_:%.+]] = 0 to 2, [[LOOP_2_]]#1 -> [[I_6_:%.+]] = max [[MAP_6_]]([[VAR_6_]]#0) to min [[MAP_7_]]([[VAR_6_]]#0){{.}}[[VAR_dim_2_]]{{.}}, [[LOOP_2_]]#2 -> [[I_7_:%.+]] = max [[MAP_8_]]([[VAR_6_]]#0, [[VAR_6_]]#1){{.}}[[VAR_dim_2_]]{{.}} to min [[MAP_9_]]([[VAR_6_]]#0, [[VAR_6_]]#1){{.}}[[VAR_dim_2_]], [[VAR_dim_3_]]{{.}}) iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:                 [[VAR_11_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:             [[VAR_12_:%.+]] = affine.apply [[MAP_10_]]([[VAR_11_]]#0, [[VAR_3_]]#1)
 // CHECK-DAG:             [[VAR_13_:%.+]] = affine.apply [[MAP_11_]]([[VAR_11_]]#1, [[VAR_6_]]#0)
@@ -58,14 +56,12 @@ func.func private @test_conv_unknown_dimensions(%arg0 : tensor<?x?x?x?xf32>, %ar
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:             [[LOAD_IMAGE_MEM_:%.+]] = krnl.load [[IMAGE_]]{{.}}[[VAR_3_]]#0, [[VAR_12_]], [[VAR_13_]], [[VAR_14_]]{{.}} : memref<?x?x?x?xf32>
 // CHECK-DAG:             [[LOAD_FILTER_MEM_:%.+]] = krnl.load [[FILTER_]]{{.}}[[VAR_4_]], [[VAR_11_]]#0, [[VAR_11_]]#1, [[VAR_11_]]#2] : memref<5x2x6x7xf32>
-// CHECK-DAG:             [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:                 [[VAR_18_:%.+]] = arith.mulf [[LOAD_IMAGE_MEM_]], [[LOAD_FILTER_MEM_]] : f32
-// CHECK:                 [[VAR_19_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_18_]] : f32
-// CHECK:                 krnl.store [[VAR_19_]], [[RES_1_]][] : memref<f32>
+// CHECK:                 [[VAR_19_:%.+]] = arith.addf [[IterArg]], [[VAR_18_]] : f32
+// CHECK:                 krnl.yield [[VAR_19_]] : f32
 // CHECK:               }
-// CHECK-DAG:           [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK-DAG:           [[LOAD_BIAS_MEM_:%.+]] = krnl.load [[BIAS_]]{{.}}[[VAR_4_]]{{.}} : memref<5xf32>
-// CHECK:               [[VAR_10_:%.+]] = arith.addf [[LOAD_RES_1_MEM_1_]], [[LOAD_BIAS_MEM_]] : f32
+// CHECK:               [[VAR_10_:%.+]] = arith.addf [[IterResult]], [[LOAD_BIAS_MEM_]] : f32
 // CHECK:               krnl.store [[VAR_10_]], [[RES_]]{{.}}[[VAR_3_]]#0, [[VAR_4_]], [[VAR_6_]]#0, [[VAR_6_]]#1] : memref<?x5x?x?xf32>
 // CHECK:             }
 // CHECK:           }
@@ -96,15 +92,13 @@ func.func private @test_conv_no_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[BIAS_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#2 -> [[I_1_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloca() : memref<f32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_2_:%.+]] = affine.apply [[MAP_0_]]([[VAR_1_]]#1, [[VAR_1_]]#2)
 // CHECK-DAG:         [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_2_:%.+]] = 0 to 27, [[LOOP_1_]]#1 -> [[I_3_:%.+]] = 0 to 58){
 // CHECK:               [[VAR_4_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
 // CHECK:               [[LOOP_2_:%.+]]:3 = krnl.define_loops 3
-// CHECK:               krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to 2, [[LOOP_2_]]#1 -> [[I_5_:%.+]] = max [[MAP_1_]]([[VAR_4_]]#0) to min [[MAP_2_]]([[VAR_4_]]#0), [[LOOP_2_]]#2 -> [[I_6_:%.+]] = max [[MAP_3_]]([[VAR_4_]]#0, [[VAR_4_]]#1) to min [[MAP_4_]]([[VAR_4_]]#0, [[VAR_4_]]#1)){
+// CHECK:               [[IterResult:%.+]] = krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to 2, [[LOOP_2_]]#1 -> [[I_5_:%.+]] = max [[MAP_1_]]([[VAR_4_]]#0) to min [[MAP_2_]]([[VAR_4_]]#0), [[LOOP_2_]]#2 -> [[I_6_:%.+]] = max [[MAP_3_]]([[VAR_4_]]#0, [[VAR_4_]]#1) to min [[MAP_4_]]([[VAR_4_]]#0, [[VAR_4_]]#1)) iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:                 [[VAR_7_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:             [[VAR_8_:%.+]] = affine.apply [[MAP_5_]]([[VAR_7_]]#0, [[VAR_1_]]#1)
 // CHECK-DAG:             [[VAR_9_:%.+]] = affine.apply [[MAP_6_]]([[VAR_7_]]#1, [[VAR_4_]]#0)
@@ -112,13 +106,11 @@ func.func private @test_conv_no_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:             [[LOAD_IMAGE_MEM_:%.+]] = krnl.load [[IMAGE_]]{{.}}[[VAR_1_]]#0, [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0] : memref<1x2x32x64xf32>
 // CHECK-DAG:             [[LOAD_FILTER_MEM_:%.+]] = krnl.load [[FILTER_]]{{.}}[[VAR_2_]], [[VAR_7_]]#0, [[VAR_7_]]#1, [[VAR_7_]]#2] : memref<5x2x6x7xf32>
-// CHECK-DAG:             [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:                 [[VAR_14_:%.+]] = arith.mulf [[LOAD_IMAGE_MEM_]], [[LOAD_FILTER_MEM_]] : f32
-// CHECK:                 [[VAR_15_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_14_]] : f32
-// CHECK:                 krnl.store [[VAR_15_]], [[RES_1_]][] : memref<f32>
+// CHECK:                 [[VAR_15_:%.+]] = arith.addf [[IterArg]], [[VAR_14_]] : f32
+// CHECK:                 krnl.yield [[VAR_15_]] : f32
 // CHECK:               }
-// CHECK:               [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_2_]], [[VAR_4_]]#0, [[VAR_4_]]#1] : memref<1x5x27x58xf32>
+// CHECK:               krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_2_]], [[VAR_4_]]#0, [[VAR_4_]]#1] : memref<1x5x27x58xf32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x5x27x58xf32>
@@ -147,15 +139,13 @@ func.func private @test_conv_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : 
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 1, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloca() : memref<f32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_2_:%.+]] = affine.apply [[MAP_0_]]([[VAR_1_]]#1, [[VAR_1_]]#2)
 // CHECK-DAG:         [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_3_:%.+]] = 0 to 27, [[LOOP_1_]]#1 -> [[I_4_:%.+]] = 0 to 58){
 // CHECK:               [[VAR_4_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
 // CHECK:               [[LOOP_2_:%.+]]:3 = krnl.define_loops 3
-// CHECK:               krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_5_:%.+]] = 0 to 2, [[LOOP_2_]]#1 -> [[I_6_:%.+]] = max [[MAP_1_]]([[VAR_4_]]#0) to min [[MAP_2_]]([[VAR_4_]]#0), [[LOOP_2_]]#2 -> [[I_7_:%.+]] = max [[MAP_3_]]([[VAR_4_]]#0, [[VAR_4_]]#1) to min [[MAP_4_]]([[VAR_4_]]#0, [[VAR_4_]]#1)){
+// CHECK:               [[IterResult:%.+]] = krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_5_:%.+]] = 0 to 2, [[LOOP_2_]]#1 -> [[I_6_:%.+]] = max [[MAP_1_]]([[VAR_4_]]#0) to min [[MAP_2_]]([[VAR_4_]]#0), [[LOOP_2_]]#2 -> [[I_7_:%.+]] = max [[MAP_3_]]([[VAR_4_]]#0, [[VAR_4_]]#1) to min [[MAP_4_]]([[VAR_4_]]#0, [[VAR_4_]]#1)) iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:                 [[VAR_9_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:             [[VAR_10_:%.+]] = affine.apply [[MAP_5_]]([[VAR_9_]]#0, [[VAR_1_]]#1)
 // CHECK-DAG:             [[VAR_11_:%.+]] = affine.apply [[MAP_6_]]([[VAR_9_]]#1, [[VAR_4_]]#0)
@@ -163,14 +153,12 @@ func.func private @test_conv_bias_no_pad(%arg0 : tensor<1x2x32x64xf32>, %arg1 : 
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:             [[LOAD_IMAGE_MEM_:%.+]] = krnl.load [[IMAGE_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]0, [[VAR_1_]]1, [[VAR_1_]]2] : memref<1x2x32x64xf32>
 // CHECK-DAG:             [[LOAD_FILTER_MEM_:%.+]] = krnl.load [[FILTER_]]{{.}}[[VAR_2_]], [[VAR_9_]]#0, [[VAR_9_]]#1, [[VAR_9_]]#2] : memref<5x2x6x7xf32>
-// CHECK-DAG:             [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:                 [[VAR_16_:%.+]] = arith.mulf [[LOAD_IMAGE_MEM_]], [[LOAD_FILTER_MEM_]] : f32
-// CHECK:                 [[VAR_17_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_16_]] : f32
-// CHECK:                 krnl.store [[VAR_17_]], [[RES_1_]][] : memref<f32>
+// CHECK:                 [[VAR_17_:%.+]] = arith.addf [[IterArg]], [[VAR_16_]] : f32
+// CHECK:                 krnl.yield [[VAR_17_]] : f32
 // CHECK:               }
-// CHECK-DAG:           [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK-DAG:           [[LOAD_BIAS_MEM_:%.+]] = krnl.load [[BIAS_]]{{.}}[[VAR_2_]]{{.}} : memref<5xf32>
-// CHECK:               [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_1_MEM_1_]], [[LOAD_BIAS_MEM_]] : f32
+// CHECK:               [[VAR_8_:%.+]] = arith.addf [[IterResult]], [[LOAD_BIAS_MEM_]] : f32
 // CHECK:               krnl.store [[VAR_8_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_2_]], [[VAR_4_]]#0, [[VAR_4_]]#1] : memref<1x5x27x58xf32>
 // CHECK:             }
 // CHECK:           }
@@ -201,15 +189,13 @@ func.func private @test_conv_no_bias_no_pad_w_group(%arg0 : tensor<1x9x32x64xf32
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[BIAS_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_0_:%.+]] = 0 to 3, [[LOOP_0_]]#2 -> [[I_1_:%.+]] = 0 to 2){
 // CHECK-DAG:         [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloca() : memref<f32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_2_:%.+]] = affine.apply [[MAP_0_]]([[VAR_1_]]#1, [[VAR_1_]]#2)
 // CHECK-DAG:         [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_2_:%.+]] = 0 to 27, [[LOOP_1_]]#1 -> [[I_3_:%.+]] = 0 to 58){
 // CHECK:               [[VAR_4_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
 // CHECK:               [[LOOP_2_:%.+]]:3 = krnl.define_loops 3
-// CHECK:               krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to 3, [[LOOP_2_]]#1 -> [[I_5_:%.+]] = max [[MAP_1_]]([[VAR_4_]]#0) to min [[MAP_2_]]([[VAR_4_]]#0), [[LOOP_2_]]#2 -> [[I_6_:%.+]] = max [[MAP_3_]]([[VAR_4_]]#0, [[VAR_4_]]#1) to min [[MAP_4_]]([[VAR_4_]]#0, [[VAR_4_]]#1)){
+// CHECK:               [[IterResult:%.+]] = krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to 3, [[LOOP_2_]]#1 -> [[I_5_:%.+]] = max [[MAP_1_]]([[VAR_4_]]#0) to min [[MAP_2_]]([[VAR_4_]]#0), [[LOOP_2_]]#2 -> [[I_6_:%.+]] = max [[MAP_3_]]([[VAR_4_]]#0, [[VAR_4_]]#1) to min [[MAP_4_]]([[VAR_4_]]#0, [[VAR_4_]]#1)) iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:                 [[VAR_7_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:             [[VAR_8_:%.+]] = affine.apply [[MAP_5_]]([[VAR_7_]]#0, [[VAR_1_]]#1)
 // CHECK-DAG:             [[VAR_9_:%.+]] = affine.apply [[MAP_6_]]([[VAR_7_]]#1, [[VAR_4_]]#0)
@@ -217,13 +203,11 @@ func.func private @test_conv_no_bias_no_pad_w_group(%arg0 : tensor<1x9x32x64xf32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:             [[LOAD_IMAGE_MEM_:%.+]] = krnl.load [[IMAGE_]]{{.}}[[VAR_1_]]#0, [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0] : memref<1x9x32x64xf32>
 // CHECK-DAG:             [[LOAD_FILTER_MEM_:%.+]] = krnl.load [[FILTER_]]{{.}}[[VAR_2_]], [[VAR_7_]]#0, [[VAR_7_]]#1, [[VAR_7_]]#2] : memref<6x3x6x7xf32>
-// CHECK-DAG:             [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:                 [[VAR_14_:%.+]] = arith.mulf [[LOAD_IMAGE_MEM_]], [[LOAD_FILTER_MEM_]] : f32
-// CHECK:                 [[VAR_15_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_14_]] : f32
-// CHECK:                 krnl.store [[VAR_15_]], [[RES_1_]][] : memref<f32>
+// CHECK:                 [[VAR_15_:%.+]] = arith.addf [[IterArg]], [[VAR_14_]] : f32
+// CHECK:                 krnl.yield [[VAR_15_]] : f32
 // CHECK:               }
-// CHECK:               [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_2_]], [[VAR_4_]]#0, [[VAR_4_]]#1] : memref<1x6x27x58xf32>
+// CHECK:               krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_2_]], [[VAR_4_]]#0, [[VAR_4_]]#1] : memref<1x6x27x58xf32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x6x27x58xf32>
@@ -253,15 +237,13 @@ func.func private @test_conv_no_bias_no_pad_w_strides(%arg0 : tensor<1x9x32x64xf
 // CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[BIAS_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#2 -> [[I_1_:%.+]] = 0 to 5){
 // CHECK-DAG:         [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
-// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloca() : memref<f32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:         [[VAR_2_:%.+]] = affine.apply [[MAP_0_]]([[VAR_1_]]#1, [[VAR_1_]]#2)
 // CHECK-DAG:         [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_2_:%.+]] = 0 to 14, [[LOOP_1_]]#1 -> [[I_3_:%.+]] = 0 to 29){
 // CHECK:               [[VAR_4_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:               krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
 // CHECK:               [[LOOP_2_:%.+]]:3 = krnl.define_loops 3
-// CHECK:               krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to 9, [[LOOP_2_]]#1 -> [[I_5_:%.+]] = max [[MAP_1_]]([[VAR_4_]]#0) to min [[MAP_2_]]([[VAR_4_]]#0), [[LOOP_2_]]#2 -> [[I_6_:%.+]] = max [[MAP_3_]]([[VAR_4_]]#0, [[VAR_4_]]#1) to min [[MAP_4_]]([[VAR_4_]]#0, [[VAR_4_]]#1)){
+// CHECK:               [[IterResult:%.+]] = krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to 9, [[LOOP_2_]]#1 -> [[I_5_:%.+]] = max [[MAP_1_]]([[VAR_4_]]#0) to min [[MAP_2_]]([[VAR_4_]]#0), [[LOOP_2_]]#2 -> [[I_6_:%.+]] = max [[MAP_3_]]([[VAR_4_]]#0, [[VAR_4_]]#1) to min [[MAP_4_]]([[VAR_4_]]#0, [[VAR_4_]]#1)) iter_args([[IterArg:%.+]] = [[CST_0_dot_000000_]]) -> (f32){
 // CHECK:                 [[VAR_7_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK-DAG:             [[VAR_8_:%.+]] = affine.apply [[MAP_5_]]([[VAR_7_]]#0, [[VAR_1_]]#1)
 // CHECK-DAG:             [[VAR_9_:%.+]] = affine.apply [[MAP_6_]]([[VAR_7_]]#1, [[VAR_4_]]#0)
@@ -269,13 +251,11 @@ func.func private @test_conv_no_bias_no_pad_w_strides(%arg0 : tensor<1x9x32x64xf
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:             [[LOAD_IMAGE_MEM_:%.+]] = krnl.load [[IMAGE_]]{{.}}[[VAR_1_]]#0, [[VAR_8_]], [[VAR_9_]], [[VAR_1_]]0] : memref<1x9x32x64xf32>
 // CHECK-DAG:             [[LOAD_FILTER_MEM_:%.+]] = krnl.load [[FILTER_]]{{.}}[[VAR_2_]], [[VAR_7_]]#0, [[VAR_7_]]#1, [[VAR_7_]]#2] : memref<5x9x6x7xf32>
-// CHECK-DAG:             [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:                 [[VAR_14_:%.+]] = arith.mulf [[LOAD_IMAGE_MEM_]], [[LOAD_FILTER_MEM_]] : f32
-// CHECK:                 [[VAR_15_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_14_]] : f32
-// CHECK:                 krnl.store [[VAR_15_]], [[RES_1_]][] : memref<f32>
+// CHECK:                 [[VAR_15_:%.+]] = arith.addf [[IterArg]], [[VAR_14_]] : f32
+// CHECK:                 krnl.yield [[VAR_15_]] : f32
 // CHECK:               }
-// CHECK:               [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:               krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_2_]], [[VAR_4_]]#0, [[VAR_4_]]#1] : memref<1x5x14x29xf32>
+// CHECK:               krnl.store [[IterResult]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_2_]], [[VAR_4_]]#0, [[VAR_4_]]#1] : memref<1x5x14x29xf32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<1x5x14x29xf32>

--- a/test/mlir/krnl/ops.mlir
+++ b/test/mlir/krnl/ops.mlir
@@ -15,7 +15,7 @@ func.func @simple_iterate(%N : index) {
 
   // GENERIC: "krnl.iterate"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) ({
   // GENERIC-NEXT: ^bb0(%{{.*}}: index, %{{.*}}: index):
-  // GENERIC-NEXT: "krnl.terminate"() : () -> ()
+  // GENERIC-NEXT: "krnl.yield"() : () -> ()
   // GENERIC-NEXT: bounds = [#{{.*}}, #{{.*}}, #{{.*}}, #{{.*}}]
 
   // CHECK: krnl.iterate(%{{.*}}, %{{.*}}) with (%{{.*}} -> %{{.*}} = 0 to 10, %{{.*}} -> %{{.*}} = 1 to 11){


### PR DESCRIPTION
Introduce the `krnl.yield` operation within the `krnl.iterate` construct.
This operation functions analogously to `affine/scf.yield`,
yielding zero or more SSA values from a `krnl.iterate` operation region and subsequently terminating said region.

With 'krnl.yield', 'krnl.iterate' will be able to have results like affine.for.
krnl.iterate with results will be look like this.
```

%y0, %y1 = krnl.iterate(%2#0, %2#1) with (%2#0 -> %arg2 = 0 to 10, %2#1 -> %arg3 = 0 to 10) iter_args(%arg4 = %cst, %arg5 = %cst) -> (f32, f32) 
    ...
    krnl.yield %val0, %val1 : f32, f32
 }
```
There're 2 iter_args which match the number of results.
The krnl.yield will yield 2 values also.
The init values for iter_args will be at end of the operands for the krnl.yield.

After convert to affine, the above example will be looks like this.
```

%0:2 = affine.for %arg2 = 0 to 10 iter_args(%arg3 = %cst, %arg4 = %cst) -> (f32, f32) {
  %1:2 = affine.for %arg5 = 0 to 10 iter_args(%arg6 = %arg3, %arg7 = %arg4) -> (f32, f32) {
  ...
  affine.yield %val0, %val1: f32, f32
affine.yield %1#0, %1#1 : f32, f32
```
The inner affine.for will use iter_args from outer affine.for as init for iter_args.
The outer affine.for will yield result of inner affine.for.

Implementing this will facilitate the avoidance of `memref.alloca` for storing reduction values.

Signed-off-by: Xiang Li <python3kgae@outlook.com>