### PR TITLE
Adding Lowering for shrink op from onnx to krnl dialect

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -187,7 +187,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **SequenceLength** |none | | | |
 | **SequenceMap** |none | | | |
 | **Shape** |15 - * |Does not support start and end attributes. Does not support int4 and uint4. | |
-| **Shrink** |none | | | |
+| **Shrink** |9 - * | | | |
 | **Sigmoid** |6 - * | | |
 | **Sign** |9 - * | | |
 | **Sin** |7 - * | | |

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -603,6 +603,45 @@ Value emitScalarOpFor<ONNXSigmoidOp>(ConversionPatternRewriter &rewriter,
 }
 
 //===----------------------------------------------------------------------===//
+// Scalar unary ops for lowering ONNXShrinkOp
+//===----------------------------------------------------------------------===//
+template <>
+struct ScalarOp<ONNXShrinkOp> {
+  using FOp = CustomScalarOp;
+  using IOp = NotSuportedScalarOp;
+};
+
+template <>
+GenOpMix getGenOpMix<ONNXShrinkOp>(Type t, Operation *op) {
+  return {{GenericOps::ArithmeticGop, 3}, {GenericOps::CompareGop, 2},
+      {GenericOps::SelectGop, 2}};
+}
+
+template <>
+Value emitScalarOpFor<ONNXShrinkOp>(ConversionPatternRewriter &rewriter,
+    Location loc, Operation *op, Type elementType,
+    ArrayRef<Value> scalarOperands) {
+  // ONNXShrinkOp: If x < -lambd, y = x + bias;
+  // If x > lambd, y = x - bias;Otherwise, y = 0.
+  CheckIfCustomScalarOpIsSupported<ONNXShrinkOp>(elementType);
+  Value operand = scalarOperands[0];
+  double biasLit = mlir::dyn_cast<ONNXShrinkOp>(op).getBias().convertToFloat();
+  double lambdLit =
+      mlir::dyn_cast<ONNXShrinkOp>(op).getLambd().convertToFloat();
+  MultiDialectBuilder<MathBuilder> create(rewriter, loc);
+  Value zero = create.math.constant(elementType, 0);
+  Value bias = create.math.constant(elementType, biasLit);
+  Value lambd = create.math.constant(elementType, lambdLit);
+  Value negLambd = create.math.sub(zero, lambd);
+  Value isLessThanNegLambd = create.math.slt(operand, negLambd);
+  Value isGreaterThanLambd = create.math.sgt(operand, lambd);
+  Value isInputSubBiasOrZero = create.math.select(
+      isGreaterThanLambd, create.math.sub(operand, bias), zero);
+  return create.math.select(
+      isLessThanNegLambd, create.math.add(operand, bias), isInputSubBiasOrZero);
+}
+
+//===----------------------------------------------------------------------===//
 // Scalar unary ops for lowering ONNXHardSigmoidOp
 //===----------------------------------------------------------------------===//
 template <>
@@ -1814,7 +1853,7 @@ bool OpFusionHelper::checkFusibleOp(Operation *useOp, Operation *defOp,
       mlir::ONNXReluOp, mlir::ONNXRoundOp, mlir::ONNXSeluOp,
       mlir::ONNXSigmoidOp, mlir::ONNXSignOp, mlir::ONNXSinOp, mlir::ONNXSinhOp,
       mlir::ONNXSoftplusOp, mlir::ONNXSoftsignOp, mlir::ONNXSqrtOp,
-      mlir::ONNXTanOp, mlir::ONNXTanhOp,
+      mlir::ONNXTanOp, mlir::ONNXTanhOp, mlir::ONNXShrinkOp,
       // Binary Op
       mlir::ONNXEqualOp, mlir::ONNXGreaterOp, mlir::ONNXGreaterOrEqualOp,
       mlir::ONNXLessOp, mlir::ONNXLessOrEqualOp, mlir::ONNXModOp,
@@ -2798,6 +2837,7 @@ void populateLoweringONNXElementwiseOpPattern(RewritePatternSet &patterns,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXRoundOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXClipOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXSeluOp>,
+      ONNXElementwiseUnaryOpLowering<mlir::ONNXShrinkOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXSigmoidOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXSignOp>,
       ONNXElementwiseUnaryOpLowering<mlir::ONNXSinOp>,

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -2925,6 +2925,18 @@ def get_test_models():
             DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
+        # ==OP== Shrink
+        # ==MIN== 9
+        "test_shrink_hard_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
+        "test_shrink_soft_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
         # ==OP== Sigmoid
         # ==MIN== 6
         "test_sigmoid_cpu": {

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -1583,3 +1583,37 @@ func.func private @test_ceil(%arg0 : tensor<?x10xf32>) -> tensor<*xf32> {
 // CHECK:           return [[RES_]] : memref<?x10xf32>
 // CHECK:         }
 }
+
+// -----
+
+func.func private @test_shrink(%arg0 : tensor<?x512xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Shrink"(%arg0) {bias=1.0:f32, lambd=2.0:f32} : (tensor<?x512xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+// mlir2FileCheck.py
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func private @test_shrink
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<?x512xf32>) -> memref<?x512xf32> {
+// CHECK-DAG:    [[CST_minus_2_dot_000000_:%.+]] = arith.constant -2.000000e+00 : f32
+// CHECK-DAG:    [[CST_2_dot_000000_:%.+]] = arith.constant 2.000000e+00 : f32
+// CHECK-DAG:    [[CST_1_dot_000000_:%.+]] = arith.constant 1.000000e+00 : f32
+// CHECK-DAG:    [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:    [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK:        [[VAR_dim_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x512xf32>
+// CHECK-DAG:    [[RES_:%.+]] = memref.alloc([[VAR_dim_]]) {{.*}}: memref<?x512xf32>
+// CHECK-DAG:    [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
+// CHECK-DAG:    [[VAR_dim_3_:%.+]] = memref.dim [[PARAM_0_]], [[CST_0_]] : memref<?x512xf32>
+// CHECK:        krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to [[map_]]([[VAR_dim_3_]]), [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 512){
+// CHECK:          [[VAR_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:          [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<?x512xf32>
+// CHECK-DAG:      [[VAR_3_:%.+]] = arith.cmpf olt, [[LOAD_PARAM_0_MEM_]], [[CST_minus_2_dot_000000_]] : f32
+// CHECK-DAG:      [[VAR_4_:%.+]] = arith.cmpf ogt, [[LOAD_PARAM_0_MEM_]], [[CST_2_dot_000000_]] : f32
+// CHECK-DAG:      [[VAR_5_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_]], [[CST_1_dot_000000_]] : f32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:      [[VAR_6_:%.+]] = arith.select [[VAR_4_]], [[VAR_5_]], [[CST_0_dot_000000_]] : f32
+// CHECK-DAG:      [[VAR_7_:%.+]] = arith.addf [[LOAD_PARAM_0_MEM_]], [[CST_1_dot_000000_]] : f32
+// CHECK:          [[VAR_8_:%.+]] = arith.select [[VAR_3_]], [[VAR_7_]], [[VAR_6_]] : f32
+// CHECK:          krnl.store [[VAR_8_]], [[RES_]]{{.}}[[VAR_1_]]#0, [[VAR_1_]]#1] : memref<?x512xf32>
+// CHECK:        }
+// CHECK:        return [[RES_]] : memref<?x512xf32>
+// CHECK:      }
+}


### PR DESCRIPTION
This pull request implements the lowering of the Shrink op from the ONNX dialect to the Krnl dialect, and add tests to validate it, addressing Issue: https://github.com/onnx/onnx-mlir/issues/3164.

This PR is ready for review. Please let me know if there are any additional improvements or adjustments needed.

Closes https://github.com/onnx/onnx-mlir/issues/3164.