### PR TITLE
Re-enable ReduceMax/Min backend tests

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -158,9 +158,9 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **ReduceL2** |13 - * |do_not_keep_dim not supported. | |
 | **ReduceLogSum** |13 - * |do_not_keep_dim not supported. | |
 | **ReduceLogSumExp** |13 - * |do_not_keep_dim not supported. | |
-| **ReduceMax** |6 - * |do_not_keep_dim not supported. | |
+| **ReduceMax** |6 - * | | |
 | **ReduceMean** |6 - * |do_not_keep_dim not supported. | |
-| **ReduceMin** |6 - * |do_not_keep_dim not supported. | |
+| **ReduceMin** |6 - * | | |
 | **ReduceProd** |13 - * |do_not_keep_dim not supported. | |
 | **ReduceSum** |6 - * |Default axis and do_not_keep_dim not supported. |Default axis and do_not_keep_dim temporarily removed due to changes in onnx 1.8.1. |
 | **ReduceSumSquare** |13 - * |Default axis and do_not_keep_dim not supported. | |

--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -158,9 +158,9 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
 | **ReduceL2** |13 - * |do_not_keep_dim not supported. | |
 | **ReduceLogSum** |13 - * |do_not_keep_dim not supported. | |
 | **ReduceLogSumExp** |13 - * |do_not_keep_dim not supported. | |
-| **ReduceMax** |6 - * | | |
-| **ReduceMean** |6 - * |do_not_keep_dim not supported. | |
-| **ReduceMin** |6 - * | | |
+| **ReduceMax** |6 - * |do_not_keep_dims not supported. | |
+| **ReduceMean** |6 - * |do_not_keep_dims not supported. | |
+| **ReduceMin** |6 - * |do_not_keep_dims not supported. | |
 | **ReduceProd** |13 - * |do_not_keep_dim not supported. | |
 | **ReduceSum** |6 - * |Default axis and do_not_keep_dim not supported. |Default axis and do_not_keep_dim temporarily removed due to changes in onnx 1.8.1. |
 | **ReduceSumSquare** |13 - * |Default axis and do_not_keep_dim not supported. | |

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -2452,24 +2452,24 @@ def get_test_models():
         # ==OP== ReduceMax
         # ==MIN== 1
         "test_reduce_max_default_axes_keepdim_example_cpu": {
-            STATIC_SHAPE:{}, 
-            DYNAMIC_SHAPE:{-1:{-1}}, 
-            CONSTANT_INPUT:{-1}
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
         },
         "test_reduce_max_default_axes_keepdims_random_cpu": {
-            STATIC_SHAPE:{}, 
-            DYNAMIC_SHAPE:{-1:{-1}}, 
-            CONSTANT_INPUT:{-1}
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
         },
         "test_reduce_max_do_not_keepdims_example_cpu": {
-            STATIC_SHAPE:{}, 
-            DYNAMIC_SHAPE:{-1:{-1}}, 
-            CONSTANT_INPUT:{-1}
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
         },
         "test_reduce_max_do_not_keepdims_random_cpu": {
-            STATIC_SHAPE:{}, 
-            DYNAMIC_SHAPE:{-1:{-1}}, 
-            CONSTANT_INPUT:{-1}
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
         },
         "test_reduce_max_keepdims_example_cpu": {
             STATIC_SHAPE: {},
@@ -2521,24 +2521,24 @@ def get_test_models():
         # ==OP== ReduceMin
         # ==MIN== 1
         "test_reduce_min_default_axes_keepdims_example_cpu": {
-            STATIC_SHAPE:{}, 
-            DYNAMIC_SHAPE:{-1:{-1}}, 
-            CONSTANT_INPUT:{-1}
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
         },
         "test_reduce_min_default_axes_keepdims_random_cpu": {
-            STATIC_SHAPE:{}, 
-            DYNAMIC_SHAPE:{-1:{-1}}, 
-            CONSTANT_INPUT:{-1}
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
         },
         "test_reduce_min_do_not_keepdims_example_cpu": {
-            STATIC_SHAPE:{}, 
-            DYNAMIC_SHAPE:{-1:{-1}}, 
-            CONSTANT_INPUT:{-1}
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
         },
         "test_reduce_min_do_not_keepdims_random_cpu": {
-            STATIC_SHAPE:{}, 
-            DYNAMIC_SHAPE:{-1:{-1}}, 
-            CONSTANT_INPUT:{-1}
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
         },
         "test_reduce_min_keepdims_example_cpu": {
             STATIC_SHAPE: {},

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -2451,11 +2451,26 @@ def get_test_models():
         },
         # ==OP== ReduceMax
         # ==MIN== 1
-        # ==LIM== do_not_keep_dim not supported.
-        # "test_reduce_max_default_axes_keepdim_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
-        # "test_reduce_max_default_axes_keepdims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
-        # "test_reduce_max_do_not_keepdims_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
-        # "test_reduce_max_do_not_keepdims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
+        "test_reduce_max_default_axes_keepdim_example_cpu": {
+            STATIC_SHAPE:{}, 
+            DYNAMIC_SHAPE:{-1:{-1}}, 
+            CONSTANT_INPUT:{-1}
+        },
+        "test_reduce_max_default_axes_keepdims_random_cpu": {
+            STATIC_SHAPE:{}, 
+            DYNAMIC_SHAPE:{-1:{-1}}, 
+            CONSTANT_INPUT:{-1}
+        },
+        "test_reduce_max_do_not_keepdims_example_cpu": {
+            STATIC_SHAPE:{}, 
+            DYNAMIC_SHAPE:{-1:{-1}}, 
+            CONSTANT_INPUT:{-1}
+        },
+        "test_reduce_max_do_not_keepdims_random_cpu": {
+            STATIC_SHAPE:{}, 
+            DYNAMIC_SHAPE:{-1:{-1}}, 
+            CONSTANT_INPUT:{-1}
+        },
         "test_reduce_max_keepdims_example_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -2505,11 +2520,26 @@ def get_test_models():
         },
         # ==OP== ReduceMin
         # ==MIN== 1
-        # ==LIM== do_not_keep_dim not supported.
-        # "test_reduce_min_default_axes_keepdims_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
-        # "test_reduce_min_default_axes_keepdims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
-        # "test_reduce_min_do_not_keepdims_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
-        # "test_reduce_min_do_not_keepdims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
+        "test_reduce_min_default_axes_keepdims_example_cpu": {
+            STATIC_SHAPE:{}, 
+            DYNAMIC_SHAPE:{-1:{-1}}, 
+            CONSTANT_INPUT:{-1}
+        },
+        "test_reduce_min_default_axes_keepdims_random_cpu": {
+            STATIC_SHAPE:{}, 
+            DYNAMIC_SHAPE:{-1:{-1}}, 
+            CONSTANT_INPUT:{-1}
+        },
+        "test_reduce_min_do_not_keepdims_example_cpu": {
+            STATIC_SHAPE:{}, 
+            DYNAMIC_SHAPE:{-1:{-1}}, 
+            CONSTANT_INPUT:{-1}
+        },
+        "test_reduce_min_do_not_keepdims_random_cpu": {
+            STATIC_SHAPE:{}, 
+            DYNAMIC_SHAPE:{-1:{-1}}, 
+            CONSTANT_INPUT:{-1}
+        },
         "test_reduce_min_keepdims_example_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -2451,6 +2451,7 @@ def get_test_models():
         },
         # ==OP== ReduceMax
         # ==MIN== 1
+        # ==LIM== do_not_keep_dims not supported.
         "test_reduce_max_default_axes_keepdim_example_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -2461,16 +2462,8 @@ def get_test_models():
             DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
-        "test_reduce_max_do_not_keepdims_example_cpu": {
-            STATIC_SHAPE: {},
-            DYNAMIC_SHAPE: {-1: {-1}},
-            CONSTANT_INPUT: {-1},
-        },
-        "test_reduce_max_do_not_keepdims_random_cpu": {
-            STATIC_SHAPE: {},
-            DYNAMIC_SHAPE: {-1: {-1}},
-            CONSTANT_INPUT: {-1},
-        },
+        # "test_reduce_max_do_not_keepdims_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
+        # "test_reduce_max_do_not_keepdims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         "test_reduce_max_keepdims_example_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -2493,7 +2486,7 @@ def get_test_models():
         },
         # ==OP== ReduceMean
         # ==MIN== 1
-        # ==LIM== do_not_keep_dim not supported.
+        # ==LIM== do_not_keep_dims not supported.
         # "test_reduce_mean_default_axes_keepdims_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # "test_reduce_mean_default_axes_keepdims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # "test_reduce_mean_do_not_keepdims_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
@@ -2520,6 +2513,7 @@ def get_test_models():
         },
         # ==OP== ReduceMin
         # ==MIN== 1
+        # ==LIM== do_not_keep_dims not supported.
         "test_reduce_min_default_axes_keepdims_example_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -2530,16 +2524,8 @@ def get_test_models():
             DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
-        "test_reduce_min_do_not_keepdims_example_cpu": {
-            STATIC_SHAPE: {},
-            DYNAMIC_SHAPE: {-1: {-1}},
-            CONSTANT_INPUT: {-1},
-        },
-        "test_reduce_min_do_not_keepdims_random_cpu": {
-            STATIC_SHAPE: {},
-            DYNAMIC_SHAPE: {-1: {-1}},
-            CONSTANT_INPUT: {-1},
-        },
+        # "test_reduce_min_do_not_keepdims_example_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
+        # "test_reduce_min_do_not_keepdims_random_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         "test_reduce_min_keepdims_example_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},


### PR DESCRIPTION
Since this PR was merged: https://github.com/onnx/onnx-mlir/pull/2744, we now have the support for `keepdims` and as a result a few of the backend test can be re-enabled. 