### PR TITLE
Fix messages about setting ONNX_MLIR_HOME

### DIFF
--- a/src/Runtime/python/onnxmlirdocker.py
+++ b/src/Runtime/python/onnxmlirdocker.py
@@ -225,8 +225,8 @@ class InferenceSession:
                 from PyRuntime import OMExecutionSession
             except ImportError:
                 raise ImportError(
-                    "Looks like you did not build the PyRuntime target, build it by running `make PyRuntime`."
-                    "You may need to set ONNX_MLIR_HOME to `onnx-mlir/build/Debug` since `make PyRuntime` outputs to `build/Debug` by default"
+                    "Looks like you did not build the PyRuntimeC target, build it by running `make PyRuntimeC`."
+                    "You may need to set ONNX_MLIR_HOME to `onnx-mlir/build/Debug` since `make PyRuntimeC` outputs to `build/Debug` by default"
                 )
 
         return OMExecutionSession(self.compiled_model, self.compile_tag)

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -55,9 +55,9 @@ try:
     from PyRuntime import OMExecutionSession
 except ImportError:
     raise ImportError(
-        "Looks like you did not build the PyRuntime target, build it by running"
-        " `make PyRuntime`. You may need to set ONNX_MLIR_HOME to"
-        " `onnx-mlir/build/Debug` since `make PyRuntime` outputs to"
+        "Looks like you did not build the PyRuntimeC target, build it by running"
+        " `make PyRuntimeC`. You may need to set ONNX_MLIR_HOME to"
+        " `onnx-mlir/build/Debug` since `make PyRuntimeC` outputs to"
         " `build/Debug` by default."
     )
 

--- a/utils/onnxmlirrun.py
+++ b/utils/onnxmlirrun.py
@@ -82,7 +82,7 @@ class InferenceSession:
             from PyRuntime import OMExecutionSession
         except ImportError:
             raise ImportError(
-                "Looks like you did not build the PyRuntime target, build it by running `make PyRuntime`.You may need to set ONNX_MLIR_HOME to `onnx-mlir/build/Debug` since `make PyRuntime` outputs to `build/Debug` by default"
+                "Looks like you did not build the PyRuntimeC target, build it by running `make PyRuntimeC`.You may need to set ONNX_MLIR_HOME to `onnx-mlir/build/Debug` since `make PyRuntimeC` outputs to `build/Debug` by default"
             )
         # Initialize status
         self.compiled = False
@@ -121,7 +121,7 @@ class InferenceSession:
             from PyRuntime import OMExecutionSession
         except ImportError:
             raise ImportError(
-                "Looks like you did not build the PyRuntime target, build it by running `make PyRuntime`.You may need to set ONNX_MLIR_HOME to `onnx-mlir/build/Debug` since `make PyRuntime` outputs to `build/Debug` by default"
+                "Looks like you did not build the PyRuntimeC target, build it by running `make PyRuntimeC`.You may need to set ONNX_MLIR_HOME to `onnx-mlir/build/Debug` since `make PyRuntimeC` outputs to `build/Debug` by default"
             )
 
         # Use the generated shared library to create an execution session.

--- a/utils/python/transformers/run_gpt2_from_huggingface.py
+++ b/utils/python/transformers/run_gpt2_from_huggingface.py
@@ -34,8 +34,8 @@ try:
     from PyCompileAndRuntime import OMCompileExecutionSession
 except ImportError:
     raise ImportError(
-        "Looks like you did not build the PyRuntime target, build it by running `make PyRuntime`."
-        "You may need to set ONNX_MLIR_HOME to `onnx-mlir/build/Debug` since `make PyRuntime` outputs to `build/Debug` by default"
+        "Looks like you did not build the PyRuntimeC target, build it by running `make PyRuntimeC`."
+        "You may need to set ONNX_MLIR_HOME to `onnx-mlir/build/Debug` since `make PyRuntimeC` outputs to `build/Debug` by default"
     )
 
 # Information to download onnx models from HuggingFace.


### PR DESCRIPTION
A message about setting ONNX_MLIR_HOME suggests to run `make PyRuntime`, but it has been changed to `make PyRuntimeC` recently, so update the message to make it correct.