### PR TITLE
Disable compliler stick/unstick on zOS

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -52,6 +52,11 @@ void configurePassesNNPA() {
   // TODO: remove this if zDNN adds support for saturation.
   if (nnpaEnableSaturation)
     nnpaEnableCompilerStickUnstick = true;
+  // Currently nnpaEnableCompilerStickUnstick not supported on zOS.
+  // TODO enable on zOS
+  if (mtriple == "s390x-ibm-zos") {
+    nnpaEnableCompilerStickUnstick = false;
+  }
 }
 
 void addONNXToZHighPasses(mlir::PassManager &pm) {


### PR DESCRIPTION
Currently we have issues generating the asm instructions needed for stick/unsick on zOS.

This PR disable this feature until we solve this issue

Issue is tracked in a separate issue