### PR TITLE
Propagate onnx.dim_params in shape inference

### DIFF
--- a/src/Dialect/Mlir/IndexExpr.cpp
+++ b/src/Dialect/Mlir/IndexExpr.cpp
@@ -237,6 +237,8 @@ bool IndexExpr::hasAffineExpr() const { return getObj().hasAffineExpr(); }
 
 bool IndexExpr::hasValue() const { return getObj().hasValue(); }
 
+bool IndexExpr::hasDimParam() const {return getObj().hasDimParam();}
+
 //===----------------------------------------------------------------------===//
 // IndexExpr list queries.
 //===----------------------------------------------------------------------===//
@@ -412,6 +414,8 @@ AffineExpr IndexExpr::getAffineExpr() const {
 }
 
 Value IndexExpr::getValue() const { return getObj().getValue(); }
+
+std::string IndexExpr::getDimParam() const { return getObj().getDimParam(); }
 
 void IndexExpr::getAffineMapAndOperands(
     AffineMap &map, SmallVectorImpl<Value> &operands) const {

--- a/src/Dialect/Mlir/IndexExpr.hpp
+++ b/src/Dialect/Mlir/IndexExpr.hpp
@@ -452,6 +452,7 @@ public:
   }
   bool hasAffineExpr() const;
   bool hasValue() const;
+  bool hasDimParam() const;
 
   // Value/values has/have to be literal and satisfy the test.
   bool isLiteralAndIdenticalTo(int b) const;               // Values equal.
@@ -486,6 +487,7 @@ public:
       mlir::AffineMap &map, llvm::SmallVectorImpl<mlir::Value> &operands) const;
   mlir::Value getValue() const;
   int64_t getShape(bool uniqueQuestionMark = false) const;
+  std::string getDimParam() const;
 
   // Helpers for list of IndexExpressions: given a (list of) IndexExpr, provide
   // the (list of) Shape/Value/OpFoldResult corresponding to the original (list

--- a/src/Dialect/Mlir/IndexExprBuilder.cpp
+++ b/src/Dialect/Mlir/IndexExprBuilder.cpp
@@ -391,8 +391,9 @@ IndexExpr IndexExprBuilder::getShapeAsSymbol(
 
 IndexExpr IndexExprBuilder::getShapeAsDim(
     Value tensorOrMemrefValue, uint64_t i) {
-  if (isLiteralShape(tensorOrMemrefValue, i))
+  if (isLiteralShape(tensorOrMemrefValue, i)) {
     return getShapeAsLiteral(tensorOrMemrefValue, i);
+  }
   if (Value val = getShapeVal(tensorOrMemrefValue, i))
     return DimIE(val);
   return QuestionmarkIndexExpr(tensorOrMemrefValue, i);

--- a/src/Dialect/Mlir/IndexExprDetail.cpp
+++ b/src/Dialect/Mlir/IndexExprDetail.cpp
@@ -87,7 +87,7 @@ std::string getDimParamUtil(Value tensorOrMemref, int64_t index) {
     int64_t argIndex = blockArg.getArgNumber();
     Block *block = blockArg.getOwner();
     Operation *op = block->getParentOp();
-    if (llvm::isa<func::FuncOp>(op)) {
+    if (op && llvm::isa<func::FuncOp>(op)) {
       func::FuncOp funcOp = llvm::cast<func::FuncOp>(op);
       //ArrayAttr dimAttr = funcOp.getArgAttrsAttr();
       DictionaryAttr dictAttr = mlir::function_interface_impl::getArgAttrDict(funcOp, argIndex);
@@ -106,7 +106,12 @@ std::string getDimParamUtil(Value tensorOrMemref, int64_t index) {
       return std::string("");
     } else {
       // Get the info from attribute "onnx.dim_param"
-      return std::string("");
+      auto opResult = llvm::cast<OpResult>(tensorOrMemref);
+      unsigned resultIndex = opResult.getResultNumber();
+      Attribute dimParamAttr = op->getAttr("onnx.dim_params_"+std::to_string(resultIndex));
+      if (!dimParamAttr)
+        return std::string("");
+      return getDimParamFromString(std::string(llvm::cast<StringAttr>(dimParamAttr).getValue().str()), index);
     }
   }
 }

--- a/src/Dialect/Mlir/IndexExprDetail.hpp
+++ b/src/Dialect/Mlir/IndexExprDetail.hpp
@@ -69,6 +69,7 @@ public:
   bool isInCurrentScope() const;
   bool hasAffineExpr() const;
   bool hasValue() const;
+  bool hasDimParam() const;
 
   // Getters.
   IndexExprScope &getScope() const;
@@ -83,6 +84,7 @@ public:
   void getAffineMapAndOperands(
       mlir::AffineMap &map, llvm::SmallVectorImpl<mlir::Value> &operands);
   mlir::Value getValue();
+  std::string getDimParam();
 
   // Setters.
   void setLiteral(int64_t val);
@@ -122,6 +124,7 @@ private:
   mlir::AffineExpr affineExpr;
   // Value expression, may be defined whenever the IndexExpr is defined.
   mlir::Value value;
+  std::string dimParam;
 };
 
 } // namespace onnx_mlir

--- a/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/ShapeHelper.cpp
@@ -89,6 +89,8 @@ static void refineDimParams(Operation *op, DimsExpr &inferredDims, Value output)
       dimParamsStr = dimParamsStr + std::to_string(i) + ":" + inferredDims[i].getDimParam();
     }
   }
+  if (dimParamsStr == "")
+    return;
   StringAttr dimParamsAttr = StringAttr::get(op->getContext(), dimParamsStr);
   op->setAttr("onnx.dim_params_"+std::to_string(resultIndex), StringAttr(dimParamsAttr));
 }

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh-arch15.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh-arch15.mlir
@@ -157,6 +157,8 @@ func.func @test_nd_qlinearmatmul_nd_nd(%arg0: tensor<?x?x384x64xf32> {onnx.dim_p
   // CHECK:         }
 }
 
+// -----
+
 func.func @test_nd_qlinearmatmul_nd_2d(%arg0: tensor<?x?x384x64xf32> {onnx.dim_params = "0:bs,1:sl"}, %arg1: tensor<64x384xf32>, %arg2: tensor<f32>, %arg3: tensor<i8>) -> tensor<?x?x384x384xf32> {
   %0 = "onnx.QuantizeLinear"(%arg0, %arg2, %arg3) : (tensor<?x?x384x64xf32>, tensor<f32>, tensor<i8>) -> tensor<?x?x384x64xi8>
   %1 = "onnx.QuantizeLinear"(%arg1, %arg2, %arg3) : (tensor<64x384xf32>, tensor<f32>, tensor<i8>) -> tensor<64x384xi8>
@@ -190,6 +192,8 @@ func.func @test_nd_qlinearmatmul_nd_2d(%arg0: tensor<?x?x384x64xf32> {onnx.dim_p
 // CHECK:           return [[VAR_19_]] : tensor<?x?x384x384xf32>
 // CHECK:         }
 }
+
+// -----
 
 func.func @test_nd_qlinearmatmul_2d_nd(%arg0: tensor<384x64xf32>, %arg1: tensor<?x?x64x384xf32> {onnx.dim_params = "0:bs,1:sl"}, %arg2: tensor<f32>, %arg3: tensor<i8>) -> tensor<?x?x384x384xf32> {
   %0 = "onnx.QuantizeLinear"(%arg0, %arg2, %arg3) : (tensor<384x64xf32>, tensor<f32>, tensor<i8>) -> tensor<384x64xi8>
@@ -226,6 +230,8 @@ func.func @test_nd_qlinearmatmul_2d_nd(%arg0: tensor<384x64xf32>, %arg1: tensor<
 // CHECK:         }
 }
 
+// -----
+
 // Do not rewrite because of potential broadcasting.
 func.func @test_nd_qlinearmatmul_nd_nd_not_rewriting(%arg0: tensor<?x?x384x64xf32> {onnx.dim_params = "0:bs,1:sl"}, %arg1: tensor<1x?x64x384xf32> {onnx.dim_params = "1:sl"}, %arg2: tensor<f32>, %arg3: tensor<i8>) -> tensor<?x?x384x384xf32> {
   %0 = "onnx.QuantizeLinear"(%arg0, %arg2, %arg3) : (tensor<?x?x384x64xf32>, tensor<f32>, tensor<i8>) -> tensor<?x?x384x64xi8>
@@ -236,10 +242,10 @@ func.func @test_nd_qlinearmatmul_nd_nd_not_rewriting(%arg0: tensor<?x?x384x64xf3
 
 // CHECK-LABEL:  func.func @test_nd_qlinearmatmul_nd_nd_not_rewriting
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?x384x64xf32> {onnx.dim_params = "0:bs,1:sl"}, [[PARAM_1_:%.+]]: tensor<1x?x64x384xf32> {onnx.dim_params = "1:sl"}, [[PARAM_2_:%.+]]: tensor<f32>, [[PARAM_3_:%.+]]: tensor<i8>) -> tensor<?x?x384x384xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[PARAM_2_]], [[PARAM_3_]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<?x?x384x64xf32>, tensor<f32>, tensor<i8>) -> tensor<?x?x384x64xi8>
-// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.QuantizeLinear"([[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {axis = 1 : si64, saturate = 1 : si64} : (tensor<1x?x64x384xf32>, tensor<f32>, tensor<i8>) -> tensor<1x?x64x384xi8>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.QLinearMatMul"([[VAR_0_]], [[PARAM_2_]], [[PARAM_3_]], [[VAR_1_]], [[PARAM_2_]], [[PARAM_3_]], [[PARAM_2_]], [[PARAM_3_]]) : (tensor<?x?x384x64xi8>, tensor<f32>, tensor<i8>, tensor<1x?x64x384xi8>, tensor<f32>, tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<?x?x384x384xi8>
-// CHECK:           [[VAR_3_:%.+]] = "onnx.DequantizeLinear"([[VAR_2_]], [[PARAM_2_]], [[PARAM_3_]]) {axis = 1 : si64} : (tensor<?x?x384x384xi8>, tensor<f32>, tensor<i8>) -> tensor<?x?x384x384xf32>
+// CHECK-DAG:       [[VAR_0_:%.+]] = "onnx.QuantizeLinear"([[PARAM_0_]], [[PARAM_2_]], [[PARAM_3_]]) {axis = 1 : si64, onnx.dim_params_0 = "0:bs,1:sl", saturate = 1 : si64} : (tensor<?x?x384x64xf32>, tensor<f32>, tensor<i8>) -> tensor<?x?x384x64xi8>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "onnx.QuantizeLinear"([[PARAM_1_]], [[PARAM_2_]], [[PARAM_3_]]) {axis = 1 : si64, onnx.dim_params_0 = "1:sl", saturate = 1 : si64} : (tensor<1x?x64x384xf32>, tensor<f32>, tensor<i8>) -> tensor<1x?x64x384xi8>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.QLinearMatMul"([[VAR_0_]], [[PARAM_2_]], [[PARAM_3_]], [[VAR_1_]], [[PARAM_2_]], [[PARAM_3_]], [[PARAM_2_]], [[PARAM_3_]]) {onnx.dim_params_0 = "0:bs,1:sl"} : (tensor<?x?x384x64xi8>, tensor<f32>, tensor<i8>, tensor<1x?x64x384xi8>, tensor<f32>, tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<?x?x384x384xi8>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.DequantizeLinear"([[VAR_2_]], [[PARAM_2_]], [[PARAM_3_]]) {axis = 1 : si64, onnx.dim_params_0 = "0:bs,1:sl"} : (tensor<?x?x384x384xi8>, tensor<f32>, tensor<i8>) -> tensor<?x?x384x384xf32>
 // CHECK:           return [[VAR_3_]] : tensor<?x?x384x384xf32>
 // CHECK:         }
 }

--- a/test/mlir/onnx/onnx_dim_analysis.mlir
+++ b/test/mlir/onnx/onnx_dim_analysis.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir-opt --onnx-dim-analysis %s -split-input-file | FileCheck %s
 
+// -----
+
 // Check if dim_analysis takes into account the relationship between inputs via dim_params.
 func.func @test_dim_params_onnx_return(%arg0: tensor<?x?xf32> {onnx.dim_params = "0:M,1:N", onnx.name = "X"}, %arg1: tensor<?x?xf32> {onnx.dim_params = "0:M,1:P", onnx.name = "Y"}) -> (tensor<?x?xf32> {onnx.dim_params = "0:M,1:N", onnx.name = "Z"}) {
   %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
@@ -11,7 +13,7 @@ func.func @test_dim_params_onnx_return(%arg0: tensor<?x?xf32> {onnx.dim_params =
 // CHECK-DAG:           "onnx.DimGroup"([[PARAM_1_]]) {axis = 1 : si64, group_id = 4 : si64} : (tensor<?x?xf32>) -> ()
 // CHECK-DAG:           "onnx.DimGroup"([[PARAM_0_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xf32>) -> ()
 // CHECK-DAG:           "onnx.DimGroup"([[PARAM_1_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xf32>) -> ()
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) {onnx.dim_params_0 = "0:M"} : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK-DAG:           "onnx.DimGroup"([[VAR_0_]]) {axis = 1 : si64, group_id = 1 : si64} : (tensor<?x?xf32>) -> ()
 // CHECK-DAG:           "onnx.DimGroup"([[VAR_0_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xf32>) -> ()
 // CHECK:           onnx.Return [[VAR_0_]] : tensor<?x?xf32>
@@ -31,7 +33,7 @@ func.func @test_dim_params_std_return(%arg0: tensor<?x?xf32> {onnx.dim_params = 
 // CHECK-DAG:           "onnx.DimGroup"([[PARAM_1_]]) {axis = 1 : si64, group_id = 4 : si64} : (tensor<?x?xf32>) -> ()
 // CHECK-DAG:           "onnx.DimGroup"([[PARAM_0_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xf32>) -> ()
 // CHECK-DAG:           "onnx.DimGroup"([[PARAM_1_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xf32>) -> ()
-// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) {onnx.dim_params_0 = "0:M"} : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK-DAG:           "onnx.DimGroup"([[VAR_0_]]) {axis = 1 : si64, group_id = 1 : si64} : (tensor<?x?xf32>) -> ()
 // CHECK-DAG:           "onnx.DimGroup"([[VAR_0_]]) {axis = 0 : si64, group_id = 0 : si64} : (tensor<?x?xf32>) -> ()
 // CHECK:           return [[VAR_0_]] : tensor<?x?xf32>

--- a/test/mlir/onnx/onnx_shape_inference.mlir
+++ b/test/mlir/onnx/onnx_shape_inference.mlir
@@ -3953,6 +3953,8 @@ func.func @test_grid_sample_same_dims(%arg0: tensor<1x3x1152x1344xf32>, %arg1: t
 // CHECK:         }
 }
 
+// -----
+
 func.func @test_grid_sample_diff_dims(%arg0: tensor<1x1x4x4xf32>, %arg1: tensor<1x6x6x2xf32>) -> tensor<*xf32> {
   %0 = "onnx.GridSample"(%arg0, %arg1) {align_corners = 1 : si64, mode = "linear", onnx_node_name = "GridSample_181", padding_mode = "border"} : (tensor<1x1x4x4xf32>, tensor<1x6x6x2xf32>) -> tensor<*xf32>
   return %0 : tensor<*xf32>
@@ -3964,6 +3966,8 @@ func.func @test_grid_sample_diff_dims(%arg0: tensor<1x1x4x4xf32>, %arg1: tensor<
 // CHECK:           return [[GRID]] : tensor<1x1x6x6xf32>
 // CHECK:         }
 }
+
+// -----
 
 func.func @test_grid_sample_6d(%arg0: tensor<1x2x4x4x4x4xf32>, %arg1: tensor<1x6x6x4x4x4xf32>) -> tensor<*xf32> {
   %0 = "onnx.GridSample"(%arg0, %arg1) {align_corners = 1 : si64, mode = "linear", onnx_node_name = "GridSample_181", padding_mode = "border"} : (tensor<1x2x4x4x4x4xf32>, tensor<1x6x6x4x4x4xf32>) -> tensor<*xf32>
@@ -3977,6 +3981,8 @@ func.func @test_grid_sample_6d(%arg0: tensor<1x2x4x4x4x4xf32>, %arg1: tensor<1x6
 // CHECK:         }
 }
 
+// -----
+
 func.func @test_grid_sample_dim_shape(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<?x?x?x2xf32>) -> tensor<*xf32> {
   %0 = "onnx.GridSample"(%arg0, %arg1) {align_corners = 1 : si64, mode = "linear", onnx_node_name = "GridSample_181", padding_mode = "border"} : (tensor<?x?x?x?xf32>, tensor<?x?x?x2xf32>) -> tensor<*xf32>
 // mlir2FileCheck.py
@@ -3987,6 +3993,8 @@ func.func @test_grid_sample_dim_shape(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<
 // CHECK:         }
   return %0 : tensor<*xf32>
 }
+
+// -----
 
 func.func @test_grid_sample_dim_shape2(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<?x?x?x?xf32>) -> tensor<*xf32> {
   %0 = "onnx.GridSample"(%arg0, %arg1) {align_corners = 1 : si64, mode = "linear", onnx_node_name = "GridSample_181", padding_mode = "border"} : (tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) -> tensor<*xf32>
@@ -3999,6 +4007,8 @@ func.func @test_grid_sample_dim_shape2(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor
   return %0 : tensor<*xf32>
 }
 
+// -----
+
 func.func @test_grid_sample_dim_shape3(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<?x10x20x2xf32>) -> tensor<*xf32> {
   %0 = "onnx.GridSample"(%arg0, %arg1) {align_corners = 1 : si64, mode = "linear", onnx_node_name = "GridSample_181", padding_mode = "border"} : (tensor<?x?x?x?xf32>, tensor<?x10x20x2xf32>) -> tensor<*xf32>
 // mlir2FileCheck.py
@@ -4008,4 +4018,18 @@ func.func @test_grid_sample_dim_shape3(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor
 // CHECK:           return [[GRID]] : tensor<?x?x10x20xf32>
 // CHECK:         }
   return %0 : tensor<*xf32>
+}
+
+// -----
+
+func.func @dim_params_1(%arg0: tensor<?x10xf32> {onnx.dim_params = "0:batch_size"}, %arg1: tensor<?x10xf32> {onnx.dim_params = "0:batch_size"}) -> (tensor<?x10xf32> {onnx.name = "sum"}) {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<?x10xf32>, tensor<?x10xf32>) -> tensor<?x10xf32>
+  %1 = "onnx.Add"(%0, %arg0) : (tensor<?x10xf32>, tensor<?x10xf32>) -> tensor<?x10xf32>
+  onnx.Return %1 : tensor<?x10xf32>
+// CHECK-LABEL:  func.func @dim_params_1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x10xf32> {onnx.dim_params = "0:batch_size"}, [[PARAM_1_:%.+]]: tensor<?x10xf32> {onnx.dim_params = "0:batch_size"}) -> (tensor<?x10xf32> {onnx.name = "sum"}) {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.Add"([[PARAM_0_]], [[PARAM_1_]]) {onnx.dim_params_0 = "0:batch_size"} : (tensor<?x10xf32>, tensor<?x10xf32>) -> tensor<?x10xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Add"([[VAR_0_]], [[PARAM_0_]]) {onnx.dim_params_0 = "0:batch_size"} : (tensor<?x10xf32>, tensor<?x10xf32>) -> tensor<?x10xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<?x10xf32>
+// CHECK:         }
 }


### PR DESCRIPTION
ONNX model provides symbolic name for dynamic dimension of input tensor with argument attribute "onnx.dim_params". This PR tries to propagate this symbolic name for dynamic dimension during shape inference with extra attribute to operation "onnx.dim_params_[n]", where n is the index of the output tensor.
The major change is on IndexExpr to carry such info, if it exists. Other changes include the use of the dim_param info in shape inference and test case.
So far, the usu of dim_param info is far from complete. The PR is kind of experimental.
At least one benefit of this approach is that the readability of the output of onnx-mlir can be improved with the symbolic names.