### PR TITLE
Fix an error in CategoryMapper

### DIFF
--- a/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
+++ b/src/Conversion/ONNXToKrnl/ML/CategoryMapper.cpp
@@ -283,8 +283,7 @@ private:
                     .failed())
               llvm_unreachable("Failed to get strides");
             Value stringMemRef =
-                createMemRef
-                    .subView(memRefType, memref, offsets, newShape, strides)
+                createMemRef.subView(memref, offsets, newShape, strides)
                     .getResult();
             inputElem = createKrnl.load(stringMemRef, loopInd);
           }

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1342,6 +1342,13 @@ memref::ViewOp MemRefBuilder::view(Value input, int64_t byteOffset,
       loc(), outputType, input, offset, outputDynSymbols);
 }
 
+memref::SubViewOp MemRefBuilder::subView(Value val,
+    llvm::SmallVectorImpl<int64_t> &offsets,
+    llvm::SmallVectorImpl<int64_t> &sizes,
+    llvm::SmallVectorImpl<int64_t> &strides) const {
+  return b().create<memref::SubViewOp>(loc(), val, offsets, sizes, strides);
+}
+
 memref::SubViewOp MemRefBuilder::subView(MemRefType outputType, Value val,
     llvm::SmallVectorImpl<int64_t> &offsets,
     llvm::SmallVectorImpl<int64_t> &sizes,

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -348,6 +348,13 @@ struct MemRefBuilder final : DialectBuilder {
       mlir::MemRefType outputType, mlir::ValueRange outputDynSymbols) const;
 
   // Create a subview of val.
+  mlir::memref::SubViewOp subView(mlir::Value val,
+      llvm::SmallVectorImpl<int64_t> &offsets, // Offset for each val dims.
+      llvm::SmallVectorImpl<int64_t> &sizes,   // Sizes for each val dims.
+      llvm::SmallVectorImpl<int64_t> &strides) // Stride for each val dims.
+      const;
+
+  // Create a subview of val.
   mlir::memref::SubViewOp subView(mlir::MemRefType outputType, mlir::Value val,
       llvm::SmallVectorImpl<int64_t> &offsets, // Offset for each val dims.
       llvm::SmallVectorImpl<int64_t> &sizes,   // Sizes for each val dims.


### PR DESCRIPTION
This PR fixes an error of result type mismatch in the lowering of CategoryMapper when the input is dynamic.

Resolves #2770 