### PR TITLE
Add coding practices for onnx-mlir

### DIFF
--- a/CODING_PRACTICE.md
+++ b/CODING_PRACTICE.md
@@ -7,6 +7,17 @@ This document contains coding practices to use when adding or updating code to t
 ## Practices
 
 * Use C++ style casting instead of C style when casting in cpp.
+
+For example, use C++ style casting:
+```
+      Value one = create.llvm.constant(llvmI64Ty, static_cast<int64_t>(1));
+```
+
+Not, C style casting:
+```
+      Value one = create.llvm.constant(llvmI64Ty, (int64_t)1);
+```
+
 * Perform bitwise operations on unsigned types and not signed.
 * Check the result of malloc() invocations.
 * Check the result of input/output operations, such as fopen() and fprintf().

--- a/CODING_PRACTICE.md
+++ b/CODING_PRACTICE.md
@@ -1,0 +1,18 @@
+<!--- SPDX-License-Identifier: Apache-2.0 -->
+
+# Coding Practices
+
+This document contains coding practices to use when adding or updating code to the onnx-mlir project.
+
+## Practices
+
+* Use C++ style casting instead of C style when casting in cpp.
+* Perform bitwise operations on unsigned types and not signed.
+* Check the result of malloc() invocations.
+* Check the result of input/output operations, such as fopen() and fprintf().
+* Use parentheses around parameter names in macro definitions. 
+
+## Contributing
+
+We are welcoming contributions from the community.
+Please consult the [CONTRIBUTING](CONTRIBUTING.md) page for help on how to proceed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ A comprehensive list of documents is found [here](docs/DocumentList.md).
 * The Krnl Dialect is used to lower ONNX operators to MLIR affine. The Krnl Dialect is defined [here](docs/Dialects/krnl.md).
 * To update the internal documentation on our dialects when there are changes, please look for guidance [here](docs/ImportONNXDefs.md#update-your-operations-status).
 
+## Coding practices for ONNX-MLIR
+
+* When adding or updating code, see [here](CODING_PRACTICE.md) for coding practices.
+
 ## Testing and debugging ONNX-MLIR
 
 * To test new code, see [here](docs/Testing.md) for instructions.


### PR DESCRIPTION
This PR adds a coding practices documentation file to describe the coding practices to use when updating or adding code to onnx-mlir.