### PR TITLE
fix for s390x-z/OS zdnnx missing member

### DIFF
--- a/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx.c
@@ -431,6 +431,10 @@ void zdnnx_create_view(const zdnn_ztensor *input, zdnn_ztensor *input_view,
 // Functions to work with spliting information
 // -----------------------------------------------------------------------------
 
+uint32_t zdnnx_get_num_tiles(zdnnx_split_info *split_info, zdnnx_axis axis) {
+  return split_info->num_tiles[axis];
+}
+
 bool zdnnx_has_one_tile(zdnnx_split_info *split_info) {
   return (split_info->flags & NO_SPLIT);
 }

--- a/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx.h
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx.h
@@ -179,10 +179,7 @@ void zdnnx_free_buffer(void *aligned_ptr);
  * @param axis axis E1, E2, E3, or E4
  * @return the number of tiles.
  */
-inline uint32_t zdnnx_get_num_tiles(
-    zdnnx_split_info *split_info, zdnnx_axis axis) {
-  return split_info->num_tiles[axis];
-}
+uint32_t zdnnx_get_num_tiles(zdnnx_split_info *split_info, zdnnx_axis axis);
 
 /**
  * \brief Check if there is only one tile in split_info.


### PR DESCRIPTION
Fix for the below issue: 

```
IEW2456E 9207 SYMBOL zdnnx_get_num_tiles UNRESOLVED.  MEMBER COULD NOT BE      

          INCLUDED FROM THE DESIGNATED CALL LIBRARY.                            

 IEW2665S 40FF MODULE *NULL*  IS NON-EXECUTABLE AND WAS NOT SAVED BECAUSE       

          STORENX=NEVER.                                                        

IEW5033 The binder ended with return code 12.

ibm-clang: error: linker command failed with exit code 12 (use -v to see invocation)
```