### PR TITLE
Reuse input buffer in lowering to krnl

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -216,7 +216,7 @@ static llvm::cl::opt<bool, true> disableKrnlOpFusionOpt(
 static llvm::cl::opt<bool, true> disableKrnlBufferReuseOpt(
     "disable-krnl-buffer-reuse",
     llvm::cl::desc("disable buffer reuse within an op in onnx-to-krnl pass"
-                  "(default=true)\n"
+                   "(default=true)\n"
                    "Set to 'false' if you want to enable buffer reuse."
                    "Default value will be false when the functionality becomes"
                    "stable."),

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -42,6 +42,7 @@ bool enableONNXHybridPass;                             // common for both
 std::vector<std::string> functionsToDecompose;         // common for both
 std::string opsForCall;                                // common for both
 bool disableKrnlOpFusion;                              // common for both
+bool disableKrnlBufferReuse;                           // common for both
 EmissionTargetType emissionTarget;                     // onnx-mlir only
 bool invokeOnnxVersionConverter;                       // onnx-mlir only
 bool preserveLocations;                                // onnx-mlir only
@@ -209,6 +210,16 @@ static llvm::cl::opt<bool, true> disableKrnlOpFusionOpt(
     llvm::cl::desc("disable op fusion in onnx-to-krnl pass (default=false)\n"
                    "Set to 'true' if you want to disable fusion."),
     llvm::cl::location(disableKrnlOpFusion), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirCommonOptions));
+
+static llvm::cl::opt<bool, true> disableKrnlBufferReuseOpt(
+    "disable-krnl-buffer-reuse",
+    llvm::cl::desc("disable buffer reuse within an op in onnx-to-krnl pass"
+                  "(default=true)\n"
+                   "Set to 'false' if you want to enable buffer reuse."
+                   "Default value will be false when the functionality becomes"
+                   "stable."),
+    llvm::cl::location(disableKrnlBufferReuse), llvm::cl::init(true),
     llvm::cl::cat(OnnxMlirCommonOptions));
 
 static llvm::cl::opt<bool, true> disableRecomposeOptionOpt("disable-recompose",

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -42,7 +42,7 @@ bool enableONNXHybridPass;                             // common for both
 std::vector<std::string> functionsToDecompose;         // common for both
 std::string opsForCall;                                // common for both
 bool disableKrnlOpFusion;                              // common for both
-bool disableKrnlBufferReuse;                           // common for both
+bool enableKrnlBufferReuse;                            // common for both
 bool disableMemRefPrefetch;                            // common for both
 EmissionTargetType emissionTarget;                     // onnx-mlir only
 bool invokeOnnxVersionConverter;                       // onnx-mlir only
@@ -213,14 +213,12 @@ static llvm::cl::opt<bool, true> disableKrnlOpFusionOpt(
     llvm::cl::location(disableKrnlOpFusion), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirCommonOptions));
 
-static llvm::cl::opt<bool, true> disableKrnlBufferReuseOpt(
-    "disable-krnl-buffer-reuse",
-    llvm::cl::desc("disable buffer reuse within an op in onnx-to-krnl pass"
-                   "(default=true)\n"
-                   "Set to 'false' if you want to enable buffer reuse."
-                   "Default value will be false when the functionality becomes"
-                   "stable."),
-    llvm::cl::location(disableKrnlBufferReuse), llvm::cl::init(true),
+static llvm::cl::opt<bool, true> enableKrnlBufferReuseOpt(
+    "enable-krnl-buffer-reuse",
+    llvm::cl::desc("enable buffer reuse within an op in onnx-to-krnl pass"
+                   "(default=false)\n"
+                   "Set to 'true' if you want to enable buffer reuse."),
+    llvm::cl::location(enableKrnlBufferReuse), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirCommonOptions));
 
 static llvm::cl::opt<bool, true> disableMemRefPrefetchOpt(

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -87,6 +87,7 @@ extern bool enableONNXHybridPass;                             // common for both
 extern std::vector<std::string> functionsToDecompose;         // common for both
 extern std::string opsForCall;                                // common for both
 extern bool disableKrnlOpFusion;                              // common for both
+extern bool disableKrnlBufferReuse;                           // common for both
 extern EmissionTargetType emissionTarget;                     // onnx-mlir only
 extern bool invokeOnnxVersionConverter;                       // onnx-mlir only
 extern bool preserveLocations;                                // onnx-mlir only

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -87,7 +87,7 @@ extern bool enableONNXHybridPass;                             // common for both
 extern std::vector<std::string> functionsToDecompose;         // common for both
 extern std::string opsForCall;                                // common for both
 extern bool disableKrnlOpFusion;                              // common for both
-extern bool disableKrnlBufferReuse;                           // common for both
+extern bool enableKrnlBufferReuse;                            // common for both
 extern bool disableMemRefPrefetch;                            // common for both
 extern EmissionTargetType emissionTarget;                     // onnx-mlir only
 extern bool invokeOnnxVersionConverter;                       // onnx-mlir only

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -28,6 +28,7 @@ using namespace mlir;
 
 namespace onnx_mlir {
 
+// Check the input, x, can be reused as the output buffer
 bool isBufferReusable(Value x, MemRefType outputType) {
   if (!x.hasOneUse())
     return false;
@@ -36,31 +37,30 @@ bool isBufferReusable(Value x, MemRefType outputType) {
   auto inputType = dyn_cast<ShapedType>(xType);
   if (!inputType)
     return false;
-
-  // ToFix: use DimAnalysis to handle dynamic shape
+  // Currently, only static shape could be reused.
+  // ToFix: use DimAnalysis to handle dynamic shape.
   if (!hasStaticShape(inputType))
     return false;
   if (!hasStaticShape(outputType))
     return false;
 
-  if (getSizeInBytes(inputType) != getSizeInBytes(outputType))
-    return false;
-
+  // Currently reuse requires that the shape has to be the same.
   // ToFix: If the shape is not the same, memref.cast can be used.
-  // Currently reuse requires that the shape has to be the same
   if (getRank(inputType) != getRank(outputType))
     return false;
-  for(int64_t i = 0; i < getRank(inputType); i++) {
+  for (int64_t i = 0; i < getRank(inputType); i++) {
     if (inputType.getShape()[i] != outputType.getShape()[i])
-      return false; 
+      return false;
   }
 
   // ToFix: The simd padding is not checked
-  // We did not record whether the memref is padded or not. How about put the
-  // VL as an attribute?
+  // We did not record whether the memref is padded or not.
+  // The padding added to the memref the as an attribute, or not needed.
   return true;
 }
 
+// Traverse the operands to find the candidate for buffer reuse.
+// Return -1, if no candidate is found.
 int whichBufferToReuse(ValueRange values, MemRefType outputType) {
   for (size_t i = 0; i < values.size(); i++) {
     if (isBufferReusable(values[i], outputType))
@@ -69,6 +69,7 @@ int whichBufferToReuse(ValueRange values, MemRefType outputType) {
   return -1;
 }
 
+// Allocate memref (as before) if no input buffer can be reused.
 Value allocOrReuse(MemRefBuilder &create, Operation *op,
     ValueRange generatedOperands, MemRefType outputMemRefType, DimsExprRef dims,
     int64_t alignment, int64_t VL = 1);
@@ -76,8 +77,11 @@ Value allocOrReuse(MemRefBuilder &create, Operation *op,
 Value allocOrReuse(MemRefBuilder &create, Operation *op,
     ValueRange generatedOperands, MemRefType outputMemRefType, DimsExprRef dims,
     int64_t alignment, int64_t VL) {
+
+  // By default, disableKrnlBufferReuse is true. Simply allocate a memref.
   if (disableKrnlBufferReuse)
-    return create.alignedAllocWithSimdPadding(outputMemRefType, dims, VL, alignment);
+    return create.alignedAllocWithSimdPadding(
+        outputMemRefType, dims, VL, alignment);
 
   // Be aware to use the op->getOperands() to check the number of uses.
   // After buffer reuse, the number of uses of the transformed Value,
@@ -91,7 +95,8 @@ Value allocOrReuse(MemRefBuilder &create, Operation *op,
     });
     return generatedOperands[indexToReuse];
   } else {
-    return create.alignedAllocWithSimdPadding(outputMemRefType, dims, VL, alignment);
+    return create.alignedAllocWithSimdPadding(
+        outputMemRefType, dims, VL, alignment);
   }
 }
 
@@ -1390,15 +1395,14 @@ static LogicalResult getPartiallyFlattenedSimdCode(
   IndexExprScope allocScope(create.vec, shapeHelper->getScope());
   DimsExpr outputDims;
   getIndexExprList<SymbolIndexExpr>(shapeHelper->getOutputDims(), outputDims);
-  // Alloc memory with padding for SIMD.
+  // Reuse the buffer from the input, or Alloc memory with padding for SIMD.
   // For the moment, its ok to go here; if we truly have partial flattening of
   // the simd code, then we only do it with static memref size that are
   // multiples of VL * unrollVL, so there should be no padding anyway. This
   // will change if we do partial flattening with non-multiple of VL *
   // unrollVL.
-  Value alloc = allocOrReuse(create.mem, op, operands, outputMemRefType, outputDims, alignment, VL);
-  //Value alloc = create.mem.alignedAllocWithSimdPadding(
-      //outputMemRefType, outputDims, VL, alignment);
+  Value alloc = allocOrReuse(
+      create.mem, op, operands, outputMemRefType, outputDims, alignment, VL);
   // Create flat inputs in the last innerDinNum dims.
   llvm::SmallVector<Value, 4> flatOperands;
   for (Value oper : operands) {

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -2002,9 +2002,10 @@ struct ONNXElementwiseUnaryOpLowering
 
     // Insert an allocation for the result of this operation.
     Value alloc;
-    if (isBufferReusable(op->getOperands()[0], outputMemRefType)) {
-      alloc = X;
+    int indexToReuse = whichBufferToReuse(elmsOp->getOperands(), outputMemRefType);
+    if (indexToReuse != -1) {
       op->dump();
+      alloc = operands[indexToReuse];
     } else
       alloc = create.mem.alignedAlloc(
           outputMemRefType, shapeHelper.getOutputDims(), alignment);

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -29,6 +29,8 @@ using namespace mlir;
 namespace onnx_mlir {
 
 bool isBufferReusable(Value x, MemRefType outputType) {
+  if (disableKrnlBufferReuse)
+    return false;
   if (!x.hasOneUse())
     return false;
 

--- a/test/mlir/conversion/onnx_to_krnl/onnx_lowering_reuse.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/onnx_lowering_reuse.mlir
@@ -1,0 +1,11 @@
+// RUN: onnx-mlir-opt --disable-krnl-op-fusion=true --disable-krnl-buffer-reuse=false --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
+
+// -----
+func.func @test_reuse(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {
+    %0 = "onnx.Add"(%arg0, %arg1) : (tensor<1024xf32>, tensor<1024xf32>) -> tensor<1024xf32>
+    %1 = "onnx.Sqrt"(%0) : (tensor<1024xf32>) -> tensor<1024xf32>
+    %2 = "onnx.Sqrt"(%1) : (tensor<1024xf32>) -> tensor<1024xf32>
+    return %2 : tensor<1024xf32>
+}
+// CHECK-LABEL: func.func @test_reuse
+// CHECK-NOT: memref.alloc

--- a/test/mlir/conversion/onnx_to_krnl/onnx_lowering_reuse.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/onnx_lowering_reuse.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt --disable-krnl-op-fusion=true --disable-krnl-buffer-reuse=false --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --disable-krnl-op-fusion=true --enable-krnl-buffer-reuse=true --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
 
 // -----
 func.func @test_reuse(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>) -> tensor<1024xf32> {


### PR DESCRIPTION
Previous,  a new memref is always created when onnx is lowered to krnl.
However, an input buffer could be reused as output, if  the input has only only one use and the shape is the same as the output. The PR tried this idea on element-wise operations.
by default, the buffer reuse is turned off.
This feature is tested with Roberta-base-11.onnx. About 80% of malloc (in either numbers or memory size) can be avoided with buffer reuse. The buffer reuse code can generate correct result, but did not bring notable performance improvement, with either SIMD on or off.