### PR TITLE
Timeout a build after 6 hours

### DIFF
--- a/.buildbot/Jenkinsfile
+++ b/.buildbot/Jenkinsfile
@@ -26,6 +26,7 @@ def call() {
       skipDefaultCheckout()
       buildDiscarder(logRotator(numToKeepStr:'1000'))
       ansiColor('xterm')
+      timeout(time: 6, unit: 'HOURS')
     }
 
     agent {


### PR DESCRIPTION
Current Jenkins build typically takes less than 3 hours. Timeout a build after 6 hours to account for the case when the build died badly (typically due to segfault) and didn't get a chance to report failure.