### PR TITLE
Add limitation for BFLOAT supported ops for NNPA

### DIFF
--- a/docs/SupportedONNXOps-NNPA.md
+++ b/docs/SupportedONNXOps-NNPA.md
@@ -10,7 +10,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 21. Limitatio
    * A * indicates onnx-mlir is compatible with the latest version of that operator available as of opset 21.
 
 
-NNPA has hardware limitations in dimension index size and tensor size, which are described in [NNPALimit.hpp](../src/Accelerators/NNPA/Support/NNPALimit.hpp). They are large enough for normal use cases, but if your model exceeds the limitations, CPU is used instead of NNPA.
+NNPA has hardware limitations in dimension index size and tensor size, which are described in [NNPALimit.hpp](../src/Accelerators/NNPA/Support/NNPALimit.hpp). They are large enough for normal use cases, but if your model exceeds the limitations, CPU is used instead of NNPA. NNPA currently only support DLFLOAT16 as its data type. Common data formats like FP32, FP16, BFLOAT need to undergo data conversions to the NNPA internal format DLFLOAT16. Hence ONNX ops which updated their tensors to BFLOAT16 will not be natively supported on NNPA.
 
 
 | Op |Supported Opsets (inclusive) |Limitations |Notes |

--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 set(NNPA_TEST_LIST
 
     # ==ARCH== NNPA
-    # ==ADDITIONAL_PARAGRAPH== NNPA has hardware limitations in dimension index size and tensor size, which are described in [NNPALimit.hpp](../src/Accelerators/NNPA/Support/NNPALimit.hpp). They are large enough for normal use cases, but if your model exceeds the limitations, CPU is used instead of NNPA.
+    # ==ADDITIONAL_PARAGRAPH== NNPA has hardware limitations in dimension index size and tensor size, which are described in [NNPALimit.hpp](../src/Accelerators/NNPA/Support/NNPALimit.hpp). They are large enough for normal use cases, but if your model exceeds the limitations, CPU is used instead of NNPA. NNPA currently only support DLFLOAT16 as its data type. Common data formats like FP32, FP16, BFLOAT need to undergo data conversions to the NNPA internal format DLFLOAT16. Hence ONNX ops which updated their tensors to BFLOAT16 will not be natively supported on NNPA.
 
     # ==OP== Add
     # ==MIN== 6


### PR DESCRIPTION
As part of [ONNX-1.17.0](https://github.com/onnx/onnx/releases/tag/v1.17.0) update the below list of Ops were modified to now support BFLOAT data types. This PR updates the NNPA supported docs with the limitation for this data type for NNPA.

### Update to support bfloat16:
[Acos](https://onnx.ai/onnx/operators/onnx__Acos.html#acos-22), [Acosh](https://onnx.ai/onnx/operators/onnx__Acosh.html#acosh-22), [Asin](https://onnx.ai/onnx/operators/onnx__Asin.html#asin-22), [Asinh](https://onnx.ai/onnx/operators/onnx__Asinh.html#asinh-22), [Atan](https://onnx.ai/onnx/operators/onnx__Atan.html#atan-22), [Atanh](https://onnx.ai/onnx/operators/onnx__Atanh.html#atanh-22), [AveragePool](https://onnx.ai/onnx/operators/onnx__AveragePool.html#averagepool-22), [Bernoulli](https://onnx.ai/onnx/operators/onnx__Bernoulli.html#bernoulli-22), [Conv](https://onnx.ai/onnx/operators/onnx__Conv.html#conv-22), [ConvTranspose](https://onnx.ai/onnx/operators/onnx__ConvTranspose.html#convtranspose-22), [Cos](https://onnx.ai/onnx/operators/onnx__Cos.html#cos-22), [Cosh](https://onnx.ai/onnx/operators/onnx__Cosh.html#cosh-22), [DeformConv](https://onnx.ai/onnx/operators/onnx__DeformConv.html#deformconv-22), [Det](https://onnx.ai/onnx/operators/onnx__Det.html#det-22), [Dropout](https://onnx.ai/onnx/operators/onnx__Dropout.html#dropout-22), [Elu](https://onnx.ai/onnx/operators/onnx__Elu.html#elu-22), [EyeLike](https://onnx.ai/onnx/operators/onnx__EyeLike.html#eyelike-22), [GRU](https://onnx.ai/onnx/operators/onnx__GRU.html#gru-22), [GlobalAveragePool](https://onnx.ai/onnx/operators/onnx__GlobalAveragePool.html#globalaveragepool-22), [GlobalLpPool](https://onnx.ai/onnx/operators/onnx__GlobalLpPool.html#globallppool-22), [GlobalMaxPool](https://onnx.ai/onnx/operators/onnx__GlobalMaxPool.html#globalmaxpool-22), [GridSample](https://onnx.ai/onnx/operators/onnx__GridSample.html#gridsample-22), [HardSigmoid](https://onnx.ai/onnx/operators/onnx__HardSigmoid.html#hardsigmoid-22), [HardSwish](https://onnx.ai/onnx/operators/onnx__HardSwish.html#hardswish-22), [InstanceNormalization](https://onnx.ai/onnx/operators/onnx__InstanceNormalization.html#instancenormalization-22), [LSTM](https://onnx.ai/onnx/operators/onnx__LSTM.html#lstm-22), [LpNormalization](https://onnx.ai/onnx/operators/onnx__LpNormalization.html#lpnormalization-22), [LpPool](https://onnx.ai/onnx/operators/onnx__LpPool.html#lppool-22), [MaxPool](https://onnx.ai/onnx/operators/onnx__MaxPool.html#maxpool-22), [MaxRoiPool](https://onnx.ai/onnx/operators/onnx__MaxRoiPool.html#maxroipool-22), [MaxUnpool](https://onnx.ai/onnx/operators/onnx__MaxUnpool.html#maxunpool-22), [Mish](https://onnx.ai/onnx/operators/onnx__Mish.html#mish-22), [Multinomial](https://onnx.ai/onnx/operators/onnx__Multinomial.html#multinomial-22), [NegativeLogLikelihoodLoss](https://onnx.ai/onnx/operators/onnx__NegativeLogLikelihoodLoss.html#negativeloglikelihoodloss-22), [RNN](https://onnx.ai/onnx/operators/onnx__RNN.html#rnn-22), [RandomNormal](https://onnx.ai/onnx/operators/onnx__RandomNormal.html#randomnormal-22), [RandomNormalLike](https://onnx.ai/onnx/operators/onnx__RandomNormalLike.html#randomnormallike-22), [RandomUniform](https://onnx.ai/onnx/operators/onnx__RandomUniform.html#randomuniform-22), [RandomUniformLike](https://onnx.ai/onnx/operators/onnx__RandomUniformLike.html#randomuniformlike-22), [RoiAlign](https://onnx.ai/onnx/operators/onnx__RoiAlign.html#roialign-22), [Round](https://onnx.ai/onnx/operators/onnx__Round.html#round-22), [Selu](https://onnx.ai/onnx/operators/onnx__Selu.html#selu-22), [Sin](https://onnx.ai/onnx/operators/onnx__Sin.html#sin-22), [Sinh](https://onnx.ai/onnx/operators/onnx__Sinh.html#sinh-22), [Softplus](https://onnx.ai/onnx/operators/onnx__Softplus.html#softplus-22), [Softsign](https://onnx.ai/onnx/operators/onnx__Softsign.html#softsign-22), [Tan](https://onnx.ai/onnx/operators/onnx__Tan.html#tan-22), [ThresholdedRelu](https://onnx.ai/onnx/operators/onnx__ThresholdedRelu.html#thresholdedrelu-22)