### PR TITLE
Omitted change from prior PR on Pow handling

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -1271,7 +1271,13 @@ public:
             (inputIsFloat && expIsInt)))
       return failure();
 
-    // Rewrite pow with a cast of the exp type to the input type.
+    // Rewrite pow with a cast of the exp type to the input type
+    // Standard is fuzzy on how to handle conversions in mix type situations. We
+    // should revisit this code if the standard change from the currently
+    // (unofficial, aka ORT) policy which is simply to convert the exponenet to
+    // the type of the base & output. This is especially "questionable" when the
+    // base is an integer type and the exponent is a float, as 0.5 could express
+    // a square root operation.
     MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
     Value newExp = create.onnx.cast(exp, inputElementType);
     Value newPow = create.onnx.pow(input, newExp);

--- a/src/Dialect/ONNX/ONNXOps/Math/ElementwiseBroadcast.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/ElementwiseBroadcast.cpp
@@ -346,9 +346,9 @@ LogicalResult ONNXPowOp::verify() {
   // Removed integer restriction.
   Type inputElementType = getElementTypeOrSelf(getX());
   Type expElementType = getElementTypeOrSelf(getY());
-  if (!(isa<IntegerType>(inputElementType) || isa<FloatType>(inputElementType)))
+  if (!isa<IntegerType, FloatType>(inputElementType))
     return emitError("Pow base (X) must be an int or a float");
-  if (!(isa<IntegerType>(expElementType) || isa<FloatType>(expElementType)))
+  if (!isa<IntegerType, FloatType>(expElementType))
     return emitError("Pow exponent (Y)must be an int or a float");
   return success();
 }


### PR DESCRIPTION
One change was not saved, this PR update the promised changes in #3175, and added the TODO which may occur if/when the specs are updated.