### PR TITLE
Compute static shape when collapsing innermost or outtermost dims

### DIFF
--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -642,25 +642,49 @@ Value OnnxBuilder::reshapeToNDim(
   int64_t end = collapseMostSignificant ? rank : N - 1;      // Exclusive.
   Value keepVals =
       slice(keepShapeType, inputShapeVals, start, end, /*steps*/ 1);
-  // Concat -1 and keep vals
+  // Compute the new collapsed dim if the old dims are static.
+  // Otherwise, concat -1 and keep vals
   Value newShapeVals;
-  if (collapseMostSignificant)
+  bool isStatic = true;
+  int64_t collapsedDim = 1;
+  if (collapseMostSignificant) {
     // NewShapeVal is [-1,M,N] where M & N are the kept vals from the input.
+    for (int64_t i = 0; i < start; ++i) {
+      if (ShapedType::isDynamic(inputShape[i])) {
+        isStatic = false;
+        break;
+      }
+      collapsedDim *= inputShape[i];
+    }
+    Value collapsedVal = minusOneVal;
+    if (isStatic)
+      collapsedVal = constantInt64({collapsedDim});
     newShapeVals =
-        concat(outputShapeType, ValueRange({minusOneVal, keepVals}), 0);
-  else
+        concat(outputShapeType, ValueRange({collapsedVal, keepVals}), 0);
+  } else {
     // NewShapeVal is [M,N,-1] where M & N are the kept vals from the input.
+    for (int64_t i = end; i < rank; ++i) {
+      if (ShapedType::isDynamic(inputShape[i])) {
+        isStatic = false;
+        break;
+      }
+      collapsedDim *= inputShape[i];
+    }
+    Value collapsedVal = minusOneVal;
+    if (isStatic)
+      collapsedVal = constantInt64({collapsedDim});
     newShapeVals =
-        concat(outputShapeType, ValueRange({keepVals, minusOneVal}), 0);
+        concat(outputShapeType, ValueRange({keepVals, collapsedVal}), 0);
+  }
   // Shape inference will infer the correct shape later, thus use -1 for
   // collapsed dims.
   llvm::SmallVector<int64_t, 4> outputDims;
   if (collapseMostSignificant)
-    outputDims.emplace_back(ShapedType::kDynamic);
+    outputDims.emplace_back(isStatic ? collapsedDim : ShapedType::kDynamic);
   for (int i = start; i < end; ++i)
     outputDims.emplace_back(inputShape[i]);
   if (!collapseMostSignificant)
-    outputDims.emplace_back(ShapedType::kDynamic);
+    outputDims.emplace_back(isStatic ? collapsedDim : ShapedType::kDynamic);
   Type outputType = RankedTensorType::get(outputDims, elementType);
   return reshape(outputType, val, newShapeVals);
 }

--- a/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
+++ b/test/mlir/accelerators/nnpa/conversion/rewrite-onnx-for-zhigh.mlir
@@ -357,8 +357,8 @@ func.func @test_matmul(%arg0: tensor<4x12x256x256xf32>, %arg1: tensor<4x12x256x6
 
 // CONSTPROP-LABEL:  func.func @test_matmul
 // CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>, [[PARAM_1_:%.+]]: tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32> {
-// CONSTPROP-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1, 256, 256]> : tensor<3xi64>
-// CONSTPROP-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[-1, 256, 64]> : tensor<3xi64>
+// CONSTPROP-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[48, 256, 256]> : tensor<3xi64>
+// CONSTPROP-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[48, 256, 64]> : tensor<3xi64>
 // CONSTPROP-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<[4, 12, 256, 64]> : tensor<4xi64>
 // CONSTPROP-NOT: separator of consecutive DAGs
 // CONSTPROP-DAG:       [[VAR_3_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
@@ -376,7 +376,7 @@ func.func @test_matmul_broadcast_1(%arg0: tensor<4x12x256x256xf32>, %arg1: tenso
 
 // CONSTPROP-LABEL:  func.func @test_matmul_broadcast_1
 // CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>, [[PARAM_1_:%.+]]: tensor<256x64xf32>) -> tensor<4x12x256x64xf32> {
-// CONSTPROP-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[-1, 256, 256]> : tensor<3xi64>
+// CONSTPROP-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<[48, 256, 256]> : tensor<3xi64>
 // CONSTPROP-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<[4, 12, 256, 64]> : tensor<4xi64>
 // CONSTPROP:           [[VAR_2_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
 // CONSTPROP:           [[VAR_3_:%.+]] = "onnx.MatMul"([[VAR_2_]], [[PARAM_1_]]) : (tensor<48x256x256xf32>, tensor<256x64xf32>) -> tensor<48x256x64xf32>
@@ -393,7 +393,7 @@ func.func @test_matmul_broadcast_2(%arg0: tensor<256x256xf32>, %arg1: tensor<4x1
 // CONSTPROP-LABEL:  func.func @test_matmul_broadcast_2
 // CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<256x256xf32>, [[PARAM_1_:%.+]]: tensor<4x12x256x64xf32>) -> tensor<4x12x256x64xf32> {
 // CONSTPROP-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[4, 12, 256, 64]> : tensor<4xi64>
-// CONSTPROP:           [[VAR_0_:%.+]] = onnx.Constant dense<[-1, 256, 64]> : tensor<3xi64>
+// CONSTPROP:           [[VAR_0_:%.+]] = onnx.Constant dense<[48, 256, 64]> : tensor<3xi64>
 // CONSTPROP:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
 // CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_1_]]) : (tensor<256x256xf32>, tensor<48x256x64xf32>) -> tensor<48x256x64xf32>
 // CONSTPROP:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<48x256x64xf32>, tensor<4xi64>) -> tensor<4x12x256x64xf32>
@@ -406,29 +406,30 @@ func.func @test_matmul_broadcast_2(%arg0: tensor<256x256xf32>, %arg1: tensor<4x1
 func.func @test_matmul_broadcast_dyn_dims(%arg0: tensor<256x?xf32>, %arg1: tensor<4x12x?x?xf32>) -> (tensor<4x12x256x?xf32>) {
     %0= "onnx.MatMul"(%arg0, %arg1) : (tensor<256x?xf32>, tensor<4x12x?x?xf32>) -> tensor<4x12x256x?xf32>
     return %0 : tensor<4x12x256x?xf32>
+
 // CONSTPROP-LABEL:  func.func @test_matmul_broadcast_dyn_dims
 // CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<256x?xf32>, [[PARAM_1_:%.+]]: tensor<4x12x?x?xf32>) -> tensor<4x12x256x?xf32> {
 // CONSTPROP-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<3> : tensor<1xi64>
-// CONSTPROP-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
-// CONSTPROP-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
-// CONSTPROP-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
-// CONSTPROP-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
-// CONSTPROP-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<-1> : tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<48> : tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<4> : tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_4_:%.+]] = onnx.Constant dense<2> : tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_5_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
 // CONSTPROP-DAG:       [[VAR_6_:%.+]] = "onnx.Shape"([[PARAM_1_]]) {start = 0 : si64} : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
-// CONSTPROP:           [[VAR_7_:%.+]] = "onnx.Slice"([[VAR_6_]], [[VAR_3_]], [[VAR_2_]], [[VAR_4_]], [[VAR_1_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// CONSTPROP:           [[VAR_8_:%.+]] = "onnx.Concat"([[VAR_5_]], [[VAR_7_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<2xi64>) -> tensor<3xi64>
-// CONSTPROP:           [[VAR_9_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_8_]]) {allowzero = 0 : si64} : (tensor<4x12x?x?xf32>, tensor<3xi64>) -> tensor<?x?x?xf32>
-// CONSTPROP-DAG:       [[VAR_10_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_9_]]) : (tensor<256x?xf32>, tensor<?x?x?xf32>) -> tensor<?x256x?xf32>
+// CONSTPROP:           [[VAR_7_:%.+]] = "onnx.Slice"([[VAR_6_]], [[VAR_4_]], [[VAR_3_]], [[VAR_5_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// CONSTPROP:           [[VAR_8_:%.+]] = "onnx.Concat"([[VAR_1_]], [[VAR_7_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<2xi64>) -> tensor<3xi64>
+// CONSTPROP:           [[VAR_9_:%.+]] = "onnx.Reshape"([[PARAM_1_]], [[VAR_8_]]) {allowzero = 0 : si64} : (tensor<4x12x?x?xf32>, tensor<3xi64>) -> tensor<48x?x?xf32>
+// CONSTPROP-DAG:       [[VAR_10_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_9_]]) : (tensor<256x?xf32>, tensor<48x?x?xf32>) -> tensor<48x256x?xf32>
 // CONSTPROP-DAG:       [[VAR_11_:%.+]] = "onnx.Shape"([[PARAM_0_]]) {start = 0 : si64} : (tensor<256x?xf32>) -> tensor<2xi64>
 // CONSTPROP-DAG:       [[VAR_12_:%.+]] = "onnx.Shape"([[PARAM_1_]]) {start = 0 : si64} : (tensor<4x12x?x?xf32>) -> tensor<4xi64>
 // CONSTPROP-NOT: separator of consecutive DAGs
-// CONSTPROP-DAG:       [[VAR_13_:%.+]] = "onnx.Slice"([[VAR_12_]], [[VAR_4_]], [[VAR_3_]], [[VAR_4_]], [[VAR_1_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
-// CONSTPROP-DAG:       [[VAR_14_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_4_]], [[VAR_1_]], [[VAR_4_]], [[VAR_1_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-// CONSTPROP-DAG:       [[VAR_15_:%.+]] = "onnx.Slice"([[VAR_12_]], [[VAR_0_]], [[VAR_2_]], [[VAR_4_]], [[VAR_1_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_13_:%.+]] = "onnx.Slice"([[VAR_12_]], [[VAR_5_]], [[VAR_4_]], [[VAR_5_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<2xi64>
+// CONSTPROP-DAG:       [[VAR_14_:%.+]] = "onnx.Slice"([[VAR_11_]], [[VAR_5_]], [[VAR_2_]], [[VAR_5_]], [[VAR_2_]]) : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+// CONSTPROP-DAG:       [[VAR_15_:%.+]] = "onnx.Slice"([[VAR_12_]], [[VAR_0_]], [[VAR_3_]], [[VAR_5_]], [[VAR_2_]]) : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
 // CONSTPROP:           [[VAR_16_:%.+]] = "onnx.Concat"([[VAR_13_]], [[VAR_14_]], [[VAR_15_]]) {axis = 0 : si64} : (tensor<2xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
-// CONSTPROP:           [[VAR_17_:%.+]] = "onnx.Reshape"([[VAR_10_]], [[VAR_16_]]) {allowzero = 0 : si64} : (tensor<?x256x?xf32>, tensor<4xi64>) -> tensor<4x12x256x?xf32>
+// CONSTPROP:           [[VAR_17_:%.+]] = "onnx.Reshape"([[VAR_10_]], [[VAR_16_]]) {allowzero = 0 : si64} : (tensor<48x256x?xf32>, tensor<4xi64>) -> tensor<4x12x256x?xf32>
 // CONSTPROP:           return [[VAR_17_]] : tensor<4x12x256x?xf32>
-
+// CONSTPROP:         }
 }
 
 // -----
@@ -580,7 +581,7 @@ func.func @softmax_nd_to_2d(%arg0: tensor<4x12x256x256xf32>) -> (tensor<4x12x256
 // CONSTPROP-LABEL:  func.func @softmax_nd_to_2d
 // CONSTPROP-SAME:   ([[PARAM_0_:%.+]]: tensor<4x12x256x256xf32>) -> tensor<4x12x256x256xf32> {
 // CONSTPROP-DAG:       [[VAR_3_:%.+]] = onnx.Constant dense<[4, 12, 256, 256]> : tensor<4xi64>
-// CONSTPROP:           [[VAR_0_:%.+]] = onnx.Constant dense<[-1, 256, 256]> : tensor<3xi64>
+// CONSTPROP:           [[VAR_0_:%.+]] = onnx.Constant dense<[48, 256, 256]> : tensor<3xi64>
 // CONSTPROP:           [[VAR_1_:%.+]] = "onnx.Reshape"([[PARAM_0_]], [[VAR_0_]]) {allowzero = 0 : si64} : (tensor<4x12x256x256xf32>, tensor<3xi64>) -> tensor<48x256x256xf32>
 // CONSTPROP-DAG:       [[VAR_2_:%.+]] = "onnx.Softmax"([[VAR_1_]]) {axis = -1 : si64} : (tensor<48x256x256xf32>) -> tensor<48x256x256xf32>
 // CONSTPROP:           [[VAR_4_:%.+]] = "onnx.Reshape"([[VAR_2_]], [[VAR_3_]]) {allowzero = 0 : si64} : (tensor<48x256x256xf32>, tensor<4xi64>) -> tensor<4x12x256x256xf32>


### PR DESCRIPTION
The helper function 
```c
Value OnnxBuilder::reshapeToNDim(
    Value val, int64_t N, bool collapseMostSignificant) const {
```
always use -1 for the collapsed dimension.

However, when all the collapsing dimensions are static we can compute a literal for the collapsed dimension, which is good for compilation passes. 

This patch adds code to compute the static collapsed dimension whenever possible.