### PR TITLE
Allows POW with different types (convert 2nd input to 1st input type)

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Math/ElementwiseBroadcast.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/ElementwiseBroadcast.cpp
@@ -347,8 +347,6 @@ LogicalResult ONNXPowOp::verify() {
   ShapedType rhsTy = mlir::cast<ShapedType>(getY().getType());
   Type rhsETy = rhsTy.getElementType();
   Type lhsETy = lhsTy.getElementType();
-  if (rhsETy != lhsETy)
-    return emitOpError("Pow with different input type not implemented yet");
   if (mlir::isa<IntegerType>(lhsETy) || mlir::isa<IntegerType>(lhsETy))
     return emitOpError("Integer power not implemented yet");
   return success();


### PR DESCRIPTION
Fix case listed in #3128 due to power with different type. Use the convention to convert the 2nd input to that of the first input (and output) type,
