### PR TITLE
Show the compilation phases

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -180,10 +180,8 @@ void showCompilePhase(std::string msg) {
   strftime(buffer, 80, "%c", timeinfo);
   std::string currentTime(buffer);
 
-  // Use blue bold text.
-  llvm::outs() << "[\033[34;1m" << CURRENT_COMPILE_PHASE++ << "/"
-               << TOTAL_COMPILE_PHASE << "\033[0m] " << currentTime << " "
-               << msg << "\n";
+  llvm::outs() << "[" << CURRENT_COMPILE_PHASE++ << "/" << TOTAL_COMPILE_PHASE
+               << "] " << currentTime << " " << msg << "\n";
 }
 
 } // namespace onnx_mlir

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -14,7 +14,9 @@
 
 #include "CompilerUtils.hpp"
 
+#include <ctime>
 #include <fstream>
+#include <iostream>
 #include <memory>
 #include <regex>
 
@@ -56,6 +58,11 @@ using namespace onnx_mlir;
 mlir::DefaultTimingManager timingManager;
 mlir::TimingScope rootTimingScope;
 namespace onnx_mlir {
+
+// Values to report current phase of compilation.
+// Increase TOTAL_COMPILE_PHASE when having more phases.
+uint64_t CURRENT_COMPILE_PHASE = 1;
+uint64_t TOTAL_COMPILE_PHASE = 5;
 
 // Make a function that forces preserving all files using the runtime arguments
 // and/or the overridePreserveFiles enum.
@@ -160,6 +167,23 @@ int Command::exec(std::string wdir) const {
   // Restore saved work directory.
   llvm::sys::fs::set_current_path(cur_wdir);
   return 0;
+}
+
+void showProgressBar(std::string msg) {
+  time_t rawtime;
+  struct tm *timeinfo;
+  char buffer[80];
+
+  // Get current date.
+  time(&rawtime);
+  timeinfo = localtime(&rawtime);
+  strftime(buffer, 80, "%c", timeinfo);
+  std::string currentTime(buffer);
+
+  // Use blue bold text.
+  llvm::outs() << "[\033[34;1m" << CURRENT_COMPILE_PHASE++ << "/"
+               << TOTAL_COMPILE_PHASE << "\033[0m] " << currentTime << " "
+               << msg << "\n";
 }
 
 } // namespace onnx_mlir
@@ -333,8 +357,10 @@ std::string getTargetFilename(
 // Returns 0 on success, error code on failure.
 static int genLLVMBitcode(const mlir::OwningOpRef<ModuleOp> &module,
     std::string outputNameNoExt, std::string optimizedBitcodeNameWithExt) {
-  auto llvmTiming = rootTimingScope.nest(
-      "[onnx-mlir] Compiling MLIR module to LLVM Optimized Bitcode");
+  std::string msg =
+      "Translating MLIR Module to LLVM and Generating LLVM Optimized Bitcode";
+  showProgressBar(msg);
+  auto llvmTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
   std::error_code error;
 
   // Write bitcode to a file.
@@ -405,8 +431,9 @@ static int genLLVMBitcode(const mlir::OwningOpRef<ModuleOp> &module,
 // Return 0 on success, error code on failure.
 static int genModelObject(
     std::string bitcodeNameWithExt, std::string &modelObjNameWithExt) {
-  auto objectTiming =
-      rootTimingScope.nest("[onnx-mlir] Compiling LLVM Bitcode to Object File");
+  std::string msg = "Generating Object from LLVM Bitcode";
+  showProgressBar(msg);
+  auto objectTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
   std::string llcPath = getToolPath("llc");
   Command llvmToObj(/*exePath=*/llcPath);
   setXllcOption({"--code-model", modelSizeStr[modelSize]});
@@ -447,8 +474,9 @@ static int genJniObject(const mlir::OwningOpRef<ModuleOp> &module,
 static int genSharedLib(std::string sharedLibNameWithExt,
     std::vector<std::string> opts, std::vector<std::string> objs,
     std::vector<std::string> libs, std::vector<std::string> libDirs) {
-  auto sharedLibTiming =
-      rootTimingScope.nest("[onnx-mlir] Linking Shared Library");
+  std::string msg = "Linking and Generating the Output Shared Library";
+  showProgressBar(msg);
+  auto sharedLibTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
 #ifdef _WIN32
   std::vector<std::string> outputOpt = {"/Fe:" + sharedLibNameWithExt};
   // link has to be before libpath since they need to be passed through to the
@@ -498,7 +526,9 @@ static int genSharedLib(std::string sharedLibNameWithExt,
 // Return 0 on success, error code on failure.
 static int genJniJar(const mlir::OwningOpRef<ModuleOp> &module,
     std::string modelSharedLibPath, std::string modelJniJarPath) {
-  auto jniJarTiming = rootTimingScope.nest("[onnx-mlir] Creating JNI Jar");
+  std::string msg = "Creating JNI Jar";
+  showProgressBar(msg);
+  auto jniJarTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
   llvm::SmallString<8> libraryPath(getLibraryPath());
   llvm::sys::path::append(libraryPath, "javaruntime.jar");
   std::string javaRuntimeJarPath = llvm::StringRef(libraryPath).str();
@@ -893,8 +923,10 @@ static int emitOutput(mlir::OwningOpRef<ModuleOp> &module,
 int compileModule(mlir::OwningOpRef<ModuleOp> &module,
     mlir::MLIRContext &context, std::string outputNameNoExt,
     EmissionTargetType emissionTarget) {
-  auto compileModuleTiming =
-      rootTimingScope.nest("[onnx-mlir] Compiling Module using MLIR");
+  std::string msg = "Compiling and Optimizing MLIR Module";
+  showProgressBar(msg);
+
+  auto compileModuleTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
 
   int rc = setupModule(module, context, outputNameNoExt);
   if (rc != CompilerSuccess)

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -59,7 +59,7 @@ mlir::DefaultTimingManager timingManager;
 mlir::TimingScope rootTimingScope;
 namespace onnx_mlir {
 
-// Values to report current phase of compilation.
+// Values to report the current phase of compilation.
 // Increase TOTAL_COMPILE_PHASE when having more phases.
 uint64_t CURRENT_COMPILE_PHASE = 1;
 uint64_t TOTAL_COMPILE_PHASE = 5;

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -31,6 +31,9 @@ extern mlir::TimingScope rootTimingScope;
 
 namespace onnx_mlir {
 
+extern uint64_t CURRENT_COMPILE_PHASE;
+extern uint64_t TOTAL_COMPILE_PHASE;
+
 struct Command {
 
   std::string _path;
@@ -46,6 +49,8 @@ struct Command {
   Command &resetArgs();
   int exec(std::string wdir = "") const;
 };
+
+void showProgressBar(std::string msg);
 
 // Registers and loads the mlir and onnx-mlir dialects needed to compile
 // end to end. Initializes accelerator(s) if required.

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -31,6 +31,8 @@ extern mlir::TimingScope rootTimingScope;
 
 namespace onnx_mlir {
 
+// Values to report the current phase of compilation.
+// Increase TOTAL_COMPILE_PHASE when having more phases.
 extern uint64_t CURRENT_COMPILE_PHASE;
 extern uint64_t TOTAL_COMPILE_PHASE;
 

--- a/src/Compiler/CompilerUtils.hpp
+++ b/src/Compiler/CompilerUtils.hpp
@@ -50,7 +50,7 @@ struct Command {
   int exec(std::string wdir = "") const;
 };
 
-void showProgressBar(std::string msg);
+void showCompilePhase(std::string msg);
 
 // Registers and loads the mlir and onnx-mlir dialects needed to compile
 // end to end. Initializes accelerator(s) if required.

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -74,8 +74,9 @@ int main(int argc, char *argv[]) {
   }
   loadDialects(context);
   setupTiming.stop();
-  auto inputFileTiming =
-      rootTimingScope.nest("[onnx-mlir] Importing Input Model to MLIR");
+  std::string msg = "Importing ONNX Model to MLIR Module";
+  showProgressBar(msg);
+  auto inputFileTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
   mlir::OwningOpRef<mlir::ModuleOp> module;
   std::string errorMessage;
   int rc = processInputFile(inputFilename, context, module, &errorMessage);

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
   loadDialects(context);
   setupTiming.stop();
   std::string msg = "Importing ONNX Model to MLIR Module";
-  showProgressBar(msg);
+  showCompilePhase(msg);
   auto inputFileTiming = rootTimingScope.nest("[onnx-mlir] " + msg);
   mlir::OwningOpRef<mlir::ModuleOp> module;
   std::string errorMessage;

--- a/test/mlir/accelerators/nnpa/module_op_be/compiler-config.mlir
+++ b/test/mlir/accelerators/nnpa/module_op_be/compiler-config.mlir
@@ -12,5 +12,5 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 // CHECK: {{.*}} opt {{.*}} -o {{.*}}.bc
-// CHECK-NEXT: {{.*}} llc {{.*}}  {{.*}} {{.*}}.bc
-// CHECK-NEXT: {{.*}} {{clang|c|g}}++{{.*}} {{.*}}.o -o {{.*}}.so -shared -fPIC -L{{.*}}/lib -lRuntimeNNPA -lzdnn -lcruntime
+// CHECK: {{.*}} llc {{.*}}  {{.*}} {{.*}}.bc
+// CHECK: {{.*}} {{clang|c|g}}++{{.*}} {{.*}}.o -o {{.*}}.so -shared -fPIC -L{{.*}}/lib -lRuntimeNNPA -lzdnn -lcruntime

--- a/test/mlir/driver/check_passthrough_options.mlir
+++ b/test/mlir/driver/check_passthrough_options.mlir
@@ -7,7 +7,7 @@
 // LLC-NOT:   opt{{.*}} --data-sections -o {{.*}}check_passthrough_options{{.*}}.bc
 // LLC:       llc{{.*}} --data-sections {{.*}}
 // LLVM:      opt{{.*}} --data-sections -o {{.*}}check_passthrough_options{{.*}}.bc
-// LLVM-NEXT: llc{{.*}} --data-sections {{.*}}
+// LLVM:      llc{{.*}} --data-sections {{.*}}
 module {
   func.func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>

--- a/test/mlir/driver/compile_phases.mlir
+++ b/test/mlir/driver/compile_phases.mlir
@@ -1,0 +1,13 @@
+// RUN: onnx-mlir %s | FileCheck %s
+
+// CHECK: [1/5] {{.*}} Importing ONNX Model to MLIR Module
+// CHECK: [2/5] {{.*}} Compiling and Optimizing MLIR Module
+// CHECK: [3/5] {{.*}} Translating MLIR Module to LLVM and Generating LLVM Optimized Bitcode
+// CHECK: [4/5] {{.*}} Generating Object from LLVM Bitcode
+// CHECK: [5/5] {{.*}} Linking and Generating the Output Shared Library
+module {
+  func.func @main_graph(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+    onnx.Return %arg0 : tensor<?xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/mlir/driver/unix/check_verbosity.mlir
+++ b/test/mlir/driver/unix/check_verbosity.mlir
@@ -2,8 +2,8 @@
 
 // REQUIRES: system-linux
 // CHECK:      opt {{.*}} -o {{.*}}check_verbosity{{.*}}.bc
-// CHECK-NEXT: llc {{.*}} -filetype=obj {{.*}} -o {{.*}}check_verbosity{{.*}}.o {{.*}}check_verbosity{{.*}}.bc
-// CHECK-NEXT: {{clang|c|g}}++{{.*}} {{.*}}check_verbosity{{.*}}.o -o {{.*}}check_verbosity{{.*}}.so -shared -fPIC -L{{.*}}/lib -lcruntime
+// CHECK:      llc {{.*}} -filetype=obj {{.*}} -o {{.*}}check_verbosity{{.*}}.o {{.*}}check_verbosity{{.*}}.bc
+// CHECK:      {{clang|c|g}}++{{.*}} {{.*}}check_verbosity{{.*}}.o -o {{.*}}check_verbosity{{.*}}.so -shared -fPIC -L{{.*}}/lib -lcruntime
 module {
   func.func @main_graph(%arg0: tensor<1x1xf32>, %arg1: tensor<1x1xf32>) -> tensor<1x1xf32> {
     %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>


### PR DESCRIPTION
This patch is to show the compilation phases which is helpful when compiling a big model that takes a long time.

This is one example of the printed information:
```shell
$ onnx-mlir -mcpu=z16 -maccel=NNPA bert_base_uncased_1.onnx
[1/5] Wed Jul  3 03:36:50 2024 Importing ONNX Model to MLIR Module
[2/5] Wed Jul  3 03:36:51 2024 Compiling and Optimizing MLIR Module
[3/5] Wed Jul  3 03:37:14 2024 Translating MLIR Module to LLVM and Generating LLVM Optimized Bitcode
[4/5] Wed Jul  3 03:37:35 2024 Generating Object from LLVM Bitcode
[5/5] Wed Jul  3 03:37:39 2024 Linking and Generating the Output Shared Library
```

Starting time is added to each phase so that users know how long the current phase takes