### PR TITLE
Fix a wrong function call

### DIFF
--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -569,7 +569,7 @@ bool extractConstantsToFile(ModuleOp &module, std::string filepath,
   OpBuilder::InsertionGuard guard(b);
   b.setInsertionPointToStart(module.getBody());
   std::string fname = llvm::sys::path::filename(filepath).str() + '\0';
-  fname = (isZOS(module)) ? krnl::e2a_s(fname) : fname;
+  fname = (isZOS(module)) ? krnl::a2e_s(fname) : fname;
   mlir::StringAttr valueAttr = mlir::StringAttr::get(context, fname);
   create.llvm.globalOp(LLVM::LLVMArrayType::get(llvmI8Ty, fname.size()),
       /*isConstant=*/true, LLVM::Linkage::Internal,


### PR DESCRIPTION
This is to fix a wrong function call that converts an ASIIC string to EBCDIC. 