### PR TITLE
Update onnx requirement to 1.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ lit~=15.0
 # numpy 1.24 deprecates np.object, np.bool, np.float, np.complex, np.str,
 # and np.int which are used heavily in onnx-mlir.
 numpy==2.0.1
-onnx==1.16.2
+onnx==1.17.0
 protobuf==4.21.12
 pytest==8.3.2
 pytest-xdist==3.6.1


### PR DESCRIPTION
The onnx submodule is using version 1.17.0, so I think the version used in the requirements should be the same