### PR TITLE
Parallel fix for new mlir

### DIFF
--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -873,9 +873,14 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
   LLVMTypeConverter typeConverter(ctx, options);
   customizeTypeConverter(typeConverter);
 
+#if 1
+  // hi alex
+  configureOpenMPToLLVMConversionLegality(target, typeConverter);
+#else
   // omp::ParallelOp can only be legalized when its region is legal
   target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsloopOp>(
       [&](Operation *op) { return typeConverter.isLegal(&op->getRegion(0)); });
+#endif
   // Currently, only minimum required OpenMP Ops are marked as legal, in the
   // future integration of OpenMP, probably more OpenMP Ops are required to be
   // marked as legal. Please refer the Conversion/OpenMPToLLVM/OpenMPtoLLVM.cpp

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -873,14 +873,9 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
   LLVMTypeConverter typeConverter(ctx, options);
   customizeTypeConverter(typeConverter);
 
-#if 1
-  // hi alex
+  // Set legality for OMP constructs.
   configureOpenMPToLLVMConversionLegality(target, typeConverter);
-#else
-  // omp::ParallelOp can only be legalized when its region is legal
-  target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsloopOp>(
-      [&](Operation *op) { return typeConverter.isLegal(&op->getRegion(0)); });
-#endif
+
   // Currently, only minimum required OpenMP Ops are marked as legal, in the
   // future integration of OpenMP, probably more OpenMP Ops are required to be
   // marked as legal. Please refer the Conversion/OpenMPToLLVM/OpenMPtoLLVM.cpp


### PR DESCRIPTION
New LLVM/MLIR bump introduced a new way to initialize the legality of the OMP ops during OMP to LLVM lowering.
This PR update our code to this new approach.

fixes #2847 