### PR TITLE
Support i8 in lowering ONNXQuantizeLinear

### DIFF
--- a/src/Conversion/ONNXToKrnl/Quantization/QuantizeLinear.cpp
+++ b/src/Conversion/ONNXToKrnl/Quantization/QuantizeLinear.cpp
@@ -126,11 +126,11 @@ struct ONNXQuantizeLinearOpLowering
     Type elementType = xMemRefType.getElementType();
     Type quantizedElementType = yMemRefType.getElementType();
 
-    // Does not support per-axis and i8.
+    // Does not support per-axis and other types rather than i8.
     assert(yScaleMemRefType.getRank() == 0 &&
            "Does not support per-axis quantization");
-    assert(quantizedElementType.isUnsignedInteger() &&
-           "Does not support i8 quantization");
+    assert(quantizedElementType.isInteger(8) &&
+           "Only support i8/ui8 quantization at this moment");
 
     // Get shape.
     ONNXQuantizeLinearOpShapeHelper shapeHelper(op, operands, &create.krnlIE);

--- a/test/mlir/conversion/onnx_to_krnl/Quantization/QuantizeLinear_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Quantization/QuantizeLinear_with_canonicalize.mlir
@@ -6,12 +6,12 @@
 // -----
 
 
-func.func @test_quantize_linear(%arg0: tensor<6xf32>, %arg1: tensor<f32>, %arg2: tensor<ui8>) -> tensor<6xui8> {
+func.func @test_quantize_linear_ui8(%arg0: tensor<6xf32>, %arg1: tensor<f32>, %arg2: tensor<ui8>) -> tensor<6xui8> {
   %0 = "onnx.QuantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<6xf32>, tensor<f32>, tensor<ui8>) -> tensor<6xui8>
   return %0 : tensor<6xui8>
 
 // mlir2FileCheck.py
-// CHECK-LABEL:  func.func @test_quantize_linear
+// CHECK-LABEL:  func.func @test_quantize_linear_ui8
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<6xf32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<ui8>) -> memref<6xui8> {
 // CHECK-DAG:       [[CST_5_dot_000000_:%.+]] = arith.constant 5.000000e-01 : f32
 // CHECK-DAG:       [[CST_2_dot_000000_:%.+]] = arith.constant 2.000000e+00 : f32
@@ -55,3 +55,51 @@ func.func @test_quantize_linear(%arg0: tensor<6xf32>, %arg1: tensor<f32>, %arg2:
 // CHECK:         }
 }
 
+// -----
+
+func.func @test_quantize_linear_i8(%arg0: tensor<6xf32>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> tensor<6xi8> {
+  %0 = "onnx.QuantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<6xf32>, tensor<f32>, tensor<i8>) -> tensor<6xi8>
+  return %0 : tensor<6xi8>
+
+// CHECK-LABEL:  func.func @test_quantize_linear_i8
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<6xf32>, [[PARAM_1_:%.+]]: memref<f32>, [[PARAM_2_:%.+]]: memref<i8>) -> memref<6xi8> {
+// CHECK-DAG:       [[CST_5_dot_000000_:%.+]] = arith.constant 5.000000e-01 : f32
+// CHECK-DAG:       [[CST_2_dot_000000_:%.+]] = arith.constant 2.000000e+00 : f32
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = arith.constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_minus_1_dot_280000_:%.+]] = arith.constant -1.280000e+02 : f32
+// CHECK-DAG:       [[CST_1_dot_270000_:%.+]] = arith.constant 1.270000e+02 : f32
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<6xi8>
+// CHECK-DAG:       [[LOAD_PARAM_1_MEM_:%.+]] = krnl.load [[PARAM_1_]][] : memref<f32>
+// CHECK-DAG:       [[LOAD_PARAM_2_MEM_:%.+]] = krnl.load [[PARAM_2_]][] : memref<i8>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.sitofp [[LOAD_PARAM_2_MEM_]] : i8 to f32
+// CHECK-DAG:       [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:           krnl.iterate([[LOOP_0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 6){
+// CHECK:             [[VAR_4_:%.+]] = krnl.get_induction_var_value([[LOOP_0_]]) : (!krnl.loop) -> index
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_4_]]{{.}} : memref<6xf32>
+// CHECK:             [[VAR_6_:%.+]] = arith.divf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_1_MEM_]] : f32
+// CHECK:             [[VAR_7_:%.+]] = math.floor [[VAR_6_]] : f32
+// CHECK:             [[VAR_8_:%.+]] = arith.subf [[VAR_6_]], [[VAR_7_]] : f32
+// CHECK-DAG:         [[VAR_9_:%.+]] = arith.cmpf ogt, [[VAR_8_]], [[CST_5_dot_000000_]] : f32
+// CHECK-DAG:         [[VAR_10_:%.+]] = arith.addf [[VAR_7_]], [[CST_1_dot_000000_]] : f32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_11_:%.+]] = arith.select [[VAR_9_]], [[VAR_10_]], [[VAR_7_]] : f32
+// CHECK-DAG:         [[VAR_12_:%.+]] = arith.mulf [[VAR_7_]], [[CST_5_dot_000000_]] : f32
+// CHECK:             [[VAR_13_:%.+]] = math.floor [[VAR_12_]] : f32
+// CHECK:             [[VAR_14_:%.+]] = arith.mulf [[VAR_13_]], [[CST_2_dot_000000_]] : f32
+// CHECK:             [[VAR_15_:%.+]] = arith.subf [[VAR_7_]], [[VAR_14_]] : f32
+// CHECK-DAG:         [[VAR_16_:%.+]] = arith.cmpf oeq, [[VAR_15_]], [[CST_1_dot_000000_]] : f32
+// CHECK-DAG:         [[VAR_17_:%.+]] = arith.addf [[VAR_7_]], [[CST_1_dot_000000_]] : f32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_18_:%.+]] = arith.select [[VAR_16_]], [[VAR_17_]], [[VAR_7_]] : f32
+// CHECK-DAG:         [[VAR_19_:%.+]] = arith.cmpf oeq, [[VAR_8_]], [[CST_5_dot_000000_]] : f32
+// CHECK:             [[VAR_20_:%.+]] = arith.select [[VAR_19_]], [[VAR_18_]], [[VAR_11_]] : f32
+// CHECK:             [[VAR_21_:%.+]] = arith.addf [[VAR_20_]], [[VAR_2_]] : f32
+// CHECK:             [[VAR_22_:%.+]] = arith.maxnumf [[VAR_21_]], [[CST_minus_1_dot_280000_]] : f32
+// CHECK:             [[VAR_23_:%.+]] = arith.minnumf [[VAR_22_]], [[CST_1_dot_270000_]] : f32
+// CHECK:             [[VAR_24_:%.+]] = arith.fptosi [[VAR_23_]] : f32 to i8
+// CHECK:             krnl.store [[VAR_24_]], [[RES_]]{{.}}[[VAR_4_]]{{.}} : memref<6xi8>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<6xi8>
+// CHECK:         }
+}


### PR DESCRIPTION
The lowering of ONNXQuantizeLinear itself supports i8, but there is an assert to check and discard the i8 case (Unfortunately, I don't know the reason for that assert).
This patch removes the assert to allow the i8 case and adds a lit test for that.