### PR TITLE
Yolo bug: run out of stack memory

### DIFF
--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -309,7 +309,7 @@ public:
                 Value vecF32H = convertOp.getResult(0);
                 Value vecF32L = convertOp.getResult(1);
                 // Save into archVL value buffer.
-                Value bufferF32 = create.mem.alignedAlloca(bufferType);
+                Value bufferF32 = create.mem.alignedAlloc(bufferType);
                 create.vec.storeIE(vecF32H, bufferF32, {litZero});
                 create.vec.storeIE(vecF32L, bufferF32, {litArchVLHalf});
                 // Save the remaining values as scalars.

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -98,6 +98,13 @@ public:
     create.krnlIE.getShapeAsSymbols(alloc, outputDims);
     int64_t rank = outputDims.size();
 
+    // hi alex:
+    create.krnl.printf("unstick dims:");
+    for(int r=0; r<rank; ++r) {
+      create.krnl.printf(" ", outputDims[r].getValue(), false);
+    }
+    create.krnl.printf("\n");
+
     // Info for SIMD Vector Length (VL) and associated types.
     int64_t archVL = 8;              // FP16 archVL.
     int64_t archVLHalf = archVL / 2; // FP32 archVL.

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -103,7 +103,7 @@ public:
     for(int r=0; r<rank; ++r) {
       create.krnl.printf(" ", outputDims[r].getValue(), false);
     }
-    create.krnl.printf("\n");
+    create.krnl.printf("\n\n\n");
 
     // Info for SIMD Vector Length (VL) and associated types.
     int64_t archVL = 8;              // FP16 archVL.
@@ -379,6 +379,13 @@ public:
     DimsExpr outputDims;
     create.krnlIE.getShapeAsSymbols(alloc, outputDims);
     int64_t rank = outputDims.size();
+
+    // hi alex:
+    create.krnl.printf("stick dims:");
+    for(int r=0; r<rank; ++r) {
+      create.krnl.printf(" ", outputDims[r].getValue(), false);
+    }
+    create.krnl.printf("\n\n\n");
 
     // Info for SIMD Vector Length (VL) and associated types.
     int64_t archVL = 8;              // FP16 archVL.

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -172,7 +172,7 @@ public:
           IndexExpr e1 = outerIndices[E1] * 64;
           inputAF[E1] = e1;
       // Translate the tile index t1 to the actual targetted data.
-#define REMOVE_LOAD_TRICK 1
+#define REMOVE_LOAD_TRICK 0
 #if REMOVE_LOAD_TRICK
           IndexExpr inputTileOffset = litZero;
 #else

--- a/test/mlir/accelerators/nnpa/transform/zlow-stick-unstick-expansion.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zlow-stick-unstick-expansion.mlir
@@ -297,7 +297,8 @@ func.func @test_unstick_expansion_127(%arg0: memref<16x8x127xf16, #map>) -> memr
 // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
 // CHECK:             [[VAR_2_:%.+]] = affine.apply [[MAP_1_]]([[VAR_1_]]#2)
 // CHECK:             [[VAR_3_:%.+]] = krnl.get_linear_offset_index [[PARAM_0_]] at {{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}} : memref<16x8x127xf16, #map>
-// CHECK:             [[VAR_4_:%.+]] = affine.apply [[MAP_2_]]([[VAR_1_]]#2){{.}}[[VAR_3_]]{{.}}
+// CHECK-DAG:         [[VAR_4_:%.+]] = affine.apply [[MAP_2_]]([[VAR_1_]]#2){{.}}[[VAR_3_]]{{.}}
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<8xf32>
 // CHECK:             krnl.prefetch [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}}, read, locality<1>, data : memref<16x8x127xf16, #map>
 // CHECK:             krnl.prefetch [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}}, write, locality<1>, data : memref<16x8x127xf32>
 // CHECK:             [[VAR_5_:%.+]] = affine.apply [[MAP_3_]]([[VAR_1_]]#2){{.}}[[VAR_3_]]{{.}}
@@ -314,41 +315,40 @@ func.func @test_unstick_expansion_127(%arg0: memref<16x8x127xf16, #map>) -> memr
 // CHECK-DAG:             [[VAR_12_:%.+]] = affine.apply [[MAP_6_]]([[I_3_]])
 // CHECK:                 [[LOAD_VAR_reinterpret_cast_MEM_3_:%.+]] = vector.load [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[VAR_12_]]{{.}} : memref<2x64xf16>, vector<8xf16>
 // CHECK:                 [[VAR_output1_:%.+]], [[VAR_output2_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
-// CHECK:                 [[VAR_output1_0_:%.+]], [[VAR_output2_1_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_1_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
-// CHECK:                 [[VAR_output1_2_:%.+]], [[VAR_output2_3_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_2_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
-// CHECK:                 [[VAR_output1_4_:%.+]], [[VAR_output2_5_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_3_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
+// CHECK:                 [[VAR_output1_1_:%.+]], [[VAR_output2_2_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_1_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
+// CHECK:                 [[VAR_output1_3_:%.+]], [[VAR_output2_4_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_2_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
+// CHECK:                 [[VAR_output1_5_:%.+]], [[VAR_output2_6_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_3_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
 // CHECK:                 [[VAR_14_:%.+]] = affine.apply [[MAP_7_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK:                 vector.store [[VAR_output1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]4] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[VAR_15_:%.+]] = arith.addi [[VAR_14_]], [[CST_4_]] : index
 // CHECK:                 vector.store [[VAR_output2_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]5] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[VAR_16_:%.+]] = arith.addi [[VAR_14_]], [[CST_8_]] : index
-// CHECK:                 vector.store [[VAR_output1_0_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]6] : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output1_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]6] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[VAR_17_:%.+]] = arith.addi [[VAR_14_]], [[CST_12_]] : index
-// CHECK:                 vector.store [[VAR_output2_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]7] : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output2_2_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]7] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[VAR_18_:%.+]] = arith.addi [[VAR_14_]], [[CST_16_]] : index
-// CHECK:                 vector.store [[VAR_output1_2_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]8] : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output1_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]8] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[VAR_19_:%.+]] = arith.addi [[VAR_14_]], [[CST_20_]] : index
-// CHECK:                 vector.store [[VAR_output2_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]9] : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output2_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]9] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[VAR_20_:%.+]] = arith.addi [[VAR_14_]], [[CST_24_]] : index
-// CHECK:                 vector.store [[VAR_output1_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_20_]]{{.}} : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output1_5_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_20_]]{{.}} : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[VAR_21_:%.+]] = arith.addi [[VAR_14_]], [[CST_28_]] : index
-// CHECK:                 vector.store [[VAR_output2_5_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_21_]]{{.}} : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output2_6_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_21_]]{{.}} : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:               }
 // CHECK:             } else {
 // CHECK:               [[LOAD_VAR_reinterpret_cast_MEM_4_:%.+]] = affine.apply [[MAP_8_]](){{.}}[[VAR_2_]]{{.}}
 // CHECK:               scf.for [[I_4_:%.+]] = [[CST_0_]] to [[LOAD_VAR_reinterpret_cast_MEM_4_]] step [[CST_8_]] {
 // CHECK:                 [[LOAD_VAR_reinterpret_cast_MEM_5_:%.+]] = vector.load [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[I_4_]]{{.}} : memref<2x64xf16>, vector<8xf16>
-// CHECK:                 [[VAR_output1_1_:%.+]], [[VAR_output2_2_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_5_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
+// CHECK:                 [[VAR_output1_1_1_:%.+]], [[VAR_output2_2_1_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_5_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
 // CHECK:                 [[VAR_12_1_:%.+]] = affine.apply [[MAP_7_]]([[I_4_]]){{.}}[[VAR_2_]]{{.}}
-// CHECK:                 vector.store [[VAR_output1_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]2] : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output1_1_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]2] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[LOAD_VAR_reinterpret_cast_MEM_3_:%.+]] = arith.addi [[VAR_12_1_]], [[CST_4_]] : index
-// CHECK:                 vector.store [[VAR_output2_2_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]3] : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output2_2_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]3] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:               }
 // CHECK-DAG:           [[VAR_8_1_:%.+]] = affine.apply [[MAP_9_]](){{.}}[[VAR_2_]]{{.}}
 // CHECK-DAG:           [[LOAD_VAR_reinterpret_cast_MEM_1_:%.+]] = affine.apply [[MAP_10_]](){{.}}[[VAR_2_]]{{.}}
 // CHECK:               [[LOAD_VAR_reinterpret_cast_MEM_6_:%.+]] = vector.load [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[LOAD_VAR_reinterpret_cast_MEM_1_]]{{.}} : memref<2x64xf16>, vector<8xf16>
 // CHECK:               [[VAR_output1_1_:%.+]], [[VAR_output2_1_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_6_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
-// CHECK:               [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<8xf32>
 // CHECK:               vector.store [[VAR_output1_1_]], [[RES_1_]]{{.}}[[CST_0_]]{{.}} : memref<8xf32>, vector<4xf32>
 // CHECK:               vector.store [[VAR_output2_1_]], [[RES_1_]]{{.}}[[CST_4_]]{{.}} : memref<8xf32>, vector<4xf32>
 // CHECK:               scf.for [[I_5_:%.+]] = [[CST_0_]] to [[VAR_8_1_]] step [[CST_1_]] {

--- a/test/mlir/accelerators/nnpa/transform/zlow-stick-unstick-expansion.mlir
+++ b/test/mlir/accelerators/nnpa/transform/zlow-stick-unstick-expansion.mlir
@@ -11,12 +11,12 @@ func.func @test_stick_expansion_with_sat(%arg0: memref<16x8x128xf32>) -> memref<
 
 // mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1, d2) -> (d0, d2 floordiv 64, 0, d1 floordiv 32, d1 mod 32, d2 mod 64)>
-// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<()[s0] -> (s0 * 64)>
-// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<()[s0, s1] -> (s1 floordiv 64)>
-// CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<()[s0, s1] -> (s0 + s1)>
-// CHECK-DAG:   [[MAP_4_:#.+]] = affine_map<()[s0, s1] -> (s1 + 8)>
-// CHECK-DAG:   [[MAP_5_:#.+]] = affine_map<()[s0, s1] -> (s1 + 16)>
-// CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<()[s0, s1] -> (s1 + 24)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0) -> (d0 * 64)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1) -> (d1 floordiv 64)>
+// CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
+// CHECK-DAG:   [[MAP_4_:#.+]] = affine_map<(d0)[s0] -> (d0 + 8)>
+// CHECK-DAG:   [[MAP_5_:#.+]] = affine_map<(d0)[s0] -> (d0 + 16)>
+// CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<(d0)[s0] -> (d0 + 24)>
 // CHECK-LABEL:  func.func @test_stick_expansion_with_sat
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<16x8x128xf32>) -> memref<16x8x128xf16, #map> {
 // CHECK-DAG:       [[CST_28_:%.+]] = arith.constant 28 : index
@@ -34,13 +34,13 @@ func.func @test_stick_expansion_with_sat(%arg0: memref<16x8x128xf32>) -> memref<
 // CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[RES_]] to offset: {{.}}[[CST_0_]]{{.}}, sizes: [2, 64], strides: [64, 1] : memref<16x8x128xf16, #map> to memref<2x64xf16>
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 16, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 8, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 2){
 // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
-// CHECK:             [[VAR_2_:%.+]] = affine.apply [[MAP_1_]](){{.}}[[VAR_1_]]#2]
+// CHECK:             [[VAR_2_:%.+]] = affine.apply [[MAP_1_]]([[VAR_1_]]#2)
 // CHECK:             [[VAR_3_:%.+]] = krnl.get_linear_offset_index [[RES_]] at {{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}} : memref<16x8x128xf16, #map>
-// CHECK:             [[VAR_4_:%.+]] = affine.apply [[MAP_2_]](){{.}}[[VAR_1_]]#2, [[VAR_3_]]{{.}}
+// CHECK:             [[VAR_4_:%.+]] = affine.apply [[MAP_2_]]([[VAR_1_]]#2, [[VAR_3_]])
 // CHECK:             krnl.prefetch [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}}, read, locality<1>, data : memref<16x8x128xf32>
 // CHECK:             krnl.prefetch [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}}, write, locality<1>, data : memref<16x8x128xf16, #map>
 // CHECK:             affine.for [[I_3_:%.+]] = 0 to 64 step 32 {
-// CHECK:               [[VAR_5_:%.+]] = affine.apply [[MAP_3_]](){{.}}[[VAR_2_]], [[I_3_]]{{.}}
+// CHECK:               [[VAR_5_:%.+]] = affine.apply [[MAP_3_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_5_]]{{.}} : memref<16x8x128xf32>, vector<4xf32>
 // CHECK-DAG:           [[VAR_7_:%.+]] = arith.addi [[VAR_5_]], [[CST_4_]] : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -86,11 +86,11 @@ func.func @test_stick_expansion_with_sat(%arg0: memref<16x8x128xf32>) -> memref<
 // CHECK-DAG:           [[VAR_39_:%.+]] = "zlow.vec_f32_to_dlf16"([[VAR_33_]], [[VAR_34_]]) : (vector<4xf32>, vector<4xf32>) -> vector<8xf16>
 // CHECK:               [[VAR_40_:%.+]] = "zlow.vec_f32_to_dlf16"([[VAR_35_]], [[VAR_36_]]) : (vector<4xf32>, vector<4xf32>) -> vector<8xf16>
 // CHECK:               vector.store [[VAR_37_]], [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[I_3_]]{{.}} : memref<2x64xf16>, vector<8xf16>
-// CHECK:               [[VAR_41_:%.+]] = affine.apply [[MAP_4_]](){{.}}[[VAR_2_]], [[I_3_]]{{.}}
+// CHECK:               [[VAR_41_:%.+]] = affine.apply [[MAP_4_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK:               vector.store [[VAR_38_]], [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[VAR_4_]]1] : memref<2x64xf16>, vector<8xf16>
-// CHECK:               [[VAR_42_:%.+]] = affine.apply [[MAP_5_]](){{.}}[[VAR_2_]], [[I_3_]]{{.}}
+// CHECK:               [[VAR_42_:%.+]] = affine.apply [[MAP_5_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK:               vector.store [[VAR_39_]], [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[VAR_4_]]2] : memref<2x64xf16>, vector<8xf16>
-// CHECK:               [[VAR_43_:%.+]] = affine.apply [[MAP_6_]](){{.}}[[VAR_2_]], [[I_3_]]{{.}}
+// CHECK:               [[VAR_43_:%.+]] = affine.apply [[MAP_6_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK:               vector.store [[VAR_40_]], [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[VAR_4_]]3] : memref<2x64xf16>, vector<8xf16>
 // CHECK:             }
 // CHECK:           }
@@ -109,12 +109,12 @@ func.func @test_stick_expansion_without_sat(%arg0: memref<16x8x128xf32>) -> memr
 
 // mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1, d2) -> (d0, d2 floordiv 64, 0, d1 floordiv 32, d1 mod 32, d2 mod 64)>
-// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<()[s0] -> (s0 * 64)>
-// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<()[s0, s1] -> (s1 floordiv 64)>
-// CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<()[s0, s1] -> (s0 + s1)>
-// CHECK-DAG:   [[MAP_4_:#.+]] = affine_map<()[s0, s1] -> (s1 + 8)>
-// CHECK-DAG:   [[MAP_5_:#.+]] = affine_map<()[s0, s1] -> (s1 + 16)>
-// CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<()[s0, s1] -> (s1 + 24)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<(d0) -> (d0 * 64)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<(d0, d1) -> (d1 floordiv 64)>
+// CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
+// CHECK-DAG:   [[MAP_4_:#.+]] = affine_map<(d0)[s0] -> (d0 + 8)>
+// CHECK-DAG:   [[MAP_5_:#.+]] = affine_map<(d0)[s0] -> (d0 + 16)>
+// CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<(d0)[s0] -> (d0 + 24)>
 // CHECK-LABEL:  func.func @test_stick_expansion_without_sat
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<16x8x128xf32>) -> memref<16x8x128xf16, #map> {
 // CHECK-DAG:       [[CST_28_:%.+]] = arith.constant 28 : index
@@ -130,13 +130,13 @@ func.func @test_stick_expansion_without_sat(%arg0: memref<16x8x128xf32>) -> memr
 // CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[RES_]] to offset: {{.}}[[CST_0_]]{{.}}, sizes: [2, 64], strides: [64, 1] : memref<16x8x128xf16, #map> to memref<2x64xf16>
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 16, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 8, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 2){
 // CHECK:             [[VAR_1_:%.+]]:3 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2) : (!krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index)
-// CHECK:             [[VAR_2_:%.+]] = affine.apply [[MAP_1_]](){{.}}[[VAR_1_]]#2]
+// CHECK:             [[VAR_2_:%.+]] = affine.apply [[MAP_1_]]([[VAR_1_]]#2)
 // CHECK:             [[VAR_3_:%.+]] = krnl.get_linear_offset_index [[RES_]] at {{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}} : memref<16x8x128xf16, #map>
-// CHECK:             [[VAR_4_:%.+]] = affine.apply [[MAP_2_]](){{.}}[[VAR_1_]]#2, [[VAR_3_]]{{.}}
+// CHECK:             [[VAR_4_:%.+]] = affine.apply [[MAP_2_]]([[VAR_1_]]#2, [[VAR_3_]])
 // CHECK:             krnl.prefetch [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}}, read, locality<1>, data : memref<16x8x128xf32>
 // CHECK:             krnl.prefetch [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_2_]]{{.}}, write, locality<1>, data : memref<16x8x128xf16, #map>
 // CHECK:             affine.for [[I_3_:%.+]] = 0 to 64 step 32 {
-// CHECK:               [[VAR_5_:%.+]] = affine.apply [[MAP_3_]](){{.}}[[VAR_2_]], [[I_3_]]{{.}}
+// CHECK:               [[VAR_5_:%.+]] = affine.apply [[MAP_3_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK-DAG:           [[LOAD_PARAM_0_MEM_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_5_]]{{.}} : memref<16x8x128xf32>, vector<4xf32>
 // CHECK-DAG:           [[VAR_7_:%.+]] = arith.addi [[VAR_5_]], [[CST_4_]] : index
 // CHECK-NOT: separator of consecutive DAGs
@@ -164,11 +164,11 @@ func.func @test_stick_expansion_without_sat(%arg0: memref<16x8x128xf32>) -> memr
 // CHECK-DAG:           [[VAR_23_:%.+]] = "zlow.vec_f32_to_dlf16"([[LOAD_PARAM_0_MEM_4_]], [[LOAD_PARAM_0_MEM_5_]]) : (vector<4xf32>, vector<4xf32>) -> vector<8xf16>
 // CHECK:               [[VAR_24_:%.+]] = "zlow.vec_f32_to_dlf16"([[LOAD_PARAM_0_MEM_6_]], [[LOAD_PARAM_0_MEM_7_]]) : (vector<4xf32>, vector<4xf32>) -> vector<8xf16>
 // CHECK:               vector.store [[VAR_21_]], [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[I_3_]]{{.}} : memref<2x64xf16>, vector<8xf16>
-// CHECK:               [[VAR_25_:%.+]] = affine.apply [[MAP_4_]](){{.}}[[VAR_2_]], [[I_3_]]{{.}}
+// CHECK:               [[VAR_25_:%.+]] = affine.apply [[MAP_4_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK:               vector.store [[VAR_22_]], [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[VAR_25_]]{{.}} : memref<2x64xf16>, vector<8xf16>
-// CHECK:               [[VAR_26_:%.+]] = affine.apply [[MAP_5_]](){{.}}[[VAR_2_]], [[I_3_]]{{.}}
+// CHECK:               [[VAR_26_:%.+]] = affine.apply [[MAP_5_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK:               vector.store [[VAR_23_]], [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[VAR_26_]]{{.}} : memref<2x64xf16>, vector<8xf16>
-// CHECK:               [[VAR_27_:%.+]] = affine.apply [[MAP_6_]](){{.}}[[VAR_2_]], [[I_3_]]{{.}}
+// CHECK:               [[VAR_27_:%.+]] = affine.apply [[MAP_6_]]([[I_3_]]){{.}}[[VAR_2_]]{{.}}
 // CHECK:               vector.store [[VAR_24_]], [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[VAR_27_]]{{.}} : memref<2x64xf16>, vector<8xf16>
 // CHECK:             }
 // CHECK:           }
@@ -338,17 +338,17 @@ func.func @test_unstick_expansion_127(%arg0: memref<16x8x127xf16, #map>) -> memr
 // CHECK:               [[LOAD_VAR_reinterpret_cast_MEM_4_:%.+]] = affine.apply [[MAP_8_]](){{.}}[[VAR_2_]]{{.}}
 // CHECK:               scf.for [[I_4_:%.+]] = [[CST_0_]] to [[LOAD_VAR_reinterpret_cast_MEM_4_]] step [[CST_8_]] {
 // CHECK:                 [[LOAD_VAR_reinterpret_cast_MEM_5_:%.+]] = vector.load [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[I_4_]]{{.}} : memref<2x64xf16>, vector<8xf16>
-// CHECK:                 [[VAR_output1_0_1_:%.+]], [[VAR_output2_1_1_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_5_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
+// CHECK:                 [[VAR_output1_1_:%.+]], [[VAR_output2_2_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_5_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
 // CHECK:                 [[VAR_12_1_:%.+]] = affine.apply [[MAP_7_]]([[I_4_]]){{.}}[[VAR_2_]]{{.}}
-// CHECK:                 vector.store [[VAR_output1_0_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]2] : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output1_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]2] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:                 [[LOAD_VAR_reinterpret_cast_MEM_3_:%.+]] = arith.addi [[VAR_12_1_]], [[CST_4_]] : index
-// CHECK:                 vector.store [[VAR_output2_1_1_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]3] : memref<16x8x127xf32>, vector<4xf32>
+// CHECK:                 vector.store [[VAR_output2_2_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1, [[VAR_1_]]3] : memref<16x8x127xf32>, vector<4xf32>
 // CHECK:               }
 // CHECK-DAG:           [[VAR_8_1_:%.+]] = affine.apply [[MAP_9_]](){{.}}[[VAR_2_]]{{.}}
 // CHECK-DAG:           [[LOAD_VAR_reinterpret_cast_MEM_1_:%.+]] = affine.apply [[MAP_10_]](){{.}}[[VAR_2_]]{{.}}
 // CHECK:               [[LOAD_VAR_reinterpret_cast_MEM_6_:%.+]] = vector.load [[VAR_reinterpret_cast_]]{{.}}[[VAR_4_]], [[LOAD_VAR_reinterpret_cast_MEM_1_]]{{.}} : memref<2x64xf16>, vector<8xf16>
 // CHECK:               [[VAR_output1_1_:%.+]], [[VAR_output2_1_:%.+]] = "zlow.vec_dlf16_to_f32"([[LOAD_VAR_reinterpret_cast_MEM_6_]]) : (vector<8xf16>) -> (vector<4xf32>, vector<4xf32>)
-// CHECK:               [[RES_1_:%.+]] = memref.alloca() {{.*}}: memref<8xf32>
+// CHECK:               [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<8xf32>
 // CHECK:               vector.store [[VAR_output1_1_]], [[RES_1_]]{{.}}[[CST_0_]]{{.}} : memref<8xf32>, vector<4xf32>
 // CHECK:               vector.store [[VAR_output2_1_]], [[RES_1_]]{{.}}[[CST_4_]]{{.}} : memref<8xf32>, vector<4xf32>
 // CHECK:               scf.for [[I_5_:%.+]] = [[CST_0_]] to [[VAR_8_1_]] step [[CST_1_]] {


### PR DESCRIPTION
After lengthy proofing of the code, I realized that there was an innocuous `aligned alloca` of 8 bytes inside an inner loop of the compiler generated unstickify. Thus, according to the current rules, a new chunk of memory was generated for each inner loop, eventually running out of memory. This happens for large benchmarks for which there are data sizes of buffers to unstickify that were not multiple of 8 (like yolo, where the images reduces from 400+ all the way to 13).

This has been fixed by having a single `aligned alloc` (heap, not stack) inside of the outer loops (to support parallelism).

A few minor cleanup was also performed.

I will review all instances of `alloca` in a subsequent PR to ensure this issue may not generate other issues in related situations.

Since we don't have a good way at this time to verify the validity of the code, I used this test case mlir file `add1-4d.mlir`

```mlir
module attributes {} {
  func.func @main_graph(%arg0: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> attributes {input_names = ["x"], output_names = ["output"]} {
    %0 = "onnx.Add"(%arg0, %arg0) : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
    %1 = "onnx.Add"(%0, %0) : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
    return %1 : tensor<?x?x?x?xf32>
  }
  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
}
```

and this set of checks which verifies that the same results are obtained with the zDNN stick/unstick and the compiler version of it.

```bash
# static sizes as the compiler generate different code sequence when shapes are known
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false -shapeInformation=0:2x3x4x3" -t "-O3 -mcpu=z16 -maccel=NNPA"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false -shapeInformation=0:2x3x4x8" -t "-O3 -mcpu=z16 -maccel=NNPA"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false -shapeInformation=0:2x3x4x13" -t "-O3 -mcpu=z16 -maccel=NNPA"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false -shapeInformation=0:2x3x4x64" -t "-O3 -mcpu=z16 -maccel=NNPA"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false -shapeInformation=0:2x3x4x72" -t "-O3 -mcpu=z16 -maccel=NNPA"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false -shapeInformation=0:2x3x4x75" -t "-O3 -mcpu=z16 -maccel=NNPA"

# dynamic sizes to make sure the generic code handle all of the above special cases
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false" -t "-O3 -mcpu=z16 -maccel=NNPA" --shape-info="0:2x3x4x3"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false" -t "-O3 -mcpu=z16 -maccel=NNPA" --shape-info="0:2x3x4x8"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false" -t "-O3 -mcpu=z16 -maccel=NNPA" --shape-info="0:2x3x4x13"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false" -t "-O3 -mcpu=z16 -maccel=NNPA" --shape-info="0:2x3x4x64"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false" -t "-O3 -mcpu=z16 -maccel=NNPA" --shape-info="0:2x3x4x72"
CheckONNXModel.py -m add1-4d.mlir -r "-O3 -mcpu=z16 -maccel=NNPA -enable-compiler-stick-unstick=false" -t "-O3 -mcpu=z16 -maccel=NNPA" --shape-info="0:2x3x4x75"
```

Note that code specialization occurs when E1 (innermost dim) is a multiple of 8 or 64.