### PR TITLE
Fix the issue where deallocation is put at the end of a function

### DIFF
--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -256,6 +256,8 @@ void addKrnlToLLVMPasses(
   mlir::bufferization::buildBufferDeallocationPipeline(
       pm, bufferDeallocOptions);
   pm.addPass(mlir::createConvertBufferizationToMemRefPass());
+  // This pass is necessary to move deallocation after the last user.
+  pm.addPass(mlir::bufferization::createOptimizeAllocationLivenessPass());
 
   // Late introduction of OpenMP, after bufferization.
   if (enableParallel) {


### PR DESCRIPTION
When LLVM version was updated in onnx-mlir and the new bufferization was used, deallocations are put at the end of a function, causing a significant performance loss.

To move the deallocations after the last user instead of at the end of the function, we need to call `createOptimizeAllocationLivenessPass`. This patch adds that call to the pass manager, which would bring the performance back.