### PR TITLE
Fuse MatMul and Mul if one of the operands of Mul is a scalar constant

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2259,6 +2259,7 @@ void ONNXMulOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<NormalizeMulPattern>(context);
   results.insert<FuseMulConvNullBiasPattern>(context);
+  results.insert<FuseScalarMulMatMulPattern>(context);
   results.insert<BinaryOpBroadcastAxisPattern<ONNXMulOp>>(context);
   results.insert<PropagateScalarConstantExpandPattern<ONNXMulOp>>(context);
   results.insert<PropagateReshapeThroughBinaryOpPattern<ONNXMulOp>>(context);

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -195,6 +195,10 @@ def IsFromONNXConstantOp: Constraint<
     CPred<"onnx_mlir::isDenseONNXConstant($0)">,
     "Is a value from ONNXConstantOp">;
 
+def IsScalarConstantTensor: Constraint<
+    CPred<"onnx_mlir::isScalarConstantTensor($0)">,
+    "Is a scalar constant ">;
+
 def IsNotFromONNXConstantOp: Constraint<
     CPred<"!(llvm::dyn_cast_or_null<ONNXConstantOp>($0.getDefiningOp()))">,
     "Is a value not from ONNXConstantOp">;
@@ -409,6 +413,29 @@ def FuseMulConvNullBiasPattern: Pat<
    (HasRankGT<0> $y),                  // constant cannot be a scalar.
    (AllDimsFromAxisToEndAre<1, 1>:$y)] // all dimensions of $y must be 1 except for the first one.
 >;
+
+//===----------------------------------------------------------------------===//
+// This is to fuse the composition: 'Mul o MatMul' into 'MatMul' if the other input
+// of Mul is a SCALAR constant and the other input of MatMul is a constant,
+// by multipling the constant inputs at compile time:
+//
+// We have:
+//   (MatMul)    z = a * b      (where b is a constant)
+//   (Mul)       y = z x c      (where c is a SCALAR constant)
+//
+// which corresponds to the following computation:
+//   y = a * new_b
+// where
+//   new_b = b x c
+//
+//===----------------------------------------------------------------------===//
+def FuseScalarMulMatMulPattern: Pat<
+ (ONNXMulOp (ONNXMatMulOp $a, $b), $c),
+ (ONNXMatMulOp $a, (ONNXMulOp $b, $c)),
+ [(IsFromONNXConstantOp $b), (IsScalarConstantTensor $c)]
+>;
+
+
 
 // TODO add pattern for non-null bias with constraints:
 // - bias must be have rank equal to 1 and

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -430,7 +430,7 @@ def FuseMulConvNullBiasPattern: Pat<
 //
 //===----------------------------------------------------------------------===//
 def FuseScalarMulMatMulPattern: Pat<
- (ONNXMulOp (ONNXMatMulOp $a, $b), $c),
+ (ONNXMulOp (either (ONNXMatMulOp $a, $b), $c)),
  (ONNXMatMulOp $a, (ONNXMulOp $b, $c)),
  [(IsFromONNXConstantOp $b), (IsScalarConstantTensor $c)]
 >;

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -2213,3 +2213,23 @@ func.func @group_norm5d_v21(%arg0: tensor<3x4x6x8x16xf32>, %arg1: tensor<4xf32>,
 // CHECK:           onnx.Return [[VAR_11_]] : tensor<3x4x6x8x16xf32>
 // CHECK:         }
 }
+
+// -----
+
+func.func @fuse_matmul_mul(%arg0: tensor<?x2048xf32>) -> (tensor<?x2048xf32>) {
+  %b = onnx.Constant dense<3.0> : tensor<2048x2048xf32>
+  %c = onnx.Constant dense<5.0> : tensor<f32>
+  %0 = "onnx.MatMul"(%arg0, %b) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
+  %1 = "onnx.Mul"(%0, %c) : (tensor<?x2048xf32>, tensor<f32>) -> tensor<?x2048xf32>
+  onnx.Return %1 : tensor<?x2048xf32>
+
+// CHECK-LABEL:  func.func @fuse_matmul_mul
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x2048xf32>) -> tensor<?x2048xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<2048x2048xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e+00> : tensor<f32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_0_]], [[VAR_1_]]) : (tensor<2048x2048xf32>, tensor<f32>) -> tensor<2048x2048xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<?x2048xf32>
+// CHECK:         }
+}
+

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -23,14 +23,14 @@ func.func @test_matmul_add_not_fused(%a0: tensor<10x10x10xf32>, %a1: tensor<10x1
 
 // -----
 
-func.func @test_matmul_mul_fused(%arg0: tensor<?x2048xf32>) -> (tensor<?x2048xf32>) {
+func.func @test_matmul_mul_fused_1(%arg0: tensor<?x2048xf32>) -> (tensor<?x2048xf32>) {
   %b = onnx.Constant dense<3.0> : tensor<2048x2048xf32>
   %c = onnx.Constant dense<5.0> : tensor<f32>
   %0 = "onnx.MatMul"(%arg0, %b) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
   %1 = "onnx.Mul"(%0, %c) : (tensor<?x2048xf32>, tensor<f32>) -> tensor<?x2048xf32>
   onnx.Return %1 : tensor<?x2048xf32>
 
-// CHECK-LABEL:  func.func @test_matmul_mul_fused
+// CHECK-LABEL:  func.func @test_matmul_mul_fused_1
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x2048xf32>) -> tensor<?x2048xf32> {
 // CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<2048x2048xf32>
 // CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e+00> : tensor<f32>
@@ -38,6 +38,25 @@ func.func @test_matmul_mul_fused(%arg0: tensor<?x2048xf32>) -> (tensor<?x2048xf3
 // CHECK:           [[VAR_3_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
 // CHECK:           onnx.Return [[VAR_3_]] : tensor<?x2048xf32>
 // CHECK:         }
+}
+
+// -----
+
+func.func @test_matmul_mul_fused_2(%arg0: tensor<?x2048xf32>) -> (tensor<?x2048xf32>) {
+  %b = onnx.Constant dense<3.0> : tensor<2048x2048xf32>
+  %c = onnx.Constant dense<5.0> : tensor<f32>
+  %0 = "onnx.MatMul"(%arg0, %b) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
+  %1 = "onnx.Mul"(%c, %0) : (tensor<f32>, tensor<?x2048xf32>) -> tensor<?x2048xf32>
+  onnx.Return %1 : tensor<?x2048xf32>
+
+// mlir2FileCheck.py
+// CHECK-LABEL:  func.func @test_matmul_mul_fused_2
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x2048xf32>) -> tensor<?x2048xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<2048x2048xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e+00> : tensor<f32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_0_]], [[VAR_1_]]) : (tensor<2048x2048xf32>, tensor<f32>) -> tensor<2048x2048xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
+// CHECK:        }
 }
 
 // -----

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -23,6 +23,39 @@ func.func @test_matmul_add_not_fused(%a0: tensor<10x10x10xf32>, %a1: tensor<10x1
 
 // -----
 
+func.func @test_matmul_mul_fused(%arg0: tensor<?x2048xf32>) -> (tensor<?x2048xf32>) {
+  %b = onnx.Constant dense<3.0> : tensor<2048x2048xf32>
+  %c = onnx.Constant dense<5.0> : tensor<f32>
+  %0 = "onnx.MatMul"(%arg0, %b) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
+  %1 = "onnx.Mul"(%0, %c) : (tensor<?x2048xf32>, tensor<f32>) -> tensor<?x2048xf32>
+  onnx.Return %1 : tensor<?x2048xf32>
+
+// CHECK-LABEL:  func.func @test_matmul_mul_fused
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x2048xf32>) -> tensor<?x2048xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<2048x2048xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e+00> : tensor<f32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_0_]], [[VAR_1_]]) : (tensor<2048x2048xf32>, tensor<f32>) -> tensor<2048x2048xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<?x2048xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_matmul_mul_not_fused(%arg0: tensor<?x3xf32>) -> (tensor<?x2xf32>) {
+  %b = onnx.Constant dense<3.0> : tensor<3x2xf32>
+  %c = onnx.Constant dense<[1.0, 5.0]> : tensor<2xf32>
+  %0 = "onnx.MatMul"(%arg0, %b) : (tensor<?x3xf32>, tensor<3x2xf32>) -> tensor<?x2xf32>
+  %1 = "onnx.Mul"(%0, %c) : (tensor<?x2xf32>, tensor<2xf32>) -> tensor<?x2xf32>
+  onnx.Return %1 : tensor<?x2xf32>
+
+// CHECK-LABEL:  func.func @test_matmul_mul_not_fused
+// CHECK: "onnx.MatMul"
+// CHECK-NEXT: "onnx.Mul"
+}
+
+// -----
+
 // onnx.MatMul ops with more than one result uses should not get fused.
 // CHECK-LABEL: func @test_sigmoid_add(%{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>) -> tensor<10x10xf32>
 func.func @test_sigmoid_add(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>, %a2: tensor<10x10xf32>) -> tensor<10x10xf32> {
@@ -2283,25 +2316,6 @@ func.func @group_norm5d_v21(%arg0: tensor<3x4x6x8x16xf32>, %arg1: tensor<4xf32>,
 // CHECK:           [[VAR_Y_:%.+]], [[VAR_Mean_:%.+]], [[VAR_InvStdDev_:%.+]] = "onnx.LayerNormalization"([[VAR_10_]], [[VAR_7_]], [[VAR_8_]]) {axis = 2 : si64, epsilon = 0.00999999977 : f32, stash_type = 1 : si64} : (tensor<3x2x2x6x8x16xf32>, tensor<2x2x1x1x1xf32>, tensor<2x2x1x1x1xf32>) -> (tensor<3x2x2x6x8x16xf32>, none, none)
 // CHECK:           [[VAR_11_:%.+]] = "onnx.Reshape"([[VAR_Y_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<3x2x2x6x8x16xf32>, tensor<5xi64>) -> tensor<3x4x6x8x16xf32>
 // CHECK:           onnx.Return [[VAR_11_]] : tensor<3x4x6x8x16xf32>
-// CHECK:         }
-}
-
-// -----
-
-func.func @fuse_matmul_mul(%arg0: tensor<?x2048xf32>) -> (tensor<?x2048xf32>) {
-  %b = onnx.Constant dense<3.0> : tensor<2048x2048xf32>
-  %c = onnx.Constant dense<5.0> : tensor<f32>
-  %0 = "onnx.MatMul"(%arg0, %b) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
-  %1 = "onnx.Mul"(%0, %c) : (tensor<?x2048xf32>, tensor<f32>) -> tensor<?x2048xf32>
-  onnx.Return %1 : tensor<?x2048xf32>
-
-// CHECK-LABEL:  func.func @fuse_matmul_mul
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x2048xf32>) -> tensor<?x2048xf32> {
-// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<2048x2048xf32>
-// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e+00> : tensor<f32>
-// CHECK:           [[VAR_2_:%.+]] = "onnx.Mul"([[VAR_0_]], [[VAR_1_]]) : (tensor<2048x2048xf32>, tensor<f32>) -> tensor<2048x2048xf32>
-// CHECK:           [[VAR_3_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
-// CHECK:           onnx.Return [[VAR_3_]] : tensor<?x2048xf32>
 // CHECK:         }
 }
 


### PR DESCRIPTION
This patch adds one optimization rule to Mul's canonicalization that fuses MatMul and Mul if one of the operands of Mul is a scalar constant.

This pattern is found in IBM granite models.