### PR TITLE
[BUG FIX] Added is implemented flag for custom op

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -898,6 +898,8 @@ ONNXCustomOpShapeHelper::ONNXCustomOpShapeHelper(Operation *op,
   setOperands(ValueRange(operandsVector));
 }
 
+bool ONNXCustomOpShapeHelper::isImplemented() { return pattern != 0; }
+
 LogicalResult ONNXCustomOpShapeHelper::computeShape() {
   if (pattern == 1) {
     return ONNXUnaryOpShapeHelper::computeShape();

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp
@@ -895,6 +895,7 @@ struct ONNXCustomOpShapeHelper : public ONNXUnaryOpShapeHelper {
       IndexExprBuilder *ieBuilder = nullptr, IndexExprScope *scope = nullptr,
       bool hasUniBroadcasting = false);
 
+  bool isImplemented() override;
   // Default shape compute (every operands of the operation and no additional
   // parameters).
   mlir::LogicalResult computeShape() override;

--- a/test/mlir/conversion/onnx_to_krnl/Additional/Custom_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Additional/Custom_with_canonicalize.mlir
@@ -9,7 +9,7 @@ func.func @test_cumstom_multiple_output(%arg0: tensor<4x2xf32>) -> tensor<4x2xf3
         [1.0, 2.0, 3.0, 4.0, 5.0], [6.0, 7.0, 8.0, 9.0, 10.0],
         [1.0, 2.0, 3.0, 4.0, 5.0], [1.0, 2.0, 3.0, 4.0, 5.0]
       ]> : tensor<4x5xf32>
-  %0,%1 = "onnx.Custom"(%cst) {function_name = "Decompose", r_value = 2 : si64} : (tensor<4x5xf32>) -> (tensor<4x2xf32>, tensor<2x5xf32>)
+  %0,%1 = "onnx.Custom"(%cst) {function_name = "Decompose", r_value = 2 : si64, shape_infer_pattern = "SameAs"} : (tensor<4x5xf32>) -> (tensor<4x2xf32>, tensor<2x5xf32>)
   %2 = "onnx.Add"(%arg0, %0) : (tensor<4x2xf32>, tensor<4x2xf32>) -> tensor<4x2xf32>
   return %2 : tensor<4x2xf32>
 }


### PR DESCRIPTION
The shapehelper for Custom op gives out isImplemented as False in case there is no pattern. This PR solves this issue https://github.com/onnx/onnx-mlir/issues/2870