### PR TITLE
Extend instrumentSignature to print data

### DIFF
--- a/docs/Dialects/onnx.md
+++ b/docs/Dialects/onnx.md
@@ -6588,10 +6588,16 @@ Effects: `MemoryEffects::Effect{}`
 
 ### `onnx.PrintSignature` (ONNXPrintSignatureOp)
 
-_ONNX Op to print type signature of its input operands_
+_ONNX Op to print type signature or data of its input operands_
 
-Print type signature of the op's input operands. This operation is introduced early
-so as to preserve the name of the original ONNX op.
+Print type signature or data of the input operands of this op.
+The parameter op_name specifies a string to be printed before the tensors.
+and usually the op_name and onnx_node_name are used.
+This operation is introduced early so as to preserve the name of the original ONNX op.
+The argument print_data control whether the data of the tensors to be printed.
+When print_data == 1, the data of the tensor will be printed. Otherwise, just shape.
+The argument input specifies the tensor to be printed. They could be a list
+of the inputs and outputs of an ONNX op.
 
 This operation is not part of the standard and was added to assist onnx-mlir.
 
@@ -6600,6 +6606,7 @@ This operation is not part of the standard and was added to assist onnx-mlir.
 <table>
 <tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
 <tr><td><code>op_name</code></td><td>::mlir::StringAttr</td><td>string attribute</td></tr>
+<tr><td><code>print_data</code></td><td>::mlir::IntegerAttr</td><td>64-bit signed integer attribute</td></tr>
 </table>
 
 #### Operands:

--- a/docs/Dialects/zlow.md
+++ b/docs/Dialects/zlow.md
@@ -850,7 +850,6 @@ Traits: `MemRefsNormalizable`
 | Operand | Description |
 | :-----: | ----------- |
 | `X` | memref of dlfloat16 type values
-| `shape` | memref of 64-bit signless integer values
 | `Out` | memref of dlfloat16 type values
 
 ### `zlow.sigmoid` (::onnx_mlir::zlow::ZLowSigmoidOp)

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -260,8 +260,7 @@ void addPassesNNPA(mlir::OwningOpRef<mlir::ModuleOp> &module,
       else if (optStr == "-O3")
         optLevel = OptLevel::O3;
       // Lower ONNX to Krnl, ZHigh to ZLow.
-      addONNXToKrnlPasses(
-          pm, optLevel, /*enableCSE*/ true, ONNXOpStats);
+      addONNXToKrnlPasses(pm, optLevel, /*enableCSE*/ true, ONNXOpStats);
 
       if (nnpaEmissionTarget >= EmitZLowIR)
         emissionTarget = EmitMLIR;

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -261,7 +261,7 @@ void addPassesNNPA(mlir::OwningOpRef<mlir::ModuleOp> &module,
         optLevel = OptLevel::O3;
       // Lower ONNX to Krnl, ZHigh to ZLow.
       addONNXToKrnlPasses(
-          pm, optLevel, /*enableCSE*/ true, instrumentSignatures, ONNXOpStats);
+          pm, optLevel, /*enableCSE*/ true, ONNXOpStats);
 
       if (nnpaEmissionTarget >= EmitZLowIR)
         emissionTarget = EmitMLIR;

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -72,6 +72,7 @@ std::string instrumentOps;                             // onnx-mlir only
 unsigned instrumentControlBits;                        // onnx-mlir only
 std::string parallelizeOps;                            // onnx-mlir only
 std::string instrumentSignatures;                      // onnx-mlir only
+std::string instrumentOnnxNode;                        // onnx-mlir only
 std::string ONNXOpStats;                               // onnx-mlir only
 int onnxOpTransformThreshold;                          // onnx-mlir only
 bool onnxOpTransformReport;                            // onnx-mlir only
@@ -503,7 +504,8 @@ static llvm::cl::opt<std::string, true> instrumentSignatureOpt(
     "instrument-signature",
     llvm::cl::desc(
         "Specify which high-level operations should be selected for printing\n"
-        "the type, shape, and data of their input/output tensors.\n"
+        "the type and shape of their input/output tensors.\n"
+        "The ops are selected by their op name.\n"
         "The instrument-signature defines the pattern to select the ops.\n"
         "\"NONE\" for no instrument (default).\n"
         "\"ALL\" or \"\" for all available operations.\n"
@@ -511,12 +513,31 @@ static llvm::cl::opt<std::string, true> instrumentSignatureOpt(
         "\"ops1,ops2, ...\" for the multiple ops.\n"
         "e.g. \"onnx.MatMul,onnx.Add\" for MatMul and Add op in onnx dialect.\n"
         "Asterisk is also available.\n"
-        "e.g. \"onnx.*\" for all onnx operations.\n"
-        "The string from op->getName() is used to match the regexp pattern.\n"
-        "Special case: if this option is started with \"onnx_node_name:\"\n"
-        "the attribute of \"onnx_node_name\", instead of the op->getName()\n"
-        "will be used to match the op, and the data value will be printed.\n"),
+        "e.g. \"onnx.*\" for all onnx operations.\n"),
     llvm::cl::location(instrumentSignatures), llvm::cl::init("NONE"),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<std::string, true> instrumentONNXNodeOpt(
+    "instrument-onnx-node",
+    llvm::cl::desc(
+        "Specify which onnx operation node will be selected for \n"
+        "inserting a runtime call after the node to print the data of\n"
+        "their input/output tensors.\n"
+        "The ops are selected by their onnx node name, which is a string\n"
+        "attribute unique to each onnx node (most of time).\n"
+        "You can find them in the output of --EmitONNXIR\n"
+        "Other instrumentation in onnx-mlir is specified by op->getName(),\n"
+        "namely, the type of onnx operation, such Add, Matmul, and etc.\n"
+        "This option is able to pinpoint to a particular node.\n"
+        "The instrument-onnx-node defines the pattern to select.\n"
+        "\"NONE\" for no instrument (default).\n"
+        "Except for the special values, the regexp is used for matching.\n"
+        "\"/layer1/MatMul, onnx.Add_0, ...\" for the multiple nodes.\n"
+        "Asterisk is also available. For example:\n"
+        "\"onnx.Add_*\" for all AddOp. This feature allows you to specify\n"
+        "part of the target of onnx_node_name, as long as it is long enough\n"
+        "to be unique.\n"),
+    llvm::cl::location(instrumentOnnxNode), llvm::cl::init("NONE"),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<std::string, true> ONNXOpStatsOpt("onnx-op-stats",

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -501,14 +501,18 @@ static llvm::cl::opt<std::string, true> parallelizeOpsOpt("parallelize-ops",
 
 static llvm::cl::opt<std::string, true> instrumentSignatureOpt(
     "instrument-signature",
-    llvm::cl::desc("Specify which high-level operations should print their"
-                   " input type(s) and shape(s)\n"
-                   "\"ALL\" or \"\" for all available operations.\n"
-                   "\"NONE\" for no instrument (default).\n"
-                   "\"ops1,ops2, ...\" for the multiple ops.\n"
-                   "e.g. \"onnx.MatMul,onnx.Add\" for MatMul and Add ops.\n"
-                   "Asterisk is also available.\n"
-                   "e.g. \"onnx.*\" for all onnx operations.\n"),
+    llvm::cl::desc(
+        "Specify which high-level operations should print their"
+        " input type(s) and shape(s)\n"
+        "\"ALL\" or \"\" for all available operations.\n"
+        "\"NONE\" for no instrument (default).\n"
+        "\"ops1,ops2, ...\" for the multiple ops.\n"
+        "e.g. \"onnx.MatMul,onnx.Add\" for MatMul and Add ops.\n"
+        "Asterisk is also available.\n"
+        "e.g. \"onnx.*\" for all onnx operations.\n"
+        "If this option is started with \"onnx_node_name\"\n"
+        "the attribute of \"onnx_node_name\", instead of the op name\n"
+        "will be used to match the op, and the data value will be printed.\n"),
     llvm::cl::location(instrumentSignatures), llvm::cl::init("NONE"),
     llvm::cl::cat(OnnxMlirOptions));
 

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -502,16 +502,19 @@ static llvm::cl::opt<std::string, true> parallelizeOpsOpt("parallelize-ops",
 static llvm::cl::opt<std::string, true> instrumentSignatureOpt(
     "instrument-signature",
     llvm::cl::desc(
-        "Specify which high-level operations should print their"
-        " input type(s) and shape(s)\n"
-        "\"ALL\" or \"\" for all available operations.\n"
+        "Specify which high-level operations should be selected for printing\n"
+        "the type, shape, and data of their input/output tensors.\n"
+        "The instrument-signature defines the pattern to select the ops.\n"
         "\"NONE\" for no instrument (default).\n"
+        "\"ALL\" or \"\" for all available operations.\n"
+        "Except for the special values, the regexp is used for matching.\n"
         "\"ops1,ops2, ...\" for the multiple ops.\n"
-        "e.g. \"onnx.MatMul,onnx.Add\" for MatMul and Add ops.\n"
+        "e.g. \"onnx.MatMul,onnx.Add\" for MatMul and Add op in onnx dialect.\n"
         "Asterisk is also available.\n"
         "e.g. \"onnx.*\" for all onnx operations.\n"
-        "If this option is started with \"onnx_node_name\"\n"
-        "the attribute of \"onnx_node_name\", instead of the op name\n"
+        "The string from op->getName() is used to match the regexp pattern.\n"
+        "Special case: if this option is started with \"onnx_node_name:\"\n"
+        "the attribute of \"onnx_node_name\", instead of the op->getName()\n"
         "will be used to match the op, and the data value will be printed.\n"),
     llvm::cl::location(instrumentSignatures), llvm::cl::init("NONE"),
     llvm::cl::cat(OnnxMlirOptions));

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -118,6 +118,7 @@ extern std::string instrumentOps;                             // onnx-mlir only
 extern unsigned instrumentControlBits;                        // onnx-mlir only
 extern std::string parallelizeOps;                            // onnx-mlir only
 extern std::string instrumentSignatures;                      // onnx-mlir only
+extern std::string instrumentOnnxNode;                        // onnx-mlir only
 extern std::string ONNXOpStats;                               // onnx-mlir only
 extern int onnxOpTransformThreshold;                          // onnx-mlir only
 extern bool onnxOpTransformReport;                            // onnx-mlir only

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -172,9 +172,9 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // Print Signatures of each op at runtime if enabled. Should not run
   // signature and instrument passes at the same time as time may include printf
   // overheads.
-  if (instrumentSignatures != "NONE")
-    pm.addNestedPass<func::FuncOp>(
-        onnx_mlir::createInstrumentONNXSignaturePass(instrumentSignatures));
+  if (instrumentSignatures != "NONE" || instrumentOnnxNode != "NONE")
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXSignaturePass(
+        instrumentSignatures, instrumentOnnxNode));
 }
 
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -214,7 +214,7 @@ void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
 
 void addKrnlToAffinePasses(mlir::PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(
-      onnx_mlir::krnl::createConvertKrnlToAffinePass());
+      onnx_mlir::krnl::createConvertKrnlToAffinePass(enableParallel));
 }
 
 void addKrnlToLLVMPasses(

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -173,8 +173,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   // signature and instrument passes at the same time as time may include printf
   // overheads.
   if (instrumentSignatures != "NONE")
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXSignaturePass(
-        instrumentSignatures));
+    pm.addNestedPass<func::FuncOp>(
+        onnx_mlir::createInstrumentONNXSignaturePass(instrumentSignatures));
 }
 
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
@@ -325,8 +325,8 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
 
   if (emissionTarget >= EmitMLIR) {
     if (inputIRLevel <= ONNXLevel)
-      addONNXToKrnlPasses(pm, OptimizationLevel, /*enableCSE*/ true,
-          ONNXOpStats);
+      addONNXToKrnlPasses(
+          pm, OptimizationLevel, /*enableCSE*/ true, ONNXOpStats);
     if (inputIRLevel <= MLIRLevel)
       addKrnlToAffinePasses(pm);
   }

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -169,10 +169,16 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   if (instrumentStage == onnx_mlir::InstrumentStages::Onnx)
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::createInstrumentPass(instrumentOps, instrumentActions));
+  // Print Signatures of each op at runtime if enabled. Should not run
+  // signature and instrument passes at the same time as time may include printf
+  // overheads.
+  if (instrumentSignatures != "NONE")
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXSignaturePass(
+        instrumentSignatures));
 }
 
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
-    std::string instrumentSignatureString, std::string ONNXOpsStatFormat) {
+    std::string ONNXOpsStatFormat) {
   if (enableCSE)
     // Eliminate common sub-expressions before lowering to Krnl.
     // TODO: enable this by default when we make sure it works flawlessly.
@@ -196,12 +202,6 @@ void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
     }
   }
 
-  // Print Signatures of each op at runtime if enabled. Should not run
-  // signature and instrument passes at the same time as time may include printf
-  // overheads.
-  if (instrumentSignatureString != "NONE")
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createInstrumentONNXSignaturePass(
-        instrumentSignatureString));
   pm.addPass(onnx_mlir::createLowerToKrnlPass(/*enableTiling*/ optLevel >= 3,
       /*enableSIMD*/ optLevel >= 3 && !disableSimdOption, enableParallel,
       /*enableFastMath*/ optLevel >= 3 && enableFastMathOption,
@@ -214,7 +214,7 @@ void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
 
 void addKrnlToAffinePasses(mlir::PassManager &pm) {
   pm.addNestedPass<func::FuncOp>(
-      onnx_mlir::krnl::createConvertKrnlToAffinePass(enableParallel));
+      onnx_mlir::krnl::createConvertKrnlToAffinePass());
 }
 
 void addKrnlToLLVMPasses(
@@ -326,7 +326,7 @@ void addPasses(mlir::OwningOpRef<ModuleOp> &module, mlir::PassManager &pm,
   if (emissionTarget >= EmitMLIR) {
     if (inputIRLevel <= ONNXLevel)
       addONNXToKrnlPasses(pm, OptimizationLevel, /*enableCSE*/ true,
-          instrumentSignatures, ONNXOpStats);
+          ONNXOpStats);
     if (inputIRLevel <= MLIRLevel)
       addKrnlToAffinePasses(pm);
   }

--- a/src/Compiler/CompilerPasses.hpp
+++ b/src/Compiler/CompilerPasses.hpp
@@ -23,7 +23,7 @@ void configurePasses();
 void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     bool donotScrubDisposableElementsAttr = false);
 void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
-    std::string instrumentSignatureString, std::string ONNXOpsStatFilename);
+    std::string ONNXOpsStatFilename);
 void addKrnlToAffinePasses(mlir::PassManager &pm);
 void addKrnlToLLVMPasses(
     mlir::OpPassManager &pm, std::string outputNameNoExt, bool enableCSE);

--- a/src/Conversion/ONNXToKrnl/Tensor/PrintSignature.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/PrintSignature.cpp
@@ -52,20 +52,24 @@ struct ONNXPrintSignatureLowering
     }
     // Control how the tensor will be printed
     // Print the only the shape.
-    std::string printControl = "%e";
+    std::string printControl = ", %t%e";
     if (printSignatureOp.getPrintData() == 1) {
       // The data of tensor will be printed
-      printControl = "%d%e";
+      printControl = "%t%d\n";
+      msg += "\n";
     }
     Value lastVal = printVal.pop_back_val();
     // Print all but the last one.
     for (Value oper : printVal) {
-      create.krnl.printTensor(msg + ", %t" + printControl, oper);
+      create.krnl.printTensor(msg + printControl, oper);
       msg = "%i";
     }
     // Print the last one with replace with new op.
+    if (printSignatureOp.getPrintData() == 0) {
+      printControl = ", %t\n%e";
+    }
     rewriter.replaceOpWithNewOp<KrnlPrintTensorOp>(
-        op, msg + ", %t\n" + printControl, lastVal);
+        op, msg + printControl, lastVal);
     return success();
   }
 };

--- a/src/Conversion/ONNXToKrnl/Tensor/PrintSignature.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/PrintSignature.cpp
@@ -50,15 +50,22 @@ struct ONNXPrintSignatureLowering
           op, msg + "(no tensors)\n%e", noneVal);
       return success();
     }
+    // Control how the tensor will be printed
+    // Print the only the shape.
+    std::string printControl = "%e";
+    if (printSignatureOp.getPrintData() == 1) {
+      // The data of tensor will be printed
+      printControl = "%d";
+    }
     Value lastVal = printVal.pop_back_val();
     // Print all but the last one.
     for (Value oper : printVal) {
-      create.krnl.printTensor(msg + ", %t%e", oper);
+      create.krnl.printTensor(msg + ", %t" + printControl, oper);
       msg = "%i";
     }
     // Print the last one with replace with new op.
     rewriter.replaceOpWithNewOp<KrnlPrintTensorOp>(
-        op, msg + ", %t\n%e", lastVal);
+        op, msg + ", %t\n" + printControl, lastVal);
     return success();
   }
 };

--- a/src/Conversion/ONNXToKrnl/Tensor/PrintSignature.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/PrintSignature.cpp
@@ -55,7 +55,7 @@ struct ONNXPrintSignatureLowering
     std::string printControl = "%e";
     if (printSignatureOp.getPrintData() == 1) {
       // The data of tensor will be printed
-      printControl = "%d";
+      printControl = "%d%e";
     }
     Value lastVal = printVal.pop_back_val();
     // Print all but the last one.

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -322,15 +322,19 @@ def ONNXNoneOp : ONNX_Op<"NoValue", [ConstantLike, Pure]> {
 //===----------------------------------------------------------------------===//
 // ONNX PrintSignatureOp.
 def ONNXPrintSignatureOp:ONNX_Op<"PrintSignature", []> {
-  let summary = "ONNX Op to print type signature of its input operands";
+  let summary = "ONNX Op to print type signature or data of its input operands";
   let description = [{
-    Print type signature of the op's input operands. This operation is introduced early
-    so as to preserve the name of the original ONNX op.
+    Print type signature of the op's input operands.
+    The parameter op_name specifies a string to be printed with the output, and usually the op_name and onnx_node_name are used.
+    This operation is introduced early so as to preserve the name of the original ONNX op.
+    The argument print_data control whether signature of data of the tensors to be printed.
+    When print_data == 1, the data of the tensor will be printed. Otherwise, the shape of the tensor will be printed.
+    The argument input specifies all the tensor to be printed.
 
     This operation is not part of the standard and was added to assist onnx-mlir.
   }];
 
-  let arguments = (ins StrAttr:$op_name, Variadic<AnyTypeOf<[AnyTensor, NoneType]>>:$input);
+  let arguments = (ins StrAttr:$op_name, SI64Attr:$print_data, Variadic<AnyTypeOf<[AnyTensor, NoneType]>>:$input);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -324,12 +324,14 @@ def ONNXNoneOp : ONNX_Op<"NoValue", [ConstantLike, Pure]> {
 def ONNXPrintSignatureOp:ONNX_Op<"PrintSignature", []> {
   let summary = "ONNX Op to print type signature or data of its input operands";
   let description = [{
-    Print type signature of the op's input operands.
-    The parameter op_name specifies a string to be printed with the output, and usually the op_name and onnx_node_name are used.
+    Print type signature or data of the input operands of this op.
+    The parameter op_name specifies a string to be printed before the tensors.
+    and usually the op_name and onnx_node_name are used.
     This operation is introduced early so as to preserve the name of the original ONNX op.
-    The argument print_data control whether signature of data of the tensors to be printed.
-    When print_data == 1, the data of the tensor will be printed. Otherwise, the shape of the tensor will be printed.
-    The argument input specifies all the tensor to be printed.
+    The argument print_data control whether the data of the tensors to be printed.
+    When print_data == 1, the data of the tensor will be printed. Otherwise, just shape.
+    The argument input specifies the tensor to be printed. They could be a list
+    of the inputs and outputs of an ONNX op.
 
     This operation is not part of the standard and was added to assist onnx-mlir.
   }];

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -63,7 +63,7 @@ std::unique_ptr<mlir::Pass> createInstrumentCleanupPass();
 /// Passes for instrumenting the ONNX ops to print their operand type
 /// signatures at runtime.
 std::unique_ptr<mlir::Pass> createInstrumentONNXSignaturePass(
-    const std::string pattern);
+    const std::string opPattern, const std::string nodePattern);
 
 /// Pass for simplifying shape-related ONNX operations.
 std::unique_ptr<mlir::Pass> createSimplifyShapeRelatedOpsPass();

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -75,7 +75,7 @@ void registerOMPasses(int optLevel) {
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
-    return createInstrumentONNXSignaturePass("NONE");
+    return createInstrumentONNXSignaturePass("NONE", "NONE");
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {


### PR DESCRIPTION
Extend instrumentSignature to be a tool that can be used to print the data of a particular onnx op at runtime.
1. Change in the op selection. If the option instrumentSignature starts with "onnx_node_name:", only the rest of the string is used as regular expression pattern, and the attribute of "onnx_node_name", instead of op->getName(), is used to match. This change allows user to target a particular onnx op.
2. When the op is mapped with onnx_node_name, the data of the tensors will be printed. Therefore, one attribute is added to onnx.PrintSignature op.
3. Consequently, the lowering of PrintSignature op is modified.
4. Another change, which may not be needed, is that the instrumentSignature pass is moved from onnx to mlir group to onnx transformation group, right after the other onnx instrumentation. I feel it is better to put all the instrumentation passes for onnx are together. A side benefit is that we can easily check the instrumentation with "--EmitONNXIR".

Future work:
If we want to debug the crash inside the execution of an onnx op, there two changes are needed:
1. Move the print input before the onnx op.
2. The output should be easily used as input to run that op alone.