### PR TITLE
fix weak hash

### DIFF
--- a/.buildbot/jenkins_common.py
+++ b/.buildbot/jenkins_common.py
@@ -120,12 +120,12 @@ def strtobool(s: str) -> bool:
 def compute_file_sha1(file_name):
     """Compute sha1 of a file."""
 
-    sha1sum = hashlib.sha1()
+    sha3_256sum = hashlib.sha3_256()
     try:
         with open(file_name, "rb") as f:
             for data in iter(lambda: f.read(READ_CHUNK_SIZE), b""):
-                sha1sum.update(data)
-        return sha1sum.hexdigest()
+                sha3_256sum.update(data)
+        return sha3_256sum.hexdigest()
     except:
         return ""
 


### PR DESCRIPTION
This updates the sha algorithm for the docker images from sha1 to sha3_256. I have avoided renaming the use of sha1 in various docker files for now with something as generic as hash, but if there is feedback to change those variable names from tied to an algorithm to being generic, I can do that as feedback.