### PR TITLE
update llvm and stablehlo

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -15,7 +15,7 @@ Firstly, install MLIR (as a part of LLVM-Project):
 ``` bash
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 7a33569510535f0b917a2e50f644bf57490aee24 && cd ..
+cd llvm-project && git checkout f8cb7987c64dcffb72414a40560055cb717dbf74 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.sh)

--- a/docs/BuildOnWindows.md
+++ b/docs/BuildOnWindows.md
@@ -52,7 +52,7 @@ Install MLIR (as a part of LLVM-Project):
 ```shell
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 7a33569510535f0b917a2e50f644bf57490aee24 && cd ..
+cd llvm-project && git checkout f8cb7987c64dcffb72414a40560055cb717dbf74 && cd ..
 ```
 
 [same-as-file]: <> (utils/build-mlir.cmd)

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -172,7 +172,7 @@ int Command::exec(std::string wdir) const {
 
   std::string errMsg;
   int rc = llvm::sys::ExecuteAndWait(_path, llvm::ArrayRef(argsRef),
-      /*Env=*/std::nullopt, /*Redirects=*/std::nullopt,
+      /*Env=*/{}, /*Redirects=*/{},
       /*SecondsToWait=*/0, /*MemoryLimit=*/0, &errMsg);
 
   if (rc != 0) {
@@ -893,9 +893,9 @@ static std::string getDataLayout(const Location &loc) {
   llvm::TargetOptions ops;
   std::string mcpuForLLVMToolchain = getTargetCPUOption(
       /*forLLVM*/ true, /*cpu only*/ true);
-  auto targetMachine =
-      std::unique_ptr<llvm::TargetMachine>{LLVMTarget.createTargetMachine(
-          mtriple, mcpuForLLVMToolchain, "" /*features*/, ops, std::nullopt)};
+  auto targetMachine = std::unique_ptr<llvm::TargetMachine>{
+      LLVMTarget.createTargetMachine(llvm::Triple(mtriple),
+          mcpuForLLVMToolchain, "" /*features*/, ops, std::nullopt)};
   if (!targetMachine) {
     emitError(loc, "failed to create target machine");
     return nullptr;

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -172,7 +172,8 @@ int Command::exec(std::string wdir) const {
 
   std::string errMsg;
   int rc = llvm::sys::ExecuteAndWait(_path, llvm::ArrayRef(argsRef),
-      /*Env=*/{}, /*Redirects=*/{},
+      /*Env=*/{},
+      /*Redirects=*/{},
       /*SecondsToWait=*/0, /*MemoryLimit=*/0, &errMsg);
 
   if (rc != 0) {

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -234,8 +234,7 @@ mlir::Value emitScalarOpFor(mlir::ConversionPatternRewriter &rewriter,
       llvm::SmallVector<mlir::Value, 4> scalarsSplatted(scalarOperands);
       MultiDialectBuilder<MathBuilder> create(rewriter, loc);
       create.math.splatToMatch(scalarsSplatted);
-      return rewriter.create<ScalarIOp<Op>>(
-          loc, elementType, scalarsSplatted, std::nullopt);
+      return rewriter.create<ScalarIOp<Op>>(loc, elementType, scalarsSplatted);
     }
     llvm_unreachable("unsupported integer operation");
   } else if (mlir::isa<mlir::FloatType>(actualElementType)) {
@@ -247,8 +246,7 @@ mlir::Value emitScalarOpFor(mlir::ConversionPatternRewriter &rewriter,
       llvm::SmallVector<mlir::Value, 4> scalarsSplatted(scalarOperands);
       MultiDialectBuilder<MathBuilder> create(rewriter, loc);
       create.math.splatToMatch(scalarsSplatted);
-      return rewriter.create<ScalarFOp<Op>>(
-          loc, elementType, scalarsSplatted, std::nullopt);
+      return rewriter.create<ScalarFOp<Op>>(loc, elementType, scalarsSplatted);
     }
     llvm_unreachable("unsupported float operation");
   } else {

--- a/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
@@ -66,7 +66,7 @@ struct ONNXSizeOpLowering : public OpConversionPattern<ONNXSizeOp> {
       }
     }
 
-    create.krnl.store(noElements, alloc, {});
+    create.krnl.store(noElements, alloc, llvm::ArrayRef<mlir::Value>());
     rewriter.replaceOp(op, alloc);
     onnxToKrnlSimdReport(op);
     return success();

--- a/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Size.cpp
@@ -66,7 +66,7 @@ struct ONNXSizeOpLowering : public OpConversionPattern<ONNXSizeOp> {
       }
     }
 
-    create.krnl.store(noElements, alloc, std::nullopt);
+    create.krnl.store(noElements, alloc, {});
     rewriter.replaceOp(op, alloc);
     onnxToKrnlSimdReport(op);
     return success();

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -157,7 +157,7 @@ def KrnlYieldOp : Op<Krnl_Dialect, "yield", [Pure, Terminator, ReturnLike,
   let arguments = (ins Variadic<AnyType>:$operands);
 
   let builders = [
-    OpBuilder<(ins), [{ build($_builder, $_state, std::nullopt); }]>
+    OpBuilder<(ins), [{ build($_builder, $_state, llvm::ArrayRef<mlir::Value>()); }]>
   ];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
@@ -204,7 +204,7 @@ def KrnlIterateOp : Op<Krnl_Dialect, "iterate", [RecursiveMemoryEffects, Implici
   let builders = [
     // Main builder.
     OpBuilder<(ins "onnx_mlir::krnl::KrnlIterateOperandPack":$operandPack,
-      CArg<"ValueRange", "std::nullopt">:$iterArgs,
+      CArg<"ValueRange", "llvm::ArrayRef<mlir::Value>()">:$iterArgs,
       CArg<"function_ref<void(OpBuilder &, Location, ValueRange, ValueRange, ValueRange)>", "nullptr">:$bodyBuilderFn)>,
     // Builder for the optimized iterate op.
     OpBuilder<(ins

--- a/src/Dialect/Mlir/DialectBuilder.cpp
+++ b/src/Dialect/Mlir/DialectBuilder.cpp
@@ -1828,7 +1828,7 @@ void SCFBuilder::forLoop(
     Value lb, Value ub, int64_t step, SCFLoopBodyFn bodyFn) const {
   MathBuilder createMath(*this);
   Value stepVal = createMath.constantIndex(step);
-  b().create<scf::ForOp>(loc(), lb, ub, stepVal, std::nullopt,
+  b().create<scf::ForOp>(loc(), lb, ub, stepVal, llvm::ArrayRef<mlir::Value>(),
       [&](OpBuilder &childBuilder, Location childLoc, Value inductionVar,
           ValueRange args) {
         SCFBuilder builder(childBuilder, childLoc);

--- a/src/Dialect/Mlir/IndexExprDetail.cpp
+++ b/src/Dialect/Mlir/IndexExprDetail.cpp
@@ -474,7 +474,7 @@ Value IndexExprImpl::getValue() {
       // specs involving float and index calculations.
       float fval = floatLit;
       value = getRewriter().create<arith::ConstantFloatOp>(
-          getLoc(), llvm::APFloat(fval), getRewriter().getF32Type());
+          getLoc(), getRewriter().getF32Type(), llvm::APFloat(fval));
     } else {
       value = getRewriter().create<arith::ConstantIndexOp>(getLoc(), intLit);
     }

--- a/src/Dialect/ONNX/AdditionalONNXOps.td
+++ b/src/Dialect/ONNX/AdditionalONNXOps.td
@@ -355,7 +355,7 @@ def ONNXYieldOp : ONNX_Op<"Yield", [Pure, ReturnLike, Terminator]> {
 
   let builders = [
     OpBuilder<(ins),
-    [{ build($_builder, $_state, std::nullopt); }]>];
+    [{ build($_builder, $_state, llvm::ArrayRef<mlir::Value>()); }]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }

--- a/utils/clone-mlir.sh
+++ b/utils/clone-mlir.sh
@@ -1,3 +1,3 @@
 git clone -n https://github.com/llvm/llvm-project.git
 # Check out a specific branch that is known to work with ONNX-MLIR.
-cd llvm-project && git checkout 7a33569510535f0b917a2e50f644bf57490aee24 && cd ..
+cd llvm-project && git checkout f8cb7987c64dcffb72414a40560055cb717dbf74 && cd ..


### PR DESCRIPTION
This PR updates llvm to commit: f8cb7987c64dcffb72414a40560055cb717dbf74
Stablehlo commit: 69d6dae46e1c7de36e6e6973654754f05353cba5

Changes:
1.  Fixed the build warning: llvm/include/llvm/ADT/ArrayRef.h:70:18: note: 'ArrayRef' has been explicitly marked deprecated here
   70 |     /*implicit*/ LLVM_DEPRECATED("Use {} or ArrayRef<T>() instead", "{}")
2.   Fixed the Build failure: Switch type and value ordering for arith Constant[XX]Op