### PR TITLE
[NNPA] Add missing message for `--opt-report=NNPAUnsupportedOps` for MatMul op

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXLegalityCheck.cpp
@@ -698,7 +698,10 @@ bool isSuitableForZDNN<ONNXMatMulOp>(
     }
     return true;
   }
-  return false; // unsupported case
+  std::string message = "Dim size of A(" + std::to_string(shapeA.size()) +
+                        ") and B(" + std::to_string(shapeB.size()) +
+                        ") is not supported.";
+  return onnxToZHighUnsupportedReport(op.getOperation(), message);
 }
 
 /// Check legality for ONNXGemm.


### PR DESCRIPTION
I found that message for `--opt-report=NNPAUnsupportedOps` was not displayed in one of the condition in MatMul op.
This PR just adds the missing message.This should have been added in PR https://github.com/onnx/onnx-mlir/pull/2819 .