### PR TITLE
removing weak attribute of errorno

### DIFF
--- a/src/Runtime/OMTensor.inc
+++ b/src/Runtime/OMTensor.inc
@@ -51,7 +51,7 @@
 #if defined(__APPLE__) || defined(__MVS__)
 // __errno_location() is called from krnl::emitErrNo() to set errno in
 // generated llvm IR, but it somehow doesn't come out of the box on MacOS or MVS.
-int *__attribute__((__weak__)) __errno_location(void) { return &errno; }
+int *__errno_location(void) { return &errno; }
 #endif
 
 #ifdef ENABLE_PYRUNTIME_LIGHT


### PR DESCRIPTION
When creating libcruntim.a on z/OS compiling with the latest version of xlc leads to this warning. 

```
xlc -I ../.. -I ../../include -q64 -Wc,DLL,EXPORTALL -qlanglvl=extc99 -D_XOPEN_SOURCE=600 -c -o OMTensor.o OMTensor.c

WARNING CCN3943 ./OMTensor.inc:54    Attribute "__weak__" is not supported on the target platform and is ignored.
INFORMATIONAL CCN4108 ./OMTensor.inc:54    The use of keyword '__attribute__' is non-portable.
```