### PR TITLE
Implicit broadcast of scalar values to vector values in the MathBuilder constructor

### DIFF
--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -228,7 +228,7 @@ mlir::Value emitScalarOpFor(mlir::ConversionPatternRewriter &rewriter,
   // int. Thus we look at the type the first input argument, and not the output
   // elementType.
   mlir::Type actualElementType =
-      MathBuilder::elementTypeWithVector(scalarOperands[0].getType());
+      MathBuilder::elementTypeOfScalarOrVector(scalarOperands[0].getType());
   // Perform int or float operation depending on the actual elementary type.
   if (mlir::isa<mlir::IntegerType>(actualElementType)) {
     // Generate the integer code only if the scalar integer op is non-void

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -228,7 +228,7 @@ mlir::Value emitScalarOpFor(mlir::ConversionPatternRewriter &rewriter,
   // int. Thus we look at the type the first input argument, and not the output
   // elementType.
   mlir::Type actualElementType =
-      MathBuilder::elementTypeOfScalarOrVector(scalarOperands[0].getType());
+      MathBuilder::elementTypeOfScalarOrVector(scalarOperands[0]);
   // Perform int or float operation depending on the actual elementary type.
   if (mlir::isa<mlir::IntegerType>(actualElementType)) {
     // Generate the integer code only if the scalar integer op is non-void

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -51,8 +51,8 @@ namespace onnx_mlir {
 // ONNX Integers as MLIR signless, and only flag the ONNX Unsigned Integer as
 // MLIR unsigned integer.
 
-/* static */ bool MathBuilder::isVector(Type type) {
-  return mlir::dyn_cast<VectorType>(type) != nullptr;
+/* static */ bool MathBuilder::isVector(Value val) {
+  return mlir::dyn_cast<VectorType>(val.getType()) != nullptr;
 }
 
 /* static */ Type MathBuilder::elementTypeOfScalarOrVector(
@@ -70,11 +70,19 @@ namespace onnx_mlir {
   return elementType;
 }
 
+/* static */ bool MathBuilder::isScalarOrVectorInteger(Value val) {
+  return isScalarOrVectorInteger(val.getType());
+}
+
 /* static */ bool MathBuilder::isScalarOrVectorInteger(
     Type elementOrVectorType) {
   Type elementType = elementTypeOfScalarOrVector(elementOrVectorType);
   return mlir::isa<IntegerType>(elementType) ||
          mlir::isa<IndexType>(elementType);
+}
+
+/* static */ bool MathBuilder::isScalarOrVectorUnsignedInteger(Value val) {
+  return isScalarOrVectorUnsignedInteger(val.getType());
 }
 
 /* static */ bool MathBuilder::isScalarOrVectorUnsignedInteger(
@@ -83,42 +91,37 @@ namespace onnx_mlir {
   return elementType.isUnsignedInteger();
 }
 
+/* static */ bool MathBuilder::isScalarOrVectorFloat(Value val) {
+  return isScalarOrVectorFloat(val.getType());
+}
+
 /* static */ bool MathBuilder::isScalarOrVectorFloat(Type elementOrVectorType) {
   Type elementType = elementTypeOfScalarOrVector(elementOrVectorType);
   return mlir::isa<FloatType>(elementType);
 }
 
 bool MathBuilder::splatToMatch(Value &first, Value &second) const {
-  bool firstIsVector = isVector(first.getType());
-  bool secondIsVector = isVector(second.getType());
-  // Both scalar or vector, nothing to do.
-  if (firstIsVector == secondIsVector) {
-    // If both vectors, ensure its the same vector length.
-    if (firstIsVector) {
-      assert(
-          VectorBuilder::compatibleTypes(first.getType(), second.getType()) &&
-          "expected compatible types");
-    }
-    // No changes in types.
-    return false;
+  Type firstType = first.getType();
+  Type secondType = second.getType();
+  VectorType firstVectorType = mlir::dyn_cast<VectorType>(firstType);
+  VectorType secondVectorType = mlir::dyn_cast<VectorType>(secondType);
+  VectorBuilder createVec(*this);
+  // Splat first if needed.
+  if (!firstVectorType && secondVectorType) {
+    firstVectorType = VectorType::get(secondVectorType.getShape(), firstType);
+    first = createVec.splat(firstVectorType, first);
+    return true;
   }
-  if (firstIsVector) {
-    // Splat second.
-    assert(!secondIsVector && "bad assumption");
-    VectorType firstVectorType = mlir::cast<VectorType>(first.getType());
-    VectorType secondVectorType =
-        VectorType::get(firstVectorType.getShape(), second.getType());
-    second = b().create<vector::SplatOp>(loc(), secondVectorType, second);
-  } else {
-    // Splat first.
-    assert(secondIsVector && "bad assumption");
-    VectorType secondVectorType = mlir::cast<VectorType>(second.getType());
-    VectorType firstVectorType =
-        VectorType::get(secondVectorType.getShape(), first.getType());
-    first = b().create<vector::SplatOp>(loc(), firstVectorType, first);
+  // Splat second if needed.
+  if (firstVectorType && !secondVectorType) {
+    secondVectorType = VectorType::get(firstVectorType.getShape(), secondType);
+    second = createVec.splat(secondVectorType, second);
+    return true;
   }
-  // Types were changed.
-  return true;
+  // Otherwise check compatibility.
+  assert(createVec.compatibleTypes(firstType, secondType) &&
+         "expected compatible types");
+  return false;
 }
 
 bool MathBuilder::splatToMatch(
@@ -132,9 +135,9 @@ bool MathBuilder::splatToMatch(
 }
 
 Value MathBuilder::abs(Value val) const {
-  if (isScalarOrVectorInteger(val.getType()))
+  if (isScalarOrVectorInteger(val))
     return b().create<math::AbsIOp>(loc(), val);
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::AbsFOp>(loc(), val);
   llvm_unreachable("expected int or float");
 }
@@ -142,7 +145,7 @@ Value MathBuilder::abs(Value val) const {
 Value MathBuilder::andi(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::AndIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
@@ -150,7 +153,7 @@ Value MathBuilder::andi(Value lhs, Value rhs) const {
 Value MathBuilder::ori(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::OrIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
@@ -158,7 +161,7 @@ Value MathBuilder::ori(Value lhs, Value rhs) const {
 Value MathBuilder::xori(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::XOrIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
@@ -166,7 +169,7 @@ Value MathBuilder::xori(Value lhs, Value rhs) const {
 Value MathBuilder::add(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType())) {
+  if (isScalarOrVectorInteger(lhs)) {
     Type elemType = elementTypeOfScalarOrVector(lhs.getType());
     if (elemType.isUnsignedInteger()) {
       unsigned elemWidth = mlir::cast<IntegerType>(elemType).getWidth();
@@ -186,9 +189,9 @@ Value MathBuilder::add(Value lhs, Value rhs) const {
 Value MathBuilder::sub(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::SubIOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return b().create<arith::SubFOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
@@ -196,7 +199,7 @@ Value MathBuilder::sub(Value lhs, Value rhs) const {
 Value MathBuilder::mul(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType())) {
+  if (isScalarOrVectorInteger(lhs)) {
     Type elemType = elementTypeOfScalarOrVector(lhs.getType());
     if (elemType.isUnsignedInteger()) {
       unsigned elemWidth = mlir::cast<IntegerType>(elemType).getWidth();
@@ -208,7 +211,7 @@ Value MathBuilder::mul(Value lhs, Value rhs) const {
     } else
       return b().create<arith::MulIOp>(loc(), lhs, rhs);
   }
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return b().create<arith::MulFOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
@@ -216,11 +219,11 @@ Value MathBuilder::mul(Value lhs, Value rhs) const {
 Value MathBuilder::div(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return b().create<arith::DivFOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return b().create<arith::DivUIOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::DivSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
@@ -228,11 +231,11 @@ Value MathBuilder::div(Value lhs, Value rhs) const {
 Value MathBuilder::rem(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return b().create<arith::RemFOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return b().create<arith::RemUIOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::RemSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
@@ -240,7 +243,7 @@ Value MathBuilder::rem(Value lhs, Value rhs) const {
 Value MathBuilder::copySign(mlir::Value rem, mlir::Value dividend) const {
   splatToMatch(rem, dividend);
   assert(rem.getType() == dividend.getType() && "expected same type");
-  if (isScalarOrVectorFloat(rem.getType()))
+  if (isScalarOrVectorFloat(rem))
     return b().create<math::CopySignOp>(loc(), rem, dividend);
   llvm_unreachable("expected float");
 }
@@ -248,9 +251,9 @@ Value MathBuilder::copySign(mlir::Value rem, mlir::Value dividend) const {
 Value MathBuilder::ceilDiv(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return b().create<arith::CeilDivUIOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::CeilDivSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
@@ -258,10 +261,10 @@ Value MathBuilder::ceilDiv(Value lhs, Value rhs) const {
 Value MathBuilder::floorDiv(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     // Using regular unsigned div is ok as it rounds toward zero.
     return b().create<arith::DivUIOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::FloorDivSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
@@ -271,7 +274,7 @@ Value MathBuilder::fma(Value lhs, Value rhs, Value acc) const {
   splatToMatch(lhs, rhs, acc);
   assert((lhs.getType() == rhs.getType()) && (rhs.getType() == acc.getType()) &&
          "expected same type");
-  if (isScalarOrVectorFloat(lhs.getType()) && isVector(lhs.getType())) {
+  if (isScalarOrVectorFloat(lhs) && isVector(lhs)) {
     return b().create<vector::FMAOp>(loc(), lhs, rhs, acc);
   }
   return add(mul(lhs, rhs), acc); // Handle broadcast there.
@@ -282,66 +285,66 @@ Value MathBuilder::erf(Value val) const {
 }
 
 Value MathBuilder::exp(Value val) const {
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::ExpOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::exp2(Value val) const {
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::Exp2Op>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::log(Value val) const {
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::LogOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::log2(Value val) const {
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::Log2Op>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::sqrt(Value val) const {
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::SqrtOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::pow(Value base, Value exp) const {
   // no broadcast, do not expect the exponent to be a vector
-  assert(!isVector(exp.getType()) && "do not support a vector exponent");
-  if (isScalarOrVectorFloat(base.getType()))
+  assert(!isVector(exp) && "do not support a vector exponent");
+  if (isScalarOrVectorFloat(base))
     return b().create<math::PowFOp>(loc(), base, exp);
   llvm_unreachable("expected base float");
 }
 
 Value MathBuilder::neg(Value val) const {
-  if (isScalarOrVectorInteger(val.getType()))
+  if (isScalarOrVectorInteger(val))
     // Returns 0 - val.
     return sub(constant(val.getType(), 0), val);
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<arith::NegFOp>(loc(), val);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::ceil(Value val) const {
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::CeilOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::floor(Value val) const {
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::FloorOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::tanh(Value val) const {
-  if (isScalarOrVectorFloat(val.getType()))
+  if (isScalarOrVectorFloat(val))
     return b().create<math::TanhOp>(loc(), val);
   llvm_unreachable("expected float");
 }
@@ -349,11 +352,11 @@ Value MathBuilder::tanh(Value val) const {
 Value MathBuilder::min(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return b().create<arith::MinNumFOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return b().create<arith::MinUIOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::MinSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
@@ -361,11 +364,11 @@ Value MathBuilder::min(Value lhs, Value rhs) const {
 Value MathBuilder::max(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return b().create<arith::MaxNumFOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return b().create<arith::MaxUIOp>(loc(), lhs, rhs);
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return b().create<arith::MaxSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
@@ -373,9 +376,9 @@ Value MathBuilder::max(Value lhs, Value rhs) const {
 Value MathBuilder::sgt(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::sgt);
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OGT);
   llvm_unreachable("expected int or float");
 }
@@ -383,9 +386,9 @@ Value MathBuilder::sgt(Value lhs, Value rhs) const {
 Value MathBuilder::sge(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::sge);
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OGE);
   llvm_unreachable("expected int or float");
 }
@@ -393,9 +396,9 @@ Value MathBuilder::sge(Value lhs, Value rhs) const {
 Value MathBuilder::slt(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::slt);
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OLT);
   llvm_unreachable("expected int or float");
 }
@@ -403,9 +406,9 @@ Value MathBuilder::slt(Value lhs, Value rhs) const {
 Value MathBuilder::sle(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::sle);
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OLE);
   llvm_unreachable("expected int or float");
 }
@@ -413,7 +416,7 @@ Value MathBuilder::sle(Value lhs, Value rhs) const {
 Value MathBuilder::ugt(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::ugt);
   llvm_unreachable("expected unsigned int");
 }
@@ -421,7 +424,7 @@ Value MathBuilder::ugt(Value lhs, Value rhs) const {
 Value MathBuilder::uge(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::uge);
   llvm_unreachable("expected unsigned int");
 }
@@ -429,7 +432,7 @@ Value MathBuilder::uge(Value lhs, Value rhs) const {
 Value MathBuilder::ult(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::ult);
   llvm_unreachable("expected unsigned int");
 }
@@ -437,35 +440,35 @@ Value MathBuilder::ult(Value lhs, Value rhs) const {
 Value MathBuilder::ule(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::ule);
   llvm_unreachable("expected unsigned int");
 }
 
 Value MathBuilder::gt(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return ugt(lhs, rhs);
   return sgt(lhs, rhs);
 }
 
 Value MathBuilder::ge(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return uge(lhs, rhs);
   return sge(lhs, rhs);
 }
 
 Value MathBuilder::lt(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return ult(lhs, rhs);
   return slt(lhs, rhs);
 }
 
 Value MathBuilder::le(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
-  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs))
     return ule(lhs, rhs);
   return sle(lhs, rhs);
 }
@@ -473,9 +476,9 @@ Value MathBuilder::le(Value lhs, Value rhs) const {
 Value MathBuilder::eq(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::eq);
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OEQ);
   llvm_unreachable("expected int or float");
 }
@@ -483,9 +486,9 @@ Value MathBuilder::eq(Value lhs, Value rhs) const {
 Value MathBuilder::neq(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isScalarOrVectorInteger(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::ne);
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::ONE);
   llvm_unreachable("expected int or float");
 }

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -185,7 +185,7 @@ Value MathBuilder::add(Value lhs, Value rhs) const {
     } else
       return b().create<arith::AddIOp>(loc(), lhs, rhs);
   }
-  if (isScalarOrVectorFloat(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs))
     return b().create<arith::AddFOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1556,30 +1556,31 @@ void SCFBuilder::yield() const { b().create<scf::YieldOp>(loc()); }
 // Vector Builder
 //===----------------------------------------------------------------------===//
 
-/*static*/ bool VectorBuilder::compatibleTypes(const Type t1, const Type t2) {
-  Type e1 = MathBuilder::elementTypeOfScalarOrVector(t1);
-  Type e2 = MathBuilder::elementTypeOfScalarOrVector(t2);
-  // Not the same element type, not compatible.
-  if (e1 != e2)
-    return false;
-  // If both are vectors, check the shapes.
+/*static*/ bool VectorBuilder::compatibleShapes(const Type t1, const Type t2) {
+  // If both are vectors, check that the shapes are identical.
   VectorType vt1 = mlir::dyn_cast<VectorType>(t1);
   VectorType vt2 = mlir::dyn_cast<VectorType>(t2);
   if (vt1 && vt2) {
     auto shape1 = vt1.getShape();
     auto shape2 = vt2.getShape();
+    // Different rank, return false.
     if (shape1.size() != shape2.size())
       return false;
-
     for (int64_t i = 0; i < (int64_t)shape1.size(); ++i)
       if (shape1[i] != shape2[i])
         return false;
     // Same dim and shapes
     return true;
   }
-  // Neither is a vector (no shape tests); or only one is a vector and the other
-  // one can thus be broadcasted to it.
+  // Neither is a vector (no shape tests) or only one is a vector (and the other
+  // one can thus be broadcasted to it), we have compatible shapes.
   return true;
+}
+
+/*static*/ bool VectorBuilder::compatibleTypes(const Type t1, const Type t2) {
+  Type e1 = MathBuilder::elementTypeOfScalarOrVector(t1);
+  Type e2 = MathBuilder::elementTypeOfScalarOrVector(t2);
+  return (e1 == e2) && compatibleShapes(t1, t2);
 }
 
 int64_t VectorBuilder::getMachineVectorLength(const Type &elementType) const {

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -55,6 +55,10 @@ namespace onnx_mlir {
   return mlir::dyn_cast<VectorType>(val.getType()) != nullptr;
 }
 
+/* static */ Type MathBuilder::elementTypeOfScalarOrVector(Value val) {
+  return elementTypeOfScalarOrVector(val.getType());
+}
+
 /* static */ Type MathBuilder::elementTypeOfScalarOrVector(
     Type elementOrVectorType) {
   VectorType vectorType = mlir::dyn_cast<VectorType>(elementOrVectorType);
@@ -170,7 +174,7 @@ Value MathBuilder::add(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
   if (isScalarOrVectorInteger(lhs)) {
-    Type elemType = elementTypeOfScalarOrVector(lhs.getType());
+    Type elemType = elementTypeOfScalarOrVector(lhs);
     if (elemType.isUnsignedInteger()) {
       unsigned elemWidth = mlir::cast<IntegerType>(elemType).getWidth();
       Value castLhs = castToSignless(lhs, elemWidth);
@@ -200,7 +204,7 @@ Value MathBuilder::mul(Value lhs, Value rhs) const {
   splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
   if (isScalarOrVectorInteger(lhs)) {
-    Type elemType = elementTypeOfScalarOrVector(lhs.getType());
+    Type elemType = elementTypeOfScalarOrVector(lhs);
     if (elemType.isUnsignedInteger()) {
       unsigned elemWidth = mlir::cast<IntegerType>(elemType).getWidth();
       Value castLhs = castToSignless(lhs, elemWidth);

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -55,7 +55,8 @@ namespace onnx_mlir {
   return mlir::dyn_cast<VectorType>(type) != nullptr;
 }
 
-/* static */ Type MathBuilder::elementTypeWithVector(Type elementOrVectorType) {
+/* static */ Type MathBuilder::elementTypeOfScalarOrVector(
+    Type elementOrVectorType) {
   VectorType vectorType = mlir::dyn_cast<VectorType>(elementOrVectorType);
   if (vectorType)
     return vectorType.getElementType();
@@ -69,56 +70,108 @@ namespace onnx_mlir {
   return elementType;
 }
 
-/* static */ bool MathBuilder::isIntegerWithVector(Type elementOrVectorType) {
-  Type elementType = elementTypeWithVector(elementOrVectorType);
+/* static */ bool MathBuilder::isScalarOrVectorInteger(
+    Type elementOrVectorType) {
+  Type elementType = elementTypeOfScalarOrVector(elementOrVectorType);
   return mlir::isa<IntegerType>(elementType) ||
          mlir::isa<IndexType>(elementType);
 }
 
-/* static */ bool MathBuilder::isUnsignedIntegerWithVector(
+/* static */ bool MathBuilder::isScalarOrVectorUnsignedInteger(
     Type elementOrVectorType) {
-  Type elementType = elementTypeWithVector(elementOrVectorType);
+  Type elementType = elementTypeOfScalarOrVector(elementOrVectorType);
   return elementType.isUnsignedInteger();
 }
 
-/* static */ bool MathBuilder::isFloatWithVector(Type elementOrVectorType) {
-  Type elementType = elementTypeWithVector(elementOrVectorType);
+/* static */ bool MathBuilder::isScalarOrVectorFloat(Type elementOrVectorType) {
+  Type elementType = elementTypeOfScalarOrVector(elementOrVectorType);
   return mlir::isa<FloatType>(elementType);
 }
 
+bool MathBuilder::splatToMatch(Value &first, Value &second) const {
+  bool firstIsVector = isVector(first.getType());
+  bool secondIsVector = isVector(second.getType());
+  // Both scalar or vector, nothing to do.
+  if (firstIsVector == secondIsVector) {
+    // If both vectors, ensure its the same vector length.
+    if (firstIsVector) {
+      VectorType firstVectorType = mlir::cast<VectorType>(first.getType());
+      VectorType secondVectorType = mlir::cast<VectorType>(second.getType());
+      auto firstShape = firstVectorType.getShape();
+      auto secondShape = secondVectorType.getShape();
+      assert(firstShape.size() == secondShape.size() && "expected same sizes");
+      for (int64_t i = 0; i < (int64_t)firstShape.size(); ++i)
+        assert(firstShape[i] == secondShape[i] && "expected same dim");
+    }
+    // No changes in types.
+    return false;
+  }
+  if (firstIsVector) {
+    // Splat second.
+    assert(!secondIsVector && "bad assumption");
+    VectorType firstVectorType = mlir::cast<VectorType>(first.getType());
+    VectorType secondVectorType =
+        VectorType::get(firstVectorType.getShape(), second.getType());
+    second = b().create<vector::SplatOp>(loc(), secondVectorType, second);
+  } else {
+    // Splat first.
+    assert(secondIsVector && "bad assumption");
+    VectorType secondVectorType = mlir::cast<VectorType>(second.getType());
+    VectorType firstVectorType =
+        VectorType::get(secondVectorType.getShape(), first.getType());
+    first = b().create<vector::SplatOp>(loc(), firstVectorType, first);
+  }
+  // Types were changed.
+  return true;
+}
+
+bool MathBuilder::splatToMatch(
+    Value &first, Value &second, Value &third) const {
+  bool changeIn12 = splatToMatch(first, second);
+  bool changeIn13 = splatToMatch(first, third);
+  if (!changeIn12 && changeIn13)
+    // Have missed changes in 1-2 pair, redo.
+    splatToMatch(first, second);
+  return changeIn12 || changeIn13;
+}
+
 Value MathBuilder::abs(Value val) const {
-  if (isIntegerWithVector(val.getType()))
+  if (isScalarOrVectorInteger(val.getType()))
     return b().create<math::AbsIOp>(loc(), val);
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::AbsFOp>(loc(), val);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::andi(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::AndIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
 
 Value MathBuilder::ori(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::OrIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
 
 Value MathBuilder::xori(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::XOrIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
 
 Value MathBuilder::add(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType())) {
-    Type elemType = elementTypeWithVector(lhs.getType());
+  if (isScalarOrVectorInteger(lhs.getType())) {
+    Type elemType = elementTypeOfScalarOrVector(lhs.getType());
     if (elemType.isUnsignedInteger()) {
       unsigned elemWidth = mlir::cast<IntegerType>(elemType).getWidth();
       Value castLhs = castToSignless(lhs, elemWidth);
@@ -129,24 +182,26 @@ Value MathBuilder::add(Value lhs, Value rhs) const {
     } else
       return b().create<arith::AddIOp>(loc(), lhs, rhs);
   }
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return b().create<arith::AddFOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::sub(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::SubIOp>(loc(), lhs, rhs);
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return b().create<arith::SubFOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::mul(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType())) {
-    Type elemType = elementTypeWithVector(lhs.getType());
+  if (isScalarOrVectorInteger(lhs.getType())) {
+    Type elemType = elementTypeOfScalarOrVector(lhs.getType());
     if (elemType.isUnsignedInteger()) {
       unsigned elemWidth = mlir::cast<IntegerType>(elemType).getWidth();
       Value castLhs = castToSignless(lhs, elemWidth);
@@ -157,66 +212,73 @@ Value MathBuilder::mul(Value lhs, Value rhs) const {
     } else
       return b().create<arith::MulIOp>(loc(), lhs, rhs);
   }
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return b().create<arith::MulFOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::div(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return b().create<arith::DivFOp>(loc(), lhs, rhs);
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return b().create<arith::DivUIOp>(loc(), lhs, rhs);
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::DivSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::rem(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return b().create<arith::RemFOp>(loc(), lhs, rhs);
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return b().create<arith::RemUIOp>(loc(), lhs, rhs);
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::RemSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::copySign(mlir::Value rem, mlir::Value dividend) const {
+  splatToMatch(rem, dividend);
   assert(rem.getType() == dividend.getType() && "expected same type");
-  if (isFloatWithVector(rem.getType()))
+  if (isScalarOrVectorFloat(rem.getType()))
     return b().create<math::CopySignOp>(loc(), rem, dividend);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::ceilDiv(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return b().create<arith::CeilDivUIOp>(loc(), lhs, rhs);
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::CeilDivSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
 
 Value MathBuilder::floorDiv(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     // Using regular unsigned div is ok as it rounds toward zero.
     return b().create<arith::DivUIOp>(loc(), lhs, rhs);
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::FloorDivSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int");
 }
 
 // return (lhs * rhs) + acc
 Value MathBuilder::fma(Value lhs, Value rhs, Value acc) const {
+  splatToMatch(lhs, rhs, acc);
   assert((lhs.getType() == rhs.getType()) && (rhs.getType() == acc.getType()) &&
          "expected same type");
-  if (isFloatWithVector(lhs.getType()) && !isa<FloatType>(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()) && isVector(lhs.getType())) {
     return b().create<vector::FMAOp>(loc(), lhs, rhs, acc);
-  return add(mul(lhs, rhs), acc);
+  }
+  return add(mul(lhs, rhs), acc); // Handle broadcast there.
 }
 
 Value MathBuilder::erf(Value val) const {
@@ -224,192 +286,210 @@ Value MathBuilder::erf(Value val) const {
 }
 
 Value MathBuilder::exp(Value val) const {
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::ExpOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::exp2(Value val) const {
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::Exp2Op>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::log(Value val) const {
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::LogOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::log2(Value val) const {
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::Log2Op>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::sqrt(Value val) const {
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::SqrtOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::pow(Value base, Value exp) const {
-  if (isFloatWithVector(base.getType()))
+  // no broadcast, do not expect the exponent to be a vector
+  assert(!isVector(exp.getType()) && "do not support a vector exponent");
+  if (isScalarOrVectorFloat(base.getType()))
     return b().create<math::PowFOp>(loc(), base, exp);
   llvm_unreachable("expected base float");
 }
 
 Value MathBuilder::neg(Value val) const {
-  if (isIntegerWithVector(val.getType()))
+  if (isScalarOrVectorInteger(val.getType()))
     // Returns 0 - val.
     return sub(constant(val.getType(), 0), val);
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<arith::NegFOp>(loc(), val);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::ceil(Value val) const {
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::CeilOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::floor(Value val) const {
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::FloorOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::tanh(Value val) const {
-  if (isFloatWithVector(val.getType()))
+  if (isScalarOrVectorFloat(val.getType()))
     return b().create<math::TanhOp>(loc(), val);
   llvm_unreachable("expected float");
 }
 
 Value MathBuilder::min(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return b().create<arith::MinNumFOp>(loc(), lhs, rhs);
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return b().create<arith::MinUIOp>(loc(), lhs, rhs);
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::MinSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::max(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return b().create<arith::MaxNumFOp>(loc(), lhs, rhs);
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return b().create<arith::MaxUIOp>(loc(), lhs, rhs);
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return b().create<arith::MaxSIOp>(loc(), lhs, rhs);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::sgt(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::sgt);
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OGT);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::sge(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::sge);
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OGE);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::slt(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::slt);
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OLT);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::sle(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::sle);
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OLE);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::ugt(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::ugt);
   llvm_unreachable("expected unsigned int");
 }
 
 Value MathBuilder::uge(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::uge);
   llvm_unreachable("expected unsigned int");
 }
 
 Value MathBuilder::ult(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::ult);
   llvm_unreachable("expected unsigned int");
 }
 
 Value MathBuilder::ule(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::ule);
   llvm_unreachable("expected unsigned int");
 }
 
 Value MathBuilder::gt(Value lhs, Value rhs) const {
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  splatToMatch(lhs, rhs);
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return ugt(lhs, rhs);
   return sgt(lhs, rhs);
 }
 
 Value MathBuilder::ge(Value lhs, Value rhs) const {
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  splatToMatch(lhs, rhs);
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return uge(lhs, rhs);
   return sge(lhs, rhs);
 }
 
 Value MathBuilder::lt(Value lhs, Value rhs) const {
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  splatToMatch(lhs, rhs);
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return ult(lhs, rhs);
   return slt(lhs, rhs);
 }
 
 Value MathBuilder::le(Value lhs, Value rhs) const {
-  if (isUnsignedIntegerWithVector(lhs.getType()))
+  splatToMatch(lhs, rhs);
+  if (isScalarOrVectorUnsignedInteger(lhs.getType()))
     return ule(lhs, rhs);
   return sle(lhs, rhs);
 }
 
 Value MathBuilder::eq(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::eq);
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::OEQ);
   llvm_unreachable("expected int or float");
 }
 
 Value MathBuilder::neq(Value lhs, Value rhs) const {
+  splatToMatch(lhs, rhs);
   assert(lhs.getType() == rhs.getType() && "expected same type");
-  if (isIntegerWithVector(lhs.getType()))
+  if (isScalarOrVectorInteger(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpIPredicate::ne);
-  if (isFloatWithVector(lhs.getType()))
+  if (isScalarOrVectorFloat(lhs.getType()))
     return createArithCmp(lhs, rhs, arith::CmpFPredicate::ONE);
   llvm_unreachable("expected int or float");
 }
@@ -422,7 +502,7 @@ Value MathBuilder::select(Value cmp, Value trueVal, Value falseVal) const {
 Value MathBuilder::constant(Type type, double val) const {
   Value constant = nullptr;
   // Could be a vector type; look at the element type.
-  Type elementType = elementTypeWithVector(type);
+  Type elementType = elementTypeOfScalarOrVector(type);
   TypeSwitch<Type>(elementType)
       .Case<Float16Type>([&](Type) {
         constant =
@@ -569,7 +649,7 @@ TypedAttr MathBuilder::positiveInfAttr(mlir::Type type) const {
 
 Value MathBuilder::negativeInf(Type type) const {
   // Strip vector type if any.
-  Type elementType = elementTypeWithVector(type);
+  Type elementType = elementTypeOfScalarOrVector(type);
   TypedAttr attr = negativeInfAttr(elementType);
   Value constant = b().create<arith::ConstantOp>(loc(), attr);
   assert(constant != nullptr && "Expecting valid constant value");
@@ -584,7 +664,7 @@ Value MathBuilder::negativeInf(Type type) const {
 
 Value MathBuilder::positiveInf(Type type) const {
   // Strip vector type if any.
-  Type elementType = elementTypeWithVector(type);
+  Type elementType = elementTypeOfScalarOrVector(type);
   TypedAttr attr = positiveInfAttr(elementType);
   Value constant = b().create<arith::ConstantOp>(loc(), attr);
   assert(constant != nullptr && "Expecting valid constant value");
@@ -601,7 +681,7 @@ Value MathBuilder::createArithCmp(
     Value lhs, Value rhs, arith::CmpIPredicate pred) const {
   Type type = lhs.getType();
   assert(type == rhs.getType() && "Operands should have the same type");
-  assert(isIntegerWithVector(type) && "expected int");
+  assert(isScalarOrVectorInteger(type) && "expected int");
   return b().create<arith::CmpIOp>(loc(), pred, lhs, rhs);
 }
 
@@ -609,7 +689,7 @@ Value MathBuilder::createArithCmp(
     Value lhs, Value rhs, arith::CmpFPredicate pred) const {
   Type type = lhs.getType();
   assert(type == rhs.getType() && "Operands should have the same type");
-  assert(isFloatWithVector(type) && "expected float");
+  assert(isScalarOrVectorFloat(type) && "expected float");
   return b().create<arith::CmpFOp>(loc(), pred, lhs, rhs);
 }
 
@@ -619,7 +699,7 @@ Value MathBuilder::createArithCmp(
 Value MathBuilder::castToSignless(Value val, int64_t width) const {
   Type valType = val.getType();
   VectorType vecType = mlir::dyn_cast<VectorType>(valType);
-  Type valElemType = elementTypeWithVector(valType);
+  Type valElemType = elementTypeOfScalarOrVector(valType);
   assert(mlir::isa<IntegerType>(valElemType) &&
          !valElemType.isSignlessInteger() && "Expecting signed integer type");
   Type destType = getTypeWithVector(vecType, b().getIntegerType(width));
@@ -631,7 +711,7 @@ Value MathBuilder::castToSignless(Value val, int64_t width) const {
 Value MathBuilder::castToUnsigned(Value val, int64_t width) const {
   Type valType = val.getType();
   VectorType vecType = mlir::dyn_cast<VectorType>(valType);
-  Type valElemType = elementTypeWithVector(valType);
+  Type valElemType = elementTypeOfScalarOrVector(valType);
   assert(mlir::isa<IntegerType>(valElemType) && "Expecting integer type");
   Type destType =
       getTypeWithVector(vecType, b().getIntegerType(width, false /*signed*/));
@@ -646,8 +726,8 @@ Value MathBuilder::cast(Type destType, Value src) const {
   Type srcType = src.getType();
   VectorType srcVecType = mlir::dyn_cast<VectorType>(srcType);
   VectorType destVecType = mlir::dyn_cast<VectorType>(destType);
-  Type srcElemType = elementTypeWithVector(srcType);
-  Type destElemType = elementTypeWithVector(destType);
+  Type srcElemType = elementTypeOfScalarOrVector(srcType);
+  Type destElemType = elementTypeOfScalarOrVector(destType);
   // Make sure we don't mix vector and scalars.
   assert(((srcVecType && destVecType) || (!srcVecType && !destVecType)) &&
          "expect both to be scalars or vectors");
@@ -1635,43 +1715,43 @@ Value VectorBuilder::reduction(
         loc(), vector::CombiningKind::MUL, value);
   }
   case CombiningKind::MAX: {
-    if (MathBuilder::isUnsignedIntegerWithVector(type))
+    if (MathBuilder::isScalarOrVectorUnsignedInteger(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::MAXUI, value);
-    if (MathBuilder::isIntegerWithVector(type))
+    if (MathBuilder::isScalarOrVectorInteger(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::MAXSI, value);
-    if (MathBuilder::isFloatWithVector(type))
+    if (MathBuilder::isScalarOrVectorFloat(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::MAXNUMF, value);
     llvm_unreachable("unknown type in max");
   }
   case CombiningKind::MIN: {
-    if (MathBuilder::isUnsignedIntegerWithVector(type))
+    if (MathBuilder::isScalarOrVectorUnsignedInteger(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::MINUI, value);
-    if (MathBuilder::isIntegerWithVector(type))
+    if (MathBuilder::isScalarOrVectorInteger(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::MINSI, value);
-    if (MathBuilder::isFloatWithVector(type))
+    if (MathBuilder::isScalarOrVectorFloat(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::MINNUMF, value);
     llvm_unreachable("unknown type in min");
   }
   case CombiningKind::AND: {
-    if (MathBuilder::isIntegerWithVector(type))
+    if (MathBuilder::isScalarOrVectorInteger(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::AND, value);
     llvm_unreachable("unknown type in and");
   }
   case CombiningKind::OR: {
-    if (MathBuilder::isIntegerWithVector(type))
+    if (MathBuilder::isScalarOrVectorInteger(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::OR, value);
     llvm_unreachable("unknown type in or");
   }
   case CombiningKind::XOR: {
-    if (MathBuilder::isIntegerWithVector(type))
+    if (MathBuilder::isScalarOrVectorInteger(type))
       return b().create<vector::ReductionOp>(
           loc(), vector::CombiningKind::XOR, value);
     llvm_unreachable("unknown type in xor");

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -319,8 +319,7 @@ Value MathBuilder::sqrt(Value val) const {
 }
 
 Value MathBuilder::pow(Value base, Value exp) const {
-  // no broadcast, do not expect the exponent to be a vector
-  assert(!isVector(exp) && "do not support a vector exponent");
+  splatToMatch(base, exp);
   if (isScalarOrVectorFloat(base))
     return b().create<math::PowFOp>(loc(), base, exp);
   llvm_unreachable("expected base float");

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -92,11 +92,14 @@ struct MathBuilder final : DialectBuilder {
 
   // Support for vectors: we provide queries that work regardless of if we have
   // (1) a scalar or (2) a vector of a basic element type.
-  static bool isVector(mlir::Type type);
+  static bool isVector(mlir::Value val);
   // The method belows ignore the vectors part of the type to provide answer on
   // the basic element types alone.
+  static bool isScalarOrVectorInteger(mlir::Value val);
   static bool isScalarOrVectorInteger(mlir::Type elementOrVectorType);
+  static bool isScalarOrVectorUnsignedInteger(mlir::Value val);
   static bool isScalarOrVectorUnsignedInteger(mlir::Type elementOrVectorType);
+  static bool isScalarOrVectorFloat(mlir::Value val);
   static bool isScalarOrVectorFloat(mlir::Type elementOrVectorType);
   // Return the basic element type regardless of if we are given (1) a scalar or
   // (2) a vector of a basic element type.
@@ -197,7 +200,7 @@ private:
   mlir::Value castToSignless(mlir::Value source, int64_t width) const;
   mlir::Value castToUnsigned(mlir::Value source, int64_t width) const;
   // If any of the first, second, or third values are vector types, splat the
-  // other ones to the same VL. Return true if values were splatted.
+  // other ones to the same VL. Return true if one or more values were splatted.
   bool splatToMatch(mlir::Value &first, mlir::Value &second) const;
   bool splatToMatch(
       mlir::Value &first, mlir::Value &second, mlir::Value &third) const;

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -440,6 +440,8 @@ struct VectorBuilder final : DialectBuilder {
   using F2 = std::function<mlir::Value(mlir::Value const, mlir::Value const)>;
   enum CombiningKind { ADD, MUL, MAX, MIN, AND, OR, XOR };
 
+  static bool compatibleTypes(const mlir::Type t1, const mlir::Type t2);
+
   // Get the machine SIMD vector length for the given elementary type.
   // This can help guide certain optimizations.
   int64_t getMachineVectorLength(const mlir::Type &elementType) const;

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -133,7 +133,7 @@ struct MathBuilder final : DialectBuilder {
   mlir::Value mul(mlir::Value lhs, mlir::Value rhs) const;      // B.
   mlir::Value neg(mlir::Value val) const;
   mlir::Value ori(mlir::Value lhs, mlir::Value rhs) const;  // B/Int only.
-  mlir::Value pow(mlir::Value base, mlir::Value exp) const; // Float only.
+  mlir::Value pow(mlir::Value base, mlir::Value exp) const; // B/Float only.
   mlir::Value rem(mlir::Value lhs, mlir::Value rhs) const;  // B.
   mlir::Value sqrt(mlir::Value val) const;                  // Float only.
   mlir::Value sub(mlir::Value lhs, mlir::Value rhs) const;  // B.

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -103,6 +103,7 @@ struct MathBuilder final : DialectBuilder {
   static bool isScalarOrVectorFloat(mlir::Type elementOrVectorType);
   // Return the basic element type regardless of if we are given (1) a scalar or
   // (2) a vector of a basic element type.
+  static mlir::Type elementTypeOfScalarOrVector(mlir::Value val);
   static mlir::Type elementTypeOfScalarOrVector(mlir::Type elementOrVectorType);
   // Return a type of the same vector shape as vectorType with a basic element
   // type of elementType. When vectorType is null, then the returned type is

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -95,64 +95,68 @@ struct MathBuilder final : DialectBuilder {
   static bool isVector(mlir::Type type);
   // The method belows ignore the vectors part of the type to provide answer on
   // the basic element types alone.
-  static bool isIntegerWithVector(mlir::Type elementOrVectorType);
-  static bool isUnsignedIntegerWithVector(mlir::Type elementOrVectorType);
-  static bool isFloatWithVector(mlir::Type elementOrVectorType);
+  static bool isScalarOrVectorInteger(mlir::Type elementOrVectorType);
+  static bool isScalarOrVectorUnsignedInteger(mlir::Type elementOrVectorType);
+  static bool isScalarOrVectorFloat(mlir::Type elementOrVectorType);
   // Return the basic element type regardless of if we are given (1) a scalar or
   // (2) a vector of a basic element type.
-  static mlir::Type elementTypeWithVector(mlir::Type elementOrVectorType);
+  static mlir::Type elementTypeOfScalarOrVector(mlir::Type elementOrVectorType);
   // Return a type of the same vector shape as vectorType with a basic element
   // type of elementType. When vectorType is null, then the returned type is
   // simply a scalar of elementType.
   static mlir::Type getTypeWithVector(
       mlir::VectorType vectorType, mlir::Type elementType);
 
+  // "B" below indicates that the operation will splat scalar values if one of
+  // the input value is itself a vector.
+
   mlir::Value abs(mlir::Value val) const;
-  mlir::Value add(mlir::Value lhs, mlir::Value rhs) const;
-  mlir::Value andi(mlir::Value lhs, mlir::Value rhs) const;     // Int only.
+  mlir::Value add(mlir::Value lhs, mlir::Value rhs) const;      // B.
+  mlir::Value andi(mlir::Value lhs, mlir::Value rhs) const;     // B/Int only.
   mlir::Value ceil(mlir::Value val) const;                      // Float only.
-  mlir::Value ceilDiv(mlir::Value lhs, mlir::Value rhs) const;  // Int only.
-  mlir::Value copySign(mlir::Value rem, mlir::Value div) const; // Float only.
-  mlir::Value div(mlir::Value lhs, mlir::Value rhs) const;
+  mlir::Value ceilDiv(mlir::Value lhs, mlir::Value rhs) const;  // B/Int only.
+  mlir::Value copySign(mlir::Value rem, mlir::Value div) const; // B/Float only.
+  mlir::Value div(mlir::Value lhs, mlir::Value rhs) const;      // B.
   mlir::Value erf(mlir::Value val) const;
   mlir::Value exp(mlir::Value val) const;                       // Float only.
   mlir::Value exp2(mlir::Value val) const;                      // Float only.
   mlir::Value floor(mlir::Value val) const;                     // Float only.
-  mlir::Value floorDiv(mlir::Value lhs, mlir::Value rhs) const; // Int only.
-  mlir::Value fma(mlir::Value lhs, mlir::Value rhs, mlir::Value acc) const;
-  mlir::Value log(mlir::Value val) const;  // Float only.
-  mlir::Value log2(mlir::Value val) const; // Float only.
-  mlir::Value mul(mlir::Value lhs, mlir::Value rhs) const;
+  mlir::Value floorDiv(mlir::Value lhs, mlir::Value rhs) const; // B/Int only.
+  mlir::Value fma(
+      mlir::Value lhs, mlir::Value rhs, mlir::Value acc) const; // B.
+  mlir::Value log(mlir::Value val) const;                       // Float only.
+  mlir::Value log2(mlir::Value val) const;                      // Float only.
+  mlir::Value mul(mlir::Value lhs, mlir::Value rhs) const;      // B.
   mlir::Value neg(mlir::Value val) const;
-  mlir::Value ori(mlir::Value lhs, mlir::Value rhs) const;  // Int only.
+  mlir::Value ori(mlir::Value lhs, mlir::Value rhs) const;  // B/Int only.
   mlir::Value pow(mlir::Value base, mlir::Value exp) const; // Float only.
-  mlir::Value rem(mlir::Value lhs, mlir::Value rhs) const;
-  mlir::Value sqrt(mlir::Value val) const; // Float only.
-  mlir::Value sub(mlir::Value lhs, mlir::Value rhs) const;
+  mlir::Value rem(mlir::Value lhs, mlir::Value rhs) const;  // B.
+  mlir::Value sqrt(mlir::Value val) const;                  // Float only.
+  mlir::Value sub(mlir::Value lhs, mlir::Value rhs) const;  // B.
   mlir::Value tanh(mlir::Value val) const;                  // Float only.
-  mlir::Value xori(mlir::Value lhs, mlir::Value rhs) const; // Int only.
+  mlir::Value xori(mlir::Value lhs, mlir::Value rhs) const; // B/Int only.
 
   mlir::Value select(
       mlir::Value cmp, mlir::Value trueVal, mlir::Value valseVal) const;
-  mlir::Value gt(mlir::Value lhs, mlir::Value rhs) const;
-  mlir::Value ge(mlir::Value lhs, mlir::Value rhs) const;
-  mlir::Value lt(mlir::Value lhs, mlir::Value rhs) const;
-  mlir::Value le(mlir::Value lhs, mlir::Value rhs) const;
-  mlir::Value eq(mlir::Value lhs, mlir::Value rhs) const;
-  mlir::Value neq(mlir::Value lhs, mlir::Value rhs) const;
+  mlir::Value gt(mlir::Value lhs, mlir::Value rhs) const;  // B.
+  mlir::Value ge(mlir::Value lhs, mlir::Value rhs) const;  // B.
+  mlir::Value lt(mlir::Value lhs, mlir::Value rhs) const;  // B.
+  mlir::Value le(mlir::Value lhs, mlir::Value rhs) const;  // B.
+  mlir::Value eq(mlir::Value lhs, mlir::Value rhs) const;  // B.
+  mlir::Value neq(mlir::Value lhs, mlir::Value rhs) const; // B.
   // Signed versions (index/signless/signed int or float)
-  mlir::Value sgt(mlir::Value lhs, mlir::Value rhs) const; // No unsigned.
-  mlir::Value sge(mlir::Value lhs, mlir::Value rhs) const; // No unsigned.
-  mlir::Value slt(mlir::Value lhs, mlir::Value rhs) const; // No unsigned.
-  mlir::Value sle(mlir::Value lhs, mlir::Value rhs) const; // No unsigned.
+  mlir::Value sgt(mlir::Value lhs, mlir::Value rhs) const; // B/No unsigned.
+  mlir::Value sge(mlir::Value lhs, mlir::Value rhs) const; // B/No unsigned.
+  mlir::Value slt(mlir::Value lhs, mlir::Value rhs) const; // B/No unsigned.
+  mlir::Value sle(mlir::Value lhs, mlir::Value rhs) const; // B/No unsigned.
   // Unsigned versions
-  mlir::Value ugt(mlir::Value lhs, mlir::Value rhs) const; // Unsigned int only
-  mlir::Value uge(mlir::Value lhs, mlir::Value rhs) const; // Unsigned int only
-  mlir::Value ult(mlir::Value lhs, mlir::Value rhs) const; // Unsigned int only
-  mlir::Value ule(mlir::Value lhs, mlir::Value rhs) const; // Unsigned int only
+  mlir::Value ugt(mlir::Value lhs, mlir::Value rhs) const; // B/Unsigned only.
+  mlir::Value uge(mlir::Value lhs, mlir::Value rhs) const; // B/Unsigned only.
+  mlir::Value ult(mlir::Value lhs, mlir::Value rhs) const; // B/Unsigned only.
+  mlir::Value ule(mlir::Value lhs, mlir::Value rhs) const; // B/Unsigned only.
 
-  mlir::Value min(mlir::Value lhs, mlir::Value rhs) const;
-  mlir::Value max(mlir::Value lhs, mlir::Value rhs) const;
+  mlir::Value min(mlir::Value lhs, mlir::Value rhs) const; // B.
+  mlir::Value max(mlir::Value lhs, mlir::Value rhs) const; // B.
 
   mlir::Value constant(mlir::Type type, double val) const;
   mlir::Value constantIndex(int64_t val) const;
@@ -192,6 +196,11 @@ private:
       mlir::Value lhs, mlir::Value rhs, mlir::arith::CmpFPredicate pred) const;
   mlir::Value castToSignless(mlir::Value source, int64_t width) const;
   mlir::Value castToUnsigned(mlir::Value source, int64_t width) const;
+  // If any of the first, second, or third values are vector types, splat the
+  // other ones to the same VL. Return true if values were splatted.
+  bool splatToMatch(mlir::Value &first, mlir::Value &second) const;
+  bool splatToMatch(
+      mlir::Value &first, mlir::Value &second, mlir::Value &third) const;
 };
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -440,6 +440,10 @@ struct VectorBuilder final : DialectBuilder {
   using F2 = std::function<mlir::Value(mlir::Value const, mlir::Value const)>;
   enum CombiningKind { ADD, MUL, MAX, MIN, AND, OR, XOR };
 
+  // Check if two types have compatible shapes (assuming that scalar will be
+  // splatted to the proper vector shape),
+  static bool compatibleShapes(const mlir::Type t1, const mlir::Type t2);
+  // Check that the two types have identical elementary types and shapes.
   static bool compatibleTypes(const mlir::Type t1, const mlir::Type t2);
 
   // Get the machine SIMD vector length for the given elementary type.


### PR DESCRIPTION
The math dialect in MLIR supports operations on scalar or vector inputs, but not a mixture of the two.

When generating SIMD code, we would like to generate a single source of code that can then be used to generate both SIMD code for the innermost SIMD loop, as well as scalar code for the remaining few iterations, if any.

The code to generate SIMD will load `memrefs` either as scalar or vectors; but often there are operations that needs constants, such as "compare to zero", "max of zero"... the scalar are needed then as a scalar in scalar code, but as a splatted constant when generating SIMD code.

The most robust method to provide this functionality is to provide implicit "splat" for each of the MathBuilder operations.

This PR does this.

This code will later be put to good use in a subsequent PR.

As an illustration of how this is used, here is a preview of where this new capability in this PR will be useful.

```C++
            emitSimdLoopIE(create.vec, simdUB, VL, // loop from 0 to simdUB by VL
                {X}, {inputAF}, // list of input values to load prior to the kernel, with their respective access function.
                {Y},  {outputAF}, // list of output values to save after the kernel is executed, with their respective function
                [&](VectorBuilder &vb,  // kernel functions with
                    ArrayRef<Value> inputVals,  // input values pre-loaded (either in scalar or simd mode)
                    SmallVectorImpl<Value> &resVals) // output values to be saved later (either in scalar or simd mode)
                 { // kernel code
                  MultiDialectBuilder<MathBuilder, VectorBuilder> create(vb);
                  Value x = inputVals[0];
                  // Scale
                  Value scaleX = create.math.div(x, scale);
                  // Round
                  Value roundX = create.math.round(scaleX);
                  // Adjust
                  Value adjustX = create.math.add(roundX, zeroPoint);
                  // Saturate
                  Value saturateX = create.math.clip(adjustX, qMin, qMax);
                  Value res = create.math.cast(quantizedElementType, saturateX);
                  resVals.emplace_back(res);
                });
```

In the above code, `scale`, `zeroPoint`, `qMin`, `qMax` are scalar that are needed in scalar or simd mode. We don't want explicit splats as we don't know in which mode we run, so we want them to be implicitly added when the `inpputVals[*]` are actually simd vectors.