### PR TITLE
Support for arch native on mac

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -926,6 +926,10 @@ std::string getTargetArchOption(bool forLLVMToolchain) {
     int64_t zArchNum = getZArchNum(march, mcpu);
     if (zArchNum != -1)
       return "--march=systemz";
+    // On mac, llc --version seem to want aarch64 or arm64.
+    if (march == "apple-m1" || march == "apple-m2" || march == "apple-m3" ||
+        march == "apple-m4")
+      return "--march=arm64";
   }
   return (march != "") ? "--march=" + march : "";
 }
@@ -1413,11 +1417,16 @@ void initCompilerConfig() {
     setLLVMOption(getLLVMOption() + " --enable-unsafe-fp-math");
   }
 
+#if 0
   if (march == "z17")
     march = "arch15";
+#endif
 
-  if (march == "native")
+  if (march == "native") {
     march = std::string(llvm::sys::getHostCPUName());
+    if (VerboseOutput)
+      llvm::outs() << "Native machine set as \"" << march << "\"\n";
+  }
 }
 
 } // namespace onnx_mlir

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -1417,11 +1417,6 @@ void initCompilerConfig() {
     setLLVMOption(getLLVMOption() + " --enable-unsafe-fp-math");
   }
 
-#if 0
-  if (march == "z17")
-    march = "arch15";
-#endif
-
   if (march == "native") {
     march = std::string(llvm::sys::getHostCPUName());
     if (VerboseOutput)

--- a/src/Dialect/Mlir/VectorMachineSupport.cpp
+++ b/src/Dialect/Mlir/VectorMachineSupport.cpp
@@ -48,8 +48,10 @@ namespace onnx_mlir {
     else
       // Default seems to be SSE
       globalVectorMachineSupport = new SSE42x86VectorMachineSupport();
-    // Arm uses arch
-  } else if (arch.compare("aarch64") == 0 || arch.compare("arm64") == 0) {
+    // Arm uses arch, and arch=native returns apple-mXXX.
+  } else if (arch.compare("aarch64") == 0 || arch.compare("arm64") == 0 ||
+             arch.compare("apple-m1") == 0 || arch.compare("apple-m2") == 0 ||
+             arch.compare("apple-m3") == 0 || arch.compare("apple-m4") == 0) {
     // Arm arch
     globalVectorMachineSupport = new NeonVectorMachineSupport();
   } else {


### PR DESCRIPTION
The -march=native results in a `apple-m1` arch (or derivatives) on Macs, which is not recognized by the `onnx-mlir` simd code generator as well as `llc`.

Add here the code to handle this properly. Also added a print of the native machine being detected under the verbose flag `-v` so that we may discover what machine is actually compiled for.