### PR TITLE
Do not fuse locations in Maxpool-Relu canonicalization

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -707,7 +707,7 @@ def ReorderReluMaxPoolPattern : Pattern<
       $X,
       $auto_pad, $ceil_mode, $dilations, $kernel_shape,
       $pads, $storage_order, $strides,
-      (returnType (GetReturnTypeForMaxPool2D $X))))],
+      (returnType (GetReturnTypeForMaxPool2D $X)), (location $maxpool)), (location $relu))],
   [
     (HasRankOf<4> $X),
     (IsStaticShapeTensor:$maxpool),

--- a/test/mlir/onnx/onnx_canonicalization_locations.mlir
+++ b/test/mlir/onnx/onnx_canonicalization_locations.mlir
@@ -1,0 +1,15 @@
+// RUN: onnx-mlir-opt --shape-inference --canonicalize="test-convergence=true" --shape-inference --cse %s -split-input-file --mlir-print-debuginfo | FileCheck %s
+
+
+func.func @test_reorder_relu_maxpool(%arg0: tensor<1x64x32x32xf32>) -> tensor<1x64x16x16xf32> {
+  %0 = "onnx.Relu"(%arg0) : (tensor<1x64x32x32xf32>) -> tensor<1x64x32x32xf32> loc("Relu")
+  %1 = "onnx.MaxPoolSingleOut"(%0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [2, 2], onnx_node_name = "onnx.MaxPoolSingleOut_1", storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x64x32x32xf32>) -> tensor<1x64x16x16xf32> loc("MaxPool")
+  return %1 : tensor<1x64x16x16xf32>
+
+  // CHECK-LABEL: func @test_reorder_relu_maxpool
+  // CHECK:           [[VAR_0_:%.+]] = "onnx.MaxPoolSingleOut"(%arg0) {auto_pad = "NOTSET", ceil_mode = 0 : si64, kernel_shape = [2, 2], storage_order = 0 : si64, strides = [2, 2]} : (tensor<1x64x32x32xf32>) -> tensor<1x64x16x16xf32> loc([[LOC_MAX_POOL:#.+]])
+  // CHECK:           [[VAR_1_:%.+]] = "onnx.Relu"([[VAR_0_]]) : (tensor<1x64x16x16xf32>) -> tensor<1x64x16x16xf32> loc([[LOC_RELU:#.+]])
+  // CHECK-DAG:       [[LOC_MAX_POOL:#.+]] = loc("MaxPool")
+  // CHECK-DAG:       [[LOC_RELU:#.+]] = loc("Relu")
+}
+


### PR DESCRIPTION
As both operations still do their original functionality and did not get merged together, I think not fusing their locations is correct in this case.

I created a new test file for the location test, as `--mlir-print-debuginfo` makes it more difficult to write LIT tests and I do not want to impact the main canonicalization LIT test by enabling this option