### PR TITLE
[NNPA] Recompose ops back to zhigh stick and unstick if they are not optimized by decomposition

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -128,11 +128,14 @@ void addONNXToZHighPasses(mlir::PassManager &pm) {
         onnx_mlir::zhigh::createZHighConstPropagationPass());
 
   // Experimental feature: Decompose stick/unstick into two phases: layout
-  // transform and data conversion.
+  // transform and data conversion. Do some optimizations after decomposing.
+  // Then, recompose again layout and data conversion if they are not optimized.
   if (nnpaEnableZHighDecomposeStickUnstick) {
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::zhigh::createZHighDecomposeStickUnstickPass());
     pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<func::FuncOp>(
+        onnx_mlir::zhigh::createZHighRecomposeToStickUnstickPass());
   }
 
   // Remove common sub-expressions.

--- a/src/Accelerators/NNPA/NNPAAccelerator.cpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.cpp
@@ -127,6 +127,10 @@ void NNPAAccelerator::registerPasses(int optLevel) const {
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return onnx_mlir::zhigh::createZHighDecomposeStickUnstickPass();
   });
+
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return onnx_mlir::zhigh::createZHighRecomposeToStickUnstickPass();
+  });
 }
 
 mlir::MemRefType NNPAAccelerator::convertTensorTypeToMemRefType(

--- a/src/Accelerators/NNPA/Pass/NNPAPasses.hpp
+++ b/src/Accelerators/NNPA/Pass/NNPAPasses.hpp
@@ -53,6 +53,8 @@ std::unique_ptr<mlir::Pass> createZHighClipToDLFloatPass();
 /// Pass for decomposing stick/unstick at ZHighIR.
 std::unique_ptr<mlir::Pass> createZHighDecomposeStickUnstickPass();
 
+/// Pass for recomposing ops back to stick/unstick at ZHighIR.
+std::unique_ptr<mlir::Pass> createZHighRecomposeToStickUnstickPass();
 } // end namespace zhigh
 
 namespace zlow {

--- a/src/Accelerators/NNPA/Transform/ZHigh/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Transform/ZHigh/CMakeLists.txt
@@ -66,3 +66,21 @@ add_onnx_mlir_library(OMZHighDecomposeStickUnstick
   ACCEL_INCLUDE_DIRS PRIVATE
   ${NNPA_INCLUDE_PATH}
   )
+
+add_onnx_mlir_rewriter(ZHighRecomposeToStickUnstick)
+add_onnx_mlir_library(OMZHighRecomposeToStickUnstick
+  ZHighRecomposeToStickUnstick.cpp
+
+  DEPENDS
+  OMLayoutHelper
+  OMONNXZHighRecomposeToStickUnstickIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRRewrite
+  MLIRTransformUtils
+  OMZHighOps
+  OMONNXOps
+
+  ACCEL_INCLUDE_DIRS PRIVATE
+  ${NNPA_INCLUDE_PATH}
+  )

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighRecomposeToStickUnstick.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighRecomposeToStickUnstick.cpp
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===--- ZHighRecomposeToStickUnstick.cpp - ZHigh High Level Optimizer ----===//
+//
+// Copyright 2024 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file implements a set of simple combiners for optimizing operations in
+// the ZHigh dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.hpp"
+#include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.hpp"
+#include "src/Accelerators/NNPA/Pass/NNPAPasses.hpp"
+#include "src/Accelerators/NNPA/Support/LayoutHelper.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+
+using namespace mlir;
+using namespace onnx_mlir;
+using namespace onnx_mlir::zhigh;
+
+namespace {
+/// Use anonymous namespace to avoid duplication symbol `populateWithGenerated`
+/// among multiple tablegen-based definitions.
+
+/// Include the patterns defined in the Declarative Rewrite framework.
+#include "src/Accelerators/NNPA/Transform/ZHigh/ONNXZHighRecomposeToStickUnstick.inc"
+} // namespace
+
+namespace onnx_mlir {
+namespace zhigh {
+
+//===----------------------------------------------------------------------===//
+// ZHigh layout propagation Pass
+//===----------------------------------------------------------------------===//
+
+struct ZHighRecomposeToStickUnstickPass
+    : public PassWrapper<ZHighRecomposeToStickUnstickPass,
+          OperationPass<func::FuncOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ZHighRecomposeToStickUnstickPass)
+
+  StringRef getArgument() const override {
+    return "zhigh-recompose-to-stick-unstick";
+  }
+
+  StringRef getDescription() const override {
+    return "Compose LayerTransform and zhigh.F32ToDLF16 (zhigh.DLF16ToF32) "
+           "back to ZHighStickOp (ZHighUnstickOp)";
+  }
+
+  void runOnOperation() override {
+    Operation *function = getOperation();
+    ConversionTarget target(getContext());
+    RewritePatternSet patterns(&getContext());
+
+    // Get patterns from tablegen.
+    populateWithGenerated(patterns);
+
+    // Get canonicalization rules for some important operations.
+    ZHighDLF16ToF32Op::getCanonicalizationPatterns(patterns, &getContext());
+    ZHighF32ToDLF16Op::getCanonicalizationPatterns(patterns, &getContext());
+    ONNXLayoutTransformOp::getCanonicalizationPatterns(patterns, &getContext());
+    (void)applyPatternsAndFoldGreedily(function, std::move(patterns));
+  }
+};
+
+std::unique_ptr<Pass> createZHighRecomposeToStickUnstickPass() {
+  return std::make_unique<ZHighRecomposeToStickUnstickPass>();
+}
+
+} // namespace zhigh
+} // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighRecomposeToStickUnstick.td
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighRecomposeToStickUnstick.td
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//===------- ZHighRecomposeToStickUnstick.td - Pattern Match --------------===//
+//
+// Copyright 2024 The IBM Research Authors.
+//
+// =============================================================================
+//
+// Defines language-specific pattern match optimizations for ZHigh using
+// Declarative Rewrite Rules (DRR) specified using TableGen records.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef RECOMPOSE_TO_STICK_UNSTICK_TD 
+#define RECOMPOSE_TO_STICK_UNSTICK_TD 
+
+#ifndef OP_BASE
+include "src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td"
+include "src/Dialect/ONNX/ONNX.td"
+#endif // OP_BASE
+
+include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.td"
+
+/// Note: The DRR definition used for defining patterns is shown below:
+///
+/// class Pattern<
+///    dag sourcePattern, list<dag> resultPatterns,
+///    list<dag> additionalConstraints = [],
+///    list<dag> supplementalPatterns = [],
+///    dag benefitsAdded = (addBenefit 0)
+/// >;
+
+//===----------------------------------------------------------------------===//
+// DRR patterns 
+//===----------------------------------------------------------------------===//
+
+def NoneLayoutAttr: NativeCodeCall<"StringAttr()">;
+
+// zhigh.Stick $input, $layout = onnx.LayoutTransform (zhigh.F32ToDLF16 $input), $layout
+// Not support NHWC layout since the stick does transpose internally. We can
+// introduce transpose explicitly, but need to evaluate its overhead.
+def RecomposeToStickPattern: Pat<
+  (ONNXLayoutTransformOp (ZHighF32ToDLF16Op $input), $layout),
+  (ZHighStickOp $input, $layout),
+  []
+>;
+
+// zhigh.Unstick $input = zhigh.F32ToDLF16 (onnx.LayoutTransform $input, $none_layout)
+// Not support NHWC layout since the unstick does transpose internally. We can
+// introduce transpose explicitly, but need to evaluate its overhead.
+def RecomposeToUnstickPattern: Pat<
+  (ZHighDLF16ToF32Op (ONNXLayoutTransformOp $input, $layout)),
+  (ZHighUnstickOp $input),
+  []
+>;
+
+#endif // RECOMPOSE_TO_STICK_UNSTICK_TD

--- a/test/mlir/accelerators/nnpa/transform/zhigh-recompose-to-stick-unstick.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zhigh-recompose-to-stick-unstick.mlir
@@ -1,0 +1,21 @@
+// RUN: onnx-mlir-opt -mcpu=z16 -maccel=NNPA --zhigh-recompose-to-stick-unstick --split-input-file %s | FileCheck %s
+
+func.func @test_relu(%arg0: tensor<1x3x5x?xf32>) -> tensor<1x3x5x?xf32> {
+  %0 = "zhigh.F32ToDLF16"(%arg0) : (tensor<1x3x5x?xf32>) -> tensor<1x3x5x?xf16>
+  %1 = "onnx.LayoutTransform"(%0) {target_layout = "4D"} : (tensor<1x3x5x?xf16>) -> tensor<1x3x5x?xf16, #zhigh.layout<{dataLayout = "4D"}>>
+  %2 = "zhigh.Relu"(%1) : (tensor<1x3x5x?xf16, #zhigh.layout<{dataLayout = "4D"}>>) -> tensor<1x3x5x?xf16, #zhigh.layout<{dataLayout = "4D"}>>
+  %3 = "onnx.LayoutTransform"(%2) : (tensor<1x3x5x?xf16, #zhigh.layout<{dataLayout = "4D"}>>) -> tensor<1x3x5x?xf16>
+  %4 = "zhigh.DLF16ToF32"(%3) : (tensor<1x3x5x?xf16>) -> tensor<1x3x5x?xf32>
+  return %4 : tensor<1x3x5x?xf32>
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @test_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x3x5x?xf32>) -> tensor<1x3x5x?xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "4D"} : (tensor<1x3x5x?xf32>) -> tensor<1x3x5x?xf16, #zhigh.layout<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Relu"([[VAR_0_]]) : (tensor<1x3x5x?xf16, #zhigh.layout<{dataLayout = "4D"}>>) -> tensor<1x3x5x?xf16, #zhigh.layout<{dataLayout = "4D"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.Unstick"([[VAR_1_]]) : (tensor<1x3x5x?xf16, #zhigh.layout<{dataLayout = "4D"}>>) -> tensor<1x3x5x?xf32>
+// CHECK:           return [[VAR_2_]] : tensor<1x3x5x?xf32>
+// CHECK:         }
+}
+
+


### PR DESCRIPTION
When using `--enable-zhigh-decompose-stick-unstick` to decompose stick and unstick into LayoutTransform, DLF16ToF32 and F32ToDLF16 ops, some optimizations are applied to remove DLF16ToF32 and F32ToDLF16 ops. But when they are not removed, we would recompose back to zhigh stick and unstick to utilize the optimized code generation for zhigh stick and unstick.

This patch adds a pass for recomposition. The pass is enabled if we compile a model with the option `--enable-zhigh-decompose-stick-unstick`.

Below is the result for roberta-base, where the number of stick and unstick dramatically decreased.

**without --enable-zhigh-decompose-stick-unstick**
<img width="235" alt="Screenshot 2024-05-15 at 14 44 24" src="https://github.com/onnx/onnx-mlir/assets/1230113/e19b18b3-91e1-4640-b5da-be2b0e799715">

**with --enable-zhigh-decompose-stick-unstick**
<img width="253" alt="Screenshot 2024-05-15 at 14 44 57" src="https://github.com/onnx/onnx-mlir/assets/1230113/8ab2eb89-e172-47c3-9dfb-e87c28fa23cd">
