### PR TITLE
Saturation in compiler generated Stickify

### DIFF
--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -191,7 +191,7 @@ public:
               // Then (is full).
               [&](SCFBuilder b) {
                 MDBuilder create(b);
-                // Loop
+                // Loop (tried unroll of 2 and 8, 4 was best).
                 const int64_t U = 4;
                 assert(U * VL <= 64 && "bad unroll");
                 create.scf.forLoop(litZero.getValue(), lit64.getValue(), U * VL,

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -45,7 +45,7 @@
 #define PREFETCH_CSU 1
 
 // TODO, integrate.
-#define SATURATION_ON 1
+#define SATURATION_ON 0
 
 using namespace mlir;
 
@@ -447,73 +447,17 @@ public:
                       vecF32Type, input, inputAF, {iL.getValue()});
                 }
                 if (saturation) {
-#if 1
-                  // Compare for mins.
+                  // Get rid of too-high values.
                   for (int64_t u = 0; u < U; ++u) {
                     vecF32H[u] = create.math.min(vecF32H[u], vecDlf16Max);
                     vecF32L[u] = create.math.min(vecF32L[u], vecDlf16Max);
                   }
-                  // Compare for maxes.
+                  // Get rid of too-low values.
                   for (int64_t u = 0; u < U; ++u) {
                     vecF32H[u] = create.math.max(vecF32H[u], vecDlf16Min);
                     vecF32L[u] = create.math.max(vecF32L[u], vecDlf16Min);
                   }
-#else 
-                  // Make the compares with min/max dlfloat16 (in fp32 format).
-                  Value vecF32LeMinH[U], vecF32LeMinL[U];
-                  Value vecF32GeMaxH[U], vecF32GeMaxL[U];
-
-#if 1
-                  // This solution aims to use a pattern that can be more easily
-                  // picked up as vec_min and vec_max.
-
-                  // Compare for mins.
-                  for (int64_t u = 0; u < U; ++u) {
-                    vecF32LeMinH[u] = create.math.le(vecF32H[u], vecDlf16Min);
-                    vecF32LeMinL[u] = create.math.le(vecF32L[u], vecDlf16Min);
-                  }
-                  // Select for mins.
-                  for (int64_t u = 0; u < U; ++u) {
-                    vecF32H[u] = create.math.select(
-                        vecF32LeMinH[u], vecDlf16Min, vecF32H[u]);
-                    vecF32L[u] = create.math.select(
-                        vecF32LeMinL[u], vecDlf16Min, vecF32L[u]);
-                  }
-                  // Compare for maxes (using the previous results).
-                  for (int64_t u = 0; u < U; ++u) {
-                    vecF32GeMaxH[u] = create.math.ge(vecF32H[u], vecDlf16Max);
-                    vecF32GeMaxL[u] = create.math.ge(vecF32L[u], vecDlf16Max);
-                  }
-                  // Select for maxes.
-                  for (int64_t u = 0; u < U; ++u) {
-                    vecF32H[u] = create.math.select(
-                        vecF32GeMaxH[u], vecDlf16Max, vecF32H[u]);
-                    vecF32L[u] = create.math.select(
-                        vecF32GeMaxL[u], vecDlf16Max, vecF32L[u]);
-                  }
-#else
-                  for (int64_t u = 0; u < U; ++u) {
-                    vecF32LeMinH[u] = create.math.le(vecF32H[u], vecDlf16Min);
-                    vecF32LeMinL[u] = create.math.le(vecF32L[u], vecDlf16Min);
-                    vecF32GeMaxH[u] = create.math.ge(vecF32H[u], vecDlf16Max);
-                    vecF32GeMaxL[u] = create.math.ge(vecF32L[u], vecDlf16Max);
-                  }
-                  // Select depending on compares. Mins first, then maxes.
-                  for (int64_t u = 0; u < U; ++u) {
-                    vecF32H[u] = create.math.select(
-                        vecF32LeMinH[u], vecDlf16Min, vecF32H[u]);
-                    vecF32L[u] = create.math.select(
-                        vecF32LeMinL[u], vecDlf16Min, vecF32L[u]);
-                  }
-                  for (int64_t u = 0; u < U; ++u) {
-                    vecF32H[u] = create.math.select(
-                        vecF32GeMaxH[u], vecDlf16Max, vecF32H[u]);
-                    vecF32L[u] = create.math.select(
-                        vecF32GeMaxL[u], vecDlf16Max, vecF32L[u]);
-                  }
-#endif
-#endif
-                } // End saturation special case.
+                }
                 // Convert f32 to dlfloat16.
                 for (int64_t u = 0; u < U; ++u) {
                   vecF16[u] = rewriter.create<ZLowConvertF32ToDLF16VectorOp>(

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -450,12 +450,12 @@ public:
 #if 1
                   // Compare for mins.
                   for (int64_t u = 0; u < U; ++u) {
-                    vecF32H[u]] = create.math.min(vecF32H[u], vecDlf16Max);
+                    vecF32H[u] = create.math.min(vecF32H[u], vecDlf16Max);
                     vecF32L[u] = create.math.min(vecF32L[u], vecDlf16Max);
                   }
                   // Compare for maxes.
                   for (int64_t u = 0; u < U; ++u) {
-                    vecF32H[u]] = create.math.max(vecF32H[u], vecDlf16Min);
+                    vecF32H[u] = create.math.max(vecF32H[u], vecDlf16Min);
                     vecF32L[u] = create.math.max(vecF32L[u], vecDlf16Min);
                   }
 #else 

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -44,8 +44,8 @@
 #define PREFETCH_CSU_DIST 0
 #define PREFETCH_CSU 1
 
-// For debug only at this time. TODO, integrate.
-#define SATURATION_ON 1
+// TODO, integrate.
+#define SATURATION_ON 0
 
 using namespace mlir;
 

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -45,7 +45,7 @@
 #define PREFETCH_CSU 1
 
 // TODO, integrate.
-#define SATURATION_ON 0
+#define SATURATION_ON 1
 
 using namespace mlir;
 
@@ -447,9 +447,22 @@ public:
                       vecF32Type, input, inputAF, {iL.getValue()});
                 }
                 if (saturation) {
+#if 1
+                  // Compare for mins.
+                  for (int64_t u = 0; u < U; ++u) {
+                    vecF32H[u]] = create.math.min(vecF32H[u], vecDlf16Max);
+                    vecF32L[u] = create.math.min(vecF32L[u], vecDlf16Max);
+                  }
+                  // Compare for maxes.
+                  for (int64_t u = 0; u < U; ++u) {
+                    vecF32H[u]] = create.math.max(vecF32H[u], vecDlf16Min);
+                    vecF32L[u] = create.math.max(vecF32L[u], vecDlf16Min);
+                  }
+#else 
                   // Make the compares with min/max dlfloat16 (in fp32 format).
                   Value vecF32LeMinH[U], vecF32LeMinL[U];
                   Value vecF32GeMaxH[U], vecF32GeMaxL[U];
+
 #if 1
                   // This solution aims to use a pattern that can be more easily
                   // picked up as vec_min and vec_max.
@@ -498,6 +511,7 @@ public:
                     vecF32L[u] = create.math.select(
                         vecF32GeMaxL[u], vecDlf16Max, vecF32L[u]);
                   }
+#endif
 #endif
                 } // End saturation special case.
                 // Convert f32 to dlfloat16.

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -450,6 +450,35 @@ public:
                   // Make the compares with min/max dlfloat16 (in fp32 format).
                   Value vecF32LeMinH[U], vecF32LeMinL[U];
                   Value vecF32GeMaxH[U], vecF32GeMaxL[U];
+#if 1
+                  // This solution aims to use a pattern that can be more easily
+                  // picked up as vec_min and vec_max.
+
+                  // Compare for mins.
+                  for (int64_t u = 0; u < U; ++u) {
+                    vecF32LeMinH[u] = create.math.le(vecF32H[u], vecDlf16Min);
+                    vecF32LeMinL[u] = create.math.le(vecF32L[u], vecDlf16Min);
+                  }
+                  // Select for mins.
+                  for (int64_t u = 0; u < U; ++u) {
+                    vecF32H[u] = create.math.select(
+                        vecF32LeMinH[u], vecDlf16Min, vecF32H[u]);
+                    vecF32L[u] = create.math.select(
+                        vecF32LeMinL[u], vecDlf16Min, vecF32L[u]);
+                  }
+                  // Compare for maxes (using the previous results).
+                  for (int64_t u = 0; u < U; ++u) {
+                    vecF32GeMaxH[u] = create.math.ge(vecF32H[u], vecDlf16Max);
+                    vecF32GeMaxL[u] = create.math.ge(vecF32L[u], vecDlf16Max);
+                  }
+                  // Select for maxes.
+                  for (int64_t u = 0; u < U; ++u) {
+                    vecF32H[u] = create.math.select(
+                        vecF32GeMaxH[u], vecDlf16Max, vecF32H[u]);
+                    vecF32L[u] = create.math.select(
+                        vecF32GeMaxL[u], vecDlf16Max, vecF32L[u]);
+                  }
+#else
                   for (int64_t u = 0; u < U; ++u) {
                     vecF32LeMinH[u] = create.math.le(vecF32H[u], vecDlf16Min);
                     vecF32LeMinL[u] = create.math.le(vecF32L[u], vecDlf16Min);
@@ -469,6 +498,7 @@ public:
                     vecF32L[u] = create.math.select(
                         vecF32GeMaxL[u], vecDlf16Max, vecF32L[u]);
                   }
+#endif
                 } // End saturation special case.
                 // Convert f32 to dlfloat16.
                 for (int64_t u = 0; u < U; ++u) {

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -425,8 +425,7 @@ public:
 #endif
 #endif
 
-          // hi alex: tune for saturation?
-          const int64_t U = 4;
+          const int64_t U = 4; // Tried 2 and 8, 4 was best.
           assert(U * VL <= 64 && "bad unroll");
           create.affine.forIE(litZero, lit64, U * VL,
               [&](AffineBuilder &b, ValueRange loopInd) {

--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -64,6 +64,7 @@ add_onnx_mlir_library(OMCompilerDialects
 
   LINK_LIBS PUBLIC
   OMAccelerator
+  OMCompilerOptions
   OMInitAccelerators
   OMKrnlOps
   OMONNXOps

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -414,9 +414,9 @@ Value MathBuilder::neq(Value lhs, Value rhs) const {
   llvm_unreachable("expected int or float");
 }
 
-Value MathBuilder::select(Value cmp, Value lhs, Value rhs) const {
-  assert(lhs.getType() == rhs.getType() && "expected same type");
-  return b().create<arith::SelectOp>(loc(), cmp, lhs, rhs);
+Value MathBuilder::select(Value cmp, Value trueVal, Value falseVal) const {
+  assert(trueVal.getType() == falseVal.getType() && "expected same type");
+  return b().create<arith::SelectOp>(loc(), cmp, trueVal, falseVal);
 }
 
 Value MathBuilder::constant(Type type, double val) const {

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -131,7 +131,8 @@ struct MathBuilder final : DialectBuilder {
   mlir::Value tanh(mlir::Value val) const;                  // Float only.
   mlir::Value xori(mlir::Value lhs, mlir::Value rhs) const; // Int only.
 
-  mlir::Value select(mlir::Value cmp, mlir::Value lhs, mlir::Value rhs) const;
+  mlir::Value select(
+      mlir::Value cmp, mlir::Value trueVal, mlir::Value valseVal) const;
   mlir::Value gt(mlir::Value lhs, mlir::Value rhs) const;
   mlir::Value ge(mlir::Value lhs, mlir::Value rhs) const;
   mlir::Value lt(mlir::Value lhs, mlir::Value rhs) const;


### PR DESCRIPTION
This algorithm adds the equivalent of this (per William Jones) to the stickify compiler generated code.

```C
static const __vector float min_vec = {-8573157376.F, -8573157376.F, -8573157376.F, -8573157376.F};
static const __vector float max_vec = {8573157376.F, 8573157376.F, 8573157376.F, 8573157376.F};

float* a = ...;
float* b = ...;
int16_t* out = ...;

__vector float* vec_a = (__vector float*)a;
__vector float* vec_b = (__vector float*)b;
__vector short* vec_out = (__vector short*)out;

*vec_out = vec_round_from_fp32(
    vec_max(vec_min(*vec_a, max_vec), min_vec),
    vec_max(vec_min(*vec_b, max_vec), min_vec),
    0);
```

When running on z16 with Roberta base 11 and 6x384 in sequential mode
```
zdnn
  zhigh.Stick, 85, 0.5742549, 48.8116667, 5.6%

compiler gen code without saturation
  zhigh.Stick, 85, 0.3593294, 30.5430000, 3.7%

compiler gen WITH saturation
  zhigh.Stick, 85, 0.4358196, 37.0446667, 4.4%
```

As shown, saturation runs still faster than zdnn based code.

Checked the asm generated, pattern use vector compare and vector select, which I believe is the best pattern at this time for floating point numbers

```
    81e6:	e7 91 10 00 24 ea 	vfchesb	%v9,%v17,%v1                    <<<<==== vadd
    81ec:	e7 20 20 00 21 8d 	vsel	%v2,%v0,%v2,%v18                   <<<<==== vshuffle
```