### PR TITLE
Handle the options passed to llvm opt and llvm llc

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -64,8 +64,6 @@ bool VerboseOutput;                                    // onnx-mlir only
 std::vector<std::string> Xopt;                         // onnx-mlir only
 std::vector<std::string> Xllc;                         // onnx-mlir only
 std::string mllvm;                                     // onnx-mlir only
-std::string mllvmopt;                                  // onnx-mlir only
-std::string mllvmllc;                                  // onnx-mlir only
 std::string instrumentOps;                             // onnx-mlir only
 unsigned instrumentControlBits;                        // onnx-mlir only
 std::string parallelizeOps;                            // onnx-mlir only
@@ -409,13 +407,19 @@ static llvm::cl::opt<bool, true> VerboseOutputOpt("v",
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::list<std::string, std::vector<std::string>> XoptOpt("Xopt",
-    llvm::cl::desc("Arguments to forward to LLVM's 'opt' option processing"),
+    llvm::cl::desc(
+        "Arguments to forward to LLVM's 'opt' option processing"
+        "Multiple arguments to 'opt' need to be pass with seperate 'Xopt'"
+        "For example, '-Xopt opt1 -Xopt opt2 ...'"),
     llvm::cl::value_desc("A valid LLVM's 'opt' option"),
     llvm::cl::location(Xopt), llvm::cl::cat(OnnxMlirOptions), llvm::cl::Hidden,
     llvm::cl::ValueRequired, llvm::cl::ZeroOrMore, llvm::cl::CommaSeparated);
 
 static llvm::cl::list<std::string, std::vector<std::string>> XllcOpt("Xllc",
-    llvm::cl::desc("Arguments to forward to LLVM's 'llc' option processing"),
+    llvm::cl::desc(
+        "Arguments to forward to LLVM's 'llc' option processing"
+        "Multiple arguments to 'llc' need to be pass with seperate 'Xllc'"
+        "For example, '-Xllc opt1 -Xllc opt2 ...'"),
     llvm::cl::value_desc("A valid LLVM's 'llc' option"),
     llvm::cl::location(Xllc), llvm::cl::cat(OnnxMlirOptions), llvm::cl::Hidden,
     llvm::cl::ValueRequired, llvm::cl::ZeroOrMore, llvm::cl::CommaSeparated);
@@ -426,18 +430,6 @@ static llvm::cl::opt<std::string, true> mllvmOpt("mllvm",
     llvm::cl::value_desc("A valid LLVM's 'opt' and 'llc' option"),
     llvm::cl::location(mllvm), llvm::cl::cat(OnnxMlirOptions), llvm::cl::Hidden,
     llvm::cl::ValueRequired);
-
-static llvm::cl::opt<std::string, true> mllvmoptOpt("mllvmopt",
-    llvm::cl::desc("Arguments to forward to LLVM's 'opt' processing"),
-    llvm::cl::value_desc("A valid LLVM's 'opt' option"),
-    llvm::cl::location(mllvmopt), llvm::cl::cat(OnnxMlirOptions),
-    llvm::cl::Hidden, llvm::cl::ValueRequired);
-
-static llvm::cl::opt<std::string, true> mllvmllcOpt("mllvmllc",
-    llvm::cl::desc("Arguments to forward to LLVM's 'llc' option processing"),
-    llvm::cl::value_desc("A valid LLVM's 'llc' option"),
-    llvm::cl::location(mllvmllc), llvm::cl::cat(OnnxMlirOptions),
-    llvm::cl::Hidden, llvm::cl::ValueRequired);
 
 static llvm::cl::opt<std::string, true> instrumentOpsOpt("instrument-ops",
     llvm::cl::desc("Specify operations to be instrumented:\n"
@@ -939,19 +931,8 @@ static std::vector<std::string> split(std::string &input) {
 std::vector<std::string> getLLVMOptions() {
   if (mllvm == "")
     return std::vector<std::string>();
+
   return split(mllvm);
-}
-
-std::vector<std::string> getLLVMOPTOptions() {
-  if (mllvmopt == "")
-    return std::vector<std::string>();
-  return split(mllvmopt);
-}
-
-std::vector<std::string> getLLVMLLCOptions() {
-  if (mllvmllc == "")
-    return std::vector<std::string>();
-  return split(mllvmllc);
 }
 
 // Support for model tag

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -64,6 +64,8 @@ bool VerboseOutput;                                    // onnx-mlir only
 std::vector<std::string> Xopt;                         // onnx-mlir only
 std::vector<std::string> Xllc;                         // onnx-mlir only
 std::string mllvm;                                     // onnx-mlir only
+std::string mllvmopt;                                  // onnx-mlir only
+std::string mllvmllc;                                  // onnx-mlir only
 std::string instrumentOps;                             // onnx-mlir only
 unsigned instrumentControlBits;                        // onnx-mlir only
 std::string parallelizeOps;                            // onnx-mlir only
@@ -424,6 +426,18 @@ static llvm::cl::opt<std::string, true> mllvmOpt("mllvm",
     llvm::cl::value_desc("A valid LLVM's 'opt' and 'llc' option"),
     llvm::cl::location(mllvm), llvm::cl::cat(OnnxMlirOptions), llvm::cl::Hidden,
     llvm::cl::ValueRequired);
+
+static llvm::cl::opt<std::string, true> mllvmoptOpt("mllvmopt",
+    llvm::cl::desc("Arguments to forward to LLVM's 'opt' processing"),
+    llvm::cl::value_desc("A valid LLVM's 'opt' option"),
+    llvm::cl::location(mllvmopt), llvm::cl::cat(OnnxMlirOptions),
+    llvm::cl::Hidden, llvm::cl::ValueRequired);
+
+static llvm::cl::opt<std::string, true> mllvmllcOpt("mllvmllc",
+    llvm::cl::desc("Arguments to forward to LLVM's 'llc' option processing"),
+    llvm::cl::value_desc("A valid LLVM's 'llc' option"),
+    llvm::cl::location(mllvmllc), llvm::cl::cat(OnnxMlirOptions),
+    llvm::cl::Hidden, llvm::cl::ValueRequired);
 
 static llvm::cl::opt<std::string, true> instrumentOpsOpt("instrument-ops",
     llvm::cl::desc("Specify operations to be instrumented:\n"
@@ -913,6 +927,32 @@ std::vector<std::string> getXllcOption() {
 void setLLVMOption(const std::string &flag) { mllvm = flag; }
 void clearLLVMOption() { mllvm.clear(); }
 std::string getLLVMOption() { return (mllvm != "") ? mllvm : std::string(); }
+
+static std::vector<std::string> split(std::string &input) {
+  std::stringstream ss(input);
+  std::istream_iterator<std::string> begin(ss);
+  std::istream_iterator<std::string> end;
+  std::vector<std::string> vstrings(begin, end);
+  return vstrings;
+}
+
+std::vector<std::string> getLLVMOptions() {
+  if (mllvm == "")
+    return std::vector<std::string>();
+  return split(mllvm);
+}
+
+std::vector<std::string> getLLVMOPTOptions() {
+  if (mllvmopt == "")
+    return std::vector<std::string>();
+  return split(mllvmopt);
+}
+
+std::vector<std::string> getLLVMLLCOptions() {
+  if (mllvmllc == "")
+    return std::vector<std::string>();
+  return split(mllvmllc);
+}
 
 // Support for model tag
 void setModelTag(const std::string &str) { modelTag = str; }

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -109,6 +109,8 @@ extern bool VerboseOutput;                                    // onnx-mlir only
 extern std::vector<std::string> Xopt;                         // onnx-mlir only
 extern std::vector<std::string> Xllc;                         // onnx-mlir only
 extern std::string mllvm;                                     // onnx-mlir only
+extern std::string mllvmopt;                                  // onnx-mlir only
+extern std::string mllvmllc;                                  // onnx-mlir only
 extern std::string instrumentOps;                             // onnx-mlir only
 extern unsigned instrumentControlBits;                        // onnx-mlir only
 extern std::string parallelizeOps;                            // onnx-mlir only
@@ -183,6 +185,10 @@ std::vector<std::string> getXllcOption();
 void setLLVMOption(const std::string &flag);
 void clearLLVMOption();
 std::string getLLVMOption();
+// Break down the result of getLLVMOption into substrings
+std::vector<std::string> getLLVMOptions();
+std::vector<std::string> getLLVMOPTOptions();
+std::vector<std::string> getLLVMLLCOptions();
 
 // Options support for OMCompilerOptions.
 using CompilerOptionList =

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -109,8 +109,6 @@ extern bool VerboseOutput;                                    // onnx-mlir only
 extern std::vector<std::string> Xopt;                         // onnx-mlir only
 extern std::vector<std::string> Xllc;                         // onnx-mlir only
 extern std::string mllvm;                                     // onnx-mlir only
-extern std::string mllvmopt;                                  // onnx-mlir only
-extern std::string mllvmllc;                                  // onnx-mlir only
 extern std::string instrumentOps;                             // onnx-mlir only
 extern unsigned instrumentControlBits;                        // onnx-mlir only
 extern std::string parallelizeOps;                            // onnx-mlir only

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -459,13 +459,12 @@ static int genLLVMBitcode(const mlir::OwningOpRef<ModuleOp> &module,
   setXoptOption({"--code-model", modelSizeStr[modelSize]});
   int rc = optBitcode
                .appendStr(getOptimizationLevelUniqueOption(
-                   {getLLVMOptions(), getLLVMOPTOptions()}))
+                   {getLLVMOptions(), getXoptOption()}))
                .appendStr(getTargetTripleOption())
                .appendStr(getTargetArchOption())
                .appendStr(getTargetCPUOption())
                .appendList(getXoptOption())
                .appendList(getLLVMOptions())
-               .appendList(getLLVMOPTOptions())
                .appendList({"-o", optimizedBitcodeNameWithExt})
                .appendStr(unoptimizedBitcodeNameWithExt)
                .exec();
@@ -484,13 +483,12 @@ static int genModelObject(
   setXllcOption({"--code-model", modelSizeStr[modelSize]});
   int rc = llvmToObj
                .appendStr(getOptimizationLevelUniqueOption(
-                   {getLLVMOptions(), getLLVMLLCOptions()}))
+                   {getLLVMOptions(), getXllcOption()}))
                .appendStr(getTargetTripleOption())
                .appendStr(getTargetArchOption())
                .appendStr(getTargetCPUOption())
                .appendList(getXllcOption())
                .appendList(getLLVMOptions())
-               .appendList(getLLVMLLCOptions())
                .appendStr("-filetype=obj")
                .appendStr("-relocation-model=pic")
                .appendList({"-o", modelObjNameWithExt})

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -72,6 +72,26 @@ enum class KeepFilesOfType { All, MLIR, LLVMIR, Bitcode, Object, None };
 // flags.
 static constexpr KeepFilesOfType overridePreserveFiles = KeepFilesOfType::None;
 
+// Get optimization level from onnx-mlir only when it is not specified
+std::string getOptimizationLevelUniqueOption(
+    std::vector<std::vector<std::string>> specialOptionsList) {
+  if (std::any_of(specialOptionsList.begin(), specialOptionsList.end(),
+          [](std::vector<std::string> specialOptions) {
+            if (std::any_of(specialOptions.begin(), specialOptions.end(),
+                    [](std::string str) {
+                      std::regex optimization("^-O[0-9]");
+                      std::smatch m;
+                      return std::regex_match(str, m, optimization);
+                    })) // End of one options
+              return true;
+            else
+              return false;
+          }))
+    return std::string();
+  else
+    return getOptimizationLevelOption();
+}
+
 static bool keepFiles(KeepFilesOfType preserve) {
   // When wanting to preserve all files, do it regardless of isBitcode.
   if (overridePreserveFiles == KeepFilesOfType::All)
@@ -437,12 +457,15 @@ static int genLLVMBitcode(const mlir::OwningOpRef<ModuleOp> &module,
   std::string optPath = getToolPath("opt");
   Command optBitcode(/*exePath=*/optPath);
   setXoptOption({"--code-model", modelSizeStr[modelSize]});
-  int rc = optBitcode.appendStr(getOptimizationLevelOption())
+  int rc = optBitcode
+               .appendStr(getOptimizationLevelUniqueOption(
+                   {getLLVMOptions(), getLLVMOPTOptions()}))
                .appendStr(getTargetTripleOption())
                .appendStr(getTargetArchOption())
                .appendStr(getTargetCPUOption())
                .appendList(getXoptOption())
-               .appendStr(getLLVMOption())
+               .appendList(getLLVMOptions())
+               .appendList(getLLVMOPTOptions())
                .appendList({"-o", optimizedBitcodeNameWithExt})
                .appendStr(unoptimizedBitcodeNameWithExt)
                .exec();
@@ -459,12 +482,15 @@ static int genModelObject(
   std::string llcPath = getToolPath("llc");
   Command llvmToObj(/*exePath=*/llcPath);
   setXllcOption({"--code-model", modelSizeStr[modelSize]});
-  int rc = llvmToObj.appendStr(getOptimizationLevelOption())
+  int rc = llvmToObj
+               .appendStr(getOptimizationLevelUniqueOption(
+                   {getLLVMOptions(), getLLVMLLCOptions()}))
                .appendStr(getTargetTripleOption())
                .appendStr(getTargetArchOption())
                .appendStr(getTargetCPUOption())
                .appendList(getXllcOption())
-               .appendStr(getLLVMOption())
+               .appendList(getLLVMOptions())
+               .appendList(getLLVMLLCOptions())
                .appendStr("-filetype=obj")
                .appendStr("-relocation-model=pic")
                .appendList({"-o", modelObjNameWithExt})


### PR DESCRIPTION
Issue #2950 discovered the issue in passing options llvm. There are several problems:
1. The string of the options has to be split into vector of strings for the command format.
2. Conflict in options. So far, the optimization level is the only example.  The level specified with  particular step should have higher priority than that for the whole compiler. Thus, I can avoid multiple "-O#" error.
3. modify the comments for mllvm, xopt, and xllc to make it easy for user to pass multiple values to these options 

I tested with some examples.