### PR TITLE
Fix for runing RunONNXModel without verify

### DIFF
--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -231,7 +231,7 @@ if not os.environ.get("ONNX_MLIR_HOME", None):
         "executables and libraries can be found, typically `onnx-mlir/build/Debug`"
     )
 
-if args.verify.lower() == "onnxruntime":
+if args.verify and args.verify.lower() == "onnxruntime":
     if not args.model or (args.model and not args.model.endswith(".onnx")):
         raise RuntimeError(
             "Set input onnx model using argument --model when verifying using onnxruntime."


### PR DESCRIPTION
A prior PR seems to have broken the script

```
alexe@AChampignon roberta-base-11 % RunONNXModel.py -m roberta-base-11.onnx
Traceback (most recent call last):
  File "/Users/alexe/OM/onnx-mlir/utils/RunONNXModel.py", line 234, in <module>
    if args.verify.lower() == "onnxruntime":
```

this PR fixes this.