### PR TITLE
Add support of return for KrnlCallOp

### DIFF
--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -89,6 +89,13 @@ def KrnlCallOp : Op<Krnl_Dialect, "call",
       DefaultValuedAttr<SI64Attr, "1">:$numOfOutput,
       Variadic<AnyType>:$parameters);
 
+  // Return Value for the Call.
+  // No return if the type is NoneType (void in llvm)
+  // Only scalar type is supported now.
+  // In future, return of memref can be supported with pointer of OMTensor.
+  // The returned memref will be created inside the call. 
+  let results = (outs Variadic<AnyTypeOf<[F32, F64, I32, I64]>>:$returnValue);
+
   // builders to build KrnlCallOp from op and operands, helping conversion from
   // onnx to krnl.
   // The name of function can be determined by the op name and elemnt type of
@@ -96,6 +103,8 @@ def KrnlCallOp : Op<Krnl_Dialect, "call",
   // Attributes of the op will be propagated to KrnlCallOp if the copyAttrs is
   // true. Or the attribute names can be specified.
   let builders = [
+      OpBuilder<(ins "std::string":$funcNameStr, "int64_t":$numOfOutput, "mlir::ValueRange":$operands)>,
+      OpBuilder<(ins "mlir::StringAttr":$funcNameStr, "IntegerAttr":$numOfOutput, "mlir::ValueRange":$operands)>,
       OpBuilder<(ins "std::string":$funcNameStr, "mlir::ValueRange":$results, "mlir::Operation *":$op, "mlir::ValueRange":$operands, "std::vector<std::string>":$attributeNames)>,
     OpBuilder<(ins "mlir::ValueRange":$results, "mlir::Operation *":$op, "mlir::ValueRange":$operands, "bool":$copyAttrs)>,
       OpBuilder<(ins "std::string":$funcNameStr, "mlir::ValueRange":$results, "mlir::Operation *":$op, "mlir::ValueRange":$operands, "std::vector<std::string>":$attributeNames)>,

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -94,7 +94,7 @@ def KrnlCallOp : Op<Krnl_Dialect, "call",
   // Only scalar type is supported now.
   // In future, return of memref can be supported with pointer of OMTensor.
   // The returned memref will be created inside the call. 
-  let results = (outs Variadic<AnyTypeOf<[F32, F64, I32, I64]>>:$returnValue);
+  let results = (outs Variadic<AnyTypeOf<[AnyFloat, AnyInteger]>>:$returnValue);
 
   // builders to build KrnlCallOp from op and operands, helping conversion from
   // onnx to krnl.

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -156,12 +156,12 @@ void KrnlCallOp::build(OpBuilder &builder, ::mlir::OperationState &odsState,
 
 void KrnlCallOp::build(OpBuilder &builder, ::mlir::OperationState &odsState,
     std::string funcName, int64_t numOfOutput, ValueRange operands) {
-    build(builder, odsState, {}, funcName, numOfOutput, operands);
+  build(builder, odsState, {}, funcName, numOfOutput, operands);
 }
 
 void KrnlCallOp::build(OpBuilder &builder, ::mlir::OperationState &odsState,
     StringAttr funcName, IntegerAttr numOfOutput, ValueRange operands) {
-    build(builder, odsState, {}, funcName, numOfOutput, operands);
+  build(builder, odsState, {}, funcName, numOfOutput, operands);
 }
 
 void KrnlCallOp::getEffects(

--- a/src/Dialect/Krnl/KrnlOps.cpp
+++ b/src/Dialect/Krnl/KrnlOps.cpp
@@ -154,6 +154,16 @@ void KrnlCallOp::build(OpBuilder &builder, ::mlir::OperationState &odsState,
   build(builder, odsState, funcNameStr, resultVals, op, operands, copyAttrs);
 }
 
+void KrnlCallOp::build(OpBuilder &builder, ::mlir::OperationState &odsState,
+    std::string funcName, int64_t numOfOutput, ValueRange operands) {
+    build(builder, odsState, {}, funcName, numOfOutput, operands);
+}
+
+void KrnlCallOp::build(OpBuilder &builder, ::mlir::OperationState &odsState,
+    StringAttr funcName, IntegerAttr numOfOutput, ValueRange operands) {
+    build(builder, odsState, {}, funcName, numOfOutput, operands);
+}
+
 void KrnlCallOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {

--- a/test/mlir/conversion/krnl_to_llvm/call_with_return.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/call_with_return.mlir
@@ -1,0 +1,10 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-llvm %s -split-input-file | FileCheck %s
+
+func.func private @test_krnl_call_with_return(%arg0: memref<2x3xi32>) -> i32 {
+  %1 = "krnl.call"() {funcName = "get_omp_num_thread", numOfOutput = 0 : si64} : () -> (i32)
+  func.return %1: i32
+// CHECK:         llvm.func @get_omp_num_thread() -> i32
+// CHECK:         llvm.func @test_krnl_call_with_return
+// CHECK:           [[VAR_0_:%.+]] = llvm.call @get_omp_num_thread() : () -> i32
+// CHECK:           llvm.return [[VAR_0_]] : i32
+}


### PR DESCRIPTION
This PR allows KrnlCallOp to have a scalar return, AnyFloat or AnyInteger, and the lowering will use the return of func.call to implement the return. When there is no return, the previous usage does not need to change.

A lit test is added. The input is
```
%1 = "krnl.call"() {funcName = "get_omp_num_thread", numOfOutput = 0 : si64} : () -> (i32)
```
The output is 
```
 %0 = llvm.call @get_omp_num_thread() : () -> i32
```
The krnl call can be generated with 
```
rewriter.create<KrnlCallOp>(loc, TypeRange(rewriter.getIntegerType(32)), "omp_get_num_thread", 0, ValueRange());
```