### PR TITLE
Update zdnn.cmake

### DIFF
--- a/src/Accelerators/NNPA/zdnn.cmake
+++ b/src/Accelerators/NNPA/zdnn.cmake
@@ -14,9 +14,7 @@ function(setup_zdnn version)
       GIT_TAG ${version}
       PREFIX ${ZDNN_PREFIX}
       BUILD_IN_SOURCE ON
-
-      # Skip autoconf and configure if config.make already exists
-      CONFIGURE_COMMAND sh -c "[ -f config.make ] || (autoconf && ./configure)"
+      CONFIGURE_COMMAND sh -c "autoconf && ./configure"
 
       # We build libzdnn.so so that obj/*.o are compiled with -fPIC
       # Then we create libzdnn.a ourselves from these PIC .o since


### PR DESCRIPTION
If we still want to skip autoconf and config if the files already exist, I can add a switch but I figured this update is so small... it is not needed. 
