### PR TITLE
Fix architecture terminology

### DIFF
--- a/docs/ONNXAI.md
+++ b/docs/ONNXAI.md
@@ -3,7 +3,7 @@
 # About
 
 ONNX-MLIR is an open-source project for compiling ONNX models into native code
-on x86, P and Z machines (and more). It is built on top of Multi-Level
+on x86, Power, s390x and other architectures. It is built on top of Multi-Level
 Intermediate Representation (MLIR) compiler infrastructure.
 
 # Slack channel


### PR DESCRIPTION
Changed the naming of P and Z which are IBM brands to the respective architectures to be consistent with listed x86 architecture example.

Re-implementation of #2930