### PR TITLE
Set coordinate_transformation_mode=asymmetric when rewriting Upsample to Reshape to get same output.

### DIFF
--- a/src/Dialect/ONNX/Transforms/Decompose.td
+++ b/src/Dialect/ONNX/Transforms/Decompose.td
@@ -239,7 +239,7 @@ def LogSoftmaxPattern
 def UpsamplePattern : Pat<
   (ONNXUpsampleOp $x, $scales, $mode),
   (ONNXResizeOp $x, (CreateNoneValue), $scales, (CreateNoneValue),
-     (GetNullIntegerAttr), (GetNullArrayAttr), (GetNullStringAttr),
+     (GetNullIntegerAttr), (GetNullArrayAttr), (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
      (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), (GetNullStringAttr),
      $mode, (GetNullFloatAttr))
 >;
@@ -248,7 +248,7 @@ def UpsampleV7Pattern : Pat<
   (ONNXUpsampleV7Op $x, $mode, $scales),
   (ONNXResizeOp $x, (CreateNoneValue),
      (ONNXConstantOpFromDenseAttr(createDenseArrayAttr $scales)),
-     (CreateNoneValue), (GetNullIntegerAttr), (GetNullArrayAttr), (GetNullStringAttr),
+     (CreateNoneValue), (GetNullIntegerAttr), (GetNullArrayAttr), (NativeCodeCall<"$_builder.getStringAttr(\"asymmetric\")">),
      (GetNullFloatAttr), (GetNullIntegerAttr), (GetNullFloatAttr), (GetNullStringAttr),
      $mode, (GetNullFloatAttr))
 >;

--- a/test/mlir/onnx/onnx_decompose.mlir
+++ b/test/mlir/onnx/onnx_decompose.mlir
@@ -304,7 +304,7 @@ func.func @test_upsample(%arg0: tensor<1x1x2x2xf32>, %arg1: tensor<4xf32>) -> te
   // CHECK-LABEL: test_upsample
   // CHECK: [[NONE_0:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK: [[NONE_1:%.+]] = "onnx.NoValue"() {value} : () -> none
-  // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], %arg1, [[NONE_1]]) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
+  // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], %arg1, [[NONE_1]]) {antialias = 0 : si64, coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
   // CHECK: onnx.Return [[RES]] : tensor<1x1x4x6xf32>
 }
 
@@ -317,7 +317,7 @@ func.func @test_upsamplev7(%arg0: tensor<1x1x2x2xf32>) -> tensor<1x1x4x6xf32> {
   // CHECK: [[NONE_0:%.+]] = "onnx.NoValue"() {value} : () -> none
   // CHECK: [[SCALES:%.+]] = onnx.Constant dense<[1.000000e-01, 2.000000e-01, 3.000000e-01, 4.000000e-01]> : tensor<4xf32>
   // CHECK: [[NONE_1:%.+]] = "onnx.NoValue"() {value} : () -> none
-  // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], [[SCALES]], [[NONE_1]]) {antialias = 0 : si64, coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
+  // CHECK: [[RES:%.+]] = "onnx.Resize"(%arg0, [[NONE_0]], [[SCALES]], [[NONE_1]]) {antialias = 0 : si64, coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, keep_aspect_ratio_policy = "stretch", mode = "nearest", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x2xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x6xf32>
   // CHECK: onnx.Return [[RES]] : tensor<1x1x4x6xf32>
 }
 


### PR DESCRIPTION
Edit: Need to investigate why onnx-runtime and the backend tests have different results

Before the rewrite would rewrite to an reshape with the default `coordinate_transformation_mode = "half_pixel"`, but this leads to a different output when comparing with onnx runtime. 
 Tested using onnx runtime, with one model having a Reshape Op and one an Upsample. With  `coordinate_transformation_mode = "half_pixel"` the output had some differences, with `coordinate_transformation_mode = "asymmetric"` the output was the same.
 Comment in ORT about this: https://github.com/microsoft/onnxruntime/issues/1179#issuecomment-522197229
 
 IMO the onnx documentation for [Upsample](https://onnx.ai/onnx/operators/onnx__Upsample.html) is not very detailed and its hard to know how to do the Upsample -> Reshape rewrite when just looking at the documentation.
