### PR TITLE
Add krnl prefetch

### DIFF
--- a/src/Conversion/KrnlToAffine/CMakeLists.txt
+++ b/src/Conversion/KrnlToAffine/CMakeLists.txt
@@ -8,6 +8,7 @@ add_onnx_mlir_library(OMKrnlToAffine
   KrnlLoad.cpp
   KrnlMatmul.cpp
   KrnlMemset.cpp
+  KrnlPrefetch.cpp
   KrnlStore.cpp
   KrnlTerminator.cpp
   KrnlToAffineHelper.cpp

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -776,6 +776,7 @@ void ConvertKrnlToAffinePass::runOnOperation() {
   target.addIllegalOp<KrnlMatMulOp>();
   target.addIllegalOp<KrnlCopyToBufferOp>();
   target.addIllegalOp<KrnlCopyFromBufferOp>();
+  target.addIllegalOp<KrnlPrefetchOp>();
   target.addLegalOp<AffineYieldOp>();
   target.addLegalOp<AffineLoadOp>();
   target.addLegalOp<AffineStoreOp>();
@@ -838,6 +839,7 @@ void populateKrnlToAffineConversion(TypeConverter &typeConverter,
       typeConverter, patterns, ctx);
   krnl::populateLoweringKrnlMatmultOpPattern(typeConverter, patterns, ctx);
   krnl::populateLoweringKrnlMemsetOpPattern(typeConverter, patterns, ctx);
+  krnl::populateLoweringKrnlPrefetchOpPattern(typeConverter, patterns, ctx);
   krnl::populateLoweringKrnlTerminatorOpPattern(typeConverter, patterns, ctx);
 }
 

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.hpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.hpp
@@ -81,6 +81,9 @@ void populateLoweringKrnlMatmultOpPattern(mlir::TypeConverter &typeConverter,
 void populateLoweringKrnlMemsetOpPattern(mlir::TypeConverter &typeConverter,
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx);
 
+void populateLoweringKrnlPrefetchOpPattern(mlir::TypeConverter &typeConverter,
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx);
+
 void populateLoweringKrnlTerminatorOpPattern(mlir::TypeConverter &typeConverter,
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx);
 

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2505,6 +2505,7 @@ struct ONNXElementwiseVariadicOpLowering
                     oprdAccessExprs, /*flattened dims*/ false, hasNoBroadcast);
             assert(succeeded(res) && "Could not compute access indices");
             Value accumulated = createKrnl.loadIE(operands[0], oprdAccessExprs);
+            
             // Iterate over the remaining operands.
             for (unsigned i = 1; i < numArgs; ++i) {
               // Obtain the next operand.

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2505,7 +2505,7 @@ struct ONNXElementwiseVariadicOpLowering
                     oprdAccessExprs, /*flattened dims*/ false, hasNoBroadcast);
             assert(succeeded(res) && "Could not compute access indices");
             Value accumulated = createKrnl.loadIE(operands[0], oprdAccessExprs);
-            
+
             // Iterate over the remaining operands.
             for (unsigned i = 1; i < numArgs; ++i) {
               // Obtain the next operand.

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2509,6 +2509,11 @@ struct ONNXElementwiseVariadicOpLowering
                     oprdAccessExprs, /*flattened dims*/ false, hasNoBroadcast);
             assert(succeeded(res) && "Could not compute access indices");
             Value accumulated = createKrnl.loadIE(operands[0], oprdAccessExprs);
+            // hi alex; temporary code to exercise a prefech operation.
+            SmallVector<IndexExpr, 4> prefetchAE = oprdAccessExprs;
+            int rank = prefetchAE.size();
+            prefetchAE[rank-1] = prefetchAE[rank-1] + LiteralIndexExpr(64);
+            createKrnl.prefetchIE(operands[0], prefetchAE, false, 3);
 
             // Iterate over the remaining operands.
             for (unsigned i = 1; i < numArgs; ++i) {

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2509,8 +2509,8 @@ struct ONNXElementwiseVariadicOpLowering
                     oprdAccessExprs, /*flattened dims*/ false, hasNoBroadcast);
             assert(succeeded(res) && "Could not compute access indices");
             Value accumulated = createKrnl.loadIE(operands[0], oprdAccessExprs);
-#if 0
-            // hi alex; temporary code to exercise a prefetch operation.
+#if 0 // hi alex, remove
+      // hi alex; temporary code to exercise a prefetch operation.
             SmallVector<IndexExpr, 4> prefetchAE = oprdAccessExprs;
             int rank = prefetchAE.size();
             prefetchAE[rank-1] = prefetchAE[rank-1] + LiteralIndexExpr(64);

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2505,13 +2505,6 @@ struct ONNXElementwiseVariadicOpLowering
                     oprdAccessExprs, /*flattened dims*/ false, hasNoBroadcast);
             assert(succeeded(res) && "Could not compute access indices");
             Value accumulated = createKrnl.loadIE(operands[0], oprdAccessExprs);
-#if 0 // hi alex, remove
-      // hi alex; temporary code to exercise a prefetch operation.
-            SmallVector<IndexExpr, 4> prefetchAE = oprdAccessExprs;
-            int rank = prefetchAE.size();
-            prefetchAE[rank-1] = prefetchAE[rank-1] + LiteralIndexExpr(64);
-            createKrnl.prefetchIE(operands[0], prefetchAE, false, 3);
-#endif
             // Iterate over the remaining operands.
             for (unsigned i = 1; i < numArgs; ++i) {
               // Obtain the next operand.

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2509,12 +2509,13 @@ struct ONNXElementwiseVariadicOpLowering
                     oprdAccessExprs, /*flattened dims*/ false, hasNoBroadcast);
             assert(succeeded(res) && "Could not compute access indices");
             Value accumulated = createKrnl.loadIE(operands[0], oprdAccessExprs);
-            // hi alex; temporary code to exercise a prefech operation.
+#if 0
+            // hi alex; temporary code to exercise a prefetch operation.
             SmallVector<IndexExpr, 4> prefetchAE = oprdAccessExprs;
             int rank = prefetchAE.size();
             prefetchAE[rank-1] = prefetchAE[rank-1] + LiteralIndexExpr(64);
             createKrnl.prefetchIE(operands[0], prefetchAE, false, 3);
-
+#endif
             // Iterate over the remaining operands.
             for (unsigned i = 1; i < numArgs; ++i) {
               // Obtain the next operand.

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -104,6 +104,20 @@ Value KrnlBuilder::getLinearOffsetIndexIE(
   return b().create<KrnlGetLinearOffsetIndexOp>(loc(), memref, indexValues);
 }
 
+void KrnlBuilder::prefetch(Value memref, ValueRange indices, bool isWrite,
+    unsigned localityHint, bool isDataCache) {
+  b().create<KrnlPrefetchOp>(
+      loc(), memref, indices, isWrite, localityHint, isDataCache);
+}
+
+void KrnlBuilder::prefetchIE(Value memref, ArrayRef<IndexExpr> indices,
+    bool isWrite, unsigned localityHint, bool isDataCache) {
+  SmallVector<Value, 4> indexValues;
+  IndexExpr::getValues(indices, indexValues);
+  b().create<KrnlPrefetchOp>(
+      loc(), memref, indexValues, isWrite, localityHint, isDataCache);
+}
+
 void KrnlBuilder::seqstore(
     mlir::Value element, mlir::Value seq, mlir::Value index) const {
   b().create<KrnlSeqStoreOp>(loc(), element, seq, index);

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -43,10 +43,17 @@ struct KrnlBuilder : public DialectBuilder {
   void storeIE(mlir::Value val, mlir::Value memref,
       mlir::ArrayRef<IndexExpr> indices) const;
 
+  // Get linear offset for given memref at given index values.
   mlir::Value getLinearOffsetIndex(
       mlir::Value memref, mlir::ValueRange indices = {}) const;
   mlir::Value getLinearOffsetIndexIE(
       mlir::Value memref, mlir::ArrayRef<IndexExpr> indices) const;
+
+  // Prefetch with identity map.
+  void prefetch(mlir::Value memref, mlir::ValueRange indices, bool isWrite,
+      unsigned localityHint, bool isDataCache = true);
+  void prefetchIE(mlir::Value memref, mlir::ArrayRef<IndexExpr> indices,
+      bool isWrite, unsigned localityHint, bool isDataCache = true);
 
   void seqstore(mlir::Value element, mlir::Value seq, mlir::Value index) const;
   void seqstore(mlir::Value element, mlir::Value seq, IndexExpr index) const;

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -712,9 +712,70 @@ def KrnlGetLinearOffsetIndexOp : Op<Krnl_Dialect, "get_linear_offset_index",
   }];
 
   let hasCustomAssemblyFormat = 1;
-  // let assemblyFormat = [{$memref `[` $indices `]` attr-dict `:` type($memref)}];
 
 }
+
+def KrnlPrefetchOp : Op<Krnl_Dialect, "prefetch",
+  [DeclareOpInterfaceMethods<AffineMapAccessInterface>,
+    //DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+    MemRefsNormalizable]> {
+  let summary = "A Krnl operation to compute a linear offset index from a N-D index.";
+
+  let description = [{
+    Given a MemRef and an N-D index (id_1, id_2, ..., id_n), prefetch the memory
+    location pointed by this memory reference.
+  }];
+
+  let arguments = (ins Arg<AnyMemRef, "the reference memref", [MemRead]>:$memref,
+      Variadic<Index>:$indices,
+      BoolAttr:$isWrite,
+      ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<3>]>:$localityHint,
+      BoolAttr:$isDataCache,
+      AffineMapAttr:$map
+   );
+
+  // let assemblyFormat = [{$memref `[` $indices `]` attr-dict `:` type($memref)}];
+  let builders = [
+    /// Builds an op with an identity map and operands.
+    OpBuilder<(ins "Value":$memref, "ValueRange":$indices, "bool":$isWrite,
+      "unsigned":$localityHint, "bool":$isDataCache)>,
+    OpBuilder<(ins "Value":$memref, "bool":$isWrite,
+      "unsigned":$localityHint, "bool":$isDataCache)>,
+    /// Builds an op with the specified map and its operands.
+    OpBuilder<(ins "Value":$memref, "AffineMap":$map,
+      "ValueRange":$mapOperands, "bool":$isWrite,
+      "unsigned":$localityHint, "bool":$isDataCache)>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Returns the operand index of the memref.
+    unsigned getMemRefOperandIndex() { return 0; }
+    Value getMemRef() { return getOperand(getMemRefOperandIndex()); }
+    void setMemRef(Value value) { setOperand(getMemRefOperandIndex(), value); }
+    MemRefType getMemRefType() {
+      return getMemref().getType().cast<MemRefType>();
+    }
+
+    /// Implements the AffineMapAccessInterface.
+    /// Returns the AffineMapAttr associated with 'memref'.
+    // Default version is fine.
+
+    /// Returns the affine map used to index the memref for this operation.
+    AffineMapAttr getAffineMapAttr() { return getMapAttr(); }
+    AffineMap getAffineMap() { return getAffineMapAttr().getValue(); }
+
+    /// Get affine map operands.
+    operand_range getMapOperands() {  return getIndices(); }
+
+    static StringRef getMapAttrStrName() { return "map"; }
+    static StringRef getIsWriteAttrStrName() { return "isWrite"; }
+    static StringRef getLocalityHintAttrStrName() { return "localityHint"; }
+    static StringRef getIsDataCacheAttrStrName() { return "isDataCache"; }
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 
 def KrnlMovableOp : Op<Krnl_Dialect, "movable", [ImplicitKrnlTerminator]> {
   let summary = "Krnl movable operation";

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -725,7 +725,7 @@ def KrnlPrefetchOp : Op<Krnl_Dialect, "prefetch",
     location pointed by this memory reference.
   }];
 
-  let arguments = (ins Arg<AnyMemRef, "the reference memref", [MemRead]>:$memref,
+  let arguments = (ins Arg<AnyMemRef, "the reference memref", [MemWrite]>:$memref,
       Variadic<Index>:$indices,
       BoolAttr:$isWrite,
       ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<3>]>:$localityHint,

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -1065,55 +1065,74 @@ void KrnlPrefetchOp::build(OpBuilder &builder, OperationState &result,
   build(builder, result, memref, {}, isWrite, localityHint, isDataCache);
 }
 
+//
+// krnl.prefetch %0[%i, %j + 5], read, locality<3>, data : memref<400x400xi32>
+// Code lifted from affine prefetch as is.
+// I have seen parsing errors when multiple '#x' are used in the indices, could
+// not tell why.
+//   krnl.prefetch %arg0[%1#0, %1#1, %3], read, locality<3>, data :
+//     memref<8x256x512xf32>
+// With only one, it works.
+//
+
 ParseResult KrnlPrefetchOp::parse(OpAsmParser &parser, OperationState &result) {
   auto &builder = parser.getBuilder();
   auto indexTy = builder.getIndexType();
 
   MemRefType type;
   OpAsmParser::UnresolvedOperand memrefInfo;
+  IntegerAttr hintInfo;
+  auto i32Type = parser.getBuilder().getIntegerType(32);
+  StringRef readOrWrite, cacheType;
+
   AffineMapAttr mapAttr;
   SmallVector<OpAsmParser::UnresolvedOperand, 1> mapOperands;
-  return failure(
-      parser.parseOperand(memrefInfo) ||
+  if (parser.parseOperand(memrefInfo) ||
       parser.parseAffineMapOfSSAIds(mapOperands, mapAttr,
           KrnlPrefetchOp::getMapAttrStrName(), result.attributes) ||
+      parser.parseComma() || parser.parseKeyword(&readOrWrite) ||
+      parser.parseComma() || parser.parseKeyword("locality") ||
+      parser.parseLess() ||
+      parser.parseAttribute(hintInfo, i32Type,
+          KrnlPrefetchOp::getLocalityHintAttrStrName(), result.attributes) ||
+      parser.parseGreater() || parser.parseComma() ||
+      parser.parseKeyword(&cacheType) ||
       parser.parseOptionalAttrDict(result.attributes) ||
       parser.parseColonType(type) ||
       parser.resolveOperand(memrefInfo, type, result.operands) ||
-      parser.resolveOperands(mapOperands, indexTy, result.operands) ||
-      parser.addTypeToList(indexTy, result.types));
+      parser.resolveOperands(mapOperands, indexTy, result.operands))
+    return failure();
+
+  if (!readOrWrite.equals("read") && !readOrWrite.equals("write"))
+    return parser.emitError(
+        parser.getNameLoc(), "rw specifier has to be 'read' or 'write'");
+  result.addAttribute(KrnlPrefetchOp::getIsWriteAttrStrName(),
+      parser.getBuilder().getBoolAttr(readOrWrite.equals("write")));
+
+  if (!cacheType.equals("data") && !cacheType.equals("instr"))
+    return parser.emitError(
+        parser.getNameLoc(), "cache type has to be 'data' or 'instr'");
+
+  result.addAttribute(KrnlPrefetchOp::getIsDataCacheAttrStrName(),
+      parser.getBuilder().getBoolAttr(cacheType.equals("data")));
+
+  return success();
 }
 
 void KrnlPrefetchOp::print(OpAsmPrinter &p) {
-  p << " " << getMemRef() << " [";
-  if (AffineMapAttr mapAttr =
-          (*this)->getAttrOfType<AffineMapAttr>(getMapAttrStrName()))
+  p << " " << getMemref() << '[';
+  AffineMapAttr mapAttr =
+      (*this)->getAttrOfType<AffineMapAttr>(getMapAttrStrName());
+  if (mapAttr)
     p.printAffineMapOfSSAIds(mapAttr, getMapOperands());
-  p << ']';
+  p << ']' << ", " << (getIsWrite() ? "write" : "read") << ", "
+    << "locality<" << getLocalityHint() << ">, "
+    << (getIsDataCache() ? "data" : "instr");
   p.printOptionalAttrDict((*this)->getAttrs(),
-      /*elidedAttrs=*/{getMapAttrStrName()});
+      /*elidedAttrs=*/{getMapAttrStrName(), getLocalityHintAttrStrName(),
+          getIsDataCacheAttrStrName(), getIsWriteAttrStrName()});
   p << " : " << getMemRefType();
 }
-
-#if 0
-#if 1
-void KrnlPrefetchOp::getEffects(
-    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
-        &effects) {}
-#else
-// hi alex: it already define them, but only for read
-void KrnlPrefetchOp::getEffects(::llvm::SmallVectorImpl<
-    ::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>>
-        &effects) {
-  for (::mlir::Value value : getODSOperands(0))
-    effects.emplace_back(::mlir::MemoryEffects::Write::get(), value, 0, false,
-        ::mlir::SideEffects::DefaultResource::get());
-  for (::mlir::Value value : getODSOperands(0))
-    effects.emplace_back(::mlir::MemoryEffects::Read::get(), value, 0, false,
-        ::mlir::SideEffects::DefaultResource::get());
-}
-#endif
-#endif
 
 //===----------------------------------------------------------------------===//
 // KrnlMemcpyOp

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -519,6 +519,10 @@ struct GenericAffineBuilder final : DialectBuilder {
   void storeIE(mlir::Value val, mlir::Value memref,
       llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
 
+  mlir::Operation *prefetch(mlir::Value memref, mlir::AffineMap map,
+      mlir::ValueRange indices, bool isWrite, unsigned localityHint,
+      bool isDataCache = true);
+
   void forIE(IndexExpr lb, IndexExpr ub, int64_t step,
       mlir::function_ref<void(GenericAffineBuilder &, mlir::Value)> builderFn)
       const;

--- a/src/Dialect/Mlir/DialectBuilder.hpp.inc
+++ b/src/Dialect/Mlir/DialectBuilder.hpp.inc
@@ -65,6 +65,15 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::storeIE(mlir::Value val,
 }
 
 template <class LOAD_OP, class STORE_OP>
+inline mlir::Operation *GenericAffineBuilder<LOAD_OP, STORE_OP>::prefetch(
+    mlir::Value memref, mlir::AffineMap map, mlir::ValueRange indices,
+    bool isWrite, unsigned localityHint, bool isDataCache) {
+  llvm::SmallVector<mlir::Value> indexArray(indices);
+  return b().template create<mlir::affine::AffinePrefetchOp>(
+      loc(), memref, map, indexArray, isWrite, localityHint, isDataCache);
+}
+
+template <class LOAD_OP, class STORE_OP>
 inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forIE(IndexExpr lb,
     IndexExpr ub, int64_t step,
     mlir::function_ref<void(GenericAffineBuilder &, mlir::Value)> builderFn)


### PR DESCRIPTION
Cannot add `affine.prefetch` during ONNX to KRNL lowering because affine prefetch check the enclosing loop nests, which are not yet `affine.for` loops during KRNL lowering. 

Thus created a placeholder `krnl.prefetch` that will later be lowered to `affine.prefetch`.