### PR TITLE
Avoid using StringAttr when lowering dense constant with i1 type

### DIFF
--- a/src/Conversion/KrnlToLLVM/KrnlGlobal.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlGlobal.cpp
@@ -177,7 +177,9 @@ private:
     uint64_t sizeInBytes = computeSizeInBytes(krnlGlobalOp);
     LLVM::GlobalOp global;
     if (!(mlir::isa<StringType>(denseAttr.getElementType())) &&
-        (!denseAttr.isSplat()) && (sizeInBytes > 1024)) {
+        !(denseAttr.getElementType().isInteger(1)) && (!denseAttr.isSplat()) &&
+        (sizeInBytes > 1024)) {
+
       ArrayRef<char> rawData = denseAttr.getRawData();
       assert(
           ((uint64_t)rawData.size() == sizeInBytes) && "Data size mismatch.");


### PR DESCRIPTION
By using this PR, segfault on GPT2 (https://github.com/onnx/onnx-mlir/issues/2822) can be avoided. Still not sure the reason why we can avoid it, but from the tests using following test cases, it seems we can not use the StringAttr for dense constant with i1 (or need to do something to use i1).

- Example including single ConstantOp with i1 type
[model.onnx.const-i1.mlir.txt](https://github.com/user-attachments/files/16104573/model.onnx.const-i1.mlir.txt)
This MLIR file includes only single ConstantOp with dense attribute of i1 type. When running this using following commands, the results were strange (wrong results, segfault, bus error) in main branch. This happened both MaxOS and z16. By using this PR, we got expected results.

```
ONNX_MLIR_HOME=${ONNX_MLIR_ROOT}/build/Debug python ${ONNX_MLIR_ROOT}/utils/RunONNXModel.py --model model.onnx.const-i1.mlir --compile-args "-O3 " --print-output
```

- GPT-2 model on MaxOS
   Numerical outputs when using the main branch were very different compared to the onnxruntime outputs, but using this PR generated correct outputs (using atol=0.01, rtol=0.05),    