### PR TITLE
Add NHWC as target for compiler enabled stickification

### DIFF
--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -68,14 +68,11 @@ public:
 
     // Generic way to handle all formats listed below.
     StringAttr layout = unstickOp.getLayoutAttr();
-    fprintf(stderr, "hi alex, unstick with layout %s\n",
-        layout.getValue().str().c_str());
     if (layout.getValue().equals_insensitive("4D") ||
         layout.getValue().equals_insensitive("3D") ||
         layout.getValue().equals_insensitive("2D") ||
         layout.getValue().equals_insensitive("3DS") ||
         layout.getValue().equals_insensitive("NCHW")) {
-      fprintf(stderr, "go for it\n");
       return generateUnstickCodeNoBuffer(rewriter, unstickOp);
     }
     // Otherwise, we don't replace and keep the zdnn call.
@@ -315,14 +312,11 @@ public:
     // Did not add the HWCK as this is typically for constants and want to
     // preserve the high level constant propagation of constant values into the
     // Convolution filters.
-    fprintf(stderr, "hi alex, unstick with layout %s\n",
-        layout.getValue().str().c_str());
     if (layout.getValue().equals_insensitive("4D") ||
         layout.getValue().equals_insensitive("3D") ||
         layout.getValue().equals_insensitive("2D") ||
         layout.getValue().equals_insensitive("3DS") ||
         layout.getValue().equals_insensitive("NCHW")) {
-      fprintf(stderr, "  go for it\n");
       return generateStickCodeNoBuffer(rewriter, stickOp);
     }
     // Otherwise, we don't replace and keep the zdnn call.

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -67,12 +67,15 @@ public:
       ZLowUnstickOp unstickOp, PatternRewriter &rewriter) const override {
 
     // Generic way to handle all formats listed below.
+    // Did not add the HWCK as this is typically for constants and want to
+    // preserve the high level constant propagation of constant values into the
+    // Convolution filters.
     StringAttr layout = unstickOp.getLayoutAttr();
     if (layout.getValue().equals_insensitive("4D") ||
         layout.getValue().equals_insensitive("3D") ||
         layout.getValue().equals_insensitive("2D") ||
         layout.getValue().equals_insensitive("3DS") ||
-        layout.getValue().equals_insensitive("NCHW")) {
+        (layout.getValue().equals_insensitive("NHWC"))) {
       return generateUnstickCodeNoBuffer(rewriter, unstickOp);
     }
     // Otherwise, we don't replace and keep the zdnn call.
@@ -316,7 +319,7 @@ public:
         layout.getValue().equals_insensitive("3D") ||
         layout.getValue().equals_insensitive("2D") ||
         layout.getValue().equals_insensitive("3DS") ||
-        layout.getValue().equals_insensitive("NCHW")) {
+        layout.getValue().equals_insensitive("NHWC")) {
       return generateStickCodeNoBuffer(rewriter, stickOp);
     }
     // Otherwise, we don't replace and keep the zdnn call.

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -68,11 +68,14 @@ public:
 
     // Generic way to handle all formats listed below.
     StringAttr layout = unstickOp.getLayoutAttr();
+    fprintf(stderr, "hi alex, unstick with layout %s\n",
+        layout.getValue().str().c_str());
     if (layout.getValue().equals_insensitive("4D") ||
         layout.getValue().equals_insensitive("3D") ||
         layout.getValue().equals_insensitive("2D") ||
         layout.getValue().equals_insensitive("3DS") ||
-        layout.getValue().equals_insensitive("NHWC")) {
+        layout.getValue().equals_insensitive("NCHW")) {
+      fprintf(stderr, "go for it\n");
       return generateUnstickCodeNoBuffer(rewriter, unstickOp);
     }
     // Otherwise, we don't replace and keep the zdnn call.
@@ -312,11 +315,14 @@ public:
     // Did not add the HWCK as this is typically for constants and want to
     // preserve the high level constant propagation of constant values into the
     // Convolution filters.
+    fprintf(stderr, "hi alex, unstick with layout %s\n",
+        layout.getValue().str().c_str());
     if (layout.getValue().equals_insensitive("4D") ||
         layout.getValue().equals_insensitive("3D") ||
         layout.getValue().equals_insensitive("2D") ||
         layout.getValue().equals_insensitive("3DS") ||
-        layout.getValue().equals_insensitive("NHWC")) {
+        layout.getValue().equals_insensitive("NCHW")) {
+      fprintf(stderr, "  go for it\n");
       return generateStickCodeNoBuffer(rewriter, stickOp);
     }
     // Otherwise, we don't replace and keep the zdnn call.

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -71,13 +71,16 @@ public:
     if (layout.getValue().equals_insensitive("4D") ||
         layout.getValue().equals_insensitive("3D") ||
         layout.getValue().equals_insensitive("2D") ||
-        layout.getValue().equals_insensitive("3DS")) {
+        layout.getValue().equals_insensitive("3DS") ||
+        layout.getValue().equals_insensitive("NHWC")) {
       return generateUnstickCodeNoBuffer(rewriter, unstickOp);
     }
     // Otherwise, we don't replace and keep the zdnn call.
     return failure();
   }
 
+  // The only requirement for this code to generate the proper code is that E1
+  // is been sticked by 64.
   LogicalResult generateUnstickCodeNoBuffer(
       PatternRewriter &rewriter, ZLowUnstickOp unstickOp) const {
     Operation *op = unstickOp.getOperation();
@@ -306,17 +309,23 @@ public:
     StringAttr layout = stickOp.getLayoutAttr();
 
     // Generic way to handle all formats listed below.
+    // Did not add the HWCK as this is typically for constants and want to
+    // preserve the high level constant propagation of constant values into the
+    // Convolution filters.
     if (layout.getValue().equals_insensitive("4D") ||
         layout.getValue().equals_insensitive("3D") ||
         layout.getValue().equals_insensitive("2D") ||
-        layout.getValue().equals_insensitive("3DS")) {
+        layout.getValue().equals_insensitive("3DS") ||
+        layout.getValue().equals_insensitive("NHWC")) {
       return generateStickCodeNoBuffer(rewriter, stickOp);
     }
     // Otherwise, we don't replace and keep the zdnn call.
     return failure();
   }
 
-  /* Version without buffer, more like zdnn */
+  // Version without buffer, more like zdnn.
+  // The only requirement for this code to generate the proper code is that E1
+  // is been sticked by 64.
   LogicalResult generateStickCodeNoBuffer(
       PatternRewriter &rewriter, ZLowStickOp stickOp) const {
     Operation *op = stickOp.getOperation();


### PR DESCRIPTION
Since NHWC is similar to 4D, add it. Did not add the HWCK as this is typically for constants and want to preserve the high level constant propagation of constant values into the Convolution filters.

Saw that during stckification, I was doing a minimum of 64 conversions; but convolutions sometimes have very small E1 dimensions (e.g. 3). So it was wasteful. I now check that if E1 is constant and very small, I do a maximum of `E1<U*VL` iterations where U is as small as possible.

Not needed for unstick as there we must do the exact number of conversions.