### PR TITLE
Reduce Runtime's dependence to LLVM (WIP)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if (ONNX_MLIR_ENABLE_PYRUNTIME_LIGHT)
+  add_subdirectory(Support)
   add_subdirectory(Runtime)
   # Accelerators introduces a target AcceleratorsInc. Define a dummy one here
   add_custom_target(AcceleratorsInc

--- a/src/Runtime/CMakeLists.txt
+++ b/src/Runtime/CMakeLists.txt
@@ -67,8 +67,8 @@ set_target_properties(OMTensorUtils
   POSITION_INDEPENDENT_CODE TRUE
   )
 
-if (ONNX_MLIR_ENABLE_PYRUNTIME_LIGHT)
-add_compile_definitions(ENABLE_PYRUNTIME_LIGHT)
+# Windows use the wrapper class for dynamic library provided by llvm
+if (WIN32)
 add_onnx_mlir_library(OMExecutionSession
   ExecutionSession.cpp
 

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -65,7 +65,7 @@ void ExecutionSession::Init(
   // llvm::StringRef(tag).equals_insensitive("NONE")
   std::string none = "NONE";
   bool equal_insensitive = std::equal(tag.begin(), tag.end(), none.begin(),
-       none.end(), [](char a, char b) { return tolower(a) == tolower(b); });
+      none.end(), [](char a, char b) { return tolower(a) == tolower(b); });
   if (!equal_insensitive)
     lowDashTag = "_" + tag;
 

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -26,7 +26,10 @@
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
 #else
+#include <algorithm>
 #include <dlfcn.h>
+#include <filesystem>
+
 #endif
 
 #include "ExecutionSession.hpp"
@@ -48,13 +51,17 @@ void ExecutionSession::Init(
 
   // If there is no tag, use the model filename without extension as a tag.
   if (tag == "") {
-    // ToFix: equivalent implementation of llvm utilities.
-    // The would not be an urgent issue, because tag is usually "NONE"
 #ifndef ENABLE_PYRUNTIME_LIGHT
     std::string fname = llvm::sys::path::filename(sharedLibPath).str();
     llvm::SmallString<256> fnameWithoutExt(fname);
     llvm::sys::path::replace_extension(fnameWithoutExt, "");
     tag = fnameWithoutExt.str().lower();
+#else
+    // Implement directly with c++
+    std::filesystem::path path(sharedLibPath);
+    tag = path.stem().string();
+    std::transform(tag.begin(), tag.end(), tag.begin(),
+        [](unsigned char c){ return std::tolower(c); });
 #endif
   }
 

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -21,16 +21,9 @@
 #include <sstream>
 #include <vector>
 
-#if defined(_WIN32)
-#include "llvm/ADT/SmallString.h"
-#include "llvm/Support/ManagedStatic.h"
-#include "llvm/Support/Path.h"
-#else
 #include <algorithm>
 #include <dlfcn.h>
 #include <filesystem>
-
-#endif
 
 #include "ExecutionSession.hpp"
 #include "OMTensorListHelper.hpp"

--- a/src/Runtime/ExecutionSession.hpp
+++ b/src/Runtime/ExecutionSession.hpp
@@ -23,10 +23,9 @@
 #include "OnnxMlirRuntime.h"
 
 // LLVM provides the wrapper class, llvm::sys::DynamicLibrary, for dynamic
-// library. When PYRUNTIME_LIGHT is built without the LLVM, the handle type for
-// dynamic library in Linux is used. DynamicLibraryHandleType is defined for
-// the two cases.
-#ifndef ENABLE_PYRUNTIME_LIGHT
+// library. Use this library only on Windows. Therefore, the Runtime does not
+// depend on llvm for Runtime component.
+#if define(_WIN32)
 #include "llvm/Support/DynamicLibrary.h"
 typedef llvm::sys::DynamicLibrary DynamicLibraryHandleType;
 #else

--- a/src/Runtime/ExecutionSession.hpp
+++ b/src/Runtime/ExecutionSession.hpp
@@ -25,7 +25,7 @@
 // LLVM provides the wrapper class, llvm::sys::DynamicLibrary, for dynamic
 // library. Use this library only on Windows. Therefore, the Runtime does not
 // depend on llvm for Runtime component.
-#if define(_WIN32)
+#if defined(_WIN32)
 #include "llvm/Support/DynamicLibrary.h"
 typedef llvm::sys::DynamicLibrary DynamicLibraryHandleType;
 #else

--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -44,29 +44,13 @@
 #include "src/Runtime/OMTensorHelper.hpp"
 #endif
 
-#ifndef ENABLE_PYRUNTIME_LIGHT
 #include "src/Support/SmallFPConversion.h"
-#endif
 
 #if defined(__APPLE__)
 // __errno_location() is called from krnl::emitErrNo() to set errno in
 // generated llvm IR, but it somehow doesn't come out of the box on MacOS.
 int *__attribute__((__weak__)) __errno_location(void) { return &errno; }
 #endif
-
-#ifdef ENABLE_PYRUNTIME_LIGHT
-// The implementation depends on src/Utility and llvm. Will be solved in
-// another PR. Here are just dummy definitions for compilation
-float om_f16_to_f32(uint16_t a) {
-  return (float) 0;
-}
-
-uint16_t  om_f32_to_f16(uint16_t a) {
-  return (uint16_t) 0;
-}
-#endif
-
-
 
 // On some platforms LLVM generates f16 conversion code that calls some
 // of these C runtime functions.

--- a/src/Support/CMakeLists.txt
+++ b/src/Support/CMakeLists.txt
@@ -1,5 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
+add_onnx_mlir_library(OMSmallFPConversion
+  SmallFPConversion.c
+  )
+set_target_properties(OMSmallFPConversion
+  PROPERTIES
+  LANGUAGE C
+  )
+
+if (ONNX_MLIR_ENABLE_PYRUNTIME_LIGHT)
+  return()
+endif()
+
 add_onnx_mlir_library(OMDiagnostic
   Diagnostic.cpp
 
@@ -33,12 +45,4 @@ add_onnx_mlir_library(OMMlirUtilities
   LINK_LIBS PUBLIC
   OMSmallFPConversion
   MLIRIR
-  )
-
-add_onnx_mlir_library(OMSmallFPConversion
-  SmallFPConversion.c
-  )
-set_target_properties(OMSmallFPConversion
-  PROPERTIES
-  LANGUAGE C
   )

--- a/test/modellib/ModelLib.cpp
+++ b/test/modellib/ModelLib.cpp
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
 #include "mlir/IR/BuiltinOps.h"
 
 #include "include/OnnxMlirRuntime.h"
@@ -69,9 +73,14 @@ bool ModelLibBuilder::checkInstructionFromEnv(
 bool ModelLibBuilder::checkInstruction(const std::string instructionName) {
   if (instructionName.empty())
     return true;
-  llvm::sys::DynamicLibrary sharedLibraryHandle =
+  DynamicLibraryHandleType sharedLibraryHandle =
       exec->getSharedLibraryHandle();
-  void *addr = sharedLibraryHandle.getAddressOfSymbol(instructionName.c_str());
+  void *addr;
+#if defined(_WIN32)
+  addr = sharedLibraryHandle.getAddressOfSymbol(instructionName.c_str());
+#else
+  addr = dlsym(sharedLibraryHandle, instructionName.c_str());
+#endif
   if (!addr) {
     printf("%s not found.\n", instructionName.c_str());
     return false;


### PR DESCRIPTION
1. Replace the llvm::system with std::filesystem
2. replace llvm::StringRef.compareCaseInsentive with implementation directly with std::string.
3. Keep the llvm StandLibrary only for windows. 

As a result, the code previous under PYRUNTIME_LIGHT for src/Runtime becomes the default code now.

Now the only source code difference is the float16 support in src/Runtime/python. There are too much code to copy from llvm. Low priority.