### PR TITLE
Making runtime omunreachable static to support clang compiler

### DIFF
--- a/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
+++ b/src/Accelerators/NNPA/Runtime/zDNNExtension/zDNNExtension.h
@@ -135,7 +135,7 @@ void zDNNExtensionInit();
 // Helper Functions
 // -----------------------------------------------------------------------------
 
-inline void omUnreachable() {
+static inline void omUnreachable() {
 // Uses compiler specific extensions if possible.
 // Even if no extension is used, undefined behavior is still raised by
 // an empty function body and the noreturn attribute.


### PR DESCRIPTION
Compiling and linking runtime files on zOS using ibm-clang compiler will error. 
```
IEW2456E 9207 SYMBOL omUnreachable UNRESOLVED.  MEMBER COULD NOT BE INCLUDED
          FROM THE DESIGNATED CALL LIBRARY.
```
Following suggestions "In C99 you need to provide an alternate (non-inline) definition of the function for when the compiler can't inline."

https://stackoverflow.com/questions/69384040/why-do-i-get-a-linking-error-with-clang-when-inlining-a-function-in-a-c-program

I am open to trying alternative methods to support clang compilers if there are other suggestions. 