### PR TITLE
On z/OS import time.h in addition to sys/time.h

### DIFF
--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/Elementwise.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/Elementwise.c
@@ -12,14 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Include pthreads (need special treatment on z/OS).
+// z/OS specific includes
 #ifdef __MVS__
-#define _OPEN_THREADS
+  // needed for pthread on z/OS
+  #define _OPEN_THREADS
+  // z/OS needs <time.h> in addition to <sys/time.h>
+  #include <time.h>
 #endif
-#include <pthread.h>
 
 #include <assert.h>
 #include <math.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/Elementwise.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/Elementwise.c
@@ -14,10 +14,10 @@
 
 // z/OS specific includes
 #ifdef __MVS__
-  // needed for pthread on z/OS
-  #define _OPEN_THREADS
-  // z/OS needs <time.h> in addition to <sys/time.h>
-  #include <time.h>
+// needed for pthread on z/OS
+#define _OPEN_THREADS
+// z/OS needs <time.h> in addition to <sys/time.h>
+#include <time.h>
 #endif
 
 #include <assert.h>

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/MatMul.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/MatMul.c
@@ -12,16 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Include pthreads (need special treatment on z/OS).
+// z/OS specific includes
 #ifdef __MVS__
-#define _OPEN_THREADS
-#define _OPEN_SYS_EXT
-#include <sys/ps.h>
+  // special treatment for pthreads on z/OS.
+  #define _OPEN_THREADS
+  #define _OPEN_SYS_EXT
+  #include <sys/ps.h>
+  // z/OS needs <time.h> in addition to <sys/time.h>
+  #include <time.h>
 #endif
-#include <pthread.h>
 
 #include <assert.h>
 #include <math.h>
+#include <pthread.h>
 #include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/MatMul.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/MatMul.c
@@ -14,12 +14,12 @@
 
 // z/OS specific includes
 #ifdef __MVS__
-  // special treatment for pthreads on z/OS.
-  #define _OPEN_THREADS
-  #define _OPEN_SYS_EXT
-  #include <sys/ps.h>
-  // z/OS needs <time.h> in addition to <sys/time.h>
-  #include <time.h>
+// special treatment for pthreads on z/OS.
+#define _OPEN_THREADS
+#define _OPEN_SYS_EXT
+#include <sys/ps.h>
+// z/OS needs <time.h> in addition to <sys/time.h>
+#include <time.h>
 #endif
 
 #include <assert.h>

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/Softmax.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/Softmax.c
@@ -12,14 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Include pthreads (need special treatment on z/OS).
+// z/OS specific includes
 #ifdef __MVS__
-#define _OPEN_THREADS
+  // needed for pthread on z/OS
+  #define _OPEN_THREADS
+  // z/OS needs <time.h> in addition to <sys/time.h>
+  #include <time.h>
 #endif
-#include <pthread.h>
 
 #include <assert.h>
 #include <math.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/Softmax.c
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/Softmax.c
@@ -14,10 +14,10 @@
 
 // z/OS specific includes
 #ifdef __MVS__
-  // needed for pthread on z/OS
-  #define _OPEN_THREADS
-  // z/OS needs <time.h> in addition to <sys/time.h>
-  #include <time.h>
+// needed for pthread on z/OS
+#define _OPEN_THREADS
+// z/OS needs <time.h> in addition to <sys/time.h>
+#include <time.h>
 #endif
 
 #include <assert.h>

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
@@ -17,8 +17,8 @@
 
 // z/OS specific includes
 #ifdef __MVS__
-  // z/OS needs <time.h> in addition to <sys/time.h>
-  #include <time.h>
+// z/OS needs <time.h> in addition to <sys/time.h>
+#include <time.h>
 #endif
 
 #include <stdlib.h>

--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
@@ -15,6 +15,12 @@
 #ifndef ONNX_MLIR_ZDNNEXTENSION_H
 #define ONNX_MLIR_ZDNNEXTENSION_H
 
+// z/OS specific includes
+#ifdef __MVS__
+  // z/OS needs <time.h> in addition to <sys/time.h>
+  #include <time.h>
+#endif
+
 #include <stdlib.h>
 #include <sys/time.h>
 


### PR DESCRIPTION
# Description
* On z/OS `CLOCKS_PER_SEC` is in time.h and `timeval` is in sys/time.sh so we need both imported.