### PR TITLE
Minor updates to CompilerUtils.cpp

### DIFF
--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -582,6 +582,9 @@ static int genJniJar(const mlir::OwningOpRef<ModuleOp> &module,
 
   // Copy javaruntime.jar to model jar.
   llvm::sys::fs::copy_file(javaRuntimeJarPath, modelJniJarPath);
+  if (VerboseOutput)
+    llvm::outs() << "cp " << javaRuntimeJarPath << " " << modelJniJarPath
+                 << "\n";
 
   // Add shared library to model jar.
   Command jar(getToolPath("jar", true));
@@ -798,8 +801,8 @@ static int emitOutputFiles(std::string outputNameNoExt,
         return rc;
     }
     if (VerboseOutput)
-      printf(
-          "Object file '%s' has been compiled.\n", modelObjNameWithExt.c_str());
+      llvm::outs() << "Object file '" << modelObjNameWithExt
+                   << "' has been compiled.\n";
   } break;
   case EmitLib: {
     std::string sharedLibNameWithExt;
@@ -813,8 +816,8 @@ static int emitOutputFiles(std::string outputNameNoExt,
         return rc;
     }
     if (VerboseOutput)
-      printf("Shared library '%s' has been compiled.\n",
-          sharedLibNameWithExt.c_str());
+      llvm::outs() << "Shared library '" << sharedLibNameWithExt
+                   << "' has been compiled.\n";
   } break;
   case EmitJNI: {
     int rc = compileModuleToJniJar(module, outputNameNoExt);
@@ -826,16 +829,17 @@ static int emitOutputFiles(std::string outputNameNoExt,
         return rc;
     }
     if (VerboseOutput)
-      printf(
-          "JNI archive '%s.jar' has been compiled.\n", outputNameNoExt.c_str());
+      llvm::outs() << "JNI archive '" << outputNameNoExt
+                   << ".jar' has been compiled.\n";
   } break;
   default: {
     // Emit the version with all constants included.
-    std::string ouputNameWithExt =
+    std::string outputNameWithExt =
         getTargetFilename(outputNameNoExt, emissionTarget);
-    int rc = outputCode(module, ouputNameWithExt);
+    int rc = outputCode(module, outputNameWithExt);
     if (VerboseOutput)
-      printf("Full MLIR code written to: \n\t%s\n\n", ouputNameWithExt.c_str());
+      llvm::outs() << "Full MLIR code written to:\n"
+                   << "\t" << outputNameWithExt << "\n\n";
     if (rc != CompilerSuccess)
       return rc;
 
@@ -845,10 +849,11 @@ static int emitOutputFiles(std::string outputNameNoExt,
       std::string tempNameWithExt = outputNameNoExt + ".tmp";
       int rc = outputCode(module, tempNameWithExt, /*largeElementLimit=*/100);
       if (VerboseOutput) {
-        printf("Constant-free MLIR Code written to: \n\t%s\n\n",
-            tempNameWithExt.c_str());
-        printf("Use:\n\t%s\nto continue lowering the code to other dialects.\n",
-            ouputNameWithExt.c_str());
+        llvm::outs() << "Constant-free MLIR Code written to:\n"
+                     << "\t" << tempNameWithExt << "\n\n";
+        llvm::outs() << "Use:\n"
+                     << "\t" << outputNameWithExt
+                     << "\nto continue lowering the code to other dialects.\n";
       }
       if (rc != CompilerSuccess)
         return rc;


### PR DESCRIPTION
- print javaruntime.jar path when -v (verbose) is specified for debugging aid
- replace printf with llvm::outs() for consistency
- fix typo ouputNameWithExt