### PR TITLE
Update the instruction for building multiple accelerators

### DIFF
--- a/docs/AddCustomAccelerators.md
+++ b/docs/AddCustomAccelerators.md
@@ -20,8 +20,9 @@ The folder content is flexible depending on each accelerator. However, we recomm
 To build accelerators in onnx-mlir, use the cmake variable `ONNX_MLIR_ACCELERATORS` when building onnx-mlir. `ONNX_MLIR_ACCELERATORS` accepts a semicolon-separated list of accelerator names. For example,
 ```bash
 $ cd build
-$ cmake .. -DONNX_MLIR_ACCELERATORS=accel1;accel2
+$ cmake .. -DONNX_MLIR_ACCELERATORS='accel1;accel2'
 ```
+Note that the list should be quoted.
 
 ### 1.2 Compile a model to run with selected accelerators.
 

--- a/src/Accelerators/CMakeLists.txt
+++ b/src/Accelerators/CMakeLists.txt
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Populate the accelerator list and add the accelerator subdirectories.
-# ONNX_MLIR_ACCELERATORS is the list of accelerators user specified
+# ONNX_MLIR_ACCELERATORS is the semicolon-separated list of accelerators user specified
+# Note that the list should be quoted, e.g. -DONNX_MLIR_ACCELERATORS='A;B'
 # ACCEL_TARGET_LIST is the list of cmake targets
 # ACCEL_LINK_LIST is the lists of accelerator libraries
 # ACCEL_INCLUDE_LIST is the list passed to inc generator
@@ -10,7 +11,8 @@ if (ONNX_MLIR_ACCELERATORS)
     add_subdirectory(${t})
 
     # If the accelerator can be built
-    if (${t}_ENABLED)
+    string(TOUPPER ${t} T)
+    if (${T}_ENABLED)
       list(APPEND ACCEL_TARGET_LIST "${t}Accel")
       list(APPEND ACCEL_LINK_LIST "OM${t}Accel")
       list(APPEND ACCEL_INCLUDE_LIST "${t}")

--- a/test/mlir/CMakeLists.txt
+++ b/test/mlir/CMakeLists.txt
@@ -4,7 +4,8 @@
 # accelerator code itself cannot be built.
 if (ONNX_MLIR_ACCELERATORS)
   foreach(t ${ONNX_MLIR_ACCELERATORS})
-    set(${t}_LIT_ENABLED 1)
+    string(TOUPPER ${t} T)
+    set(${T}_LIT_ENABLED 1)
     list(APPEND ACCEL_LIT_LIST "${t}")
   endforeach(t)
 endif(ONNX_MLIR_ACCELERATORS)


### PR DESCRIPTION
This PR updates `docs/AddCustomAccelerators.md` with instructions to build multiple accelerators.