### PR TITLE
Add Lowering of ThresholdedRelu op from ONNX to Krnl Dialect

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -209,7 +209,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **Tan** |7 - * | | |
 | **Tanh** |6 - * | | |
 | **TfIdfVectorizer** |none | | | |
-| **ThresholdedRelu** |none | | | |
+| **ThresholdedRelu** |10 - * | | | |
 | **Tile** |6 - * | | |
 | **TopK** |10 - * |`K`, the number of top elements to retrieve, must have static shape. | |
 | **Transpose** |6 - * |Does not support int4 and uint4. | |

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -3184,6 +3184,23 @@ def get_test_models():
             DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
+        # ==OP== ThresholdedRelu
+        # ==MIN== 10
+        "test_thresholdedrelu_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
+        "test_thresholdedrelu_default_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
+        "test_thresholdedrelu_example_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
         # ==OP== Tile
         # ==MIN== 6
         "test_tile_cpu": {

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
@@ -1884,6 +1884,49 @@ func.func private @test_selu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 
 // -----
 
+func.func private @test_thresholdedrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
+  %0 = "onnx.ThresholdedRelu"(%arg0) {alpha=1.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<()[s0] -> (s0 * 40 + 128)>
+// CHECK-DAG:   [[MAP_1_:#.+]] = affine_map<()[s0] -> (s0 * 10)>
+// CHECK-DAG:   [[MAP_2_:#.+]] = affine_map<()[s0, s1, s2] -> (s2)>
+// CHECK-LABEL:  func.func private @test_thresholdedrelu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x10xf32>) -> memref<?x10xf32> {
+// CHECK-DAG:       [[CST_VEC_1_:%.+]] = arith.constant dense<1.000000e+00> : vector<32xf32>
+// CHECK-DAG:       [[CST_VEC_0_:%.+]] = arith.constant dense<0.000000e+00> : vector<32xf32>
+// CHECK:           [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK:           [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x10xf32>
+// CHECK:           [[VAR_0_:%.+]] = affine.apply [[MAP_0_]](){{.*}}[[VAR_dim_]]{{.*}}
+// CHECK:           [[RES_:%.+]] = memref.alloc([[VAR_0_]]) {{.*}}: memref<?xi8>
+// CHECK-DAG:       [[VAR_view_:%.+]] = memref.view [[RES_]]{{.*}}[[CST_0_]]{{.*}}[[VAR_dim_]]{{.*}} : memref<?xi8> to memref<?x10xf32>
+// CHECK-DAG:       [[VAR_dim_1_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x10xf32>
+// CHECK:           [[VAR_1_:%.+]] = affine.apply [[MAP_1_]](){{.*}}[[VAR_dim_1_]]{{.*}}
+// CHECK:           [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
+// CHECK:           affine.store [[VAR_1_]], [[RES_1_]][0] : memref<1xindex>
+// CHECK:           [[VAR_reshape_:%.+]] = memref.reshape [[PARAM_0_]]([[RES_1_]]) : (memref<?x10xf32>, memref<1xindex>) -> memref<?xf32>
+// CHECK:           [[VAR_2_:%.+]] = affine.apply [[MAP_1_]](){{.*}}[[VAR_dim_]]{{.*}}
+// CHECK:           [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
+// CHECK:           affine.store [[VAR_2_]], [[RES_2_]][0] : memref<1xindex>
+// CHECK:           [[VAR_reshape_4_:%.+]] = memref.reshape [[VAR_view_]]([[RES_2_]]) : (memref<?x10xf32>, memref<1xindex>) -> memref<?xf32>
+// CHECK:           krnl.iterate() with (){
+// CHECK:             [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:             [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+// CHECK:             krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to [[MAP_2_]](){{.*}}[[VAR_dim_]], [[VAR_dim_1_]], [[VAR_2_]]{{.*}}){
+// CHECK:               [[VAR_4_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
+// CHECK:               [[VAR_load_:%.+]] = vector.load [[VAR_reshape_]]{{.*}}[[VAR_4_]]{{.*}} : memref<?xf32>, vector<32xf32>
+// CHECK:               [[VAR_cmp_:%.+]] = arith.cmpf ogt, [[VAR_load_]], [[CST_VEC_1_]] : vector<32xf32>
+// CHECK:               [[VAR_sel_:%.+]] = arith.select [[VAR_cmp_]], [[VAR_load_]], [[CST_VEC_0_]] : vector<32xi1>, vector<32xf32>
+// CHECK:               vector.store [[VAR_sel_]], [[VAR_reshape_4_]]{{.*}}[[VAR_4_]]{{.*}} : memref<?xf32>, vector<32xf32>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return [[VAR_view_]] : memref<?x10xf32>
+// CHECK:         }
+}
+
+// -----
+
 
 func.func private @test_hardsigmoid(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.HardSigmoid"(%arg0) {alpha=1.0:f32, beta=2.0:f32} : (tensor<?x10xf32>) -> tensor<*xf32>


### PR DESCRIPTION
This pull request implements the lowering of the `ThresholdedRelu` op from the ONNX dialect to the Krnl dialect, and add tests to validate it, addressing Issue #3151.

This PR is ready for review. Please let me know if there are any additional improvements or adjustments needed.

Closes #3151.
