### PR TITLE
[mlir2FileCheck tool] handle multiple output arguments

### DIFF
--- a/utils/mlir2FileCheck.py
+++ b/utils/mlir2FileCheck.py
@@ -268,12 +268,18 @@ def process_line(i, line):
         new_line = process_name(new_line, def1_pat, "BLOCK_TILE_", ",", 1)
         new_line = process_name(new_line, def2_pat, "BLOCK_IN_", " =", 1)
     else:
-        definitions = def_qual_pat.findall(new_line)
+        def_qual_pat2 = re.compile(r"((?:%(?:[a-zA-Z0-9][a-zA-Z0-9_\-]*)(?::\d+)?,?\s+)*)=")
+        definitions = def_qual_pat2.findall(new_line)
         for d in definitions:
-            (name, num) = d
-            x = use_name(name, num, " =")
-            y = record_name_def(name, num, "VAR_" + name, " =", 0, new_line)
-            new_line = new_line.replace(x, y)
+            arg_def_pat = re.compile(r"%([a-zA-Z0-9][a-zA-Z0-9_\-]*)(:\d+)?")
+            arg_defs = d.split(",")
+            for arg_def in arg_defs:
+                args = arg_def_pat.findall(arg_def)
+                for arg in args:
+                    (name, num) = arg
+                    x = use_name(name, num, "")
+                    y = record_name_def(name, num, "VAR_" + name, "", 0, new_line)
+                    new_line = new_line.replace(x, y)
 
     # Process uses and map use.
     uses = use_qual_pat.findall(new_line)

--- a/utils/mlir2FileCheck.py
+++ b/utils/mlir2FileCheck.py
@@ -268,7 +268,9 @@ def process_line(i, line):
         new_line = process_name(new_line, def1_pat, "BLOCK_TILE_", ",", 1)
         new_line = process_name(new_line, def2_pat, "BLOCK_IN_", " =", 1)
     else:
-        def_qual_pat2 = re.compile(r"((?:%(?:[a-zA-Z0-9][a-zA-Z0-9_\-]*)(?::\d+)?,?\s+)*)=")
+        def_qual_pat2 = re.compile(
+            r"((?:%(?:[a-zA-Z0-9][a-zA-Z0-9_\-]*)(?::\d+)?,?\s+)*)="
+        )
         definitions = def_qual_pat2.findall(new_line)
         for d in definitions:
             arg_def_pat = re.compile(r"%([a-zA-Z0-9][a-zA-Z0-9_\-]*)(:\d+)?")


### PR DESCRIPTION
The python script `mlir2FileCheck` does not handle multiple output arguments, for example, it prints out:
```
// CHECK:           [[VAR_Out_]], [[VAR_RecScale_]], [[VAR_Offset_:%.+]] = ....
```

where only the last output has `:%.+`. The correct one would be
```
// CHECK:           [[VAR_Out_:%.+]], [[VAR_RecScale_:%.+]], [[VAR_Offset_:%.+]] = "
```

This fixes the issue by defining a new regex that captures a repeated group that contains all output arguments, then parses them.