### PR TITLE
Update Ops documentation for ONNX 1.16.2

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -36,8 +36,8 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **BitwiseOr** |18 - * | | |
 | **BitwiseXor** |18 - * | | |
 | **BlackmanWindow** |none | | | |
-| **Cast** |6 - * |Cast only between float and double types. Only ppc64le and MacOS platforms support float16. | |
-| **CastLike** |19 - * |CastLike only between float and double types. Only ppc64le and MacOS platforms support float16. | |
+| **Cast** |6 - * |Cast only between float and double types. Only ppc64le and MacOS platforms support float16. Does not support int4 and uint4. | |
+| **CastLike** |19 - * |CastLike only between float and double types. Only ppc64le and MacOS platforms support float16. Does not support int4 and uint4. | |
 | **CastMap** |none | | | |
 | **CategoryMapper** |none | | | |
 | **Ceil** |6 - * | | |
@@ -48,8 +48,8 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **Compress** |9 - * | | |
 | **Concat** |6 - * | | |
 | **ConcatFromSequence** |none | | | |
-| **Constant** |6 - * | | |
-| **ConstantOfShape** |9 - * | | |
+| **Constant** |6 - * |Does not support int4 and uint4. | |
+| **ConstantOfShape** |9 - * |Does not support int4 and uint4. | |
 | **Conv** |6 - * | | |
 | **ConvInteger** |none | | | |
 | **ConvTranspose** |6 - * |Spatial dimensions (H and W in input `X`, and kH and kW in input `W`) must be static dimension. | |
@@ -59,7 +59,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **DFT** |17 - * | | |
 | **DeformConv** |none | | | |
 | **DepthToSpace** |13 - * | | |
-| **DequantizeLinear** |10 - * |Only support for per-tensor or layer dequantization. No support for per-axis dequantization. | |
+| **DequantizeLinear** |10 - * |Only support for per-tensor or layer dequantization. No support for per-axis dequantization. Does not support int4 and uint4. | |
 | **Det** |none | | | |
 | **DictVectorizer** |none | | | |
 | **Div** |6 - * |No support for short integers. | |
@@ -73,7 +73,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **Expand** |8 - * |Input `shape` must have static shape. | |
 | **EyeLike** |none | | | |
 | **FeatureVectorizer** |none | | | |
-| **Flatten** |6 - * | | |
+| **Flatten** |6 - * |Does not support int4 and uint4. | |
 | **Floor** |6 - * | | |
 | **GRU** |7 - * |W, B and R must be constants. | |
 | **Gather** |6 - * | | |
@@ -94,8 +94,8 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **HardSigmoid** |6 - * | | |
 | **HardSwish** |none | | | |
 | **Hardmax** |6 - * | | |
-| **Identity** |16 - * |Sequence identity not supported. | |
-| **If** |16 - * |Sequence and Optional outputs are not supported. | |
+| **Identity** |16 - * |Sequence identity not supported. Does not support int4 and uint4. | |
+| **If** |16 - * |Sequence and Optional outputs are not supported. Does not support int4 and uint4. | |
 | **Imputer** |none | | | |
 | **InstanceNormalization** |6 - * | | |
 | **IsInf** |20 - * |Currently no support for float16 infinity value. Only for float32 and float64. | |
@@ -111,7 +111,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **LinearRegressor** |none | | | |
 | **Log** |6 - * | | |
 | **LogSoftmax** |13 - * |Axis 0, 1, and default currently disabled due to changes in ONNX 1.8.1/Opset 13. |Temporally removed due to changes in onnx 1.8.1. |
-| **Loop** |6 - * |Input must have static shape. | |
+| **Loop** |6 - * |Input must have static shape. Does not support int4 and uint4. | |
 | **LpNormalization** |none | | | |
 | **LpPool** |none | | | |
 | **MatMul** |6 - * | | |
@@ -142,11 +142,11 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **OptionalHasElement** |none | | | |
 | **Or** |7 - * | | |
 | **PRelu** |6 - * | | |
-| **Pad** |6 - * |axes input not supported. | |
+| **Pad** |6 - * |axes input not supported. Does not support int4 and uint4. | |
 | **Pow** |7 - * |No support for power with integer types. | |
 | **QLinearConv** |none | | | |
 | **QLinearMatMul** |none | | | |
-| **QuantizeLinear** |10 - * |Do not support per-axis and i8 quantization. | |
+| **QuantizeLinear** |10 - * |Does not support per-axis and i8 quantization. Does not support int4 and uint4. | |
 | **RNN** |7 - * |W, B and R must be constants. | |
 | **RandomNormal** |none | | | |
 | **RandomNormalLike** |none | | | |
@@ -165,7 +165,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **ReduceSum** |6 - * |Default axis and do_not_keep_dim not supported. |Default axis and do_not_keep_dim temporarily removed due to changes in onnx 1.8.1. |
 | **ReduceSumSquare** |13 - * |Default axis and do_not_keep_dim not supported. | |
 | **Relu** |6 - * | | |
-| **Reshape** |6 - * |allowzero not supported. Input `shape` must have static dimension. | |
+| **Reshape** |6 - * |allowzero not supported. Input `shape` must have static dimension. Does not support int4 and uint4. | |
 | **Resize** |10 - * |Missing support for linear, cubic, crop, pytorch_half_pixel, and floor. Attributes antialias, axes and keep_aspect_ratio_policy are not supported. `scales` and `sizes` must have static dimension. | |
 | **ReverseSequence** |10 - * | | |
 | **RoiAlign** |none | | | |
@@ -174,7 +174,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **SVMClassifier** |none | | | |
 | **SVMRegressor** |none | | | |
 | **Scaler** |none | | | |
-| **Scan** |8 - * |Does not support dynamic shapes. |Precision issue with newer opset, maybe just unsupported. Dynamic shape?. |
+| **Scan** |8 - * |Does not support dynamic shapes. Does not support int4 and uint4. |Precision issue with newer opset, maybe just unsupported. Dynamic shape?. |
 | **Scatter** |none | | | |
 | **ScatterElements** |11 - * |Does not support duplicate indices. | |
 | **ScatterND** |11 - * |Does not support scatternd add/multiply. | |
@@ -186,13 +186,13 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **SequenceInsert** |11 - * |Does not support unranked sequence element. | |
 | **SequenceLength** |none | | | |
 | **SequenceMap** |none | | | |
-| **Shape** |15 - * |Does not support start and end attributes. | |
+| **Shape** |15 - * |Does not support start and end attributes. Does not support int4 and uint4. | |
 | **Shrink** |none | | | |
 | **Sigmoid** |6 - * | | |
 | **Sign** |9 - * | | |
 | **Sin** |7 - * | | |
 | **Sinh** |9 - * | | |
-| **Size** |13 - * | | |
+| **Size** |13 - * |Does not support int4 and uint4. | |
 | **Slice** |13 - * |Axis must be a constant argument. |Add tests to slices, currently have none. |
 | **Softmax** |6 - * | | |
 | **SoftmaxCrossEntropyLoss** |none | | | |
@@ -202,7 +202,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **Split** |6 - * |Does not support static and dynamic shape, zero size splits. |Temporally removed due to changes in onnx 1.8.1. |
 | **SplitToSequence** |none | | | |
 | **Sqrt** |6 - * | | |
-| **Squeeze** |6 - * |Does not support static and dynamic shape. |Temporally removed due to changes in onnx 1.8.1. |
+| **Squeeze** |6 - * |Does not support static and dynamic shape. Does not support int4 and uint4. |Temporally removed due to changes in onnx 1.8.1. |
 | **StringNormalizer** |none | | | |
 | **Sub** |6 - * |Does not support short integers. | |
 | **Sum** |6 - * | | |
@@ -212,12 +212,12 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **ThresholdedRelu** |none | | | |
 | **Tile** |6 - * | | |
 | **TopK** |10 - * |`K`, the number of top elements to retrieve, must have static shape. | |
-| **Transpose** |6 - * | | |
+| **Transpose** |6 - * |Does not support int4 and uint4. | |
 | **TreeEnsembleClassifier** |none | | | |
 | **TreeEnsembleRegressor** |none | | | |
 | **Trilu** |14 - * | | |
 | **Unique** |11 - * | | |
-| **Unsqueeze** |6 - * |Does not support static and dynamic shape. |Temporally removed due to changes in onnx 1.8.1. |
+| **Unsqueeze** |6 - * |Does not support static and dynamic shape. Does not support int4 and uint4. |Temporally removed due to changes in onnx 1.8.1. |
 | **Upsample** |7 - * |Input `X` and `Y` must have static shape. | |
 | **Where** |9 - * | | |
 | **Xor** |7 - * | | |

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -395,7 +395,7 @@ def get_test_models():
         },
         # ==OP== Cast
         # ==MIN== 6
-        # ==LIM== Cast only between float and double types. Only ppc64le and MacOS platforms support float16.
+        # ==LIM== Cast only between float and double types. Only ppc64le and MacOS platforms support float16. Does not support int4 and uint4.
         "test_cast_FLOAT_to_DOUBLE_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -434,7 +434,7 @@ def get_test_models():
         "test_cast_STRING_to_FLOAT_cpu": {},  # appears unsupported at this time
         # ==OP== CastLike
         # ==MIN== 19
-        # ==LIM== CastLike only between float and double types. Only ppc64le and MacOS platforms support float16.
+        # ==LIM== CastLike only between float and double types. Only ppc64le and MacOS platforms support float16. Does not support int4 and uint4.
         "test_castlike_FLOAT_to_DOUBLE_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -615,10 +615,12 @@ def get_test_models():
         },
         # ==OP== Constant
         # ==MIN== 1
+        # ==LIM== Does not support int4 and uint4.
         # By def, no dynamic shapes.
         "test_constant_cpu": {STATIC_SHAPE: {}},
         # ==OP== ConstantOfShape
         # ==MIN== 9
+        # ==LIM== Does not support int4 and uint4.
         # By def, no dynamic shapes.
         "test_constantofshape_float_ones_cpu": {STATIC_SHAPE: {}},
         "test_constantofshape_int_zeros_cpu": {STATIC_SHAPE: {}},
@@ -790,7 +792,7 @@ def get_test_models():
         },
         # ==OP== DequantizeLinear
         # ==MIN== 10
-        # ==LIM== Only support for per-tensor or layer dequantization. No support for per-axis dequantization.
+        # ==LIM== Only support for per-tensor or layer dequantization. No support for per-axis dequantization. Does not support int4 and uint4.
         # "test_dequantizelinear_axis_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         "test_dequantizelinear_cpu": {
             STATIC_SHAPE: {},
@@ -981,6 +983,7 @@ def get_test_models():
         },
         # ==OP== Flatten
         # ==MIN== 1
+        # ==LIM== Does not support int4 and uint4.
         "test_flatten_axis0_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -1358,7 +1361,7 @@ def get_test_models():
         },
         # ==OP== Identity
         # ==MIN== 16
-        # ==LIM== Sequence identity not supported.
+        # ==LIM== Sequence identity not supported. Does not support int4 and uint4.
         "test_identity_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -1368,7 +1371,7 @@ def get_test_models():
         # "test_identity_opt_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # ==OP== If
         # ==MIN== 16
-        # ==LIM== Sequence and Optional outputs are not supported.
+        # ==LIM== Sequence and Optional outputs are not supported. Does not support int4 and uint4.
         "test_if_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -1785,7 +1788,7 @@ def get_test_models():
         },
         # ==OP== Loop
         # ==MIN== 1
-        # ==LIM== Input must have static shape.
+        # ==LIM== Input must have static shape. Does not support int4 and uint4.
         "test_loop11_cpu": {
             STATIC_SHAPE: {},
             # Need to enable ConvertSeqToMemrefPass for dynamic test.
@@ -2264,7 +2267,7 @@ def get_test_models():
         },
         # ==OP== Pad
         # ==MIN== 2
-        # ==LIM== axes input not supported
+        # ==LIM== axes input not supported. Does not support int4 and uint4.
         "test_constant_pad_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {0: {-1}},
@@ -2317,7 +2320,7 @@ def get_test_models():
         },
         # ==OP== QuantizeLinear
         # ==MIN== 10
-        # ==LIM== Do not support per-axis and i8 quantization.
+        # ==LIM== Does not support per-axis and i8 quantization. Does not support int4 and uint4.
         # "test_quantizelinear_axis_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         "test_quantizelinear_cpu": {
             STATIC_SHAPE: {},
@@ -2623,7 +2626,7 @@ def get_test_models():
         },
         # ==OP== Reshape
         # ==MIN== 5
-        # ==LIM== allowzero not supported. Input `shape` must have static dimension.
+        # ==LIM== allowzero not supported. Input `shape` must have static dimension. Does not support int4 and uint4.
         "test_reshape_extended_dims_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {0: {-1}},
@@ -2802,7 +2805,7 @@ def get_test_models():
         },
         # ==OP== Scan
         # ==MIN== 8
-        # ==LIM== Does not support dynamic shapes.
+        # ==LIM== Does not support dynamic shapes. Does not support int4 and uint4.
         # ==TODO== Precision issue with newer opset, maybe just unsupported. Dynamic shape?
         #  "test_scan_sum_cpu": {STATIC_SHAPE:{}},
         "test_scan9_sum_cpu": {STATIC_SHAPE: {}},
@@ -2859,7 +2862,7 @@ def get_test_models():
         # "test_sequence_insert_at_back_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # ==OP== Shape
         # ==MIN== 15
-        # ==LIM== Does not support start and end attributes.
+        # ==LIM== Does not support start and end attributes. Does not support int4 and uint4.
         "test_shape_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -2915,6 +2918,7 @@ def get_test_models():
         },
         # ==OP== Size
         # ==MIN== 13
+        # ==LIM== Does not support int4 and uint4.
         "test_size_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -3042,7 +3046,7 @@ def get_test_models():
         },
         # ==OP== Squeeze
         # ==MIN== 1
-        # ==LIM== Does not support static and dynamic shape.
+        # ==LIM== Does not support static and dynamic shape. Does not support int4 and uint4.
         # ==TODO== Temporally removed due to changes in onnx 1.8.1
         # "test_squeeze_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # "test_squeeze_negative_axes_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
@@ -3141,6 +3145,7 @@ def get_test_models():
         },
         # ==OP== Transpose
         # ==MIN== 1
+        # ==LIM== Does not support int4 and uint4. 
         "test_transpose_default_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -3286,7 +3291,7 @@ def get_test_models():
         },
         # ==OP== Unsqueeze
         # ==MIN== 1
-        # ==LIM== Does not support static and dynamic shape.
+        # ==LIM== Does not support static and dynamic shape. Does not support int4 and uint4.
         # ==TODO== Temporally removed due to changes in onnx 1.8.1
         # "test_unsqueeze_axis_0_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # "test_unsqueeze_axis_1_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -3145,7 +3145,7 @@ def get_test_models():
         },
         # ==OP== Transpose
         # ==MIN== 1
-        # ==LIM== Does not support int4 and uint4. 
+        # ==LIM== Does not support int4 and uint4.
         "test_transpose_default_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},


### PR DESCRIPTION
ONNX now supports in4 and uint4 but we do not have the hardware to do so. Indicating that we do not support these data types for the latest Opset version.

Update to support int4 and uint4:
[Cast](https://onnx.ai/onnx/operators/onnx__Cast.html#cast-21), [CastLike](https://onnx.ai/onnx/operators/onnx__CastLike.html#CastLike-21), [Constant](https://onnx.ai/onnx/operators/onnx__Constant.html#Constant-21), [ConstantOfShape](https://onnx.ai/onnx/operators/onnx__ConstantOfShape.html#ConstantOfShape-21), [Identity](https://onnx.ai/onnx/operators/onnx__Identity.html#Identity-21), [If](https://onnx.ai/onnx/operators/onnx__If.html#If-21), [Loop](https://onnx.ai/onnx/operators/onnx__Loop.html#Loop-21), [Reshape](https://onnx.ai/onnx/operators/onnx__Reshape.html#Reshape-21), [Scan](https://onnx.ai/onnx/operators/onnx__Scan.html#Scan-21), [Shape](https://onnx.ai/onnx/operators/onnx__Shape.html#Shape-21), [Size](https://onnx.ai/onnx/operators/onnx__Size.html#Size-21)
Update to support float8e4m3fnuz, float8e5m2, float8e5m2fnuz, int4 and uint4:
[Flatten](https://onnx.ai/onnx/operators/onnx__Flatten.html#Flatten-21), [Pad](https://onnx.ai/onnx/operators/onnx__Pad.html#Pad-21), [Squeeze](https://onnx.ai/onnx/operators/onnx__Squeeze.html#Squeeze-21), [Transpose](https://onnx.ai/onnx/operators/onnx__Transpose.html#Transpose-21), [Unsqueeze](https://onnx.ai/onnx/operators/onnx__Unsqueeze.html#Unsqueeze-21)
Support blocked quantization. Support int4, uint4, int16, and uint16:
[DequantizeLinear](https://onnx.ai/onnx/operators/onnx__DequantizeLinear.html#DequantizeLinear-21), [QuantizeLinear](https://onnx.ai/onnx/operators/onnx__QuantizeLinear.html#QuantizeLinear-21),
Support bfloat16 and float16 scales. Support float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz quantized tensors:
[QLinearMatMul](https://onnx.ai/onnx/operators/onnx__QLinearMatMul.html#QLinearMatMul-21),