### PR TITLE
A pattern to simplify WhereOp

### DIFF
--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -10029,6 +10029,7 @@ def ONNXUpsampleV7Op:ONNX_Op<"UpsampleV7",
 
 def ONNXWhereOp:ONNX_Op<"Where",
   [Pure, DeclareOpInterfaceMethods<ShapeInferenceOpInterface>, DeclareOpInterfaceMethods<ShapeHelperOpInterface>]> {
+  let hasCanonicalizer = 1;
   let summary = "ONNX Where operation";
   let description = [{
   Return elements, either from X or Y, depending on condition.

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -205,6 +205,16 @@ def IsFromONNXConstantOpWithDenseElementsAttr: Constraint<
          CPred<" isa<DenseElementsAttr>(onnx_mlir::getONNXConstantOp($_self).getValueAttr()) ">
         ]>, "Value is not a ONNXConstantOp with a DenseElementsAttr">;
 
+def IsNegativeSplatConstant: Constraint<
+  CPred<"onnx_mlir::isNegativeSplatConstant($_self)">,
+  "Is a splat constant with a negative value."
+>;
+
+def AreAllDimSizes: Constraint<
+  CPred<"onnx_mlir::areAllDimSizes($_self)">,
+  "All values in the input ValueRange are dimension sizes."
+>;
+
 def AreTheSameAxesConstant: Constraint<
     CPred<"onnx_mlir::AreTheSameAxesConstant("
           "(onnx_mlir::hasShapeAndRank($0) ? $0.getType().cast<ShapedType>().getRank() : 0),"
@@ -1022,6 +1032,23 @@ def ShapeTransformComposePattern : Pat<
   (ONNXShapeTransformOp (ONNXShapeTransformOp $arg, $map1), $map2),
   (ONNXShapeTransformOp $arg, (GetComposedMap $map2, $map1)),
   []
+>;
+
+//===----------------------------------------------------------------------===//
+// Canonicalization for ONNXWhere
+//===----------------------------------------------------------------------===//
+
+// In this pattern, the condition in onnx.Where is always false, so we can replace
+// onnx.Where by its "false" value.
+// Condition in this pattern is a comparision between dimension sizes and negative values.
+// Since dimension sizes are always positive, the condition is evaluated to false.
+
+// This pattern was found in xlm-roberta-base-language-detection model in HuggingFace.
+
+def AlwaysFalseWherePattern : Pat<
+ (ONNXWhereOp (ONNXEqualOp (ONNXConcatOp $dims, $_), $negative_constant), $true_val, $false_val),
+ (replaceWithValue $false_val),
+ [(IsNegativeSplatConstant:$negative_constant), (AreAllDimSizes:$dims)]
 >;
 
 #endif // ONNX_REWRITE

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -360,6 +360,7 @@ OpsWithCanonicalizer = [
     "Transpose",
     "Unsqueeze",
     "UnsqueezeV11",
+    "Where",
     "Xor",
 ]
 


### PR DESCRIPTION
This patch adds a canonicalization rule to WhereOp to simplify the following pattern (found in the model xlm-roberta-base-language-detection):
```mlir
    %0 = onnx.Constant dense<-1> : tensor<2xi64>
    %1 = onnx.Constant dense<1> : tensor<2xi64>
    %2 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
    %3 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
    %4 = "onnx.Concat"(%2, %3) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
    %5 = "onnx.Equal"(%4, %0) : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi1>
    %6 = "onnx.Where"(%5, %1, %4) : (tensor<2xi1>, tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
```

Since the condition of where, i.e. `%5`, is always false (it compares dimension sizes with -1, and dimension sizes are always positive so the result is false), `onnx.Where` can be replaced by its "false" value that is `%4`.
into 

```mlir
    %0 = "onnx.Dim"(%arg0) {axis = 0 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
    %1 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
    %2 = "onnx.Concat"(%0, %1) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
```

This simplification of WhereOp helps DimAnalysis work well with the model xlm-roberta-base-language-detection so that all MatMuls could run on NNPA.