### PR TITLE
added support for bitwise_not op

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -32,7 +32,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **Binarizer** |none | | | |
 | **BitShift** |none | | | |
 | **BitwiseAnd** |18 - * | | |
-| **BitwiseNot** |none | | | |
+| **BitwiseNot** |18 - * | | | 
 | **BitwiseOr** |18 - * | | |
 | **BitwiseXor** |18 - * | | |
 | **BlackmanWindow** |none | | | |

--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -32,7 +32,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **Binarizer** |none | | | |
 | **BitShift** |none | | | |
 | **BitwiseAnd** |18 - * | | |
-| **BitwiseNot** |18 - * | Does not support uint16 and uint8 | | 
+| **BitwiseNot** |18 - * | Only supports signed integers | | 
 | **BitwiseOr** |18 - * | | |
 | **BitwiseXor** |18 - * | | |
 | **BlackmanWindow** |none | | | |

--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -32,7 +32,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **Binarizer** |none | | | |
 | **BitShift** |none | | | |
 | **BitwiseAnd** |18 - * | | |
-| **BitwiseNot** |18 - * | | | 
+| **BitwiseNot** |18 - * | Does not support uint16 and uint8 | | 
 | **BitwiseOr** |18 - * | | |
 | **BitwiseXor** |18 - * | | |
 | **BlackmanWindow** |none | | | |

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -813,6 +813,11 @@ struct ScalarOp<ONNXBitwiseNotOp> {
 };
 
 template <>
+GenOpMix getGenOpMix<ONNXBitwiseNotOp>(Type t, Operation *op) {
+  return {{GenericOps::ArithmeticGop, 1}};
+}
+
+template <>
 Value emitScalarOpFor<ONNXBitwiseNotOp>(ConversionPatternRewriter &rewriter,
     Location loc, Operation *op, Type elementType,
     ArrayRef<Value> scalarOperands) {

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -821,7 +821,7 @@ Value emitScalarOpFor<ONNXBitwiseNotOp>(ConversionPatternRewriter &rewriter,
   Value operand = scalarOperands[0];
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
   // NOT(x) = XOR(x,-1)
-  Value one = create.math.constant(elementType,-1);
+  Value one = create.math.constant(elementType, -1);
   return create.math.xori(operand, one);
 }
 

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -797,7 +797,6 @@ Value emitScalarOpFor<ONNXCeluOp>(ConversionPatternRewriter &rewriter,
   Value expMinusOne = create.math.sub(expVal, one);
   Value scaled = create.math.mul(alpha, expMinusOne);
 
-
   // Combine parts: positivePart + min(0, scaled)
   Value negativePart = create.math.min(zero, scaled);
   return create.math.add(positivePart, negativePart);
@@ -814,12 +813,6 @@ struct ScalarOp<ONNXBitwiseNotOp> {
 };
 
 template <>
-GenOpMix getGenOpMix<ONNXBitwiseNotOp>(Type t, Operation *op) {
-  return {{GenericOps::ArithmeticGop, 1},
-      {GenericOps::MulGop, 1}};
-}
-
-template <>
 Value emitScalarOpFor<ONNXBitwiseNotOp>(ConversionPatternRewriter &rewriter,
     Location loc, Operation *op, Type elementType,
     ArrayRef<Value> scalarOperands) {
@@ -827,9 +820,9 @@ Value emitScalarOpFor<ONNXBitwiseNotOp>(ConversionPatternRewriter &rewriter,
   CheckIfCustomScalarOpIsSupported<ONNXBitwiseNotOp>(elementType);
   Value operand = scalarOperands[0];
   MultiDialectBuilder<MathBuilder> create(rewriter, loc);
-  Value ones = create.math.constant(elementType, -1);
-  auto alpha = create.math.mul(ones, operand);
-  return create.math.sub(operand,alpha);
+  // NOT(x) = XOR(x,-1)
+  Value one = create.math.constant(elementType,-1);
+  return create.math.xori(operand, one);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1837,10 +1830,10 @@ bool OpFusionHelper::checkFusibleOp(Operation *useOp, Operation *defOp,
       mlir::ONNXCosOp, mlir::ONNXCoshOp, mlir::ONNXDequantizeLinearOp,
       mlir::ONNXCeluOp, mlir::ONNXEluOp, mlir::ONNXErfOp, mlir::ONNXAcosOp,
       mlir::ONNXAcoshOp, mlir::ONNXAsinOp, mlir::ONNXAsinhOp, mlir::ONNXAtanhOp,
-      mlir::ONNXExpOp, mlir::ONNXFloorOp, mlir::ONNXGeluOp,mlir::ONNXBitwiseNotOp,
-      mlir::ONNXHardSigmoidOp, mlir::ONNXHardSwishOp, mlir::ONNXIsInfOp,
-      mlir::ONNXIsNaNOp, mlir::ONNXLeakyReluOp, mlir::ONNXLogOp,
-      mlir::ONNXNegOp, mlir::ONNXNotOp, mlir::ONNXReciprocalOp,
+      mlir::ONNXExpOp, mlir::ONNXFloorOp, mlir::ONNXGeluOp,
+      mlir::ONNXBitwiseNotOp, mlir::ONNXHardSigmoidOp, mlir::ONNXHardSwishOp,
+      mlir::ONNXIsInfOp, mlir::ONNXIsNaNOp, mlir::ONNXLeakyReluOp,
+      mlir::ONNXLogOp, mlir::ONNXNegOp, mlir::ONNXNotOp, mlir::ONNXReciprocalOp,
       mlir::ONNXReluOp, mlir::ONNXRoundOp, mlir::ONNXSeluOp,
       mlir::ONNXSigmoidOp, mlir::ONNXSignOp, mlir::ONNXSinOp, mlir::ONNXSinhOp,
       mlir::ONNXSoftplusOp, mlir::ONNXSoftsignOp, mlir::ONNXSqrtOp,

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -396,12 +396,7 @@ def get_test_models():
         },
         # ==OP== BitwiseNot
         # ==MIN== 18
-        "test_bitwise_not_i32_2d_cpu": {
-            STATIC_SHAPE: {},
-            DYNAMIC_SHAPE: {-1: {-1}},
-            CONSTANT_INPUT: {-1},
-        },
-        "test_bitwise_not_i16_3d_cpu": {
+        "test_bitwise_not_2d_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -394,6 +394,18 @@ def get_test_models():
             DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
+        # ==OP== BitwiseNot
+        # ==MIN== 18
+        "test_bitwise_not_i32_2d_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
+        "test_bitwise_not_i16_3d_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
         # ==OP== Cast
         # ==MIN== 6
         # ==LIM== Cast only between float and double types. Only ppc64le and MacOS platforms support float16. Does not support int4 and uint4.

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -1186,17 +1186,15 @@ func.func private @test_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 func.func private @test_bitwise_not(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
   %0 = "onnx.BitwiseNot"(%arg0) : (tensor<2x3xi32>) -> tensor<*xi32>
   "func.return"(%0) : (tensor<*xi32>) -> ()
-// mlir2FileCheck.py
-// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func private @test_bitwise_not
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3xi32>) -> memref<2x3xi32> {
-// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x3xi32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3){
 // CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
-// CHECK:             [[VAR_3_:%.+]] = arith.xori [[LOAD_PARAM_0_MEM_]], [[CST_1_]] : i32
+// CHECK:             [[VAR_3_:%.+]] = arith.xori [[LOAD_PARAM_0_MEM_]], [[CST_minus_1_]] : i32
 // CHECK:             krnl.store [[VAR_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<2x3xi32>

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -1183,21 +1183,21 @@ func.func private @test_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 }
 
 // -----
-func.func private @test_bitwise_not(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
-  %0 = "onnx.BitwiseNot"(%arg0) : (tensor<2x3xi32>) -> tensor<*xi32>
+func.func private @test_bitwise_not(%arg0 : tensor<128x512xi32>) -> tensor<*xi32> {
+  %0 = "onnx.BitwiseNot"(%arg0) : (tensor<128x512xi32>) -> tensor<*xi32>
   "func.return"(%0) : (tensor<*xi32>) -> ()
 // CHECK-LABEL:  func.func private @test_bitwise_not
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3xi32>) -> memref<2x3xi32> {
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<128x512xi32>) -> memref<128x512xi32> {
 // CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
-// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x3xi32>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<128x512xi32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3){
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 128, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 512){
 // CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<128x512xi32>
 // CHECK:             [[VAR_3_:%.+]] = arith.xori [[LOAD_PARAM_0_MEM_]], [[CST_minus_1_]] : i32
-// CHECK:             krnl.store [[VAR_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
+// CHECK:             krnl.store [[VAR_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<128x512xi32>
 // CHECK:           }
-// CHECK:           return [[RES_]] : memref<2x3xi32>
+// CHECK:           return [[RES_]] : memref<128x512xi32>
 // CHECK:         }
 }
 // -----

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -1190,15 +1190,14 @@ func.func private @test_bitwise_not(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
 // CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:  func.func private @test_bitwise_not
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3xi32>) -> memref<2x3xi32> {
-// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant -1 : i32
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x3xi32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3){
 // CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
 // CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
-// CHECK:             [[VAR_3_:%.+]] = arith.muli [[LOAD_PARAM_0_MEM_]], [[CST_minus_1_]] : i32
-// CHECK:             [[VAR_4_:%.+]] = arith.subi [[LOAD_PARAM_0_MEM_]], [[VAR_3_]] : i32
-// CHECK:             krnl.store [[VAR_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
+// CHECK:             [[VAR_3_:%.+]] = arith.xori [[LOAD_PARAM_0_MEM_]], [[CST_1_]] : i32
+// CHECK:             krnl.store [[VAR_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
 // CHECK:           }
 // CHECK:           return [[RES_]] : memref<2x3xi32>
 // CHECK:         }

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -1183,6 +1183,27 @@ func.func private @test_leakyrelu(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 }
 
 // -----
+func.func private @test_bitwise_not(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
+  %0 = "onnx.BitwiseNot"(%arg0) : (tensor<2x3xi32>) -> tensor<*xi32>
+  "func.return"(%0) : (tensor<*xi32>) -> ()
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func private @test_bitwise_not
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3xi32>) -> memref<2x3xi32> {
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x3xi32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3){
+// CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
+// CHECK:             [[VAR_3_:%.+]] = arith.muli [[LOAD_PARAM_0_MEM_]], [[CST_minus_1_]] : i32
+// CHECK:             [[VAR_4_:%.+]] = arith.subi [[LOAD_PARAM_0_MEM_]], [[VAR_3_]] : i32
+// CHECK:             krnl.store [[VAR_4_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
+// CHECK:           }
+// CHECK:           return [[RES_]] : memref<2x3xi32>
+// CHECK:         }
+}
+// -----
 
 func.func private @test_celu(%arg0 : tensor<?x3x224x224xf32>) -> tensor<?x3x224x224xf32> {
   %0 = "onnx.Celu"(%arg0) {alpha = 1.000000e+00 : f32} : (tensor<?x3x224x224xf32>) -> tensor<?x3x224x224xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
@@ -1721,29 +1721,16 @@ func.func private @test_bitwise_not(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
   
 // CHECK-LABEL:  func.func private @test_bitwise_not
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3xi32>) -> memref<2x3xi32> {
-// CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<-1> : vector<8xi32>
-// CHECK-DAG:       [[CST_6_:%.+]] = arith.constant 6 : index
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
-// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<32xi8>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_view_:%.+]] = memref.view [[RES_]]{{.}}[[CST_0_]]{{.}}[] : memref<32xi8> to memref<2x3xi32>
-// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
-// CHECK:           affine.store [[CST_6_]], [[RES_1_]][0] : memref<1xindex>
-// CHECK-DAG:       [[VAR_reshape_:%.+]] = memref.reshape [[PARAM_0_]]([[RES_1_]]) : (memref<2x3xi32>, memref<1xindex>) -> memref<6xi32>
-// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
-// CHECK:           affine.store [[CST_6_]], [[RES_2_]][0] : memref<1xindex>
-// CHECK:           [[VAR_reshape_2_:%.+]] = memref.reshape [[VAR_view_]]([[RES_2_]]) : (memref<2x3xi32>, memref<1xindex>) -> memref<6xi32>
-// CHECK:           krnl.iterate() with (){
-// CHECK:             [[LOOP_0_:%.+]] = krnl.define_loops 1
-// CHECK:             [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 8 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
-// CHECK:             krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 6){
-// CHECK:               [[VAR_1_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
-// CHECK:               [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_1_]]{{.}} : memref<6xi32>, vector<8xi32>
-// CHECK:               [[VAR_3_:%.+]] = arith.xori [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<8xi32>
-// CHECK:               vector.store [[VAR_3_]], [[VAR_reshape_2_]]{{.}}[[VAR_1_]]{{.}} : memref<6xi32>, vector<8xi32>
-// CHECK:             }
+// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x3xi32>
+// CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3){
+// CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
+// CHECK:             [[VAR_3_:%.+]] = arith.xori [[LOAD_PARAM_0_MEM_]], [[CST_minus_1_]] : i32
+// CHECK:             krnl.store [[VAR_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
 // CHECK:           }
-// CHECK:           return [[VAR_view_]] : memref<2x3xi32>
+// CHECK:           return [[RES_]] : memref<2x3xi32>
 // CHECK:         }
 }
 

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
@@ -1715,22 +1715,32 @@ func.func private @test_celu(%arg0 : tensor<?x3x224x224xf32>) -> tensor<?x3x224x
 }
 // -----
 
-func.func private @test_bitwise_not(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
-  %0 = "onnx.BitwiseNot"(%arg0) : (tensor<2x3xi32>) -> tensor<*xi32>
+func.func private @test_bitwise_not(%arg0 : tensor<128x512xi32>) -> tensor<*xi32> {
+  %0 = "onnx.BitwiseNot"(%arg0) : (tensor<128x512xi32>) -> tensor<*xi32>
   "func.return"(%0) : (tensor<*xi32>) -> ()
   
 // CHECK-LABEL:  func.func private @test_bitwise_not
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x3xi32>) -> memref<2x3xi32> {
-// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
-// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<2x3xi32>
-// CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
-// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 3){
-// CHECK:             [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
-// CHECK:             [[VAR_3_:%.+]] = arith.xori [[LOAD_PARAM_0_MEM_]], [[CST_minus_1_]] : i32
-// CHECK:             krnl.store [[VAR_3_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<2x3xi32>
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<128x512xi32>) -> memref<128x512xi32> {
+// CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<-1> : vector<32xi32>
+// CHECK-DAG:       [[CST_65536_:%.+]] = arith.constant 65536 : index
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<128x512xi32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
+// CHECK:           affine.store [[CST_65536_]], [[RES_1_]][0] : memref<1xindex>
+// CHECK-DAG:       [[VAR_reshape_:%.+]] = memref.reshape [[PARAM_0_]]([[RES_1_]]) : (memref<128x512xi32>, memref<1xindex>) -> memref<65536xi32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1xindex>
+// CHECK:           affine.store [[CST_65536_]], [[RES_2_]][0] : memref<1xindex>
+// CHECK:           [[VAR_reshape_2_:%.+]] = memref.reshape [[RES_]]([[RES_]]_1) : (memref<128x512xi32>, memref<1xindex>) -> memref<65536xi32>
+// CHECK:           krnl.iterate() with (){
+// CHECK:             [[LOOP_0_:%.+]] = krnl.define_loops 1
+// CHECK:             [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+// CHECK:             krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 65536){
+// CHECK:               [[VAR_1_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
+// CHECK:               [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_1_]]{{.}} : memref<65536xi32>, vector<32xi32>
+// CHECK:               [[VAR_3_:%.+]] = arith.xori [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<32xi32>
+// CHECK:               vector.store [[VAR_3_]], [[VAR_reshape_2_]]{{.}}[[VAR_1_]]{{.}} : memref<65536xi32>, vector<32xi32>
+// CHECK:             }
 // CHECK:           }
-// CHECK:           return [[RES_]] : memref<2x3xi32>
+// CHECK:           return [[RES_]] : memref<128x512xi32>
 // CHECK:         }
 }
 

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir-opt -O3 --mtriple=s390x-ibm-loz --march=z16 --shape-inference --convert-onnx-to-krnl %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt -O3 --mtriple=s390x-ibm-loz --march=z16 --shape-inference --convert-onnx-to-krnl --canonicalize %s -split-input-file | FileCheck %s
 
 // use --mtriple=s390x-ibm-loz --march=z16 to enable SIMD as we now need a machine
 // can also use --march=x86-64 instead.
@@ -1739,14 +1739,12 @@ func.func private @test_bitwise_not(%arg0 : tensor<2x3xi32>) -> tensor<*xi32> {
 // CHECK:             krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 6){
 // CHECK:               [[VAR_1_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
 // CHECK:               [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_1_]]{{.}} : memref<6xi32>, vector<8xi32>
-// CHECK:               [[VAR_3_:%.+]] = arith.muli [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<8xi32>
-// CHECK:               [[VAR_4_:%.+]] = arith.subi [[LOAD_VAR_reshape_MEM_]], [[VAR_3_]] : vector<8xi32>
-// CHECK:               vector.store [[VAR_4_]], [[VAR_reshape_2_]]{{.}}[[VAR_1_]]{{.}} : memref<6xi32>, vector<8xi32>
+// CHECK:               [[VAR_3_:%.+]] = arith.xori [[LOAD_VAR_reshape_MEM_]], [[VAR_cst_]] : vector<8xi32>
+// CHECK:               vector.store [[VAR_3_]], [[VAR_reshape_2_]]{{.}}[[VAR_1_]]{{.}} : memref<6xi32>, vector<8xi32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           return [[VAR_view_]] : memref<2x3xi32>
 // CHECK:         }
-  
 }
 
 // -----


### PR DESCRIPTION
Added support for the BitwiseNot operation in the ONNX to Krnl lowering path. Also included corresponding test cases in Elementwise_with_canonicalize.mlir and Elementwise_with_canonicalize_O3.mlir. This implementation addresses and 
closes https://github.com/onnx/onnx-mlir/issues/3155

