### PR TITLE
try to use new buffer deallocation

### DIFF
--- a/src/Compiler/CompilerDialects.cpp
+++ b/src/Compiler/CompilerDialects.cpp
@@ -46,8 +46,8 @@ DialectRegistry registerDialects(ArrayRef<accel::Accelerator::Kind> accels) {
   for (auto *accel : accel::Accelerator::getAccelerators())
     accel->registerDialects(registry);
 
-  if (useOldBufferization)
-    memref::registerAllocationOpInterfaceExternalModels(registry);
+  memref::registerAllocationOpInterfaceExternalModels(registry);
+  arith::registerBufferDeallocationOpInterfaceExternalModels(registry);
 
   return registry;
 }

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -42,6 +42,7 @@ bool enableONNXHybridPass;                             // common for both
 std::vector<std::string> functionsToDecompose;         // common for both
 std::string opsForCall;                                // common for both
 bool disableKrnlOpFusion;                              // common for both
+bool disableMemRefPrefetch;                            // common for both
 EmissionTargetType emissionTarget;                     // onnx-mlir only
 bool invokeOnnxVersionConverter;                       // onnx-mlir only
 bool preserveLocations;                                // onnx-mlir only
@@ -209,6 +210,13 @@ static llvm::cl::opt<bool, true> disableKrnlOpFusionOpt(
     llvm::cl::desc("disable op fusion in onnx-to-krnl pass (default=false)\n"
                    "Set to 'true' if you want to disable fusion."),
     llvm::cl::location(disableKrnlOpFusion), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true> disableMemRefPrefetchOpt(
+    "disable-memref-prefetch",
+    llvm::cl::desc("disable generation of memref.prefetch (default=false)\n"
+                   "Set to 'true' if you want to disable prefetch."),
+    llvm::cl::location(disableMemRefPrefetch), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirCommonOptions));
 
 static llvm::cl::opt<bool, true> disableRecomposeOptionOpt("disable-recompose",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -87,6 +87,7 @@ extern bool enableONNXHybridPass;                             // common for both
 extern std::vector<std::string> functionsToDecompose;         // common for both
 extern std::string opsForCall;                                // common for both
 extern bool disableKrnlOpFusion;                              // common for both
+extern bool disableMemRefPrefetch;                            // common for both
 extern EmissionTargetType emissionTarget;                     // onnx-mlir only
 extern bool invokeOnnxVersionConverter;                       // onnx-mlir only
 extern bool preserveLocations;                                // onnx-mlir only

--- a/src/Dialect/Krnl/CMakeLists.txt
+++ b/src/Dialect/Krnl/CMakeLists.txt
@@ -20,6 +20,7 @@ add_onnx_mlir_library(OMKrnlOps
   OMSpecializedKernelOpInterface
 
   LINK_LIBS PUBLIC
+  OMCompilerOptions
   OMONNXOps
   MLIRLLVMCommonConversion
   MLIRAffineDialect

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -14,6 +14,7 @@
 
 #include "llvm/ADT/TypeSwitch.h"
 
+#include "src/Compiler/CompilerOptions.hpp"
 #include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
 #include "src/Dialect/Krnl/DialectBuilder.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
@@ -149,12 +150,16 @@ Value KrnlBuilder::getLinearOffsetIndexIE(
 
 void KrnlBuilder::prefetch(Value memref, ValueRange indices, bool isWrite,
     unsigned localityHint, bool isDataCache) {
+  if (disableMemRefPrefetch)
+    return;
   b().create<KrnlPrefetchOp>(
       loc(), memref, indices, isWrite, localityHint, isDataCache);
 }
 
 void KrnlBuilder::prefetchIE(Value memref, ArrayRef<IndexExpr> indices,
     bool isWrite, unsigned localityHint, bool isDataCache) {
+  if (disableMemRefPrefetch)
+    return;
   SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
   b().create<KrnlPrefetchOp>(

--- a/src/Dialect/Mlir/CMakeLists.txt
+++ b/src/Dialect/Mlir/CMakeLists.txt
@@ -12,6 +12,7 @@ add_onnx_mlir_library(OMMlirDialects
   OMSpecializedKernelOpInterface
 
   LINK_LIBS PUBLIC
+  OMCompilerOptions
   MLIRMathDialect
   MLIRAffineDialect
   MLIRSCFDialect

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Support/Debug.h"
 
 // Please do not add dependences on ONNX or KRNL dialects.
+#include "src/Compiler/CompilerOptions.hpp"
 #include "src/Dialect/Mlir/DialectBuilder.hpp"
 #include "src/Dialect/Mlir/VectorMachineSupport.hpp"
 
@@ -1642,6 +1643,8 @@ Value MemRefBuilder::dim(Value val, Value index) const {
 
 void MemRefBuilder::prefetch(Value memref, ValueRange indices, bool isWrite,
     unsigned locality, bool isData) {
+  if (disableMemRefPrefetch)
+    return;
   b().create<memref::PrefetchOp>(
       loc(), memref, indices, isWrite, locality, isData);
 }
@@ -1649,6 +1652,8 @@ void MemRefBuilder::prefetch(Value memref, ValueRange indices, bool isWrite,
 void MemRefBuilder::prefetchIE(Value memref,
     llvm::SmallVectorImpl<IndexExpr> &indices, bool isWrite, unsigned locality,
     bool isData) {
+  if (disableMemRefPrefetch)
+    return;
   SmallVector<Value, 4> indexVals;
   IndexExpr::getValues(indices, indexVals);
   prefetch(memref, indexVals, isWrite, locality, isData);


### PR DESCRIPTION
onnx-mlir is using the old buffer deallocation by default (option `--use-old-bufferization`). If that option is set to false, there is some compilation error. This PR is trying to fix this issue.
1. register the bufferizaton interface for the dialects that may be used. For NNPA, dialects, `memref` and `arith` may be used.
2. After that change, there is an error for memref.prefetch. Its memory side effect is not defined. Need further investigation with MLIR community. Current workaround is to add a flag, `disable-memref-prefetch`, in builder to generate nothing for prefetch.

With these changes, roberta model can be compiled with the new deallocation with command:
```
Debug/bin/onnx-mlir --O3 --EmitLib --mtriple=s390x-ibm-loz --mcpu=z16 --maccel=NNPA --disable-memref-prefetch=true   --use-old-bufferization=false roberta-base-11.onnx
```

Here is the execution time of for this model:
without deallocation: 10.6
old deallocation: 4.6
new deallocation: 4.8