### PR TITLE
fix CVE-2025-32434

### DIFF
--- a/docs/mnist_example/requirements.txt
+++ b/docs/mnist_example/requirements.txt
@@ -1,4 +1,4 @@
 numpy~=1.22.2
 pillow~=10.3.0
-torch~=2.5.0
+torch~=2.6.0
 torchvision~=0.20.0


### PR DESCRIPTION
Fix the MNIST-example requirements.txt https://nvd.nist.gov/vuln/detail/CVE-2025-32434 