### PR TITLE
Remove most warnings (includes building for NNPA)

### DIFF
--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -555,7 +555,7 @@ TensorType OnnxBuilder::toTensor(Type input) const {
   return RankedTensorType::get(aTy.getShape(), elementTy);
 }
 
-TypeRange OnnxBuilder::toTensors(TypeRange inputs) const {
+SmallVector<Type, 4> OnnxBuilder::toTensors(TypeRange inputs) const {
   if (llvm::all_of(inputs, [](Type t) { return (mlir::isa<TensorType>(t)); }))
     return inputs;
   assert(llvm::all_of(inputs, [](Type t) {
@@ -570,7 +570,7 @@ TypeRange OnnxBuilder::toTensors(TypeRange inputs) const {
     }
     resultTypes.emplace_back(RankedTensorType::get(aTy.getShape(), elementTy));
   }
-  return TypeRange(resultTypes);
+  return resultTypes;
 }
 
 Value OnnxBuilder::toMemref(Value input) const {

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -232,7 +232,7 @@ struct OnnxBuilder : DialectBuilder {
   // Convert a Type to TensorType if it is of MemRefType.
   mlir::TensorType toTensor(mlir::Type input) const;
   // Convert Type to TypeRange of TensorType if it is of MemRefType.
-  mlir::TypeRange toTensors(mlir::TypeRange inputs) const;
+  mlir::SmallVector<mlir::Type, 4> toTensors(mlir::TypeRange inputs) const;
   // Convert a Value to MemrefType if it is of TensorType.
   mlir::Value toMemref(mlir::Value input) const;
 


### PR DESCRIPTION
I saw one warning where we return a stack object. It's in the `toTensors`, and I fixed this using Tong's suggestion of returning a `SmallVector<Types, 4>`.

Then there were also 2 warnings, associated with creating arrays on the stack with a runtime size:
```
   int num = ...
   char buff[num]
```
which is not supported by all compilers. Also, if `num` is large, we may run out of stack. Replaced both instance with dynamic allocation asserting if results of malloc are null.