### PR TITLE
Opening binary constants files fix on zOS

### DIFF
--- a/src/Runtime/OMExternalConstant.inc
+++ b/src/Runtime/OMExternalConstant.inc
@@ -74,6 +74,9 @@ void omMMapBinaryFile(
   memcpy(tPath, fname, tLen);
   __a2e_s(tPath);
   fname = tPath;
+  fname[tLen] = '\0';
+
+
 #endif
 
   if (constAddr == NULL) {
@@ -168,6 +171,7 @@ void omGetExternalConstantAddr(
     return;
 
   outputAddr[0] = (char *)baseAddr[0] + offset;
+
 }
 
 #endif

--- a/src/Runtime/OMExternalConstant.inc
+++ b/src/Runtime/OMExternalConstant.inc
@@ -75,8 +75,6 @@ void omMMapBinaryFile(
   __a2e_s(tPath);
   fname = tPath;
   fname[tLen] = '\0';
-
-
 #endif
 
   if (constAddr == NULL) {
@@ -171,7 +169,6 @@ void omGetExternalConstantAddr(
     return;
 
   outputAddr[0] = (char *)baseAddr[0] + offset;
-
 }
 
 #endif

--- a/src/Runtime/OMExternalConstant.inc
+++ b/src/Runtime/OMExternalConstant.inc
@@ -64,17 +64,13 @@ void omMMapBinaryFile(
   char *fname = filename;
 #ifdef __MVS__
   // Convert the file name to EBCDIC for the open call.
-  char *tPath;
-  size_t tLen = strlen(fname);
-  tPath = (char *)malloc(tLen);
+  char *tPath = strdup(fname);
   if (!tPath) {
-    fprintf(stderr, "Error while malloc");
+    fprintf(stderr, "Error while strdup");
     return;
   }
-  memcpy(tPath, fname, tLen);
   __a2e_s(tPath);
   fname = tPath;
-  fname[tLen] = '\0';
 #endif
 
   if (constAddr == NULL) {


### PR DESCRIPTION
Addressing issue https://github.com/onnx/onnx-mlir/issues/2987.

After linking the .so, run this client command resulted with an extra backtick or misc characters getting added to file name after converting from ASCII to EBCIDIC.

```
client/bin/modelzoo --lib mnist-8-with-binary.so --file mnist-8.tests --validate -m VERBOSE --fc-parms 0.01,0.158752,9,10
Saved mnist-8-with-binary.so for debug testing with C clients
Created mnist-8-with-binary.jar for Java clients
Iteration 0 dataset 0: Reading
gen_data_set_lists() loading 1 input tensor(s):
gen_next_tensor() processing tensor with shape ( 1 1 28 28 ) totaling 784 elements of type ONNX_TYPE_FLOAT
gen_data_set_lists() loading 1 expected output tensor(s):
gen_next_tensor() processing tensor with shape ( 1 10 ) totaling 10 elements of type ONNX_TYPE_FLOAT
Iteration 0 dataset 0: Running
Error while opening mnist-8.constants.bin`
Error while opening mnist-8.constants.bin�K������k�K������k`��K�����`
```