### PR TITLE
Code cleanup and some upgrade to builders

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.cpp
@@ -207,7 +207,7 @@ Value getLSTMGRUGetYc(
 SmallVector<Value, 4> emitONNXSplitOp(Location loc, PatternRewriter &rewriter,
     Value input, IntegerAttr axis, ArrayAttr split) {
   Type elementType = mlir::cast<ShapedType>(input.getType()).getElementType();
-  SmallVector<mlir::Type> outputTypes;
+  SmallVector<Type> outputTypes;
   int64_t splitNum = split.size();
   ArrayRef<int64_t> inputShape =
       mlir::cast<RankedTensorType>(input.getType()).getShape();

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.cpp
@@ -76,7 +76,7 @@ ValueRange splitAlongAxis(
 bool isF32ScalarConstantTensor(Value v) {
   if (!isScalarConstantTensor(v))
     return false;
-  auto t = dyn_cast<ShapedType>(v.getType());
+  auto t = mlir::dyn_cast<ShapedType>(v.getType());
   return t.getElementType().isF32();
 }
 
@@ -93,7 +93,7 @@ Value getDynShape(Location loc, PatternRewriter &rewriter, Value x) {
     llvm_unreachable("The input must have shape and rank");
 
   OnnxBuilder create(rewriter, loc);
-  auto t = dyn_cast<ShapedType>(x.getType());
+  auto t = mlir::dyn_cast<ShapedType>(x.getType());
   int64_t r = t.getRank();
   SmallVector<Value> dims;
   for (int64_t i = 0; i < r; ++i) {

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHighCommon.cpp
@@ -73,7 +73,7 @@ ValueRange splitAlongAxis(
   return splits;
 }
 
-bool isF32ScalarConstantTensor(mlir::Value v) {
+bool isF32ScalarConstantTensor(Value v) {
   if (!isScalarConstantTensor(v))
     return false;
   auto t = dyn_cast<ShapedType>(v.getType());

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.cpp
@@ -416,44 +416,44 @@ double estimateTimeForUnstickOp(Value oper) {
 bool estimateTimeForOpWithModel(Operation *op, const DimAnalysis *dimAnalysis,
     double &cpuEstimatedTime, double &nnpaEstimatedTime) {
   bool opHasModel = true;
-  if (auto addOp = dyn_cast<ONNXAddOp>(op))
+  if (auto addOp = mlir::dyn_cast<ONNXAddOp>(op))
     estimateTimeForOp(addOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto divOp = dyn_cast<ONNXDivOp>(op))
+  else if (auto divOp = mlir::dyn_cast<ONNXDivOp>(op))
     estimateTimeForOp(divOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto maxOp = dyn_cast<ONNXMaxOp>(op))
+  else if (auto maxOp = mlir::dyn_cast<ONNXMaxOp>(op))
     estimateTimeForOp(maxOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto minOp = dyn_cast<ONNXMinOp>(op))
+  else if (auto minOp = mlir::dyn_cast<ONNXMinOp>(op))
     estimateTimeForOp(minOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto mulOp = dyn_cast<ONNXMulOp>(op))
+  else if (auto mulOp = mlir::dyn_cast<ONNXMulOp>(op))
     estimateTimeForOp(mulOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto powOp = dyn_cast<ONNXPowOp>(op))
+  else if (auto powOp = mlir::dyn_cast<ONNXPowOp>(op))
     estimateTimeForOp(powOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto subOp = dyn_cast<ONNXSubOp>(op))
+  else if (auto subOp = mlir::dyn_cast<ONNXSubOp>(op))
     estimateTimeForOp(subOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
   // Unary elementwise NNPA candidate ops.
-  else if (auto expOp = dyn_cast<ONNXExpOp>(op))
+  else if (auto expOp = mlir::dyn_cast<ONNXExpOp>(op))
     estimateTimeForOp(expOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto logOp = dyn_cast<ONNXLogOp>(op))
+  else if (auto logOp = mlir::dyn_cast<ONNXLogOp>(op))
     estimateTimeForOp(logOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto reluOp = dyn_cast<ONNXReluOp>(op))
+  else if (auto reluOp = mlir::dyn_cast<ONNXReluOp>(op))
     estimateTimeForOp(reluOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto sigmoidOp = dyn_cast<ONNXSigmoidOp>(op))
+  else if (auto sigmoidOp = mlir::dyn_cast<ONNXSigmoidOp>(op))
     estimateTimeForOp(
         sigmoidOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto softmaxOp = dyn_cast<ONNXSoftmaxOp>(op))
+  else if (auto softmaxOp = mlir::dyn_cast<ONNXSoftmaxOp>(op))
     estimateTimeForOp(
         softmaxOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto tanhOp = dyn_cast<ONNXTanhOp>(op))
+  else if (auto tanhOp = mlir::dyn_cast<ONNXTanhOp>(op))
     estimateTimeForOp(tanhOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
   // Reduce
-  else if (auto reduceMeanOp = dyn_cast<ONNXReduceMeanV13Op>(op))
+  else if (auto reduceMeanOp = mlir::dyn_cast<ONNXReduceMeanV13Op>(op))
     estimateTimeForOp(
         reduceMeanOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
   // Matmul.
-  else if (auto matMulOp = dyn_cast<ONNXMatMulOp>(op))
+  else if (auto matMulOp = mlir::dyn_cast<ONNXMatMulOp>(op))
     estimateTimeForOp(
         matMulOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
-  else if (auto gemmOp = dyn_cast<ONNXGemmOp>(op))
+  else if (auto gemmOp = mlir::dyn_cast<ONNXGemmOp>(op))
     estimateTimeForOp(gemmOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
   else
     opHasModel = false;

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -219,7 +219,7 @@ bool canInferencePadsForNNPAConv(ONNXConvOp op) {
 // Create an ArrayAttr of IntegerAttr(s) of zero values.
 // This function is used for padding attribute in Conv.
 ArrayAttr getPadsForNNPAConv(PatternRewriter &rewriter, Value ret) {
-  ONNXConvOp op = dyn_cast<ONNXConvOp>(ret.getDefiningOp());
+  ONNXConvOp op = mlir::dyn_cast<ONNXConvOp>(ret.getDefiningOp());
   ONNXConvOpShapeHelper shapeHelper(op.getOperation(), {});
   shapeHelper.computeShapeAndAssertOnFailure();
   SmallVector<int64_t, 4> vals;
@@ -451,7 +451,7 @@ public:
     if (isa<BlockArgument>(B))
       return false;
     bool BIsZero = false;
-    if (auto expandOp = dyn_cast<ONNXExpandOp>(B.getDefiningOp())) {
+    if (auto expandOp = mlir::dyn_cast<ONNXExpandOp>(B.getDefiningOp())) {
       Value input = expandOp.getInput();
       if (isDenseONNXConstant(input)) {
         // Expand's input is 0?

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
@@ -501,7 +501,7 @@ struct ZHighToZLowStickOpLowering : public ConversionPattern {
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const final {
     Location loc = op->getLoc();
-    ZHighStickOp stickOp = cast<ZHighStickOp>(op);
+    ZHighStickOp stickOp = mlir::cast<ZHighStickOp>(op);
 
     ZHighStickOpAdaptor operandAdaptor(operands);
     Value input = operandAdaptor.getIn();
@@ -1557,7 +1557,7 @@ struct ZHighToZLowStickifiedConstantOfShapeOpLowering
     Location loc = op->getLoc();
     MDBuilder create(rewriter, loc);
 
-    auto stickOp = cast<ZHighStickifiedConstantOfShapeOp>(op);
+    auto stickOp = mlir::cast<ZHighStickifiedConstantOfShapeOp>(op);
     FloatAttr value = stickOp.getValueAttr();
     Type i16Ty = rewriter.getI16Type();
     Type i64Ty = rewriter.getI64Type();

--- a/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVM.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVM.cpp
@@ -98,7 +98,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowStickOp stickOp = cast<ZLowStickOp>(op);
+    ZLowStickOp stickOp = mlir::cast<ZLowStickOp>(op);
 
     ZLowStickOpAdaptor operandAdaptor(operands);
     // Do not get element type from adaptor since the type can be opaque.
@@ -154,7 +154,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowStickForLSTMOp stickForLSTMOp = cast<ZLowStickForLSTMOp>(op);
+    ZLowStickForLSTMOp stickForLSTMOp = mlir::cast<ZLowStickForLSTMOp>(op);
 
     ZLowStickForLSTMOpAdaptor operandAdaptor(operands);
     Type llvmElementTy = typeConverter->convertType(
@@ -240,7 +240,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowStickForGRUOp stickForGRUOp = cast<ZLowStickForGRUOp>(op);
+    ZLowStickForGRUOp stickForGRUOp = mlir::cast<ZLowStickForGRUOp>(op);
 
     ZLowStickForGRUOpAdaptor operandAdaptor(operands);
     Type llvmElementTy = typeConverter->convertType(
@@ -324,7 +324,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowLSTMOp lstmOp = cast<ZLowLSTMOp>(op);
+    ZLowLSTMOp lstmOp = mlir::cast<ZLowLSTMOp>(op);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowLSTMOpAdaptor operandAdaptor(operands);
@@ -520,7 +520,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowGRUOp gruOp = cast<ZLowGRUOp>(op);
+    ZLowGRUOp gruOp = mlir::cast<ZLowGRUOp>(op);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowGRUOpAdaptor operandAdaptor(operands);
@@ -675,7 +675,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowUnstickOp unstickOp = cast<ZLowUnstickOp>(op);
+    ZLowUnstickOp unstickOp = mlir::cast<ZLowUnstickOp>(op);
 
     ZLowUnstickOpAdaptor operandAdaptor(operands);
     Type llvmElementTy = typeConverter->convertType(
@@ -732,7 +732,7 @@ public:
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
     MLIRContext *context = rewriter.getContext();
-    UnaryElementwiseOp unaryOp = cast<UnaryElementwiseOp>(op);
+    UnaryElementwiseOp unaryOp = mlir::cast<UnaryElementwiseOp>(op);
     typename UnaryElementwiseOp::Adaptor operandAdaptor(operands);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
@@ -810,7 +810,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    BinaryElementwiseOp binaryOp = cast<BinaryElementwiseOp>(op);
+    BinaryElementwiseOp binaryOp = mlir::cast<BinaryElementwiseOp>(op);
     typename BinaryElementwiseOp::Adaptor operandAdaptor(operands);
 
     Value input1 = operandAdaptor.getX();
@@ -888,7 +888,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowSoftmaxOp softmaxOp = cast<ZLowSoftmaxOp>(op);
+    ZLowSoftmaxOp softmaxOp = mlir::cast<ZLowSoftmaxOp>(op);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowSoftmaxOpAdaptor operandAdaptor(operands);
@@ -971,7 +971,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowMatMulOp matmulOp = cast<ZLowMatMulOp>(op);
+    ZLowMatMulOp matmulOp = mlir::cast<ZLowMatMulOp>(op);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowMatMulOpAdaptor operandAdaptor(operands);
@@ -1109,7 +1109,7 @@ public:
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
     MLIRContext *context = rewriter.getContext();
-    ZLowConv2DOp convOp = cast<ZLowConv2DOp>(op);
+    ZLowConv2DOp convOp = mlir::cast<ZLowConv2DOp>(op);
     ZLowConv2DOpAdaptor operandAdaptor(operands);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
@@ -1256,7 +1256,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    POOLOP poolOp = cast<POOLOP>(op);
+    POOLOP poolOp = mlir::cast<POOLOP>(op);
     typename POOLOP::Adaptor operandAdaptor(operands);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
@@ -1360,7 +1360,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowMeanReduce2DOp meanOp = cast<ZLowMeanReduce2DOp>(op);
+    ZLowMeanReduce2DOp meanOp = mlir::cast<ZLowMeanReduce2DOp>(op);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     ZLowMeanReduce2DOpAdaptor operandAdaptor(operands);
@@ -1429,7 +1429,7 @@ public:
       ConversionPatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    ZLowBatchNormOp batchnormOp = cast<ZLowBatchNormOp>(op);
+    ZLowBatchNormOp batchnormOp = mlir::cast<ZLowBatchNormOp>(op);
 
     ZLowBatchNormOpAdaptor operandAdaptor(operands);
     Type llvmElementTy = typeConverter->convertType(

--- a/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.cpp
@@ -364,7 +364,7 @@ std::vector<Value> getDimsFromShapeMemRefBySize(PatternRewriter &rewriter,
           bitcastOp.getArg().getDefiningOp());
       if (addressOfOp) {
         LLVM::GlobalOp globalOp =
-            dyn_cast_or_null<LLVM::GlobalOp>(SymbolTable::lookupSymbolIn(
+            mlir::dyn_cast_or_null<LLVM::GlobalOp>(SymbolTable::lookupSymbolIn(
                 module, addressOfOp.getGlobalNameAttr()));
         if (globalOp) {
           DenseElementsAttr valueAttr =

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.cpp
@@ -71,10 +71,10 @@ LogicalResult OpTrait::impl::verifySameOperandsAndResultLayout(Operation *op) {
 namespace onnx_mlir {
 namespace zhigh {
 
-std::vector<mlir::Type> getZHighAuxSplitResultType(
+std::vector<Type> getZHighAuxSplitResultType(
     Value input, int64_t axis, ArrayAttr split) {
   Type elementType = mlir::cast<ShapedType>(input.getType()).getElementType();
-  std::vector<mlir::Type> outputTypes;
+  std::vector<Type> outputTypes;
   if (split.size() == 0) {
     llvm_unreachable("Unsupported split (size==0)");
   } else {

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/BatchNorm/BatchNorm.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/BatchNorm/BatchNorm.cpp
@@ -24,7 +24,7 @@ namespace zhigh {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighBatchNormOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Conv2D/Conv2D.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Conv2D/Conv2D.cpp
@@ -139,7 +139,7 @@ LogicalResult ZHighConv2DOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighConv2DOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getInput()) || !hasRankedType(getInputKernel()))
     return success();
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/DLF16ToF32/DLF16ToF32.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/DLF16ToF32/DLF16ToF32.cpp
@@ -33,7 +33,7 @@ void ZHighDLF16ToF32Op::build(
   Type elementType = builder.getF32Type();
   Type resType = UnrankedTensorType::get(elementType);
 
-  if (auto inType = dyn_cast<RankedTensorType>(input.getType()))
+  if (auto inType = mlir::dyn_cast<RankedTensorType>(input.getType()))
     resType = RankedTensorType::get(inType.getShape(), elementType);
 
   build(builder, state, resType, input);

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/DLF16ToF32/DLF16ToF32.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/DLF16ToF32/DLF16ToF32.cpp
@@ -44,7 +44,7 @@ void ZHighDLF16ToF32Op::build(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighDLF16ToF32Op::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Elementwise/Elementwise.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Elementwise/Elementwise.cpp
@@ -22,7 +22,7 @@ namespace zhigh {
 //===----------------------------------------------------------------------===//
 // AddOp
 LogicalResult ZHighAddOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -30,7 +30,7 @@ LogicalResult ZHighAddOp::inferShapes(
 // SubOp
 
 LogicalResult ZHighSubOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -38,7 +38,7 @@ LogicalResult ZHighSubOp::inferShapes(
 // MulOp
 
 LogicalResult ZHighMulOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -46,7 +46,7 @@ LogicalResult ZHighMulOp::inferShapes(
 // DivOp
 
 LogicalResult ZHighDivOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -54,7 +54,7 @@ LogicalResult ZHighDivOp::inferShapes(
 // MinOp
 
 LogicalResult ZHighMinOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -62,7 +62,7 @@ LogicalResult ZHighMinOp::inferShapes(
 // MaxOp
 
 LogicalResult ZHighMaxOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -70,7 +70,7 @@ LogicalResult ZHighMaxOp::inferShapes(
 // LogOp
 
 LogicalResult ZHighLogOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -78,7 +78,7 @@ LogicalResult ZHighLogOp::inferShapes(
 // ExpOp
 
 LogicalResult ZHighExpOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -86,7 +86,7 @@ LogicalResult ZHighExpOp::inferShapes(
 // ReluOp
 
 LogicalResult ZHighReluOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -94,7 +94,7 @@ LogicalResult ZHighReluOp::inferShapes(
 // TanhOp
 
 LogicalResult ZHighTanhOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 
@@ -102,7 +102,7 @@ LogicalResult ZHighTanhOp::inferShapes(
 // SigmoiOp
 
 LogicalResult ZHighSigmoidOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/F32ToDLF16/F32ToDLF16.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/F32ToDLF16/F32ToDLF16.cpp
@@ -44,7 +44,7 @@ void ZHighF32ToDLF16Op::build(OpBuilder &builder, OperationState &state,
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighF32ToDLF16Op::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/F32ToDLF16/F32ToDLF16.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/F32ToDLF16/F32ToDLF16.cpp
@@ -33,7 +33,7 @@ void ZHighF32ToDLF16Op::build(OpBuilder &builder, OperationState &state,
   Type elementType = builder.getF16Type();
   Type resType = UnrankedTensorType::get(elementType);
 
-  if (auto inType = dyn_cast<RankedTensorType>(input.getType()))
+  if (auto inType = mlir::dyn_cast<RankedTensorType>(input.getType()))
     resType = RankedTensorType::get(inType.getShape(), elementType);
 
   build(builder, state, resType, input, saturation);

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/GRU/FixGRUY.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/GRU/FixGRUY.cpp
@@ -24,7 +24,7 @@ namespace zhigh {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighFixGRUYOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/GRU/FixGRUYh.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/GRU/FixGRUYh.cpp
@@ -41,7 +41,7 @@ LogicalResult ZHighFixGRUYhOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighFixGRUYhOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getY()))
     return success();
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/GRU/GRU.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/GRU/GRU.cpp
@@ -51,14 +51,14 @@ LogicalResult ZHighGRUOpShapeHelper::computeShape() {
   if (isAllTimesteps)
     hnOutputDims.emplace_back(S);
   else
-    hnOutputDims.emplace_back(LiteralIndexExpr(1));
+    hnOutputDims.emplace_back(LitIE(1));
   hnOutputDims.emplace_back(D);
   hnOutputDims.emplace_back(B);
   hnOutputDims.emplace_back(H);
 
   // Shape for cf_ouput : [1, B, H]
   DimsExpr cfOutputDims;
-  cfOutputDims.emplace_back(LiteralIndexExpr(1));
+  cfOutputDims.emplace_back(LitIE(1));
   cfOutputDims.emplace_back(B);
   cfOutputDims.emplace_back(H);
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/GRU/GRU.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/GRU/GRU.cpp
@@ -137,7 +137,7 @@ LogicalResult ZHighGRUOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighGRUOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getInput()) || !hasRankedType(getHiddenWeights()))
     return success();
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/LSTM/LSTM.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/LSTM/LSTM.cpp
@@ -139,7 +139,7 @@ LogicalResult ZHighLSTMOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighLSTMOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getInput()) || !hasRankedType(getHiddenWeights()))
     return success();
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/LSTM/LSTM.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/LSTM/LSTM.cpp
@@ -51,14 +51,14 @@ LogicalResult ZHighLSTMOpShapeHelper::computeShape() {
   if (isAllTimesteps)
     hnOutputDims.emplace_back(S);
   else
-    hnOutputDims.emplace_back(LiteralIndexExpr(1));
+    hnOutputDims.emplace_back(LitIE(1));
   hnOutputDims.emplace_back(D);
   hnOutputDims.emplace_back(B);
   hnOutputDims.emplace_back(H);
 
   // Shape for cf_ouput : [1, D, B, H]
   DimsExpr cfOutputDims;
-  cfOutputDims.emplace_back(LiteralIndexExpr(1));
+  cfOutputDims.emplace_back(LitIE(1));
   cfOutputDims.emplace_back(D);
   cfOutputDims.emplace_back(B);
   cfOutputDims.emplace_back(H);

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/MatMul/MatMul.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/MatMul/MatMul.cpp
@@ -94,7 +94,7 @@ LogicalResult ZHighMatMulOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighMatMulOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getX()) || !hasRankedType(getY()))
     return success();
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/MeanReduce2D/MeanReduce2D.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/MeanReduce2D/MeanReduce2D.cpp
@@ -38,8 +38,8 @@ LogicalResult ZHighMeanReduce2DOpShapeHelper::computeShape() {
 
   // Input is NHWC, and H and W are reduction dimensions.
   outputDims.emplace_back(inputDims[0]);
-  outputDims.emplace_back(LiteralIndexExpr(1));
-  outputDims.emplace_back(LiteralIndexExpr(1));
+  outputDims.emplace_back(LitIE(1));
+  outputDims.emplace_back(LitIE(1));
   outputDims.emplace_back(inputDims[3]);
 
   // Save the final result.

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/MeanReduce2D/MeanReduce2D.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/MeanReduce2D/MeanReduce2D.cpp
@@ -52,7 +52,7 @@ LogicalResult ZHighMeanReduce2DOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighMeanReduce2DOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getInput()))
     return success();
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/OpHelper.cpp
@@ -217,7 +217,7 @@ bool oneIsOfLayout(Type t1, Type t2,
 
 /// Check if ONNXReshapeOp is reshaping 2D to 4D by tiling each input dimension.
 bool isTiling2DTo4D(Value val) {
-  auto reshapeOp = dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
+  auto reshapeOp = mlir::dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
   if (!reshapeOp)
     return false;
 
@@ -246,7 +246,7 @@ bool isTiling2DTo4D(Value val) {
 /// Check if ONNXReshapeOp is reshaping 3D to 4D by tiling the first input
 /// dimension.
 bool isTiling3DTo4D(Value val) {
-  auto reshapeOp = dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
+  auto reshapeOp = mlir::dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
   if (!reshapeOp)
     return false;
 
@@ -276,7 +276,7 @@ bool isTiling3DTo4D(Value val) {
 /// Check if a 4D tensor is collapsed into 2D by merging the each two
 /// dimensions.
 bool isCollapsing4DTo2D(Value val) {
-  auto reshapeOp = dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
+  auto reshapeOp = mlir::dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
   if (!reshapeOp)
     return false;
 
@@ -305,7 +305,7 @@ bool isCollapsing4DTo2D(Value val) {
 /// Check if a 4D tensor is collapsed into 3D by merging the first two
 /// dimensions.
 bool isCollapsing4DTo3D(Value val) {
-  auto reshapeOp = dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
+  auto reshapeOp = mlir::dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
   if (!reshapeOp)
     return false;
 
@@ -336,7 +336,7 @@ AffineMapAttr getTiling2DTo4DMap(OpBuilder &b, Value val) {
   assert(isTiling2DTo4D(val) &&
          "ONNXReshapeOp is not suitable for getting a tiling affine map");
 
-  auto reshapeOp = dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
+  auto reshapeOp = mlir::dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
   Value output = reshapeOp.getReshaped();
   Type outputType = output.getType();
   ArrayRef<int64_t> outputShape = getShape(outputType);
@@ -361,7 +361,7 @@ AffineMapAttr getTiling3DTo4DMap(OpBuilder &b, Value val) {
   assert(isTiling3DTo4D(val) &&
          "ONNXReshapeOp is not suitable for getting a tiling affine map");
 
-  auto reshapeOp = dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
+  auto reshapeOp = mlir::dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
   Value output = reshapeOp.getReshaped();
   Type outputType = output.getType();
   ArrayRef<int64_t> outputShape = getShape(outputType);
@@ -384,7 +384,7 @@ AffineMapAttr getCollapsing4DTo2DMap(OpBuilder &b, Value val) {
   assert(isCollapsing4DTo2D(val) &&
          "ONNXReshapeOp is not suitable for getting a collapsing affine map");
 
-  auto reshapeOp = dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
+  auto reshapeOp = mlir::dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
   Value input = reshapeOp.getData();
   Type inputType = input.getType();
   ArrayRef<int64_t> inputShape = getShape(inputType);
@@ -409,7 +409,7 @@ AffineMapAttr getCollapsing4DTo3DMap(OpBuilder &b, Value val) {
   assert(isCollapsing4DTo3D(val) &&
          "ONNXReshapeOp is not suitable for getting a collapsing affine map");
 
-  auto reshapeOp = dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
+  auto reshapeOp = mlir::dyn_cast<ONNXReshapeOp>(val.getDefiningOp());
   Value input = reshapeOp.getData();
   Type inputType = input.getType();
   ArrayRef<int64_t> inputShape = getShape(inputType);

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Pooling/Pooling.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Pooling/Pooling.cpp
@@ -94,7 +94,7 @@ template struct ZHighPoolingOpShapeHelper<ZHighAvgPool2DOp>;
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighMaxPool2DOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getInput()))
     return success();
 
@@ -110,7 +110,7 @@ LogicalResult ZHighMaxPool2DOp::inferShapes(
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighAvgPool2DOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getInput()))
     return success();
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Softmax/Softmax.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Softmax/Softmax.cpp
@@ -20,7 +20,7 @@ namespace onnx_mlir {
 namespace zhigh {
 
 LogicalResult ZHighSoftmaxOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());
 }
 

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/Stick.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Stick/Stick.cpp
@@ -106,7 +106,7 @@ LogicalResult ZHighStickOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighStickOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   Value input = getIn();
   if (isa<NoneType>(input.getType()) || !hasRankedType(input))
     return success();

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickForGRU/StickForGRU.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickForGRU/StickForGRU.cpp
@@ -50,7 +50,7 @@ LogicalResult ZHighStickForGRUOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighStickForGRUOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getZGate()) && !hasRankedType(getRGate()) &&
       !hasRankedType(getHGate()))
     return success();

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickForGRU/StickForGRU.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickForGRU/StickForGRU.cpp
@@ -37,7 +37,7 @@ LogicalResult ZHighStickForGRUOpShapeHelper::computeShape() {
 
   for (int64_t i = 0; i < rank - 1; ++i)
     outputDims.emplace_back(zGateDims[i]);
-  IndexExpr lastDim = zGateDims[rank - 1] * LiteralIndexExpr(3);
+  IndexExpr lastDim = zGateDims[rank - 1] * LitIE(3);
   outputDims.emplace_back(lastDim);
 
   // Save the final result.

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickForLSTM/StickForLSTM.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickForLSTM/StickForLSTM.cpp
@@ -37,7 +37,7 @@ LogicalResult ZHighStickForLSTMOpShapeHelper::computeShape() {
 
   for (int64_t i = 0; i < rank - 1; ++i)
     outputDims.emplace_back(fGateDims[i]);
-  IndexExpr lastDim = fGateDims[rank - 1] * LiteralIndexExpr(4);
+  IndexExpr lastDim = fGateDims[rank - 1] * LitIE(4);
   outputDims.emplace_back(lastDim);
 
   // Save the final result.

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickForLSTM/StickForLSTM.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickForLSTM/StickForLSTM.cpp
@@ -50,7 +50,7 @@ LogicalResult ZHighStickForLSTMOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighStickForLSTMOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getFGate()) && !hasRankedType(getIGate()) &&
       !hasRankedType(getCGate()) && !hasRankedType(getOGate()))
     return success();

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickifiedConstantOfShape/StickifiedConstantOfShape.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/StickifiedConstantOfShape/StickifiedConstantOfShape.cpp
@@ -92,7 +92,7 @@ LogicalResult ZHighStickifiedConstantOfShapeOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighStickifiedConstantOfShapeOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   Value shape = getShape();
   if (!hasRankedType(shape))
     return success();

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Unstick/Unstick.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Unstick/Unstick.cpp
@@ -100,7 +100,7 @@ LogicalResult ZHighUnstickOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ZHighUnstickOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   if (!hasRankedType(getIn()))
     return success();
 

--- a/src/Accelerators/NNPA/Dialect/ZLow/DialectBuilder.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZLow/DialectBuilder.cpp
@@ -26,9 +26,7 @@ namespace onnx_mlir {
 // =============================================================================
 
 // Return null if none is found.
-ElementsAttr IndexExprBuilderForZLow::getConst(Value value) {
-  return nullptr;
-}
+ElementsAttr IndexExprBuilderForZLow::getConst(Value value) { return nullptr; }
 
 Value IndexExprBuilderForZLow::getVal(Value intArrayVal, uint64_t i) {
   MultiDialectBuilder<AffineBuilder, MathBuilder> create(*this);

--- a/src/Accelerators/NNPA/Dialect/ZLow/DialectBuilder.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZLow/DialectBuilder.cpp
@@ -34,7 +34,7 @@ Value IndexExprBuilderForZLow::getVal(Value intArrayVal, uint64_t i) {
   MultiDialectBuilder<AffineBuilder, MathBuilder> create(*this);
   uint64_t rank = getShapedTypeRank(intArrayVal);
   if (rank == 0)
-    return create.affine.load(intArrayVal, {});
+    return create.affine.load(intArrayVal);
   uint64_t size = getArraySize(intArrayVal);
   assert(i < size && "out of bound reference");
   Value iVal = create.math.constantIndex(i);

--- a/src/Accelerators/NNPA/Dialect/ZLow/DialectBuilder.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZLow/DialectBuilder.cpp
@@ -26,7 +26,7 @@ namespace onnx_mlir {
 // =============================================================================
 
 // Return null if none is found.
-ElementsAttr IndexExprBuilderForZLow::getConst(mlir::Value value) {
+ElementsAttr IndexExprBuilderForZLow::getConst(Value value) {
   return nullptr;
 }
 

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighClipToDLFloat.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighClipToDLFloat.cpp
@@ -70,7 +70,7 @@ bool valueFromZTensor(Value tensor) {
     return valueFromZTensor(op->getOperand(0));
 
   // PadOp
-  if (auto padOp = dyn_cast<ONNXPadOp>(op)) {
+  if (auto padOp = mlir::dyn_cast<ONNXPadOp>(op)) {
     Value padVal = padOp.getConstantValue();
     // Only support default constant value that is 0 at this moment.
     if (isNoneValue(padVal))
@@ -96,7 +96,7 @@ public:
     Type inputElementType = getElementType(input.getType());
 
     // Only clip if the input is in float > 16 bit.
-    auto floatType = dyn_cast<FloatType>(inputElementType);
+    auto floatType = mlir::dyn_cast<FloatType>(inputElementType);
     if (!floatType)
       return failure();
     if (floatType.getWidth() <= 16)

--- a/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.cpp
+++ b/src/Accelerators/NNPA/Transform/ZHigh/ZHighLayoutPropagation.cpp
@@ -47,7 +47,7 @@ std::pair<bool, StringAttr> areProducedByUnstickOpSameLayout(
       !isa<ZHighUnstickOp>(first.getDefiningOp()))
     return std::make_pair(false, nullptr);
   Value firstStickifiedVal =
-      cast<ZHighUnstickOp>(first.getDefiningOp()).getIn();
+      mlir::cast<ZHighUnstickOp>(first.getDefiningOp()).getIn();
   StringAttr firstLayout = convertZTensorDataLayoutToStringAttr(
       rewriter, getZTensorLayout(firstStickifiedVal.getType()));
 
@@ -56,7 +56,7 @@ std::pair<bool, StringAttr> areProducedByUnstickOpSameLayout(
     using namespace onnx_mlir::zhigh;
     if (mlir::isa<BlockArgument>(v) || !isa<ZHighUnstickOp>(v.getDefiningOp()))
       return false;
-    Value stickifiedVal = cast<ZHighUnstickOp>(v.getDefiningOp()).getIn();
+    Value stickifiedVal = mlir::cast<ZHighUnstickOp>(v.getDefiningOp()).getIn();
     StringAttr nextLayout = convertZTensorDataLayoutToStringAttr(
         rewriter, getZTensorLayout(stickifiedVal.getType()));
     return (nextLayout == firstLayout);
@@ -127,7 +127,7 @@ public:
       return failure();
 
     // Input is a CPU tensor, do nothing.
-    auto unstickOp = dyn_cast<ZHighUnstickOp>(input.getDefiningOp());
+    auto unstickOp = mlir::dyn_cast<ZHighUnstickOp>(input.getDefiningOp());
     if (!unstickOp)
       return failure();
 
@@ -182,8 +182,8 @@ public:
       return failure();
 
     // Input is a CPU tensor, do nothing.
-    auto unstickAOp = dyn_cast<ZHighUnstickOp>(A.getDefiningOp());
-    auto unstickBOp = dyn_cast<ZHighUnstickOp>(B.getDefiningOp());
+    auto unstickAOp = mlir::dyn_cast<ZHighUnstickOp>(A.getDefiningOp());
+    auto unstickBOp = mlir::dyn_cast<ZHighUnstickOp>(B.getDefiningOp());
     if (!unstickAOp || !unstickBOp)
       return failure();
 

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -244,7 +244,7 @@ public:
                     tripCount - (archVL - 1);
                 create.scf.forLoop(litZero.getValue(),
                     tripCountWithoutPartialLastVL.getValue(), archVL,
-                    [&](SCFBuilder b, ValueRange loopIn) {
+                    [&](SCFBuilder b, ValueRange loopInd) {
                       MDBuilder create(b);
                       IndexExprScope innerScope(b, &middleScope);
                       Value loopIndex = loopInd[0];

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -454,7 +454,7 @@ public:
 #endif
 #endif
 
-          create.affine.forIE(litZero, simdLoopUB, totVL,
+          create.affine.forLoopIE(litZero, simdLoopUB, totVL,
               [&](AffineBuilder &b, ValueRange loopInd) {
                 MDBuilder create(b);
                 DimsExpr inputAF;

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -199,9 +199,10 @@ public:
                 const int64_t totVL = unrollVL * archVL;
                 assert(totVL <= 64 && "bad unroll");
                 create.scf.forLoop(litZero.getValue(), lit64.getValue(), totVL,
-                    [&](SCFBuilder b, Value loopIndex) {
+                    [&](SCFBuilder b, ValueRange loopInd) {
                       MDBuilder create(b);
                       IndexExprScope innerScope(b, &outerScope);
+                      Value loopIndex = loopInd[0];
                       IndexExpr l = DimIE(loopIndex);
                       Value vecF16[unrollVL], vecF32H[unrollVL],
                           vecF32L[unrollVL];
@@ -243,9 +244,10 @@ public:
                     tripCount - (archVL - 1);
                 create.scf.forLoop(litZero.getValue(),
                     tripCountWithoutPartialLastVL.getValue(), archVL,
-                    [&](SCFBuilder b, Value loopIndex) {
+                    [&](SCFBuilder b, ValueRange loopIn) {
                       MDBuilder create(b);
                       IndexExprScope innerScope(b, &middleScope);
+                      Value loopIndex = loopInd[0];
                       IndexExpr l = DimIE(loopIndex);
                       // Load f16 values from input via reinterpreted data tile.
                       Value vecF16 = create.vec.loadIE(vecF16Type, inputAsTx64,
@@ -280,9 +282,10 @@ public:
                 // Save the remaining values as scalars.
                 create.scf.forLoop(litZero.getValue(),
                     remainingScalarValues.getValue(), 1,
-                    [&](SCFBuilder b, Value loopIndex) {
+                    [&](SCFBuilder b, ValueRange loopInd) {
                       MDBuilder create(b);
                       IndexExprScope innerScope(b, &middleScope);
+                      Value loopIndex = loopInd[0];
                       IndexExpr l = DimIE(loopIndex);
                       // Load converted value.
                       Value f32 = create.krnl.loadIE(bufferF32, {l});

--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -257,7 +257,7 @@ private:
     onnx::TypeProto onnxType;
     if (mlir::isa<NoneType>(mlirType)) {
       // Done: Uninitialized TypeProto onnxType represents NoneType.
-    } else if (auto mlirTensorType = dyn_cast<TensorType>(mlirType)) {
+    } else if (auto mlirTensorType = mlir::dyn_cast<TensorType>(mlirType)) {
       onnx::TypeProto::Tensor &onnxTensorType = *onnxType.mutable_tensor_type();
       onnxTensorType.set_elem_type(
           mlirTypeToOnnxType(mlirTensorType.getElementType()));
@@ -823,7 +823,7 @@ private:
                "Op contains subgraph attributes but does not "
                "implement HasOnnxSubgraphOpInterface interface.");
         auto opWithSubgraph =
-            cast<HasOnnxSubgraphOpInterface>(op.getOperation());
+            mlir::cast<HasOnnxSubgraphOpInterface>(op.getOperation());
         auto regionIdx = opWithSubgraph.getSubgraphRegionIdx(attr.name());
         auto &region = op->getRegion(regionIdx);
         region.push_back(new Block);
@@ -839,7 +839,7 @@ private:
       }
     }
     if (auto opWithTypeInference =
-            dyn_cast<ResultTypeInferenceOpInterface>(op.getOperation())) {
+            mlir::dyn_cast<ResultTypeInferenceOpInterface>(op.getOperation())) {
       auto outTypes = opWithTypeInference.resultTypeInference();
       for (int i = 0; i < node.output().size(); i++) {
         OpResult result = op->getResult(i);
@@ -1416,8 +1416,8 @@ private:
     if (output.type().value_case() == onnx::TypeProto::kTensorType) {
       Type outTy = ImportType(output.type(), dim_params);
       if (std::getenv("IMPORTER_FORCE_DYNAMIC"))
-        outTy =
-            UnrankedTensorType::get(cast<TensorType>(outTy).getElementType());
+        outTy = UnrankedTensorType::get(
+            mlir::cast<TensorType>(outTy).getElementType());
       if (output.type().tensor_type().has_shape()) {
         val.setType(outTy);
       }

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -242,7 +242,7 @@ static void loadMLIR(std::string inputFilename, mlir::MLIRContext &context,
   if ((numOfFuncOp == 1) && (!shapeInformation.empty())) {
     ModelInputShaper modelInputShaper_;
     modelInputShaper_.setShapeInformation(shapeInformation);
-    auto funcType = dyn_cast<FunctionType>(funcOp.getFunctionType());
+    auto funcType = mlir::dyn_cast<FunctionType>(funcOp.getFunctionType());
     ArrayRef<Type> argTypes = funcType.getInputs();
     SmallVector<Type, 4> newArgTypes;
     for (uint64_t i = 0; i < argTypes.size(); ++i) {
@@ -320,13 +320,15 @@ static void tailorLLVMIR(llvm::Module &llvmModule) {
           llvmModule.getNamedGlobal(StringRef("_entry_point_arrays" + tag))) {
     if (GV->isConstant() && GV->hasDefinitiveInitializer()) {
       llvm::Constant *initializer = GV->getInitializer();
-      llvm::ArrayType *AT = dyn_cast<llvm::ArrayType>(initializer->getType());
+      llvm::ArrayType *AT =
+          mlir::dyn_cast<llvm::ArrayType>(initializer->getType());
       for (uint64_t i = 0; i < AT->getNumElements() - 1; ++i) {
         llvm::GlobalVariable *entryGV = llvmModule.getNamedGlobal(
             StringRef("_entry_point_" + std::to_string(i) + tag));
         if (entryGV->isConstant()) {
           llvm::ConstantDataSequential *entry =
-              dyn_cast<llvm::ConstantDataSequential>(entryGV->getInitializer());
+              mlir::dyn_cast<llvm::ConstantDataSequential>(
+                  entryGV->getInitializer());
           exportedFuncs.emplace_back(entry->getAsCString());
         }
       }

--- a/src/Compiler/DisposableGarbageCollector.cpp
+++ b/src/Compiler/DisposableGarbageCollector.cpp
@@ -28,7 +28,7 @@ DisposableGarbageCollector::~DisposableGarbageCollector() {}
 void DisposableGarbageCollector::runAfterPass(Pass *pass, Operation *op) {
   if (!disposablePool.isActive())
     return;
-  ModuleOp moduleOp = dyn_cast<ModuleOp>(op);
+  ModuleOp moduleOp = mlir::dyn_cast<ModuleOp>(op);
   if (!moduleOp)
     return;
   disposablePool.garbageCollectUnreachable(

--- a/src/Conversion/KrnlSeqToMemref/KrnlSeqAlloc.cpp
+++ b/src/Conversion/KrnlSeqToMemref/KrnlSeqAlloc.cpp
@@ -41,7 +41,7 @@ public:
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
     KrnlSeqAllocOpAdaptor operandAdaptor(operands);
-    KrnlSeqAllocOp thisOp = dyn_cast<KrnlSeqAllocOp>(op);
+    KrnlSeqAllocOp thisOp = mlir::dyn_cast<KrnlSeqAllocOp>(op);
     Location loc = op->getLoc();
     MultiDialectBuilder<MathBuilder, MemRefBuilder> create(rewriter, loc);
 

--- a/src/Conversion/KrnlSeqToMemref/KrnlSeqExtract.cpp
+++ b/src/Conversion/KrnlSeqToMemref/KrnlSeqExtract.cpp
@@ -41,7 +41,7 @@ public:
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
     KrnlSeqExtractOpAdaptor operandAdaptor(operands);
-    KrnlSeqExtractOp thisOp = dyn_cast<KrnlSeqExtractOp>(op);
+    KrnlSeqExtractOp thisOp = mlir::dyn_cast<KrnlSeqExtractOp>(op);
     Location loc = op->getLoc();
     MultiDialectBuilder<MathBuilder, MemRefBuilder> create(rewriter, loc);
 

--- a/src/Conversion/KrnlSeqToMemref/KrnlSeqExtract.cpp
+++ b/src/Conversion/KrnlSeqToMemref/KrnlSeqExtract.cpp
@@ -62,7 +62,7 @@ public:
         llvm_unreachable(
             "Not implemented: type of onnx seq element is not tensor");
       auto outputType = mlir::cast<MemRefType>(output.getType());
-      SmallVector<mlir::Value, 4> allocParams;
+      SmallVector<Value, 4> allocParams;
       for (size_t i = 0; i < outputType.getShape().size(); i++) {
         if (outputType.isDynamicDim(i)) {
           allocParams.emplace_back(create.mem.dim(output, i));

--- a/src/Conversion/KrnlSeqToMemref/KrnlSeqStore.cpp
+++ b/src/Conversion/KrnlSeqToMemref/KrnlSeqStore.cpp
@@ -46,7 +46,7 @@ public:
     // Allocate a new tensor and copy input tensor into it
     auto inputType =
         mlir::cast<MemRefType>(operandAdaptor.getInput().getType());
-    SmallVector<mlir::Value, 4> allocParams;
+    SmallVector<Value, 4> allocParams;
     for (size_t i = 0; i < inputType.getShape().size(); i++) {
       if (inputType.isDynamicDim(i)) {
         allocParams.emplace_back(create.mem.dim(operandAdaptor.getInput(), i));

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -154,7 +154,7 @@ public:
    */
   struct Movable {
     std::optional<KrnlMovableOp> movableOp;
-    std::optional<llvm::SmallVector<mlir::Value, 4>> loopsToSkip;
+    std::optional<llvm::SmallVector<Value, 4>> loopsToSkip;
 
     // Movable that stores a KrnlMovableOp.
     explicit Movable(KrnlMovableOp op) : movableOp(op) {}
@@ -289,7 +289,7 @@ public:
   }
 
 private:
-  llvm::DenseMap<mlir::Value, llvm::SmallVector<Movable, 4>> movingPlan;
+  llvm::DenseMap<Value, llvm::SmallVector<Movable, 4>> movingPlan;
 };
 
 /*!

--- a/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
+++ b/src/Conversion/KrnlToAffine/ConvertKrnlToAffine.cpp
@@ -171,7 +171,7 @@ public:
         // Only skip non-unroll loops.  Loops that are unrolled are by
         // definitions a loop whose loopRef is used by a KrnlUnrollOp.
         if (llvm::all_of(val.getUsers(), [&](Operation *user) {
-              return dyn_cast_or_null<KrnlUnrollOp>(user);
+              return mlir::dyn_cast_or_null<KrnlUnrollOp>(user);
             }))
           values.emplace_back(val);
       }
@@ -265,10 +265,10 @@ public:
 
         // Move iterator to point to the next AffineFor Op.
         while (insertPt != loopBody.end() &&
-               (!dyn_cast_or_null<AffineForOp>(&*insertPt) ||
-                   !dyn_cast_or_null<AffineParallelOp>(&*insertPt)) &&
+               (!mlir::dyn_cast_or_null<AffineForOp>(&*insertPt) ||
+                   !mlir::dyn_cast_or_null<AffineParallelOp>(&*insertPt)) &&
                loopToSkip) {
-          assert(dyn_cast_or_null<KrnlMovableOp>(&*insertPt) &&
+          assert(mlir::dyn_cast_or_null<KrnlMovableOp>(&*insertPt) &&
                  "Expecting a KrnlMovableOp");
           insertPt++;
         }
@@ -338,7 +338,7 @@ static void markLoopBodyAsMovable(
           movableRegion, builder, delimeterOp->getLoc());
 
       mover.toMoveUnder(LoopBodyMover::Movable(movableOp), root);
-      if (auto iterateOp = dyn_cast_or_null<KrnlIterateOp>(delimeterOp))
+      if (auto iterateOp = mlir::dyn_cast_or_null<KrnlIterateOp>(delimeterOp))
         mover.toMoveUnder(LoopBodyMover::Movable(iterateOp), root);
 
       movableBeginOp = delimeterOp->getNextNode();
@@ -354,11 +354,12 @@ static void lowerGetInductionVariableValueOp(
   for (const auto &operandAndResult : zippedOperandsResults) {
     auto operand = std::get<0>(operandAndResult);
     auto result = std::get<1>(operandAndResult);
-    if (auto forOp = dyn_cast_or_null<AffineForOp>(loopRefToOp[operand])) {
+    if (auto forOp =
+            mlir::dyn_cast_or_null<AffineForOp>(loopRefToOp[operand])) {
       result.replaceAllUsesWith(forOp.getInductionVar());
     } else {
       auto parallelOp =
-          dyn_cast_or_null<AffineParallelOp>(loopRefToOp[operand]);
+          mlir::dyn_cast_or_null<AffineParallelOp>(loopRefToOp[operand]);
       assert(parallelOp && "expected affine.parallelOp only");
       result.replaceAllUsesWith(parallelOp.getIVs()[0]);
     }
@@ -423,7 +424,8 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
       // For last optimized loop.
       // yield the iterateOp yield value.
       builder.setInsertionPointToEnd(forOp.getBody());
-      auto Yield = cast<KrnlYieldOp>(iterateOp.getBody()->getTerminator());
+      auto Yield =
+          mlir::cast<KrnlYieldOp>(iterateOp.getBody()->getTerminator());
       builder.create<AffineYieldOp>(iterateOp.getLoc(), Yield.getOperands());
 
       // replace use of iterateOp iterArgs with forOp iterArgs.
@@ -554,7 +556,8 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
       auto innerForOp = newForOps.back();
       auto prevTerm = innerForOp.getBody()->getTerminator();
       builder.setInsertionPointToEnd(innerForOp.getBody());
-      auto iterTerm = cast<KrnlYieldOp>(iterateOp.getBody()->getTerminator());
+      auto iterTerm =
+          mlir::cast<KrnlYieldOp>(iterateOp.getBody()->getTerminator());
       builder.create<AffineYieldOp>(iterateOp.getLoc(), iterTerm.getOperands());
       // Remove the old terminator.
       prevTerm->erase();
@@ -569,7 +572,8 @@ static void lowerIterateOp(KrnlIterateOp &iterateOp, OpBuilder &builder,
     // When there's no loop but iterateOp has result.
     else if (!isLoop && iterateHasResult) {
       // Replace use of iteratedOp with the yield value.
-      auto Yield = cast<KrnlYieldOp>(iterateOp.getBody()->getTerminator());
+      auto Yield =
+          mlir::cast<KrnlYieldOp>(iterateOp.getBody()->getTerminator());
       for (auto [result, yieldValue] :
           llvm::zip(iterateOp.getResults(), Yield.getOperands())) {
         result.replaceAllUsesWith(yieldValue);
@@ -666,7 +670,7 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
       }
     }
 
-  if (auto iterateOp = dyn_cast_or_null<KrnlIterateOp>(op)) {
+  if (auto iterateOp = mlir::dyn_cast_or_null<KrnlIterateOp>(op)) {
     LLVM_DEBUG(llvm::dbgs()
                << DEBUG_TYPE << " interpret iterate op " << iterateOp << "\n");
     // If an iterateOp has no unoptimized loop references, then we need to lower
@@ -676,7 +680,7 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
       opsToErase.insert(iterateOp);
     }
     return success();
-  } else if (auto blockOp = dyn_cast_or_null<KrnlBlockOp>(op)) {
+  } else if (auto blockOp = mlir::dyn_cast_or_null<KrnlBlockOp>(op)) {
     LLVM_DEBUG(llvm::dbgs()
                << DEBUG_TYPE << " interpret block op " << blockOp << "\n");
     SmallVector<AffineForOp, 2> tiledLoops;
@@ -709,7 +713,7 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
 
     opsToErase.insert(op);
     return success();
-  } else if (auto permuteOp = dyn_cast_or_null<KrnlPermuteOp>(op)) {
+  } else if (auto permuteOp = mlir::dyn_cast_or_null<KrnlPermuteOp>(op)) {
     LLVM_DEBUG(llvm::dbgs()
                << DEBUG_TYPE << " interpret permute op " << permuteOp << "\n");
     // TODO(tjingrant): call it whenever an operation lowering completes.
@@ -731,7 +735,7 @@ static LogicalResult interpretOperation(Operation *op, OpBuilder &builder,
 
     opsToErase.insert(op);
     return success();
-  } else if (auto parallelOp = dyn_cast_or_null<KrnlParallelOp>(op)) {
+  } else if (auto parallelOp = mlir::dyn_cast_or_null<KrnlParallelOp>(op)) {
     // Parallelism the given loop by transform the tagged affine.for op to
     // affine.parallel
     LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << " interpret parallel op "
@@ -846,7 +850,8 @@ void ConvertKrnlToAffinePass::runOnOperation() {
   // Move invariant instructions outside of the loops as many as possible. This
   // helps make loops perfectly nested, which facilitates transformations.
   funcOp.walk([&](KrnlIterateOp loopOp) {
-    moveLoopInvariantCode(cast<LoopLikeOpInterface>(loopOp.getOperation()));
+    moveLoopInvariantCode(
+        mlir::cast<LoopLikeOpInterface>(loopOp.getOperation()));
   });
 
   // We use the end of the function body as a staging area for movable ops.
@@ -879,10 +884,10 @@ void ConvertKrnlToAffinePass::runOnOperation() {
     std::vector<KrnlIterateOp> iterateOps;
     for (auto result : defineOp.getResults())
       for (auto *user : result.getUsers())
-        if (auto iterateOp = dyn_cast_or_null<KrnlIterateOp>(user))
+        if (auto iterateOp = mlir::dyn_cast_or_null<KrnlIterateOp>(user))
           if (std::find(iterateOps.begin(), iterateOps.end(), iterateOp) ==
               iterateOps.end())
-            iterateOps.push_back(dyn_cast<KrnlIterateOp>(user));
+            iterateOps.push_back(mlir::dyn_cast<KrnlIterateOp>(user));
 
     // Lower iterate operations and record the mapping between loop references
     // and affine for loop operations in loopRefToOp map.
@@ -924,8 +929,9 @@ void ConvertKrnlToAffinePass::runOnOperation() {
         auto &blockOps = block.getOperations();
         for (auto itr = blockOps.begin(); itr != blockOps.end(); ++itr) {
           Operation *genericOp = &(*itr);
-          if (auto getIVOp = dyn_cast_or_null<KrnlGetInductionVariableValueOp>(
-                  genericOp)) {
+          if (auto getIVOp =
+                  mlir::dyn_cast_or_null<KrnlGetInductionVariableValueOp>(
+                      genericOp)) {
             lowerGetInductionVariableValueOp(getIVOp, loopRefToOp);
             opsToErase.insert(genericOp);
           }
@@ -944,13 +950,14 @@ void ConvertKrnlToAffinePass::runOnOperation() {
 
   funcOp->walk([&](Operation *op) {
     if (SpecializedKernelOpInterface kernelOp =
-            dyn_cast<SpecializedKernelOpInterface>(op)) {
+            mlir::dyn_cast<SpecializedKernelOpInterface>(op)) {
       OperandRange loopRefs = kernelOp.getLoopRefs();
       for (auto loopRef : loopRefs)
         opsToErase.insert(loopRefToOp[loopRef]);
       kernelOp.getLoopRefs().clear();
     }
-    if (auto getIVOp = dyn_cast_or_null<KrnlGetInductionVariableValueOp>(op)) {
+    if (auto getIVOp =
+            mlir::dyn_cast_or_null<KrnlGetInductionVariableValueOp>(op)) {
       lowerGetInductionVariableValueOp(getIVOp, loopRefToOp);
       opsToErase.insert(op);
     }

--- a/src/Conversion/KrnlToAffine/KrnlCopyFromBuffer.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlCopyFromBuffer.cpp
@@ -39,7 +39,8 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    KrnlCopyFromBufferOp copyFromBufferOp = cast<KrnlCopyFromBufferOp>(op);
+    KrnlCopyFromBufferOp copyFromBufferOp =
+        mlir::cast<KrnlCopyFromBufferOp>(op);
     Location loc = copyFromBufferOp.getLoc();
     MultiDialectBuilder<AffineBuilderKrnlMem, IndexExprBuilderForKrnl> create(
         rewriter, loc);

--- a/src/Conversion/KrnlToAffine/KrnlCopyFromBuffer.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlCopyFromBuffer.cpp
@@ -123,9 +123,9 @@ public:
         // Nothing to write.
       } else {
         // Loop to copy the data.
-        createAffine.forIE(zeroIE, writeUBs[i], 1,
-            [&](AffineBuilderKrnlMem &createAffine, Value index) {
-              loopIndices.emplace_back(index);
+        createAffine.forLoopIE(zeroIE, writeUBs[i], 1,
+            [&](AffineBuilderKrnlMem &createAffine, ValueRange loopInd) {
+              loopIndices.emplace_back(loopInd[0]);
               genCopyLoops(createAffine, enclosingScope, buffMemref, destMemref,
                   zeroIE, starts, writeUBs, loopIndices, i + 1, buffRank);
               loopIndices.pop_back_n(1);

--- a/src/Conversion/KrnlToAffine/KrnlCopyToBuffer.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlCopyToBuffer.cpp
@@ -168,9 +168,9 @@ public:
       if (readUBs[i].isLiteralAndIdenticalTo(0)) {
         // Nothing to read, skip.
       } else {
-        createAffine.forIE(zeroIE, readUBs[i], 1,
-            [&](AffineBuilderKrnlMem &createAffine, Value index) {
-              loopIndices.emplace_back(index);
+        createAffine.forLoopIE(zeroIE, readUBs[i], 1,
+            [&](AffineBuilderKrnlMem &createAffine, ValueRange loopInd) {
+              loopIndices.emplace_back(loopInd[0]);
               genCopyLoops(createAffine, enclosingScope, buffMemref,
                   sourceMemref, srcLoopMap, padVal, zeroIE, starts, readUBs,
                   padUBs, loopIndices, i + 1, buffRank,
@@ -181,9 +181,9 @@ public:
       if (padUBs[i].isLiteralAndIdenticalTo(0)) {
         // No padding needed.
       } else {
-        createAffine.forIE(readUBs[i], padUBs[i], 1,
-            [&](AffineBuilderKrnlMem &createAffine, Value index) {
-              loopIndices.emplace_back(index);
+        createAffine.forLoopIE(readUBs[i], padUBs[i], 1,
+            [&](AffineBuilderKrnlMem &createAffine, ValueRange loopInd) {
+              loopIndices.emplace_back(loopInd[0]);
               genCopyLoops(createAffine, enclosingScope, buffMemref,
                   sourceMemref, srcLoopMap, padVal, zeroIE, starts, readUBs,
                   padUBs, loopIndices, i + 1, buffRank,

--- a/src/Conversion/KrnlToAffine/KrnlCopyToBuffer.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlCopyToBuffer.cpp
@@ -39,7 +39,7 @@ public:
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
     // Get info from operands.
-    KrnlCopyToBufferOp copyToBufferOp = cast<KrnlCopyToBufferOp>(op);
+    KrnlCopyToBufferOp copyToBufferOp = mlir::cast<KrnlCopyToBufferOp>(op);
     Location loc = copyToBufferOp.getLoc();
     MultiDialectBuilder<AffineBuilderKrnlMem, IndexExprBuilderForKrnl> create(
         rewriter, loc);

--- a/src/Conversion/KrnlToAffine/KrnlGetLinearOffsetIndex.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlGetLinearOffsetIndex.cpp
@@ -63,8 +63,8 @@ public:
     SmallVector<IndexExpr, 4> dims;
     create.krnlIE.getShapeAsDims(memref, dims);
     // Compute the linear offset using strides.
-    IndexExpr offsetIE = LiteralIndexExpr(0);
-    IndexExpr strideIE = LiteralIndexExpr(1);
+    IndexExpr offsetIE = LitIE(0);
+    IndexExpr strideIE = LitIE(1);
     for (int64_t i = rank - 1; i >= 0; --i) {
       IndexExpr strideOffset = strideIE * DimIndexExpr(indices[i]);
       offsetIE = offsetIE + strideOffset;

--- a/src/Conversion/KrnlToAffine/KrnlGetLinearOffsetIndex.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlGetLinearOffsetIndex.cpp
@@ -66,7 +66,7 @@ public:
     IndexExpr offsetIE = LitIE(0);
     IndexExpr strideIE = LitIE(1);
     for (int64_t i = rank - 1; i >= 0; --i) {
-      IndexExpr strideOffset = strideIE * DimIndexExpr(indices[i]);
+      IndexExpr strideOffset = strideIE * DimIE(indices[i]);
       offsetIE = offsetIE + strideOffset;
       if (i > 0)
         strideIE = strideIE * dims[i];

--- a/src/Conversion/KrnlToAffine/KrnlLoad.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlLoad.cpp
@@ -38,7 +38,7 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto loadOp = cast<KrnlLoadOp>(op);
+    auto loadOp = mlir::cast<KrnlLoadOp>(op);
     KrnlLoadOpAdaptor operandAdaptor(loadOp);
 
     // Prepare inputs.

--- a/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
@@ -168,7 +168,7 @@ public:
     SmallVector<IndexExpr, 4> aStart, bStart, cStart;
     for (int t = 0; t < aRank - 2; t++)
       aStart.emplace_back(
-          SymbolIndexExpr(operandAdaptor.getAGlobalIndexMemStart()[t]));
+          SymIE(operandAdaptor.getAGlobalIndexMemStart()[t]));
     aStart.emplace_back(
         iGlobalIndexComputeStart -
         DimIndexExpr(operandAdaptor.getAGlobalIndexMemStart()[aRank - 2]));
@@ -178,7 +178,7 @@ public:
     // B[k, j];
     for (int t = 0; t < bRank - 2; t++)
       bStart.emplace_back(
-          SymbolIndexExpr(operandAdaptor.getBGlobalIndexMemStart()[t]));
+          SymIE(operandAdaptor.getBGlobalIndexMemStart()[t]));
     bStart.emplace_back(
         kGlobalIndexComputeStart -
         DimIndexExpr(operandAdaptor.getBGlobalIndexMemStart()[bRank - 2]));
@@ -188,7 +188,7 @@ public:
     // C[i, j]
     for (int t = 0; t < cRank - 2; t++)
       cStart.emplace_back(
-          SymbolIndexExpr(operandAdaptor.getCGlobalIndexMemStart()[t]));
+          SymIE(operandAdaptor.getCGlobalIndexMemStart()[t]));
     cStart.emplace_back(
         iGlobalIndexComputeStart -
         DimIndexExpr(operandAdaptor.getCGlobalIndexMemStart()[cRank - 2]));

--- a/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
@@ -225,7 +225,7 @@ public:
       // SIMD code generator.
       if (matVectorProduct) {
         // clang-format off
-        create.affineKMem.ifThenElse(indexScope, allFullTiles,
+        create.affineKMem.ifThenElseIE(indexScope, allFullTiles,
           /* then full tiles */ [&](AffineBuilderKrnlMem &createAffine) {
           genSimdMatVect(createAffine, matmulOp, elementType, aStart, bStart,
             cStart, iComputeTileSize, jComputeTileSize, kComputeTileSize,
@@ -237,7 +237,7 @@ public:
         // clang-format on
       } else {
         // clang-format off
-        create.affineKMem.ifThenElse(indexScope, allFullTiles,
+        create.affineKMem.ifThenElseIE(indexScope, allFullTiles,
           /* then full tiles */ [&](AffineBuilderKrnlMem &createAffine) {
           genSimdMatMat(createAffine, matmulOp, elementType, aStart, bStart,
              cStart, iComputeTileSize, jComputeTileSize, kComputeTileSize,
@@ -245,7 +245,7 @@ public:
         }, /* has some partial tiles */ [&](AffineBuilderKrnlMem &createAffine) {
           // Trip regardless of full/partial for N & K
           // Test if SIMD dim (M) is full.
-          createAffine.ifThenElse(indexScope, jFullTiles,
+          createAffine.ifThenElseIE(indexScope, jFullTiles,
             /* full SIMD */ [&](AffineBuilderKrnlMem &createAffine) {
             genSimdMatMat(createAffine, matmulOp, elementType, aStart, bStart,
                cStart, iTrip, jComputeTileSize, kTrip, vectorLen, /*unroll*/ false);
@@ -267,7 +267,7 @@ public:
     } else {
       // Scalar code generator.
       // clang-format off
-      create.affineKMem.ifThenElse(indexScope, allFullTiles,
+      create.affineKMem.ifThenElseIE(indexScope, allFullTiles,
         /* then full */ [&](AffineBuilderKrnlMem &createAffine) {
         genScalar(createAffine, matmulOp, elementType, aStart, bStart, cStart,
           iComputeTileSize, jComputeTileSize, kComputeTileSize,

--- a/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
@@ -48,7 +48,7 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto matmulOp = cast<KrnlMatMulOp>(op);
+    auto matmulOp = mlir::cast<KrnlMatMulOp>(op);
     KrnlMatMulOpAdaptor operandAdaptor(matmulOp);
     // Option.
     bool fullUnrollAndJam = matmulOp.getUnroll();

--- a/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
@@ -167,34 +167,31 @@ public:
     // A[i, k];
     SmallVector<IndexExpr, 4> aStart, bStart, cStart;
     for (int t = 0; t < aRank - 2; t++)
-      aStart.emplace_back(
-          SymIE(operandAdaptor.getAGlobalIndexMemStart()[t]));
+      aStart.emplace_back(SymIE(operandAdaptor.getAGlobalIndexMemStart()[t]));
     aStart.emplace_back(
         iGlobalIndexComputeStart -
-        DimIndexExpr(operandAdaptor.getAGlobalIndexMemStart()[aRank - 2]));
+        DimIE(operandAdaptor.getAGlobalIndexMemStart()[aRank - 2]));
     aStart.emplace_back(
         kGlobalIndexComputeStart -
-        DimIndexExpr(operandAdaptor.getAGlobalIndexMemStart()[aRank - 1]));
+        DimIE(operandAdaptor.getAGlobalIndexMemStart()[aRank - 1]));
     // B[k, j];
     for (int t = 0; t < bRank - 2; t++)
-      bStart.emplace_back(
-          SymIE(operandAdaptor.getBGlobalIndexMemStart()[t]));
+      bStart.emplace_back(SymIE(operandAdaptor.getBGlobalIndexMemStart()[t]));
     bStart.emplace_back(
         kGlobalIndexComputeStart -
-        DimIndexExpr(operandAdaptor.getBGlobalIndexMemStart()[bRank - 2]));
+        DimIE(operandAdaptor.getBGlobalIndexMemStart()[bRank - 2]));
     bStart.emplace_back(
         jGlobalIndexComputeStart -
-        DimIndexExpr(operandAdaptor.getBGlobalIndexMemStart()[bRank - 1]));
+        DimIE(operandAdaptor.getBGlobalIndexMemStart()[bRank - 1]));
     // C[i, j]
     for (int t = 0; t < cRank - 2; t++)
-      cStart.emplace_back(
-          SymIE(operandAdaptor.getCGlobalIndexMemStart()[t]));
+      cStart.emplace_back(SymIE(operandAdaptor.getCGlobalIndexMemStart()[t]));
     cStart.emplace_back(
         iGlobalIndexComputeStart -
-        DimIndexExpr(operandAdaptor.getCGlobalIndexMemStart()[cRank - 2]));
+        DimIE(operandAdaptor.getCGlobalIndexMemStart()[cRank - 2]));
     cStart.emplace_back(
         jGlobalIndexComputeStart -
-        DimIndexExpr(operandAdaptor.getCGlobalIndexMemStart()[cRank - 1]));
+        DimIE(operandAdaptor.getCGlobalIndexMemStart()[cRank - 1]));
 
     // Now determine if we have full/partial tiles. This is determined by the
     // outer dimensions of the original computations, as by definition tiling

--- a/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMatmul.cpp
@@ -122,7 +122,7 @@ public:
                             jGlobalUB.getLiteral() == 1;
 
     // Investigate SIMD
-    IndexExpr vectorLen = LiteralIndexExpr(1); // Assume no simd.
+    IndexExpr vectorLen = LitIE(1); // Assume no simd.
     if (simdize) {
       if (matVectorProduct) {
         // Matrix (I x K) times vector (K x 1). We currently vectorize along the
@@ -134,7 +134,7 @@ public:
           uint64_t archVL = create.vec.getArchVectorLength(elementType);
           if (i % archVL == 0 && k % archVL == 0) {
             // Right now, vector length must be archVL.
-            vectorLen = LiteralIndexExpr(archVL);
+            vectorLen = LitIE(archVL);
           } else {
             simdize = false;
             LLVM_DEBUG(llvm::dbgs() << "Matmul: mat*vec with bad sizes: i " << i

--- a/src/Conversion/KrnlToAffine/KrnlMemset.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMemset.cpp
@@ -35,7 +35,7 @@ public:
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
     // Get info from operands.
-    auto memsetOp = cast<KrnlMemsetOp>(op);
+    auto memsetOp = mlir::cast<KrnlMemsetOp>(op);
     bool delayed = memsetOp.getDelayed();
     KrnlMemsetOpAdaptor operandAdaptor(memsetOp);
     Value destMemRef(operandAdaptor.getDest());

--- a/src/Conversion/KrnlToAffine/KrnlMemset.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMemset.cpp
@@ -58,7 +58,7 @@ public:
     SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
     SmallVector<int64_t, 4> steps(rank, 1);
     // Copy data,
-    create.affineKMem.forIE(lbs, ubs, steps,
+    create.affineKMem.forLoopsIE(lbs, ubs, steps,
         [&](AffineBuilderKrnlMem &createAffine, ValueRange indices) {
           createAffine.store(destVal, destMemRef, indices);
         });

--- a/src/Conversion/KrnlToAffine/KrnlMemset.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlMemset.cpp
@@ -55,7 +55,7 @@ public:
     SmallVector<IndexExpr, 4> ubs;
     create.krnlIE.getShapeAsDims(destMemRef, ubs);
     int rank = ubs.size();
-    SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(rank, LitIE(0));
     SmallVector<int64_t, 4> steps(rank, 1);
     // Copy data,
     create.affineKMem.forLoopsIE(lbs, ubs, steps,

--- a/src/Conversion/KrnlToAffine/KrnlStore.cpp
+++ b/src/Conversion/KrnlToAffine/KrnlStore.cpp
@@ -38,7 +38,7 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto storeOp = cast<KrnlStoreOp>(op);
+    auto storeOp = mlir::cast<KrnlStoreOp>(op);
     KrnlStoreOpAdaptor operandAdaptor(storeOp);
 
     // Prepare inputs.

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -246,7 +246,7 @@ void PostfixEntrypointNames(ModuleOp &module) {
             .getValue()
             .str();
     func::FuncOp entryPointFunc =
-        dyn_cast<func::FuncOp>(module.lookupSymbol(entryPointFuncName));
+        mlir::dyn_cast<func::FuncOp>(module.lookupSymbol(entryPointFuncName));
     assert(entryPointFunc && "entry point func must exist");
     // Update the function name.
     entryPointFunc.setSymName(
@@ -278,12 +278,12 @@ void recordInputOutputMemRefTypes(ModuleOp &module,
     assert(entryPointFunc && isa<func::FuncOp>(entryPointFunc) &&
            "entry point func must exist and be an llvm func op");
     auto entryPointTy = mlir::dyn_cast<FunctionType>(
-        dyn_cast<func::FuncOp>(entryPointFunc).getFunctionType());
+        mlir::dyn_cast<func::FuncOp>(entryPointFunc).getFunctionType());
     SmallVector<MemRefType, 4> inputTypes, outputTypes;
     for (Type ty : entryPointTy.getInputs())
-      inputTypes.emplace_back(dyn_cast<MemRefType>(ty));
+      inputTypes.emplace_back(mlir::dyn_cast<MemRefType>(ty));
     for (Type ty : entryPointTy.getResults())
-      outputTypes.emplace_back(dyn_cast<MemRefType>(ty));
+      outputTypes.emplace_back(mlir::dyn_cast<MemRefType>(ty));
     inputMemRefTypes.emplace(
         std::make_pair(entryPointFuncName.str(), inputTypes));
     outputMemRefTypes.emplace(

--- a/src/Conversion/KrnlToLLVM/KrnlCall.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlCall.cpp
@@ -102,7 +102,7 @@ private:
 
     // Check the original type, not after type conversion
     Type ty = original.getType();
-    if (auto originalMemRef = dyn_cast<MemRefType>(ty)) {
+    if (auto originalMemRef = mlir::dyn_cast<MemRefType>(ty)) {
       auto int64Ty = IntegerType::get(context, 64);
       auto memRefTy = mlir::dyn_cast<LLVM::LLVMStructType>(parameter.getType());
       auto memRefRank = krnl::getRankFromMemRefType(memRefTy);

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -202,7 +202,7 @@ public:
     auto *staticEntryPointFunc =
         module.lookupSymbol(staticEntryPointFuncName.lower());
     auto staticEntryPointFuncTy = mlir::cast<LLVM::LLVMFunctionType>(
-        cast<LLVM::LLVMFuncOp>(staticEntryPointFunc).getFunctionType());
+        mlir::cast<LLVM::LLVMFuncOp>(staticEntryPointFunc).getFunctionType());
     LLVM_DEBUG(llvm::dbgs() << "Static entry point function type: "
                             << staticEntryPointFuncTy << "\n");
     // Static entry point is wrapped with prefix `_mlir_ciface` automatically by
@@ -216,7 +216,7 @@ public:
            isa<LLVM::LLVMFuncOp>(wrappedStaticEntryPointFunc) &&
            "entry point func must exist and be an llvm func op");
     auto wrappedStaticEntryPointOp =
-        cast<LLVM::LLVMFuncOp>(wrappedStaticEntryPointFunc);
+        mlir::cast<LLVM::LLVMFuncOp>(wrappedStaticEntryPointFunc);
     auto wrappedStaticEntryPointTy = mlir::cast<LLVM::LLVMFunctionType>(
         wrappedStaticEntryPointOp.getFunctionType());
 

--- a/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlEntryPoint.cpp
@@ -268,7 +268,7 @@ public:
     auto outMemRefsType =
         mlir::dyn_cast<LLVM::LLVMStructType>(outMemRefs.getType());
 
-    std::vector<mlir::Value> outMemRefList;
+    std::vector<Value> outMemRefList;
     if (numOutputs == 1) {
       // If only one output tensor exists, the tensor's corresponding memref
       // descriptor will be returned as is.

--- a/src/Conversion/KrnlToLLVM/KrnlFindIndex.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlFindIndex.cpp
@@ -32,7 +32,7 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto findIndexOp = cast<KrnlFindIndexOp>(op);
+    auto findIndexOp = mlir::cast<KrnlFindIndexOp>(op);
     MLIRContext *ctx = findIndexOp.getContext();
     Location loc = findIndexOp.getLoc();
     KrnlFindIndexOpAdaptor operandAdaptor(operands);

--- a/src/Conversion/KrnlToLLVM/KrnlInstrument.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlInstrument.cpp
@@ -82,14 +82,14 @@ public:
       else
         name.pop_back(); // remove last "-"
       Location newLoc = NameLoc::get(rewriter.getStringAttr(name));
-      nodeName = cast<NameLoc>(newLoc).getName();
+      nodeName = mlir::cast<NameLoc>(newLoc).getName();
     } else if (auto fileLineColLoc = mlir::dyn_cast<FileLineColLoc>(loc)) {
       std::string filename =
           llvm::sys::path::filename(fileLineColLoc.getFilename().str()).str();
       std::string name =
           filename + ":" + std::to_string(fileLineColLoc.getLine());
       Location newLoc = NameLoc::get(rewriter.getStringAttr(name));
-      nodeName = cast<NameLoc>(newLoc).getName();
+      nodeName = mlir::cast<NameLoc>(newLoc).getName();
     } else
       nodeName = StringRef("NOTSET");
     LLVM_DEBUG(

--- a/src/Conversion/KrnlToLLVM/KrnlPrint.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlPrint.cpp
@@ -34,7 +34,7 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto printOp = cast<KrnlPrintOp>(op);
+    auto printOp = mlir::cast<KrnlPrintOp>(op);
     Location loc = printOp.getLoc();
     KrnlPrintOpAdaptor operandAdaptor(operands);
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);

--- a/src/Conversion/KrnlToLLVM/KrnlPrintTensor.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlPrintTensor.cpp
@@ -34,7 +34,7 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto printTensorOp = cast<KrnlPrintTensorOp>(op);
+    auto printTensorOp = mlir::cast<KrnlPrintTensorOp>(op);
     MLIRContext *context = printTensorOp.getContext();
     Location loc = printTensorOp.getLoc();
     KrnlPrintTensorOpAdaptor operandAdaptor(operands);

--- a/src/Conversion/KrnlToLLVM/KrnlRandomNormal.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlRandomNormal.cpp
@@ -41,7 +41,7 @@ public:
       ConversionPatternRewriter &rewriter) const final {
     KrnlRandomNormalOpAdaptor operandAdaptor(operands);
     Location loc = op->getLoc();
-    mlir::Type inType = op->getOperand(2).getType();
+    Type inType = op->getOperand(2).getType();
     MultiDialectBuilder<LLVMBuilder> create(rewriter, loc);
 
     // Get a symbol reference to the memcpy function, inserting it if necessary.

--- a/src/Conversion/KrnlToLLVM/KrnlUnaryMath.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlUnaryMath.cpp
@@ -37,7 +37,7 @@ struct MathFunctionName {
 
 template <>
 struct MathFunctionName<KrnlErfOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
       return "erff";
     if (type.isF64())
@@ -48,7 +48,7 @@ struct MathFunctionName<KrnlErfOp> {
 
 template <>
 struct MathFunctionName<KrnlAcosOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
       return "acosf";
     if (type.isF64())
@@ -59,7 +59,7 @@ struct MathFunctionName<KrnlAcosOp> {
 
 template <>
 struct MathFunctionName<KrnlAcoshOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
       return "acoshf";
     if (type.isF64())
@@ -70,7 +70,7 @@ struct MathFunctionName<KrnlAcoshOp> {
 
 template <>
 struct MathFunctionName<KrnlAsinOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
       return "asinf";
     if (type.isF64())
@@ -81,7 +81,7 @@ struct MathFunctionName<KrnlAsinOp> {
 
 template <>
 struct MathFunctionName<KrnlAsinhOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
       return "asinhf";
     if (type.isF64())
@@ -92,7 +92,7 @@ struct MathFunctionName<KrnlAsinhOp> {
 
 template <>
 struct MathFunctionName<KrnlAtanOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
       return "atanf";
     if (type.isF64())
@@ -103,7 +103,7 @@ struct MathFunctionName<KrnlAtanOp> {
 
 template <>
 struct MathFunctionName<KrnlTanOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
       return "tanf";
     if (type.isF64())
@@ -114,7 +114,7 @@ struct MathFunctionName<KrnlTanOp> {
 
 template <>
 struct MathFunctionName<KrnlAtanhOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
       return "atanhf";
     if (type.isF64())
@@ -125,7 +125,7 @@ struct MathFunctionName<KrnlAtanhOp> {
 
 template <>
 struct MathFunctionName<KrnlIsInfOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
     if (type.isF32())
 #if (__APPLE__)
       return "__isinff";
@@ -140,7 +140,7 @@ struct MathFunctionName<KrnlIsInfOp> {
 
 template <>
 struct MathFunctionName<KrnlIsNaNOp> {
-  static std::string functionName(mlir::Type type) {
+  static std::string functionName(Type type) {
 
     if (type.isF32())
 #if (__APPLE__)
@@ -168,9 +168,9 @@ public:
     Location loc = op->getLoc();
 
     // get the LLVM type for the function args and result
-    mlir::Type inType = op->getOperand(0).getType();
-    mlir::Type outType = op->getResultTypes().front();
-    mlir::Type llvmInType, llvmOutType;
+    Type inType = op->getOperand(0).getType();
+    Type outType = op->getResultTypes().front();
+    Type llvmInType, llvmOutType;
     if (inType.isF16())
       llvmInType = FloatType::getF16(context);
     else if (inType.isF32())
@@ -207,8 +207,8 @@ private:
   // declare float <mathFuncName>(float)
   //
   FlatSymbolRefAttr getOrInsertUnaryMathFunction(PatternRewriter &rewriter,
-      ModuleOp module, std::string mathFuncName, mlir::Type llvmInType,
-      mlir::Type llvmOutType) const {
+      ModuleOp module, std::string mathFuncName, Type llvmInType,
+      Type llvmOutType) const {
     auto *context = module.getContext();
     if (module.lookupSymbol<LLVM::LLVMFuncOp>(mathFuncName))
       return SymbolRefAttr::get(context, mathFuncName);
@@ -216,7 +216,7 @@ private:
     // Create function declaration.
     // auto llvmF32Ty = FloatType::get(context);
     auto llvmFnType = LLVM::LLVMFunctionType::get(
-        llvmOutType, ArrayRef<mlir::Type>({llvmInType}));
+        llvmOutType, ArrayRef<Type>({llvmInType}));
 
     // Insert the unary math function into the body of the parent module.
     PatternRewriter::InsertionGuard insertGuard(rewriter);

--- a/src/Conversion/KrnlToLLVM/KrnlUnaryMath.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlUnaryMath.cpp
@@ -215,8 +215,8 @@ private:
 
     // Create function declaration.
     // auto llvmF32Ty = FloatType::get(context);
-    auto llvmFnType = LLVM::LLVMFunctionType::get(
-        llvmOutType, ArrayRef<Type>({llvmInType}));
+    auto llvmFnType =
+        LLVM::LLVMFunctionType::get(llvmOutType, ArrayRef<Type>({llvmInType}));
 
     // Insert the unary math function into the body of the parent module.
     PatternRewriter::InsertionGuard insertGuard(rewriter);

--- a/src/Conversion/KrnlToLLVM/KrnlVectorTypeCast.cpp
+++ b/src/Conversion/KrnlToLLVM/KrnlVectorTypeCast.cpp
@@ -41,7 +41,7 @@ public:
 
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto krnlVectorTypeCastOp = cast<KrnlVectorTypeCastOp>(op);
+    auto krnlVectorTypeCastOp = mlir::cast<KrnlVectorTypeCastOp>(op);
     MemRefType sourceType =
         mlir::cast<MemRefType>(krnlVectorTypeCastOp.getOperand().getType());
     MemRefType targetType = krnlVectorTypeCastOp.getType();

--- a/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
+++ b/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
@@ -154,7 +154,7 @@ struct ONNXLayoutTransformOpLowering
             create.krnl.memcpy(alloc, input, len, allocOffset, inputOffset);
           } else {
             // Compute if we have a last tile.
-            IndexExpr modLit = LiteralIndexExpr(modVal);
+            IndexExpr modLit = LitIE(modVal);
             IndexExpr isFull =
                 create.krnlIE.isTileFull(memAF[E1], modLit, SymIE(ub1));
             IndexExpr isFullLogical = isFull >= 0;
@@ -218,7 +218,7 @@ struct ONNXLayoutTransformOpLowering
     IndexExprScope outerScope(create.krnl);
     SmallVector<IndexExpr, 4> ubs;
     create.krnlIE.getShapeAsDims(data, ubs);
-    SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(rank, LitIE(0));
 
     // Insert an allocation and deallocation for the result of this
     // operation.

--- a/src/Conversion/ONNXToKrnl/Additional/ShapeTransform.cpp
+++ b/src/Conversion/ONNXToKrnl/Additional/ShapeTransform.cpp
@@ -55,7 +55,7 @@ struct ONNXShapeTransformOpLowering : public ConversionPattern {
 
     // Element-wise moving of data.
     ValueRange loopDef = create.krnl.defineLoops(inputRank);
-    SmallVector<IndexExpr, 4> lbs(inputRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(inputRank, LitIE(0));
     SmallVector<IndexExpr, 4> ubs;
     create.krnlIE.getShapeAsDims(input, ubs);
 

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -452,7 +452,7 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
     if (srcTy.getRank() > 0) {
       IndexExprScope childScope(create.krnl);
       ValueRange loopDef = create.krnl.defineLoops(srcTy.getRank());
-      SmallVector<IndexExpr, 4> lbs(srcTy.getRank(), LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(srcTy.getRank(), LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(src, ubs);
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -331,7 +331,7 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
   void allocateMemoryForVFinal(Location loc,
       ConversionPatternRewriter &rewriter, Operation *op,
       ONNXLoopOpAdaptor adaptor, SmallVectorImpl<Value> &outputs) const {
-    auto loopOp = dyn_cast<ONNXLoopOp>(op);
+    auto loopOp = mlir::dyn_cast<ONNXLoopOp>(op);
     for (const auto &ioPair :
         llvm::zip(adaptor.getVInitial(), loopOp.v_final())) {
       auto vInit = std::get<0>(ioPair);
@@ -360,7 +360,7 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
       ConversionPatternRewriter &rewriter, Operation *op,
       ONNXLoopOpAdaptor adaptor, SmallVectorImpl<Value> &outputs,
       bool isWhile = false) const {
-    auto loopOp = dyn_cast<ONNXLoopOp>(op);
+    auto loopOp = mlir::dyn_cast<ONNXLoopOp>(op);
     for (const auto &opScanOutput : loopOp.scan_outputs()) {
       // Convert opScanOutput's type to MemRefType.
       Type convertedType = typeConverter->convertType(opScanOutput.getType());
@@ -481,7 +481,7 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
   // iteration variable
 
   bool isWhileLoop(Operation *op) const {
-    auto onnxLoopOp = dyn_cast<ONNXLoopOp>(op);
+    auto onnxLoopOp = mlir::dyn_cast<ONNXLoopOp>(op);
 
     // Check whether continue condition is modified or not
     // Code copied from src/Dialect/ONNX/Rewrite.cpp
@@ -517,7 +517,7 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
   LogicalResult rewriteWithSCFWhile(Operation *op, ValueRange operands,
       ConversionPatternRewriter &rewriter) const {
     Location loc = ONNXLoc<ONNXLoopOp>(op);
-    auto loopOp = dyn_cast<ONNXLoopOp>(op);
+    auto loopOp = mlir::dyn_cast<ONNXLoopOp>(op);
     MultiDialectBuilder<KrnlBuilder, MemRefBuilder, MathBuilder> create(
         rewriter, loc);
 

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Loop.cpp
@@ -281,7 +281,7 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
           // Here loop is assumed to be executed at least once.
           Value firstElement =
               create.krnl.load(output, create.math.constantIndex(0));
-          SmallVector<mlir::Value, 4> allocParams;
+          SmallVector<Value, 4> allocParams;
           SmallVector<int64_t, 4> dims;
           dims.emplace_back(
               mlir::cast<MemRefType>(output.getType()).getShape()[0]);
@@ -328,9 +328,9 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
     return success();
   }
 
-  void allocateMemoryForVFinal(mlir::Location loc,
+  void allocateMemoryForVFinal(Location loc,
       ConversionPatternRewriter &rewriter, Operation *op,
-      ONNXLoopOpAdaptor adaptor, SmallVectorImpl<mlir::Value> &outputs) const {
+      ONNXLoopOpAdaptor adaptor, SmallVectorImpl<Value> &outputs) const {
     auto loopOp = dyn_cast<ONNXLoopOp>(op);
     for (const auto &ioPair :
         llvm::zip(adaptor.getVInitial(), loopOp.v_final())) {
@@ -356,9 +356,9 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
     }
   }
 
-  void allocateMemoryForScanOutput(mlir::Location loc,
+  void allocateMemoryForScanOutput(Location loc,
       ConversionPatternRewriter &rewriter, Operation *op,
-      ONNXLoopOpAdaptor adaptor, SmallVectorImpl<mlir::Value> &outputs,
+      ONNXLoopOpAdaptor adaptor, SmallVectorImpl<Value> &outputs,
       bool isWhile = false) const {
     auto loopOp = dyn_cast<ONNXLoopOp>(op);
     for (const auto &opScanOutput : loopOp.scan_outputs()) {
@@ -380,7 +380,7 @@ struct ONNXLoopOpLowering : public OpConversionPattern<ONNXLoopOp> {
         alloc = create.mem.alignedAlloc(memRefType);
       else {
         auto rankedScanOutTy = memRefType;
-        SmallVector<mlir::Value, 4> allocParams;
+        SmallVector<Value, 4> allocParams;
 
         // Check the loop accumulation dimension
         if (rankedScanOutTy.isDynamicDim(0)) {

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Scan.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Scan.cpp
@@ -202,7 +202,7 @@ struct ONNXScanOpLowering : public OpConversionPattern<ONNXScanOp> {
       ConversionPatternRewriter &rewriter, const TypeConverter *typeConverter,
       Operation *op, ONNXScanOpAdaptor adaptor,
       SmallVectorImpl<Value> &outputs) {
-    auto scanOp = dyn_cast<ONNXScanOp>(op);
+    auto scanOp = mlir::dyn_cast<ONNXScanOp>(op);
     for (const auto &ioPair :
         llvm::zip(scanOp.getVInitial(), scanOp.v_final())) {
       auto vInit = std::get<0>(ioPair);
@@ -227,7 +227,7 @@ struct ONNXScanOpLowering : public OpConversionPattern<ONNXScanOp> {
       ConversionPatternRewriter &rewriter, const TypeConverter *typeConverter,
       Operation *op, ONNXScanOpAdaptor adaptor,
       SmallVectorImpl<Value> &outputs) {
-    auto scanOp = dyn_cast<ONNXScanOp>(op);
+    auto scanOp = mlir::dyn_cast<ONNXScanOp>(op);
     for (const auto &opScanOutput : scanOp.scan_outputs()) {
       // Convert opScanOutput's type to MemRefType.
       Type convertedType = typeConverter->convertType(opScanOutput.getType());

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Scan.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Scan.cpp
@@ -317,7 +317,7 @@ struct ONNXScanOpLowering : public OpConversionPattern<ONNXScanOp> {
     if (srcTy.getRank() > 0) {
       IndexExprScope childScope(create.krnl);
       ValueRange loopDef = create.krnl.defineLoops(srcTy.getRank());
-      SmallVector<IndexExpr, 4> lbs(srcTy.getRank(), LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(srcTy.getRank(), LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(src, ubs);
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
@@ -348,7 +348,7 @@ struct ONNXScanOpLowering : public OpConversionPattern<ONNXScanOp> {
       ValueRange loopDef =
           create.krnl.defineLoops(srcTy.getRank() - readPrefix.size());
       SmallVector<IndexExpr, 4> lbs(
-          srcTy.getRank() - readPrefix.size(), LiteralIndexExpr(0));
+          srcTy.getRank() - readPrefix.size(), LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       for (int i = readIV.size(); i < srcTy.getRank(); i++)
         ubs.emplace_back(create.krnlIE.getShapeAsDim(src, i));

--- a/src/Conversion/ONNXToKrnl/ControlFlow/Scan.cpp
+++ b/src/Conversion/ONNXToKrnl/ControlFlow/Scan.cpp
@@ -198,10 +198,10 @@ struct ONNXScanOpLowering : public OpConversionPattern<ONNXScanOp> {
     return success();
   }
 
-  static void allocateMemoryForVFinal(mlir::Location loc,
+  static void allocateMemoryForVFinal(Location loc,
       ConversionPatternRewriter &rewriter, const TypeConverter *typeConverter,
       Operation *op, ONNXScanOpAdaptor adaptor,
-      SmallVectorImpl<mlir::Value> &outputs) {
+      SmallVectorImpl<Value> &outputs) {
     auto scanOp = dyn_cast<ONNXScanOp>(op);
     for (const auto &ioPair :
         llvm::zip(scanOp.getVInitial(), scanOp.v_final())) {
@@ -223,10 +223,10 @@ struct ONNXScanOpLowering : public OpConversionPattern<ONNXScanOp> {
     }
   }
 
-  static void allocateMemoryForScanOutput(mlir::Location loc,
+  static void allocateMemoryForScanOutput(Location loc,
       ConversionPatternRewriter &rewriter, const TypeConverter *typeConverter,
       Operation *op, ONNXScanOpAdaptor adaptor,
-      SmallVectorImpl<mlir::Value> &outputs) {
+      SmallVectorImpl<Value> &outputs) {
     auto scanOp = dyn_cast<ONNXScanOp>(op);
     for (const auto &opScanOutput : scanOp.scan_outputs()) {
       // Convert opScanOutput's type to MemRefType.
@@ -248,7 +248,7 @@ struct ONNXScanOpLowering : public OpConversionPattern<ONNXScanOp> {
         MemRefBuilder createMemRef(rewriter, loc);
         OnnxBuilder onnxBuilder(rewriter, loc);
         auto rankedScanOutTy = memRefType;
-        SmallVector<mlir::Value, 4> allocParams;
+        SmallVector<Value, 4> allocParams;
         for (int i = 0; i < rankedScanOutTy.getRank(); i++) {
           if (rankedScanOutTy.isDynamicDim(i)) {
             if (i == 0) {
@@ -274,9 +274,9 @@ struct ONNXScanOpLowering : public OpConversionPattern<ONNXScanOp> {
     }
   }
 
-  static mlir::Value allocateMemoryForBodyScanInput(mlir::Location loc,
+  static Value allocateMemoryForBodyScanInput(Location loc,
       ConversionPatternRewriter &rewriter, const TypeConverter *typeConverter,
-      mlir::Type bodyScanInputTy) {
+      Type bodyScanInputTy) {
     // Convert type to MemRefType.
     Type convertedType = typeConverter->convertType(bodyScanInputTy);
     assert(convertedType && mlir::isa<MemRefType>(convertedType) &&

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -47,7 +47,7 @@ public:
     StringRef entryPointName = funcRefAttr.getLeafReference().getValue();
     Operation *entryPointOp = module.lookupSymbol(entryPointName);
     assert(entryPointOp && "entry point name not found!");
-    func::FuncOp entryPointFunc = cast<func::FuncOp>(entryPointOp);
+    func::FuncOp entryPointFunc = mlir::cast<func::FuncOp>(entryPointOp);
 
     IntegerAttr numInputsAttr =
         rewriter.getI32IntegerAttr(entryPointFunc.getArgumentTypes().size());

--- a/src/Conversion/ONNXToKrnl/Math/CumSum.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/CumSum.cpp
@@ -147,8 +147,8 @@ struct ONNXCumSumOpLowering : public OpConversionPattern<ONNXCumSumOp> {
       nos = create.math.log2(nos);
       nos = create.math.cast(i64Ty, nos);
       // Use this when math::CeilOp is available in MLIR.
-      // numberOfStep = SymbolIndexExpr(nos);
-      numberOfStep = SymbolIndexExpr(nos) + LitIE(1);
+      // numberOfStep = SymIE(nos);
+      numberOfStep = SymIE(nos) + LitIE(1);
     }
 
     // Input and output have the same shape, so they share the bounds.

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -304,7 +304,7 @@ struct ScalarOp<ONNXGeluOp> {
 
 template <>
 GenOpMix getGenOpMix<ONNXGeluOp>(Type t, Operation *op) {
-  StringRef approximate = dyn_cast<ONNXGeluOp>(op).getApproximate();
+  StringRef approximate = mlir::dyn_cast<ONNXGeluOp>(op).getApproximate();
   if (approximate.equals_insensitive("none"))
     return {{GenericOps::ArithmeticGop, 1}, {GenericOps::ErfGop, 1},
         {GenericOps::MulGop, 3}};
@@ -327,7 +327,7 @@ Value emitScalarOpFor<ONNXGeluOp>(ConversionPatternRewriter &rewriter,
   // "none". "approximate = none" simply implies no approximation will take
   // place. However, "approximate" can also have a string value of "tanh" which
   // indicates the use of tanh approximation.
-  StringRef approximate = dyn_cast<ONNXGeluOp>(op).getApproximate();
+  StringRef approximate = mlir::dyn_cast<ONNXGeluOp>(op).getApproximate();
 
   // Local constants
   Value half = create.math.constant(elementType, 0.5);
@@ -388,8 +388,10 @@ Value emitScalarOpFor<ONNXIsInfOp>(ConversionPatternRewriter &rewriter,
   Value negInf = create.math.negativeInf(inputType);
   Value posInf = create.math.positiveInf(inputType);
 
-  double detectNegAttribute = dyn_cast<ONNXIsInfOp>(op).getDetectNegative();
-  double detectPosAttribute = dyn_cast<ONNXIsInfOp>(op).getDetectPositive();
+  double detectNegAttribute =
+      mlir::dyn_cast<ONNXIsInfOp>(op).getDetectNegative();
+  double detectPosAttribute =
+      mlir::dyn_cast<ONNXIsInfOp>(op).getDetectPositive();
 
   // Three different cases: Infinity, Negative Infinity and Positive Infinity
   bool detectInf = detectPosAttribute == 1 && detectNegAttribute == 1;
@@ -551,8 +553,10 @@ Value emitScalarOpFor<ONNXHardSigmoidOp>(ConversionPatternRewriter &rewriter,
   //                                  Constant 1)
   CheckIfCustomScalarOpIsSupported<ONNXHardSigmoidOp>(elementType);
   Value operand = scalarOperands[0];
-  double alphaLit = dyn_cast<ONNXHardSigmoidOp>(op).getAlpha().convertToFloat();
-  double betaLit = dyn_cast<ONNXHardSigmoidOp>(op).getBeta().convertToFloat();
+  double alphaLit =
+      mlir::dyn_cast<ONNXHardSigmoidOp>(op).getAlpha().convertToFloat();
+  double betaLit =
+      mlir::dyn_cast<ONNXHardSigmoidOp>(op).getBeta().convertToFloat();
   // Create constants.
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
   Value zero = create.math.constant(elementType, 0);
@@ -591,7 +595,7 @@ Value emitScalarOpFor<ONNXEluOp>(ConversionPatternRewriter &rewriter,
   //                          %X)
   CheckIfCustomScalarOpIsSupported<ONNXEluOp>(elementType);
   Value operand = scalarOperands[0];
-  double alphaLit = dyn_cast<ONNXEluOp>(op).getAlpha().convertToFloat();
+  double alphaLit = mlir::dyn_cast<ONNXEluOp>(op).getAlpha().convertToFloat();
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
   Value zero = create.math.constant(elementType, 0);
   Value one = create.math.constant(elementType, 1);
@@ -651,7 +655,8 @@ Value emitScalarOpFor<ONNXLeakyReluOp>(ConversionPatternRewriter &rewriter,
   //                                %X)
   CheckIfCustomScalarOpIsSupported<ONNXLeakyReluOp>(elementType);
   Value operand = scalarOperands[0];
-  double alphaLit = dyn_cast<ONNXLeakyReluOp>(op).getAlpha().convertToFloat();
+  double alphaLit =
+      mlir::dyn_cast<ONNXLeakyReluOp>(op).getAlpha().convertToFloat();
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
   Value zero = create.math.constant(elementType, 0);
   auto alpha = create.math.constant(elementType, alphaLit);
@@ -717,8 +722,8 @@ Value emitScalarOpFor<ONNXSeluOp>(ConversionPatternRewriter &rewriter,
   //                                         alpha)))
   CheckIfCustomScalarOpIsSupported<ONNXSeluOp>(elementType);
   Value operand = scalarOperands[0];
-  double alphaLit = dyn_cast<ONNXSeluOp>(op).getAlpha().convertToFloat();
-  double gammaLit = dyn_cast<ONNXSeluOp>(op).getGamma().convertToFloat();
+  double alphaLit = mlir::dyn_cast<ONNXSeluOp>(op).getAlpha().convertToFloat();
+  double gammaLit = mlir::dyn_cast<ONNXSeluOp>(op).getGamma().convertToFloat();
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
   Value zero = create.math.constant(elementType, 0);
   Value alpha = create.math.constant(elementType, alphaLit);

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1976,7 +1976,7 @@ struct ONNXElementwiseUnaryOpLowering
     // Only create krnl.iterate if one of the operands is not scalar tensor.
     if (!isScalar) {
       ValueRange loopDef = create.krnl.defineLoops(outputRank);
-      SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(X, ubs);
       if (enableParallel) {
@@ -2157,7 +2157,7 @@ struct ONNXElementwiseBinaryOpLowering
     // Only create krnl.iterate if one of the operands is not scalar tensor.
     if (!isScalar) {
       ValueRange loopDef = create.krnl.defineLoops(outputRank);
-      SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
       // TODO adjust in the future
@@ -2332,7 +2332,7 @@ struct ONNXElementwiseVariadicOpLowering
     // Only create krnl.iterate if one of the operands is not scalar tensor.
     if (!isScalar) {
       ValueRange loopDef = create.krnl.defineLoops(outputRank);
-      SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
 
@@ -2456,7 +2456,7 @@ struct ONNXWhereOpLowering : public ConversionPattern {
     // Only create krnl.iterate if one of the operands is not scalar tensor.
     if (!hasAllScalarValues(operands)) {
       ValueRange loopDef = create.krnl.defineLoops(outputRank);
-      SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
       if (enableParallel) {

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1483,9 +1483,9 @@ static LogicalResult getPartiallyFlattenedSimdCode(
 //===----------------------------------------------------------------------===//
 
 // Function pointer type for the emitScalarOpFor<T> of elementwise Ops.
-typedef mlir::Value (*EmitScalarFunc)(mlir::ConversionPatternRewriter &rewriter,
-    mlir::Location loc, mlir::Operation *op, mlir::Type elementType,
-    mlir::ArrayRef<mlir::Value> scalarOperands);
+typedef Value (*EmitScalarFunc)(ConversionPatternRewriter &rewriter,
+    Location loc, mlir::Operation *op, Type elementType,
+    mlir::ArrayRef<Value> scalarOperands);
 
 // Utility class for Op fusion.
 // Start from the root op, which is being lowered as an Elementwise Op.

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -64,7 +64,7 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
     ValueRange loopDef = create.krnl.defineLoops(3);
     SmallVector<Value, 2> outerLoopDef{loopDef[0], loopDef[1]};
     SmallVector<Value, 1> innerLoopDef{loopDef[2]};
-    SmallVector<IndexExpr, 3> loopLbs(3, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 3> loopLbs(3, LitIE(0));
     IndexExpr outerUb0 = shapeHelper.getOutputDims()[0];
     IndexExpr outerUb1 = shapeHelper.getOutputDims()[1];
     IndexExpr innerUb = shapeHelper.aDims[1];

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -122,7 +122,7 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
               // If dim > 1, use loop index, otherwise broadcast on 0's element.
               DimIndexExpr dim(shapeHelper.cDims[x]);
               cAccess.emplace_back(
-                  IndexExpr::select(dim > 1, DimIndexExpr(outerIndices[x]), 0)
+                  IndexExpr::select(dim > 1, DimIE(outerIndices[x]), 0)
                       .getValue());
             }
             Value c = create.krnl.load(adaptor.getC(), cAccess);
@@ -387,7 +387,7 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
               // If dim > 1, use loop index, otherwise broadcast on 0's element.
               DimIndexExpr dim(shapeHelper.cDims[x]);
               cAccess.emplace_back(
-                  IndexExpr::select(dim > 1, DimIndexExpr(outerIndices[x]), 0)
+                  IndexExpr::select(dim > 1, DimIE(outerIndices[x]), 0)
                       .getValue());
             }
             Value c = createKrnl.load(adaptor.getC(), cAccess);

--- a/src/Conversion/ONNXToKrnl/Math/Hardmax.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Hardmax.cpp
@@ -39,7 +39,7 @@ static Value emitArgmax(ConversionPatternRewriter &rewriter, Location loc,
   // Allocate and initialize the result.
   // Th result has the same shape as the input except the axis dimension is 1.
   SmallVector<IndexExpr, 4> outputUBS(inputUBS);
-  outputUBS[axis] = LiteralIndexExpr(1);
+  outputUBS[axis] = LitIE(1);
   SmallVector<int64_t, 4> outputShape;
   for (const IndexExpr &dim : outputUBS)
     outputShape.push_back(
@@ -49,7 +49,7 @@ static Value emitArgmax(ConversionPatternRewriter &rewriter, Location loc,
   create.krnl.memset(resMemRef, zero);
 
   ValueRange loopDef = create.krnl.defineLoops(rank);
-  SmallVector<IndexExpr> lbs(rank, LiteralIndexExpr(0));
+  SmallVector<IndexExpr> lbs(rank, LitIE(0));
   create.krnl.iterateIE(loopDef, loopDef, lbs, inputUBS,
       [&](KrnlBuilder &createKrnl, ValueRange inputLoopInd) {
         MultiDialectBuilder<KrnlBuilder, MathBuilder, SCFBuilder> create(
@@ -118,7 +118,7 @@ struct ONNXHardmaxOpLowering : public OpConversionPattern<ONNXHardmaxOp> {
     // Produce the final result.
     // Set value to 1 if index is argmax. Otherwise, 0.
     ValueRange loopDef = create.krnl.defineLoops(rank);
-    SmallVector<IndexExpr> lbs(rank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr> lbs(rank, LitIE(0));
     create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           MultiDialectBuilder<KrnlBuilder, MathBuilder, SCFBuilder> create(

--- a/src/Conversion/ONNXToKrnl/Math/LRN.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LRN.cpp
@@ -62,7 +62,7 @@ struct ONNXLRNOpLowering : public OpConversionPattern<ONNXLRNOp> {
         create.mem.alignedAlloc(outputMemRefType, shapeHelper.getOutputDims());
 
     ValueRange outputLoopDef = create.krnl.defineLoops(outputRank);
-    SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
     create.krnl.iterateIE(outputLoopDef, outputLoopDef, lbs,
         shapeHelper.getOutputDims(),
         [&](KrnlBuilder &createKrnl, ValueRange outputLoopInd) {
@@ -79,17 +79,17 @@ struct ONNXLRNOpLowering : public OpConversionPattern<ONNXLRNOp> {
           constexpr int loopIndexForC = 1;
           DimIndexExpr cIE(outputLoopInd[loopIndexForC]);
           DimIndexExpr CIE = create.krnlIE.getShapeAsDim(input, loopIndexForC);
-          SymbolIndexExpr sizeIE = LiteralIndexExpr(sizeLit);
+          SymbolIndexExpr sizeIE = LitIE(sizeLit);
 
           SmallVector<IndexExpr, 2> lbMaxList;
-          lbMaxList.emplace_back(LiteralIndexExpr(0));
+          lbMaxList.emplace_back(LitIE(0));
           lbMaxList.emplace_back(
-              cIE - (sizeIE - 1).floorDiv(LiteralIndexExpr(2)));
+              cIE - (sizeIE - 1).floorDiv(LitIE(2)));
 
           SmallVector<IndexExpr, 2> ubMinList;
           ubMinList.emplace_back(CIE);
           ubMinList.emplace_back(
-              cIE + 1 + (sizeIE - 1).ceilDiv(LiteralIndexExpr(2)));
+              cIE + 1 + (sizeIE - 1).ceilDiv(LitIE(2)));
 
           // Initialize sum, single scalar, no need for default alignment.
           MemRefType scalarMemRefType = MemRefType::get({}, elementType, {}, 0);

--- a/src/Conversion/ONNXToKrnl/Math/LRN.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LRN.cpp
@@ -121,9 +121,9 @@ struct ONNXLRNOpLowering : public OpConversionPattern<ONNXLRNOp> {
           Value loadVal = create.krnl.load(input, loadIndices);
           Value squareVal = create.math.mul(loadVal, loadVal);
 
-          Value sumValue = create.krnl.load(sumAlloc, ArrayRef<Value>{});
+          Value sumValue = create.krnl.load(sumAlloc);
           sumValue = create.math.add(sumValue, squareVal);
-          create.krnl.store(sumValue, sumAlloc, ArrayRef<Value>{});
+          create.krnl.store(sumValue, sumAlloc);
 
           // Compute and store the output
           // y = x / ((bias + (alpha / nsize) * square_sum) ** beta)

--- a/src/Conversion/ONNXToKrnl/Math/LRN.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LRN.cpp
@@ -83,13 +83,11 @@ struct ONNXLRNOpLowering : public OpConversionPattern<ONNXLRNOp> {
 
           SmallVector<IndexExpr, 2> lbMaxList;
           lbMaxList.emplace_back(LitIE(0));
-          lbMaxList.emplace_back(
-              cIE - (sizeIE - 1).floorDiv(LitIE(2)));
+          lbMaxList.emplace_back(cIE - (sizeIE - 1).floorDiv(LitIE(2)));
 
           SmallVector<IndexExpr, 2> ubMinList;
           ubMinList.emplace_back(CIE);
-          ubMinList.emplace_back(
-              cIE + 1 + (sizeIE - 1).ceilDiv(LitIE(2)));
+          ubMinList.emplace_back(cIE + 1 + (sizeIE - 1).ceilDiv(LitIE(2)));
 
           // Initialize sum, single scalar, no need for default alignment.
           MemRefType scalarMemRefType = MemRefType::get({}, elementType, {}, 0);

--- a/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MatMul.cpp
@@ -59,7 +59,7 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
     int outerLoopNum = shapeHelper.getOutputDims().size();
     int totLoopNum = outerLoopNum + 1; // Add reduction inner loop.
     ValueRange loopDef = create.krnl.defineLoops(totLoopNum);
-    SmallVector<IndexExpr, 4> loopLbs(totLoopNum, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> loopLbs(totLoopNum, LitIE(0));
     SmallVector<IndexExpr, 4> loopUbs; // All getOutputDims, plus reduction.
     SmallVector<Value, 4> outerLoops;  // All but the last loop def.
     for (int i = 0; i < outerLoopNum; ++i) {
@@ -408,7 +408,7 @@ struct ONNXMatMulOpLowering : public OpConversionPattern<ONNXMatMulOp> {
     if (enableParallel) {
       int64_t parId;
       // Could check out more than the outer dim of the broadcasts...
-      SmallVector<IndexExpr, 1> lb(1, LiteralIndexExpr(0)),
+      SmallVector<IndexExpr, 1> lb(1, LitIE(0)),
           ub(1, shapeHelper.getOutputDims()[0]);
       if (findSuitableParallelDimension(lb, ub, 0, 1, parId,
               /*min iter for going parallel*/ 4)) {

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -409,9 +409,9 @@ bool emitFullSIMDReductionFor(ConversionPatternRewriter &rewriter, Location loc,
     res2 = create.math.div(res2, divisorForMean);
 
   // Save result.
-  create.affineKMem.store(res1, alloc1, {});
+  create.affineKMem.store(res1, alloc1);
   if (hasTwoRed)
-    create.affineKMem.store(res2, alloc2, {});
+    create.affineKMem.store(res2, alloc2);
 
   if (hasTwoRed)
     onnxToKrnlSimdReport(op, /*successful*/ true, totVL,

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -1231,8 +1231,9 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
                 Value startOfLastBlockVal = blockedCurrIndex.getValue();
                 Value blockedUBVal = blockedUB.getValue();
                 create.scf.forLoop(startOfLastBlockVal, blockedUBVal, 1,
-                    [&](SCFBuilder &scf, Value blockLocalInd) {
+                    [&](SCFBuilder &scf, ValueRange loopInd) {
                       MDBuilder create(scf);
+                      Value blockLocalInd = loopInd[0];
                       // Output induction variables: same as the outer loop, but
                       // with the blocked index replaced by the inner index.
                       SmallVector<Value, 4> outLoopInd =

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -1216,7 +1216,7 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
           Value initVec = create.vec.splat(vecType, identity);
           IndexExprScope innerScope(ck);
           IndexExpr blockedCurrIndex =
-              DimIndexExpr(blockedOutLoopInd[flatOutRank - 1]);
+              DimIE(blockedOutLoopInd[flatOutRank - 1]);
           IndexExpr blockedUB = SymIE(flatOutDims[flatOutRank - 1].getValue());
           IndexExpr isFull =
               create.krnlIE.isTileFull(blockedCurrIndex, LitIE(VL), blockedUB);

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -729,8 +729,8 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
         // When axes is dynamic, generate a Krnl loop
         KrnlBuilder createKrnl(rewriter, loc);
         ValueRange loopDef = createKrnl.defineLoops(1);
-        createKrnl.iterateIE(loopDef, loopDef, {LitIE(0)},
-            {axisShape0}, [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
+        createKrnl.iterateIE(loopDef, loopDef, {LitIE(0)}, {axisShape0},
+            [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
               Value axe = createKrnl.load(axesVal, loopInd[0]);
               Value cond = create.math.slt(axe, zeroValue);
               Value dim = create.math.select(
@@ -1217,10 +1217,9 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
           IndexExprScope innerScope(ck);
           IndexExpr blockedCurrIndex =
               DimIndexExpr(blockedOutLoopInd[flatOutRank - 1]);
-          IndexExpr blockedUB =
-              SymbolIndexExpr(flatOutDims[flatOutRank - 1].getValue());
-          IndexExpr isFull = create.krnlIE.isTileFull(
-              blockedCurrIndex, LitIE(VL), blockedUB);
+          IndexExpr blockedUB = SymIE(flatOutDims[flatOutRank - 1].getValue());
+          IndexExpr isFull =
+              create.krnlIE.isTileFull(blockedCurrIndex, LitIE(VL), blockedUB);
           Value zero = create.math.constantIndex(0);
           Value isNotFullVal = create.math.slt(isFull.getValue(), zero);
           create.scf.ifThenElse(

--- a/src/Conversion/ONNXToKrnl/Math/TopK.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/TopK.cpp
@@ -69,7 +69,7 @@ struct ONNXTopKOpLowering : public OpConversionPattern<ONNXTopKOp> {
         /*ascending=*/ascendingMode);
 
     // Produce the final result.
-    SmallVector<IndexExpr> zeroDims(rank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr> zeroDims(rank, LitIE(0));
     ValueRange loopDef = create.krnl.defineLoops(rank);
     create.krnl.iterateIE(loopDef, loopDef, zeroDims, resDims,
         [&](KrnlBuilder &createKrnl, ValueRange resLoopInd) {

--- a/src/Conversion/ONNXToKrnl/Math/Trilu.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Trilu.cpp
@@ -54,7 +54,7 @@ struct ONNXTriluOpLowering : public OpConversionPattern<ONNXTriluOp> {
     if (isNoneValue(triluOp.getK()))
       k = create.math.constantIndex(0);
     else
-      k = create.math.castToIndex(create.krnl.load(adaptor.getK(), {}));
+      k = create.math.castToIndex(create.krnl.load(adaptor.getK()));
 
     // Insert an allocation and deallocation for the result of this operation.
     SmallVector<IndexExpr, 4> ubs;

--- a/src/Conversion/ONNXToKrnl/Math/Trilu.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Trilu.cpp
@@ -63,7 +63,7 @@ struct ONNXTriluOpLowering : public OpConversionPattern<ONNXTriluOp> {
 
     // Main loop.
     ValueRange loopDef = create.krnl.defineLoops(rank);
-    SmallVector<IndexExpr> lbs(rank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr> lbs(rank, LitIE(0));
     create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           MultiDialectBuilder<KrnlBuilder, MathBuilder, SCFBuilder> create(

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -187,8 +187,8 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
                           create.krnl.loadIE(inputOperand, inputAccessFct);
                       // Create access fct for filter: [co, ciPerG, kh, kw].
                       SmallVector<IndexExpr, 4> filterAccessFct;
-                      filterAccessFct.emplace_back(DimIndexExpr(co));
-                      filterAccessFct.emplace_back(DimIndexExpr(ciPerG));
+                      filterAccessFct.emplace_back(DimIE(co));
+                      filterAccessFct.emplace_back(DimIE(ciPerG));
 
                       for (int i = 0; i < spacialRank; ++i) {
                         DimIndexExpr k(redIndices[1 + i]);
@@ -213,7 +213,7 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
             resAccessFunc.emplace_back(SymIE(outerIndices[0]));
             resAccessFunc.emplace_back(coInOutputSpacial);
             for (Value o : outputSpatialIndices)
-              resAccessFunc.emplace_back(DimIndexExpr(o));
+              resAccessFunc.emplace_back(DimIE(o));
             create.krnl.storeIE(result, alloc, resAccessFunc);
           }); // Output spacial loops.
     };

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -96,9 +96,9 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
       // Compute the channel out index "co".
       DimIndexExpr g(outerIndices[1]);
       DimIndexExpr coPerGroup(outerIndices[2]);
-      IndexExpr co = g * SymbolIndexExpr(COPerGroup) + coPerGroup;
+      IndexExpr co = g * SymIE(COPerGroup) + coPerGroup;
       // Compute g * CIPerGroup for later use.
-      IndexExpr gTimesCIPerGroup = g * SymbolIndexExpr(CIPerGroup);
+      IndexExpr gTimesCIPerGroup = g * SymIE(CIPerGroup);
       // Determine the bounds for the output spacial dimensions.
       int spacialRank = outputRank - spatialStartIndex;
       ValueRange outputSpacialLoops = create.krnl.defineLoops(spacialRank);
@@ -106,7 +106,7 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
       for (int i = spatialStartIndex; i < outputRank; ++i) {
         outputSpacialLbs.emplace_back(iZero);
         outputSpacialUbs.emplace_back(
-            SymbolIndexExpr(shapeHelper.getOutputDims()[i]));
+            SymIE(shapeHelper.getOutputDims()[i]));
       }
       // Spacial loops.
       // for ho = 0 .. HO:
@@ -126,7 +126,7 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
             SmallVector<IndexExpr, 4> redLbs, redUbs, pMinOS;
             // First: loop over channel in per group.
             redLbs.emplace_back(iZero);
-            redUbs.emplace_back(SymbolIndexExpr(CIPerGroup));
+            redUbs.emplace_back(SymIE(CIPerGroup));
             // For each spacial dim, do the following.
             for (int i = 0; i < spacialRank; ++i) {
               // Get data for dis spacial dimension.
@@ -172,7 +172,7 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
                       inputAccessFct.emplace_back(n);
                       // ci = g * CIPerG + ciPerG
                       DimIndexExpr ciPerG(redIndices[0]);
-                      IndexExpr ci = SymbolIndexExpr(gTimesCIPerGroup) + ciPerG;
+                      IndexExpr ci = SymIE(gTimesCIPerGroup) + ciPerG;
                       inputAccessFct.emplace_back(ci);
                       for (int i = 0; i < spacialRank; ++i) {
                         // for each spacial dims: access is o * s + k * d - p.
@@ -210,7 +210,7 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
               result = create.math.add(result, bias);
             }
             SmallVector<IndexExpr, 4> resAccessFunc;
-            resAccessFunc.emplace_back(SymbolIndexExpr(outerIndices[0]));
+            resAccessFunc.emplace_back(SymIE(outerIndices[0]));
             resAccessFunc.emplace_back(coInOutputSpacial);
             for (Value o : outputSpatialIndices)
               resAccessFunc.emplace_back(DimIndexExpr(o));

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -47,7 +47,7 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
     auto biasOperand = operandAdaptor.getB();
     bool hasBias = !mlir::isa<NoneType>(biasOperand.getType());
     int64_t groupNum = convOp.getGroup();
-    IndexExpr G = LiteralIndexExpr(groupNum);
+    IndexExpr G = LitIE(groupNum);
     Value fZero = create.math.constant(memRefType.getElementType(), 0);
 
     // Bounds for output sizes: [N x CO x HO x WO]:
@@ -71,8 +71,8 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
     IndexExpr CIPerGroup = create.krnlIE.getShapeAsSymbol(filterOperand, 1);
 
     // Determine the bounds for the loops over batch & channel out.
-    IndexExpr iZero = LiteralIndexExpr(0);
-    IndexExpr iOne = LiteralIndexExpr(1);
+    IndexExpr iZero = LitIE(0);
+    IndexExpr iOne = LitIE(1);
 
     SmallVector<Value, 3> lbsStorage, ubsStorage, stepsStorage;
     SmallVector<IndexExpr, 3> outerLbs = {iZero, iZero, iZero};

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -105,8 +105,7 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
       SmallVector<IndexExpr, 3> outputSpacialLbs, outputSpacialUbs;
       for (int i = spatialStartIndex; i < outputRank; ++i) {
         outputSpacialLbs.emplace_back(iZero);
-        outputSpacialUbs.emplace_back(
-            SymIE(shapeHelper.getOutputDims()[i]));
+        outputSpacialUbs.emplace_back(SymIE(shapeHelper.getOutputDims()[i]));
       }
       // Spacial loops.
       // for ho = 0 .. HO:

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -774,9 +774,10 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
     });
     // Perform reduction of entire vectors.
     IndexExpr izero = LiteralIndexExpr(0);
-    create.affineKMem.forIE(izero, redDim, totVL,
-        [&](onnx_mlir::AffineBuilderKrnlMem &ck, mlir::Value j) {
+    create.affineKMem.forLoopIE(izero, redDim, totVL,
+        [&](onnx_mlir::AffineBuilderKrnlMem &ck, ValueRange loopInd) {
           MDBuilder create(ck);
+          Value j = loopInd[0];
           // load X, compute X**2, sum into reductions.
           inlineFor(create, B, [&](int64_t d, Value o) {
             Value ii = create.math.add(i, o);
@@ -828,9 +829,10 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
       invStdDev[d] = create.math.div(oneFloat, stdDev);
     });
     // Normalize of entire vectors.
-    create.affineKMem.forIE(izero, redDim, totVL,
-        [&](onnx_mlir::AffineBuilderKrnlMem &ck, mlir::Value j) {
+    create.affineKMem.forLoopIE(izero, redDim, totVL,
+        [&](onnx_mlir::AffineBuilderKrnlMem &ck, ValueRange loopInd) {
           MDBuilder create(ck);
+          Value j = loopInd[0];
           // load X, compute X**2, sum into reductions.
           inlineFor(create, B, [&](int64_t d, Value o) {
             Value ii = create.math.add(i, o);

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -980,8 +980,9 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
                 Value startOfLastBlockVal = blockedCurrIndex.getValue();
                 Value blockedUBVal = blockedUB.getValue();
                 create.scf.forLoop(startOfLastBlockVal, blockedUBVal, 1,
-                    [&](SCFBuilder &scf, Value blockLocalInd) {
+                    [&](SCFBuilder &scf, ValueRange loopInd) {
                       MDBuilder create(scf);
+                      Value blockLocalInd = loopInd[0];
                       generateIterWithSIMD(rewriter, create, lnOp, XFlatMemRef,
                           scaleFlatMemRef, biasFlatMemRef, YFlatMemRef,
                           meanFlatMemRef, invStdDevFlatMemRef, tmpRedMemRef,

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -219,7 +219,7 @@ struct ONNXInstanceNormalizationOpLowering
           SmallVector<IndexExpr, 4> lbs(rank - 2, iZero);
           SmallVector<IndexExpr, 4> ubs;
           for (int d = 2; d < rank; ++d)
-            ubs.emplace_back(SymbolIndexExpr(inputBounds[d]));
+            ubs.emplace_back(SymIE(inputBounds[d]));
 
           // First compute the mean: store zero in reduction value, then sum up
           // all of the values in the channel, and divide by the number of
@@ -967,7 +967,7 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
           Value tmpRedMemRef = create.mem.alignedAlloca(tmpRedType);
           Value tmpRedMemRef2 = create.mem.alignedAlloca(tmpRedType);
           IndexExpr blockedCurrIndex = DimIndexExpr(blockedLoopIndices[0]);
-          IndexExpr blockedUB = SymbolIndexExpr(XFlatDims[0]);
+          IndexExpr blockedUB = SymIE(XFlatDims[0]);
           IndexExpr isFull = create.krnlIE.isTileFull(
               blockedCurrIndex, LitIE(B), blockedUB);
           Value zero = create.math.constantIndex(0);

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -968,8 +968,8 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
           Value tmpRedMemRef2 = create.mem.alignedAlloca(tmpRedType);
           IndexExpr blockedCurrIndex = DimIE(blockedLoopIndices[0]);
           IndexExpr blockedUB = SymIE(XFlatDims[0]);
-          IndexExpr isFull = create.krnlIE.isTileFull(
-              blockedCurrIndex, LitIE(B), blockedUB);
+          IndexExpr isFull =
+              create.krnlIE.isTileFull(blockedCurrIndex, LitIE(B), blockedUB);
           Value zero = create.math.constantIndex(0);
           Value isNotFullVal = create.math.slt(isFull.getValue(), zero);
           create.scf.ifThenElse(

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -966,7 +966,7 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
           IndexExprScope innerScope(ck);
           Value tmpRedMemRef = create.mem.alignedAlloca(tmpRedType);
           Value tmpRedMemRef2 = create.mem.alignedAlloca(tmpRedType);
-          IndexExpr blockedCurrIndex = DimIndexExpr(blockedLoopIndices[0]);
+          IndexExpr blockedCurrIndex = DimIE(blockedLoopIndices[0]);
           IndexExpr blockedUB = SymIE(XFlatDims[0]);
           IndexExpr isFull = create.krnlIE.isTileFull(
               blockedCurrIndex, LitIE(B), blockedUB);

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -224,7 +224,7 @@ struct ONNXInstanceNormalizationOpLowering
           // First compute the mean: store zero in reduction value, then sum up
           // all of the values in the channel, and divide by the number of
           // values.
-          create.krnl.store(fZero, tmpMemRef, {});
+          create.krnl.store(fZero, tmpMemRef);
           // Iterate over kernel and add values.
           ValueRange spatial2_loopDef = create.krnl.defineLoops(rank - 2);
           create.krnl.iterateIE(spatial2_loopDef, spatial2_loopDef, lbs, ubs,
@@ -236,7 +236,7 @@ struct ONNXInstanceNormalizationOpLowering
                 for (int d = 0; d < rank - 2; ++d)
                   inputAccessFct.emplace_back(spatial_loopInd[d]);
                 // tmp += input[n,c, spatial dims]
-                Value oldSum = create.krnl.load(tmpMemRef, {});
+                Value oldSum = create.krnl.load(tmpMemRef);
                 Value val = create.krnl.load(inputMemRef, inputAccessFct);
                 Value newSum = create.math.add(oldSum, val);
                 create.krnl.store(newSum, tmpMemRef);
@@ -244,7 +244,7 @@ struct ONNXInstanceNormalizationOpLowering
           Value sum = create.krnl.load(tmpMemRef);
           Value mean = create.math.div(sum, meanDenom);
           // Second, compute the standard dev: sum of (val - mean)2 / (num-1).
-          create.krnl.store(fZero, tmpMemRef, {});
+          create.krnl.store(fZero, tmpMemRef);
           // Iterate over kernel and add values.
           create.krnl.iterateIE(spatial_loopDef, spatial_loopDef, lbs, ubs,
               [&](KrnlBuilder &createKrnl, ValueRange spatial_loopInd) {

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -359,9 +359,9 @@ struct ONNXPoolOpLowering : public OpConversionPattern<PoolOp> {
             // s0, input dim
             ic.emplace_back(create.krnlIE.getShapeAsDim(inputOperand, j));
             // s1, kernel dim
-            ic.emplace_back(SymbolIndexExpr(shapeHelper.kernelShape[i]));
+            ic.emplace_back(SymIE(shapeHelper.kernelShape[i]));
             // s2, pad dim
-            ic.emplace_back(SymbolIndexExpr(shapeHelper.pads[i]));
+            ic.emplace_back(SymIE(shapeHelper.pads[i]));
             // s3, stride dim
             ic.emplace_back(LitIE(shapeHelper.strides[i]));
             // s4, dilation dim

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -334,7 +334,7 @@ struct ONNXPoolOpLowering : public OpConversionPattern<PoolOp> {
           // pixel.
           SmallVector<IndexExpr, 4> outputIndices;
           for (unsigned int i = 0; i < outputShape.size(); ++i)
-            outputIndices.emplace_back(DimIndexExpr(loopInd[i]));
+            outputIndices.emplace_back(DimIE(loopInd[i]));
 
           // 2.1 Emit: output[n][c][ho][wo] = identity
           create.krnl.store(identity, reductionVal);

--- a/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Pooling.cpp
@@ -153,7 +153,7 @@ void postProcessPoolingWindow<ONNXAveragePoolOp>(
   Value numerator = create.krnl.load(alloc, resultIndices);
   Value denominator;
   if (countIncludePad) {
-    IndexExpr kernelSize = LiteralIndexExpr(1);
+    IndexExpr kernelSize = LitIE(1);
     for (unsigned int i = 0; i < kernelShape.size(); ++i)
       kernelSize = kernelSize * kernelShape[i];
     denominator = kernelSize.getValue();
@@ -320,7 +320,7 @@ struct ONNXPoolOpLowering : public OpConversionPattern<PoolOp> {
     //     for ho in range(HO):
     //       for wo in range(WO):
     ValueRange calcLoopDef = create.krnl.defineLoops(outputShape.size());
-    SmallVector<IndexExpr, 4> lbs(outputShape.size(), LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(outputShape.size(), LitIE(0));
     SmallVector<IndexExpr, 4> ubs;
     create.krnlIE.getShapeAsDims(alloc, ubs);
     create.krnl.iterateIE(calcLoopDef, calcLoopDef, lbs, ubs,
@@ -363,9 +363,9 @@ struct ONNXPoolOpLowering : public OpConversionPattern<PoolOp> {
             // s2, pad dim
             ic.emplace_back(SymbolIndexExpr(shapeHelper.pads[i]));
             // s3, stride dim
-            ic.emplace_back(LiteralIndexExpr(shapeHelper.strides[i]));
+            ic.emplace_back(LitIE(shapeHelper.strides[i]));
             // s4, dilation dim
-            ic.emplace_back(LiteralIndexExpr(shapeHelper.dilations[i]));
+            ic.emplace_back(LitIE(shapeHelper.dilations[i]));
             IVExprs.emplace_back(ic);
           }
 

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -255,7 +255,7 @@ namespace {
 // Returns the DenseElementsAttr of input if it's a krnl.global constant or
 // onnx.Constant, or if it's one step removed from a krnl/onnx constant by a
 // builtin.unrealized_conversion_cast. Otherwise returns a nullptr attribute.
-DenseElementsAttr getDenseElementAttrFromConstValue(mlir::Value value) {
+DenseElementsAttr getDenseElementAttrFromConstValue(Value value) {
   Operation *definingOp = value.getDefiningOp();
   if (auto castOp = dyn_cast_or_null<UnrealizedConversionCastOp>(definingOp)) {
     if (castOp.getNumOperands() != 1)
@@ -376,7 +376,7 @@ Value emitArgSort(ConversionPatternRewriter &rewriter, Location loc,
   ValueRange loopDef = create.krnl.defineLoops(rank);
   create.krnl.iterateIE(loopDef, loopDef, lbs, outerUbs,
       [&](KrnlBuilder &createKrnl, ValueRange iLoopInd) {
-        IndexExpr i1 = DimIndexExpr(iLoopInd[axis]) + oneIE;
+        IndexExpr i1 = DimIE(iLoopInd[axis]) + oneIE;
         ValueRange swapLoopDef = createKrnl.defineLoops(1);
         createKrnl.iterateIE(swapLoopDef, swapLoopDef, {i1}, {ubs[axis]},
             [&](KrnlBuilder &ck, ValueRange swapLoopInd) {

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -421,7 +421,7 @@ Value getOptionalScalarValue(ConversionPatternRewriter &rewriter, Location loc,
   if (mlir::isa<NoneType>(optionalScalar.getType())) {
     return create.math.constant(elementType, defaultValue);
   } else if (mlir::cast<ShapedType>(optionalScalar.getType()).getRank() == 0) {
-    return create.krnl.load(optionalScalar, {});
+    return create.krnl.load(optionalScalar);
   } else {
     Value zero = create.math.constantIndex(0);
     return create.krnl.load(optionalScalar, {zero});

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -318,8 +318,7 @@ Value foldOrEmitONNXTransposeOpKrnl(ConversionPatternRewriter &rewriter,
 /// Emit MemRef ReinterpretCastOp to create a new view for 'data'.
 /// The new view is created using the given 'outputDims'.
 Value emitMemRefReinterpretCastOp(ConversionPatternRewriter &rewriter,
-    Location loc, Value data, SmallVectorImpl<IndexExpr> &outputDims,
-    Type outputType) {
+    Location loc, Value data, DimsExpr &outputDims, Type outputType) {
   MemRefBuilder createMemRef(rewriter, loc);
   Value newView = createMemRef.reinterpretCast(data, outputDims);
   // Set type to the output type to avoid unrealized_conversion_cast.

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -159,8 +159,7 @@ mlir::Value foldOrEmitONNXTransposeOpKrnl(
 /// The new view is created using the given 'outputDims'.
 mlir::Value emitMemRefReinterpretCastOp(
     mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
-    mlir::Value data, llvm::SmallVectorImpl<IndexExpr> &outputDims,
-    mlir::Type outputType);
+    mlir::Value data, DimsExpr &outputDims, mlir::Type outputType);
 
 /// Emit krnl iterate to compute argsort of a given MemRef along a given axis.
 /// Output MemRef has the same shape as the input MemRef but is of IndexType.

--- a/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
+++ b/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
@@ -297,7 +297,7 @@ struct ONNXNonMaxSuppressionOpLowering
     // the first dimension size is larger than necessary.
     // Output shape : [num_selected_indices, 3]
     SmallVector<IndexExpr, 2> outputDims = {
-        numSelectedIndicesIE, LiteralIndexExpr(3)};
+        numSelectedIndicesIE, LitIE(3)};
     SmallVector<int64_t, 2> outputShape;
     if (numSelectedIndicesIE.isLiteral())
       outputShape.emplace_back(numSelectedIndicesIE.getLiteral());
@@ -440,7 +440,7 @@ struct ONNXNonMaxSuppressionOpLowering
     // Insert allocation and deallocation for the final output.
     Value effectiveNSI = create.krnl.load(effectiveNumSelectedIndices);
     SmallVector<IndexExpr, 2> resDims = {
-        DimIndexExpr(effectiveNSI), LiteralIndexExpr(3)};
+        DimIndexExpr(effectiveNSI), LitIE(3)};
     Value resMemRef = create.mem.alignedAlloc(
         MemRefType::get({ShapedType::kDynamic, 3}, elementType), resDims);
 

--- a/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
+++ b/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
@@ -290,7 +290,7 @@ struct ONNXNonMaxSuppressionOpLowering
       boxes = tryToUnflip(rewriter, loc, boxes);
 
     // The total number of output selected indices.
-    IndexExpr numSelectedIndicesIE = bsIE * csIE * DimIndexExpr(MOPC);
+    IndexExpr numSelectedIndicesIE = bsIE * csIE * DimIE(MOPC);
 
     // Allocate a MemRef for the output. This MemRef is NOT the final output
     // since the number of selected indices has yet not suppressed by IOU. So
@@ -440,7 +440,7 @@ struct ONNXNonMaxSuppressionOpLowering
     // Insert allocation and deallocation for the final output.
     Value effectiveNSI = create.krnl.load(effectiveNumSelectedIndices);
     SmallVector<IndexExpr, 2> resDims = {
-        DimIndexExpr(effectiveNSI), LitIE(3)};
+        DimIE(effectiveNSI), LitIE(3)};
     Value resMemRef = create.mem.alignedAlloc(
         MemRefType::get({ShapedType::kDynamic, 3}, elementType), resDims);
 

--- a/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
+++ b/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
@@ -115,7 +115,7 @@ static void suppressByScores(ConversionPatternRewriter &rewriter, Location loc,
   // Compute the effective max output per class.
   Value effectiveMaxPerClass =
       create.mem.alloca(MemRefType::get({}, indexType));
-  create.krnl.store(zero, effectiveMaxPerClass, {});
+  create.krnl.store(zero, effectiveMaxPerClass);
 
   ValueRange bcLoopDef = create.krnl.defineLoops(2);
   create.krnl.iterate(bcLoopDef, bcLoopDef, {zero, zero}, {bs, cs},
@@ -126,7 +126,7 @@ static void suppressByScores(ConversionPatternRewriter &rewriter, Location loc,
 
         // Reset the number of scores whose value is greater than the
         // threshold. Counting is done per class.
-        create.krnl.store(zero, topk, {});
+        create.krnl.store(zero, topk);
 
         // Count the number of scores whose value is greater than the
         // threshold. Counting is done per class.
@@ -139,22 +139,22 @@ static void suppressByScores(ConversionPatternRewriter &rewriter, Location loc,
               Value score = createKrnl.load(scores, {b, c, s});
               // Increase the counter if score > threshold.
               Value gt = createMath.sgt(score, scoreThreshold);
-              Value topkVal = createKrnl.load(topk, {});
+              Value topkVal = createKrnl.load(topk);
               Value topkPlusOneVal = createMath.add(topkVal, one);
               topkVal = createMath.select(gt, topkPlusOneVal, topkVal);
-              createKrnl.store(topkVal, topk, {});
+              createKrnl.store(topkVal, topk);
             });
 
         // Update the effective max output per class.
-        Value x = create.krnl.load(topk, {});
-        Value y = create.krnl.load(effectiveMaxPerClass, {});
-        create.krnl.store(create.math.max(x, y), effectiveMaxPerClass, {});
+        Value x = create.krnl.load(topk);
+        Value y = create.krnl.load(effectiveMaxPerClass);
+        create.krnl.store(create.math.max(x, y), effectiveMaxPerClass);
       });
 
   // Suppress the number of output bounding boxes per class.
-  Value x = create.krnl.load(maxOutputPerClass, {});
-  Value y = create.krnl.load(effectiveMaxPerClass, {});
-  create.krnl.store(create.math.min(x, y), maxOutputPerClass, {});
+  Value x = create.krnl.load(maxOutputPerClass);
+  Value y = create.krnl.load(effectiveMaxPerClass);
+  create.krnl.store(create.math.min(x, y), maxOutputPerClass);
 }
 
 /// Bounding boxes may contain a mix of flipped and non-flipped boxes. Try to
@@ -275,10 +275,10 @@ struct ONNXNonMaxSuppressionOpLowering
     Value maxOutputPerClass = create.mem.alloca(MemRefType::get({}, indexType));
     // 1. Suppress by using spatial dimension size.
     Value x = create.math.castToIndex(maxOutputBoxPerClass);
-    create.krnl.store(create.math.min(x, ss), maxOutputPerClass, {});
+    create.krnl.store(create.math.min(x, ss), maxOutputPerClass);
     // 2. Suppress by score threshold.
     suppressByScores(rewriter, loc, scores, scoreTH, maxOutputPerClass);
-    Value MOPC = create.krnl.load(maxOutputPerClass, {});
+    Value MOPC = create.krnl.load(maxOutputPerClass);
 
     // Sort scores in the descending order.
     Value order = emitArgSort(rewriter, loc, scores, /*axis=*/2,
@@ -315,7 +315,7 @@ struct ONNXNonMaxSuppressionOpLowering
     // Final output shape : [effective_num_selected_indices, 3]
     Value effectiveNumSelectedIndices =
         create.mem.alloca(MemRefType::get({}, indexType));
-    create.krnl.store(zero, effectiveNumSelectedIndices, {});
+    create.krnl.store(zero, effectiveNumSelectedIndices);
 
     // Suppress by using IOU.
     // Iterate over all bounding boxes in the descending order of scores.
@@ -327,7 +327,7 @@ struct ONNXNonMaxSuppressionOpLowering
           MultiDialectBuilder<KrnlBuilder, MathBuilder, MemRefBuilder> create(
               createKrnl);
           // Keep trace of the number of output boxes per class.
-          create.krnl.store(zero, effectiveMaxOutputPerClass, {});
+          create.krnl.store(zero, effectiveMaxOutputPerClass);
           // Keep trace of removed indices per class.
           DimIndexExpr ssIE(ss);
           SmallVector<IndexExpr, 1> dims = {ssIE};
@@ -355,7 +355,7 @@ struct ONNXNonMaxSuppressionOpLowering
                 Value checkScore = create.math.sgt(score, scoreTH);
                 // 2. Have not yet got enough outputs.
                 Value currentMOPC =
-                    create.krnl.load(effectiveMaxOutputPerClass, {});
+                    create.krnl.load(effectiveMaxOutputPerClass);
                 Value checkMOPC = create.math.slt(currentMOPC, MOPC);
                 // 3. Bounding box has not yet been removed.
                 Value isRemoved =
@@ -381,7 +381,7 @@ struct ONNXNonMaxSuppressionOpLowering
                 // Store the index of the selected box to the output.
                 // out_index = effective_num_selected_indices
                 // selected_indices[out_index] = [b, c, selected_box_index]
-                Value soVal = create.krnl.load(effectiveNumSelectedIndices, {});
+                Value soVal = create.krnl.load(effectiveNumSelectedIndices);
                 create.krnl.store(b, selectedMemRef, {soVal, zero});
                 create.krnl.store(c, selectedMemRef, {soVal, one});
                 create.krnl.store(selectedBI, selectedMemRef, {soVal, two});
@@ -438,7 +438,7 @@ struct ONNXNonMaxSuppressionOpLowering
         });
 
     // Insert allocation and deallocation for the final output.
-    Value effectiveNSI = create.krnl.load(effectiveNumSelectedIndices, {});
+    Value effectiveNSI = create.krnl.load(effectiveNumSelectedIndices);
     SmallVector<IndexExpr, 2> resDims = {
         DimIndexExpr(effectiveNSI), LiteralIndexExpr(3)};
     Value resMemRef = create.mem.alignedAlloc(

--- a/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
+++ b/src/Conversion/ONNXToKrnl/ObjectDetection/NonMaxSuppression.cpp
@@ -296,8 +296,7 @@ struct ONNXNonMaxSuppressionOpLowering
     // since the number of selected indices has yet not suppressed by IOU. So
     // the first dimension size is larger than necessary.
     // Output shape : [num_selected_indices, 3]
-    SmallVector<IndexExpr, 2> outputDims = {
-        numSelectedIndicesIE, LitIE(3)};
+    SmallVector<IndexExpr, 2> outputDims = {numSelectedIndicesIE, LitIE(3)};
     SmallVector<int64_t, 2> outputShape;
     if (numSelectedIndicesIE.isLiteral())
       outputShape.emplace_back(numSelectedIndicesIE.getLiteral());
@@ -439,8 +438,7 @@ struct ONNXNonMaxSuppressionOpLowering
 
     // Insert allocation and deallocation for the final output.
     Value effectiveNSI = create.krnl.load(effectiveNumSelectedIndices);
-    SmallVector<IndexExpr, 2> resDims = {
-        DimIE(effectiveNSI), LitIE(3)};
+    SmallVector<IndexExpr, 2> resDims = {DimIE(effectiveNSI), LitIE(3)};
     Value resMemRef = create.mem.alignedAlloc(
         MemRefType::get({ShapedType::kDynamic, 3}, elementType), resDims);
 

--- a/src/Conversion/ONNXToKrnl/Quantization/DynamicQuantizeLinear.cpp
+++ b/src/Conversion/ONNXToKrnl/Quantization/DynamicQuantizeLinear.cpp
@@ -94,12 +94,12 @@ struct ONNXDynamicQuantizeLinearOpLowering
     Value X = adaptor.getX();
 
     // MemRefType for inputs and outputs.
-    auto xMemRefType = dyn_cast<MemRefType>(X.getType());
-    auto yMemRefType = dyn_cast<MemRefType>(
+    auto xMemRefType = mlir::dyn_cast<MemRefType>(X.getType());
+    auto yMemRefType = mlir::dyn_cast<MemRefType>(
         typeConverter->convertType(dqlOp.getResult(0).getType()));
-    auto yScaleMemRefType = dyn_cast<MemRefType>(
+    auto yScaleMemRefType = mlir::dyn_cast<MemRefType>(
         typeConverter->convertType(dqlOp.getResult(1).getType()));
-    auto yZeroPointMemRefType = dyn_cast<MemRefType>(
+    auto yZeroPointMemRefType = mlir::dyn_cast<MemRefType>(
         typeConverter->convertType(dqlOp.getResult(2).getType()));
 
     // Types

--- a/src/Conversion/ONNXToKrnl/Quantization/QuantizeLinear.cpp
+++ b/src/Conversion/ONNXToKrnl/Quantization/QuantizeLinear.cpp
@@ -117,8 +117,8 @@ struct ONNXQuantizeLinearOpLowering
     Value YZeroPoint = qlOp.getYZeroPoint(); // Optional input.
 
     // MemRefType for inputs and outputs.
-    auto xMemRefType = dyn_cast<MemRefType>(X.getType());
-    auto yMemRefType = dyn_cast<MemRefType>(
+    auto xMemRefType = mlir::dyn_cast<MemRefType>(X.getType());
+    auto yMemRefType = mlir::dyn_cast<MemRefType>(
         typeConverter->convertType(qlOp.getResult().getType()));
     MemRefType yScaleMemRefType = mlir::cast<MemRefType>(YScale.getType());
 

--- a/src/Conversion/ONNXToKrnl/RNN/RNNBase.cpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNNBase.cpp
@@ -88,7 +88,7 @@ void initializeIntermediateStates(ConversionPatternRewriter &rewriter,
       rewriter, loc);
   IndexExprScope childScope(create.krnl);
   ValueRange loopDef = create.krnl.defineLoops(nLoops);
-  SmallVector<IndexExpr, 4> lbs(nLoops, LiteralIndexExpr(0));
+  SmallVector<IndexExpr, 4> lbs(nLoops, LitIE(0));
   Value boundVal = (direction == FORWARD || direction == BIDIRECTIONAL)
                        ? forwardHt
                        : reverseHt;

--- a/src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp
+++ b/src/Conversion/ONNXToKrnl/RNN/RNNBase.hpp
@@ -161,10 +161,10 @@ struct ONNXRNNOpLowering : public mlir::OpConversionPattern<RNNOp> {
     if (direction == FORWARD || direction == BIDIRECTIONAL) {
       IndexExprScope childScope(create.krnl);
       mlir::ValueRange loopDef = create.krnl.defineLoops(1);
-      llvm::SmallVector<IndexExpr, 4> lbs(1, LiteralIndexExpr(0));
+      llvm::SmallVector<IndexExpr, 4> lbs(1, LitIE(0));
       llvm::SmallVector<IndexExpr, 4> ubs;
       if (!mlir::ShapedType::isDynamic(sequenceDimSize))
-        ubs.emplace_back(LiteralIndexExpr(sequenceDimSize));
+        ubs.emplace_back(LitIE(sequenceDimSize));
       else
         ubs.emplace_back(create.krnlIE.getShapeAsDim(X, 0));
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
@@ -186,10 +186,10 @@ struct ONNXRNNOpLowering : public mlir::OpConversionPattern<RNNOp> {
     if (direction == REVERSE || direction == BIDIRECTIONAL) {
       IndexExprScope childScope(create.krnl);
       mlir::ValueRange loopDef = create.krnl.defineLoops(1);
-      llvm::SmallVector<IndexExpr, 4> lbs(1, LiteralIndexExpr(0));
+      llvm::SmallVector<IndexExpr, 4> lbs(1, LitIE(0));
       llvm::SmallVector<IndexExpr, 4> ubs;
       if (!mlir::ShapedType::isDynamic(sequenceDimSize))
-        ubs.emplace_back(LiteralIndexExpr(sequenceDimSize));
+        ubs.emplace_back(LitIE(sequenceDimSize));
       else
         ubs.emplace_back(create.krnlIE.getShapeAsDim(X, 0));
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceAt.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceAt.cpp
@@ -39,7 +39,7 @@ struct ONNXSequenceAtOpLowering : public OpConversionPattern<ONNXSequenceAtOp> {
     auto dimSize = create.mem.dim(input_sequence, 0);
     SymbolIndexExpr boundIE(dimSize);
     IndexExpr positionIE =
-        SymbolIndexExpr(create.krnl.load(adaptor.getPosition()));
+        SymIE(create.krnl.load(adaptor.getPosition()));
     // Handle the negative position
     IndexExpr condIE = positionIE < 0;
     IndexExpr fixedPosition = positionIE + boundIE;

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceAt.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceAt.cpp
@@ -38,8 +38,7 @@ struct ONNXSequenceAtOpLowering : public OpConversionPattern<ONNXSequenceAtOp> {
 
     auto dimSize = create.mem.dim(input_sequence, 0);
     SymbolIndexExpr boundIE(dimSize);
-    IndexExpr positionIE =
-        SymIE(create.krnl.load(adaptor.getPosition()));
+    IndexExpr positionIE = SymIE(create.krnl.load(adaptor.getPosition()));
     // Handle the negative position
     IndexExpr condIE = positionIE < 0;
     IndexExpr fixedPosition = positionIE + boundIE;

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceErase.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceErase.cpp
@@ -55,7 +55,7 @@ struct ONNXSequenceEraseOpLowering
       // Erase the end of the sequence
       positionIE = boundIE - 1;
     } else {
-      positionIE = SymbolIndexExpr(create.krnl.load(adaptor.getPosition()));
+      positionIE = SymIE(create.krnl.load(adaptor.getPosition()));
       // Handle the negative position
       IndexExpr correctionIE = positionIE + boundIE;
       IndexExpr conditionIE = positionIE < 0;

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceErase.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceErase.cpp
@@ -65,7 +65,7 @@ struct ONNXSequenceEraseOpLowering
     // Copy the elements before the position
     KrnlBuilder createKrnl(rewriter, loc);
     SmallVector<IndexExpr, 1> lbs;
-    lbs.emplace_back(LiteralIndexExpr(0));
+    lbs.emplace_back(LitIE(0));
     SmallVector<IndexExpr, 1> ubs;
     ubs.emplace_back(positionIE);
     ValueRange firstLoopDef = createKrnl.defineLoops(1);

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceInsert.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceInsert.cpp
@@ -59,7 +59,7 @@ struct ONNXSequenceInsertOpLowering
       // ToDo (chentong): backward shape inference may help
       positionIE = boundIE;
     } else {
-      positionIE = SymbolIndexExpr(create.krnl.load(adaptor.getPosition()));
+      positionIE = SymIE(create.krnl.load(adaptor.getPosition()));
       // Handle the negative position
       IndexExpr condIE = positionIE < 0;
       IndexExpr fixedPosition = positionIE + boundIE;

--- a/src/Conversion/ONNXToKrnl/Sequence/SequenceInsert.cpp
+++ b/src/Conversion/ONNXToKrnl/Sequence/SequenceInsert.cpp
@@ -78,7 +78,7 @@ struct ONNXSequenceInsertOpLowering
       // the loop will not be reached at runtime.
     } else {
       SmallVector<IndexExpr, 1> lbs;
-      lbs.emplace_back(LiteralIndexExpr(0));
+      lbs.emplace_back(LitIE(0));
       SmallVector<IndexExpr, 1> ubs;
       ubs.emplace_back(positionIE);
       ValueRange firstLoopDef = createKrnl.defineLoops(1);

--- a/src/Conversion/ONNXToKrnl/Tensor/ArgMinMax.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ArgMinMax.cpp
@@ -98,7 +98,7 @@ struct ONNXArgMinMaxOpLowering : public OpConversionPattern<ARG_OP> {
 
     // 1. Krnl loops to initialize the result.
     ValueRange initLoopDef = create.krnl.defineLoops(reducedRank);
-    SmallVector<IndexExpr, 4> initLbs(reducedRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> initLbs(reducedRank, LitIE(0));
     create.krnl.iterateIE(initLoopDef, initLoopDef, initLbs, outputDims,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           createKrnl.store(minusOne, alloc, loopInd);
@@ -106,7 +106,7 @@ struct ONNXArgMinMaxOpLowering : public OpConversionPattern<ARG_OP> {
 
     // 2. Krnl loop to calculate arg min/arg max.
     ValueRange calcLoopDef = create.krnl.defineLoops(dataRank);
-    SmallVector<IndexExpr, 4> lbs(dataRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(dataRank, LitIE(0));
     SmallVector<IndexExpr, 4> ubs;
     create.krnlIE.getShapeAsDims(data, ubs);
     create.krnl.iterateIE(calcLoopDef, calcLoopDef, lbs, ubs,

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -111,7 +111,7 @@ struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
                 IndexExprScope IEScope(&rewriter, loc);
                 IndexExpr writeOffset = DimIndexExpr(loopInd[r]);
                 IndexExpr accumulatedOffsetIE =
-                    SymbolIndexExpr(accumulatedOffsetValue);
+                    SymIE(accumulatedOffsetValue);
                 writeOffset = writeOffset + accumulatedOffsetIE;
                 writeIndices.emplace_back(writeOffset.getValue());
               }

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -109,7 +109,7 @@ struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
                 writeIndices.emplace_back(loopInd[r]);
               else {
                 IndexExprScope IEScope(&rewriter, loc);
-                IndexExpr writeOffset = DimIndexExpr(loopInd[r]);
+                IndexExpr writeOffset = DimIE(loopInd[r]);
                 IndexExpr accumulatedOffsetIE =
                     SymIE(accumulatedOffsetValue);
                 writeOffset = writeOffset + accumulatedOffsetIE;

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -75,7 +75,7 @@ struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
     // dim of different inputs.
     SmallVector<IndexExpr, 4> commonUB(shapeHelper.getOutputDims());
     // IndexExprScope IEScope(&rewriter, loc);
-    IndexExpr accumulatedOffset = LiteralIndexExpr(0);
+    IndexExpr accumulatedOffset = LitIE(0);
     for (unsigned int i = 0; i < inputNum; ++i) {
       // Since the accumulatedOffsetValue will be used in a nested
       // IndexExprScope, we get the Value of this IndexExpr and pass it as a
@@ -84,7 +84,7 @@ struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
       OpBuilder::InsertionGuard insertGuard(rewriter);
       // Create loop.
       ValueRange loopDef = create.krnl.defineLoops(rank);
-      SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(rank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(operands[i], ubs);
       // For each input, only the dimension 'axis' is different

--- a/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Concat.cpp
@@ -110,8 +110,7 @@ struct ONNXConcatOpLowering : public OpConversionPattern<ONNXConcatOp> {
               else {
                 IndexExprScope IEScope(&rewriter, loc);
                 IndexExpr writeOffset = DimIE(loopInd[r]);
-                IndexExpr accumulatedOffsetIE =
-                    SymIE(accumulatedOffsetValue);
+                IndexExpr accumulatedOffsetIE = SymIE(accumulatedOffsetValue);
                 writeOffset = writeOffset + accumulatedOffsetIE;
                 writeIndices.emplace_back(writeOffset.getValue());
               }

--- a/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
@@ -125,7 +125,7 @@ struct ONNXConcatShapeTransposeOpLowering
     // optimization. Difference may come from constant vs. dynamic, or dynamic
     // dim of different inputs.
     SmallVector<IndexExpr, 4> commonUB = outputConcatDims;
-    IndexExpr accumulatedOffset = LiteralIndexExpr(0);
+    IndexExpr accumulatedOffset = LitIE(0);
     for (unsigned int i = 0; i < numInputs; ++i) {
       // Since the accumulatedOffsetValue will be used in a nested
       // IndexExprScope, we get the Value of this IndexExpr and pass it as a
@@ -134,7 +134,7 @@ struct ONNXConcatShapeTransposeOpLowering
       OpBuilder::InsertionGuard insertGuard(rewriter);
       // Create loop.
       ValueRange loopDef = create.krnl.defineLoops(rank);
-      SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(rank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(operands[i], ubs);
       // For each input, only the dimension 'axis' is different

--- a/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
@@ -148,7 +148,7 @@ struct ONNXConcatShapeTransposeOpLowering
                 writeIndices.emplace_back(loopInd[r]);
               else {
                 IndexExprScope IEScope(&rewriter, loc);
-                IndexExpr writeOffset = DimIndexExpr(loopInd[r]);
+                IndexExpr writeOffset = DimIE(loopInd[r]);
                 IndexExpr accumulatedOffsetIE =
                     SymIE(accumulatedOffsetValue);
                 writeOffset = writeOffset + accumulatedOffsetIE;

--- a/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
@@ -149,8 +149,7 @@ struct ONNXConcatShapeTransposeOpLowering
               else {
                 IndexExprScope IEScope(&rewriter, loc);
                 IndexExpr writeOffset = DimIE(loopInd[r]);
-                IndexExpr accumulatedOffsetIE =
-                    SymIE(accumulatedOffsetValue);
+                IndexExpr accumulatedOffsetIE = SymIE(accumulatedOffsetValue);
                 writeOffset = writeOffset + accumulatedOffsetIE;
                 writeIndices.emplace_back(writeOffset.getValue());
               }

--- a/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConcatShapeTranspose.cpp
@@ -150,7 +150,7 @@ struct ONNXConcatShapeTransposeOpLowering
                 IndexExprScope IEScope(&rewriter, loc);
                 IndexExpr writeOffset = DimIndexExpr(loopInd[r]);
                 IndexExpr accumulatedOffsetIE =
-                    SymbolIndexExpr(accumulatedOffsetValue);
+                    SymIE(accumulatedOffsetValue);
                 writeOffset = writeOffset + accumulatedOffsetIE;
                 writeIndices.emplace_back(writeOffset.getValue());
               }

--- a/src/Conversion/ONNXToKrnl/Tensor/ConstantOfShape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ConstantOfShape.cpp
@@ -80,7 +80,7 @@ struct ONNXConstantOfShapeOpLowering
     if (!hasAllScalarValues({alloc})) {
       IndexExprScope childScope(&rewriter, loc);
       ValueRange loopDef = create.krnl.defineLoops(rank);
-      SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+      SmallVector<IndexExpr, 4> lbs(rank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,

--- a/src/Conversion/ONNXToKrnl/Tensor/Dim.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Dim.cpp
@@ -43,7 +43,7 @@ struct ONNXDimOpLowering : public OpConversionPattern<ONNXDimOp> {
     Type elementType = outputMemRefType.getElementType();
 
     // Output is 1D memref of one element.
-    SmallVector<IndexExpr, 1> outputDims(1, LiteralIndexExpr(1));
+    SmallVector<IndexExpr, 1> outputDims(1, LitIE(1));
     Value alloc = create.mem.alignedAlloc(outputMemRefType, outputDims);
 
     // Write the dimension at axis to the output.

--- a/src/Conversion/ONNXToKrnl/Tensor/GatherElements.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/GatherElements.cpp
@@ -73,7 +73,7 @@ struct ONNXGatherElementsOpLowering
     //   output[i][j]...[n] = data[i][j]..[index]..[n] (index used at axis dim.)
     //
     ValueRange loopDef = create.krnl.defineLoops(indicesRank);
-    DimsExpr lbs(indicesRank, LiteralIndexExpr(0));
+    DimsExpr lbs(indicesRank, LitIE(0));
     create.krnl.iterateIE(loopDef, loopDef, lbs, indicesDims,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           // Insert code inside the loop.

--- a/src/Conversion/ONNXToKrnl/Tensor/GatherND.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/GatherND.cpp
@@ -133,8 +133,7 @@ struct ONNXGatherNDOpLowering : public OpConversionPattern<ONNXGatherNDOp> {
     // }
     // output.reshape(outputShape)
     ValueRange loopDef = create.krnl.defineLoops(2);
-    DimsExpr lbs(2, LitIE(0)),
-        ubs = {newIndicesShape[0], newIndicesShape[1]};
+    DimsExpr lbs(2, LitIE(0)), ubs = {newIndicesShape[0], newIndicesShape[1]};
 
     if (emitPrintStmts) {
       create.krnl.printTensor("reshapedIndices: ", reshapedIndices);

--- a/src/Conversion/ONNXToKrnl/Tensor/GatherND.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/GatherND.cpp
@@ -154,7 +154,7 @@ struct ONNXGatherNDOpLowering : public OpConversionPattern<ONNXGatherNDOp> {
           // Access function for 'reshapedData'. The first index is equal to the
           // first loop index.
           DimsExpr reshapedDataAccessFct;
-          IndexExpr ind = SymbolIndexExpr(loopInd[0]);
+          IndexExpr ind = SymIE(loopInd[0]);
           reshapedDataAccessFct.emplace_back(ind);
 
           // The last index of the access function for 'reshapedIndices' is
@@ -213,7 +213,7 @@ struct ONNXGatherNDOpLowering : public OpConversionPattern<ONNXGatherNDOp> {
             ValueRange innerLoopDef = create.krnl.defineLoops(1);
             create.krnl.iterate(innerLoopDef, innerLoopDef, {zero}, {last},
                 [&](KrnlBuilder &createKrnl, ValueRange innerLoopInd) {
-                  IndexExpr ind = SymbolIndexExpr(innerLoopInd[0]);
+                  IndexExpr ind = SymIE(innerLoopInd[0]);
                   reshapedDataAccessFct.emplace_back(ind);
                   assert((int64_t)reshapedDataAccessFct.size() ==
                              reshapedDataRank &&

--- a/src/Conversion/ONNXToKrnl/Tensor/GatherND.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/GatherND.cpp
@@ -133,7 +133,7 @@ struct ONNXGatherNDOpLowering : public OpConversionPattern<ONNXGatherNDOp> {
     // }
     // output.reshape(outputShape)
     ValueRange loopDef = create.krnl.defineLoops(2);
-    DimsExpr lbs(2, LiteralIndexExpr(0)),
+    DimsExpr lbs(2, LitIE(0)),
         ubs = {newIndicesShape[0], newIndicesShape[1]};
 
     if (emitPrintStmts) {
@@ -162,7 +162,7 @@ struct ONNXGatherNDOpLowering : public OpConversionPattern<ONNXGatherNDOp> {
           // The loaded values from 'reshapedIndices' are the next set of
           // indices to push to the `reshapedDataAccessFct`.
           for (unsigned i = 0; i < indicesLastDim; ++i) {
-            IndexExpr ind = LiteralIndexExpr(i);
+            IndexExpr ind = LitIE(i);
             reshapedIndicesAccessFct.emplace_back(ind);
 
             if (emitPrintStmts)

--- a/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
@@ -107,7 +107,7 @@ struct ONNXNonZeroOpLowering : public OpConversionPattern<ONNXNonZeroOp> {
     Value zero = create.math.constant(xElementType, 0);
 
     // Bounds for the input tensor.
-    SmallVector<IndexExpr, 4> xLbs(xRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> xLbs(xRank, LitIE(0));
     SmallVector<IndexExpr, 4> xUbs;
     create.krnlIE.getShapeAsDims(X, xUbs);
 
@@ -162,7 +162,7 @@ struct ONNXNonZeroOpLowering : public OpConversionPattern<ONNXNonZeroOp> {
     // non zero values.
     Value numberOfZeros = create.krnl.load(nonzeroCount);
     SmallVector<IndexExpr, 2> dimExprs;
-    dimExprs.emplace_back(LiteralIndexExpr(xRank));
+    dimExprs.emplace_back(LitIE(xRank));
     dimExprs.emplace_back(DimIndexExpr(numberOfZeros));
     Value resMemRef = create.mem.alignedAlloc(resMemRefType, dimExprs);
 

--- a/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/NonZero.cpp
@@ -163,7 +163,7 @@ struct ONNXNonZeroOpLowering : public OpConversionPattern<ONNXNonZeroOp> {
     Value numberOfZeros = create.krnl.load(nonzeroCount);
     SmallVector<IndexExpr, 2> dimExprs;
     dimExprs.emplace_back(LitIE(xRank));
-    dimExprs.emplace_back(DimIndexExpr(numberOfZeros));
+    dimExprs.emplace_back(DimIE(numberOfZeros));
     Value resMemRef = create.mem.alignedAlloc(resMemRefType, dimExprs);
 
     // Emit code to compute the output for each dimension.

--- a/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
@@ -102,7 +102,7 @@ struct ONNXPadOpLowering : public OpConversionPattern<ONNXPadOp> {
             SmallVector<IndexExpr, 4> resLoopInd;
             for (uint64_t i = 0; i < rank; ++i) {
               IndexExpr resInd =
-                  DimIndexExpr(dataLoopInd[i]) + shapeHelper.pads[i];
+                  DimIE(dataLoopInd[i]) + shapeHelper.pads[i];
               resLoopInd.emplace_back(resInd);
             }
             Value dataValue = createKrnl.load(data, dataLoopInd);
@@ -122,7 +122,7 @@ struct ONNXPadOpLowering : public OpConversionPattern<ONNXPadOp> {
                 createKrnl);
             SmallVector<IndexExpr, 4> dataLoopInd;
             for (uint64_t i = 0; i < rank; ++i) {
-              IndexExpr dataInd = DimIndexExpr(resLoopInd[i]);
+              IndexExpr dataInd = DimIE(resLoopInd[i]);
               IndexExpr pad = shapeHelper.pads[i];
               IndexExpr dim = create.krnlIE.getShapeAsDim(data, i);
               if (padMode.equals_insensitive("edge")) {

--- a/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Pad.cpp
@@ -101,8 +101,7 @@ struct ONNXPadOpLowering : public OpConversionPattern<ONNXPadOp> {
           [&](KrnlBuilder &createKrnl, ValueRange dataLoopInd) {
             SmallVector<IndexExpr, 4> resLoopInd;
             for (uint64_t i = 0; i < rank; ++i) {
-              IndexExpr resInd =
-                  DimIE(dataLoopInd[i]) + shapeHelper.pads[i];
+              IndexExpr resInd = DimIE(dataLoopInd[i]) + shapeHelper.pads[i];
               resLoopInd.emplace_back(resInd);
             }
             Value dataValue = createKrnl.load(data, dataLoopInd);

--- a/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
@@ -150,7 +150,7 @@ struct ONNXRangeOpLowering : public OpConversionPattern<ONNXRangeOp> {
 
     // Acc index:
     SmallVector<IndexExpr, 4> accIndex;
-    accIndex.emplace_back(LiteralIndexExpr(0));
+    accIndex.emplace_back(LitIE(0));
 
     // Initialize accumulator with value:
     create.krnl.storeIE(loadedStart, acc, accIndex);
@@ -158,7 +158,7 @@ struct ONNXRangeOpLowering : public OpConversionPattern<ONNXRangeOp> {
     ValueRange loopDef = create.krnl.defineLoops(1);
     SmallVector<IndexExpr, 4> ubs;
     create.krnlIE.getShapeAsDims(alloc, ubs);
-    create.krnl.iterateIE(loopDef, loopDef, {LiteralIndexExpr(0)}, ubs,
+    create.krnl.iterateIE(loopDef, loopDef, {LitIE(0)}, ubs,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           // Emit body of the loop:
           // output[i] = start + (i * delta);

--- a/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Range.cpp
@@ -167,7 +167,7 @@ struct ONNXRangeOpLowering : public OpConversionPattern<ONNXRangeOp> {
 
           // Store result:
           SmallVector<IndexExpr, 4> resultIndices;
-          resultIndices.emplace_back(DimIndexExpr(loopInd[0]));
+          resultIndices.emplace_back(DimIE(loopInd[0]));
           createKrnl.storeIE(result, alloc, resultIndices);
 
           // Increment result:

--- a/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Resize.cpp
@@ -118,7 +118,7 @@ struct ONNXResizeOpLowering : public OpConversionPattern<ONNXResizeOp> {
     Value one = create.math.constantIndex(1);
 
     ValueRange loopDef = create.krnl.defineLoops(rank);
-    SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(rank, LitIE(0));
     SmallVector<IndexExpr, 4> ubs;
     create.krnlIE.getShapeAsDims(alloc, ubs);
     create.krnl.iterateIE(

--- a/src/Conversion/ONNXToKrnl/Tensor/ReverseSequence.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ReverseSequence.cpp
@@ -94,7 +94,7 @@ struct ONNXReverseSequenceOpLowering
 
     // Define loops and iteration trip counts (equivalent to size of output)
     ValueRange loopDef = create.krnl.defineLoops(outputRank);
-    SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
     create.krnl.iterateIE(loopDef, loopDef, lbs, shapeHelper.getOutputDims(),
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           IndexExprScope innerLoopScope(&rewriter, shapeHelper.getScope());

--- a/src/Conversion/ONNXToKrnl/Tensor/ScatterElements.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ScatterElements.cpp
@@ -74,7 +74,7 @@ struct ONNXScatterElementsOpLowering
     //   output[i][j]..[index]..[n] = val (index used at position axis)
     //
     ValueRange loopDef = create.krnl.defineLoops(updatesRank);
-    DimsExpr lbs(updatesRank, LiteralIndexExpr(0)), ubs;
+    DimsExpr lbs(updatesRank, LitIE(0)), ubs;
     create.krnlIE.getShapeAsDims(updates, ubs);
     create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {

--- a/src/Conversion/ONNXToKrnl/Tensor/ScatterND.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ScatterND.cpp
@@ -69,7 +69,7 @@ struct ONNXScatterNDOpLowering : public OpConversionPattern<ONNXScatterNDOp> {
     //     output[indices[idx]] = updates[idx]
     //
     ValueRange loopDef = create.krnl.defineLoops(updatesRank);
-    DimsExpr lbs(updatesRank, LiteralIndexExpr(0)), ubs;
+    DimsExpr lbs(updatesRank, LitIE(0)), ubs;
     create.krnlIE.getShapeAsDims(updates, ubs);
     create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
@@ -91,7 +91,7 @@ struct ONNXScatterNDOpLowering : public OpConversionPattern<ONNXScatterNDOp> {
           DimsExpr outputAccessFct;
           for (unsigned i = 0; i < dataRank; ++i) {
             if (i < indicesRank - 1) {
-              IndexExpr ind = LiteralIndexExpr(i);
+              IndexExpr ind = LitIE(i);
               DimsExpr indicesAccessFct(indicesAccessFctFirst);
               indicesAccessFct.emplace_back(ind);
               Value indexVal = createKrnl.loadIE(indices, indicesAccessFct);

--- a/src/Conversion/ONNXToKrnl/Tensor/ScatterND.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ScatterND.cpp
@@ -98,7 +98,7 @@ struct ONNXScatterNDOpLowering : public OpConversionPattern<ONNXScatterNDOp> {
               IndexExpr index = NonAffineIndexExpr(indexVal);
               outputAccessFct.emplace_back(index);
             } else {
-              IndexExpr index = SymbolIndexExpr(
+              IndexExpr index = SymIE(
                   loopInd[std::min<unsigned>(i, loopInd.size() - 1)]);
               outputAccessFct.emplace_back(index);
             }

--- a/src/Conversion/ONNXToKrnl/Tensor/ScatterND.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ScatterND.cpp
@@ -98,8 +98,8 @@ struct ONNXScatterNDOpLowering : public OpConversionPattern<ONNXScatterNDOp> {
               IndexExpr index = NonAffineIndexExpr(indexVal);
               outputAccessFct.emplace_back(index);
             } else {
-              IndexExpr index = SymIE(
-                  loopInd[std::min<unsigned>(i, loopInd.size() - 1)]);
+              IndexExpr index =
+                  SymIE(loopInd[std::min<unsigned>(i, loopInd.size() - 1)]);
               outputAccessFct.emplace_back(index);
             }
           }

--- a/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Shape.cpp
@@ -59,7 +59,7 @@ struct ONNXShapeOpLowering : public OpConversionPattern<ONNXShapeOp> {
     for (uint64_t i = 0; i < selectedData.size(); ++i) {
       Value val = selectedData[i].getValue();
       Value intVal = create.math.cast(elementType, val);
-      create.krnl.storeIE(intVal, alloc, {LiteralIndexExpr(i)});
+      create.krnl.storeIE(intVal, alloc, {LitIE(i)});
     }
     rewriter.replaceOp(op, alloc);
     onnxToKrnlSimdReport(op);

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -58,8 +58,8 @@ struct ONNXSliceOpLowering : public OpConversionPattern<ONNXSliceOp> {
           SmallVector<IndexExpr, 4> loadIndices, storeIndices;
           for (int ii = 0; ii < outputRank; ++ii) {
             DimIndexExpr inductionIndex(loopInd[ii]);
-            IndexExpr start = SymbolIndexExpr(shapeHelper.starts[ii]);
-            IndexExpr step = SymbolIndexExpr(shapeHelper.steps[ii]);
+            IndexExpr start = SymIE(shapeHelper.starts[ii]);
+            IndexExpr step = SymIE(shapeHelper.steps[ii]);
             loadIndices.emplace_back((step * inductionIndex) + start);
             storeIndices.emplace_back(inductionIndex);
           }

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -47,7 +47,7 @@ struct ONNXSliceOpLowering : public OpConversionPattern<ONNXSliceOp> {
         create.mem.alignedAlloc(outputMemRefType, shapeHelper.getOutputDims());
 
     ValueRange loopDef = create.krnl.defineLoops(outputRank);
-    SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
     create.krnl.iterateIE(loopDef, loopDef, lbs, shapeHelper.getOutputDims(),
         [&](KrnlBuilder &createKrnl, ValueRange loopInd) {
           IndexExprScope loopScope(createKrnl);

--- a/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Split.cpp
@@ -64,7 +64,7 @@ LogicalResult ONNXSplitOpLoweringCommon(OP_TYPE splitOp, OP_ADAPTOR adaptor,
         rewriter, loc);
 
     ValueRange loopDef = create.krnl.defineLoops(rank);
-    SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(rank, LitIE(0));
 
     SmallVector<IndexExpr, 4> ubs;
     create.krnlIE.getShapeAsDims(allocs[i], ubs);

--- a/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Tile.cpp
@@ -78,7 +78,7 @@ struct ONNXTileOpLowering : public OpConversionPattern<ONNXTileOp> {
         create.mem.alignedAlloc(memRefType, shapeHelper.getOutputDims());
 
     ValueRange loopDef = create.krnl.defineLoops(outputRank);
-    SmallVector<IndexExpr, 4> lbs(outputRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
 
     create.krnl.iterateIE(loopDef, loopDef, lbs, shapeHelper.getOutputDims(),
         [&](KrnlBuilder &createKrnl, ValueRange indices) {

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -166,7 +166,7 @@ private:
           SmallVector<IndexExpr, 4> storeIndices;
           for (uint64_t i = 0; i < rank; ++i) {
             Value index = indices[ArrayAttrIntVal(permAttr, i)];
-            storeIndices.emplace_back(DimIndexExpr(index));
+            storeIndices.emplace_back(DimIE(index));
           }
           Value loadData = createKrnl.load(inputMemRef, indices);
           createKrnl.storeIE(loadData, outputMemRef, storeIndices);

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -245,12 +245,12 @@ private:
             // source offset
             DimIndexExpr srcIndex(indices[i]);
             srcOffsetIE =
-                srcOffsetIE + srcIndex * SymbolIndexExpr(inStrides[i]);
+                srcOffsetIE + srcIndex * SymIE(inStrides[i]);
             // destination offset
             DimIndexExpr destIndex(indices[ArrayAttrIntVal(permAttr, i)]);
             // Note: index for outStrides is not the permuted index.
             destOffsetIE =
-                destOffsetIE + destIndex * SymbolIndexExpr(outStrides[i]);
+                destOffsetIE + destIndex * SymIE(outStrides[i]);
           }
           // call memcpy.
           create.krnl.memcpy(outputMemRef, inputMemRef, elemsToCopyI64,

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -244,13 +244,11 @@ private:
           for (uint64_t i = 0; i < outerRank; ++i) {
             // source offset
             DimIndexExpr srcIndex(indices[i]);
-            srcOffsetIE =
-                srcOffsetIE + srcIndex * SymIE(inStrides[i]);
+            srcOffsetIE = srcOffsetIE + srcIndex * SymIE(inStrides[i]);
             // destination offset
             DimIndexExpr destIndex(indices[ArrayAttrIntVal(permAttr, i)]);
             // Note: index for outStrides is not the permuted index.
-            destOffsetIE =
-                destOffsetIE + destIndex * SymIE(outStrides[i]);
+            destOffsetIE = destOffsetIE + destIndex * SymIE(outStrides[i]);
           }
           // call memcpy.
           create.krnl.memcpy(outputMemRef, inputMemRef, elemsToCopyI64,

--- a/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Transpose.cpp
@@ -143,7 +143,7 @@ private:
       bool enableParallel) const {
     uint64_t rank = mlir::cast<MemRefType>(outputMemRef.getType()).getRank();
     ValueRange loopDef = create->krnl.defineLoops(rank);
-    SmallVector<IndexExpr, 4> lbs(rank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(rank, LitIE(0));
     SmallVector<IndexExpr, 4> ubs;
     create->krnlIE.getShapeAsDims(inputMemRef, ubs);
 
@@ -192,13 +192,13 @@ private:
     // Strides
     SmallVector<IndexExpr, 4> inStrides, outStrides;
     inStrides.resize_for_overwrite(rank);
-    inStrides[rank - 1] = LiteralIndexExpr(1);
-    IndexExpr strideIE = LiteralIndexExpr(1);
+    inStrides[rank - 1] = LitIE(1);
+    IndexExpr strideIE = LitIE(1);
     for (int i = rank - 2; i >= 0; --i) {
       strideIE = strideIE * inUBs[i + 1];
       inStrides[i] = strideIE;
     }
-    strideIE = LiteralIndexExpr(1);
+    strideIE = LitIE(1);
     outStrides.resize_for_overwrite(rank);
     for (int i = rank - 2; i >= 0; --i) {
       strideIE = strideIE * outUBs[i + 1];
@@ -207,7 +207,7 @@ private:
 
     // The number of elements in a block to copy, computed for the last N
     // dimensions.
-    IndexExpr elemsToCopy = LiteralIndexExpr(1);
+    IndexExpr elemsToCopy = LitIE(1);
     for (uint64_t i = rank - numLastDims; i < rank; ++i)
       elemsToCopy = elemsToCopy * inUBs[i];
     Value elemsToCopyI64 = create->math.cast(i64Ty, elemsToCopy.getValue());
@@ -220,7 +220,7 @@ private:
 
     // Main loop defined over the outer-most dimensions.
     ValueRange loopDef = create->krnl.defineLoops(outerRank);
-    SmallVector<IndexExpr, 4> lbs(outerRank, LiteralIndexExpr(0));
+    SmallVector<IndexExpr, 4> lbs(outerRank, LitIE(0));
     if (enableParallel) {
       int64_t parId;
       // Note that if there is only 1 dim, lastExclusiveDim is automatically
@@ -239,8 +239,8 @@ private:
           MultiDialectBuilder<MathBuilder, KrnlBuilder> create(createKrnl);
           IndexExprScope loopScope(createKrnl);
           // Compute destination and source offsets for memcpy.
-          IndexExpr destOffsetIE = LiteralIndexExpr(0);
-          IndexExpr srcOffsetIE = LiteralIndexExpr(0);
+          IndexExpr destOffsetIE = LitIE(0);
+          IndexExpr srcOffsetIE = LitIE(0);
           for (uint64_t i = 0; i < outerRank; ++i) {
             // source offset
             DimIndexExpr srcIndex(indices[i]);

--- a/src/Conversion/ONNXToKrnl/Tensor/Unique.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Unique.cpp
@@ -134,7 +134,7 @@ struct ONNXUniqueOpLowering : public ConversionPattern {
     // Calculate shapes of output Tensors
     //
     Value total = create.krnl.load(uniqueCount);
-    NonAffineIndexExpr totalDimExpr = DimIndexExpr(total);
+    NonAffineIndexExpr totalDimExpr = DimIE(total);
     DimsExpr outputYDims;
     DimsExpr outputIndexDims;
     DimsExpr outputInverseIndexDims;

--- a/src/Conversion/ONNXToKrnl/Tensor/Unique.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Unique.cpp
@@ -126,14 +126,14 @@ struct ONNXUniqueOpLowering : public ConversionPattern {
     Type indexTy = rewriter.getIndexType();
     Value iZero = create.math.constantIndex(0);
     Value uniqueCount = create.mem.alloca(MemRefType::get({}, indexTy));
-    create.krnl.store(iZero, uniqueCount, {});
+    create.krnl.store(iZero, uniqueCount);
     Value noneValue;
     emitArgUnique(rewriter, loc, uniqueCount, X, axis, /*sorted=*/sorted,
         noneValue, noneValue, noneValue, noneValue, /*count_only=*/true);
     //
     // Calculate shapes of output Tensors
     //
-    Value total = create.krnl.load(uniqueCount, {});
+    Value total = create.krnl.load(uniqueCount);
     NonAffineIndexExpr totalDimExpr = DimIndexExpr(total);
     DimsExpr outputYDims;
     DimsExpr outputIndexDims;
@@ -211,7 +211,7 @@ struct ONNXUniqueOpLowering : public ConversionPattern {
     //
     // Emit a Unique call to get the outputs
     //
-    create.krnl.store(iZero, uniqueCount, {});
+    create.krnl.store(iZero, uniqueCount);
     emitArgUnique(rewriter, loc, uniqueCount, X, axis, /*sorted=*/sorted,
         outputY, indices, inverseIndices, counts, /*count_only=*/false);
     if (isNoneValue(indices))

--- a/src/Conversion/ONNXToStablehlo/ONNXToStablehloCommon.cpp
+++ b/src/Conversion/ONNXToStablehlo/ONNXToStablehloCommon.cpp
@@ -117,7 +117,7 @@ DenseIntElementsAttr GetI64ElementsAttr(
 namespace {
 // Returns the DenseElementsAttr of input if it's a stablehlo constant or
 // onnx.Constant. Otherwise returns a nullptr attribute.
-DenseElementsAttr getDenseElementAttrFromConstValue(mlir::Value value) {
+DenseElementsAttr getDenseElementAttrFromConstValue(Value value) {
   Operation *definingOp = value.getDefiningOp();
   if (auto globalOp = dyn_cast_or_null<stablehlo::ConstantOp>(definingOp)) {
     return mlir::dyn_cast<DenseElementsAttr>(globalOp.getValueAttr());

--- a/src/Conversion/ONNXToStablehlo/RNN/LSTM.cpp
+++ b/src/Conversion/ONNXToStablehlo/RNN/LSTM.cpp
@@ -497,7 +497,7 @@ void stateToOutput<ONNXLSTMOp, LstmState>(ConversionPatternRewriter &rewriter,
 template <>
 void calculateStateWithUnroll<ONNXLSTMOp, LstmState, LstmActivationPack,
     LstmWeightPack, LstmBiasPack>(mlir::ConversionPatternRewriter &rewriter,
-    mlir::Location loc, llvm::StringRef direction, int64_t sequenceDimSize,
+    Location loc, llvm::StringRef direction, int64_t sequenceDimSize,
     Value X, LstmState &state, LstmActivationPack activationForward,
     LstmActivationPack activationReverse, LstmWeightPack weightForward,
     LstmWeightPack weightReverse, LstmBiasPack biasForward,
@@ -506,10 +506,10 @@ void calculateStateWithUnroll<ONNXLSTMOp, LstmState, LstmActivationPack,
 
   if (direction == FORWARD || direction == BIDIRECTIONAL) {
     for (int64_t i = 0; i < sequenceDimSize; i++) {
-      mlir::Value directionIV = create.onnx.constantInt64({0});
-      mlir::Value sequenceIV = create.onnx.constantInt64({i});
+      Value directionIV = create.onnx.constantInt64({0});
+      Value sequenceIV = create.onnx.constantInt64({i});
       // Get a slice of X at the current timestep.
-      mlir::Value Xt = emitXSliceAt(rewriter, loc, X, sequenceIV);
+      Value Xt = emitXSliceAt(rewriter, loc, X, sequenceIV);
       // Emit calculation for one RNN step.
       calculateState<LstmState, LstmActivationPack, LstmWeightPack,
           LstmBiasPack>(rewriter, loc, Xt, state, activationForward,
@@ -520,12 +520,12 @@ void calculateStateWithUnroll<ONNXLSTMOp, LstmState, LstmActivationPack,
 
   if (direction == REVERSE || direction == BIDIRECTIONAL) {
     for (int64_t i = 0; i < sequenceDimSize; i++) {
-      mlir::Value directionIV =
+      Value directionIV =
           create.onnx.constantInt64({(direction == REVERSE) ? 0 : 1});
-      mlir::Value reverseSequenceIV =
+      Value reverseSequenceIV =
           create.onnx.constantInt64({sequenceDimSize - i - 1});
       // Get a slice of X at the current timestep.
-      mlir::Value Xt = emitXSliceAt(rewriter, loc, X, reverseSequenceIV);
+      Value Xt = emitXSliceAt(rewriter, loc, X, reverseSequenceIV);
       // Emit calculation for one RNN step.
       calculateState<LstmState, LstmActivationPack, LstmWeightPack,
           LstmBiasPack>(rewriter, loc, Xt, state, activationReverse,
@@ -538,7 +538,7 @@ void calculateStateWithUnroll<ONNXLSTMOp, LstmState, LstmActivationPack,
 template <>
 void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
     LstmWeightPack, LstmBiasPack>(mlir::ConversionPatternRewriter &rewriter,
-    mlir::Location loc, llvm::StringRef direction, int64_t sequenceDimSize,
+    Location loc, llvm::StringRef direction, int64_t sequenceDimSize,
     Value X, LstmState &state, LstmActivationPack activationForward,
     LstmActivationPack activationReverse, LstmWeightPack weightForward,
     LstmWeightPack weightReverse, LstmBiasPack biasForward,
@@ -546,8 +546,8 @@ void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
   MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
 
   if (direction == FORWARD || direction == BIDIRECTIONAL) {
-    mlir::Value directionIV = create.onnx.constantInt64({0});
-    mlir::Value sequenceIV = create.onnx.constantInt64({0});
+    Value directionIV = create.onnx.constantInt64({0});
+    Value sequenceIV = create.onnx.constantInt64({0});
     SmallVector<Value> operands = {
         sequenceIV, state.allHForward, state.forwardHt, state.forwardCt};
     SmallVector<Type> returnedTypes = {sequenceIV.getType(),
@@ -565,7 +565,7 @@ void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(&condBlock);
       BlockArgument lhs = condBlock.getArgument(0);
-      mlir::Value rhs = create.onnx.constantInt64({sequenceDimSize});
+      Value rhs = create.onnx.constantInt64({sequenceDimSize});
       Value compareResult = rewriter.create<::stablehlo::CompareOp>(
           loc, lhs, rhs, ::stablehlo::ComparisonDirection::LT);
       compareResult = rewriter.create<::stablehlo::ReshapeOp>(
@@ -583,12 +583,12 @@ void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
       state.allHForward = allH;
       state.forwardHt = ht;
       state.forwardCt = ct;
-      mlir::Value Xt = emitXSliceAt(rewriter, loc, X, seqIV);
+      Value Xt = emitXSliceAt(rewriter, loc, X, seqIV);
       calculateState<LstmState, LstmActivationPack, LstmWeightPack,
           LstmBiasPack>(rewriter, loc, Xt, state, activationForward,
           weightForward, biasForward, seqIV, directionIV, sequenceLens,
           initialH, /*enableUnroll=*/false, /*isForward=*/true);
-      mlir::Value one = create.onnx.constantInt64({1});
+      Value one = create.onnx.constantInt64({1});
       Value newSeqIV = create.onnx.add(seqIV, one);
       rewriter.create<::stablehlo::ReturnOp>(loc,
           ValueRange(
@@ -600,9 +600,9 @@ void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
   }
 
   if (direction == REVERSE || direction == BIDIRECTIONAL) {
-    mlir::Value directionIV =
+    Value directionIV =
         create.onnx.constantInt64({(direction == REVERSE) ? 0 : 1});
-    mlir::Value reverseSequenceIV =
+    Value reverseSequenceIV =
         create.onnx.constantInt64({sequenceDimSize - 1});
 
     SmallVector<Value> operands = {
@@ -622,7 +622,7 @@ void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(&condBlock);
       BlockArgument lhs = condBlock.getArgument(0);
-      mlir::Value rhs = create.onnx.constantInt64({0});
+      Value rhs = create.onnx.constantInt64({0});
       Value compareResult = rewriter.create<::stablehlo::CompareOp>(
           loc, lhs, rhs, ::stablehlo::ComparisonDirection::GE);
       compareResult = rewriter.create<::stablehlo::ReshapeOp>(
@@ -640,12 +640,12 @@ void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
       state.allHReverse = allH;
       state.reverseHt = ht;
       state.reverseCt = ct;
-      mlir::Value Xt = emitXSliceAt(rewriter, loc, X, revseqIV);
+      Value Xt = emitXSliceAt(rewriter, loc, X, revseqIV);
       calculateState<LstmState, LstmActivationPack, LstmWeightPack,
           LstmBiasPack>(rewriter, loc, Xt, state, activationReverse,
           weightReverse, biasReverse, revseqIV, directionIV, sequenceLens,
           initialH, /*enableUnroll=*/false, /*isForward=*/false);
-      mlir::Value one = create.onnx.constantInt64({1});
+      Value one = create.onnx.constantInt64({1});
       Value newrevseqIV = create.onnx.sub(revseqIV, one);
       rewriter.create<::stablehlo::ReturnOp>(
           loc, ValueRange({newrevseqIV, state.allHReverse, state.reverseHt,

--- a/src/Conversion/ONNXToStablehlo/RNN/LSTM.cpp
+++ b/src/Conversion/ONNXToStablehlo/RNN/LSTM.cpp
@@ -497,8 +497,8 @@ void stateToOutput<ONNXLSTMOp, LstmState>(ConversionPatternRewriter &rewriter,
 template <>
 void calculateStateWithUnroll<ONNXLSTMOp, LstmState, LstmActivationPack,
     LstmWeightPack, LstmBiasPack>(mlir::ConversionPatternRewriter &rewriter,
-    Location loc, llvm::StringRef direction, int64_t sequenceDimSize,
-    Value X, LstmState &state, LstmActivationPack activationForward,
+    Location loc, llvm::StringRef direction, int64_t sequenceDimSize, Value X,
+    LstmState &state, LstmActivationPack activationForward,
     LstmActivationPack activationReverse, LstmWeightPack weightForward,
     LstmWeightPack weightReverse, LstmBiasPack biasForward,
     LstmBiasPack biasReverse, Value sequenceLens, Value initialH) {
@@ -538,8 +538,8 @@ void calculateStateWithUnroll<ONNXLSTMOp, LstmState, LstmActivationPack,
 template <>
 void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
     LstmWeightPack, LstmBiasPack>(mlir::ConversionPatternRewriter &rewriter,
-    Location loc, llvm::StringRef direction, int64_t sequenceDimSize,
-    Value X, LstmState &state, LstmActivationPack activationForward,
+    Location loc, llvm::StringRef direction, int64_t sequenceDimSize, Value X,
+    LstmState &state, LstmActivationPack activationForward,
     LstmActivationPack activationReverse, LstmWeightPack weightForward,
     LstmWeightPack weightReverse, LstmBiasPack biasForward,
     LstmBiasPack biasReverse, Value sequenceLens, Value initialH) {
@@ -602,8 +602,7 @@ void calculateStateWithLoop<ONNXLSTMOp, LstmState, LstmActivationPack,
   if (direction == REVERSE || direction == BIDIRECTIONAL) {
     Value directionIV =
         create.onnx.constantInt64({(direction == REVERSE) ? 0 : 1});
-    Value reverseSequenceIV =
-        create.onnx.constantInt64({sequenceDimSize - 1});
+    Value reverseSequenceIV = create.onnx.constantInt64({sequenceDimSize - 1});
 
     SmallVector<Value> operands = {
         reverseSequenceIV, state.allHReverse, state.reverseHt, state.reverseCt};

--- a/src/Conversion/ONNXToStablehlo/RNN/RNNBase.cpp
+++ b/src/Conversion/ONNXToStablehlo/RNN/RNNBase.cpp
@@ -34,8 +34,8 @@ Value allocAllHidden(
 }
 
 /// Allocate the hidden or cell output.
-mlir::Value allocHiddenOrCell(mlir::ConversionPatternRewriter &rewriter,
-    mlir::Location loc, mlir::Value X, mlir::Value W, mlir::Value R) {
+Value allocHiddenOrCell(mlir::ConversionPatternRewriter &rewriter,
+    Location loc, Value X, Value W, Value R) {
   MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
   RankedTensorType zeroType = RankedTensorType::get(
       {/*num_directions=*/dimAt(W, 0), /*batch_size=*/dimAt(X, 1),

--- a/src/Conversion/ONNXToStablehlo/RNN/RNNBase.cpp
+++ b/src/Conversion/ONNXToStablehlo/RNN/RNNBase.cpp
@@ -34,8 +34,8 @@ Value allocAllHidden(
 }
 
 /// Allocate the hidden or cell output.
-Value allocHiddenOrCell(mlir::ConversionPatternRewriter &rewriter,
-    Location loc, Value X, Value W, Value R) {
+Value allocHiddenOrCell(mlir::ConversionPatternRewriter &rewriter, Location loc,
+    Value X, Value W, Value R) {
   MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
   RankedTensorType zeroType = RankedTensorType::get(
       {/*num_directions=*/dimAt(W, 0), /*batch_size=*/dimAt(X, 1),

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -127,7 +127,7 @@ Value TosaBuilder::getSplattedConst(float val, llvm::ArrayRef<int64_t> shape) {
   return constOp;
 }
 
-Value TosaBuilder::transpose(mlir::Value &value, llvm::ArrayRef<int32_t> perm) {
+Value TosaBuilder::transpose(Value &value, llvm::ArrayRef<int32_t> perm) {
   int64_t valueRank = mlir::cast<RankedTensorType>(value.getType()).getRank();
   assert((valueRank == (int64_t)perm.size()) &&
          "value and perm vector don't have the same rank");
@@ -158,7 +158,7 @@ Value TosaBuilder::slice(Value &inputConst, llvm::ArrayRef<int64_t> size,
   return newSliceInput;
 }
 
-Value TosaBuilder::reshape(mlir::Value &value, llvm::ArrayRef<int64_t> shape) {
+Value TosaBuilder::reshape(Value &value, llvm::ArrayRef<int64_t> shape) {
   auto shapeAttr = rewriter().getDenseI64ArrayAttr(shape);
   auto valueType = mlir::cast<ShapedType>(value.getType());
   Type newValueType = RankedTensorType::get(
@@ -168,7 +168,7 @@ Value TosaBuilder::reshape(mlir::Value &value, llvm::ArrayRef<int64_t> shape) {
       rewriter(), loc(), newValueType, value, shapeAttr);
 }
 
-Value TosaBuilder::mul(mlir::Value &lhs, mlir::Value &rhs, int32_t shift) {
+Value TosaBuilder::mul(Value &lhs, Value &rhs, int32_t shift) {
   if (needsRankBroadcast({lhs, rhs})) {
     llvm::SmallVector<Value, 4> valueVec = equalizeRanks({lhs, rhs});
     lhs = valueVec[0];
@@ -182,7 +182,7 @@ Value TosaBuilder::mul(mlir::Value &lhs, mlir::Value &rhs, int32_t shift) {
       rewriter(), loc(), newValueType, lhs, rhs, shift);
 }
 
-Value TosaBuilder::intdiv(mlir::Value &lhs, mlir::Value &rhs) {
+Value TosaBuilder::intdiv(Value &lhs, Value &rhs) {
   Type lhsElementType = mlir::cast<ShapedType>(lhs.getType()).getElementType();
   Type rhsElementType = mlir::cast<ShapedType>(rhs.getType()).getElementType();
   assert((lhsElementType.isSignlessInteger(32) &&
@@ -203,7 +203,7 @@ Value TosaBuilder::intdiv(mlir::Value &lhs, mlir::Value &rhs) {
       rewriter(), loc(), newValueType, lhs, rhs);
 }
 
-Value TosaBuilder::reciprocal(mlir::Value &input) {
+Value TosaBuilder::reciprocal(Value &input) {
   auto inputType = mlir::cast<ShapedType>(input.getType());
   Type newValueType = RankedTensorType::get(
       llvm::SmallVector<int64_t, 4>(inputType.getRank(), ShapedType::kDynamic),
@@ -213,7 +213,7 @@ Value TosaBuilder::reciprocal(mlir::Value &input) {
 }
 
 template <typename T>
-Value TosaBuilder::binaryOp(mlir::Value &lhs, mlir::Value &rhs) {
+Value TosaBuilder::binaryOp(Value &lhs, Value &rhs) {
   if (needsRankBroadcast({lhs, rhs})) {
     llvm::SmallVector<Value, 4> valueVec = equalizeRanks({lhs, rhs});
     lhs = valueVec[0];
@@ -227,10 +227,10 @@ Value TosaBuilder::binaryOp(mlir::Value &lhs, mlir::Value &rhs) {
 }
 
 template Value TosaBuilder::binaryOp<mlir::tosa::AddOp>(
-    mlir::Value &lhs, mlir::Value &rhs);
+    Value &lhs, Value &rhs);
 
 template Value TosaBuilder::binaryOp<mlir::tosa::SubOp>(
-    mlir::Value &lhs, mlir::Value &rhs);
+    Value &lhs, Value &rhs);
 // =============================================================================
 // IndexExpr Builder for Lowering using Shape/TOSA Dialect.
 // =============================================================================

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -226,11 +226,9 @@ Value TosaBuilder::binaryOp(Value &lhs, Value &rhs) {
   return tosa::CreateOpAndInfer<T>(rewriter(), loc(), newValueType, lhs, rhs);
 }
 
-template Value TosaBuilder::binaryOp<mlir::tosa::AddOp>(
-    Value &lhs, Value &rhs);
+template Value TosaBuilder::binaryOp<mlir::tosa::AddOp>(Value &lhs, Value &rhs);
 
-template Value TosaBuilder::binaryOp<mlir::tosa::SubOp>(
-    Value &lhs, Value &rhs);
+template Value TosaBuilder::binaryOp<mlir::tosa::SubOp>(Value &lhs, Value &rhs);
 // =============================================================================
 // IndexExpr Builder for Lowering using Shape/TOSA Dialect.
 // =============================================================================

--- a/src/Conversion/ONNXToTOSA/Math/ReduceMean.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/ReduceMean.cpp
@@ -83,7 +83,7 @@ public:
       numElemsOnReducedAxis *= inputType.getShape()[axisVal];
     }
     double divScale = 1.0 / static_cast<double>(numElemsOnReducedAxis);
-    mlir::Type reduceElementType = inputType.getElementType();
+    Type reduceElementType = inputType.getElementType();
 
     auto val = onnx_mlir::tosa::convertReduceOpCommon<mlir::tosa::ReduceSumOp>(
         rewriter, op, outputType, input, newAxesAttr, keepDims,

--- a/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
@@ -30,7 +30,7 @@ namespace {
 
 void handleIncludePadAttr(
     ConversionPatternRewriter &rewriter, Operation *op, Value input) {
-  mlir::Location loc = op->getLoc();
+  Location loc = op->getLoc();
 
   // Get shape.
   IndexExprBuilderForTosa createTosaIE(rewriter, loc);

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -36,13 +36,13 @@ namespace onnx_mlir {
 namespace tosa {
 
 mlir::RankedTensorType reduceAxisToOne(llvm::ArrayRef<int64_t> shape,
-    mlir::Type elementType, mlir::Attribute encoding) {
+    Type elementType, Attribute encoding) {
   return mlir::RankedTensorType::get(
       llvm::SmallVector<int64_t, 4>(shape.size(), 1), elementType, encoding);
 }
 
-mlir::Value buildOnnxToTosaPaddingConstOp(mlir::PatternRewriter &rewriter,
-    llvm::ArrayRef<int64_t> onnxPads, mlir::Location loc,
+Value buildOnnxToTosaPaddingConstOp(mlir::PatternRewriter &rewriter,
+    llvm::ArrayRef<int64_t> onnxPads, Location loc,
     const std::initializer_list<int64_t> &initialVals,
     const std::initializer_list<int64_t> &lastVals) {
 

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -35,8 +35,8 @@ using namespace mlir;
 namespace onnx_mlir {
 namespace tosa {
 
-mlir::RankedTensorType reduceAxisToOne(llvm::ArrayRef<int64_t> shape,
-    Type elementType, Attribute encoding) {
+mlir::RankedTensorType reduceAxisToOne(
+    llvm::ArrayRef<int64_t> shape, Type elementType, Attribute encoding) {
   return mlir::RankedTensorType::get(
       llvm::SmallVector<int64_t, 4>(shape.size(), 1), elementType, encoding);
 }

--- a/src/Dialect/Krnl/DialectBuilder.cpp
+++ b/src/Dialect/Krnl/DialectBuilder.cpp
@@ -56,30 +56,14 @@ static StringRef getFormat(const Type &inputType) {
 
 //====---------------- Support for Krnl Builder ----------------------===//
 
-Value KrnlBuilder::load(Value memref, ValueRange indices) const {
-  if (indices.size() == 0) {
-    // case memref<1xdtype>
-    MemRefType type = dyn_cast_or_null<MemRefType>(memref.getType());
-    assert(type && "Not MemRefType");
-    if (type.getRank() == 1 && type.getShape()[0] == 1) {
-      MultiDialectBuilder<MathBuilder> create(*this);
-      Value iZero = create.math.constantIndex(0);
-      return b().create<KrnlLoadOp>(loc(), memref, ValueRange({iZero}));
-    }
-  }
-  return b().create<KrnlLoadOp>(loc(), memref, indices);
-}
-
-mlir::Value KrnlBuilder::load(mlir::Value memref, mlir::ValueRange indices,
-    mlir::ValueRange offsets) const {
+Value KrnlBuilder::load(Value memref, ValueRange indices,
+    ValueRange offsets) const {
+  // Handle offsets.
   SmallVector<Value, 4> computedIndices;
   MathBuilder createMath(*this);
   createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
-  return load(memref, computedIndices);
-}
-
-Value KrnlBuilder::loadIE(Value memref, ArrayRef<IndexExpr> indices) const {
-  if (indices.size() == 0) {
+  // Perform load.
+  if (computedIndices.size() == 0) {
     // case memref<1xdtype>
     MemRefType type = dyn_cast_or_null<MemRefType>(memref.getType());
     assert(type && "Not MemRefType");
@@ -89,13 +73,22 @@ Value KrnlBuilder::loadIE(Value memref, ArrayRef<IndexExpr> indices) const {
       return b().create<KrnlLoadOp>(loc(), memref, ValueRange({iZero}));
     }
   }
-  SmallVector<Value, 4> indexValues;
-  IndexExpr::getValues(indices, indexValues);
-  return b().create<KrnlLoadOp>(loc(), memref, indexValues);
+  return b().create<KrnlLoadOp>(loc(), memref, computedIndices);
 }
 
-void KrnlBuilder::store(Value val, Value memref, ValueRange indices) const {
-  if (indices.size() == 0) {
+Value KrnlBuilder::loadIE(
+    Value memref, ArrayRef<IndexExpr> indices, ValueRange offsets) const {
+  SmallVector<Value, 4> indexValues;
+  IndexExpr::getValues(indices, indexValues);
+  return load(memref, indexValues, offsets);
+}
+
+void KrnlBuilder::store(Value val, Value memref,
+    ValueRange indices, ValueRange offsets) const {
+  SmallVector<Value, 4> computedIndices;
+  MathBuilder createMath(*this);
+  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  if (computedIndices.size() == 0) {
     // case memref<1xdtype>
     MemRefType type = dyn_cast_or_null<MemRefType>(memref.getType());
     assert(type && "Not MemRefType");
@@ -106,33 +99,14 @@ void KrnlBuilder::store(Value val, Value memref, ValueRange indices) const {
       return;
     }
   }
-  b().create<KrnlStoreOp>(loc(), val, memref, indices);
+  b().create<KrnlStoreOp>(loc(), val, memref, computedIndices);
 }
 
-void KrnlBuilder::store(mlir::Value val, mlir::Value memref,
-    mlir::ValueRange indices, mlir::ValueRange offsets) const {
-  SmallVector<Value, 4> computedIndices;
-  MathBuilder createMath(*this);
-  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
-  store(val, memref, computedIndices);
-}
-
-void KrnlBuilder::storeIE(
-    Value val, Value memref, ArrayRef<IndexExpr> indices) const {
-  if (indices.size() == 0) {
-    // case memref<1xdtype>
-    MemRefType type = dyn_cast_or_null<MemRefType>(memref.getType());
-    assert(type && "Not MemRefType");
-    if (type.getRank() == 1 && type.getShape()[0] == 1) {
-      MultiDialectBuilder<MathBuilder> create(*this);
-      Value iZero = create.math.constantIndex(0);
-      b().create<KrnlStoreOp>(loc(), val, memref, ValueRange({iZero}));
-      return;
-    }
-  }
+void KrnlBuilder::storeIE(Value val, Value memref, ArrayRef<IndexExpr> indices,
+    ValueRange offsets) const {
   SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
-  b().create<KrnlStoreOp>(loc(), val, memref, indexValues);
+  store(val, memref, indexValues, offsets);
 }
 
 Value KrnlBuilder::getLinearOffsetIndex(
@@ -162,12 +136,12 @@ void KrnlBuilder::prefetchIE(Value memref, ArrayRef<IndexExpr> indices,
 }
 
 void KrnlBuilder::seqstore(
-    mlir::Value element, mlir::Value seq, mlir::Value index) const {
+    Value element, Value seq, Value index) const {
   b().create<KrnlSeqStoreOp>(loc(), element, seq, index);
 }
 
 void KrnlBuilder::seqstore(
-    mlir::Value element, mlir::Value seq, IndexExpr index) const {
+    Value element, Value seq, IndexExpr index) const {
   b().create<KrnlSeqStoreOp>(loc(), element, seq, index.getValue());
 }
 
@@ -221,7 +195,7 @@ void KrnlBuilder::iterate(ValueRange originalLoops, ValueRange optimizedLoops,
   iterate(originalLoops, optimizedLoops, lbs, ubs, {}, bodyBuilderFnWrapper);
 }
 
-mlir::KrnlIterateOp KrnlBuilder::iterate(ValueRange originalLoops,
+KrnlIterateOp KrnlBuilder::iterate(ValueRange originalLoops,
     ValueRange optimizedLoops, ValueRange lbs, ValueRange ubs, ValueRange inits,
     function_ref<void(
         KrnlBuilder &createKrnl, ValueRange indices, ValueRange iterArgs)>
@@ -257,7 +231,7 @@ void KrnlBuilder::iterateIE(ValueRange originalLoops, ValueRange optimizedLoops,
 
 KrnlIterateOp KrnlBuilder::iterateIE(ValueRange originalLoops,
     ValueRange optimizedLoops, ArrayRef<IndexExpr> lbs, ArrayRef<IndexExpr> ubs,
-    mlir::ValueRange inits,
+    ValueRange inits,
     function_ref<void(
         KrnlBuilder &createKrnl, ValueRange indices, ValueRange iterArgs)>
         bodyBuilderFn) const {
@@ -351,7 +325,7 @@ bool static hasOneElementInInnermostDims(Value value, int64_t innerDim) {
   ShapedType type = mlir::dyn_cast<ShapedType>(value.getType());
   assert(type && "expected shaped type");
   int64_t rank = type.getRank();
-  mlir::ArrayRef<int64_t> shape = type.getShape();
+  ArrayRef<int64_t> shape = type.getShape();
   for (int64_t i = std::max((int64_t)0, rank - innerDim); i < rank; ++i)
     if (shape[i] != 1)
       return false;
@@ -495,7 +469,7 @@ void KrnlBuilder::simdIterateIE(IndexExpr lb, IndexExpr ub, int64_t VL,
       });
 }
 
-void KrnlBuilder::yield(mlir::ValueRange iterArgs) const {
+void KrnlBuilder::yield(ValueRange iterArgs) const {
   b().create<KrnlYieldOp>(loc(), iterArgs);
 }
 
@@ -625,13 +599,13 @@ void KrnlBuilder::printf(
 // =============================================================================
 
 // Return null if none is found.
-ElementsAttr IndexExprBuilderForKrnl::getConst(mlir::Value value) {
+ElementsAttr IndexExprBuilderForKrnl::getConst(Value value) {
   auto definingOp = value.getDefiningOp();
-  if (auto globalOp = dyn_cast_or_null<mlir::KrnlGlobalOp>(definingOp)) {
+  if (auto globalOp = dyn_cast_or_null<KrnlGlobalOp>(definingOp)) {
     if (globalOp.getValue().has_value())
       return mlir::dyn_cast<ElementsAttr>(globalOp.getValueAttr());
   } else if (auto globalOp =
-                 dyn_cast_or_null<mlir::ONNXConstantOp>(definingOp)) {
+                 dyn_cast_or_null<ONNXConstantOp>(definingOp)) {
     if (globalOp.getValue().has_value())
       return mlir::dyn_cast<ElementsAttr>(globalOp.getValueAttr());
   }

--- a/src/Dialect/Krnl/DialectBuilder.hpp
+++ b/src/Dialect/Krnl/DialectBuilder.hpp
@@ -30,19 +30,16 @@ struct KrnlBuilder : public DialectBuilder {
   KrnlBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
   virtual ~KrnlBuilder() {}
 
-  mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
-  // When ranks of offsets<indices, add offsets to the least significant dims.
-  mlir::Value load(mlir::Value memref, mlir::ValueRange indices,
-      mlir::ValueRange offsets) const;
-  mlir::Value loadIE(
-      mlir::Value memref, mlir::ArrayRef<IndexExpr> indices) const;
-  void store(
-      mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
-  // When ranks of offsets<indices, add offsets to the least significant dims.
-  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
-      mlir::ValueRange offsets) const;
+  // Add offsets (if any) to the least significant dims.
+  mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {},
+      mlir::ValueRange offsets = {}) const;
+  mlir::Value loadIE(mlir::Value memref, mlir::ArrayRef<IndexExpr> indices = {},
+      mlir::ValueRange offsets = {}) const;
+  // Add offsets (if any) to the least significant dims.
+  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {},
+      mlir::ValueRange offsets = {}) const;
   void storeIE(mlir::Value val, mlir::Value memref,
-      mlir::ArrayRef<IndexExpr> indices) const;
+      mlir::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets = {}) const;
 
   // Get linear offset for given memref at given index values.
   mlir::Value getLinearOffsetIndex(

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -596,7 +596,7 @@ ParseResult KrnlIterateOp::parse(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
-::llvm::SmallVector<mlir::Region *> KrnlIterateOp::getLoopRegions() {
+::llvm::SmallVector<Region *> KrnlIterateOp::getLoopRegions() {
   return {&getBodyRegion()};
 }
 

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1678,19 +1678,19 @@ void SCFBuilder::ifThenElse(Value cond,
 }
 
 void SCFBuilder::forLoop(Value lowerBound, Value upperBound, int64_t step,
-    function_ref<void(SCFBuilder &createSCF, Value)> bodyFn) const {
+    function_ref<void(SCFBuilder &createSCF, ValueRange)> bodyFn) const {
   MathBuilder createMath(*this);
   Value stepVal = createMath.constantIndex(step);
   b().create<scf::ForOp>(loc(), lowerBound, upperBound, stepVal, std::nullopt,
       [&](OpBuilder &childBuilder, Location childLoc, Value inductionVar,
           ValueRange args) {
         SCFBuilder builder(childBuilder, childLoc);
-        bodyFn(builder, inductionVar);
+        bodyFn(builder, {inductionVar});
         yield();
       });
 }
 
-void SCFBuilder::parallelLoop(ValueRange lowerBounds, ValueRange upperBounds,
+void SCFBuilder::parallelLoops(ValueRange lowerBounds, ValueRange upperBounds,
     ValueRange steps,
     function_ref<void(SCFBuilder &createSCF, ValueRange)> bodyFn) const {
   // SmallVectorImpl<Value> ivStorage;

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -320,7 +320,7 @@ Value MathBuilder::round(Value x) const {
   return select(rEqualHalf, y2, y1);
 }
 
-Value MathBuilder::copySign(mlir::Value rem, mlir::Value dividend) const {
+Value MathBuilder::copySign(Value rem, Value dividend) const {
   splatToMatch(rem, dividend);
   assert(rem.getType() == dividend.getType() && "expected same type");
   if (isScalarOrVectorFloat(rem))
@@ -643,7 +643,7 @@ Value MathBuilder::constantIndex(int64_t val) const {
   return b().create<arith::ConstantOp>(loc(), constantAttr);
 }
 
-TypedAttr MathBuilder::negativeInfAttr(mlir::Type type) const {
+TypedAttr MathBuilder::negativeInfAttr(Type type) const {
   TypedAttr attr;
   TypeSwitch<Type>(type)
       .Case<Float32Type>([&](Type) {
@@ -688,7 +688,7 @@ TypedAttr MathBuilder::negativeInfAttr(mlir::Type type) const {
   return attr;
 }
 
-TypedAttr MathBuilder::positiveInfAttr(mlir::Type type) const {
+TypedAttr MathBuilder::positiveInfAttr(Type type) const {
   TypedAttr attr;
   TypeSwitch<Type>(type)
       .Case<Float32Type>([&](Type) {
@@ -1015,9 +1015,8 @@ Value MathBuilder::castToIndex(Value src) const {
 // Add offsets to least significant values in indices. So if indices has 4
 // values, (i, j, k, l) and offsets has 2 values (K, L), the results will be (i,
 // j, k+K, l+L).
-void MathBuilder::addOffsetToLeastSignificant(mlir::ValueRange indices,
-    mlir::ValueRange offsets,
-    llvm::SmallVectorImpl<mlir::Value> &computedIndices) const {
+void MathBuilder::addOffsetToLeastSignificant(ValueRange indices,
+    ValueRange offsets, llvm::SmallVectorImpl<Value> &computedIndices) const {
   int64_t indexRank = indices.size();
   int64_t offsetRank = offsets.size();
   int64_t firstOffset = indexRank - offsetRank;
@@ -1033,7 +1032,7 @@ void MathBuilder::addOffsetToLeastSignificant(mlir::ValueRange indices,
   }
 }
 
-void MathBuilder::addOffsetToLeastSignificant(mlir::ArrayRef<IndexExpr> indices,
+void MathBuilder::addOffsetToLeastSignificant(ArrayRef<IndexExpr> indices,
     ValueRange offsets, llvm::SmallVectorImpl<Value> &computedIndices) const {
   SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
@@ -1278,7 +1277,7 @@ bool MemRefBuilder::getStaticAndDynamicMemSize(MemRefType type,
 // Alloc functions with alignment and padding for SIMD
 
 Value MemRefBuilder::alignedAllocWithSimdPadding(
-    mlir::MemRefType type, int64_t VL, int64_t alignment) const {
+    MemRefType type, int64_t VL, int64_t alignment) const {
   llvm::SmallVector<Value, 4> dynSymbols;
   return alignedAllocWithSimdPadding(type, dynSymbols, VL, alignment);
 }
@@ -1752,32 +1751,32 @@ int64_t VectorBuilder::getArchVectorLength(Value vecValue) const {
   return getArchVectorLength(vecType.getElementType());
 }
 
-mlir::Value VectorBuilder::load(mlir::VectorType vecType, mlir::Value memref,
-    mlir::ValueRange indices, mlir::ValueRange offsets) const {
-  llvm::SmallVector<mlir::Value, 4> computedIndices;
+Value VectorBuilder::load(VectorType vecType, Value memref, ValueRange indices,
+    ValueRange offsets) const {
+  llvm::SmallVector<Value, 4> computedIndices;
   MultiDialectBuilder<MathBuilder> create(*this);
   create.math.addOffsetToLeastSignificant(indices, offsets, computedIndices);
   return b().create<vector::LoadOp>(loc(), vecType, memref, computedIndices);
 }
 
-mlir::Value VectorBuilder::loadIE(mlir::VectorType vecType, mlir::Value memref,
-    llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const {
-  llvm::SmallVector<mlir::Value, 4> indexValues;
+Value VectorBuilder::loadIE(VectorType vecType, Value memref,
+    llvm::ArrayRef<IndexExpr> indices, ValueRange offsets) const {
+  llvm::SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
   return load(vecType, memref, indexValues, offsets);
 }
 
-void VectorBuilder::store(mlir::Value val, mlir::Value memref,
-    mlir::ValueRange indices, mlir::ValueRange offsets) const {
-  llvm::SmallVector<mlir::Value, 4> computedIndices;
+void VectorBuilder::store(
+    Value val, Value memref, ValueRange indices, ValueRange offsets) const {
+  llvm::SmallVector<Value, 4> computedIndices;
   MultiDialectBuilder<MathBuilder> create(*this);
   create.math.addOffsetToLeastSignificant(indices, offsets, computedIndices);
   b().create<vector::StoreOp>(loc(), val, memref, computedIndices);
 }
 
-void VectorBuilder::storeIE(mlir::Value val, mlir::Value memref,
-    llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const {
-  llvm::SmallVector<mlir::Value, 4> indexValues;
+void VectorBuilder::storeIE(Value val, Value memref,
+    llvm::ArrayRef<IndexExpr> indices, ValueRange offsets) const {
+  llvm::SmallVector<Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
   store(val, memref, indexValues, offsets);
 }

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1637,9 +1637,8 @@ void MemRefBuilder::prefetch(Value memref, ValueRange indices, bool isWrite,
       loc(), memref, indices, isWrite, locality, isData);
 }
 
-void MemRefBuilder::prefetchIE(Value memref,
-    llvm::SmallVectorImpl<IndexExpr> &indices, bool isWrite, unsigned locality,
-    bool isData) {
+void MemRefBuilder::prefetchIE(Value memref, ArrayRef<IndexExpr> indices,
+    bool isWrite, unsigned locality, bool isData) {
   SmallVector<Value, 4> indexVals;
   IndexExpr::getValues(indices, indexVals);
   prefetch(memref, indexVals, isWrite, locality, isData);

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1583,25 +1583,21 @@ memref::ViewOp MemRefBuilder::view(Value input, int64_t byteOffset,
       loc(), outputType, input, offset, outputDynSymbols);
 }
 
-memref::SubViewOp MemRefBuilder::subView(Value val,
-    llvm::SmallVectorImpl<int64_t> &offsets,
-    llvm::SmallVectorImpl<int64_t> &sizes,
-    llvm::SmallVectorImpl<int64_t> &strides) const {
+memref::SubViewOp MemRefBuilder::subView(Value val, ArrayRef<int64_t> offsets,
+    ArrayRef<int64_t> sizes, ArrayRef<int64_t> strides) const {
   return b().create<memref::SubViewOp>(loc(), val, offsets, sizes, strides);
 }
 
 memref::SubViewOp MemRefBuilder::subView(MemRefType outputType, Value val,
-    llvm::SmallVectorImpl<int64_t> &offsets,
-    llvm::SmallVectorImpl<int64_t> &sizes,
-    llvm::SmallVectorImpl<int64_t> &strides) const {
+    ArrayRef<int64_t> offsets, ArrayRef<int64_t> sizes,
+    ArrayRef<int64_t> strides) const {
   return b().create<memref::SubViewOp>(
       loc(), outputType, val, offsets, sizes, strides);
 }
 
 memref::SubViewOp MemRefBuilder::subView(Value input,
-    llvm::SmallVectorImpl<IndexExpr> &offsetsIE,
-    llvm::SmallVectorImpl<IndexExpr> &sizesIE,
-    llvm::SmallVectorImpl<IndexExpr> &stridesIE) const {
+    ArrayRef<IndexExpr> offsetsIE, ArrayRef<IndexExpr> sizesIE,
+    ArrayRef<IndexExpr> stridesIE) const {
   SmallVector<OpFoldResult, 4> offsets, sizes, strides;
   IndexExpr::getOpOrFoldResults(offsetsIE, offsets);
   IndexExpr::getOpOrFoldResults(sizesIE, sizes);

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1933,7 +1933,7 @@ Value VectorBuilder::reduction(
 // For example, when we passe N=VL input vectors, the output has one vector;
 // when we passe N=2VL input vectors, the output has 2 vectors...
 
-void VectorBuilder::multiReduction(SmallVectorImpl<Value> &inputVecArray,
+void VectorBuilder::multiReduction(ArrayRef<Value> inputVecArray,
     F2 reductionFct, SmallVectorImpl<Value> &outputVecArray) {
   uint64_t N = inputVecArray.size();
   assert(N > 0 && "expected at least one value to reduce");

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1225,9 +1225,9 @@ bool MemRefBuilder::getStaticAndDynamicMemSize(MemRefType type,
   Type elementType = type.getElementType();
   assert(!(mlir::isa<VectorType>(elementType)) && "unsupported vector type");
   ArrayRef<int64_t> shape = type.getShape();
-  staticSize = 1;                // Multiplication of static sizes.
-  dynSize = LitIE(1); // Multiplication of dyn sizes.
-  bool staticShape = true;       // Static until proven otherwise.
+  staticSize = 1;          // Multiplication of static sizes.
+  dynSize = LitIE(1);      // Multiplication of dyn sizes.
+  bool staticShape = true; // Static until proven otherwise.
   int64_t rank = type.getRank();
   // Process with range [lb inclusive, ub exclusive)
   int64_t lb = 0, ub = rank;
@@ -1321,8 +1321,7 @@ Value MemRefBuilder::alignedAllocWithSimdPadding(MemRefType type,
     // and padding bit sizes), and then doing a ceil division by
     // 8 (number of bits in a byte).
     IndexExpr totBitSize = LitIE(staticSize * bitWidth) * dynSize;
-    IndexExpr totPaddedBitSize =
-        totBitSize + LitIE(paddingSize * bitWidth);
+    IndexExpr totPaddedBitSize = totBitSize + LitIE(paddingSize * bitWidth);
     totPaddedByteSize = totPaddedBitSize.ceilDiv(LitIE(8));
   }
   if (staticShape)

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1084,8 +1084,7 @@ IntegerAttr MemRefBuilder::computeAlignment(int64_t alignment) const {
 // values from the list of index expressions that represent the shape of the
 // memref.
 
-void MemRefBuilder::computeDynSymbols(MemRefType type,
-    llvm::SmallVectorImpl<IndexExpr> &dims,
+void MemRefBuilder::computeDynSymbols(MemRefType type, DimsExprRef dims,
     llvm::SmallVectorImpl<Value> &dynSymbols) const {
   dynSymbols.clear();
   int64_t rank = type.getRank();

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1250,7 +1250,7 @@ bool MemRefBuilder::getStaticAndDynamicMemSize(MemRefType type,
       if (i >= lb && i < ub) {
         // Keep track of static shape and dynamic sizes only when inbounds.
         staticShape = false;
-        dynSize = dynSize * SymbolIndexExpr(dynSymbols[iDim]);
+        dynSize = dynSize * SymIE(dynSymbols[iDim]);
       }
       iDim++;
     } else {

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -368,23 +368,23 @@ struct MemRefBuilder final : DialectBuilder {
 
   // Create a subview of val.
   mlir::memref::SubViewOp subView(mlir::Value val,
-      llvm::SmallVectorImpl<int64_t> &offsets, // Offset for each val dims.
-      llvm::SmallVectorImpl<int64_t> &sizes,   // Sizes for each val dims.
-      llvm::SmallVectorImpl<int64_t> &strides) // Stride for each val dims.
+      mlir::ArrayRef<int64_t> offsets, // Offset for each val dims.
+      mlir::ArrayRef<int64_t> sizes,   // Sizes for each val dims.
+      mlir::ArrayRef<int64_t> strides) // Stride for each val dims.
       const;
 
   // Create a subview of val.
   mlir::memref::SubViewOp subView(mlir::MemRefType outputType, mlir::Value val,
-      llvm::SmallVectorImpl<int64_t> &offsets, // Offset for each val dims.
-      llvm::SmallVectorImpl<int64_t> &sizes,   // Sizes for each val dims.
-      llvm::SmallVectorImpl<int64_t> &strides) // Stride for each val dims.
+      mlir::ArrayRef<int64_t> offsets, // Offset for each val dims.
+      mlir::ArrayRef<int64_t> sizes,   // Sizes for each val dims.
+      mlir::ArrayRef<int64_t> strides) // Stride for each val dims.
       const;
 
   // Create a subview of val. Size of 1 => remove that dim.
   mlir::memref::SubViewOp subView(mlir::Value val,
-      llvm::SmallVectorImpl<IndexExpr> &offsets, // Offset for each val dims.
-      llvm::SmallVectorImpl<IndexExpr> &sizes,   // Sizes for each val dims.
-      llvm::SmallVectorImpl<IndexExpr> &strides) // Stride for each val dims.
+      mlir::ArrayRef<IndexExpr> offsets, // Offset for each val dims.
+      mlir::ArrayRef<IndexExpr> sizes,   // Sizes for each val dims.
+      mlir::ArrayRef<IndexExpr> strides) // Stride for each val dims.
       const;
 
   mlir::Value dim(mlir::Value val, int64_t index) const;

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -368,7 +368,7 @@ struct MemRefBuilder final : DialectBuilder {
   // Does not support layouts at this time. Does only work for values that are
   // then loaded with affine or memref scalar load/store (MLIR limitations).
   mlir::Value collapseShape(mlir::Value input,
-      llvm::ArrayRef<mlir::ReassociationIndices> reassociation);
+      mlir::ArrayRef<mlir::ReassociationIndices> reassociation);
 
   // Create a view of input value (<byte size>xi8) starting at byteOffset and
   // shaped by outputType.
@@ -478,7 +478,7 @@ struct VectorBuilder final : DialectBuilder {
   mlir::Value load(mlir::VectorType vecType, mlir::Value memref,
       mlir::ValueRange indices, mlir::ValueRange offsets) const;
   mlir::Value loadIE(mlir::VectorType vecType, mlir::Value memref,
-      llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
+      mlir::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
   // Vector store: memref can be a scalar, will store the vector values.
   void store(
       mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
@@ -486,7 +486,7 @@ struct VectorBuilder final : DialectBuilder {
   void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
       mlir::ValueRange offsets) const;
   void storeIE(mlir::Value val, mlir::Value memref,
-      llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
+      mlir::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
 
   // Splat: a single value is copied.
   mlir::Value splat(mlir::VectorType vecType, mlir::Value val) const;
@@ -526,14 +526,14 @@ struct GenericAffineBuilder final : DialectBuilder {
   // Add offsets (if any) to the least significant memref dims.
   mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {},
       mlir::ValueRange offsets = {}) const;
-  mlir::Value loadIE(mlir::Value memref, llvm::ArrayRef<IndexExpr> indices = {},
+  mlir::Value loadIE(mlir::Value memref, mlir::ArrayRef<IndexExpr> indices = {},
       mlir::ValueRange offsets = {}) const;
 
   // Add offsets (if any) to the least significant memref dims.
   void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {},
       mlir::ValueRange offsets = {}) const;
   void storeIE(mlir::Value val, mlir::Value memref,
-      llvm::ArrayRef<IndexExpr> indices = {},
+      mlir::ArrayRef<IndexExpr> indices = {},
       mlir::ValueRange offsets = {}) const;
 
   mlir::Operation *prefetch(mlir::Value memref, mlir::AffineMap map,
@@ -543,15 +543,13 @@ struct GenericAffineBuilder final : DialectBuilder {
   void forLoopIE(IndexExpr lb, IndexExpr ub, int64_t step,
       mlir::function_ref<void(GenericAffineBuilder &, mlir::ValueRange)>
           builderFn) const;
-  void forLoopsIE(llvm::SmallVectorImpl<IndexExpr> &lbs,
-      llvm::SmallVectorImpl<IndexExpr> &ubs,
-      llvm::SmallVectorImpl<int64_t> &steps,
+  void forLoopsIE(mlir::ArrayRef<IndexExpr> lbs, mlir::ArrayRef<IndexExpr> ubs,
+      mlir::ArrayRef<int64_t> steps,
       mlir::function_ref<void(GenericAffineBuilder &, mlir::ValueRange)>
           builderFn) const;
 
   // This if then else construct has no arguments to the blocks.
-  void ifThenElse(IndexExprScope &scope,
-      llvm::SmallVectorImpl<IndexExpr> &conditions,
+  void ifThenElseIE(IndexExprScope &scope, mlir::ArrayRef<IndexExpr> conditions,
       mlir::function_ref<void(GenericAffineBuilder &createAffine)> thenFn,
       mlir::function_ref<void(GenericAffineBuilder &createAffine)> elseFn)
       const;
@@ -563,9 +561,8 @@ struct GenericAffineBuilder final : DialectBuilder {
 
 private:
   // Support for multiple forLoopIE loops.
-  void recursionForLoopsIE(llvm::SmallVectorImpl<IndexExpr> &lbs,
-      llvm::SmallVectorImpl<IndexExpr> &ubs,
-      llvm::SmallVectorImpl<int64_t> &steps,
+  void recursionForLoopsIE(mlir::ArrayRef<IndexExpr> lbs,
+      mlir::ArrayRef<IndexExpr> ubs, mlir::ArrayRef<int64_t> steps,
       llvm::SmallVectorImpl<mlir::Value> &loopIndices,
       mlir::function_ref<void(GenericAffineBuilder &, mlir::ValueRange)>
           builderFn) const;
@@ -614,7 +611,7 @@ struct LLVMBuilder final : DialectBuilder {
 
   // BrOp
   void br(
-      llvm::ArrayRef<mlir::Value> destOperands, mlir::Block *destBlock) const;
+      mlir::ArrayRef<mlir::Value> destOperands, mlir::Block *destBlock) const;
 
   // CallOp
   mlir::Value call(mlir::ArrayRef<mlir::Type> resultTypes,
@@ -626,8 +623,8 @@ struct LLVMBuilder final : DialectBuilder {
 
   // CondBrOp
   void condBr(mlir::Value cond, mlir::Block *trueBlock,
-      llvm::ArrayRef<mlir::Value> trueOperands, mlir::Block *falseBlock,
-      llvm::ArrayRef<mlir::Value> falseOperands) const;
+      mlir::ArrayRef<mlir::Value> trueOperands, mlir::Block *falseBlock,
+      mlir::ArrayRef<mlir::Value> falseOperands) const;
 
   // ConstantOp
   mlir::Value constant(mlir::Type type, int64_t val) const;
@@ -639,7 +636,7 @@ struct LLVMBuilder final : DialectBuilder {
 
   // ExtractValueOp
   mlir::Value extractValue(mlir::Type resultType, mlir::Value container,
-      llvm::ArrayRef<int64_t> position) const;
+      mlir::ArrayRef<int64_t> position) const;
 
   // FuncOp (assume non-variadic functions, otherwise add support like in
   // seen in `call` in this file).
@@ -648,7 +645,7 @@ struct LLVMBuilder final : DialectBuilder {
 
   // GEPOp
   mlir::Value getElemPtr(mlir::Type resultType, mlir::Type elemType,
-      mlir::Value base, llvm::ArrayRef<mlir::LLVM::GEPArg> indices) const;
+      mlir::Value base, mlir::ArrayRef<mlir::LLVM::GEPArg> indices) const;
 
   // GlobalOp
   mlir::LLVM::GlobalOp globalOp(mlir::Type resultType, bool isConstant,
@@ -665,7 +662,7 @@ struct LLVMBuilder final : DialectBuilder {
 
   // InsertValueOp
   mlir::Value insertValue(mlir::Type resultType, mlir::Value container,
-      mlir::Value val, llvm::ArrayRef<int64_t> position) const;
+      mlir::Value val, mlir::ArrayRef<int64_t> position) const;
 
   // Inttoptr
   mlir::Value inttoptr(mlir::Type type, mlir::Value val) const;
@@ -717,7 +714,7 @@ struct LLVMBuilder final : DialectBuilder {
   // Get or insert a function declaration at the beginning of the module.
   mlir::FlatSymbolRefAttr getOrInsertSymbolRef(mlir::ModuleOp module,
       llvm::StringRef symName, mlir::Type resultType,
-      llvm::ArrayRef<mlir::Type> operandTypes, bool isVarArg = false) const;
+      mlir::ArrayRef<mlir::Type> operandTypes, bool isVarArg = false) const;
 
   /// Generate code that looks like "if then with optional else" at LLVM.
   /// The following prototype code will be generated:

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -390,7 +390,7 @@ struct MemRefBuilder final : DialectBuilder {
   mlir::Value dim(mlir::Value val, int64_t index) const;
   mlir::Value dim(mlir::Value val, mlir::Value index) const;
 
-  void prefetchIE(mlir::Value memref, llvm::SmallVectorImpl<IndexExpr> &indices,
+  void prefetchIE(mlir::Value memref, mlir::ArrayRef<IndexExpr> indices,
       bool isWrite, unsigned locality, bool isData = true);
   void prefetch(mlir::Value memref, mlir::ValueRange indices, bool isWrite,
       unsigned locality, bool isData = true);

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -523,29 +523,27 @@ struct GenericAffineBuilder final : DialectBuilder {
   GenericAffineBuilder(const DialectBuilder &db) : DialectBuilder(db) {}
   virtual ~GenericAffineBuilder() {}
 
-  mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {}) const;
-  // When ranks of offsets<indices, add offsets to the least significant dims.
-  mlir::Value load(mlir::Value memref, mlir::ValueRange indices,
-      mlir::ValueRange offsets) const;
-  mlir::Value loadIE(mlir::Value memref, llvm::ArrayRef<IndexExpr> indices,
-      mlir::ValueRange offsets) const;
+  // Add offsets (if any) to the least significant memref dims.
+  mlir::Value load(mlir::Value memref, mlir::ValueRange indices = {},
+      mlir::ValueRange offsets = {}) const;
+  mlir::Value loadIE(mlir::Value memref, llvm::ArrayRef<IndexExpr> indices = {},
+      mlir::ValueRange offsets = {}) const;
 
-  void store(
-      mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
-  // When ranks of offsets<indices, add offsets to the least significant dims.
-  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
-      mlir::ValueRange offsets) const;
+  // Add offsets (if any) to the least significant memref dims.
+  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {},
+      mlir::ValueRange offsets = {}) const;
   void storeIE(mlir::Value val, mlir::Value memref,
-      llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
+      llvm::ArrayRef<IndexExpr> indices = {},
+      mlir::ValueRange offsets = {}) const;
 
   mlir::Operation *prefetch(mlir::Value memref, mlir::AffineMap map,
       mlir::ValueRange indices, bool isWrite, unsigned localityHint,
       bool isDataCache = true);
 
-  void forIE(IndexExpr lb, IndexExpr ub, int64_t step,
-      mlir::function_ref<void(GenericAffineBuilder &, mlir::Value)> builderFn)
-      const;
-  void forIE(llvm::SmallVectorImpl<IndexExpr> &lbs,
+  void forLoopIE(IndexExpr lb, IndexExpr ub, int64_t step,
+      mlir::function_ref<void(GenericAffineBuilder &, mlir::ValueRange)>
+          builderFn) const;
+  void forLoopsIE(llvm::SmallVectorImpl<IndexExpr> &lbs,
       llvm::SmallVectorImpl<IndexExpr> &ubs,
       llvm::SmallVectorImpl<int64_t> &steps,
       mlir::function_ref<void(GenericAffineBuilder &, mlir::ValueRange)>
@@ -564,8 +562,8 @@ struct GenericAffineBuilder final : DialectBuilder {
   void yield() const;
 
 private:
-  // Support for multiple forIE loops.
-  void recursionForIE(llvm::SmallVectorImpl<IndexExpr> &lbs,
+  // Support for multiple forLoopIE loops.
+  void recursionForLoopsIE(llvm::SmallVectorImpl<IndexExpr> &lbs,
       llvm::SmallVectorImpl<IndexExpr> &ubs,
       llvm::SmallVectorImpl<int64_t> &steps,
       llvm::SmallVectorImpl<mlir::Value> &loopIndices,

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -408,7 +408,7 @@ private:
   mlir::IntegerAttr computeAlignment(int64_t alignment) const;
   void computeDynSymbols(
       mlir::MemRefType type, // Use type to determine dynamic dimensions.
-      llvm::SmallVectorImpl<IndexExpr> &dims, // Get dyn syms from index expr.
+      DimsExprRef dims, // Get dyn syms from index expr.
       llvm::SmallVectorImpl<mlir::Value> &dynSymbols) // Output dim symbols.
       const;
   void computeDynSymbols(

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -492,7 +492,7 @@ struct VectorBuilder final : DialectBuilder {
   mlir::Value mergeHigh(mlir::Value lhs, mlir::Value rhs, int64_t step) const;
   mlir::Value mergeLow(mlir::Value lhs, mlir::Value rhs, int64_t step) const;
   mlir::Value reduction(CombiningKind kind, mlir::Value value) const;
-  void multiReduction(llvm::SmallVectorImpl<mlir::Value> &inputVecArray,
+  void multiReduction(mlir::ArrayRef<mlir::Value> inputVecArray,
       F2 reductionFct, llvm::SmallVectorImpl<mlir::Value> &outputVecArray);
 
 private:

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -426,9 +426,9 @@ struct SCFBuilder final : DialectBuilder {
       mlir::function_ref<void(SCFBuilder &createSCF)> elseFn = nullptr) const;
   // Create a for loop.
   void forLoop(mlir::Value lowerBound, mlir::Value upperBound, int64_t step,
-      mlir::function_ref<void(SCFBuilder &, mlir::Value)> bodyFn) const;
+      mlir::function_ref<void(SCFBuilder &, mlir::ValueRange)> bodyFn) const;
   // Create a parallel for loop.
-  void parallelLoop(mlir::ValueRange lowerBounds, mlir::ValueRange upperBounds,
+  void parallelLoops(mlir::ValueRange lowerBounds, mlir::ValueRange upperBounds,
       mlir::ValueRange steps,
       mlir::function_ref<void(SCFBuilder &, mlir::ValueRange)> bodyFn) const;
   void yield() const;

--- a/src/Dialect/Mlir/DialectBuilder.hpp
+++ b/src/Dialect/Mlir/DialectBuilder.hpp
@@ -463,21 +463,19 @@ struct VectorBuilder final : DialectBuilder {
   // Vector load: memref is expected to be scalar, will load a vector's worth
   // of values: e.g. %result = vector.load %base[%i, %j] :
   // memref<100x100xf32>, vector<8xf32>.
+  // Add offsets (if any) to the least significant memref dims.
   mlir::Value load(mlir::VectorType vecType, mlir::Value memref,
-      mlir::ValueRange indices = {}) const;
-  // When ranks of offsets<indices, add offsets to the least significant dims.
-  mlir::Value load(mlir::VectorType vecType, mlir::Value memref,
-      mlir::ValueRange indices, mlir::ValueRange offsets) const;
+      mlir::ValueRange indices = {}, mlir::ValueRange offsets = {}) const;
   mlir::Value loadIE(mlir::VectorType vecType, mlir::Value memref,
-      mlir::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
+      mlir::ArrayRef<IndexExpr> indices = {},
+      mlir::ValueRange offsets = {}) const;
   // Vector store: memref can be a scalar, will store the vector values.
-  void store(
-      mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {}) const;
-  // When ranks of offsets<indices, add offsets to the least significant dims.
-  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices,
-      mlir::ValueRange offsets) const;
+  // Add offsets (if any) to the least significant memref dims.
+  void store(mlir::Value val, mlir::Value memref, mlir::ValueRange indices = {},
+      mlir::ValueRange offsets = {}) const;
   void storeIE(mlir::Value val, mlir::Value memref,
-      mlir::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const;
+      mlir::ArrayRef<IndexExpr> indices = {},
+      mlir::ValueRange offsets = {}) const;
 
   // Splat: a single value is copied.
   mlir::Value splat(mlir::VectorType vecType, mlir::Value val) const;

--- a/src/Dialect/Mlir/DialectBuilder.hpp.inc
+++ b/src/Dialect/Mlir/DialectBuilder.hpp.inc
@@ -24,14 +24,10 @@ mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::load(mlir::Value memref,
 
 template <class LOAD_OP, class STORE_OP>
 mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::loadIE(mlir::Value memref,
-    llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const {
+    mlir::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const {
   llvm::SmallVector<mlir::Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
   return load(memref, indexValues, offsets);
-  //llvm::SmallVector<mlir::Value, 4> computedIndices;
-  //MathBuilder createMath(*this);
-  //createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
-  //return load(memref, computedIndices);
 }
 
 template <class LOAD_OP, class STORE_OP>
@@ -46,15 +42,11 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::store(mlir::Value val,
 
 template <class LOAD_OP, class STORE_OP>
 inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::storeIE(mlir::Value val,
-    mlir::Value memref, llvm::ArrayRef<IndexExpr> indices,
+    mlir::Value memref, mlir::ArrayRef<IndexExpr> indices,
     mlir::ValueRange offsets) const {
-        llvm::SmallVector<mlir::Value, 4> indexValues;
+  llvm::SmallVector<mlir::Value, 4> indexValues;
   IndexExpr::getValues(indices, indexValues);
   store(val, memref, indexValues, offsets);
-  //llvm::SmallVector<mlir::Value, 4> computedIndices;
-  //MathBuilder createMath(*this);
-  //createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
-  //store(val, memref, computedIndices);
 }
 
 template <class LOAD_OP, class STORE_OP>
@@ -89,9 +81,8 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forLoopIE(IndexExpr lb,
 
 template <class LOAD_OP, class STORE_OP>
 inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forLoopsIE(
-    llvm::SmallVectorImpl<IndexExpr> &lbs,
-    llvm::SmallVectorImpl<IndexExpr> &ubs,
-    llvm::SmallVectorImpl<int64_t> &steps,
+    mlir::ArrayRef<IndexExpr> lbs, mlir::ArrayRef<IndexExpr> ubs,
+    mlir::ArrayRef<int64_t> steps,
     mlir::function_ref<void(GenericAffineBuilder &, mlir::ValueRange)>
         builderFn) const {
   assert(lbs.size() == ubs.size() && "expected identical sizes");
@@ -102,8 +93,8 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forLoopsIE(
 
 // This if then else construct has no arguments to the blocks.
 template <class LOAD_OP, class STORE_OP>
-inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::ifThenElse(
-    IndexExprScope &scope, llvm::SmallVectorImpl<IndexExpr> &conditions,
+inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::ifThenElseIE(
+    IndexExprScope &scope, mlir::ArrayRef<IndexExpr> conditions,
     mlir::function_ref<void(GenericAffineBuilder &createAffine)> thenFn,
     mlir::function_ref<void(GenericAffineBuilder &createAffine)> elseFn) const {
   int64_t rank = conditions.size();
@@ -146,6 +137,12 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::ifThenElse(
 }
 
 template <class LOAD_OP, class STORE_OP>
+mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::apply(
+    mlir::AffineMap map, mlir::ValueRange operands) const {
+  return b().template create<mlir::affine::AffineApplyOp>(loc(), map, operands);
+}
+
+template <class LOAD_OP, class STORE_OP>
 inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::yield() const {
   b().template create<mlir::affine::AffineYieldOp>(loc());
 }
@@ -153,9 +150,8 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::yield() const {
 // Support for multiple forLoopIE loops.
 template <class LOAD_OP, class STORE_OP>
 void GenericAffineBuilder<LOAD_OP, STORE_OP>::recursionForLoopsIE(
-    llvm::SmallVectorImpl<IndexExpr> &lbs,
-    llvm::SmallVectorImpl<IndexExpr> &ubs,
-    llvm::SmallVectorImpl<int64_t> &steps,
+    mlir::ArrayRef<IndexExpr> lbs, mlir::ArrayRef<IndexExpr> ubs,
+    mlir::ArrayRef<int64_t> steps,
     llvm::SmallVectorImpl<mlir::Value> &loopIndices,
     mlir::function_ref<void(GenericAffineBuilder &, mlir::ValueRange)>
         builderFn) const {
@@ -186,10 +182,4 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::appendToBlock(
   } else
     b().setInsertionPoint(&block->back());
   builderFn(block->getArguments());
-}
-
-template <class LOAD_OP, class STORE_OP>
-mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::apply(
-    mlir::AffineMap map, mlir::ValueRange operands) const {
-  return b().template create<mlir::affine::AffineApplyOp>(loc(), map, operands);
 }

--- a/src/Dialect/Mlir/DialectBuilder.hpp.inc
+++ b/src/Dialect/Mlir/DialectBuilder.hpp.inc
@@ -13,35 +13,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Implementation of GenericAffineBuilder
-template <class LOAD_OP, class STORE_OP>
-mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::load(
-    mlir::Value memref, mlir::ValueRange indices) const {
-  return b().template create<LOAD_OP>(loc(), memref, indices);
-}
-
 template <class LOAD_OP, class STORE_OP>
 mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::load(mlir::Value memref,
     mlir::ValueRange indices, mlir::ValueRange offsets) const {
   llvm::SmallVector<mlir::Value, 4> computedIndices;
   MathBuilder createMath(*this);
   createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
-  return load(memref, computedIndices);
+  return b().template create<LOAD_OP>(loc(), memref, computedIndices);
 }
 
 template <class LOAD_OP, class STORE_OP>
 mlir::Value GenericAffineBuilder<LOAD_OP, STORE_OP>::loadIE(mlir::Value memref,
     llvm::ArrayRef<IndexExpr> indices, mlir::ValueRange offsets) const {
-  llvm::SmallVector<mlir::Value, 4> computedIndices;
-  MathBuilder createMath(*this);
-  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
-  return load(memref, computedIndices);
-}
-
-template <class LOAD_OP, class STORE_OP>
-inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::store(
-    mlir::Value val, mlir::Value memref, mlir::ValueRange indices) const {
-  b().template create<STORE_OP>(loc(), val, memref, indices);
+  llvm::SmallVector<mlir::Value, 4> indexValues;
+  IndexExpr::getValues(indices, indexValues);
+  return load(memref, indexValues, offsets);
+  //llvm::SmallVector<mlir::Value, 4> computedIndices;
+  //MathBuilder createMath(*this);
+  //createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  //return load(memref, computedIndices);
 }
 
 template <class LOAD_OP, class STORE_OP>
@@ -51,17 +41,20 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::store(mlir::Value val,
   llvm::SmallVector<mlir::Value, 4> computedIndices;
   MathBuilder createMath(*this);
   createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
-  store(val, memref, computedIndices);
+  b().template create<STORE_OP>(loc(), val, memref, computedIndices);
 }
 
 template <class LOAD_OP, class STORE_OP>
 inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::storeIE(mlir::Value val,
     mlir::Value memref, llvm::ArrayRef<IndexExpr> indices,
     mlir::ValueRange offsets) const {
-  llvm::SmallVector<mlir::Value, 4> computedIndices;
-  MathBuilder createMath(*this);
-  createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
-  store(val, memref, computedIndices);
+        llvm::SmallVector<mlir::Value, 4> indexValues;
+  IndexExpr::getValues(indices, indexValues);
+  store(val, memref, indexValues, offsets);
+  //llvm::SmallVector<mlir::Value, 4> computedIndices;
+  //MathBuilder createMath(*this);
+  //createMath.addOffsetToLeastSignificant(indices, offsets, computedIndices);
+  //store(val, memref, computedIndices);
 }
 
 template <class LOAD_OP, class STORE_OP>
@@ -74,10 +67,10 @@ inline mlir::Operation *GenericAffineBuilder<LOAD_OP, STORE_OP>::prefetch(
 }
 
 template <class LOAD_OP, class STORE_OP>
-inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forIE(IndexExpr lb,
+inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forLoopIE(IndexExpr lb,
     IndexExpr ub, int64_t step,
-    mlir::function_ref<void(GenericAffineBuilder &, mlir::Value)> builderFn)
-    const {
+    mlir::function_ref<void(GenericAffineBuilder &, mlir::ValueRange)>
+        builderFn) const {
   // Transform IndexExpressions into value maps and list of operands.
   mlir::AffineMap lbMap, ubMap;
   llvm::SmallVector<mlir::Value, 8> lbOperands, ubOperands;
@@ -89,13 +82,13 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forIE(IndexExpr lb,
       [&](mlir::OpBuilder &b, mlir::Location loc, mlir::Value index,
           mlir::ValueRange args) {
         GenericAffineBuilder createAffine(b, loc);
-        builderFn(createAffine, index);
+        builderFn(createAffine, {index});
         createAffine.yield();
       });
 }
 
 template <class LOAD_OP, class STORE_OP>
-inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forIE(
+inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forLoopsIE(
     llvm::SmallVectorImpl<IndexExpr> &lbs,
     llvm::SmallVectorImpl<IndexExpr> &ubs,
     llvm::SmallVectorImpl<int64_t> &steps,
@@ -104,7 +97,7 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::forIE(
   assert(lbs.size() == ubs.size() && "expected identical sizes");
   assert(lbs.size() == steps.size() && "expected identical sizes");
   llvm::SmallVector<mlir::Value> loopIndices;
-  recursionForIE(lbs, ubs, steps, loopIndices, builderFn);
+  recursionForLoopsIE(lbs, ubs, steps, loopIndices, builderFn);
 }
 
 // This if then else construct has no arguments to the blocks.
@@ -157,9 +150,9 @@ inline void GenericAffineBuilder<LOAD_OP, STORE_OP>::yield() const {
   b().template create<mlir::affine::AffineYieldOp>(loc());
 }
 
-// Support for multiple forIE loops.
+// Support for multiple forLoopIE loops.
 template <class LOAD_OP, class STORE_OP>
-void GenericAffineBuilder<LOAD_OP, STORE_OP>::recursionForIE(
+void GenericAffineBuilder<LOAD_OP, STORE_OP>::recursionForLoopsIE(
     llvm::SmallVectorImpl<IndexExpr> &lbs,
     llvm::SmallVectorImpl<IndexExpr> &ubs,
     llvm::SmallVectorImpl<int64_t> &steps,
@@ -169,10 +162,10 @@ void GenericAffineBuilder<LOAD_OP, STORE_OP>::recursionForIE(
   int d = loopIndices.size();
   if (d < (int)lbs.size()) {
     // Issue a loop and recurse again.
-    forIE(lbs[d], ubs[d], steps[d],
-        [&](GenericAffineBuilder &createAffine, mlir::Value i) {
-          loopIndices.emplace_back(i);
-          recursionForIE(lbs, ubs, steps, loopIndices, builderFn);
+    forLoopIE(lbs[d], ubs[d], steps[d],
+        [&](GenericAffineBuilder &createAffine, mlir::ValueRange loopInd) {
+          loopIndices.emplace_back(loopInd[0]);
+          recursionForLoopsIE(lbs, ubs, steps, loopIndices, builderFn);
         });
   } else {
     // Call lambda function

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -574,10 +574,9 @@ IndexExpr IndexExpr::binaryOp(IndexExpr const b, bool propagateIntoMinMax,
   bool canBeAffine = (affineExprFct != nullptr);
   bool resIsAffine = resIsLit || (canBeAffine && isAffine() && b.isAffine() &&
                                      (!affineWithLitB || b.isLiteral()));
-  if (resIsAffine)
-    // Test if we have a neutral value.
-    if (hasNeutralA && isIdentical(*this, neutralVal))
-      return b.deepCopy(); // Copy of the other value (use same questionmark).
+  // Test if we have a neutral value.
+  if (hasNeutralA && isIdentical(*this, neutralVal))
+    return b.deepCopy(); // Copy of the other value (use same questionmark).
   if (hasNeutralB && isIdentical(b, neutralVal)) {
     return deepCopy(); // Copy of the other value (use same questionmark).
   }

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -872,10 +872,10 @@ IndexExpr IndexExpr::operator!() const {
 
 IndexExpr IndexExpr::operator+(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return LiteralIndexExpr(aa.getLiteral() + bb.getLiteral());
+    return LitIE(aa.getLiteral() + bb.getLiteral());
   };
   F2 litFloatFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return LiteralIndexExpr(aa.getFloatLiteral() + bb.getFloatLiteral());
+    return LitIE(aa.getFloatLiteral() + bb.getFloatLiteral());
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     return AffineIndexExpr(aa.getAffineExpr() + bb.getAffineExpr());
@@ -894,10 +894,10 @@ IndexExpr IndexExpr::operator+(IndexExpr const b) const {
 
 IndexExpr IndexExpr::operator-(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return LiteralIndexExpr(aa.getLiteral() - bb.getLiteral());
+    return LitIE(aa.getLiteral() - bb.getLiteral());
   };
   F2 litFloatFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return LiteralIndexExpr(aa.getFloatLiteral() - bb.getFloatLiteral());
+    return LitIE(aa.getFloatLiteral() - bb.getFloatLiteral());
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     return AffineIndexExpr(aa.getAffineExpr() - bb.getAffineExpr());
@@ -916,10 +916,10 @@ IndexExpr IndexExpr::operator-(IndexExpr const b) const {
 
 IndexExpr IndexExpr::operator*(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return LiteralIndexExpr(aa.getLiteral() * bb.getLiteral());
+    return LitIE(aa.getLiteral() * bb.getLiteral());
   };
   F2 litFloatFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
-    return LiteralIndexExpr(aa.getFloatLiteral() * bb.getFloatLiteral());
+    return LitIE(aa.getFloatLiteral() * bb.getFloatLiteral());
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     return AffineIndexExpr(aa.getAffineExpr() * bb.getAffineExpr());
@@ -945,7 +945,7 @@ IndexExpr IndexExpr::floorDiv(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     int64_t rval =
         std::floor((1.0 * aa.getLiteral()) / (1.0 * bb.getLiteral()));
-    return LiteralIndexExpr(rval);
+    return LitIE(rval);
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     // Operand bb must be a literal.
@@ -972,7 +972,7 @@ IndexExpr IndexExpr::floorDiv(IndexExpr const b) const {
 IndexExpr IndexExpr::ceilDiv(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     int64_t rval = std::ceil((1.0 * aa.getLiteral()) / (1.0 * bb.getLiteral()));
-    return LiteralIndexExpr(rval);
+    return LitIE(rval);
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     // Operand bb must be a literal.
@@ -997,7 +997,7 @@ IndexExpr IndexExpr::ceilDiv(IndexExpr const b) const {
 IndexExpr IndexExpr::operator%(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     int64_t rval = llvm::mod(aa.getLiteral(), bb.getLiteral());
-    return LiteralIndexExpr(rval);
+    return LitIE(rval);
   };
   F2 affineExprFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     // Operand bb must be a literal.
@@ -1022,7 +1022,7 @@ IndexExpr IndexExpr::operator%(IndexExpr const b) const {
 IndexExpr IndexExpr::operator/(IndexExpr const b) const {
   F2 litFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     double rval = aa.getFloatLiteral() / bb.getFloatLiteral();
-    return LiteralIndexExpr(rval);
+    return LitIE(rval);
   };
   F2 valueFct = [](IndexExpr const aa, IndexExpr const bb) -> IndexExpr {
     MathBuilder createMath(aa.getRewriter(), aa.getLoc());
@@ -1039,7 +1039,7 @@ IndexExpr IndexExpr::operator/(IndexExpr const b) const {
 IndexExpr IndexExpr::ceil() const {
   F1 litFct = [](IndexExpr const aa) -> IndexExpr {
     double rval = std::ceil(aa.getFloatLiteral());
-    return LiteralIndexExpr(rval);
+    return LitIE(rval);
   };
   F1 valueFct = [](IndexExpr const aa) -> IndexExpr {
     MathBuilder createMath(aa.getRewriter(), aa.getLoc());
@@ -1055,7 +1055,7 @@ IndexExpr IndexExpr::ceil() const {
 IndexExpr IndexExpr::floor() const {
   F1 litFct = [](IndexExpr const aa) -> IndexExpr {
     double rval = std::floor(aa.getFloatLiteral());
-    return LiteralIndexExpr(rval);
+    return LitIE(rval);
   };
   F1 valueFct = [](IndexExpr const aa) -> IndexExpr {
     MathBuilder createMath(aa.getRewriter(), aa.getLoc());
@@ -1072,7 +1072,7 @@ IndexExpr IndexExpr::floor() const {
 IndexExpr IndexExpr::convertToFloat() const {
   F1 litFct = [](IndexExpr const aa) -> IndexExpr {
     double rval = (double)aa.getLiteral();
-    return LiteralIndexExpr(rval);
+    return LitIE(rval);
   };
   F1 valueFct = [](IndexExpr const aa) -> IndexExpr {
     MathBuilder createMath(aa.getRewriter(), aa.getLoc());
@@ -1089,7 +1089,7 @@ IndexExpr IndexExpr::convertToFloat() const {
 IndexExpr IndexExpr::convertToIndex() const {
   F1 litFct = [](IndexExpr const aa) -> IndexExpr {
     int64_t rval = (int64_t)aa.getFloatLiteral();
-    return LiteralIndexExpr(rval);
+    return LitIE(rval);
   };
   F1 valueFct = [](IndexExpr const aa) -> IndexExpr {
     MathBuilder createMath(aa.getRewriter(), aa.getLoc());
@@ -1223,7 +1223,7 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
 
 /*static*/ IndexExpr IndexExpr::min(
     IndexExpr const first, int64_t const second) {
-  SmallVector<IndexExpr, 2> list = {first, LiteralIndexExpr(second)};
+  SmallVector<IndexExpr, 2> list = {first, LitIE(second)};
   return min(list);
 }
 
@@ -1282,7 +1282,7 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
 
 /*static*/ IndexExpr IndexExpr::max(
     IndexExpr const first, int64_t const second) {
-  SmallVector<IndexExpr, 2> list = {first, LiteralIndexExpr(second)};
+  SmallVector<IndexExpr, 2> list = {first, LitIE(second)};
   return max(list);
 }
 
@@ -1313,15 +1313,15 @@ bool IndexExpr::retrieveAffineMinMax(
 //===----------------------------------------------------------------------===//
 
 IndexExpr IndexExpr::operator+(int64_t const b) const {
-  return *this + LiteralIndexExpr(b);
+  return *this + LitIE(b);
 }
 
 IndexExpr IndexExpr::operator-(int64_t const b) const {
-  return *this - LiteralIndexExpr(b);
+  return *this - LitIE(b);
 }
 
 IndexExpr IndexExpr::operator*(int64_t const b) const {
-  return *this * LiteralIndexExpr(b);
+  return *this * LitIE(b);
 }
 
 IndexExpr IndexExpr::operator==(IndexExpr const b) const {
@@ -1331,7 +1331,7 @@ IndexExpr IndexExpr::operator==(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator==(int64_t const b) const {
-  return *this == LiteralIndexExpr(b);
+  return *this == LitIE(b);
 }
 
 IndexExpr IndexExpr::operator!=(IndexExpr const b) const {
@@ -1341,7 +1341,7 @@ IndexExpr IndexExpr::operator!=(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator!=(int64_t const b) const {
-  return *this != LiteralIndexExpr(b);
+  return *this != LitIE(b);
 }
 
 IndexExpr IndexExpr::operator<=(IndexExpr const b) const {
@@ -1351,7 +1351,7 @@ IndexExpr IndexExpr::operator<=(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator<=(int64_t const b) const {
-  return *this <= LiteralIndexExpr(b);
+  return *this <= LitIE(b);
 }
 
 IndexExpr IndexExpr::operator<(IndexExpr const b) const {
@@ -1361,7 +1361,7 @@ IndexExpr IndexExpr::operator<(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator<(int64_t const b) const {
-  return *this < LiteralIndexExpr(b);
+  return *this < LitIE(b);
 }
 
 IndexExpr IndexExpr::operator>=(IndexExpr const b) const {
@@ -1371,7 +1371,7 @@ IndexExpr IndexExpr::operator>=(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator>=(int64_t const b) const {
-  return *this >= LiteralIndexExpr(b);
+  return *this >= LitIE(b);
 }
 
 IndexExpr IndexExpr::operator>(IndexExpr const b) const {
@@ -1381,36 +1381,36 @@ IndexExpr IndexExpr::operator>(IndexExpr const b) const {
 }
 
 IndexExpr IndexExpr::operator>(int64_t const b) const {
-  return *this > LiteralIndexExpr(b);
+  return *this > LitIE(b);
 }
 
 IndexExpr IndexExpr::operator%(int64_t const b) const {
-  return *this % LiteralIndexExpr(b);
+  return *this % LitIE(b);
 }
 
 IndexExpr IndexExpr::floorDiv(int64_t const b) const {
-  return this->floorDiv(LiteralIndexExpr(b));
+  return this->floorDiv(LitIE(b));
 }
 
 IndexExpr IndexExpr::ceilDiv(int64_t const b) const {
-  return this->ceilDiv(LiteralIndexExpr(b));
+  return this->ceilDiv(LitIE(b));
 }
 
 IndexExpr IndexExpr::clamp(int64_t min, IndexExpr max) {
-  return clamp(LiteralIndexExpr(min), max);
+  return clamp(LitIE(min), max);
 }
 
 /*static*/ IndexExpr IndexExpr::select(
     IndexExpr const compare, int64_t const trueVal, IndexExpr const falseVal) {
-  return select(compare, LiteralIndexExpr(trueVal), falseVal);
+  return select(compare, LitIE(trueVal), falseVal);
 }
 /*static*/ IndexExpr IndexExpr::select(
     IndexExpr const compare, IndexExpr const trueVal, int64_t const falseVal) {
-  return select(compare, trueVal, LiteralIndexExpr(falseVal));
+  return select(compare, trueVal, LitIE(falseVal));
 }
 /*static*/ IndexExpr IndexExpr::select(
     IndexExpr const compare, int64_t const trueVal, int64_t const falseVal) {
-  return select(compare, LiteralIndexExpr(trueVal), LiteralIndexExpr(falseVal));
+  return select(compare, LitIE(trueVal), LitIE(falseVal));
 }
 
 IndexExpr IndexExpr::selectOrSelf(
@@ -1961,7 +1961,7 @@ void getIndexExprListFromInt(
     ArrayRef<int64_t> inputList, llvm::SmallVectorImpl<IndexExpr> &outputList) {
   outputList.clear();
   for (int64_t item : inputList)
-    outputList.emplace_back(LiteralIndexExpr(item));
+    outputList.emplace_back(LitIE(item));
 }
 
 // Create a list of IndexExpr of kind LiteralIndexExpr/Questionmark from a
@@ -1974,7 +1974,7 @@ void getIndexExprListFromShape(
       outputList.emplace_back(QuestionmarkIndexExpr(/*isFloat*/ false));
     else {
       assert(item >= 0 && "expected kDynamic, not -1");
-      outputList.emplace_back(LiteralIndexExpr(item));
+      outputList.emplace_back(LitIE(item));
     }
   }
 }

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -885,7 +885,7 @@ IndexExpr IndexExpr::operator+(IndexExpr const b) const {
   // Neutral value: a + 0 = a, 0 + b = b.
   if (areFloat(b))
     return binaryOp(
-        b, true, false, true, true, 0.0, litFloatFct, nullptr, valueFct);
+        b, false, false, true, true, 0.0, litFloatFct, nullptr, valueFct);
   return binaryOp(
       b, true, false, true, true, 0.0, litFct, affineExprFct, valueFct);
 }
@@ -907,7 +907,7 @@ IndexExpr IndexExpr::operator-(IndexExpr const b) const {
   // Neutral value: a - 0 = a.
   if (areFloat(b))
     return binaryOp(
-        b, true, false, false, true, 0.0, litFloatFct, nullptr, valueFct);
+        b, false, false, false, true, 0.0, litFloatFct, nullptr, valueFct);
   return binaryOp(
       b, true, false, false, true, 0.0, litFct, affineExprFct, valueFct);
 }

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -338,7 +338,7 @@ bool IndexExpr::isLiteralAndSmallerThan(IndexExpr const b) const {
 }
 
 // All element in list are literals.
-/*static*/ bool IndexExpr::isLiteral(mlir::ArrayRef<IndexExpr> list) {
+/*static*/ bool IndexExpr::isLiteral(ArrayRef<IndexExpr> list) {
   for (IndexExpr i : list)
     if (!i.isLiteral())
       return false;
@@ -346,8 +346,7 @@ bool IndexExpr::isLiteralAndSmallerThan(IndexExpr const b) const {
 }
 
 // All element in list are literals and non-negative (i.e. >= 0).
-/*static*/ bool IndexExpr::isNonNegativeLiteral(
-    mlir::ArrayRef<IndexExpr> list) {
+/*static*/ bool IndexExpr::isNonNegativeLiteral(ArrayRef<IndexExpr> list) {
   for (IndexExpr i : list)
     if (!i.isLiteral() || i.getLiteral() < 0)
       return false;
@@ -462,7 +461,7 @@ void IndexExpr::debugPrint(const std::string &msg) const {
 }
 
 void IndexExpr::debugPrint(
-    const std::string &msg, const SmallVectorImpl<IndexExpr> &list) {
+    const std::string &msg, const ArrayRef<IndexExpr> list) {
   LLVM_DEBUG({
     int s = list.size();
     llvm::dbgs() << msg.c_str() << " (" << s << " elements)\n";
@@ -525,7 +524,7 @@ void IndexExpr::debugPrint(
 
 /* static*/ void IndexExpr::getAffineMapAndOperands(
     ArrayRef<IndexExpr> indexExprArray, AffineMap &map,
-    SmallVectorImpl<mlir::Value> &operands) {
+    SmallVectorImpl<Value> &operands) {
   assert(indexExprArray.size() > 0 && "expected at least one index expr");
   SmallVector<AffineExpr, 8> affineExprList;
   for (IndexExpr expr : indexExprArray) {
@@ -1291,8 +1290,8 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
 // IndexExpr Ops Derivatives
 //===----------------------------------------------------------------------===//
 
-bool IndexExpr::retrieveAffineMinMax(bool &isMin,
-    llvm::SmallVectorImpl<mlir::Value> &vals, mlir::AffineMap &map) const {
+bool IndexExpr::retrieveAffineMinMax(
+    bool &isMin, llvm::SmallVectorImpl<Value> &vals, AffineMap &map) const {
   Value val = this->getValue();
   auto minOp = val.getDefiningOp<affine::AffineMinOp>();
   auto maxOp = val.getDefiningOp<affine::AffineMaxOp>();

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -593,7 +593,7 @@ IndexExpr IndexExpr::binaryOp(IndexExpr const b, bool propagateIntoMinMax,
     // Use affine values.
     return affineExprFct(*this, b);
   // See if we have a min/max on one side that we can propagate into.
-  if (propagateIntoMinMax) {
+  if (canBeAffine && propagateIntoMinMax) {
     Value valA = this->getValue();
     bool hasMinMaxA = valA.getDefiningOp<affine::AffineMinOp>() ||
                       valA.getDefiningOp<affine::AffineMaxOp>();

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -593,14 +593,13 @@ IndexExpr IndexExpr::binaryOp(IndexExpr const b, bool propagateIntoMinMax,
     // Use affine values.
     return affineExprFct(*this, b);
   // See if we have a min/max on one side that we can propagate into.
-  bool hasMinMaxA = false, hasMinMaxB = false;
   if (propagateIntoMinMax) {
     Value valA = this->getValue();
-    hasMinMaxA = valA.getDefiningOp<affine::AffineMinOp>() ||
-                 valA.getDefiningOp<affine::AffineMaxOp>();
+    bool hasMinMaxA = valA.getDefiningOp<affine::AffineMinOp>() ||
+                      valA.getDefiningOp<affine::AffineMaxOp>();
     Value valB = b.getValue();
-    hasMinMaxB = valB.getDefiningOp<affine::AffineMinOp>() ||
-                 valB.getDefiningOp<affine::AffineMaxOp>();
+    bool hasMinMaxB = valB.getDefiningOp<affine::AffineMinOp>() ||
+                      valB.getDefiningOp<affine::AffineMaxOp>();
     // Can handle only cases where either a or b are min/max and the other one
     // is affine.
     if ((hasMinMaxA && !hasMinMaxB && b.isAffine()) ||

--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -338,7 +338,7 @@ bool IndexExpr::isLiteralAndSmallerThan(IndexExpr const b) const {
 }
 
 // All element in list are literals.
-/*static*/ bool IndexExpr::isLiteral(SmallVectorImpl<IndexExpr> &list) {
+/*static*/ bool IndexExpr::isLiteral(mlir::ArrayRef<IndexExpr> list) {
   for (IndexExpr i : list)
     if (!i.isLiteral())
       return false;
@@ -347,7 +347,7 @@ bool IndexExpr::isLiteralAndSmallerThan(IndexExpr const b) const {
 
 // All element in list are literals and non-negative (i.e. >= 0).
 /*static*/ bool IndexExpr::isNonNegativeLiteral(
-    SmallVectorImpl<IndexExpr> &list) {
+    mlir::ArrayRef<IndexExpr> list) {
   for (IndexExpr i : list)
     if (!i.isLiteral() || i.getLiteral() < 0)
       return false;
@@ -820,8 +820,8 @@ IndexExpr IndexExpr::operator!() const {
 
 // The affine reduction lambda function processes the whole list and must init
 // the result. Literal and Values treat one operation at a time
-/* static*/ IndexExpr IndexExpr::reductionOp(SmallVectorImpl<IndexExpr> &vals,
-    F2Self litRed, Flist affineRed, F2Self valueRed) {
+/* static*/ IndexExpr IndexExpr::reductionOp(
+    ArrayRef<IndexExpr> vals, F2Self litRed, Flist affineRed, F2Self valueRed) {
   // If no values, result is undefined.
   int size = vals.size();
   if (size == 0)
@@ -1169,7 +1169,7 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
   return NonAffineIndexExpr(results);
 }
 
-/*static*/ IndexExpr IndexExpr::min(SmallVectorImpl<IndexExpr> &vals) {
+/*static*/ IndexExpr IndexExpr::min(ArrayRef<IndexExpr> vals) {
   // Res is already an literal int, we are reducing into it.
   F2Self litFct = [](IndexExpr res, IndexExpr const aa) -> IndexExpr {
     if (aa.isLiteralAndSmallerThan(res))
@@ -1177,13 +1177,13 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
     return res;
   };
   Flist affineExprFct = [&](IndexExpr res,
-                            SmallVectorImpl<IndexExpr> &vvals) -> IndexExpr {
+                            ArrayRef<IndexExpr> vvals) -> IndexExpr {
     // Create a list of affine expression
     assert(vvals.size() > 1 && "come here only with 2 or more values");
     SmallVector<AffineExpr, 4> affineExprs;
     // Important to get the affine expressions before getting the
     // dims/symbols.
-    for (IndexExpr &vv : vvals) {
+    for (IndexExpr vv : vvals) {
       affineExprs.emplace_back(vv.getAffineExpr());
     }
     // Compute a map including the list of affine expressions.
@@ -1228,7 +1228,7 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
   return min(list);
 }
 
-/*static*/ IndexExpr IndexExpr::max(SmallVectorImpl<IndexExpr> &vals) {
+/*static*/ IndexExpr IndexExpr::max(ArrayRef<IndexExpr> vals) {
   // Res is already an literal int, we are reducing into it.
   F2Self litFct = [](IndexExpr res, IndexExpr const aa) -> IndexExpr {
     if (aa.isLiteralAndGreaterThan(res))
@@ -1236,13 +1236,13 @@ IndexExpr IndexExpr::clamp(IndexExpr const min, IndexExpr const max) const {
     return res;
   };
   Flist affineExprFct = [&](IndexExpr res,
-                            SmallVectorImpl<IndexExpr> &vvals) -> IndexExpr {
+                            ArrayRef<IndexExpr> vvals) -> IndexExpr {
     // Create a list of affine expression
     assert(vvals.size() > 1 && "come here only with 2 or more values");
     SmallVector<AffineExpr, 4> affineExprs;
     // Important to get the affine expressions before getting the
     // dims/symbols.
-    for (IndexExpr &vv : vvals) {
+    for (IndexExpr vv : vvals) {
       affineExprs.emplace_back(vv.getAffineExpr());
     }
     // Compute a map including the list of affine expressions.

--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -404,6 +404,7 @@ private:
 //===----------------------------------------------------------------------===//
 
 using DimsExpr = llvm::SmallVector<IndexExpr, 4>;
+using DimsExprRef = mlir::ArrayRef<IndexExpr>;
 
 // Data structure that is the public interface for IndexExpr. It is a shallow
 // data structure that is simply a pointer to the actual data (IndexExprImpl).
@@ -470,8 +471,8 @@ public:
   bool isLiteralAndSmallerThan(double b) const;            // Values smaller.
   bool isLiteralAndSmallerThan(IndexExpr const b) const;   // Values smaller.
   // Test if all element in list are literals.
-  static bool isLiteral(llvm::SmallVectorImpl<IndexExpr> &list);
-  static bool isNonNegativeLiteral(llvm::SmallVectorImpl<IndexExpr> &list);
+  static bool isLiteral(mlir::ArrayRef<IndexExpr> list);
+  static bool isNonNegativeLiteral(mlir::ArrayRef<IndexExpr> list);
 
   // Getters.
   IndexExprScope &getScope() const { return *getScopePtr(); }
@@ -564,10 +565,10 @@ public:
   IndexExpr selectOrSelf(IndexExpr const compare, int64_t const trueVal) const;
 
   // Return min or max of a list of IndexExpr.
-  static IndexExpr min(llvm::SmallVectorImpl<IndexExpr> &vals);
+  static IndexExpr min(mlir::ArrayRef<IndexExpr> vals);
   static IndexExpr min(IndexExpr const first, IndexExpr const second);
   static IndexExpr min(IndexExpr const first, int64_t const second);
-  static IndexExpr max(llvm::SmallVectorImpl<IndexExpr> &vals);
+  static IndexExpr max(mlir::ArrayRef<IndexExpr> vals);
   static IndexExpr max(IndexExpr const first, IndexExpr const second);
   static IndexExpr max(IndexExpr const first, int64_t const second);
 
@@ -598,8 +599,7 @@ protected:
   using F1 = std::function<IndexExpr(IndexExpr const)>;
   using F2 = std::function<IndexExpr(IndexExpr const, IndexExpr const)>;
   using F2Self = std::function<IndexExpr(IndexExpr, IndexExpr const)>;
-  using Flist =
-      std::function<IndexExpr(IndexExpr, llvm::SmallVectorImpl<IndexExpr> &)>;
+  using Flist = std::function<IndexExpr(IndexExpr, mlir::ArrayRef<IndexExpr>)>;
   using F3 = std::function<IndexExpr(
       IndexExpr const, IndexExpr const, IndexExpr const)>;
   // Support for operations: common handling for multiple operations.
@@ -617,8 +617,8 @@ protected:
       mlir::arith::CmpIPredicate comparePred, IndexExpr const b) const;
   IndexExpr compareOp(
       mlir::arith::CmpFPredicate comparePred, IndexExpr const b) const;
-  static IndexExpr reductionOp(llvm::SmallVectorImpl<IndexExpr> &vals,
-      F2Self litRed, Flist affineRed, F2Self valueRed);
+  static IndexExpr reductionOp(mlir::ArrayRef<IndexExpr> vals, F2Self litRed,
+      Flist affineRed, F2Self valueRed);
   // Data: pointer to implemented object.
   IndexExprImpl *indexExprObj = nullptr;
 };

--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -582,7 +582,7 @@ public:
   // Debug (enable running with --debug-only=index-expr, for example).
   void debugPrint(const std::string &msg) const;
   static void debugPrint(
-      const std::string &msg, const llvm::SmallVectorImpl<IndexExpr> &list);
+      const std::string &msg, const mlir::ArrayRef<IndexExpr> list);
 
 protected:
   // Private queries.
@@ -882,7 +882,7 @@ inline llvm::SmallVector<IndexExpr, 4> SymListIE(mlir::ValueRange range) {
 
 // Create a list of IndexExpr of kind INDEX_EXPR from another list of IndexExpr.
 template <class INDEX_EXPR>
-void getIndexExprList(const llvm::SmallVectorImpl<IndexExpr> &inputList,
+void getIndexExprList(const mlir::ArrayRef<IndexExpr> inputList,
     llvm::SmallVectorImpl<IndexExpr> &outputList) {
   outputList.clear();
   for (auto item : inputList)
@@ -890,14 +890,14 @@ void getIndexExprList(const llvm::SmallVectorImpl<IndexExpr> &inputList,
 }
 
 inline llvm::SmallVector<IndexExpr, 4> DimListIE(
-    const llvm::SmallVectorImpl<IndexExpr> &inputList) {
+    const mlir::ArrayRef<IndexExpr> inputList) {
   llvm::SmallVector<IndexExpr, 4> outputList;
   getIndexExprList<DimIndexExpr>(inputList, outputList);
   return outputList;
 }
 
 inline llvm::SmallVector<IndexExpr, 4> SymListIE(
-    const llvm::SmallVectorImpl<IndexExpr> &inputList) {
+    const mlir::ArrayRef<IndexExpr> inputList) {
   llvm::SmallVector<IndexExpr, 4> outputList;
   getIndexExprList<SymbolIndexExpr>(inputList, outputList);
   return outputList;

--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -237,8 +237,8 @@ result in a new Dim variable.
     for (int ii = 0; ii < outputRank; ++ii) {
       Value inductionVal = outputLoops.getInductionVar(ii);
       DimIndexExpr inductionIndex(inductionVal);
-      IndexExpr start = SymbolIndexExpr(shapeHelper.starts[ii]);
-      IndexExpr step = SymbolIndexExpr(shapeHelper.steps[ii]);
+      IndexExpr start = SymIE(shapeHelper.starts[ii]);
+      IndexExpr step = SymIE(shapeHelper.steps[ii]);
       loadIndices.emplace_back((step * inductionIndex) + start);
       storeIndices.emplace_back(inductionIndex);
     }
@@ -842,7 +842,7 @@ inline IndexExpr operator*(int64_t const a, const IndexExpr &b) {
   return b * a;
 }
 inline IndexExpr operator-(int64_t const a, const IndexExpr &b) {
-  return LiteralIndexExpr(a) - b;
+  return LitIE(a) - b;
 }
 
 //===----------------------------------------------------------------------===//
@@ -870,13 +870,13 @@ void getIndexExprList(
 
 inline llvm::SmallVector<IndexExpr, 4> DimListIE(mlir::ValueRange range) {
   llvm::SmallVector<IndexExpr, 4> outputList;
-  getIndexExprList<DimIndexExpr>(range, outputList);
+  getIndexExprList<DimIE>(range, outputList);
   return outputList;
 }
 
 inline llvm::SmallVector<IndexExpr, 4> SymListIE(mlir::ValueRange range) {
   llvm::SmallVector<IndexExpr, 4> outputList;
-  getIndexExprList<SymbolIndexExpr>(range, outputList);
+  getIndexExprList<SymIE>(range, outputList);
   return outputList;
 }
 
@@ -892,14 +892,14 @@ void getIndexExprList(const mlir::ArrayRef<IndexExpr> inputList,
 inline llvm::SmallVector<IndexExpr, 4> DimListIE(
     const mlir::ArrayRef<IndexExpr> inputList) {
   llvm::SmallVector<IndexExpr, 4> outputList;
-  getIndexExprList<DimIndexExpr>(inputList, outputList);
+  getIndexExprList<DimIE>(inputList, outputList);
   return outputList;
 }
 
 inline llvm::SmallVector<IndexExpr, 4> SymListIE(
     const mlir::ArrayRef<IndexExpr> inputList) {
   llvm::SmallVector<IndexExpr, 4> outputList;
-  getIndexExprList<SymbolIndexExpr>(inputList, outputList);
+  getIndexExprList<SymIE>(inputList, outputList);
   return outputList;
 }
 

--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -610,9 +610,9 @@ protected:
   IndexExpr unaryOp(
       bool resIsFloat, F1 litFct, F1 affineExprFct, F1 valueFct) const;
   // Res is float is the same as a & b.
-  IndexExpr binaryOp(IndexExpr const b, bool affineWithLitB, bool hasNeutralA,
-      bool hasNeutralB, double neutralVal, F2 fInteger, F2 fAffine,
-      F2 fValue) const;
+  IndexExpr binaryOp(IndexExpr const b, bool propagateIntoMinMax,
+      bool affineWithLitB, bool hasNeutralA, bool hasNeutralB,
+      double neutralVal, F2 fInteger, F2 fAffine, F2 fValue) const;
   IndexExpr compareOp(
       mlir::arith::CmpIPredicate comparePred, IndexExpr const b) const;
   IndexExpr compareOp(

--- a/src/Dialect/Mlir/IndexExprBuilder.cpp
+++ b/src/Dialect/Mlir/IndexExprBuilder.cpp
@@ -234,7 +234,7 @@ IndexExpr IndexExprBuilder::getValFromArray(
     }
     Value castedVal = createMath.castToIndex(val);
     if (makeSymbol)
-      return SymbolIndexExpr(castedVal);
+      return SymIE(castedVal);
     else
       return DimIndexExpr(castedVal);
   }
@@ -381,7 +381,7 @@ IndexExpr IndexExprBuilder::getShapeAsSymbol(
   if (isLiteralShape(tensorOrMemrefValue, i))
     return getShapeAsLiteral(tensorOrMemrefValue, i);
   if (Value val = getShapeVal(tensorOrMemrefValue, i))
-    return SymbolIndexExpr(val);
+    return SymIE(val);
   return QuestionmarkIndexExpr(tensorOrMemrefValue, i);
 }
 

--- a/src/Dialect/Mlir/IndexExprBuilder.cpp
+++ b/src/Dialect/Mlir/IndexExprBuilder.cpp
@@ -236,7 +236,7 @@ IndexExpr IndexExprBuilder::getValFromArray(
     if (makeSymbol)
       return SymIE(castedVal);
     else
-      return DimIndexExpr(castedVal);
+      return DimIE(castedVal);
   }
   return QuestionmarkIndexExpr(isFloat);
 }
@@ -390,7 +390,7 @@ IndexExpr IndexExprBuilder::getShapeAsDim(
   if (isLiteralShape(tensorOrMemrefValue, i))
     return getShapeAsLiteral(tensorOrMemrefValue, i);
   if (Value val = getShapeVal(tensorOrMemrefValue, i))
-    return DimIndexExpr(val);
+    return DimIE(val);
   return QuestionmarkIndexExpr(tensorOrMemrefValue, i);
 }
 

--- a/src/Dialect/Mlir/IndexExprBuilder.cpp
+++ b/src/Dialect/Mlir/IndexExprBuilder.cpp
@@ -130,14 +130,14 @@ IndexExpr IndexExprBuilder::getIntFromArrayAsLiteral(
   if (i >= size)
     return UndefinedIndexExpr();
   int64_t val = mlir::cast<IntegerAttr>(intAttrArray.getValue()[i]).getInt();
-  return LiteralIndexExpr(val);
+  return LitIE(val);
 }
 
 IndexExpr IndexExprBuilder::getIntFromArrayAsLiteral(
     ArrayAttr intAttrArray, uint64_t i, int64_t outOfBoundVal) {
   IndexExpr indexExpr = getIntFromArrayAsLiteral(intAttrArray, i);
   // Undefined value are set to default value.
-  return indexExpr.isUndefined() ? LiteralIndexExpr(outOfBoundVal) : indexExpr;
+  return indexExpr.isUndefined() ? LitIE(outOfBoundVal) : indexExpr;
 }
 
 void IndexExprBuilder::getIntFromArrayAsLiterals(
@@ -204,10 +204,10 @@ IndexExpr IndexExprBuilder::getValFromArray(
     if (isFloat) {
       double floatVal =
           getFloatValue(elementsAttr, elType, i).convertToDouble();
-      return LiteralIndexExpr(floatVal);
+      return LitIE(floatVal);
     } else {
       int64_t intVal = getIntValue(elementsAttr, elType, i).getSExtValue();
-      return LiteralIndexExpr(intVal);
+      return LitIE(intVal);
     }
   }
   // If our scalar array is not a constant; we have a runtime value.
@@ -220,10 +220,10 @@ IndexExpr IndexExprBuilder::getValFromArray(
       if (isFloat) {
         double floatVal =
             getFloatValue(elementsAttr, elType, 0).convertToDouble();
-        return LiteralIndexExpr(floatVal);
+        return LitIE(floatVal);
       } else {
         int64_t intVal = getIntValue(elementsAttr, elType, 0).getSExtValue();
-        return LiteralIndexExpr(intVal);
+        return LitIE(intVal);
       }
     }
     // Otherwise, we can write code.
@@ -278,21 +278,21 @@ IndexExpr IndexExprBuilder::getIntFromArrayAsSymbolWithOutOfBound(
     Value intArray, uint64_t i, int64_t defaultLiteral) {
   IndexExpr indexExpr = getIntFromArrayAsSymbol(intArray, i);
   // Undefined value are set to default value.
-  return indexExpr.isUndefined() ? LiteralIndexExpr(defaultLiteral) : indexExpr;
+  return indexExpr.isUndefined() ? LitIE(defaultLiteral) : indexExpr;
 }
 
 IndexExpr IndexExprBuilder::getIntFromArrayAsDimWithOutOfBound(
     Value intArray, uint64_t i, int64_t defaultLiteral) {
   IndexExpr indexExpr = getIntFromArrayAsDim(intArray, i);
   // Undefined value are set to default value.
-  return indexExpr.isUndefined() ? LiteralIndexExpr(defaultLiteral) : indexExpr;
+  return indexExpr.isUndefined() ? LitIE(defaultLiteral) : indexExpr;
 }
 
 IndexExpr IndexExprBuilder::getFloatFromArrayAsNonAffineWithOutOfBound(
     Value floatArray, uint64_t i, double defaultLiteral) {
   IndexExpr indexExpr = getFloatFromArrayAsNonAffine(floatArray, i);
   // Undefined value are set to default value.
-  return indexExpr.isUndefined() ? LiteralIndexExpr(defaultLiteral) : indexExpr;
+  return indexExpr.isUndefined() ? LitIE(defaultLiteral) : indexExpr;
 }
 
 void IndexExprBuilder::getIntFromArrayAsSymbols(
@@ -373,7 +373,7 @@ IndexExpr IndexExprBuilder::getShapeAsLiteral(
   int64_t shape = getShape(tensorOrMemrefValue, i);
   assert(
       shape != ShapedType::kDynamic && "expected compile time constant shape");
-  return LiteralIndexExpr(shape);
+  return LitIE(shape);
 }
 
 IndexExpr IndexExprBuilder::getShapeAsSymbol(
@@ -430,7 +430,7 @@ IndexExpr IndexExprBuilder::isTileFull(
   // However, if UB is divisible by Block, then its full no matter what.
   if (UB.isLiteral() && (UB.getLiteral() % block.getLiteral() == 0)) {
     // Last tile is guaranteed to be full because UB is divisible by block.
-    return LiteralIndexExpr(1); // 1 >= 0 is true
+    return LitIE(1); // 1 >= 0 is true
   }
   // True if i <= (UB - block), namely UB - block - i >= 0.
   // Affine expressions compared to >= 0

--- a/src/Dialect/Mlir/VectorMachineSupport.cpp
+++ b/src/Dialect/Mlir/VectorMachineSupport.cpp
@@ -190,7 +190,7 @@ int64_t Z16VectorMachineSupport::computeArchVectorLength(
 // =============================================================================
 
 int64_t SSE42x86VectorMachineSupport::computeArchVectorLength(
-    GenericOps Gop, mlir::Type elementType) {
+    GenericOps Gop, Type elementType) {
   int64_t bitWidth = elementType.getIntOrFloatBitWidth();
   int64_t archVL = VectorMachineSupport::getArchVectorLength(elementType);
   bool isFloat = mlir::isa<FloatType>(elementType);
@@ -276,7 +276,7 @@ int64_t SSE42x86VectorMachineSupport::computeArchVectorLength(
 // =============================================================================
 
 int64_t NeonVectorMachineSupport::computeArchVectorLength(
-    GenericOps Gop, mlir::Type elementType) {
+    GenericOps Gop, Type elementType) {
   int64_t bitWidth = elementType.getIntOrFloatBitWidth();
   int64_t archVL = VectorMachineSupport::getArchVectorLength(elementType);
   bool isFloat = mlir::isa<FloatType>(elementType);

--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -296,8 +296,8 @@ Value OnnxBuilder::reshape(Type outputType, Value input, Value shape) const {
       toTensor(outputType), toTensor(input), toTensor(shape));
 }
 
-Value OnnxBuilder::reshape(Type outputType, Value input, Value shape,
-    mlir::IntegerAttr allowZero) const {
+Value OnnxBuilder::reshape(
+    Type outputType, Value input, Value shape, IntegerAttr allowZero) const {
   return createTypedOpAndInferShapes<ONNXReshapeOp>(
       toTensor(outputType), toTensor(input), toTensor(shape), allowZero);
 }

--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -107,9 +107,9 @@ static bool handleAndTestInBound(int64_t &axis, ShapedType type) {
 /// Given a QuestionMarkIndexExpr representing a dynamic dimension, find the
 /// same dynamic dimensions in the inputs.
 static void findAndAddSameDim(const QuestionmarkIndexExpr &qmOuputIE,
-    mlir::Operation *op, mlir::ValueRange operands,
+    mlir::Operation *op, ValueRange operands,
     DimAnalysis::DimSetT &sameDims) {
-  mlir::Location loc = op->getLoc();
+  Location loc = op->getLoc();
   IndexExprBuilderForAnalysis createIE(loc);
 
   // Cannot process if the question mark is not a specific one.

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -28,7 +28,7 @@
 #define UNSUPPORTED_OPS(OP_TYPE)                                               \
   /* shape inference interface method */                                       \
   mlir::LogicalResult mlir::OP_TYPE::inferShapes(                              \
-      std::function<void(Region &)> doShapeInference) {                  \
+      std::function<void(Region &)> doShapeInference) {                        \
     return mlir::success();                                                    \
   }
 

--- a/src/Dialect/ONNX/ONNXOps.cpp
+++ b/src/Dialect/ONNX/ONNXOps.cpp
@@ -28,7 +28,7 @@
 #define UNSUPPORTED_OPS(OP_TYPE)                                               \
   /* shape inference interface method */                                       \
   mlir::LogicalResult mlir::OP_TYPE::inferShapes(                              \
-      std::function<void(mlir::Region &)> doShapeInference) {                  \
+      std::function<void(Region &)> doShapeInference) {                  \
     return mlir::success();                                                    \
   }
 

--- a/src/Dialect/ONNX/ONNXOps/Additional/ConcatShapeTranspose.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/ConcatShapeTranspose.cpp
@@ -113,7 +113,7 @@ LogicalResult ONNXConcatShapeTransposeOpShapeHelper::computeShape() {
   assert(start <= end && "Start must not be greater than end");
 
   // Output is the actual number of values (1D)
-  setOutputDims({LiteralIndexExpr(end - start)}, 0);
+  setOutputDims({LitIE(end - start)}, 0);
 
   // For the transpose
   DimsExpr outputTransposeDims(commonRank);

--- a/src/Dialect/ONNX/ONNXOps/Additional/Return.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/Return.cpp
@@ -44,8 +44,8 @@ bool shapeIsSameOrMoreSpecific(ShapedType lhs, ShapedType rhs) {
 
 // True if the types are the same up to shape specificity.
 bool typeIsSameOrMoreSpecific(Type lhs, Type rhs) {
-  ShapedType lhsShaped = dyn_cast<ShapedType>(lhs);
-  ShapedType rhsShaped = dyn_cast<ShapedType>(rhs);
+  ShapedType lhsShaped = mlir::dyn_cast<ShapedType>(lhs);
+  ShapedType rhsShaped = mlir::dyn_cast<ShapedType>(rhs);
 
   if (!lhsShaped && !rhsShaped) {
     return lhs == rhs;
@@ -67,7 +67,7 @@ bool typeIsSameOrMoreSpecific(Type lhs, Type rhs) {
 // Implementation is adapted from mlir/lib/Dialect/Func/IR/FuncOps.cpp
 // relaxing the type check to allow more specific shapes.
 LogicalResult ONNXReturnOp::verify() {
-  auto function = cast<func::FuncOp>((*this)->getParentOp());
+  auto function = mlir::cast<func::FuncOp>((*this)->getParentOp());
 
   // The operand number and types must match the function signature.
   const auto &results = function.getFunctionType().getResults();

--- a/src/Dialect/ONNX/ONNXOps/Additional/ShapeTransform.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/ShapeTransform.cpp
@@ -67,7 +67,7 @@ LogicalResult ONNXShapeTransformOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXShapeTransformOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   Operation *op = getOperation();
   // If any input is not ranked tensor, do nothing.
   if (!hasShapeAndRank(op))

--- a/src/Dialect/ONNX/ONNXOps/Additional/ShapeTransform.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Additional/ShapeTransform.cpp
@@ -93,13 +93,13 @@ LogicalResult ONNXShapeTransformOp::verify() {
     return emitError("Does not support affine_map with symbols");
 
   // Only support static shape at this moment.
-  auto inputType = dyn_cast<ShapedType>(input.getType());
+  auto inputType = mlir::dyn_cast<ShapedType>(input.getType());
   if (inputType && !inputType.hasStaticShape())
     return emitError("Does not support input with dynamic shape");
 
   // If input and output have static shape, check that the same number of
   // elements are the same.
-  if (auto outputType = dyn_cast<ShapedType>(output.getType()))
+  if (auto outputType = mlir::dyn_cast<ShapedType>(output.getType()))
     if (outputType.hasStaticShape()) {
       uint64_t elementsInput = 1;
       for (uint64_t d : inputType.getShape())

--- a/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ControlFlow/Loop.cpp
@@ -39,7 +39,7 @@ std::vector<Type> ONNXLoopOp::resultTypeInference() {
       resultTypes.push_back(ty);
     } else { // scan output
       // Erase any rank and shape. Shape inference will add a leading dimension.
-      Type elementType = cast<ShapedType>(ty).getElementType();
+      Type elementType = mlir::cast<ShapedType>(ty).getElementType();
       resultTypes.push_back(UnrankedTensorType::get(elementType));
     }
   }

--- a/src/Dialect/ONNX/ONNXOps/ControlFlow/Scan.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ControlFlow/Scan.cpp
@@ -50,7 +50,7 @@ std::vector<Type> ONNXScanOp::resultTypeInference() {
       resultTypes.push_back(ty);
     } else { // scan output
       // Erase any rank and shape. Shape inference will add a leading dimension.
-      Type elementType = cast<ShapedType>(ty).getElementType();
+      Type elementType = mlir::cast<ShapedType>(ty).getElementType();
       resultTypes.push_back(UnrankedTensorType::get(elementType));
     }
   }

--- a/src/Dialect/ONNX/ONNXOps/ML/OneHotEncoder.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ML/OneHotEncoder.cpp
@@ -46,7 +46,7 @@ LogicalResult ONNXOneHotEncoderOpShapeHelper::computeShape() {
   // total category count will determine the size of the extra dimension
   DimsExpr outputDims;
   createIE->getShapeAsDims(X, outputDims);
-  outputDims.emplace_back(LiteralIndexExpr(outDim));
+  outputDims.emplace_back(LitIE(outDim));
 
   // Save the final result.
   setOutputDims(outputDims);

--- a/src/Dialect/ONNX/ONNXOps/Math/DFT.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/DFT.cpp
@@ -88,7 +88,7 @@ LogicalResult ONNXGenericDFTOpShapeHelper<ONNXDFTOp>::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXDFTOp::inferShapes(
-    std::function<void(mlir::Region &)> doShapeInference) {
+    std::function<void(Region &)> doShapeInference) {
   // Cannot infer the output shape if the operands shape isn't known yet.
   if (!hasShapeAndRank(getOperation()))
     return success();

--- a/src/Dialect/ONNX/ONNXOps/Math/DFT.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/DFT.cpp
@@ -67,7 +67,7 @@ LogicalResult ONNXGenericDFTOpShapeHelper<OP_TYPE>::customComputeShape(
       }
     }
   }
-  outputDims.emplace_back(LiteralIndexExpr(2));
+  outputDims.emplace_back(LitIE(2));
 
   // Save the final result.
   setOutputDims(outputDims);

--- a/src/Dialect/ONNX/ONNXOps/Math/Gemm.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/Gemm.cpp
@@ -66,10 +66,10 @@ LogicalResult ONNXGemmOpShapeHelper::computeShape() {
   if (hasBias) {
     if (cRank == 0) {
       // Broadcast for scalar: both dims are 1.
-      cDims = {LiteralIndexExpr(1), LiteralIndexExpr(1)};
+      cDims = {LitIE(1), LitIE(1)};
     } else if (cRank == 1) {
       // First dim is the one padded.
-      cDims = {LiteralIndexExpr(1), createIE->getShapeAsDim(C, 0)};
+      cDims = {LitIE(1), createIE->getShapeAsDim(C, 0)};
     } else {
       assert(cRank == 2 && "illegal path");
       cDims = {createIE->getShapeAsDim(C, 0), createIE->getShapeAsDim(C, 1)};

--- a/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
@@ -389,7 +389,7 @@ LogicalResult ONNXConvTransposeOpShapeHelper::computeShape() {
     // Kernel shape from attribute, default from Weight's spatial dims.
     if (kernelShapeOpt.has_value()) {
       kernelShape.emplace_back(
-          LiteralIndexExpr(ArrayAttrIntVal(kernelShapeOpt, i)));
+          LitIE(ArrayAttrIntVal(kernelShapeOpt, i)));
     } else {
       int ii = i + spatialOffset;
       kernelShape.emplace_back(createIE->getShapeAsSymbol(wValue, ii));
@@ -402,7 +402,7 @@ LogicalResult ONNXConvTransposeOpShapeHelper::computeShape() {
   // Pads, at this stage a given compile-time literal or default 0.
   for (int i = 0; i < 2 * spatialRank; ++i) {
     int64_t p = padOpt.has_value() ? ArrayAttrIntVal(padOpt, i) : 0;
-    pads.emplace_back(LiteralIndexExpr(p));
+    pads.emplace_back(LitIE(p));
   }
 
   // Handle output size: start by inserting batch size and output channels.
@@ -410,7 +410,7 @@ LogicalResult ONNXConvTransposeOpShapeHelper::computeShape() {
   outputDims.emplace_back(createIE->getShapeAsDim(xValue, 0));
   outputDims.emplace_back(
       createIE->getShapeAsDim(wValue, 1) *
-      LiteralIndexExpr(groupNum)); // CO may be different from CI.
+      LitIE(groupNum)); // CO may be different from CI.
 
   LiteralIndexExpr zeroIE(0);
   LiteralIndexExpr oneIE(1);

--- a/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Conv.cpp
@@ -388,8 +388,7 @@ LogicalResult ONNXConvTransposeOpShapeHelper::computeShape() {
         dilationOpt.has_value() ? ArrayAttrIntVal(dilationOpt, i) : 1);
     // Kernel shape from attribute, default from Weight's spatial dims.
     if (kernelShapeOpt.has_value()) {
-      kernelShape.emplace_back(
-          LitIE(ArrayAttrIntVal(kernelShapeOpt, i)));
+      kernelShape.emplace_back(LitIE(ArrayAttrIntVal(kernelShapeOpt, i)));
     } else {
       int ii = i + spatialOffset;
       kernelShape.emplace_back(createIE->getShapeAsSymbol(wValue, ii));
@@ -408,9 +407,8 @@ LogicalResult ONNXConvTransposeOpShapeHelper::computeShape() {
   // Handle output size: start by inserting batch size and output channels.
   DimsExpr outputDims;
   outputDims.emplace_back(createIE->getShapeAsDim(xValue, 0));
-  outputDims.emplace_back(
-      createIE->getShapeAsDim(wValue, 1) *
-      LitIE(groupNum)); // CO may be different from CI.
+  outputDims.emplace_back(createIE->getShapeAsDim(wValue, 1) *
+                          LitIE(groupNum)); // CO may be different from CI.
 
   LiteralIndexExpr zeroIE(0);
   LiteralIndexExpr oneIE(1);

--- a/src/Dialect/ONNX/ONNXOps/NN/NNHelper.cpp.inc
+++ b/src/Dialect/ONNX/ONNXOps/NN/NNHelper.cpp.inc
@@ -46,7 +46,7 @@ LogicalResult ONNXGenericPoolOpShapeHelper<OP_TYPE>::customComputeShape(
     // Kernel shape from attribute, default from Weight's spatial dims.
     if (kernelShapeOpt.has_value()) {
       kernelShape.emplace_back(
-          LiteralIndexExpr(ArrayAttrIntVal(kernelShapeOpt, i)));
+          LitIE(ArrayAttrIntVal(kernelShapeOpt, i)));
     } else {
       assert(hasFilter && "no kernel shape and no filter: unkown kernel shape");
       int ii = i + spatialOffset;
@@ -56,7 +56,7 @@ LogicalResult ONNXGenericPoolOpShapeHelper<OP_TYPE>::customComputeShape(
   // Pads, at this stage a given compile-time literal or default 0.
   for (int i = 0; i < 2 * spatialRank; ++i) {
     int64_t p = padOpt.has_value() ? ArrayAttrIntVal(padOpt, i) : 0;
-    pads.emplace_back(LiteralIndexExpr(p));
+    pads.emplace_back(LitIE(p));
   }
 
   // Handle output size: start by inserting batch size and output channels.

--- a/src/Dialect/ONNX/ONNXOps/NN/NNHelper.cpp.inc
+++ b/src/Dialect/ONNX/ONNXOps/NN/NNHelper.cpp.inc
@@ -45,8 +45,7 @@ LogicalResult ONNXGenericPoolOpShapeHelper<OP_TYPE>::customComputeShape(
         dilationOpt.has_value() ? ArrayAttrIntVal(dilationOpt, i) : 1);
     // Kernel shape from attribute, default from Weight's spatial dims.
     if (kernelShapeOpt.has_value()) {
-      kernelShape.emplace_back(
-          LitIE(ArrayAttrIntVal(kernelShapeOpt, i)));
+      kernelShape.emplace_back(LitIE(ArrayAttrIntVal(kernelShapeOpt, i)));
     } else {
       assert(hasFilter && "no kernel shape and no filter: unkown kernel shape");
       int ii = i + spatialOffset;

--- a/src/Dialect/ONNX/ONNXOps/NN/Normalization.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Normalization.cpp
@@ -260,7 +260,7 @@ mlir::LogicalResult ONNXLNOpShapeHelper<OP_TYPE>::computeShape() {
   if (hasMean) {
     DimsExpr meanShape(getOutputDims(0));
     for (int64_t r = axis; r < XRank; ++r)
-      meanShape[r] = LiteralIndexExpr(1);
+      meanShape[r] = LitIE(1);
     setOutputDims(meanShape, 1, false);
   }
 
@@ -268,7 +268,7 @@ mlir::LogicalResult ONNXLNOpShapeHelper<OP_TYPE>::computeShape() {
   if (hasInvStdDev) {
     DimsExpr invStdDevShape(getOutputDims(0));
     for (int64_t r = axis; r < XRank; ++r)
-      invStdDevShape[r] = LiteralIndexExpr(1);
+      invStdDevShape[r] = LitIE(1);
     setOutputDims(invStdDevShape, invStdDevIndex, false);
   }
   return success();

--- a/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/Pooling.cpp
@@ -39,7 +39,7 @@ LogicalResult ONNXGenericGlobalPoolOpShapeHelper<OP_TYPE>::computeShape() {
   outputDims.emplace_back(xDims[1]);
   // Spatial dimensions are reduced to 1.
   for (int i = 2; i < (int)xDims.size(); ++i)
-    outputDims.emplace_back(LiteralIndexExpr(1));
+    outputDims.emplace_back(LitIE(1));
   // Save the final result.
   setOutputDims(outputDims);
   return success();
@@ -62,7 +62,7 @@ LogicalResult ONNXMaxRoiPoolOpShapeHelper::computeShape() {
 
   // 4-D tensor : (num_rois, channels, pooled_shape[0], pooled_shape[1]).
   DimsExpr outputDims;
-  outputDims.push_back(LiteralIndexExpr(numRois));
+  outputDims.push_back(LitIE(numRois));
   outputDims.push_back(channel);
   outputDims.push_back(pooledDims[0]);
   outputDims.push_back(pooledDims[1]);

--- a/src/Dialect/ONNX/ONNXOps/NN/RoiAlign.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/RoiAlign.cpp
@@ -39,8 +39,8 @@ LogicalResult ONNXRoiAlignOpShapeHelper::computeShape() {
   int64_t height = roiAlignOp.getOutputHeight();
   int64_t width = roiAlignOp.getOutputWidth();
 
-  DimsExpr outputDims = {batchIndicesDims[0], xDims[1],
-      LitIE(height), LitIE(width)};
+  DimsExpr outputDims = {
+      batchIndicesDims[0], xDims[1], LitIE(height), LitIE(width)};
 
   // Save the final result.
   setOutputDims(outputDims);

--- a/src/Dialect/ONNX/ONNXOps/NN/RoiAlign.cpp
+++ b/src/Dialect/ONNX/ONNXOps/NN/RoiAlign.cpp
@@ -40,7 +40,7 @@ LogicalResult ONNXRoiAlignOpShapeHelper::computeShape() {
   int64_t width = roiAlignOp.getOutputWidth();
 
   DimsExpr outputDims = {batchIndicesDims[0], xDims[1],
-      LiteralIndexExpr(height), LiteralIndexExpr(width)};
+      LitIE(height), LitIE(width)};
 
   // Save the final result.
   setOutputDims(outputDims);

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -318,7 +318,7 @@ ONNXConstantOp getONNXConstantOp(Value value) {
 }
 
 bool getI64ValuesFromONNXConstantOp(
-    mlir::Value val, mlir::SmallVectorImpl<int64_t> &iRes) {
+    Value val, mlir::SmallVectorImpl<int64_t> &iRes) {
   ElementsAttr elemsAttr = getElementAttributeFromONNXValue(val);
   if (!elemsAttr)
     return false;
@@ -390,7 +390,7 @@ bool HasSpecifiedConstantShape(Value value, Value shape) {
 
 /// Test if a value is a scalar constant tensor or not, i.e. tensor<dtype> or
 /// tensor<1xdtype>.
-bool isScalarConstantTensor(mlir::Value v) {
+bool isScalarConstantTensor(Value v) {
   if (!hasShapeAndRank(v))
     return false;
 

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -234,7 +234,7 @@ std::vector<IndexExpr> getIndexExprsForConvWindow(
   SmallVector<IndexExpr, 2> endExprs = {end1, end2};
   windowEndExpr = IndexExpr::min(endExprs);
   // kernelOffsetExpr
-  SmallVector<IndexExpr, 2> kernelExprs = {LiteralIndexExpr(0), start2};
+  SmallVector<IndexExpr, 2> kernelExprs = {LitIE(0), start2};
   kernelOffsetExpr = IndexExpr::min(kernelExprs);
 
   return std::vector<IndexExpr>{

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -124,8 +124,8 @@ bool hasCustomONNXTensorDataLayout(const Type type) {
 }
 
 bool sameRank(Value tensorOrMemref1, Value tensorOrMemref2) {
-  auto type1 = dyn_cast_or_null<ShapedType>(tensorOrMemref1.getType());
-  auto type2 = dyn_cast_or_null<ShapedType>(tensorOrMemref2.getType());
+  auto type1 = mlir::dyn_cast_or_null<ShapedType>(tensorOrMemref1.getType());
+  auto type2 = mlir::dyn_cast_or_null<ShapedType>(tensorOrMemref2.getType());
   if (!type1 || !type2)
     return false;
   if (!type1.hasRank() || !type2.hasRank())
@@ -314,7 +314,7 @@ ElementsAttr getElementAttributeFromONNXValue(Value value) {
 
 // Returns the ConstantOp which defines an MLIR Value or null.
 ONNXConstantOp getONNXConstantOp(Value value) {
-  return dyn_cast_or_null<ONNXConstantOp>(value.getDefiningOp());
+  return mlir::dyn_cast_or_null<ONNXConstantOp>(value.getDefiningOp());
 }
 
 bool getI64ValuesFromONNXConstantOp(
@@ -394,7 +394,7 @@ bool isScalarConstantTensor(Value v) {
   if (!hasShapeAndRank(v))
     return false;
 
-  auto t = dyn_cast<ShapedType>(v.getType());
+  auto t = mlir::dyn_cast<ShapedType>(v.getType());
   int64_t r = t.getRank();
   return isDenseONNXConstant(v) &&
          ((r == 0) || ((r == 1) && (t.getShape()[0] == 1)));
@@ -438,7 +438,7 @@ bool hasOneUseExceptDimOp(Value val) {
 
 // Create an ArrayAttr from a dense ConstantOp
 ArrayAttr createArrayAttrFromConstantOp(ONNXConstantOp constOp) {
-  auto elements = cast<ElementsAttr>(constOp.getValueAttr());
+  auto elements = mlir::cast<ElementsAttr>(constOp.getValueAttr());
   SmallVector<Attribute> values(elements.getValues<Attribute>());
   return ArrayAttr::get(constOp.getContext(), values);
 }
@@ -447,7 +447,7 @@ ArrayAttr createArrayAttrFromConstantOp(ONNXConstantOp constOp) {
 DenseElementsAttr createDenseElementsAttrFromFloatAttr(
     PatternRewriter &rewriter, Type elementType, FloatAttr attr) {
   auto tensorType = RankedTensorType::get({1}, elementType);
-  auto ftype = cast<FloatType>(elementType);
+  auto ftype = mlir::cast<FloatType>(elementType);
   APFloat f = attr.getValue();
   bool ignored;
   f.convert(ftype.getFloatSemantics(), APFloat::rmNearestTiesToEven, &ignored);
@@ -528,7 +528,7 @@ DenseElementsAttr createDenseElementsAttrFromSize(
 /// Check whether a value is produced by a dense ONNXConstantOp.
 bool isDenseONNXConstant(Value result) {
   ONNXConstantOp constOp =
-      dyn_cast_or_null<ONNXConstantOp>(result.getDefiningOp());
+      mlir::dyn_cast_or_null<ONNXConstantOp>(result.getDefiningOp());
 
   // Must be a constant.
   if (!constOp)

--- a/src/Dialect/ONNX/ONNXOps/Quantize/DequantizeLinear.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Quantize/DequantizeLinear.cpp
@@ -68,7 +68,7 @@ LogicalResult ONNXDequantizeLinearOpShapeHelper::computeShape() {
     if (a < 0)
       a += r;
     if (!outputDims[a].isLiteral()) {
-      outputDims[a] = LiteralIndexExpr(d);
+      outputDims[a] = LitIE(d);
     }
     LLVM_DEBUG(llvm::dbgs() << "literal: " << outputDims[a].getLiteral()
                             << " d = " << d << "\n");

--- a/src/Dialect/ONNX/ONNXOps/RNN/RNN.cpp
+++ b/src/Dialect/ONNX/ONNXOps/RNN/RNN.cpp
@@ -58,7 +58,7 @@ LogicalResult ONNXGenericRNNShapeHelper<OP_TYPE>::customComputeShape(
   // Get hidden size from hidden_size attribute.
   IndexExpr hiddenSize;
   if (operandAdaptor.getHiddenSize().has_value()) {
-    hiddenSize = LiteralIndexExpr(operandAdaptor.getHiddenSize().value());
+    hiddenSize = LitIE(operandAdaptor.getHiddenSize().value());
   } else {
     // Infer hidden_size from wShape and rShape if possible.
     if (rDims[2].isLiteral())
@@ -84,9 +84,9 @@ LogicalResult ONNXGenericRNNShapeHelper<OP_TYPE>::customComputeShape(
   IndexExpr numDir;
   if ((operandAdaptor.getDirection() == "forward") ||
       (operandAdaptor.getDirection() == "reverse"))
-    numDir = LiteralIndexExpr(1);
+    numDir = LitIE(1);
   else if (operandAdaptor.getDirection() == "bidirectional")
-    numDir = LiteralIndexExpr(2);
+    numDir = LitIE(2);
   else
     return op->emitError(
         "direction attribute must be one of the strings: forward, "

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -102,12 +102,12 @@ static void refineDims(Operation *op, DimsExpr &inferredDims, Value output) {
 
     // InferredDim is unknown at shape inference: update it.
     if (inferredDims[i].isQuestionmark()) {
-      inferredDims[i] = LiteralIndexExpr(existingDims[i]);
+      inferredDims[i] = LitIE(existingDims[i]);
       continue;
     }
     // inferredDim is unknown at lowering: use existing dim for efficiency.
     if (!inferredDims[i].isLiteral()) {
-      inferredDims[i] = LiteralIndexExpr(existingDims[i]);
+      inferredDims[i] = LitIE(existingDims[i]);
       continue;
     }
     // inferredDim is different from existingDim. Believe in existingDim.
@@ -124,7 +124,7 @@ static void refineDims(Operation *op, DimsExpr &inferredDims, Value output) {
                      << "] the inferred dim (" << inferredDims[i].getLiteral()
                      << ") is different from the existing dim ("
                      << existingDims[i] << "). Use the existing dim instead.\n";
-      inferredDims[i] = LiteralIndexExpr(existingDims[i]);
+      inferredDims[i] = LitIE(existingDims[i]);
     }
   }
 }
@@ -460,7 +460,7 @@ bool ONNXBroadcastOpShapeHelper::hasManageableBroadcastForInnerDims(
                           << " dim analysis\n");
   // Keep track of cumulative inner dim sizes.
   collapsedLiteralSize = 1;
-  collapsedDynamicSize = LiteralIndexExpr(1);
+  collapsedDynamicSize = LitIE(1);
   // Keep track of ones, scalar, and broadcast per input.
   llvm::SmallBitVector isOne(dimNum, true);
   llvm::SmallBitVector isScalar(dimNum, true);
@@ -708,7 +708,7 @@ LogicalResult ONNXBroadcastOpShapeHelper::getAccessExprs(Value operand,
     // Compute access index based on broadcasting rules.
     if (operandDim.isLiteralAndIdenticalTo(1)) {
       // Dim of size 1: access is always 0.
-      operandAccessExprs.emplace_back(LiteralIndexExpr(0));
+      operandAccessExprs.emplace_back(LitIE(0));
     } else if (noBroadcasting || useLoopIndexNoMatterWhat) {
       // No broadcasting or we can use the loop index no matter what -> just use
       // the index.
@@ -764,7 +764,7 @@ bool ONNXUnaryOpShapeHelper::hasManageableBroadcastForInnerDims(
   int64_t outputRank = output.size();
   // Keep track of cumulative inner dim sizes.
   collapsedLiteralSize = 1;
-  collapsedDynamicSize = LiteralIndexExpr(1);
+  collapsedDynamicSize = LitIE(1);
   for (int64_t r = 0; r < outputRank; ++r) {
     if (output[r].isLiteral())
       collapsedLiteralSize *= output[r].getLiteral();
@@ -826,7 +826,7 @@ void updateType(Operation *op, Value val, ArrayRef<int64_t> shape,
       if (ShapedType::isDynamic(d) || d == -1)
         inferredDims.emplace_back(QuestionmarkIndexExpr(/*isFloat*/ false));
       else
-        inferredDims.emplace_back(LiteralIndexExpr(d));
+        inferredDims.emplace_back(LitIE(d));
     }
     refineDims(op, inferredDims, val);
     IndexExpr::getShape(inferredDims, inferredShape);

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -906,7 +906,7 @@ ONNXCustomOpShapeHelper::ONNXCustomOpShapeHelper(Operation *op,
     return;
   }
 
-  std::vector<mlir::Value> operandsVector;
+  std::vector<Value> operandsVector;
   for (auto indexAttr : inputIndexAttrs.value()) {
     operandsVector.push_back(
         inputs[mlir::cast<IntegerAttr>(indexAttr).getInt()]);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ArgMinMax.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ArgMinMax.cpp
@@ -55,8 +55,8 @@ LogicalResult ONNXArgMinMaxOpShapeHelper<OP_TYPE>::computeShape() {
   outputDims.resize(reducedRank);
   for (int64_t i = 0; i < reducedRank; i++) {
     if (isKeepdims)
-      outputDims[i] = (i != axisValue) ? createIE->getShapeAsDim(data, i)
-                                       : LitIE(1);
+      outputDims[i] =
+          (i != axisValue) ? createIE->getShapeAsDim(data, i) : LitIE(1);
     else
       outputDims[i] = (i < axisValue) ? createIE->getShapeAsDim(data, i)
                                       : createIE->getShapeAsDim(data, i + 1);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ArgMinMax.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ArgMinMax.cpp
@@ -56,7 +56,7 @@ LogicalResult ONNXArgMinMaxOpShapeHelper<OP_TYPE>::computeShape() {
   for (int64_t i = 0; i < reducedRank; i++) {
     if (isKeepdims)
       outputDims[i] = (i != axisValue) ? createIE->getShapeAsDim(data, i)
-                                       : LiteralIndexExpr(1);
+                                       : LitIE(1);
     else
       outputDims[i] = (i < axisValue) ? createIE->getShapeAsDim(data, i)
                                       : createIE->getShapeAsDim(data, i + 1);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Constant.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Constant.cpp
@@ -50,9 +50,9 @@ LogicalResult ONNXConstantOpShapeHelper::computeShape() {
 std::vector<Type> ONNXConstantOp::resultTypeInference() {
   ShapedType type;
   if (auto attr = getValueAttr()) {
-    type = cast<ElementsAttr>(attr).getShapedType();
+    type = mlir::cast<ElementsAttr>(attr).getShapedType();
   } else if (auto attr = getSparseValueAttr()) {
-    type = cast<ElementsAttr>(attr).getShapedType();
+    type = mlir::cast<ElementsAttr>(attr).getShapedType();
   } else if (auto attr = getValueFloatAttr()) {
     type = RankedTensorType::get({}, FloatType::getF32(getContext()));
   } else if (auto attr = getValueFloatsAttr()) {

--- a/src/Dialect/ONNX/ONNXOps/Tensor/ConstantOfShape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/ConstantOfShape.cpp
@@ -93,7 +93,7 @@ LogicalResult ONNXConstantOfShapeOp::verify() {
 std::vector<Type> ONNXConstantOfShapeOp::resultTypeInference() {
   Type elementType;
   if (auto attr = getValueAttr()) {
-    elementType = cast<ElementsAttr>(attr).getElementType();
+    elementType = mlir::cast<ElementsAttr>(attr).getElementType();
   } else {
     elementType = FloatType::getF32(getContext());
   }
@@ -106,7 +106,7 @@ std::vector<Type> ONNXConstantOfShapeOp::resultTypeInference() {
 
 LogicalResult ONNXConstantOfShapeOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
-  ShapedType inputType = cast<ShapedType>(getInput().getType());
+  ShapedType inputType = mlir::cast<ShapedType>(getInput().getType());
   if (!inputType.hasStaticShape())
     return success();
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Expand.cpp
@@ -40,7 +40,7 @@ LogicalResult ONNXExpandOpShapeHelper::computeShape() {
   if (ShapedType::isDynamic(shapeType.getShape()[0]))
     return op->emitError("expected size of shape parameter to be defined");
 
-  if (ONNXShapeOp shapeOp = dyn_cast_or_null<ONNXShapeOp>(shapeDefOp)) {
+  if (ONNXShapeOp shapeOp = mlir::dyn_cast_or_null<ONNXShapeOp>(shapeDefOp)) {
     assert(mlir::isa<ShapedType>(shapeOp.getData().getType()) && "expected");
     // Consider a first case where the expand.shape is produced by a shape op.
     // Infer its shape and use it as the requested shape.

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Flatten.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Flatten.cpp
@@ -42,13 +42,13 @@ LogicalResult ONNXFlattenOpShapeHelper::computeShape() {
 
   // Warning: code does appear to only work for shape inference.
   // Compute outputDims.
-  DimsExpr outputDims = {LiteralIndexExpr(1), LiteralIndexExpr(1)};
+  DimsExpr outputDims = {LitIE(1), LitIE(1)};
   for (int64_t i = 0; i < axis; ++i) {
     if (ShapedType::isDynamic(inputShape[i])) {
       outputDims[0] = QuestionmarkIndexExpr(/*isFloat*/ false);
       break;
     }
-    outputDims[0] = outputDims[0] * LiteralIndexExpr(inputShape[i]);
+    outputDims[0] = outputDims[0] * LitIE(inputShape[i]);
   }
 
   for (int64_t i = axis; i < inputRank; ++i) {
@@ -56,7 +56,7 @@ LogicalResult ONNXFlattenOpShapeHelper::computeShape() {
       outputDims[1] = QuestionmarkIndexExpr(/*isFloat*/ false);
       break;
     }
-    outputDims[1] = outputDims[1] * LiteralIndexExpr(inputShape[i]);
+    outputDims[1] = outputDims[1] * LitIE(inputShape[i]);
   }
 
   setOutputDims(outputDims);

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Reshape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Reshape.cpp
@@ -51,12 +51,12 @@ LogicalResult ONNXReshapeOpShapeHelper::computeShape() {
   // Compute the total number of elements using the input data operand.
   // dataRank will be 0 if Data is unranked tensor.
   // The number of element will not be computed
-  IndexExpr numOfElements = LiteralIndexExpr(1);
+  IndexExpr numOfElements = LitIE(1);
   for (unsigned i = 0; i < dataRank; ++i)
     numOfElements = numOfElements * createIE->getShapeAsDim(data, i);
 
   // Compute the total number of elements from the shape values.
-  IndexExpr numOfElementsFromShape = LiteralIndexExpr(1);
+  IndexExpr numOfElementsFromShape = LitIE(1);
   for (unsigned i = 0; i < outputRank; ++i) {
     IndexExpr dimShape = createIE->getIntFromArrayAsSymbol(shape, i);
     if (dimShape.isUndefined())
@@ -74,7 +74,7 @@ LogicalResult ONNXReshapeOpShapeHelper::computeShape() {
 
     // dimShape == -1: use 1 to compute the number of elements to avoid
     // negative value.
-    dim = dim.selectOrSelf(dim == -1, LiteralIndexExpr(1));
+    dim = dim.selectOrSelf(dim == -1, LitIE(1));
     numOfElementsFromShape = numOfElementsFromShape * dim;
   }
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Resize.cpp
@@ -26,7 +26,7 @@ namespace onnx_mlir {
 
 namespace {
 bool isEmptyTensor(Value input) {
-  if (ShapedType shapedType = dyn_cast<ShapedType>(input.getType())) {
+  if (ShapedType shapedType = mlir::dyn_cast<ShapedType>(input.getType())) {
     return shapedType.hasStaticShape() && shapedType.getNumElements() == 0;
   } else {
     return false;
@@ -94,12 +94,13 @@ LogicalResult ONNXResizeOpShapeHelper::computeShape() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ONNXResizeOp::verify() {
-  // Cannot verify if scales or sizes have unknown shapes.
-  if (auto scalesShapedType = dyn_cast<ShapedType>(getScales().getType())) {
+  // Cannot verify if scales or sizes have unknown sha∑pes.
+  if (auto scalesShapedType =
+          mlir::dyn_cast<ShapedType>(getScales().getType())) {
     if (!scalesShapedType.hasStaticShape())
       return success();
   }
-  if (auto sizesShapedType = dyn_cast<ShapedType>(getSizes().getType())) {
+  if (auto sizesShapedType = mlir::dyn_cast<ShapedType>(getSizes().getType())) {
     if (!sizesShapedType.hasStaticShape())
       return success();
   }

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Shape.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Shape.cpp
@@ -61,7 +61,7 @@ LogicalResult ONNXShapeOpShapeHelper::computeShape() {
     return op->emitError("Start must not be greater than end");
 
   // Output shape is a 1D vector with "end-start" values
-  DimsExpr outputDims(1, LiteralIndexExpr(end - start));
+  DimsExpr outputDims(1, LitIE(end - start));
   setOutputDims(outputDims);
   return success();
 }

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -126,8 +126,8 @@ LogicalResult ONNXSliceOpShapeHelper::computeShape() {
     if (steps[i].isUndefined()) {
       // have one unset, put the defaults (start was already at zero, so we
       // are fine).
-      starts[i] = LiteralIndexExpr(0);
-      steps[i] = LiteralIndexExpr(1);
+      starts[i] = LitIE(0);
+      steps[i] = LitIE(1);
       DimIndexExpr dimInput = createIE->getShapeAsDim(data, i);
       ends[i] = dimInput;
       outputDims[i] = dimInput;

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Slice.cpp
@@ -163,7 +163,8 @@ LogicalResult ONNXSliceOp::inferShapes(
   if (!isNoneValue(axes) && !getONNXConstantOp(axes))
     return success();
 
-  const auto startsType = dyn_cast<RankedTensorType>(getStarts().getType());
+  const auto startsType =
+      mlir::dyn_cast<RankedTensorType>(getStarts().getType());
   assert(startsType != nullptr && "starts type is not a RankedTensorType");
   auto startsDim = startsType.getShape()[0];
   {

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Unsqueeze.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Unsqueeze.cpp
@@ -64,7 +64,7 @@ LogicalResult ONNXCommonUnsqueezeOpShapeHelper<OP_TYPE>::customComputeShape(
     if (std::find(unsqueezedAxes.begin(), unsqueezedAxes.end(), i) !=
         unsqueezedAxes.end())
       // found i in unsqueeze axles.
-      outputDims.emplace_back(LiteralIndexExpr(1));
+      outputDims.emplace_back(LitIE(1));
     else
       outputDims.emplace_back(createIE->getShapeAsDim(data, j++));
 

--- a/src/Dialect/ONNX/ONNXOps/Tensor/Upsample.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Tensor/Upsample.cpp
@@ -52,7 +52,7 @@ LogicalResult ONNXUpsampleOpShapeHelper::computeShape() {
         // When shape is also constant, replace questionmark by actual value.
         double dim = xShape[i].getLiteral();
         double scale = valueAttr.getValues<FloatAttr>()[i].getValueAsDouble();
-        outputDims[i] = LiteralIndexExpr((int64_t)(dim * scale));
+        outputDims[i] = LitIE((int64_t)(dim * scale));
       }
     }
   }

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -319,7 +319,7 @@ bool hasUnitStrides(ArrayAttr strides) {
 
 // Check if v's shape N x C x D1 x D2 ... x Dn has static dims D1 ... Dn.
 bool hasStaticSpatialDims(Value v) {
-  ShapedType type = cast<ShapedType>(v.getType());
+  ShapedType type = mlir::cast<ShapedType>(v.getType());
   if (!type.hasRank())
     return false;
   // Shape has the form N x C x D1 x D2 ... x Dn.
@@ -334,7 +334,7 @@ bool hasStaticSpatialDims(Value v) {
 bool shouldDecomposeConvTransposeOp(Value convTransposeResult) {
 #ifdef ONNX_MLIR_DECOMP_ONNX_CONVTRANSPOSE
   ONNXConvTransposeOp op =
-      cast<ONNXConvTransposeOp>(convTransposeResult.getDefiningOp());
+      mlir::cast<ONNXConvTransposeOp>(convTransposeResult.getDefiningOp());
   return hasShapeAndRank(convTransposeResult) &&
          hasStaticSpatialDims(op.getX()) && hasStaticSpatialDims(op.getW());
 #else

--- a/src/Dialect/ONNX/Transforms/Decompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Decompose.cpp
@@ -118,7 +118,7 @@ DenseElementsAttr createDenseArrayAttrOrEmpty(
 }
 
 Value createSequenceConstructOp(
-    PatternRewriter &rewriter, mlir::Value seq, mlir::OperandRange inputs) {
+    PatternRewriter &rewriter, Value seq, OperandRange inputs) {
   Type resType = seq.getType();
   Location loc = seq.getLoc();
   Value position = rewriter.create<ONNXNoneOp>(loc);

--- a/src/Dialect/ONNX/Transforms/Recompose.cpp
+++ b/src/Dialect/ONNX/Transforms/Recompose.cpp
@@ -230,7 +230,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
     if (!isScalarTensor(epsilon))
       return reportFailure("RMS epsilon is expected to be scalar");
     ONNXConstantOp epsilonOp =
-        dyn_cast<ONNXConstantOp>(epsilon.getDefiningOp());
+        mlir::dyn_cast<ONNXConstantOp>(epsilon.getDefiningOp());
     if (!epsilonOp)
       return reportFailure("RMS epsilon needs to be a constant");
     epsilonAttr = epsilonOp.getValueFloatAttr();
@@ -266,7 +266,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
 
     if (hasFullPattern) {
       // Verify that the mReduceOp uses x as well.
-      auto lnOp = cast<ONNXReduceMeanV13Op>(mReduceOp);
+      auto lnOp = mlir::cast<ONNXReduceMeanV13Op>(mReduceOp);
       Value x2 = lnOp.getData();
       if (x1 != x2)
         hasFullPattern = reportFailure(
@@ -304,7 +304,7 @@ struct RecomposeLayerNormFromMulPattern : public OpRewritePattern<ONNXMulOp> {
 
 private:
   static bool suitableAxis(Operation *op, int64_t xRank, int64_t &axis) {
-    ONNXReduceMeanV13Op reduceOp = cast<ONNXReduceMeanV13Op>(op);
+    ONNXReduceMeanV13Op reduceOp = mlir::cast<ONNXReduceMeanV13Op>(op);
     if (reduceOp.getKeepdims() != 1)
       return reportFailure("need keepdims = 1");
     ArrayAttr axesAttr = reduceOp.getAxesAttr();
@@ -378,8 +378,8 @@ struct RecomposeQLinearMatMulFromQuantizeLinearPattern
         matmulOp, quantizeOp, qlX, 0);
     if (!matchMatMul)
       return false;
-    matA = cast<ONNXMatMulOp>(matmulOp).getA();
-    matB = cast<ONNXMatMulOp>(matmulOp).getB();
+    matA = mlir::cast<ONNXMatMulOp>(matmulOp).getA();
+    matB = mlir::cast<ONNXMatMulOp>(matmulOp).getB();
     // Matching input A of MatMul.
     auto dlOpA = matA.getDefiningOp<ONNXDequantizeLinearOp>();
     if (!dlOpA)

--- a/src/Dialect/ONNX/Transforms/ShapeInference.cpp
+++ b/src/Dialect/ONNX/Transforms/ShapeInference.cpp
@@ -24,17 +24,17 @@ namespace onnx_mlir {
 namespace {
 
 bool hasDynamicOrUnknownShape(Type type) {
-  if (auto tensorType = dyn_cast<TensorType>(type))
+  if (auto tensorType = mlir::dyn_cast<TensorType>(type))
     return !tensorType.hasStaticShape();
 
   if (mlir::isa<NoneType>(type))
     return false;
 
-  if (auto seqType = dyn_cast<SeqType>(type))
+  if (auto seqType = mlir::dyn_cast<SeqType>(type))
     return ShapedType::isDynamic(seqType.getLength()) ||
            hasDynamicOrUnknownShape(seqType.getElementType());
 
-  if (auto optType = dyn_cast<OptType>(type))
+  if (auto optType = mlir::dyn_cast<OptType>(type))
     return hasDynamicOrUnknownShape(optType.getElementType());
 
   llvm_unreachable("unknown type");

--- a/src/Dialect/ONNX/Transforms/SimplifyShapeRelatedOps.cpp
+++ b/src/Dialect/ONNX/Transforms/SimplifyShapeRelatedOps.cpp
@@ -79,7 +79,7 @@ void getDimsInt64(Value val, SmallVectorImpl<int64_t> &result) {
   SmallVector<Value, 4> dims;
   getDims(val, dims);
   for (Value v : dims) {
-    if (auto constOp = dyn_cast<ONNXConstantOp>(v.getDefiningOp())) {
+    if (auto constOp = mlir::dyn_cast<ONNXConstantOp>(v.getDefiningOp())) {
       auto valueAttr = mlir::cast<ElementsAttr>(constOp.getValueAttr());
       int64_t dim = valueAttr.getSplatValue<int64_t>();
       result.emplace_back(dim);

--- a/src/Support/TypeUtilities.cpp
+++ b/src/Support/TypeUtilities.cpp
@@ -31,7 +31,7 @@ bool isRankedShapedType(Type ty) {
 }
 
 /// Check if a type has static shape.
-bool hasStaticShape(mlir::Type ty) {
+bool hasStaticShape(Type ty) {
   if (!isRankedShapedType(ty))
     return false;
   return mlir::cast<ShapedType>(ty).hasStaticShape();

--- a/test/mlir/conversion/onnx_to_krnl/NN/Pooling.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/NN/Pooling.mlir
@@ -110,6 +110,14 @@ func.func private @test_maxpool_pooling_operation(%arg0 : tensor<1x3x32x32xf32>)
 // CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<(d0, d1) -> (0, d1)>
 // CHECK-DAG:   [[MAP_7_:#.+]] = affine_map<(d0, d1) -> (32, d1 + 2)>
 // CHECK-DAG:   [[MAP_8_:#.+]] = affine_map<(d0)[s0, s1, s2, s3, s4] -> (s0 - ((s2 ceildiv s4) * s4 - s2), -(d0 * s3 - s2) + s0, d0 * s3 + (s1 - 1) * s4 - s2 - ((s2 ceildiv s4) * s4 - s2) + 1, d0 * s3 + (s1 - 1) * s4 - s2 - (d0 * s3 - s2) + 1)>
+// CHECK-DAG:   [[MAP_9_:#.+]] = affine_map<(d0, d1, d2) -> (d2)>
+// CHECK-DAG:   [[MAP_10_:#.+]] = affine_map<(d0, d1, d2) -> (d0)>
+// CHECK-DAG:   [[MAP_11_:#.+]] = affine_map<(d0, d1, d2) -> (d2 + d0)>
+// CHECK-DAG:   [[MAP_12_:#.+]] = affine_map<(d0, d1, d2) -> (d2, d2 + d0)>
+// CHECK-DAG:   [[MAP_13_:#.+]] = affine_map<(d0, d1, d2, d3) -> (d3)>
+// CHECK-DAG:   [[MAP_14_:#.+]] = affine_map<(d0, d1, d2, d3) -> (d1)>
+// CHECK-DAG:   [[MAP_15_:#.+]] = affine_map<(d0, d1, d2, d3) -> (d3 + d1)>
+// CHECK-DAG:   [[MAP_16_:#.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d3 + d1)>
 // CHECK-LABEL:  func.func private @test_maxpool_pooling_operation
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1x3x32x32xf32>) -> memref<1x3x31x31xf32> {
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
@@ -181,13 +189,21 @@ func.func private @test_maxpool_pooling_operation(%arg0 : tensor<1x3x32x32xf32>)
 // CHECK-DAG:         [[VAR_13_:%.+]] = arith.subi [[VAR_10_]], [[VAR_9_]] : index
 // CHECK-DAG:         [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_4_:%.+]] = 0 to min [[MAP_8_]]([[VAR_1_]]#2){{.}}[[CST_32_2_]], [[CST_2_4_]], [[CST_0_7_]], [[CST_1_9_]], [[CST_1_10_]]{{.}}, [[LOOP_1_]]#1 -> [[I_5_:%.+]] = 0 to min [[MAP_8_]]([[VAR_1_]]#3){{.}}[[CST_32_3_]], [[CST_2_5_]], [[CST_0_8_]], [[CST_1_11_]], [[CST_1_12_]]{{.}}){
-// CHECK-DAG:           [[VAR_16_:%.+]] = arith.addi [[I_4_]], [[VAR_4_]] : index
-// CHECK-DAG:           [[VAR_17_:%.+]] = arith.addi [[I_5_]], [[VAR_9_]] : index
+// CHECK-DAG:           [[CST_0_11_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:           [[VAR_16_:%.+]] = affine.apply [[MAP_9_]]([[VAR_1_]]#2, [[VAR_1_]]#3, [[I_4_]])
+// CHECK-DAG:           [[VAR_17_:%.+]] = affine.apply [[MAP_10_]]([[VAR_1_]]#2, [[VAR_1_]]#3, [[I_4_]])
+// CHECK-DAG:           [[VAR_18_:%.+]] = affine.apply [[MAP_11_]]([[VAR_1_]]#2, [[VAR_1_]]#3, [[I_4_]])
+// CHECK-DAG:           [[VAR_19_:%.+]] = affine.max [[MAP_12_]]([[VAR_1_]]#2, [[VAR_1_]]#3, [[I_4_]])
+// CHECK-DAG:           [[CST_0_12_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:           [[VAR_20_:%.+]] = affine.apply [[MAP_13_]]([[VAR_1_]]#2, [[VAR_1_]]#3, [[I_4_]], [[I_5_]])
+// CHECK-DAG:           [[VAR_21_:%.+]] = affine.apply [[MAP_14_]]([[VAR_1_]]#2, [[VAR_1_]]#3, [[I_4_]], [[I_5_]])
+// CHECK-DAG:           [[VAR_22_:%.+]] = affine.apply [[MAP_15_]]([[VAR_1_]]#2, [[VAR_1_]]#3, [[I_4_]], [[I_5_]])
+// CHECK-DAG:           [[VAR_23_:%.+]] = affine.max [[MAP_16_]]([[VAR_1_]]#2, [[VAR_1_]]#3, [[I_4_]], [[I_5_]])
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]6, [[VAR_1_]]7] : memref<1x3x32x32xf32>
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]9, [[VAR_23_]]{{.}} : memref<1x3x32x32xf32>
 // CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
-// CHECK:               [[VAR_20_:%.+]] = arith.maxnumf [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_20_]], [[RES_1_]][] : memref<f32>
+// CHECK:               [[VAR_26_:%.+]] = arith.maxnumf [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:               krnl.store [[VAR_26_]], [[RES_1_]][] : memref<f32>
 // CHECK:             }
 // CHECK:             [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
 // CHECK:             krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]#2, [[VAR_1_]]#3] : memref<1x3x31x31xf32>

--- a/test/mlir/conversion/onnx_to_krnl/NN/Pooling_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/NN/Pooling_with_canonicalize.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
 
+// -----
+
 // Adding canonicalize is important here as this is the only way to check the values of the map,
 // which are otherwise before the function, and thus are hard to test.
 
@@ -7,55 +9,58 @@ func.func private @test_pool_unknown_dimensions(%arg0 : tensor<1x3x?x32xf32>) ->
   %0 = "onnx.AveragePool"(%arg0) {auto_pad = "NOTSET", kernel_shape = [2, 2]} : (tensor<1x3x?x32xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
 
-// CHECK-DAG: [[MAP_0_:#.+]] = affine_map<()[s0] -> (s0 - 1)>
-// CHECK-DAG: [[MAP_1_:#.+]] = affine_map<(d0) -> (d0)>
-// CHECK-DAG: [[MAP_2_:#.+]] = affine_map<(d0) -> (0, d0)>
-// CHECK-DAG: [[MAP_3_:#.+]] = affine_map<(d0)[s0] -> (s0, d0 + 2)>
-// CHECK-DAG: [[MAP_4_:#.+]] = affine_map<(d0) -> (32, d0 + 2)>
-// CHECK-DAG: [[MAP_5_:#.+]] = affine_map<(d0)[s0, s1, s2, s3, s4] -> (s0 - ((s2 ceildiv s4) * s4 - s2), -(d0 * s3 - s2) + s0, d0 * s3 + (s1 - 1) * s4 - s2 - ((s2 ceildiv s4) * s4 - s2) + 1, d0 * s3 + (s1 - 1) * s4 - s2 - (d0 * s3 - s2) + 1)>
-// CHECK-LABEL:  func private @test_pool_unknown_dimensions
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0] -> (s0 - 1)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0) -> (0, d0)>
+// CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<(d0)[s0] -> (s0, d0 + 2)>
+// CHECK-DAG:   [[MAP_4_:#.+]] = affine_map<(d0) -> (32, d0 + 2)>
+// CHECK-DAG:   [[MAP_5_:#.+]] = affine_map<(d0)[s0, s1, s2, s3, s4] -> (s0 - ((s2 ceildiv s4) * s4 - s2), -(d0 * s3 - s2) + s0, d0 * s3 + (s1 - 1) * s4 - s2 - ((s2 ceildiv s4) * s4 - s2) + 1, d0 * s3 + (s1 - 1) * s4 - s2 - (d0 * s3 - s2) + 1)>
+// CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<(d0, d1) -> (d1, d0 + d1)>
+// CHECK-LABEL:  func.func private @test_pool_unknown_dimensions
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<1x3x?x32xf32>) -> memref<1x3x?x31xf32> {
-// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : index
-// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_32_:%.+]] = arith.constant 32 : index
 // CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
-// CHECK:           [[VAR_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<1x3x?x32xf32>
-// CHECK:           [[VAR_1_:%.+]] = affine.apply [[MAP_0_]](){{.}}[[VAR_0_]]{{.}}
-// CHECK-DAG:       [[VAR_2_:%.+]] = memref.alloc([[VAR_1_]]) {{.*}}: memref<1x3x?x31xf32>
-// CHECK-DAG:       [[VAR_4_:%.+]] = memref.alloca() : memref<f32>
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK:           [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<1x3x?x32xf32>
+// CHECK:           [[VAR_0_:%.+]] = affine.apply [[MAP_0_]](){{.}}[[VAR_dim_]]{{.}}
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<1x3x?x31xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloca() : memref<f32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to [[MAP_1_]]([[VAR_1_]]), [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 31){
-// CHECK:             [[IV:%.+]]:4 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
-// CHECK:             krnl.store [[CST_0_dot_000000_]], [[VAR_4_]][] : memref<f32>
-// CHECK-DAG:         [[VAR_5_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<1x3x?x32xf32>
-// CHECK-DAG:         [[VAR_6_:%.+]] = affine.max [[MAP_2_]]([[IV]]#2)
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 1, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to [[MAP_1_]]([[VAR_0_]]), [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 31){
+// CHECK:             [[VAR_2_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK:             krnl.store [[CST_0_dot_000000_]], [[RES_1_]][] : memref<f32>
+// CHECK-DAG:         [[VAR_dim_0_:%.+]] = memref.dim [[PARAM_0_]], [[CST_2_]] : memref<1x3x?x32xf32>
+// CHECK-DAG:         [[VAR_3_:%.+]] = affine.max [[MAP_2_]]([[VAR_2_]]#2)
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_7_:%.+]] = affine.min [[MAP_3_]]([[IV]]#2){{.}}[[VAR_5_]]{{.}}
-// CHECK-DAG:         [[VAR_8_:%.+]] = affine.max [[MAP_2_]]([[IV]]#3)
-// CHECK-DAG:         [[VAR_9_:%.+]] = affine.min [[MAP_4_]]([[IV]]#3)
+// CHECK-DAG:         [[VAR_4_:%.+]] = affine.min [[MAP_3_]]([[VAR_2_]]#2){{.}}[[VAR_dim_0_]]{{.}}
+// CHECK-DAG:         [[VAR_5_:%.+]] = affine.max [[MAP_2_]]([[VAR_2_]]#3)
+// CHECK-DAG:         [[VAR_6_:%.+]] = affine.min [[MAP_4_]]([[VAR_2_]]#3)
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:         [[VAR_10_:%.+]] = arith.subi [[VAR_7_]], [[VAR_6_]] : index
-// CHECK-DAG:         [[VAR_11_:%.+]] = arith.subi [[VAR_9_]], [[VAR_8_]] : index
+// CHECK-DAG:         [[VAR_7_:%.+]] = arith.subi [[VAR_4_]], [[VAR_3_]] : index
+// CHECK-DAG:         [[VAR_8_:%.+]] = arith.subi [[VAR_6_]], [[VAR_5_]] : index
 // CHECK-DAG:         [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
-// CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_4_:%.+]] = 0 to min [[MAP_5_]]([[IV]]#2){{.}}[[VAR_5_]], [[CST_2_]], [[CST_0_]], [[CST_1_]], [[CST_1_]]{{.}}, [[LOOP_1_]]#1 -> [[I_5_:%.+]] = 0 to min [[MAP_5_]]([[IV]]#3){{.}}[[CST_32_]], [[CST_2_]], [[CST_0_]], [[CST_1_]], [[CST_1_]]{{.}}){
-// CHECK-DAG:           [[VAR_19_:%.+]] = arith.addi [[I_4_]], [[VAR_6_]] : index
-// CHECK-DAG:           [[VAR_20_:%.+]] = arith.addi [[I_5_]], [[VAR_8_]] : index
+// CHECK:             krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_4_:%.+]] = 0 to min [[MAP_5_]]([[VAR_2_]]#2){{.}}[[VAR_dim_0_]], [[CST_2_]], [[CST_0_]], [[CST_1_]], [[CST_1_]]{{.}}, [[LOOP_1_]]#1 -> [[I_5_:%.+]] = 0 to min [[MAP_5_]]([[VAR_2_]]#3){{.}}[[CST_32_]], [[CST_2_]], [[CST_0_]], [[CST_1_]], [[CST_1_]]{{.}}){
+// CHECK-DAG:           [[VAR_16_:%.+]] = affine.max [[MAP_6_]]([[VAR_2_]]#2, [[I_4_]])
+// CHECK-DAG:           [[VAR_17_:%.+]] = affine.max [[MAP_6_]]([[VAR_2_]]#3, [[I_5_]])
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[IV]]#0, [[IV]]#1, [[VAR_19_]], [[VAR_20_]]{{.}} : memref<1x3x?x32xf32>
-// CHECK-DAG:           [[LOAD_VAR_4_MEM_:%.+]] = krnl.load [[VAR_4_]][] : memref<f32>
-// CHECK:               [[VAR_23_:%.+]] = arith.addf [[LOAD_VAR_4_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:               krnl.store [[VAR_23_]], [[VAR_4_]][] : memref<f32>
+// CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_16_]], [[VAR_17_]]{{.}} : memref<1x3x?x32xf32>
+// CHECK-DAG:           [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
+// CHECK:               [[VAR_20_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:               krnl.store [[VAR_20_]], [[RES_1_]][] : memref<f32>
 // CHECK:             }
-// CHECK:             [[LOAD_VAR_4_MEM_1_:%.+]] = krnl.load [[VAR_4_]][] : memref<f32>
-// CHECK:             krnl.store [[LOAD_VAR_4_MEM_1_]], [[VAR_2_]]{{.}}[[IV]]#0, [[IV]]#1, [[IV]]#2, [[IV]]#3{{.}} : memref<1x3x?x31xf32>
-// CHECK-DAG:         [[LOAD_VAR_2_MEM_:%.+]] = krnl.load [[VAR_2_]]{{.}}[[IV]]#0, [[IV]]#1, [[IV]]#2, [[IV]]#3{{.}} : memref<1x3x?x31xf32>
-// CHECK-DAG:         [[VAR_15_:%.+]] = arith.muli [[VAR_10_]], [[VAR_11_]] : index
-// CHECK:             [[VAR_16_:%.+]] = arith.index_cast [[VAR_15_]] : index to i64
-// CHECK:             [[VAR_17_:%.+]] = arith.sitofp [[VAR_16_]] : i64 to f32
-// CHECK:             [[VAR_18_:%.+]] = arith.divf [[LOAD_VAR_2_MEM_]], [[VAR_17_]] : f32
-// CHECK:             krnl.store [[VAR_18_]], [[VAR_2_]]{{.}}[[IV]]#0, [[IV]]#1, [[IV]]#2, [[IV]]#3{{.}} : memref<1x3x?x31xf32>
+// CHECK:             [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]][] : memref<f32>
+// CHECK:             krnl.store [[LOAD_RES_1_MEM_1_]], [[RES_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_2_]]#2, [[VAR_2_]]#3] : memref<1x3x?x31xf32>
+// CHECK-DAG:         [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_2_]]#2, [[VAR_2_]]#3] : memref<1x3x?x31xf32>
+// CHECK-DAG:         [[VAR_12_:%.+]] = arith.muli [[VAR_7_]], [[VAR_8_]] : index
+// CHECK:             [[VAR_13_:%.+]] = arith.index_cast [[VAR_12_]] : index to i64
+// CHECK:             [[VAR_14_:%.+]] = arith.sitofp [[VAR_13_]] : i64 to f32
+// CHECK:             [[VAR_15_:%.+]] = arith.divf [[LOAD_RES_MEM_]], [[VAR_14_]] : f32
+// CHECK:             krnl.store [[VAR_15_]], [[RES_]]{{.}}[[VAR_2_]]#0, [[VAR_2_]]#1, [[VAR_2_]]#2, [[VAR_2_]]#3] : memref<1x3x?x31xf32>
 // CHECK:           }
-// CHECK:           return [[VAR_2_]] : memref<1x3x?x31xf32>
+// CHECK:           return [[RES_]] : memref<1x3x?x31xf32>
 // CHECK:         }
 }
+

--- a/test/modellib/ConvModel.cpp
+++ b/test/modellib/ConvModel.cpp
@@ -101,7 +101,7 @@ bool Conv2DLibBuilder::build() {
   // Use the convOp shape inference method to compute output shape, and unset
   // the shape so that we don't leave IR in a inconsistent state.
   convOp.getX().setType(xType); // Use static dims to infer shape.
-  LogicalResult res = convOp.inferShapes([](mlir::Region &) {});
+  LogicalResult res = convOp.inferShapes([](Region &) {});
   if (failed(res))
     return false;
 


### PR DESCRIPTION
This PR has some functional changes, a few cosmetic changes, and many non-functional changes

### Functional change:

The expression below is not seen as affine
```mlir
  %1 = affine.max(%affine1, %affine2)
 %2 = arithmetic.add(%1, %affine3)
```
where the `%affine` expressions are affine. However, sinking the add (or subtract) into both side of the max make that expr `%2` affine again.

### Cosmetic changes:

Most `builder.forLoop` take a lambda function that has a `ValueRange` option but one or two that take a `Value`. I normalized all to `ValueRange` (with possibly only one value), so that I may reuse the same lambda function for different builders (aka Affine or SCF). This change may have an impact on usage of a few `forLoop` constructs

We started using `DimsExpr` instead of `SmallVector<IndexExpr, 4>` for dimension expressions. I normalized all to the `DimsExpr`. We also passed `SmallVectorImp<IndexExpr> &dim` by references, I changed to to using the LLVM approved `ArrayRef<IndexExpr>`. Also created a `DimsExprRef` alias when the array of index expression is for a dimension expression. This should not have an impact on the usage of the functions.

Generally changed `SmallVector<XXX> &x` to `ArrayRef<XXX> x`.

There were various instances of `builder.load` and `store` that took different parameters depending on the builder. Now they all take the same parameters: possibly zero or more indices (Values or IndexExpr) and zero or more offsets (Values). This should not change where things are used. Since indices and offsets are optional, removed the `{}` found in the code.

### Non-functional changes.

I introduced `DimIE`, `SymIE`, and `LitIE` as shortcuts to the dimension, symbol, and literal index expressions. Changed to the shorter notation to have more compact code.

Lots of code that is `using mlir` still used `mlir::Value` ... removed the redundant `mlir::` for most patterns.

Our usage of `mlir::` in front of casts is very inconsistent. Most use `mlir` prefix, a few places use `llvm`, and a very few places don't use anything. Out of abundance of caution, I tried to add `mlir` to all casts. Maybe if they are really not needed, they can be removed.

We also use `mlir` or `llvm` in front of `ArrayRef` and `SmallVector` and `cast`. Again, we should probably use only one pattern. Did not cleanup that.
