### PR TITLE
Added krnl region to krnl dialect builder

### DIFF
--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -118,6 +118,17 @@ Value KrnlBuilder::vectorTypeCast(Value sourceMemref, int64_t vectorLen) const {
   return b().create<KrnlVectorTypeCastOp>(loc(), sourceMemref, vectorLen);
 }
 
+void KrnlBuilder::region(
+    function_ref<void(KrnlBuilder &createKrnl)> bodyBuilderFn) const {
+  KrnlBuilder createKrnl(b(), loc());
+  KrnlRegionOp regionOp = b().create<KrnlRegionOp>(loc());
+  {
+    OpBuilder::InsertionGuard guard(b());
+    b().setInsertionPointToStart(&regionOp.getBodyRegion().front());
+    bodyBuilderFn(createKrnl);
+  }
+}
+
 ValueRange KrnlBuilder::defineLoops(int64_t originalLoopNum) const {
   return b()
       .template create<KrnlDefineLoopsOp>(loc(), originalLoopNum)

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -53,6 +53,9 @@ struct KrnlBuilder : public DialectBuilder {
 
   mlir::Value vectorTypeCast(mlir::Value sourceMemref, int64_t vectorLen) const;
 
+  void region(
+      mlir::function_ref<void(KrnlBuilder &createKrnl)> bodyBuilderFn) const;
+
   mlir::ValueRange defineLoops(int64_t originalLoopNum) const;
   mlir::ValueRange block(mlir::Value loop, int64_t blockSize) const;
   void permute(mlir::ValueRange loops, mlir::ArrayRef<int64_t> map) const;


### PR DESCRIPTION
Added a function in Krnl Dialect Builder to create a region using the standard format

``` c++
  create.krnl.region([&](KrnlBuilder &createKrnl) {
   // code inside the body of the region
  });
```

Did not test, as there is no easy place to use it in the current code base.