### PR TITLE
Use macos-13 for Github Action MacOS

### DIFF
--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -17,8 +17,7 @@ jobs:
         sudo rm -rf /Library/Frameworks/Python.framework/Versions/3* /usr/local/Frameworks/Python.framework/Versions/3* /usr/local/bin/python3* || true
     - name: install tools that are needed for compilation
       run: |
-        brew install automake ninja pybind11
-        sudo brew libtool || true
+        brew install automake libtool ninja pybind11
     - name: install protobuf
       run: |
         cd ~/work

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -17,7 +17,8 @@ jobs:
         sudo rm -rf /Library/Frameworks/Python.framework/Versions/3* /usr/local/Frameworks/Python.framework/Versions/3* /usr/local/bin/python3* || true
     - name: install tools that are needed for compilation
       run: |
-        brew install automake ninja pybind11 libtool
+        brew install automake ninja pybind11
+        sudo brew libtool || true
     - name: install protobuf
       run: |
         cd ~/work

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -18,10 +18,6 @@ jobs:
     - name: install tools that are needed for compilation
       run: |
         brew install automake libtool ninja pybind11
-    - name: install protobuf
-      run: |
-        cd ~/work
-        sudo sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: cache MLIR directory
       id: cache-mlir
       uses: actions/cache@v3
@@ -39,6 +35,11 @@ jobs:
         cd ~/work/onnx-mlir/onnx-mlir
         python3 -m pip install --upgrade wheel
         python3 -m pip install -r requirements.txt
+        python3 -m pip install distutils 
+    - name: install protobuf
+      run: |
+        cd ~/work
+        sudo sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: install third_party/onnx
       run: |
         cd ~/work/onnx-mlir/onnx-mlir/third_party/onnx

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -18,15 +18,10 @@ jobs:
     - name: install tools that are needed for compilation
       run: |
         brew install automake libtool ninja pybind11
-    - name: install python requirements
-      run: |
-        cd ~/work/onnx-mlir/onnx-mlir
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install -r requirements.txt
-        python3 -m pip install distutils 
     - name: install protobuf
       run: |
         cd ~/work
+        python3 -m pip install distutils
         sudo sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: cache MLIR directory
       id: cache-mlir
@@ -40,6 +35,11 @@ jobs:
         cd ~/work/onnx-mlir
         sh ~/work/onnx-mlir/onnx-mlir/utils/clone-mlir.sh
         sh ~/work/onnx-mlir/onnx-mlir/utils/build-mlir.sh
+    - name: install python requirements
+      run: |
+        cd ~/work/onnx-mlir/onnx-mlir
+        python3 -m pip install --upgrade wheel
+        python3 -m pip install -r requirements.txt
     - name: install third_party/onnx
       run: |
         cd ~/work/onnx-mlir/onnx-mlir/third_party/onnx

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -4,14 +4,14 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.10'
     - name: install tools that are needed for compilation
       run: |
         brew install automake libtool ninja pybind11

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -11,16 +11,13 @@ jobs:
         submodules: recursive
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: remove system python
       run: |
         sudo rm -rf /Library/Frameworks/Python.framework/Versions/3* /usr/local/Frameworks/Python.framework/Versions/3* /usr/local/bin/python3* || true
     - name: install tools that are needed for compilation
       run: |
         brew install automake libtool ninja pybind11
-    - name: install setuptools 
-      run: |
-        python3 -m pip --break-system-packages install setuptools
     - name: install protobuf
       run: |
         cd ~/work

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -21,7 +21,6 @@ jobs:
     - name: install protobuf
       run: |
         cd ~/work
-        python3 -m pip install distutils
         sudo sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: cache MLIR directory
       id: cache-mlir

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -12,13 +12,16 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+    - name: remove system python
+      run: |
+        sudo rm -rf /Library/Frameworks/Python.framework/Versions/3* /usr/local/Frameworks/Python.framework/Versions/3* /usr/local/bin/python3* || true
     - name: install tools that are needed for compilation
       run: |
-        brew install automake libtool ninja pybind11
+        brew install automake ninja pybind11
     - name: install protobuf
       run: |
         cd ~/work
-        sudo sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
+        sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: cache MLIR directory
       id: cache-mlir
       uses: actions/cache@v3

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -17,7 +17,7 @@ jobs:
         sudo rm -rf /Library/Frameworks/Python.framework/Versions/3* /usr/local/Frameworks/Python.framework/Versions/3* /usr/local/bin/python3* || true
     - name: install tools that are needed for compilation
       run: |
-        brew install automake ninja pybind11
+        brew install automake ninja pybind11 libtool
     - name: install protobuf
       run: |
         cd ~/work

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -20,7 +20,7 @@ jobs:
         brew install automake libtool ninja pybind11
     - name: install setuptools 
       run: |
-        python3 -m pip install setuptools
+        python3 -m pip --break-system-packages install setuptools
     - name: install protobuf
       run: |
         cd ~/work

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: install protobuf
       run: |
         cd ~/work
-        sudo h ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
+        sudo sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: cache MLIR directory
       id: cache-mlir
       uses: actions/cache@v3

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -18,6 +18,7 @@ jobs:
     - name: install tools that are needed for compilation
       run: |
         brew install automake libtool ninja pybind11
+        python3 -m pip install setuptools
     - name: install protobuf
       run: |
         cd ~/work

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -18,6 +18,8 @@ jobs:
     - name: install tools that are needed for compilation
       run: |
         brew install automake libtool ninja pybind11
+    - name: install setuptools 
+      run: |
         python3 -m pip install setuptools
     - name: install protobuf
       run: |

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -18,6 +18,16 @@ jobs:
     - name: install tools that are needed for compilation
       run: |
         brew install automake libtool ninja pybind11
+    - name: install python requirements
+      run: |
+        cd ~/work/onnx-mlir/onnx-mlir
+        python3 -m pip install --upgrade wheel
+        python3 -m pip install -r requirements.txt
+        python3 -m pip install distutils 
+    - name: install protobuf
+      run: |
+        cd ~/work
+        sudo sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: cache MLIR directory
       id: cache-mlir
       uses: actions/cache@v3
@@ -30,16 +40,6 @@ jobs:
         cd ~/work/onnx-mlir
         sh ~/work/onnx-mlir/onnx-mlir/utils/clone-mlir.sh
         sh ~/work/onnx-mlir/onnx-mlir/utils/build-mlir.sh
-    - name: install python requirements
-      run: |
-        cd ~/work/onnx-mlir/onnx-mlir
-        python3 -m pip install --upgrade wheel
-        python3 -m pip install -r requirements.txt
-        python3 -m pip install distutils 
-    - name: install protobuf
-      run: |
-        cd ~/work
-        sudo sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: install third_party/onnx
       run: |
         cd ~/work/onnx-mlir/onnx-mlir/third_party/onnx

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: install protobuf
       run: |
         cd ~/work
-        sh ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
+        sudo h ~/work/onnx-mlir/onnx-mlir/utils/install-protobuf.sh
     - name: cache MLIR directory
       id: cache-mlir
       uses: actions/cache@v3

--- a/.github/workflows/macos-amd64-build.yml
+++ b/.github/workflows/macos-amd64-build.yml
@@ -12,9 +12,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    - name: remove system python
-      run: |
-        sudo rm -rf /Library/Frameworks/Python.framework/Versions/3* /usr/local/Frameworks/Python.framework/Versions/3* /usr/local/bin/python3* || true
     - name: install tools that are needed for compilation
       run: |
         brew install automake libtool ninja pybind11


### PR DESCRIPTION
The macos-latest version is macos 14 that removed python 3.10, so it failed to install protobuf 4.21.12 using python 3.11 or 3.12 in macos 14. So, specifically use macos-13 to avoid unexpected failures, and we would update the macos version at a good timing in the future.