### PR TITLE
Optimize ONNXLayoutTransform

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -138,9 +138,8 @@ void addONNXToZHighPasses(mlir::PassManager &pm) {
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::zhigh::createZHighDecomposeStickUnstickPass());
     pm.addPass(mlir::createCanonicalizerPass());
-    // hi alex: disable to investigate performance issue
-    // pm.addNestedPass<func::FuncOp>(
-    //    onnx_mlir::zhigh::createZHighRecomposeToStickUnstickPass());
+    pm.addNestedPass<func::FuncOp>(
+        onnx_mlir::zhigh::createZHighRecomposeToStickUnstickPass());
   }
 
   // Remove common sub-expressions.

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -138,8 +138,9 @@ void addONNXToZHighPasses(mlir::PassManager &pm) {
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::zhigh::createZHighDecomposeStickUnstickPass());
     pm.addPass(mlir::createCanonicalizerPass());
-    pm.addNestedPass<func::FuncOp>(
-        onnx_mlir::zhigh::createZHighRecomposeToStickUnstickPass());
+    // hi alex: disable to investigate performance issue
+    // pm.addNestedPass<func::FuncOp>(
+    //    onnx_mlir::zhigh::createZHighRecomposeToStickUnstickPass());
   }
 
   // Remove common sub-expressions.

--- a/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
+++ b/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
@@ -233,7 +233,14 @@ struct ONNXLayoutTransformOpLowering
     bool outValid = inspectMappedLowestDim(outMemRefType, outMod);
     if (inValid && outValid && rank >= 2) {
       // For the moment, support only a mod in the one or the other direction.
-      if ((inMod == -1 && outMod > 16) || (inMod > 15 && outMod == -1)) {
+      if ((inMod == -1 && outMod >= 16) || (inMod >= 16 && outMod == -1)) {
+        return generateLayoutWithMod(
+            rewriter, create, op, alloc, data, lbs, ubs, inMod, outMod);
+      }
+      if (inMod == outMod && inMod != -1) {
+        // We have 2 identical mods, do it too.
+        // TODO: this scenario may need to be tested thoroughly once we generate
+        // this pattern.
         return generateLayoutWithMod(
             rewriter, create, op, alloc, data, lbs, ubs, inMod, outMod);
       }

--- a/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
+++ b/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
@@ -149,6 +149,7 @@ struct ONNXLayoutTransformOpLowering
     assert(rank >= 2 && "expect rank of 2 or more");
     assert((inModVal == -1 || outModVal == -1 || inModVal == outModVal) &&
            "bad mods");
+    LLVM_DEBUG(llvm::dbgs() << "use fast pattern\n");
     int64_t modVal = (inModVal > outModVal) ? inModVal : outModVal;
     // Create loop iterations. Note that we iterate over E1 as tiles of modVal
     // elements.
@@ -165,10 +166,10 @@ struct ONNXLayoutTransformOpLowering
       if (findSuitableParallelDimension(lbs, ubs, 0, rank, parId, 8)) {
         create.krnl.parallel(loopDefs[parId]);
         onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId],
-            "layout transform normal->mapped");
+            "layout transform fast pattern");
       } else {
         onnxToKrnlParallelReport(op, false, -1, -1,
-            "no dim with enough work in layout transform normal->mapped");
+            "no dim with enough work in layout transform fast pattern");
       }
     }
 

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-krnl/onnx-on-ztensor.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-krnl/onnx-on-ztensor.mlir
@@ -125,3 +125,62 @@ func.func @test_onnx_layout_transform_on_ztensor(%arg0: tensor<3x5x7xf32, #zhigh
 // CHECK:           return [[RES_]] : memref<3x5x7xf16, #map1>
 // CHECK:         }
 }
+
+// -----
+
+// Check the layout transform is working properly.
+
+  func.func @layout_transform_to_from_3DS(%arg0: tensor<?x?x?xf16>) -> tensor<?x?x?xf16> {
+    %0 = "onnx.LayoutTransform"(%arg0) {target_layout = "3DS"} : (tensor<?x?x?xf16>) -> tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3DS"}>>
+    %1 = "onnx.LayoutTransform"(%0) : (tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<?x?x?xf16>
+    return %1 : tensor<?x?x?xf16>
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1, d2) -> (d0, d2 floordiv 64, 0, d1 floordiv 32, d1 mod 32, d2 mod 64)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1, d2) -> (d2)>
+// CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<(d0, d1, d2) -> (d0 ceildiv 64)>
+// CHECK-DAG:   [[MAP_4_:#.+]] = affine_map<()[s0] -> (s0 * 64)>
+// CHECK-DAG:   [[MAP_5_:#.+]] = affine_map<()[s0, s1] -> (s0 * -64 + s1 - 64)>
+// CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<()[s0, s1] -> (s0 - s1 * 64)>
+// CHECK-LABEL:  func.func @layout_transform_to_from_3DS
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x?x?xf16>) -> memref<?x?x?xf16> {
+// CHECK-DAG:       [[CST_64_:%.+]] = arith.constant 64 : i64
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x?x?xf16>
+// CHECK-DAG:       [[VAR_dim_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_1_]] : memref<?x?x?xf16>
+// CHECK-DAG:       [[VAR_dim_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<?x?x?xf16>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_dim_]], [[VAR_dim_]]_0, [[VAR_dim_]]_1) {{.*}}: memref<?x?x?xf16, #map>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:3 = krnl.define_loops 3
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[MAP_1_]]([[VAR_dim_1_]], [[VAR_dim_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to [[MAP_2_]]([[VAR_dim_1_]], [[VAR_dim_]], [[VAR_dim_]]_0), [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to [[MAP_3_]]([[VAR_dim_1_]], [[VAR_dim_]], [[VAR_dim_]]_0)){
+// CHECK:             [[VAR_2_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
+// CHECK:             [[VAR_3_:%.+]] = affine.apply [[MAP_4_]](){{.}}[[VAR_2_]]#2]
+// CHECK-DAG:         [[VAR_4_:%.+]] = krnl.get_linear_offset_index [[RES_]] at {{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_3_]]{{.}} : memref<?x?x?xf16, #map>
+// CHECK-DAG:         [[VAR_5_:%.+]] = krnl.get_linear_offset_index [[PARAM_0_]] at {{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_3_]]{{.}} : memref<?x?x?xf16>
+// CHECK:             "krnl.memcpy"([[RES_]], [[PARAM_0_]], [[CST_64_]], [[VAR_4_]], [[VAR_5_]]) : (memref<?x?x?xf16, #map>, memref<?x?x?xf16>, i64, index, index) -> ()
+// CHECK:           }
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc([[VAR_dim_]], [[VAR_dim_]]_0, [[VAR_dim_]]_1) {{.*}}: memref<?x?x?xf16>
+// CHECK-DAG:       [[LOOP_1_:%.+]]:3 = krnl.define_loops 3
+// CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2) with ([[LOOP_1_]]#0 -> [[I_3_:%.+]] = 0 to [[MAP_1_]]([[VAR_dim_1_]], [[VAR_dim_]]), [[LOOP_1_]]#1 -> [[I_4_:%.+]] = 0 to [[MAP_2_]]([[VAR_dim_1_]], [[VAR_dim_]], [[VAR_dim_]]_0), [[LOOP_1_]]#2 -> [[I_5_:%.+]] = 0 to [[MAP_3_]]([[VAR_dim_1_]], [[VAR_dim_]], [[VAR_dim_]]_0)){
+// CHECK:             [[VAR_2_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
+// CHECK:             [[VAR_3_1_:%.+]] = affine.apply [[MAP_4_]](){{.}}[[VAR_2_1_]]#2]
+// CHECK-DAG:         [[VAR_4_1_:%.+]] = krnl.get_linear_offset_index [[RES_1_]] at {{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#1, [[VAR_3_1_]]{{.}} : memref<?x?x?xf16>
+// CHECK-DAG:         [[VAR_5_1_:%.+]] = krnl.get_linear_offset_index [[RES_]] at {{.}}[[VAR_2_1_]]#0, [[VAR_2_1_]]#1, [[VAR_3_1_]]{{.}} : memref<?x?x?xf16, #map>
+// CHECK-DAG:         [[VAR_6_:%.+]] = affine.apply [[MAP_5_]](){{.}}[[VAR_2_1_]]#2, [[VAR_dim_1_]]{{.}}
+// CHECK:             [[VAR_7_:%.+]] = arith.cmpi sge, [[VAR_6_]], [[CST_0_]] : index
+// CHECK:             scf.if [[VAR_7_]] {
+// CHECK:               "krnl.memcpy"([[RES_1_]], [[RES_]], [[CST_64_]], [[VAR_4_1_]], [[VAR_5_1_]]) : (memref<?x?x?xf16>, memref<?x?x?xf16, #map>, i64, index, index) -> ()
+// CHECK:             } else {
+// CHECK:               [[VAR_8_:%.+]] = affine.apply [[MAP_6_]](){{.}}[[VAR_dim_1_]], [[VAR_2_1_]]#2]
+// CHECK:               [[VAR_9_:%.+]] = arith.index_cast [[VAR_8_]] : index to i64
+// CHECK:               "krnl.memcpy"([[RES_1_]], [[RES_]], [[VAR_9_]], [[VAR_4_1_]], [[VAR_5_1_]]) : (memref<?x?x?xf16>, memref<?x?x?xf16, #map>, i64, index, index) -> ()
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return [[RES_1_]] : memref<?x?x?xf16>
+// CHECK:         }
+}
+


### PR DESCRIPTION
Right now, under the `--enable-zhigh-decompose-stick-unstick` flag, we decompose the stick/unstick into a data conversion and a layout transformation.

The layout transformation op lowering to KRNL was implemented using a simple load/store saving one value at a time.
That implementation significantly lagged in performance compared to zDNN stick/unstick and the compiler generated pattern for stick/unstick.

This implementation look at one stick at a time (guaranteed to be contiguous in memory) and generate a mem copy for all (typically 64) values at once.

It works in a non NNPA context. Given a map `(d0, d1, d2)` it simply checks that the mapped version is either `d2` (identity) or `d2 mod lit` (last dim tiled by `lit` constant value).

When storing into a tiled array, the code does not check for the last tile; it may overwrite data that is unused to begin with.
When storing into a non-tiled array (aka `d2` mapping), then the last tile is handled precisely.

In Roberta (6x384) the sequential time of the layout transformation went from 405ms to 81ms (5x speedup).

Lit test:
``` mlir
    %0 = "onnx.LayoutTransform"(%arg0) {target_layout = "3DS"} : (tensor<?x?x?xf16>) -> tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3DS"}>>
    %1 = "onnx.LayoutTransform"(%0) : (tensor<?x?x?xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<?x?x?xf16>
```

becomes (no bound check to tiled data)
``` mlir
    %alloc = memref.alloc(%dim, %dim_0, %dim_1) {alignment = 4096 : i64} : memref<?x?x?xf16, #map>
    %0:3 = krnl.define_loops 3
    krnl.iterate(%0#0, %0#1, %0#2) with (%0#0 -> %arg1 = 0 to #map1(%dim_1, %dim), %0#1 -> %arg2 = 0 to #map2(%dim_1, %dim, %dim_0), %0#2 -> %arg3 = 0 to #map3(%dim_1, %dim, %dim_0)){
      %2:3 = krnl.get_induction_var_value(%0#0, %0#1, %0#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
      %3 = affine.apply #map4()[%2#2]
      %4 = krnl.get_linear_offset_index %alloc at [%2#0, %2#1, %3] : memref<?x?x?xf16, #map>
      %5 = krnl.get_linear_offset_index %arg0 at [%2#0, %2#1, %3] : memref<?x?x?xf16>
      "krnl.memcpy"(%alloc, %arg0, %c64_i64, %4, %5) : (memref<?x?x?xf16, #map>, memref<?x?x?xf16>, i64, index, index) -> ()
    }
```
and (bound check to untiled data)
``` mlir
    %alloc_2 = memref.alloc(%dim, %dim_0, %dim_1) {alignment = 16 : i64} : memref<?x?x?xf16>
    %1:3 = krnl.define_loops 3
    krnl.iterate(%1#0, %1#1, %1#2) with (%1#0 -> %arg1 = 0 to #map1(%dim_1, %dim), %1#1 -> %arg2 = 0 to #map2(%dim_1, %dim, %dim_0), %1#2 -> %arg3 = 0 to #map3(%dim_1, %dim, %dim_0)){
      %2:3 = krnl.get_induction_var_value(%1#0, %1#1, %1#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
      %3 = affine.apply #map4()[%2#2]
      %4 = krnl.get_linear_offset_index %alloc_2 at [%2#0, %2#1, %3] : memref<?x?x?xf16>
      %5 = krnl.get_linear_offset_index %alloc at [%2#0, %2#1, %3] : memref<?x?x?xf16, #map>
      %6 = affine.apply #map5()[%2#2, %dim_1]
      %7 = arith.cmpi sge, %6, %c0 : index
      scf.if %7 {
        "krnl.memcpy"(%alloc_2, %alloc, %c64_i64, %4, %5) : (memref<?x?x?xf16>, memref<?x?x?xf16, #map>, i64, index, index) -> ()
      } else {
        %8 = affine.apply #map6()[%dim_1, %2#2]
        %9 = arith.index_cast %8 : index to i64
        "krnl.memcpy"(%alloc_2, %alloc, %9, %4, %5) : (memref<?x?x?xf16>, memref<?x?x?xf16, #map>, i64, index, index) -> ()
      }
    }
```

I will also investigate if transforming some `krnl.memcpy` into unrolled simd loop may yield better results (which it appears that it should as the compiler generated stick/unstick are still faster), at least for some small sizes. 
This will be in a subsequent PR.
