### PR TITLE
[NNPA]Update condition to apply unstickStickRemoval optimization

### DIFF
--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowRewrite.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowRewrite.cpp
@@ -88,6 +88,7 @@ public:
         continue;
       // UnstickOp must be before the stick operation.
       if (userOp.getOut() == stickInput &&
+          user->getBlock() == stickOp.getOperation()->getBlock() &&
           user->isBeforeInBlock(stickOp.getOperation())) {
         unstickOp = userOp;
         break;


### PR DESCRIPTION
It seems we need to check the operations are in the same block before using `isBeforeInBlock()`.

Example in MLIR: https://github.com/llvm/llvm-project/blob/main/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp#L940-L941

Without this, we get following error.

```
mlir::operation::isBeforeInBlock(mlir::Operation*): Assertion `other && other->block == block && "Expected other operation to have the same parent block."' failed.
``` 