### PR TITLE
Update Supported Range for Rank in NNPA

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -30,7 +30,7 @@ bool onnxToZHighUnsupportedReport(Operation *op, const std::string &message) {
       !message.empty()) {
     StringAttr opName = op->getName().getIdentifier();
     std::string nodeNameStr = getNodeNameInPresenceOfOpt(op);
-    printf("==NNPA-UNSUPPORTEDOPS-REPORT== %s, %s, %s\n", opName.data(),
+    printf("==NNPA-UNSUPPORTEDOPS-REPORT==, %s, %s, %s\n", opName.data(),
         nodeNameStr.c_str(), message.c_str());
   }
   return false;

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -4,7 +4,7 @@
 
 //===---------- ONNXLegalityCheck.cpp - Check legality for ONNX ops -------===//
 //
-// Copyright 2019-2023 The IBM Research Authors.
+// Copyright 2019-2024 The IBM Research Authors.
 //
 // =============================================================================
 //
@@ -89,14 +89,13 @@ bool isValidElementTypeAndRank(Operation *op, Value val, bool donotCheckRank) {
         return onnxToZHighUnsupportedReport(op, message);
       }
       int64_t rank = valueType.getRank();
-      bool supportedRank = (rank == 0) || (rank > 4);
-      if (supportedRank) {
+      if ((rank == 0) || (rank > 4)) {
         std::string message =
             "Rank " + std::to_string(rank) +
             " is not supported. zAIU only supports rank in range of (0, 4].";
         return onnxToZHighUnsupportedReport(op, message);
       }
-      return supportedRank;
+      return true;
     } else {
       std::string message = "Element type is not F16 or F32.";
       return onnxToZHighUnsupportedReport(op, message);

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -90,7 +90,7 @@ bool isValidElementTypeAndRank(Operation *op, Value val, bool donotCheckRank) {
       }
       int64_t rank = valueType.getRank();
       bool supportedRank = (rank == 0) || (rank > 4);
-      if (!supportedRank) {
+      if (supportedRank) {
         std::string message =
             "Rank " + std::to_string(rank) +
             " is not supported. zAIU only supports rank in range of (0, 4].";

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -30,7 +30,7 @@ bool onnxToZHighUnsupportedReport(Operation *op, const std::string &message) {
       !message.empty()) {
     StringAttr opName = op->getName().getIdentifier();
     std::string nodeNameStr = getNodeNameInPresenceOfOpt(op);
-    printf("==NNPA-UNSUPPORTEDOPS-REPORT==, %s, %s, %s\n", opName.data(),
+    printf("==NNPA-UNSUPPORTEDOPS-REPORT== %s, %s, %s\n", opName.data(),
         nodeNameStr.c_str(), message.c_str());
   }
   return false;
@@ -89,13 +89,14 @@ bool isValidElementTypeAndRank(Operation *op, Value val, bool donotCheckRank) {
         return onnxToZHighUnsupportedReport(op, message);
       }
       int64_t rank = valueType.getRank();
-      if ((rank == 0) || (rank > 5)) {
+      bool supportedRank = (rank == 0) || (rank > 4);
+      if (!supportedRank) {
         std::string message =
             "Rank " + std::to_string(rank) +
             " is not supported. zAIU only supports rank in range of (0, 4].";
         return onnxToZHighUnsupportedReport(op, message);
       }
-      return true;
+      return supportedRank;
     } else {
       std::string message = "Element type is not F16 or F32.";
       return onnxToZHighUnsupportedReport(op, message);
@@ -103,6 +104,27 @@ bool isValidElementTypeAndRank(Operation *op, Value val, bool donotCheckRank) {
   }
   std::string message = "Value is not shaped type.";
   return onnxToZHighUnsupportedReport(op, message);
+}
+
+bool isValidElementTypeAndRank(Value val, bool donotCheckRank) {
+  if (val.getType().isa<NoneType>())
+    return true;
+  if (auto valueType = val.getType().dyn_cast_or_null<ShapedType>()) {
+    Type elementType = (valueType) ? valueType.getElementType() : val.getType();
+    // Element type must be in 16 or F32.
+    if (elementType.isa<FloatType>() &&
+        (elementType.cast<FloatType>().getWidth() == 16 ||
+            elementType.cast<FloatType>().getWidth() == 32)) {
+      if (donotCheckRank)
+        return true;
+      // Rank must be in range of (0, 4].
+      if (!valueType.hasRank())
+        return false;
+      int64_t rank = valueType.getRank();
+      return ((rank > 0) && (rank <= 4));
+    }
+  }
+  return false;
 }
 
 /// Common legality check for pooling ops.
@@ -1274,7 +1296,7 @@ bool isSuitableForZDNN<ONNXConvOp>(
       ShapedType::isDynamic(shapeOutput[2]) ||
       ShapedType::isDynamic(shapeOutput[3]))
     return onnxToZHighUnsupportedReport(op,
-        "Height and/or width have dynamic dimensions. They are not support.");
+        "Height and/or width have dynamic dimensions. They are not supported.");
 
   // Do not support group.
   if (operandAdaptor.getGroup() != 1)

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -106,27 +106,6 @@ bool isValidElementTypeAndRank(Operation *op, Value val, bool donotCheckRank) {
   return onnxToZHighUnsupportedReport(op, message);
 }
 
-bool isValidElementTypeAndRank(Value val, bool donotCheckRank) {
-  if (val.getType().isa<NoneType>())
-    return true;
-  if (auto valueType = val.getType().dyn_cast_or_null<ShapedType>()) {
-    Type elementType = (valueType) ? valueType.getElementType() : val.getType();
-    // Element type must be in 16 or F32.
-    if (elementType.isa<FloatType>() &&
-        (elementType.cast<FloatType>().getWidth() == 16 ||
-            elementType.cast<FloatType>().getWidth() == 32)) {
-      if (donotCheckRank)
-        return true;
-      // Rank must be in range of (0, 4].
-      if (!valueType.hasRank())
-        return false;
-      int64_t rank = valueType.getRank();
-      return ((rank > 0) && (rank <= 4));
-    }
-  }
-  return false;
-}
-
 /// Common legality check for pooling ops.
 template <typename POOLOP, typename POOLOPAdaptor, typename POOLOPShapeHelper>
 bool checkLegalityPoolOpsCommon(


### PR DESCRIPTION
This PR is a fix to the issue found here: https://github.com/onnx/onnx-mlir/issues/2850

We were receiving an error: `Could not get layout by rank. Rank must be 1, 2, 3, or 4` because the check for the rank was off. After several hours of testing, I was able to narrow it down to this commit [cf651e7](https://github.com/onnx/onnx-mlir/commit/cf651e75ba88e391b786b9c7e7009d6efcd02c49) and from there I was able to figure out `src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp` specifically` bool isValidElementTypeAndRank` was generating an incorrect result. 

I noticed it had to do with the range for the rank, previously it was `(rank == 0) || (rank > 5) `but this means if rank is  equal to zero or if rank is greater than 5 but we were not covering the case of `5` itself. That is why the code was throwing a weird error on the `onnx.Slice` operation because it did not know how to handle when the `rank == 5`, the check did not cover this scenario. 

```
%224 = "onnx.Slice"(%223, %40, %39, %39, %6) {onnx_node_name = "TFNodes/yolo_evaluation_layer_1/strided_slice_10"} : (tensor<?x?x?x3x85xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?x?x?x3x2xf32>
The rank is: 5
```

So it should be `(rank == 0) || (rank >= 5)` or `(rank == 0) || (rank > 4)` since rank 4 is handled or` !((rank > 0) && (rank <= 4))`. 