### PR TITLE
Update op definitions to make them work with the new bufferization

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
@@ -57,9 +57,9 @@ llvm::cl::opt<bool> nnpaEnableCompilerStickUnstick(
 
 llvm::cl::opt<bool> nnpaEnableScalarBcastBinary(
     "nnpa-enable-scalar-bcast-binary",
-    llvm::cl::desc("Enable the lowering to NNPA the broadcasting binary ops "
-                   "whose one of the operands is scalar. Currently support "
-                   "ONNXDiv only. Default is false."),
+    llvm::cl::desc("Enable the lowering to NNPA of binary operations with "
+                   "broadcasting of a scalar operand."
+                   "Currently only enable ONNXDiv. Default is false."),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
 
 llvm::cl::opt<std::string> nnpaLoadDevicePlacementFile{

--- a/src/Accelerators/NNPA/Dialect/ZLow/ZLow.td
+++ b/src/Accelerators/NNPA/Dialect/ZLow/ZLow.td
@@ -45,7 +45,8 @@ def ZMemRef : MemRefOf<[DLF16]>;
 
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def ZLowAddOp:ZLow_Op<"add", [MemRefsNormalizable]> {
+def ZLowAddOp:ZLow_Op<"add", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow add operation";
   let description = [{
   ZLow operation to perform an add.
@@ -57,7 +58,8 @@ def ZLowAddOp:ZLow_Op<"add", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowSubOp:ZLow_Op<"sub", [MemRefsNormalizable]> {
+def ZLowSubOp:ZLow_Op<"sub", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow sub operation";
   let description = [{
   ZLow operation to perform a sub.
@@ -69,7 +71,8 @@ def ZLowSubOp:ZLow_Op<"sub", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowMulOp:ZLow_Op<"mul", [MemRefsNormalizable]> {
+def ZLowMulOp:ZLow_Op<"mul", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow mul operation";
   let description = [{
   ZLow operation to perform a mul.
@@ -81,7 +84,8 @@ def ZLowMulOp:ZLow_Op<"mul", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowDivOp:ZLow_Op<"div", [MemRefsNormalizable]> {
+def ZLowDivOp:ZLow_Op<"div", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow div operation";
   let description = [{
   ZLow operation to perform a div.
@@ -93,7 +97,8 @@ def ZLowDivOp:ZLow_Op<"div", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowLogOp:ZLow_Op<"log", [MemRefsNormalizable]> {
+def ZLowLogOp:ZLow_Op<"log", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow log operation";
   let description = [{
   ZLow operation to perform a log.
@@ -104,7 +109,8 @@ def ZLowLogOp:ZLow_Op<"log", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowExpOp:ZLow_Op<"exp", [MemRefsNormalizable]> {
+def ZLowExpOp:ZLow_Op<"exp", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow exp operation";
   let description = [{
   ZLow operation to perform a exp.
@@ -115,7 +121,8 @@ def ZLowExpOp:ZLow_Op<"exp", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowMinOp:ZLow_Op<"min", [MemRefsNormalizable]> {
+def ZLowMinOp:ZLow_Op<"min", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow min operation";
   let description = [{
   ZLow operation to perform a min.
@@ -127,7 +134,8 @@ def ZLowMinOp:ZLow_Op<"min", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowMaxOp:ZLow_Op<"max", [MemRefsNormalizable]> {
+def ZLowMaxOp:ZLow_Op<"max", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow max operation";
   let description = [{
   ZLow operation to perform a max.
@@ -139,7 +147,8 @@ def ZLowMaxOp:ZLow_Op<"max", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowReluOp:ZLow_Op<"relu", [MemRefsNormalizable]> {
+def ZLowReluOp:ZLow_Op<"relu", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow relu operation";
   let description = [{
   ZLow operation to perform a relu.
@@ -150,7 +159,8 @@ def ZLowReluOp:ZLow_Op<"relu", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowTanhOp:ZLow_Op<"tanh", [MemRefsNormalizable]> {
+def ZLowTanhOp:ZLow_Op<"tanh", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow tanh operation";
   let description = [{
   ZLow operation to perform a tanh.
@@ -161,7 +171,8 @@ def ZLowTanhOp:ZLow_Op<"tanh", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowSigmoidOp:ZLow_Op<"sigmoid", [MemRefsNormalizable]> {
+def ZLowSigmoidOp:ZLow_Op<"sigmoid", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow sigmoid operation";
   let description = [{
   ZLow operation to perform a sigmoid.
@@ -172,7 +183,8 @@ def ZLowSigmoidOp:ZLow_Op<"sigmoid", [MemRefsNormalizable]> {
                        StrAttr:$layout);
 }
 
-def ZLowSoftmaxOp:ZLow_Op<"softmax", [MemRefsNormalizable]> {
+def ZLowSoftmaxOp:ZLow_Op<"softmax", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow softmax operation";
   let description = [{
   ZLow operation to perform a softmax.
@@ -186,7 +198,8 @@ def ZLowSoftmaxOp:ZLow_Op<"softmax", [MemRefsNormalizable]> {
                        StrAttr:$act_func);
 }
 
-def ZLowMatMulOp:ZLow_Op<"matmul", [MemRefsNormalizable]> {
+def ZLowMatMulOp:ZLow_Op<"matmul", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow matmul operation";
   let description = [{
   ZLow operation to perform a matmul.
@@ -214,7 +227,8 @@ def ZLowMatMulOp:ZLow_Op<"matmul", [MemRefsNormalizable]> {
                        DefaultValuedAttr<SI64Attr, "-1">:$is_stacked);
 }
 
-def ZLowLSTMOp:ZLow_Op<"lstm", [MemRefsNormalizable]> {
+def ZLowLSTMOp:ZLow_Op<"lstm", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow lstm operation";
   let description = [{
   ZLow operation to perform a lstm.
@@ -245,7 +259,8 @@ def ZLowLSTMOp:ZLow_Op<"lstm", [MemRefsNormalizable]> {
                        DefaultValuedStrAttr<StrAttr, "none">:$prev_layer);
 }
 
-def ZLowGRUOp:ZLow_Op<"gru", [MemRefsNormalizable]> {
+def ZLowGRUOp:ZLow_Op<"gru", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow gru operation";
   let description = [{
   ZLow operation to perform a gru.
@@ -274,7 +289,8 @@ def ZLowGRUOp:ZLow_Op<"gru", [MemRefsNormalizable]> {
                        DefaultValuedStrAttr<StrAttr, "none">:$prev_layer);
 }
 
-def ZLowStickOp:ZLow_Op<"stick", [MemRefsNormalizable]> {
+def ZLowStickOp:ZLow_Op<"stick", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow stick operation";
   let description = [{
   "ZLow operation to perform a stick."
@@ -289,7 +305,8 @@ def ZLowStickOp:ZLow_Op<"stick", [MemRefsNormalizable]> {
   ];
 }
 
-def ZLowStickForLSTMOp:ZLow_Op<"stickForLSTM", [MemRefsNormalizable]> {
+def ZLowStickForLSTMOp:ZLow_Op<"stickForLSTM", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow stick operation for LSTM";
   let description = [{
   ZLow operation to perform a stick for LSTM.
@@ -304,7 +321,8 @@ def ZLowStickForLSTMOp:ZLow_Op<"stickForLSTM", [MemRefsNormalizable]> {
                        DefaultValuedStrAttr<StrAttr, "none">:$prev_layer);
 }
 
-def ZLowStickForGRUOp:ZLow_Op<"stickForGRU", [MemRefsNormalizable]> {
+def ZLowStickForGRUOp:ZLow_Op<"stickForGRU", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow stick operation for GRU";
   let description = [{
   ZLow operation to perform a stick for GRU.
@@ -318,7 +336,8 @@ def ZLowStickForGRUOp:ZLow_Op<"stickForGRU", [MemRefsNormalizable]> {
                        DefaultValuedStrAttr<StrAttr, "none">:$prev_layer);
 }
 
-def ZLowUnstickOp:ZLow_Op<"unstick", [MemRefsNormalizable]> {
+def ZLowUnstickOp:ZLow_Op<"unstick", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow unstick operation";
   let description = [{
   ZLow operation to perform a unstick.
@@ -333,7 +352,8 @@ def ZLowUnstickOp:ZLow_Op<"unstick", [MemRefsNormalizable]> {
   ];
 }
 
-def ZLowConv2DOp:ZLow_Op<"conv2d", [MemRefsNormalizable]> {
+def ZLowConv2DOp:ZLow_Op<"conv2d", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow 2D convolution operation";
   let description = [{
   ZLow operation to perform 2D convolution.
@@ -361,7 +381,8 @@ def ZLowConv2DOp:ZLow_Op<"conv2d", [MemRefsNormalizable]> {
                        DefaultValuedStrAttr<StrAttr, "ACT_NONE">:$act_func);
 }
 
-def ZLowAvgPool2DOp:ZLow_Op<"avgpool2d", [MemRefsNormalizable]> {
+def ZLowAvgPool2DOp:ZLow_Op<"avgpool2d", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow 2D average pooling operation";
   let description = [{
   ZLow operation to perform 2D average pooling.
@@ -385,7 +406,8 @@ def ZLowAvgPool2DOp:ZLow_Op<"avgpool2d", [MemRefsNormalizable]> {
                   );
 }
 
-def ZLowMaxPool2DOp:ZLow_Op<"maxpool2d", [MemRefsNormalizable]> {
+def ZLowMaxPool2DOp:ZLow_Op<"maxpool2d", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow 2D max pooling operation";
   let description = [{
   ZLow operation to perform 2D max pooling.
@@ -409,7 +431,8 @@ def ZLowMaxPool2DOp:ZLow_Op<"maxpool2d", [MemRefsNormalizable]> {
                   );
 }
 
-def ZLowMeanReduce2DOp:ZLow_Op<"meanreduce2d", [MemRefsNormalizable]> {
+def ZLowMeanReduce2DOp:ZLow_Op<"meanreduce2d", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow 2D mean reduce operation";
   let description = [{
   ZLow operation to perform 2D mean reduce.
@@ -424,7 +447,8 @@ def ZLowMeanReduce2DOp:ZLow_Op<"meanreduce2d", [MemRefsNormalizable]> {
                        ZMemRef:$output);
 }
 
-def ZLowBatchNormOp:ZLow_Op<"batchnorm", [MemRefsNormalizable]> {
+def ZLowBatchNormOp:ZLow_Op<"batchnorm", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "ZLow batchnorm operation";
   let description = [{
   ZLow operation to perform batchnorm.

--- a/src/Accelerators/NNPA/Dialect/ZLow/ZLowOps.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZLow/ZLowOps.cpp
@@ -42,6 +42,322 @@ void ZLowDialect::initialize() {
       >();
 }
 
+void ZLowAddOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getY(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowSubOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getY(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowMulOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getY(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowDivOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getY(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowMinOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getY(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowMaxOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getY(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowLogOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowExpOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowReluOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowTanhOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowSigmoidOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowSoftmaxOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getWorkArea(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowMatMulOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getY(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getBias(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowLSTMOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getHnOutput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Write::get(), getCfOutput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getH0(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getC0(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInputWeights(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInputBias(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getHiddenWeights(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getHiddenBias(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getWorkArea(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowGRUOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getHnOutput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getH0(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInputWeights(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInputBias(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getHiddenWeights(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getHiddenBias(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getWorkArea(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowStickOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+}
+
+void ZLowStickForLSTMOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getFGate(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getIGate(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getCGate(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getOGate(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowStickForGRUOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getZGate(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getRGate(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getHGate(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowUnstickOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOut(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getX(), SideEffects::DefaultResource::get());
+}
+
+void ZLowConv2DOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOutput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInputKernel(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInputBias(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowAvgPool2DOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOutput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowMaxPool2DOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOutput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowMeanReduce2DOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOutput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
+void ZLowBatchNormOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getOutput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getInput(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getA(), SideEffects::DefaultResource::get());
+  effects.emplace_back(
+      MemoryEffects::Read::get(), getB(), SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Read::get(), getShape(),
+      SideEffects::DefaultResource::get());
+}
+
 } // namespace zlow
 } // namespace onnx_mlir
 

--- a/src/Conversion/KrnlToLLVM/KrnlGlobal.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlGlobal.cpp
@@ -342,8 +342,8 @@ private:
     baseAddr = create.llvm.bitcast(i8PtrType, baseAddr);
     for (size_t offset : offsets) {
       // Get each str with gep base, offset.
-      Value gepOp =
-          create.llvm.getElemPtr(i8PtrType, i8Type, baseAddr, {offset});
+      Value gepOp = create.llvm.getElemPtr(
+          i8PtrType, i8Type, baseAddr, {(int32_t)offset});
       lastValue =
           create.llvm.insertValue(arrayType, lastValue, gepOp, {index++});
     }

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -341,7 +341,8 @@ def KrnlEntryPointOp : Op<Krnl_Dialect, "entry_point"> {
   }];
 }
 
-def KrnlMemcpyOp : Op<Krnl_Dialect, "memcpy", [MemRefsNormalizable]> {
+def KrnlMemcpyOp : Op<Krnl_Dialect, "memcpy", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Krnl memcpy operation";
   let description = [{
     Copy `num_elems` elements from `src` to `dest` MemRef.
@@ -1176,6 +1177,7 @@ def KrnlInstrumentOp : Op<Krnl_Dialect, "runtime_instrument",
 }
 
 def KrnlMemsetOp : Op<Krnl_Dialect, "memset", [MemRefsNormalizable,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     TypesMatchWith<"type of 'value' matches element type of 'dest'",
                    "dest", "value",
                    "$_self.cast<MemRefType>().getElementType()">]> {

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -1029,6 +1029,30 @@ void KrnlGetLinearOffsetIndexOp::print(OpAsmPrinter &p) {
   p << " : " << getMemRefType();
 }
 
+//===----------------------------------------------------------------------===//
+// KrnlMemcpyOp
+//===----------------------------------------------------------------------===//
+
+void KrnlMemcpyOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), getSrc(),
+      SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Write::get(), getDest(),
+      SideEffects::DefaultResource::get());
+}
+
+//===----------------------------------------------------------------------===//
+// KrnlMemsetOp
+//===----------------------------------------------------------------------===//
+
+void KrnlMemsetOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), getDest(),
+      SideEffects::DefaultResource::get());
+}
+
 } // namespace mlir
 
 #define GET_OP_CLASSES


### PR DESCRIPTION
The new bufferization mechanism in recent LLVM was slower than the old one, and we proposed `--use-old-bufferization=true` to use the old one.

Today, I tested the new mechanism again by `--use-old-bufferization=false`, and it failed to compile a model. To fix it, we need to add  `DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]>` to all operations that work with MemRef.

This PR is to add `DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]>` to krnl and zlow ops.