### PR TITLE
Make verifyInputTensor true by default

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -577,8 +577,8 @@ static llvm::cl::opt<bool, true> verifyInputTensorsOpt("verifyInputTensors",
     llvm::cl::desc(
         "Verify input tensors whenever the entry point function is called.\n"
         "Data type and shape are verified. Enable this may introduce overhead "
-        "at runtime."),
-    llvm::cl::location(verifyInputTensors), llvm::cl::init(false),
+        "at runtime. Default is true"),
+    llvm::cl::location(verifyInputTensors), llvm::cl::init(true),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> allowSortingOpt("allowSorting",


### PR DESCRIPTION
When the input to the model is not generated according to the model signature, the provided input may not match the signature and cause weird errors. Turning the check on by default will detect such errors. The overhead should be neglectable even for a toy model.  