### PR TITLE
Including __errno_location call for MVS

### DIFF
--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -48,9 +48,9 @@
 #include "src/Support/SmallFPConversion.h"
 #endif
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__MVS__)
 // __errno_location() is called from krnl::emitErrNo() to set errno in
-// generated llvm IR, but it somehow doesn't come out of the box on MacOS.
+// generated llvm IR, but it somehow doesn't come out of the box on MacOS or MVS.
 int *__attribute__((__weak__)) __errno_location(void) { return &errno; }
 #endif
 


### PR DESCRIPTION
Fixing errors when creating `libcruntime.a` on z/OS when the model includes constants.bin file.

 
```
IEW2456E 9207 SYMBOL __errno_location UNRESOLVED.  MEMBER COULD NOT BE INCLUDED
          FROM THE DESIGNATED CALL LIBRARY.
 IEW2665S 40FF MODULE *NULL*  IS NON-EXECUTABLE AND WAS NOT SAVED BECAUSE
          STORENX=NEVER.
```