### PR TITLE
Revert the rule that rewrites a quantize-dequantize pair to identity

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -1863,6 +1863,4 @@ void ONNXWhereOp::getCanonicalizationPatterns(
 
 // on the ONNXDequantizeLinearOp.
 void ONNXDequantizeLinearOp::getCanonicalizationPatterns(
-    RewritePatternSet &result, MLIRContext *context) {
-  result.insert<QuantizeDequantizePattern>(context);
-}
+    RewritePatternSet &result, MLIRContext *context) {}

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -1055,15 +1055,4 @@ def AlwaysFalseWherePattern : Pat<
  [(IsNegativeSplatConstant:$negative_constant), (AreAllDimSizes:$dims)]
 >;
 
-//===----------------------------------------------------------------------===//
-// Canonicalization for ONNXDequantizeLinear
-//===----------------------------------------------------------------------===//
-
-// Convert QuantizeLinear+DequantizeLinear to Identity.
-def QuantizeDequantizePattern: Pat<
-  (ONNXDequantizeLinearOp (ONNXQuantizeLinearOp $x, $x_scale, $x_zeropoint, $x_axis, $x_saturate),
-                           $y_scale, $y_zeropoint, $y_axis),
-  (replaceWithValue $x)
->;
-
 #endif // ONNX_REWRITE

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -1826,17 +1826,3 @@ func.func @test_where_with_always_false_3(%arg0: tensor<?x?xi64>) -> tensor<2xi6
 // CHECK:         }
 }
 
-// -----
-
-func.func @test_dequantize_linear(%arg0: tensor<?x?x768xf32>, %arg1: tensor<f32>, %arg2: tensor<i8>) -> (tensor<?x?x768xf32>) {
-    %0 = "onnx.QuantizeLinear"(%arg0, %arg1, %arg2) {axis = 1 : si64} : (tensor<?x?x768xf32>, tensor<f32>, tensor<i8>) -> tensor<?x?x768xi8>
-    %1 = "onnx.DequantizeLinear"(%0, %arg1, %arg2) {axis = 1 : si64} : (tensor<?x?x768xi8>, tensor<f32>, tensor<i8>) -> tensor<?x?x768xf32>
-    return %1: tensor<?x?x768xf32>
-
-// CHECK-LABEL:  func.func @test_dequantize_linear
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x768xf32>, [[PARAM_1_:%.+]]: tensor<f32>, [[PARAM_2_:%.+]]: tensor<i8>) -> tensor<?x?x768xf32> {
-// CHECK-NOT:       "onnx.QuantizeLinear"
-// CHECK-NOT:       "onnx.DequantizeLinear"
-// CHECK:           return [[PARAM_0_]] : tensor<?x?x768xf32>
-// CHECK:         }
-}


### PR DESCRIPTION
Remove the rule that rewrites a quantize-dequantize pair to identity. It's because there is a rounding in the QuantizeLinear's formulas so that the pair is mathematically not the same as identity.  