### PR TITLE
Fix importing Cast opset >=19

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -906,10 +906,15 @@ private:
     std::vector<NamedAttribute> attributes;
     for (int i = 0; i < node.attribute_size(); ++i) {
       auto attr = node.attribute(i);
-      auto mlir_type = convertONNXTypeToMLIRType(
-          builder_, static_cast<onnx::TensorProto_DataType>(attr.i()));
-      Attribute mlirAttr = TypeAttr::get(mlir_type);
-      attributes.push_back(builder_.getNamedAttr(attr.name(), mlirAttr));
+      if (attr.name() == "to") {
+        auto mlir_type = convertONNXTypeToMLIRType(
+            builder_, static_cast<onnx::TensorProto_DataType>(attr.i()));
+        Attribute mlirAttr = TypeAttr::get(mlir_type);
+        attributes.push_back(builder_.getNamedAttr(attr.name(), mlirAttr));
+      } else {
+        NamedAttribute na = convertOnnxAttributeProtoToMlirNamedAttribute(attr);
+        attributes.push_back(na);
+      }
     }
 
     // If the node has a name, then import it.

--- a/test/mlir/onnx/parse/test_cast.onnxtext
+++ b/test/mlir/onnx/parse/test_cast.onnxtext
@@ -1,0 +1,17 @@
+// RUN: onnx-mlir --EmitONNXBasic --printIR %s | FileCheck %s
+
+<
+   ir_version: 7,
+   opset_import: ["" : 19],
+   producer_name: "backend-test"
+>
+test_cast (int64[1] x) => (float[1] y) {
+   y = Cast<saturate = 0, to = 1>(x)
+}
+
+// CHECK-LABEL:  func.func @main_graph
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1xi64> {onnx.name = "x"}) -> (tensor<1xf32> {onnx.name = "y"}) {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Cast"([[PARAM_0_]]) {saturate = 0 : si64, to = f32} : (tensor<1xi64>) -> tensor<1xf32>
+// CHECK:           onnx.Return [[VAR_0_]] : tensor<1xf32>
+// CHECK:         }
+// CHECK:         "onnx.EntryPoint"() {func = @main_graph} : () -> ()


### PR DESCRIPTION
ONNXCast opset >=19 introduces a new attribute `saturate` and onnx-mlir wrongly imported the attribute.

For example, onnx-mlir imported ONNXCast as follows:
```mlir
%755 = "onnx.Cast"(%746) {onnx_node_name = "/bert/Cast", saturate = f32, to = f32} : (tensor<?x?x?x?xi64>) -> tensor<?x?x?x?xf32>
```
where `saturate = f32` was wrong, it would be `saturate = 0 : si64` or `saturate = 1 : si64`.

This patch fixes the issue by fixing the importing code for Cast's attributes.

