### PR TITLE
Write a constant value to a file without buffering

### DIFF
--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -516,7 +516,7 @@ bool extractConstantsToFile(ModuleOp &module, std::string filepath,
     return (leftAlign < rightAlign);
   });
 
-  // Pack all constants into a single buffer in order to save to file.
+  // Store each constant into single file.
   // Constants with the highest alignment will be packed first in the file.
   // The file will be mmaped later at runtime and aligned at the page boundary,
   // So every constants must be correctly aligned in the packed constant. Pads

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -543,7 +543,7 @@ bool extractConstantsToFile(ModuleOp &module, std::string filepath,
       packedConst.insert(packedConst.end(), pads.begin(), pads.end());
     }
 
-    op.setOffsetAttr(b.getI64IntegerAttr(totalConstSize));
+    op.setOffsetAttr(b.getI64IntegerAttr(totalConstSize + packedConst.size()));
     op.removeValueAttr();
     packedConst.insert(packedConst.end(), rawData.begin(), rawData.end());
     outfile.write(packedConst.data(), packedConst.size());

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -522,7 +522,7 @@ bool extractConstantsToFile(ModuleOp &module, std::string filepath,
   // So every constants must be correctly aligned. Pads are added if necessary.
   llvm::sys::fs::remove(filepath);
   std::ofstream outfile(filepath, std::ios::app | std::ios::binary);
-  int64_t totalConstSize = 0;
+  uint64_t totalConstSize = 0;
   for (int64_t i = globalOfInterest.size() - 1; i >= 0; --i) {
     KrnlGlobalOp op = globalOfInterest[i];
     ArrayRef<char> rawData = getRawData(op);


### PR DESCRIPTION
This PR partially solves an issue of memory consumption reported in https://github.com/onnx/onnx-mlir/issues/2821 

We found that there is a spike in memory consumption when writing a constant into a file (`model.constants.bin`). This is because all constants into a buffer once and write it to a file at once. This PR changes to write the constant to the file without the buffering. This removes the spike in memory consumption.
 
