### PR TITLE
Remove a spike of memory usage in ScrubDisposablePass.

### DIFF
--- a/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
@@ -122,9 +122,8 @@ void DisposablePool::scrub(ModuleOp moduleOp, OpAttrDictionary opsAttrs) {
         for (auto &[id, translation] : batch) {
           auto &[disposable, dense] = translation;
           dense = disposable.toDenseElementsAttr();
-          // TODO: Consider calling disposable.dispose() here to free up memory
-          //       on the go to make memory available to create the next
-          //       DenseElementsAttr. In that case should we lock mutex?
+          disposable.dispose();
+          // TODO: In that case should we lock mutex?
         }
       }
     };

--- a/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
@@ -122,14 +122,8 @@ void DisposablePool::scrub(ModuleOp moduleOp, OpAttrDictionary opsAttrs) {
         for (auto &[id, translation] : batch) {
           auto &[disposable, dense] = translation;
           dense = disposable.toDenseElementsAttr();
-        }
-
-        // Delete DisposableElementsAttr for each batch with lock after
-        // conversion.
-        {
-          const std::lock_guard<std::mutex> lock(translationMutex);
-          for (auto &[id, translation] : batch) {
-            auto &[disposable, dense] = translation;
+          {
+            const std::lock_guard<std::mutex> lock(translationMutex);
             disposable.dispose();
           }
         }

--- a/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
+++ b/src/Dialect/ONNX/ElementsAttr/DisposablePool.cpp
@@ -126,14 +126,13 @@ void DisposablePool::scrub(ModuleOp moduleOp, OpAttrDictionary opsAttrs) {
 
         // Delete DisposableElementsAttr for each batch with lock after
         // conversion.
-        auto deleteBatch = [&translationMutex, &batch]() {
+        {
           const std::lock_guard<std::mutex> lock(translationMutex);
           for (auto &[id, translation] : batch) {
             auto &[disposable, dense] = translation;
             disposable.dispose();
           }
-        };
-        deleteBatch();
+        }
       }
     };
     MLIRContext *ctx = moduleOp.getContext();

--- a/src/Dialect/ONNX/Transforms/ScrubDisposablePass.cpp
+++ b/src/Dialect/ONNX/Transforms/ScrubDisposablePass.cpp
@@ -15,9 +15,6 @@
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
-#include <sys/time.h>
-// #include <time.h>
-
 using namespace mlir;
 
 namespace onnx_mlir {
@@ -33,8 +30,6 @@ struct ScrubDisposablePass
   StringRef getArgument() const override { return "scrub-disposable"; }
 
   void runOnOperation() final {
-    struct timeval start_t, end_t;
-    gettimeofday(&start_t, NULL);    
     ModuleOp moduleOp = getOperation();
     DisposablePool *pool = getDisposablePool();
     pool->scrub(
@@ -42,9 +37,6 @@ struct ScrubDisposablePass
                       {ONNXConstantOfShapeOp::getOperationName(), "value"}});
     if (closeAfter)
       pool->close();
-    gettimeofday(&end_t, NULL);
-    double totalTime = (((end_t.tv_sec * 1000000.) + end_t.tv_usec) - ((start_t.tv_sec * 1000000) + start_t.tv_usec)) / 1000;
-    llvm::dbgs() << "ScrubDisposablePass " << totalTime << " msec\n";    
   }
 
   DisposablePool *getDisposablePool() {

--- a/src/Dialect/ONNX/Transforms/ScrubDisposablePass.cpp
+++ b/src/Dialect/ONNX/Transforms/ScrubDisposablePass.cpp
@@ -15,6 +15,9 @@
 #include "src/Dialect/ONNX/ONNXDialect.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 
+#include <sys/time.h>
+// #include <time.h>
+
 using namespace mlir;
 
 namespace onnx_mlir {
@@ -30,6 +33,8 @@ struct ScrubDisposablePass
   StringRef getArgument() const override { return "scrub-disposable"; }
 
   void runOnOperation() final {
+    struct timeval start_t, end_t;
+    gettimeofday(&start_t, NULL);    
     ModuleOp moduleOp = getOperation();
     DisposablePool *pool = getDisposablePool();
     pool->scrub(
@@ -37,6 +42,9 @@ struct ScrubDisposablePass
                       {ONNXConstantOfShapeOp::getOperationName(), "value"}});
     if (closeAfter)
       pool->close();
+    gettimeofday(&end_t, NULL);
+    double totalTime = (((end_t.tv_sec * 1000000.) + end_t.tv_usec) - ((start_t.tv_sec * 1000000) + start_t.tv_usec)) / 1000;
+    llvm::dbgs() << "ScrubDisposablePass " << totalTime << " msec\n";    
   }
 
   DisposablePool *getDisposablePool() {


### PR DESCRIPTION
This PR removes a spike in memory usage. When checking memory usage in a LLM (Mistral-7b), ScrubDisposablePass consumes a lot of memory only for a moment(spike about 50GB). This is likely to due to the fact that having both denseElementsAttr and disposalElementsAttr are hold during conversion. 
In Mistral-7b model, the spike is about 23GB, and total memory usage including spike is about 50GB.  This PR removes the spike and total memory usage reduces to 27GB.  
