### PR TITLE
[NNPA] Fix some bugs for ReduceMin/Max

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/ONNXToZHigh.td
@@ -471,7 +471,7 @@ def replaceONNXReduceMeanV13Pattern : Pat<
 def replaceONNXReduceMaxPattern : Pat<
   (ONNXReduceMaxOp:$res $data, $axes, $keepdims, $noop_with_empty_axes),
   (ZHighUnstickOp (ZHighReduceMaxOp (ZHighStickOp:$s_x $data, (NoneLayoutAttr), 
-                                    (GetDefaultSaturation)), (GetStringAttr<"REDUCE_OP_MAXIMUM">))),
+                                    (GetDefaultSaturation)))),
   [(IsCompatibleWithNNPALevelArch15)]
 >;
 
@@ -484,7 +484,7 @@ def replaceONNXReduceMaxPattern : Pat<
 def replaceONNXReduceMinPattern : Pat<
   (ONNXReduceMinOp:$res $data, $axes, $keepdims, $noop_with_empty_axes),
   (ZHighUnstickOp (ZHighReduceMinOp (ZHighStickOp:$s_x $data, (NoneLayoutAttr), 
-                                    (GetDefaultSaturation)), (GetStringAttr<"REDUCE_OP_MINIMUM">))),
+                                    (GetDefaultSaturation)))),
   [(IsCompatibleWithNNPALevelArch15)]
 >;
 //===----------------------------------------------------------------------===//

--- a/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.cpp
@@ -69,8 +69,7 @@ ApiRegistry RegisterAllApis(MLIRContext *context) {
     ApiSpec(API::ZDNN_LOG, "zdnn_log_ext", int32Ty, {opaquePtrTy, opaquePtrTy}, false),
     ApiSpec(API::ZDNN_EXP, "zdnn_exp_ext", int32Ty, {opaquePtrTy, opaquePtrTy}, false),
     ApiSpec(API::ZDNN_INVSQRT, "zdnn_invsqrt_ext", int32Ty, {opaquePtrTy, float32Ty, opaquePtrTy}, false),                     
-    ApiSpec(API::ZDNN_REDUCEMAX, "zdnn_reduce_ext", int32Ty, {opaquePtrTy, opaquePtrTy, int64Ty, opaquePtrTy}, false),
-    ApiSpec(API::ZDNN_REDUCEMIN, "zdnn_reduce_ext", int32Ty, {opaquePtrTy, opaquePtrTy, int64Ty, opaquePtrTy}, false),
+    ApiSpec(API::ZDNN_REDUCE, "zdnn_reduce_ext", int32Ty, {opaquePtrTy, opaquePtrTy, int64Ty, opaquePtrTy}, false),
     // Activation operations
     ApiSpec(API::ZDNN_LEAKY_RELU, "zdnn_leaky_relu_ext", int32Ty, {opaquePtrTy, opaquePtrTy, float32Ty, opaquePtrTy}, false),
     ApiSpec(API::ZDNN_RELU, "zdnn_relu_ext", int32Ty, {opaquePtrTy, opaquePtrTy, opaquePtrTy}, false),

--- a/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.hpp
+++ b/src/Accelerators/NNPA/Conversion/ZLowToLLVM/ZLowToLLVMCommon.hpp
@@ -48,8 +48,9 @@ enum class API {
   ZDNN_LOG,
   ZDNN_EXP,
   ZDNN_INVSQRT,
-  ZDNN_REDUCEMAX,
-  ZDNN_REDUCEMIN,
+  // Reduction operations
+  ZDNN_REDUCE,
+  ZDNN_MEANREDUCE2D,
   // Activation operations
   ZDNN_RELU,
   ZDNN_GELU,
@@ -68,7 +69,6 @@ enum class API {
   ZDNN_CONV2D,
   ZDNN_AVGPOOL2D,
   ZDNN_MAXPOOL2D,
-  ZDNN_MEANREDUCE2D,
   ZDNN_BATCHNORM,
   ZDNN_LEAKY_RELU,
   // Scalar operations.

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
@@ -654,14 +654,13 @@ def ZHighReduceMaxOp:ZHigh_Op<"ReduceMax", [Pure, SameOperandsAndResultLayout,
      ZHigh operation to perform a ReduceMax.
      op_type: REDUCE_OP_MAXIMUM or REDUCE_OP_MINIMUM.
    }];
-   let arguments = (ins AnyTypeOf<[AnyZTensor]>:$data,
-                       DefaultValuedStrAttr<StrAttr, "REDUCE_OP_MAXIMUM">:$op_type);
+   let arguments = (ins AnyTypeOf<[AnyZTensor]>:$data);
    let results = (outs AnyTypeOf<[AnyZTensor]>:$output);
    let builders = [
-    OpBuilder<(ins "::mlir::Value":$data, "::mlir::StringAttr":$op_type), [{
+    OpBuilder<(ins "::mlir::Value":$data), [{
       Type elementType = mlir::cast<ShapedType>(data.getType()).getElementType();
       UnrankedTensorType resType = UnrankedTensorType::get(elementType);
-      build($_builder, $_state, resType, data, op_type);
+      build($_builder, $_state, resType, data);
     }]>
   ];
    let extraClassDefinition = [{
@@ -682,14 +681,13 @@ def ZHighReduceMinOp:ZHigh_Op<"ReduceMin", [Pure, SameOperandsAndResultLayout,
      ZHigh operation to perform a ReduceMin.
      op_type: REDUCE_OP_MAXIMUM or REDUCE_OP_MINIMUM.
    }];
-   let arguments = (ins AnyTypeOf<[AnyZTensor]>:$data,
-                       DefaultValuedStrAttr<StrAttr, "REDUCE_OP_MINIMUM">:$op_type);
+   let arguments = (ins AnyTypeOf<[AnyZTensor]>:$data);
    let results = (outs AnyTypeOf<[AnyZTensor]>:$output);
    let builders = [
-    OpBuilder<(ins "::mlir::Value":$data, "::mlir::StringAttr":$op_type), [{
+    OpBuilder<(ins "::mlir::Value":$data), [{
       Type elementType = mlir::cast<ShapedType>(data.getType()).getElementType();
       UnrankedTensorType resType = UnrankedTensorType::get(elementType);
-      build($_builder, $_state, resType, data, op_type);
+      build($_builder, $_state, resType, data);
     }]>
   ];
    let extraClassDefinition = [{

--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Reduction/Reduction.cpp
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps/Reduction/Reduction.cpp
@@ -29,9 +29,6 @@ LogicalResult ZHighReductionOpShapeHelper<OP_TYPE>::computeShape() {
   // Get operand.
   Value data = operandAdaptor.getData();
 
-  // Get Rank
-  int64_t rank = createIE->getShapedTypeRank(data);
-
   // Output dims of result.
   DimsExpr outputDims;
 
@@ -39,15 +36,15 @@ LogicalResult ZHighReductionOpShapeHelper<OP_TYPE>::computeShape() {
   SmallVector<IndexExpr, 4> inputDims;
   createIE->getShapeAsDims(data, inputDims);
 
-  int64_t axis = rank - 1;
+  // NNPA only supports reduction over the innermost dimension.
+  // So set the innermost dimension of the output to one.
+  int64_t axis = inputDims.size() - 1;
   LiteralIndexExpr one(1);
   // Copy the input until the second to last dimension
   for (int64_t i = 0; i < axis; ++i) {
     outputDims.emplace_back(inputDims[i]);
   }
-  // The innermost dimension or last dimension needs to be reduced to one
-  outputDims.emplace_back(
-      one); // NNPA is always true for keepdims so we will reduce the dimension
+  outputDims.emplace_back(one);
 
   // Save the final result.
   setOutputDims(outputDims);

--- a/src/Accelerators/NNPA/Dialect/ZLow/ZLow.td
+++ b/src/Accelerators/NNPA/Dialect/ZLow/ZLow.td
@@ -259,8 +259,7 @@ def ZLowReduceMaxOp:ZLow_Op<"reducemax", [MemRefsNormalizable]> {
                        MemRefOf<[I8]>:$work_area,
                        MemRefOf<[I64]>:$shape,
                        ZMemRef:$Out,
-                       StrAttr:$layout,
-                       StrAttr:$op_type);
+                       StrAttr:$layout);
 }
 
 def ZLowReduceMinOp:ZLow_Op<"reducemin", [MemRefsNormalizable]> {
@@ -272,8 +271,7 @@ def ZLowReduceMinOp:ZLow_Op<"reducemin", [MemRefsNormalizable]> {
                        MemRefOf<[I8]>:$work_area,
                        MemRefOf<[I64]>:$shape,
                        ZMemRef:$Out,
-                       StrAttr:$layout,
-                       StrAttr:$op_type);
+                       StrAttr:$layout);
 }
 
 def ZLowMatMulOp:ZLow_Op<"matmul", [MemRefsNormalizable,

--- a/test/accelerators/NNPA/backend/CMakeLists.txt
+++ b/test/accelerators/NNPA/backend/CMakeLists.txt
@@ -438,31 +438,14 @@ set(NNPA_TEST_LIST_ARCH_15
     # ==OP== ReduceMax
     # ==LEVEL== arch15
     # ==MIN== 1
-    # ==LIM== - We do no support `do_not_keepdims` backend tests. 
-    # test_reduce_max_bool_inputs_cpu,zdnn_reduce_ext
-    test_reduce_max_default_axes_keepdim_example_cpu,zdnn_reduce_ext
-    test_reduce_max_default_axes_keepdims_random_cpu,zdnn_reduce_ext
-    # test_reduce_max_do_not_keepdims_example_cpu,zdnn_reduce_ext
-    # test_reduce_max_do_not_keepdims_random_cpu,zdnn_reduce_ext
-    test_reduce_max_keepdims_example_cpu,zdnn_reduce_ext
-    test_reduce_max_keepdims_random_cpu,zdnn_reduce_ext
-    test_reduce_max_negative_axes_keepdims_example_cpu,zdnn_reduce_ext
-    test_reduce_max_negative_axes_keepdims_random_cpu,zdnn_reduce_ext
+    # ==LIM== - We do not support `do_not_keepdims` backend tests. Only support reduction over the innermost dimension.
+    # Currrently, there is no backend test in ONNX that does reduction on the innermost dimension.
 
     # ==OP== ReduceMin
     # ==LEVEL== arch15 
     # ==MIN== 1
-    # ==LIM== - We do no support `do_not_keepdims` backend tests. 
-    # test_reduce_min_bool_inputs_cpu,zdnn_reduce_ext
-    test_reduce_min_default_axes_keepdims_example_cpu,zdnn_reduce_ext
-    test_reduce_min_default_axes_keepdims_random_cpu,zdnn_reduce_ext 
-    # test_reduce_min_do_not_keepdims_example_cpu,zdnn_reduce_ext 
-    # test_reduce_min_do_not_keepdims_random_cpu,zdnn_reduce_ext     
-    test_reduce_min_empty_set_cpu,zdnn_reduce_ext
-    test_reduce_min_keepdims_example_cpu,zdnn_reduce_ext
-    test_reduce_min_keepdims_random_cpu,zdnn_reduce_ext
-    test_reduce_min_negative_axes_keepdims_example_cpu,zdnn_reduce_ext
-    test_reduce_min_negative_axes_keepdims_random_cpu,zdnn_reduce_ext
+    # ==LIM== - We do not support `do_not_keepdims` backend tests. Only support reduction over the innermost dimension.
+    # Currrently, there is no backend test in ONNX that does reduction on the innermost dimension.
 
     # ==OP== Sqrt
     # ==LEVEL== arch15

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/reducemax.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/reducemax.mlir
@@ -1,17 +1,75 @@
-// RUN: onnx-mlir-opt --march=arch15 --maccel=NNPA --shape-inference --convert-onnx-to-zhigh %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --march=arch15 --maccel=NNPA --shape-inference --convert-onnx-to-zhigh --canonicalize %s -split-input-file | FileCheck %s
 
- func.func @test_reduce_max_axes_defined_noop_0(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
-  %cst = "onnx.Constant"() {value = dense<[2]> : tensor<1xi64> } : () -> tensor<1xi64>
-  %0 ="onnx.ReduceMax"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
-  "func.return"(%0) : (tensor<*xf32>) -> ()
+func.func @test_reduce_max_axes_defined_noop_0(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
+   %cst = "onnx.Constant"() {value = dense<[2]> : tensor<1xi64> } : () -> tensor<1xi64>
+   %0 ="onnx.ReduceMax"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_reduce_max_axes_defined_noop_0
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>) -> tensor<3x2x1xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "3DS"} : (tensor<3x2x2xf32>) -> tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.ReduceMax"([[VAR_1_]]) {op_type = "REDUCE_OP_MAXIMUM"} : (tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<*xf16>
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "3DS"} : (tensor<3x2x2xf32>) -> tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.ReduceMax"([[VAR_1_]]) : (tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<*xf16>
 // CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf16>) -> tensor<3x2x1xf32>
 // CHECK:           return [[VAR_3_]] : tensor<3x2x1xf32>
 // CHECK:         }
- }
+}
+
+// -----
+
+func.func @test_reduce_max_axes_minus_one(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
+   %cst = "onnx.Constant"() {value = dense<-1> : tensor<1xi64> } : () -> tensor<1xi64>
+   %0 ="onnx.ReduceMax"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_reduce_max_axes_minus_one
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>) -> tensor<3x2x1xf32> {
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "3DS"} : (tensor<3x2x2xf32>) -> tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.ReduceMax"([[VAR_1_]]) : (tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<*xf16>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf16>) -> tensor<3x2x1xf32>
+// CHECK:           return [[VAR_3_]] : tensor<3x2x1xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_reduce_max_not_lowered_unknown_axis(%arg0 : tensor<3x2x2xf32>, %arg1: tensor<1xi64>) -> tensor<*xf32> {
+   %0 ="onnx.ReduceMax"(%arg0, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_reduce_max_not_lowered_unknown_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<?x?x?xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.ReduceMax"([[PARAM_0_]], [[PARAM_1_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>) -> tensor<?x?x?xf32>
+// CHECK:           return [[VAR_0_]] : tensor<?x?x?xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_reduce_max_axes_not_lowered_not_innermost_axis(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
+   %cst = "onnx.Constant"() {value = dense<0> : tensor<1xi64> } : () -> tensor<1xi64>
+   %0 ="onnx.ReduceMax"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_reduce_max_axes_not_lowered_not_innermost_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>) -> tensor<1x2x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.ReduceMax"([[PARAM_0_]], [[VAR_0_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>) -> tensor<1x2x2xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1x2x2xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_reduce_max_axes_not_lowered_not_multiple_axes(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
+   %cst = "onnx.Constant"() {value = dense<[2, 0]> : tensor<2xi64> } : () -> tensor<2xi64>
+   %0 ="onnx.ReduceMax"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<2xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_reduce_max_axes_not_lowered_not_multiple_axes
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>) -> tensor<1x2x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.ReduceMax"([[PARAM_0_]], [[VAR_0_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<2xi64>) -> tensor<1x2x1xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1x2x1xf32>
+// CHECK:         }
+}

--- a/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/reducemin.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/onnx-to-zhigh/reducemin.mlir
@@ -1,17 +1,75 @@
-// RUN: onnx-mlir-opt --march=arch15 --maccel=NNPA --shape-inference --convert-onnx-to-zhigh %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --march=arch15 --maccel=NNPA --shape-inference --convert-onnx-to-zhigh --canonicalize %s -split-input-file | FileCheck %s
 
- func.func @test_reduce_min_axes_defined_noop_0(%arg0: tensor<1x2x4xf32>) -> tensor<*xf32> {
-   %0 = "onnx.Constant"() {value = dense<[2]> : tensor<1xi64> } : () -> tensor<1xi64>
-   %1 ="onnx.ReduceMin"(%arg0, %0) {keepdims = 1: si64, noop_with_empty_axes = 0: si64} : (tensor<1x2x4xf32>, tensor<1xi64>) -> tensor<*xf32>
-  "func.return"(%1) : (tensor<*xf32>) -> ()
+func.func @test_reduce_min_axes_defined_noop_0(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
+   %cst = "onnx.Constant"() {value = dense<[2]> : tensor<1xi64> } : () -> tensor<1xi64>
+   %0 ="onnx.ReduceMin"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
 
 // mlir2FileCheck.py
 // CHECK-LABEL:  func.func @test_reduce_min_axes_defined_noop_0
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x2x4xf32>) -> tensor<1x2x1xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "3DS"} : (tensor<1x2x4xf32>) -> tensor<1x2x4xf16, #zhigh.layout<{dataLayout = "3DS"}>>
-// CHECK:           [[VAR_2_:%.+]] = "zhigh.ReduceMin"([[VAR_1_]]) {op_type = "REDUCE_OP_MINIMUM"} : (tensor<1x2x4xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<*xf16>
-// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf16>) -> tensor<1x2x1xf32>
-// CHECK:           return [[VAR_3_]] : tensor<1x2x1xf32>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>) -> tensor<3x2x1xf32> {
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "3DS"} : (tensor<3x2x2xf32>) -> tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.ReduceMin"([[VAR_1_]]) : (tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<*xf16>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf16>) -> tensor<3x2x1xf32>
+// CHECK:           return [[VAR_3_]] : tensor<3x2x1xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_reduce_min_axes_minus_one(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
+   %cst = "onnx.Constant"() {value = dense<-1> : tensor<1xi64> } : () -> tensor<1xi64>
+   %0 ="onnx.ReduceMin"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_reduce_min_axes_minus_one
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>) -> tensor<3x2x1xf32> {
+// CHECK:           [[VAR_1_:%.+]] = "zhigh.Stick"([[PARAM_0_]]) {layout = "3DS"} : (tensor<3x2x2xf32>) -> tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>
+// CHECK:           [[VAR_2_:%.+]] = "zhigh.ReduceMin"([[VAR_1_]]) : (tensor<3x2x2xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<*xf16>
+// CHECK:           [[VAR_3_:%.+]] = "zhigh.Unstick"([[VAR_2_]]) : (tensor<*xf16>) -> tensor<3x2x1xf32>
+// CHECK:           return [[VAR_3_]] : tensor<3x2x1xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_reduce_min_not_lowered_unknown_axis(%arg0 : tensor<3x2x2xf32>, %arg1: tensor<1xi64>) -> tensor<*xf32> {
+   %0 ="onnx.ReduceMin"(%arg0, %arg1) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_reduce_min_not_lowered_unknown_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>, [[PARAM_1_:%.+]]: tensor<1xi64>) -> tensor<?x?x?xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.ReduceMin"([[PARAM_0_]], [[PARAM_1_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>) -> tensor<?x?x?xf32>
+// CHECK:           return [[VAR_0_]] : tensor<?x?x?xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_reduce_min_axes_not_lowered_not_innermost_axis(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
+   %cst = "onnx.Constant"() {value = dense<0> : tensor<1xi64> } : () -> tensor<1xi64>
+   %0 ="onnx.ReduceMin"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_reduce_min_axes_not_lowered_not_innermost_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>) -> tensor<1x2x2xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.ReduceMin"([[PARAM_0_]], [[VAR_0_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>) -> tensor<1x2x2xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1x2x2xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_reduce_min_axes_not_lowered_not_multiple_axes(%arg0 : tensor<3x2x2xf32>) -> tensor<*xf32> {
+   %cst = "onnx.Constant"() {value = dense<[2, 0]> : tensor<2xi64> } : () -> tensor<2xi64>
+   %0 ="onnx.ReduceMin"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<2xi64>)-> tensor<*xf32>
+   "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// CHECK-LABEL:  func.func @test_reduce_min_axes_not_lowered_not_multiple_axes
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x2x2xf32>) -> tensor<1x2x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = onnx.Constant dense<[2, 0]> : tensor<2xi64>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.ReduceMin"([[PARAM_0_]], [[VAR_0_]]) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<2xi64>) -> tensor<1x2x1xf32>
+// CHECK:           return [[VAR_1_]] : tensor<1x2x1xf32>
 // CHECK:         }
 }

--- a/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/reducemax.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/reducemax.mlir
@@ -4,13 +4,22 @@ func.func @reduce_max_axes_defined_noop_0(%arg0: tensor<3x4x5xf16, #zhigh.layout
   %0 = "zhigh.ReduceMax"(%arg0) : (tensor<3x4x5xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<3x4x1xf16, #zhigh.layout<{dataLayout = "3DS"}>>
   return %0 : tensor<3x4x1xf16, #zhigh.layout<{dataLayout = "3DS"}>>
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1, d2) -> (d0, d2 floordiv 64, 0, d1 floordiv 32, d1 mod 32, d2 mod 64)>
 // CHECK-LABEL:  func.func @reduce_max_axes_defined_noop_0
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3x4x5xf16, #map>) -> memref<3x4x1xf16, #map> {
-// CHECK:           [[VAR_0_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : memref<3x4x5xf16, #map> to tensor<3x4x5xf16, #zhigh.layout<{dataLayout = "3DS"}>>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.ReduceMax"([[VAR_0_]]) {op_type = "REDUCE_OP_MAXIMUM"} : (tensor<3x4x5xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<3x4x1xf16, #zhigh.layout<{dataLayout = "3DS"}>>
-// CHECK:           [[VAR_2_:%.+]] = builtin.unrealized_conversion_cast [[VAR_1_]] : tensor<3x4x1xf16, #zhigh.layout<{dataLayout = "3DS"}>> to memref<3x4x1xf16, #map>
-// CHECK:           return [[VAR_2_]] : memref<3x4x1xf16, #map>
+// CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : i64
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : i64
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<3x4x1xf16, #map>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<3xi64>
+// CHECK:           krnl.store [[CST_3_]], [[RES_1_]]{{.}}[[CST_0_]]{{.}} : memref<3xi64>
+// CHECK:           krnl.store [[CST_4_]], [[RES_1_]]{{.}}[[CST_1_]]{{.}} : memref<3xi64>
+// CHECK:           krnl.store [[CST_5_]], [[RES_1_]]{{.}}[[CST_2_]]{{.}} : memref<3xi64>
+// CHECK:           [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<8192xi8>
+// CHECK:           "zlow.reducemax"([[PARAM_0_]], [[RES_2_]], [[RES_1_]], [[RES_]]) {layout = "3DS"} : (memref<3x4x5xf16, #map>, memref<8192xi8>, memref<3xi64>, memref<3x4x1xf16, #map>) -> ()
+// CHECK:           return [[RES_]] : memref<3x4x1xf16, #map>
 // CHECK:         }
 }

--- a/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/reducemin.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/zhigh-to-zlow/reducemin.mlir
@@ -4,13 +4,22 @@ func.func @reduce_min_axes_defined_noop_0(%arg0: tensor<3x4x5xf16, #zhigh.layout
   %0 = "zhigh.ReduceMin"(%arg0) : (tensor<3x4x5xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<3x4x1xf16, #zhigh.layout<{dataLayout = "3DS"}>>
   return %0 : tensor<3x4x1xf16, #zhigh.layout<{dataLayout = "3DS"}>>
 
-// mlir2FileCheck.py
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1, d2) -> (d0, d2 floordiv 64, 0, d1 floordiv 32, d1 mod 32, d2 mod 64)>
 // CHECK-LABEL:  func.func @reduce_min_axes_defined_noop_0
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<3x4x5xf16, #map>) -> memref<3x4x1xf16, #map> {
-// CHECK:           [[VAR_0_:%.+]] = builtin.unrealized_conversion_cast [[PARAM_0_]] : memref<3x4x5xf16, #map> to tensor<3x4x5xf16, #zhigh.layout<{dataLayout = "3DS"}>>
-// CHECK:           [[VAR_1_:%.+]] = "zhigh.ReduceMin"([[VAR_0_]]) {op_type = "REDUCE_OP_MINIMUM"} : (tensor<3x4x5xf16, #zhigh.layout<{dataLayout = "3DS"}>>) -> tensor<3x4x1xf16, #zhigh.layout<{dataLayout = "3DS"}>>
-// CHECK:           [[VAR_2_:%.+]] = builtin.unrealized_conversion_cast [[VAR_1_]] : tensor<3x4x1xf16, #zhigh.layout<{dataLayout = "3DS"}>> to memref<3x4x1xf16, #map>
-// CHECK:           return [[VAR_2_]] : memref<3x4x1xf16, #map>
+// CHECK-DAG:       [[CST_5_:%.+]] = arith.constant 5 : i64
+// CHECK-DAG:       [[CST_4_:%.+]] = arith.constant 4 : i64
+// CHECK-DAG:       [[CST_3_:%.+]] = arith.constant 3 : i64
+// CHECK-DAG:       [[CST_2_:%.+]] = arith.constant 2 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<3x4x1xf16, #map>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<3xi64>
+// CHECK:           krnl.store [[CST_3_]], [[RES_1_]]{{.}}[[CST_0_]]{{.}} : memref<3xi64>
+// CHECK:           krnl.store [[CST_4_]], [[RES_1_]]{{.}}[[CST_1_]]{{.}} : memref<3xi64>
+// CHECK:           krnl.store [[CST_5_]], [[RES_1_]]{{.}}[[CST_2_]]{{.}} : memref<3xi64>
+// CHECK:           [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<8192xi8>
+// CHECK:           "zlow.reducemin"([[PARAM_0_]], [[RES_2_]], [[RES_1_]], [[RES_]]) {layout = "3DS"} : (memref<3x4x5xf16, #map>, memref<8192xi8>, memref<3xi64>, memref<3x4x1xf16, #map>) -> ()
+// CHECK:           return [[RES_]] : memref<3x4x1xf16, #map>
 // CHECK:         }
 }


### PR DESCRIPTION
Currently, ReduceMin/ReduceMax failed to run on NNPA. This patch is to make them work and produce correct results.

Test program:
```
module {
  func.func @main_graph(%arg0: tensor<3x2x2xf32> {onnx.name = "x"}) -> (tensor<*xf32> {onnx.name = "y"}) {
   %cst = "onnx.Constant"() {value = dense<[2]> : tensor<1xi64> } : () -> tensor<1xi64>
   %0 ="onnx.ReduceMax"(%arg0, %cst) {keepdims = 1 : si64, noop_with_empty_axes = 0 : si64} : (tensor<3x2x2xf32>, tensor<1xi64>)-> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
  }
  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
}
```

Output using this patch:
```
python ../utils/RunONNXModel.py -m reducemax.mlir -c "-O3 -march=arch15 -maccel=NNPA" --print-input --print-output
Temporary directory has been created at <TemporaryDirectory '/tmp/tmpxs_l058r'>

Compiling the model ...
  took  0.14967317699847626  seconds.

Loading the compiled model ...
  took  0.0001287180020881351  seconds.

Generating random inputs using seed 42 ...
  - 1st input's shape (3, 2, 2), element type float32. Value ranges [-0.1, 0.1]
  done.

The 1st input x:[3x2x2xfloat32] is:
 [[[-0.02509198  0.09014286]
  [ 0.04639879  0.0197317 ]]

 [[-0.06879627 -0.0688011 ]
  [-0.08838328  0.07323523]]

 [[ 0.020223    0.04161451]
  [-0.0958831   0.09398197]]]

Running inference ...
  1st iteration, 8.331799836014397e-05, seconds
The 1st output y:[3x2x1xfloat32] is:
 [[[ 0.09008789]
  [ 0.04638672]]

 [[-0.06884766]
  [ 0.07324219]]

 [[ 0.04162598]
  [ 0.09399414]]]
```