### PR TITLE
[NNPA] Simplify rules in zhigh-to-onnx pass and change some pass order

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -111,7 +111,7 @@ void addONNXToZHighPasses(mlir::PassManager &pm) {
         onnx_mlir::zhigh::createZHighClipToDLFloatPass());
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createConstPropONNXToONNXPass());
   }
-  
+
   // One more call to ONNX shape inference/canonicalization/... to update shape
   // if possible.
   if (enableONNXHybridPass) {

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighToONNX.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ZHighToONNX.td
@@ -37,52 +37,30 @@ def CreateONNXMaxOp : NativeCodeCall<"$_builder.create<ONNXMaxOp>($_loc, $0.getT
 // ONNXAddOp %X = ZHighUnstickOp (ZHighAddOp (ZHighStickOp %X),
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
-def replaceZHighAddPattern1 : Pat<
-  (ZHighUnstickOp (ZHighAddOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
-  (ONNXAddOp $x, (ZHighUnstickOp $y)),
-  [(NotBlockArgument:$x), (HasOneUse:$s_x)]
->;
-
-def replaceZHighAddPattern2 : Pat<
-  (ZHighUnstickOp (ZHighAddOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
-  (ONNXAddOp (ZHighUnstickOp $x), $y),
-  [(NotBlockArgument:$y), (HasOneUse:$s_y)]
+def replaceZHighAddPattern : Pat<
+  (ZHighUnstickOp (ZHighAddOp (ZHighStickOp:$s_x $x, $_, $_), (ZHighStickOp:$s_y $y, $_, $_))),
+  (ONNXAddOp $x, $y),
+  [(NotBlockArgument:$x), (HasOneUse:$s_x), (NotBlockArgument:$y), (HasOneUse:$s_y)]
 >;
 
 //===----------------------------------------------------------------------===//
 // ONNXMulOp %X = ZHighUnstickOp (ZHighMulOp (ZHighStickOp %X),
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
-def replaceZHighMulPattern1 : Pat<
-  (ZHighUnstickOp (ZHighMulOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
-  (ONNXMulOp $x, (ZHighUnstickOp $y)),
-  [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
-  (addBenefit 1)
->;
-
-def replaceZHighMulPattern2 : Pat<
-  (ZHighUnstickOp (ZHighMulOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
-  (ONNXMulOp (ZHighUnstickOp $x), $y),
-  [(NotBlockArgument:$y), (HasOneUse:$s_y)], [],
-  (addBenefit 0)
+def replaceZHighMulPattern : Pat<
+  (ZHighUnstickOp (ZHighMulOp (ZHighStickOp:$s_x $x, $_, $_), (ZHighStickOp:$s_y $y, $_, $_))),
+  (ONNXMulOp $x, $y),
+  [(NotBlockArgument:$x), (HasOneUse:$s_x), (NotBlockArgument:$y), (HasOneUse:$s_y)]
 >;
 
 //===----------------------------------------------------------------------===//
 // ONNXSubOp %X = ZHighUnstickOp (ZHighSubOp (ZHighStickOp %X),
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
-def replaceZHighSubPattern1 : Pat<
-  (ZHighUnstickOp (ZHighSubOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
-  (ONNXSubOp $x, (ZHighUnstickOp $y)),
-  [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
-  (addBenefit 1)
->;
-
-def replaceZHighSubPattern2 : Pat<
-  (ZHighUnstickOp (ZHighSubOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
-  (ONNXSubOp (ZHighUnstickOp $x), $y),
-  [(NotBlockArgument:$y), (HasOneUse:$s_y)], [ ],
-  (addBenefit 0)
+def replaceZHighSubPattern : Pat<
+  (ZHighUnstickOp (ZHighSubOp (ZHighStickOp:$s_x $x, $_, $_), (ZHighStickOp:$s_y $y, $_, $_))),
+  (ONNXSubOp $x, $y),
+  [(NotBlockArgument:$x), (HasOneUse:$s_x), (NotBlockArgument:$y), (HasOneUse:$s_y)]
 >;
 
 //===----------------------------------------------------------------------===//
@@ -90,54 +68,30 @@ def replaceZHighSubPattern2 : Pat<
 // %X),(ZHighStickOp %Y))
 // Note: turn off this pattern since NNPA is faster at this moment.
 //===----------------------------------------------------------------------===//
-//def replaceZHighDivPattern1 : Pat<
-//  (ZHighUnstickOp (ZHighDivOp (ZHighStickOp:$s_x $x, $_), $y)),
-//  (ONNXDivOp $x, (ZHighUnstickOp $y)),
-//  [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
-//  (addBenefit 1)
-//>;
-//
-//def replaceZHighDivPattern2 : Pat<
-//  (ZHighUnstickOp (ZHighDivOp $x, (ZHighStickOp:$s_y $y, $_))),
-//  (ONNXDivOp (ZHighUnstickOp $x), $y),
-//  [(NotBlockArgument:$y), (HasOneUse:$s_y)], [ ],
-//  (addBenefit 0)
-//>;
+// def replaceZHighDivPattern : Pat<
+//   (ZHighUnstickOp (ZHighDivOp (ZHighStickOp:$s_x $x, $_, $_), (ZHighStickOp:$s_y $y, $_, $_))),
+//   (ONNXDivOp $x, $y),
+//   [(NotBlockArgument:$x), (HasOneUse:$s_x), (NotBlockArgument:$y), (HasOneUse:$s_y)]
+// >;
 
 //===----------------------------------------------------------------------===//
 // ONNXMinOp %X = ZHighUnstickOp (ZHighMinOp (ZHighStickOp %X),
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
-def replaceZHighMinPattern1 : Pat<
-  (ZHighUnstickOp:$u (ZHighMinOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
-  (CreateONNXMinOp $u, $x, (ZHighUnstickOp $y)),
-  [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
-  (addBenefit 1)
->;
-
-def replaceZHighMinPattern2 : Pat<
-  (ZHighUnstickOp:$u (ZHighMinOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
-  (CreateONNXMinOp $u, (ZHighUnstickOp $x), $y),
-  [(NotBlockArgument:$y), (HasOneUse:$s_y)], [ ],
-  (addBenefit 0)
+def replaceZHighMinPattern : Pat<
+  (ZHighUnstickOp:$u (ZHighMinOp (ZHighStickOp:$s_x $x, $_, $_), (ZHighStickOp:$s_y $y, $_, $_))),
+  (CreateONNXMinOp $u, $x, $y),
+  [(NotBlockArgument:$x), (HasOneUse:$s_x), (NotBlockArgument:$y), (HasOneUse:$s_y)]
 >;
 
 //===----------------------------------------------------------------------===//
 // ONNXMaxOp %X = ZHighUnstickOp (ZHighMaxOp (ZHighStickOp %X),
 // (ZHighStickOp %Y))
 //===----------------------------------------------------------------------===//
-def replaceZHighMaxPattern1 : Pat<
-  (ZHighUnstickOp:$u (ZHighMaxOp (ZHighStickOp:$s_x $x, $_, $_), $y)),
-  (CreateONNXMaxOp $u, $x, (ZHighUnstickOp $y)),
-  [(NotBlockArgument:$x), (HasOneUse:$s_x)], [ ],
-  (addBenefit 1)
->;
-
-def replaceZHighMaxPattern2 : Pat<
-  (ZHighUnstickOp:$u (ZHighMaxOp $x, (ZHighStickOp:$s_y $y, $_, $_))),
-  (CreateONNXMaxOp $u, (ZHighUnstickOp $x), $y),
-  [(NotBlockArgument:$y), (HasOneUse:$s_y)], [ ],
-  (addBenefit 0)
+def replaceZHighMaxPattern : Pat<
+  (ZHighUnstickOp:$u (ZHighMaxOp (ZHighStickOp:$s_x $x, $_, $_), (ZHighStickOp:$s_y $y, $_, $_))),
+  (CreateONNXMaxOp $u, $x, $y),
+  [(NotBlockArgument:$x), (HasOneUse:$s_x), (NotBlockArgument:$y), (HasOneUse:$s_y)]
 >;
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Simplify some rules in `zhigh-to-onnx` pass and change the order of calling `zhigh-to-onnx` and `constprop-zhigh` in which `constprop-zhigh` is called after `zhigh-to-onnx` so that `zhigh-to-onnx` can recompose `stick->nnpa_op->unstick` back into an onnx op.