### PR TITLE
Added lowering for MeanVarianceNorm From ONNX-To-Krnl

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -121,7 +121,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **MaxRoiPool** |none | | | |
 | **MaxUnpool** |none | | | |
 | **Mean** |6 - * | | |
-| **MeanVarianceNormalization** |13 - * | | | |
+| **MeanVarianceNormalization** |9 - * | | | |
 | **MelWeightMatrix** |none | | | |
 | **Min** |6 - * |Does not support unsigned numbers. Only ppc64le and MacOS platforms support float16. | |
 | **Mish** |18 - * | | | |

--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -121,7 +121,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **MaxRoiPool** |none | | | |
 | **MaxUnpool** |none | | | |
 | **Mean** |6 - * | | |
-| **MeanVarianceNormalization** |none | | | |
+| **MeanVarianceNormalization** |13 - * | | | |
 | **MelWeightMatrix** |none | | | |
 | **Min** |6 - * |Does not support unsigned numbers. Only ppc64le and MacOS platforms support float16. | |
 | **Mish** |18 - * | | | |

--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -22,6 +22,7 @@ add_onnx_mlir_library(OMONNXToKrnl
   Math/LRN.cpp
   Math/MatMul.cpp
   Math/MatMulInteger.cpp
+  Math/MeanVarianceNormalization.cpp
   Math/QLinearMatMul.cpp
   Math/RandomNormal.cpp
   Math/RandomNormalLike.cpp

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -217,6 +217,7 @@ void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
   populateLoweringONNXTriluOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXMatMulOpPattern(patterns, typeConverter, ctx, dimAnalysis, enableTiling, enableSIMD, enableParallel);
   populateLoweringONNXMatMulIntegerOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXMeanVarianceNormalizationOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXRandomNormalOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXRandomNormalLikeOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXLRNOpPattern(patterns, typeConverter, ctx);

--- a/src/Conversion/ONNXToKrnl/Math/MeanVarianceNormalization.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MeanVarianceNormalization.cpp
@@ -1,0 +1,157 @@
+#include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+#include "src/Dialect/Krnl/KrnlHelper.hpp"
+#include "src/Dialect/Mlir/DialectBuilder.hpp"
+#include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+struct ONNXMeanVarianceNormalizationOpLowering
+    : public OpConversionPattern<ONNXMeanVarianceNormalizationOp> {
+  ONNXMeanVarianceNormalizationOpLowering(
+      TypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern(typeConverter, ctx) {}
+
+  LogicalResult matchAndRewrite(ONNXMeanVarianceNormalizationOp op,
+      ONNXMeanVarianceNormalizationOpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const final {
+    Location loc = ONNXLoc<ONNXMeanVarianceNormalizationOp>(op);
+    Value X = adaptor.getX();
+    ArrayAttr axesAttr = adaptor.getAxes();
+
+    MultiDialectBuilder<MathBuilder, MemRefBuilder, KrnlBuilder,
+        IndexExprBuilderForKrnl>
+        create(rewriter, loc);
+    IndexExprScope scope(create.krnl);
+    MemRefType XType = X.getType().cast<MemRefType>();
+    Type elementType = XType.getElementType();
+    int64_t rank = XType.getRank();
+
+    SmallVector<int64_t> axes;
+    for (Attribute attr : axesAttr)
+      axes.push_back(cast<IntegerAttr>(attr).getInt());
+
+    // Compute divisor (product of sizes along reduction axes)
+    // This divisor is the number of elements being reduced over:
+    float div = 1.0;
+    ArrayRef<int64_t> inputShape = XType.getShape();
+    for (int64_t axis : axes)
+      div *= inputShape[axis];
+    Value divValue = create.math.constant(elementType, div);
+
+    // Create reduction shape:
+    // shape with 1 on axes being reduced, inputShape[i] elsewhere
+    SmallVector<int64_t> reductionShape;
+    for (int64_t i = 0; i < rank; ++i)
+      reductionShape.push_back(llvm::is_contained(axes, i) ? 1 : inputShape[i]);
+    MemRefType reductionType = MemRefType::get(reductionShape, elementType);
+
+    // Initialize accumulators for sum(X) and sum(X^2)
+    Value zero = create.math.constant(elementType, 0.0);
+    Value sumX = create.mem.alignedAlloc(reductionType);
+    Value sumX2 = create.mem.alignedAlloc(reductionType);
+    create.krnl.memset(sumX, zero);
+    create.krnl.memset(sumX2, zero);
+
+    // Define full input loop bounds
+    SmallVector<IndexExpr> lbs(rank, LitIE(0)), ubs;
+    for (int64_t i = 0; i < rank; ++i)
+      ubs.emplace_back(create.krnlIE.getShapeAsDim(X, i));
+
+    // Loop over full input tensor to accumulate sum and sum of squares:
+    // sumX = ∑ X
+    // sumX2 = ∑ X^2
+    ValueRange loops = create.krnl.defineLoops(rank);
+    create.krnl.iterateIE(loops, loops, lbs, ubs,
+        [&](const KrnlBuilder &createKrnl, ValueRange loopIVs) {
+          MultiDialectBuilder<KrnlBuilder, MathBuilder> create(createKrnl);
+          Value x = create.krnl.load(X, loopIVs);
+          Value x2 = create.math.mul(x, x);
+
+          // Map full indices to reduction indices by replacing
+          // axes indices with 0 (since reduced dims collapse)
+          SmallVector<Value> redIVs;
+          for (int64_t i = 0; i < rank; ++i)
+            redIVs.push_back(llvm::is_contained(axes, i)
+                                 ? create.math.constantIndex(0)
+                                 : loopIVs[i]);
+
+          Value prevSum = create.krnl.load(sumX, redIVs);
+          Value prevSum2 = create.krnl.load(sumX2, redIVs);
+          create.krnl.store(create.math.add(prevSum, x), sumX, redIVs);
+          create.krnl.store(create.math.add(prevSum2, x2), sumX2, redIVs);
+        });
+
+    // Allocate buffers for mean and standard deviation:
+    Value mean = create.mem.alignedAlloc(reductionType);
+    Value stddev = create.mem.alignedAlloc(reductionType);
+
+    // Loop over reduced shape to compute mean and stddev:
+    // mean = sumX / divisor
+    // variance = (sumX2 / divisor) - mean^2
+    // stddev = sqrt(abs(variance))
+    SmallVector<IndexExpr> redLbs(rank, LitIE(0)), redUbs;
+    for (int64_t i = 0; i < rank; ++i)
+      redUbs.emplace_back(llvm::is_contained(axes, i)
+                              ? IndexExpr(LitIE(1))
+                              : create.krnlIE.getShapeAsDim(X, i));
+
+    ValueRange redLoops = create.krnl.defineLoops(rank);
+    create.krnl.iterateIE(redLoops, redLoops, redLbs, redUbs,
+        [&](const KrnlBuilder &createKrnl, ValueRange redIVs) {
+          MultiDialectBuilder<KrnlBuilder, MathBuilder> create(createKrnl);
+
+          Value sX = create.krnl.load(sumX, redIVs);
+          Value sX2 = create.krnl.load(sumX2, redIVs);
+          Value m = create.math.div(sX, divValue);
+          Value var = create.math.div(sX2, divValue);
+
+          Value sub = create.math.sub(var, create.math.mul(m, m));
+          // Variance can be slightly negative due to numerical error, so abs is
+          // used
+          Value std = create.math.sqrt(create.math.abs(sub));
+
+          create.krnl.store(m, mean, redIVs);
+          create.krnl.store(std, stddev, redIVs);
+        });
+
+    // Allocate buffer for normalized output tensor (same shape as X)
+    Value norm = create.mem.alignedAlloc(XType);
+
+    // Normalize input tensor:
+    // For each element x:
+    //   normalized_x = (x - mean) / stddev
+    // where mean and stddev are broadcast over the reduced axes.
+    ValueRange normLoops = create.krnl.defineLoops(rank);
+    create.krnl.iterateIE(normLoops, normLoops, lbs, ubs,
+        [&](const KrnlBuilder &createKrnl, ValueRange loopIVs) {
+          MultiDialectBuilder<KrnlBuilder, MathBuilder> create(createKrnl);
+
+          SmallVector<Value> redIVs;
+          for (int64_t i = 0; i < rank; ++i)
+            redIVs.push_back(llvm::is_contained(axes, i)
+                                 ? create.math.constantIndex(0)
+                                 : loopIVs[i]);
+
+          Value x = create.krnl.load(X, loopIVs);
+          Value m = create.krnl.load(mean, redIVs);
+          Value std = create.krnl.load(stddev, redIVs);
+          Value diff = create.math.sub(x, m);
+          Value normVal = create.math.div(diff, std);
+          create.krnl.store(normVal, norm, loopIVs);
+        });
+
+    rewriter.replaceOp(op, norm);
+    onnxToKrnlSimdReport(op);
+    return success();
+  }
+};
+
+void populateLoweringONNXMeanVarianceNormalizationOpPattern(
+    RewritePatternSet &patterns, TypeConverter &typeConverter,
+    MLIRContext *ctx) {
+  patterns.insert<ONNXMeanVarianceNormalizationOpLowering>(typeConverter, ctx);
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/Math/MeanVarianceNormalization.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/MeanVarianceNormalization.cpp
@@ -32,29 +32,63 @@ struct ONNXMeanVarianceNormalizationOpLowering
     for (Attribute attr : axesAttr)
       axes.push_back(cast<IntegerAttr>(attr).getInt());
 
+    SmallVector<int64_t> actualAxes;
+    if (axes.empty() && rank > 0) {
+      for (int64_t i = 0; i < rank; ++i)
+        actualAxes.push_back(i);
+    } else {
+      actualAxes = axes;
+    }
     // Compute divisor (product of sizes along reduction axes)
-    // This divisor is the number of elements being reduced over:
-    float div = 1.0;
+    // This divisor is the number of elements being reduced over
     ArrayRef<int64_t> inputShape = XType.getShape();
-    for (int64_t axis : axes)
-      div *= inputShape[axis];
-    Value divValue = create.math.constant(elementType, div);
+    Value divValue;
+    if (actualAxes.empty()) {
+      divValue = create.math.constant(elementType, 1.0f);
+    } else {
+      Value currentProduct = create.math.constant(elementType, 1.0f);
+      for (int64_t current_axis : actualAxes) {
+        Value dimSizeVal;
+        if (inputShape[current_axis] == ShapedType::kDynamic) {
+          Value dimValIndex = create.mem.dim(X, current_axis);
+          dimSizeVal = create.math.cast(elementType, dimValIndex);
+        } else {
+          if (inputShape[current_axis] == 0) {
+            currentProduct = create.math.constant(elementType, 0.0f);
+            break;
+          }
+          dimSizeVal = create.math.constant(
+              elementType, static_cast<float>(inputShape[current_axis]));
+        }
+        currentProduct = create.math.mul(currentProduct, dimSizeVal);
+      }
+      divValue = currentProduct;
+    }
 
-    // Create reduction shape:
-    // shape with 1 on axes being reduced, inputShape[i] elsewhere
     SmallVector<int64_t> reductionShape;
-    for (int64_t i = 0; i < rank; ++i)
-      reductionShape.push_back(llvm::is_contained(axes, i) ? 1 : inputShape[i]);
+    SmallVector<Value> reductionDynOperands;
+    if (rank > 0) {
+      for (int64_t i = 0; i < rank; ++i) {
+        if (llvm::is_contained(actualAxes, i)) {
+          reductionShape.push_back(1);
+        } else {
+          reductionShape.push_back(inputShape[i]);
+          if (inputShape[i] == ShapedType::kDynamic) {
+            reductionDynOperands.push_back(create.mem.dim(X, i));
+          }
+        }
+      }
+    }
+
     MemRefType reductionType = MemRefType::get(reductionShape, elementType);
 
-    // Initialize accumulators for sum(X) and sum(X^2)
-    Value zero = create.math.constant(elementType, 0.0);
-    Value sumX = create.mem.alignedAlloc(reductionType);
-    Value sumX2 = create.mem.alignedAlloc(reductionType);
-    create.krnl.memset(sumX, zero);
-    create.krnl.memset(sumX2, zero);
+    // Initialize accumulators (sumX, sumX2)
+    Value zeroFloat = create.math.constant(elementType, 0.0f);
+    Value sumX = create.mem.alignedAlloc(reductionType, reductionDynOperands);
+    Value sumX2 = create.mem.alignedAlloc(reductionType, reductionDynOperands);
+    create.krnl.memset(sumX, zeroFloat);
+    create.krnl.memset(sumX2, zeroFloat);
 
-    // Define full input loop bounds
     SmallVector<IndexExpr> lbs(rank, LitIE(0)), ubs;
     for (int64_t i = 0; i < rank; ++i)
       ubs.emplace_back(create.krnlIE.getShapeAsDim(X, i));
@@ -73,7 +107,7 @@ struct ONNXMeanVarianceNormalizationOpLowering
           // axes indices with 0 (since reduced dims collapse)
           SmallVector<Value> redIVs;
           for (int64_t i = 0; i < rank; ++i)
-            redIVs.push_back(llvm::is_contained(axes, i)
+            redIVs.push_back(llvm::is_contained(actualAxes, i) // Use actualAxes
                                  ? create.math.constantIndex(0)
                                  : loopIVs[i]);
 
@@ -83,17 +117,17 @@ struct ONNXMeanVarianceNormalizationOpLowering
           create.krnl.store(create.math.add(prevSum2, x2), sumX2, redIVs);
         });
 
-    // Allocate buffers for mean and standard deviation:
-    Value mean = create.mem.alignedAlloc(reductionType);
-    Value stddev = create.mem.alignedAlloc(reductionType);
+    // Allocate buffers for mean and standard deviation
+    Value mean = create.mem.alignedAlloc(reductionType, reductionDynOperands);
+    Value stddev = create.mem.alignedAlloc(reductionType, reductionDynOperands);
 
-    // Loop over reduced shape to compute mean and stddev:
+    // Loop over reduced shape to compute mean and stddev
     // mean = sumX / divisor
     // variance = (sumX2 / divisor) - mean^2
     // stddev = sqrt(abs(variance))
     SmallVector<IndexExpr> redLbs(rank, LitIE(0)), redUbs;
     for (int64_t i = 0; i < rank; ++i)
-      redUbs.emplace_back(llvm::is_contained(axes, i)
+      redUbs.emplace_back(llvm::is_contained(actualAxes, i) // Use actualAxes
                               ? IndexExpr(LitIE(1))
                               : create.krnlIE.getShapeAsDim(X, i));
 
@@ -117,11 +151,19 @@ struct ONNXMeanVarianceNormalizationOpLowering
         });
 
     // Allocate buffer for normalized output tensor (same shape as X)
-    Value norm = create.mem.alignedAlloc(XType);
+    SmallVector<Value> XTypeDynOperands;
+    if (rank > 0) {
+      for (int64_t i = 0; i < rank; ++i) {
+        if (inputShape[i] == ShapedType::kDynamic) {
+          XTypeDynOperands.push_back(create.mem.dim(X, i));
+        }
+      }
+    }
+    Value norm = create.mem.alignedAlloc(XType, XTypeDynOperands);
 
-    // Normalize input tensor:
+    // Normalize input tensor
     // For each element x:
-    //   normalized_x = (x - mean) / stddev
+    // normalized_x = (x - mean) / stddev
     // where mean and stddev are broadcast over the reduced axes.
     ValueRange normLoops = create.krnl.defineLoops(rank);
     create.krnl.iterateIE(normLoops, normLoops, lbs, ubs,
@@ -130,7 +172,7 @@ struct ONNXMeanVarianceNormalizationOpLowering
 
           SmallVector<Value> redIVs;
           for (int64_t i = 0; i < rank; ++i)
-            redIVs.push_back(llvm::is_contained(axes, i)
+            redIVs.push_back(llvm::is_contained(actualAxes, i) // Use actualAxes
                                  ? create.math.constantIndex(0)
                                  : loopIVs[i]);
 

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -342,6 +342,8 @@ void populateLoweringONNXMatMulOpPattern(mlir::RewritePatternSet &,
     bool enableTiling, bool enableSIMD, bool enableParallel);
 void populateLoweringONNXMatMulIntegerOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXMeanVarianceNormalizationOpPattern(
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXQLinearMatMulOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXRandomNormalOpPattern(

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -2145,6 +2145,13 @@ def get_test_models():
             DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
+        # ==OP== MeanVarianceNormalization
+        # ==MIN== 13
+        "test_mvn_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
         # ==OP== Neg
         # ==MIN== 6
         "test_neg_example_cpu": {

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -1689,11 +1689,12 @@ func.func @test_mish(%arg0 : tensor<64x128xf32>) -> tensor<*xf32> {
 func.func private @test_meanvariancenormalization(%arg0 : tensor<2x4x3x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.MeanVarianceNormalization"(%arg0) {axes=[0,2,3]} : (tensor<2x4x3x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
+
 // CHECK-LABEL:  func.func private @test_meanvariancenormalization
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4x3x10xf32>) -> memref<2x4x3x10xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
-// CHECK-DAG:       [[CST_6_dot_000000_:%.+]] = arith.constant 6.000000e+01 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_6_dot_000000_:%.+]] = arith.constant 6.000000e+01 : f32
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
 // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
 // CHECK:           krnl.memset [[RES_]], [[CST_0_dot_000000_]] : memref<1x4x1x1xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize.mlir
@@ -1684,3 +1684,60 @@ func.func @test_mish(%arg0 : tensor<64x128xf32>) -> tensor<*xf32> {
 // CHECK:           return [[RES_]] : memref<64x128xf32>
 // CHECK:         }
 }
+// -----
+
+func.func private @test_meanvariancenormalization(%arg0 : tensor<2x4x3x10xf32>) -> tensor<*xf32> {
+  %0 = "onnx.MeanVarianceNormalization"(%arg0) {axes=[0,2,3]} : (tensor<2x4x3x10xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+// CHECK-LABEL:  func.func private @test_meanvariancenormalization
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4x3x10xf32>) -> memref<2x4x3x10xf32> {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_6_dot_000000_:%.+]] = arith.constant 6.000000e+01 : f32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
+// CHECK:           krnl.memset [[RES_]], [[CST_0_dot_000000_]] : memref<1x4x1x1xf32>
+// CHECK:           krnl.memset [[RES_1_]], [[CST_0_dot_000000_]] : memref<1x4x1x1xf32>
+// CHECK:           [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 3, [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 10){
+// CHECK:             [[VAR_3_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1, [[VAR_3_]]#2, [[VAR_3_]]#3] : memref<2x4x3x10xf32>
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.mulf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK-DAG:         [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[CST_0_]], [[VAR_3_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK-DAG:         [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]]{{.}}[[CST_0_]], [[VAR_3_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK:             [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_8_]], [[RES_]]{{.}}[[CST_0_]], [[VAR_3_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK:             [[VAR_9_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_5_]] : f32
+// CHECK:             krnl.store [[VAR_9_]], [[RES_1_]]{{.}}[[CST_0_]], [[VAR_3_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK:           }
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
+// CHECK-DAG:       [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
+// CHECK-DAG:       [[LOOP_1_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) with ([[LOOP_1_]]#0 -> [[I_4_:%.+]] = 0 to 1, [[LOOP_1_]]#1 -> [[I_5_:%.+]] = 0 to 4, [[LOOP_1_]]#2 -> [[I_6_:%.+]] = 0 to 1, [[LOOP_1_]]#3 -> [[I_7_:%.+]] = 0 to 1){
+// CHECK:             [[VAR_3_1_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK-DAG:         [[LOAD_RES_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2, [[VAR_3_1_]]#3] : memref<1x4x1x1xf32>
+// CHECK-DAG:         [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2, [[VAR_3_1_]]#3] : memref<1x4x1x1xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[LOAD_RES_MEM_2_:%.+]] = arith.divf [[LOAD_RES_MEM_1_]], [[CST_6_dot_000000_]] : f32
+// CHECK-DAG:         [[LOAD_RES_1_MEM_2_:%.+]] = arith.divf [[LOAD_RES_1_MEM_1_]], [[CST_6_dot_000000_]] : f32
+// CHECK:             [[VAR_8_1_:%.+]] = arith.mulf [[LOAD_RES_MEM_2_]], [[LOAD_RES_MEM_2_]] : f32
+// CHECK:             [[VAR_9_1_:%.+]] = arith.subf [[LOAD_RES_1_MEM_2_]], [[VAR_8_1_]] : f32
+// CHECK:             [[VAR_10_:%.+]] = math.absf [[VAR_9_1_]] : f32
+// CHECK:             [[VAR_11_:%.+]] = math.sqrt [[VAR_10_]] : f32
+// CHECK:             krnl.store [[LOAD_RES_MEM_2_]], [[RES_2_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2, [[VAR_3_1_]]#3] : memref<1x4x1x1xf32>
+// CHECK:             krnl.store [[VAR_11_]], [[RES_3_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2, [[VAR_3_1_]]#3] : memref<1x4x1x1xf32>
+// CHECK:           }
+// CHECK-DAG:       [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<2x4x3x10xf32>
+// CHECK-DAG:       [[LOOP_2_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2, [[LOOP_2_]]#3) with ([[LOOP_2_]]#0 -> [[I_8_:%.+]] = 0 to 2, [[LOOP_2_]]#1 -> [[I_9_:%.+]] = 0 to 4, [[LOOP_2_]]#2 -> [[I_10_:%.+]] = 0 to 3, [[LOOP_2_]]#3 -> [[I_11_:%.+]] = 0 to 10){
+// CHECK:             [[VAR_3_2_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2, [[LOOP_2_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_3_2_]]#0, [[VAR_3_2_]]#1, [[VAR_3_2_]]#2, [[VAR_3_2_]]#3] : memref<2x4x3x10xf32>
+// CHECK-DAG:         [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_2_]]{{.}}[[CST_0_]], [[VAR_3_2_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK-DAG:         [[LOAD_RES_MEM_2_:%.+]] = krnl.load [[RES_3_]]{{.}}[[CST_0_]], [[VAR_3_2_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK:             [[LOAD_RES_1_MEM_2_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_1_]], [[LOAD_RES_1_MEM_1_]] : f32
+// CHECK:             [[VAR_8_2_:%.+]] = arith.divf [[LOAD_RES_1_MEM_2_]], [[LOAD_RES_MEM_2_]] : f32
+// CHECK:             krnl.store [[VAR_8_2_]], [[RES_4_]]{{.}}[[VAR_3_2_]]#0, [[VAR_3_2_]]#1, [[VAR_3_2_]]#2, [[VAR_3_2_]]#3] : memref<2x4x3x10xf32>
+// CHECK:           }
+// CHECK:           return [[RES_4_]] : memref<2x4x3x10xf32>
+// CHECK:         }
+}

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
@@ -2615,11 +2615,12 @@ func.func @test_mish(%arg0 : tensor<64x128xf32>) -> tensor<*xf32> {
 func.func private @test_meanvariancenormalization(%arg0 : tensor<2x4x3x10xf32>) -> tensor<*xf32> {
   %0 = "onnx.MeanVarianceNormalization"(%arg0) {axes=[0,2,3]} : (tensor<2x4x3x10xf32>) -> tensor<*xf32>
   "func.return"(%0) : (tensor<*xf32>) -> ()
+  
 // CHECK-LABEL:  func.func private @test_meanvariancenormalization
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4x3x10xf32>) -> memref<2x4x3x10xf32> {
 // CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
-// CHECK-DAG:       [[CST_6_dot_000000_:%.+]] = arith.constant 6.000000e+01 : f32
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_6_dot_000000_:%.+]] = arith.constant 6.000000e+01 : f32
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
 // CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
 // CHECK:           krnl.memset [[RES_]], [[CST_0_dot_000000_]] : memref<1x4x1x1xf32>

--- a/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/Elementwise_with_canonicalize_O3.mlir
@@ -2610,3 +2610,60 @@ func.func @test_mish(%arg0 : tensor<64x128xf32>) -> tensor<*xf32> {
 // CHECK:           return [[RES_]] : memref<64x128xf32>
 // CHECK:         }
 }
+// ----- 
+
+func.func private @test_meanvariancenormalization(%arg0 : tensor<2x4x3x10xf32>) -> tensor<*xf32> {
+  %0 = "onnx.MeanVarianceNormalization"(%arg0) {axes=[0,2,3]} : (tensor<2x4x3x10xf32>) -> tensor<*xf32>
+  "func.return"(%0) : (tensor<*xf32>) -> ()
+// CHECK-LABEL:  func.func private @test_meanvariancenormalization
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<2x4x3x10xf32>) -> memref<2x4x3x10xf32> {
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_6_dot_000000_:%.+]] = arith.constant 6.000000e+01 : f32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
+// CHECK:           krnl.memset [[RES_]], [[CST_0_dot_000000_]] : memref<1x4x1x1xf32>
+// CHECK:           krnl.memset [[RES_1_]], [[CST_0_dot_000000_]] : memref<1x4x1x1xf32>
+// CHECK:           [[LOOP_0_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 2, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 4, [[LOOP_0_]]#2 -> [[I_2_:%.+]] = 0 to 3, [[LOOP_0_]]#3 -> [[I_3_:%.+]] = 0 to 10){
+// CHECK:             [[VAR_3_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1, [[LOOP_0_]]#2, [[LOOP_0_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1, [[VAR_3_]]#2, [[VAR_3_]]#3] : memref<2x4x3x10xf32>
+// CHECK-DAG:         [[VAR_5_:%.+]] = arith.mulf [[LOAD_PARAM_0_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK-DAG:         [[LOAD_RES_MEM_:%.+]] = krnl.load [[RES_]]{{.}}[[CST_0_]], [[VAR_3_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK-DAG:         [[LOAD_RES_1_MEM_:%.+]] = krnl.load [[RES_1_]]{{.}}[[CST_0_]], [[VAR_3_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK:             [[VAR_8_:%.+]] = arith.addf [[LOAD_RES_MEM_]], [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_8_]], [[RES_]]{{.}}[[CST_0_]], [[VAR_3_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK:             [[VAR_9_:%.+]] = arith.addf [[LOAD_RES_1_MEM_]], [[VAR_5_]] : f32
+// CHECK:             krnl.store [[VAR_9_]], [[RES_1_]]{{.}}[[CST_0_]], [[VAR_3_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK:           }
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
+// CHECK-DAG:       [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<1x4x1x1xf32>
+// CHECK-DAG:       [[LOOP_1_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) with ([[LOOP_1_]]#0 -> [[I_4_:%.+]] = 0 to 1, [[LOOP_1_]]#1 -> [[I_5_:%.+]] = 0 to 4, [[LOOP_1_]]#2 -> [[I_6_:%.+]] = 0 to 1, [[LOOP_1_]]#3 -> [[I_7_:%.+]] = 0 to 1){
+// CHECK:             [[VAR_3_1_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1, [[LOOP_1_]]#2, [[LOOP_1_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK-DAG:         [[LOAD_RES_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2, [[VAR_3_1_]]#3] : memref<1x4x1x1xf32>
+// CHECK-DAG:         [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2, [[VAR_3_1_]]#3] : memref<1x4x1x1xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[LOAD_RES_MEM_2_:%.+]] = arith.divf [[LOAD_RES_MEM_1_]], [[CST_6_dot_000000_]] : f32
+// CHECK-DAG:         [[LOAD_RES_1_MEM_2_:%.+]] = arith.divf [[LOAD_RES_1_MEM_1_]], [[CST_6_dot_000000_]] : f32
+// CHECK:             [[VAR_8_1_:%.+]] = arith.mulf [[LOAD_RES_MEM_2_]], [[LOAD_RES_MEM_2_]] : f32
+// CHECK:             [[VAR_9_1_:%.+]] = arith.subf [[LOAD_RES_1_MEM_2_]], [[VAR_8_1_]] : f32
+// CHECK:             [[VAR_10_:%.+]] = math.absf [[VAR_9_1_]] : f32
+// CHECK:             [[VAR_11_:%.+]] = math.sqrt [[VAR_10_]] : f32
+// CHECK:             krnl.store [[LOAD_RES_MEM_2_]], [[RES_2_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2, [[VAR_3_1_]]#3] : memref<1x4x1x1xf32>
+// CHECK:             krnl.store [[VAR_11_]], [[RES_3_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1, [[VAR_3_1_]]#2, [[VAR_3_1_]]#3] : memref<1x4x1x1xf32>
+// CHECK:           }
+// CHECK-DAG:       [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<2x4x3x10xf32>
+// CHECK-DAG:       [[LOOP_2_:%.+]]:4 = krnl.define_loops 4
+// CHECK:           krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2, [[LOOP_2_]]#3) with ([[LOOP_2_]]#0 -> [[I_8_:%.+]] = 0 to 2, [[LOOP_2_]]#1 -> [[I_9_:%.+]] = 0 to 4, [[LOOP_2_]]#2 -> [[I_10_:%.+]] = 0 to 3, [[LOOP_2_]]#3 -> [[I_11_:%.+]] = 0 to 10){
+// CHECK:             [[VAR_3_2_:%.+]]:4 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1, [[LOOP_2_]]#2, [[LOOP_2_]]#3) : (!krnl.loop, !krnl.loop, !krnl.loop, !krnl.loop) -> (index, index, index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_3_2_]]#0, [[VAR_3_2_]]#1, [[VAR_3_2_]]#2, [[VAR_3_2_]]#3] : memref<2x4x3x10xf32>
+// CHECK-DAG:         [[LOAD_RES_1_MEM_1_:%.+]] = krnl.load [[RES_2_]]{{.}}[[CST_0_]], [[VAR_3_2_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK-DAG:         [[LOAD_RES_MEM_2_:%.+]] = krnl.load [[RES_3_]]{{.}}[[CST_0_]], [[VAR_3_2_]]#1, [[CST_0_]], [[CST_0_]]{{.}} : memref<1x4x1x1xf32>
+// CHECK:             [[LOAD_RES_1_MEM_2_:%.+]] = arith.subf [[LOAD_PARAM_0_MEM_1_]], [[LOAD_RES_1_MEM_1_]] : f32
+// CHECK:             [[VAR_8_2_:%.+]] = arith.divf [[LOAD_RES_1_MEM_2_]], [[LOAD_RES_MEM_2_]] : f32
+// CHECK:             krnl.store [[VAR_8_2_]], [[RES_4_]]{{.}}[[VAR_3_2_]]#0, [[VAR_3_2_]]#1, [[VAR_3_2_]]#2, [[VAR_3_2_]]#3] : memref<2x4x3x10xf32>
+// CHECK:           }
+// CHECK:           return [[RES_4_]] : memref<2x4x3x10xf32>
+// CHECK:         }
+}


### PR DESCRIPTION
Added support for the MeanVarianceNormalization operation in the ONNX to Krnl lowering . Also included corresponding test cases in Elementwise_with_canonicalize.mlir and Elementwise_with_canonicalize_O3.mlir. 

This implementation addresses and
 closes https://github.com/onnx/onnx-mlir/issues/3168