### PR TITLE
Add onnx-mlir option to debug small optimizations

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -600,6 +600,20 @@ static llvm::cl::opt<bool, true> enable_bound_check("enable-bound-check",
     llvm::cl::location(enableBoundCheck), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
+#if ONNX_MLIR_IS_DEBUG_BUILD
+static llvm::cl::opt<bool, true> test_compiler_opt("test-compiler-opt",
+    llvm::cl::desc(
+        "Help compiler writers test a new (small) optimization. When false, "
+        "the old approach should be used. When true, the new opt should be "
+        "used. Utilities such as CheckONNXModel.py can then verify that the "
+        "new opt deliver the same results.\n"
+        "E.g. CheckONNXModel.py -m test.mlir -t -O3 -a test-compiler-opt=true\n"
+        "Once the new opt works, it should not rely this option any more.\n"
+        "Only defined in DEBUG build and default to false.\n"),
+    llvm::cl::location(DEBUG_COMPILER_OPT), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirOptions));
+#endif
+
 // Options for onnx-mlir-opt only
 static llvm::cl::opt<bool, true> split_input_file_opt("split-input-file",
     llvm::cl::desc("Split the input file into pieces and process each "

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -600,7 +600,8 @@ static llvm::cl::opt<bool, true> enable_bound_check("enable-bound-check",
     llvm::cl::location(enableBoundCheck), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
-#if ONNX_MLIR_IS_DEBUG_BUILD
+#if defined(_DEBUG)
+// Option only available in debug mode: set using command options.
 static llvm::cl::opt<bool, true> test_compiler_opt("test-compiler-opt",
     llvm::cl::desc(
         "Help compiler writers test a new (small) optimization. When false, "
@@ -610,8 +611,12 @@ static llvm::cl::opt<bool, true> test_compiler_opt("test-compiler-opt",
         "E.g. CheckONNXModel.py -m test.mlir -t -O3 -a test-compiler-opt=true\n"
         "Once the new opt works, it should not rely this option any more.\n"
         "Only defined in DEBUG build and default to false.\n"),
-    llvm::cl::location(DEBUG_COMPILER_OPT), llvm::cl::init(false),
+    llvm::cl::location(debugTestCompilerOpt), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
+bool debugTestCompilerOpt;
+#else
+// Option only available in debug mode: disable when not in debug.
+bool debugTestCompilerOpt = false;
 #endif
 
 // Options for onnx-mlir-opt only

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -131,6 +131,12 @@ extern OptReport optReport;                                   // onnx-mlir only
 extern bool useOldBufferization;                              // onnx-mlir only
 extern bool enableTiming;                                     // onnx-mlir only
 extern bool enableBoundCheck;                                 // onnx-mlir only
+#if ONNX_MLIR_IS_DEBUG_BUILD
+extern bool DEBUG_COMPILER_OPT; // onnx-mlir (debug) only
+#else
+#define DEBUG_COMPILER_OPT false
+#endif
+
 extern bool split_input_file;          // onnx-mlir-opt only
 extern bool verify_diagnostics;        // onnx-mlir-opt only
 extern bool verify_passes;             // onnx-mlir-opt only

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -131,11 +131,7 @@ extern OptReport optReport;                                   // onnx-mlir only
 extern bool useOldBufferization;                              // onnx-mlir only
 extern bool enableTiming;                                     // onnx-mlir only
 extern bool enableBoundCheck;                                 // onnx-mlir only
-#if ONNX_MLIR_IS_DEBUG_BUILD
-extern bool DEBUG_COMPILER_OPT; // onnx-mlir (debug) only
-#else
-#define DEBUG_COMPILER_OPT false
-#endif
+extern bool debugTestCompilerOpt;                             // onnx-mlir only
 
 extern bool split_input_file;          // onnx-mlir-opt only
 extern bool verify_diagnostics;        // onnx-mlir-opt only


### PR DESCRIPTION
Help to debug a new feature in the compiler and test that it does not change the outputs of a given test.

Say you have a new feature you want to test: enable it under the `debugTestCompilerOpt ` guard:

```C++
#include "src/Compiler/CompilerOptions.hpp"
[...]

    if (debugTestCompilerOpt) {
      // New code
      emitMinMaxReductionToScalar(rewriter, loc, op, X, XMin, XMax);
    } else {
      // Old code
      Value none = create.onnx.none();
      XMax = create.onnx.toMemref(
          create.onnx.reduceMax(yScaleMemRefType, X, none, false));
      XMin = create.onnx.toMemref(
          create.onnx.reduceMin(yScaleMemRefType, X, none, false));
    }
```

and compile onnx-mlir (Debug version). Then you may run a test like this:

```bash
CheckONNXModel.py -m model.mlir -r "-O3 -mcpu=z16 -maccel=NNPA" -a "-test-compiler-opt"
```
where the model will be first compiled and run with the options listed after the `-r` (r for reference compiler option) and its result will be compared to a second compiled and run test with the options listed `-r` and `-a` (a for add to the reference compiler options). Namely here, run with all the same options but enable the new compiler code guarded by `debugTestCompilerOpt`.

Once all of the manual tests are satisfied, remove the `debugTestCompilerOpt ` guard and push the code for PR review.

This option is default `false` and is not accessible in the RELEASE build as it should only be used for temporary testing.

Some entirely new optimizations have their own flags, but often we have small tweaks and its convenient to have this infrastructure so that we may run development tests without additional code to write for testing.