### PR TITLE
Disabled building tests default (like LLVM), enabled for our CIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(onnx-mlir)
 
-option(ONNX_MLIR_BUILD_TESTS "Build ONNX-MLIR test executables. If OFF, just generate build targets." ON)
+# Like in LLVM, default tests are off. Lit-tests are always on.
+option(ONNX_MLIR_BUILD_TESTS "Build ONNX-MLIR test executables. If OFF, just generate build targets." OFF)
 option(ONNX_MLIR_CCACHE_BUILD "Set to ON for a ccache enabled build." OFF)
 option(ONNX_MLIR_ENABLE_STABLEHLO "Enable StableHLO support." ON)
 option(ONNX_MLIR_ENABLE_WERROR "Enable warnings as errors." OFF)

--- a/docker/Dockerfile.onnx-mlir
+++ b/docker/Dockerfile.onnx-mlir
@@ -43,6 +43,7 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
     && CC=clang CXX=clang++ \
        cmake -DMLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
              -DCMAKE_BUILD_TYPE=Release \
+             -DONNX_MLIR_BUILD_TESTS=ON \
              -DLLVM_ENABLE_ASSERTIONS=ON \
              -DCMAKE_INSTALL_MESSAGE=NEVER \
              -DONNX_MLIR_ACCELERATORS=${ACCEL} .. \

--- a/docker/Dockerfile.onnx-mlir-dev
+++ b/docker/Dockerfile.onnx-mlir-dev
@@ -32,6 +32,7 @@ RUN LLVM_PROJECT_ROOT=${WORK_DIR}/llvm-project \
     && CC=clang CXX=clang++ \
        cmake -DMLIR_DIR=${LLVM_PROJECT_ROOT}/build/lib/cmake/mlir \
              -DCMAKE_BUILD_TYPE=Debug \
+             -DONNX_MLIR_BUILD_TESTS=ON \
              -DONNX_MLIR_TEST_OPTLEVEL=0 \
              -DONNX_MLIR_ACCELERATORS=${ACCEL} .. \
 # Run the cppcheck scanner on s390x

--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -57,6 +57,10 @@ This project uses lit ([LLVM's Integrated Tester](https://llvm.org/docs/CommandG
 
 To build ONNX-MLIR, use the following commands (maybe with additional `-DCMAKE_CXX_FLAGS` argument described [below](#enable-cpu-optimizations)):
 
+To build a version with extended tests, keep the `-DONNX_MLIR_BUILD_TESTS=ON` line below.
+Note that the extended tests requires the installation of `onnx` via a pip install of `third_party/onnx`. To build a version without a dependence on `third_party/onnx`, remove the `-DONNX_MLIR_BUILD_TESTS=ON` line or set to `OFF`.
+The lightweight Literal tests are build regardless of this option.
+
 [same-as-file]: <> ({"ref": "utils/install-onnx-mlir.sh", "skip-doc": 2})
 ```bash
 git clone --recursive https://github.com/onnx/onnx-mlir.git
@@ -68,6 +72,7 @@ if [[ -z "$pythonLocation" ]]; then
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
         -DCMAKE_BUILD_TYPE=Release \
+        -DONNX_MLIR_BUILD_TESTS=ON \
         -DLLVM_ENABLE_ASSERTIONS=ON \
         -DMLIR_DIR=${MLIR_DIR} \
         ..
@@ -75,6 +80,7 @@ else
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
         -DCMAKE_BUILD_TYPE=Release \
+        -DONNX_MLIR_BUILD_TESTS=ON \
         -DLLVM_ENABLE_ASSERTIONS=ON \
         -DPython3_ROOT_DIR=$pythonLocation \
         -DMLIR_DIR=${MLIR_DIR} \

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -108,6 +108,10 @@ call cmake --build . --config Release
 ```
 After the above commands succeed, an `onnx-mlir` executable should appear in the `Debug/bin` or `Release/bin` directory.
 
+To build a version with extended tests, add the `-DONNX_MLIR_BUILD_TESTS=ON` line above.
+Note that the extended tests requires the installation of `onnx` via a pip install of `third_party/onnx`. To build a version without a dependence on `third_party/onnx`, do not add the `-DONNX_MLIR_BUILD_TESTS=ON` line or set to `OFF`.
+The lightweight Literal tests are build regardless of this option.
+
 ### Trouble shooting build issues
 
 Check this [page](TestingHighLevel.md) for helpful hints.

--- a/docs/doc_check/CMakeLists.txt
+++ b/docs/doc_check/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 set(check_cmd ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check.py)
 
 add_custom_target(check-doc

--- a/test/accelerators/NNPA/CMakeLists.txt
+++ b/test/accelerators/NNPA/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 add_custom_target(check-onnx-backend-numerical-nnpa)
 
 add_subdirectory(backend)

--- a/test/backend-cpp/CMakeLists.txt
+++ b/test/backend-cpp/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 add_custom_target(backend-cpp)
 set_target_properties(backend-cpp PROPERTIES FOLDER "Tests")
 

--- a/test/backend/CMakeLists.txt
+++ b/test/backend/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 file(GENERATE
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/conftest.py
   INPUT ${CMAKE_CURRENT_SOURCE_DIR}/conftest.py

--- a/test/compilerlib/CMakeLists.txt
+++ b/test/compilerlib/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 add_onnx_mlir_executable(CompilerLibTest
   CompilerLibTest.cpp
 

--- a/test/mlir/CMakeLists.txt
+++ b/test/mlir/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Just like LLVM, ONNX_MLIR_BUILD_TESTS=false does not disable lit tests.
+
 # Turn on lit test for specified accelerators even if the
 # accelerator code itself cannot be built.
 if (ONNX_MLIR_ACCELERATORS)

--- a/test/modellib/CMakeLists.txt
+++ b/test/modellib/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 add_onnx_mlir_library(ModelLib
   CategoryMapperModel.cpp
   ConvModel.cpp

--- a/test/numerical/CMakeLists.txt
+++ b/test/numerical/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 add_custom_target(numerical)
 set_target_properties(numerical PROPERTIES FOLDER "Tests")
 

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 add_onnx_mlir_library(PerfLib
   PerfHelper.cpp
   EXCLUDE_FROM_OM_LIBS

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (NOT ONNX_MLIR_BUILD_TESTS)
+  set(EXCLUDE_FROM_ALL ON)
+endif()
+
 add_custom_target(unittest)
 set_target_properties(unittest PROPERTIES FOLDER "Tests")
 

--- a/utils/install-onnx-mlir.sh
+++ b/utils/install-onnx-mlir.sh
@@ -5,6 +5,7 @@ if [[ -z "$pythonLocation" ]]; then
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
         -DCMAKE_BUILD_TYPE=Release \
+        -DONNX_MLIR_BUILD_TESTS=ON \
         -DLLVM_ENABLE_ASSERTIONS=ON \
         -DMLIR_DIR=${MLIR_DIR} \
         ..
@@ -12,6 +13,7 @@ else
   cmake -G Ninja \
         -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
         -DCMAKE_BUILD_TYPE=Release \
+        -DONNX_MLIR_BUILD_TESTS=ON \
         -DLLVM_ENABLE_ASSERTIONS=ON \
         -DPython3_ROOT_DIR=$pythonLocation \
         -DMLIR_DIR=${MLIR_DIR} \


### PR DESCRIPTION
As mentioned in #1059, our default builds require onnx to be installed. 

This PR implements the changes requested in that issue:
1) all extensive tests are predicated by `ONNX_MLIR_BUILD_TESTS` being `ON`
2) default `ONNX_MLIR_BUILD_TESTS` value switched to off.
3) Our CIs add the `ONNX_MLIR_BUILD_TESTS=ON` define.

That way, folks just building a default `onnx-mlir` will not build the tests, and thus we are not dependent on `onnx` third party to be installed.

For folks using their own scripts for testing, you must now add

```
        -DONNX_MLIR_BUILD_TESTS=ON \
```

to your `cmake` command.