### PR TITLE
Check time and localtime during compile

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -170,18 +170,21 @@ int Command::exec(std::string wdir) const {
 }
 
 void showCompilePhase(std::string msg) {
-  time_t rawTime;
+  time_t rawTime = 0;
   struct tm *timeInfo;
-  char buffer[80];
+  char buffer[80] = "";
   // Remember first time.
   static time_t firstRawTime;
   static bool hasFirstRawTime = false;
 
   // Get current date.
-  time(&rawTime);
-  timeInfo = localtime(&rawTime);
-  strftime(buffer, 80, "%c", timeInfo);
-  std::string currentTime(buffer);
+  std::string currentTime("");
+  if (time(&rawTime) == -1 || (timeInfo = localtime(&rawTime)) == NULL ||
+      (strftime(buffer, 80, "%c", timeInfo)) == 0) {
+    currentTime = "Error obtaining current time";
+  } else {
+    currentTime = buffer;
+  }
 
   // Compute time difference in seconds.
   int diff = 0;


### PR DESCRIPTION
This PR adds checks for the result from time() and localtime() calls.