### PR TITLE
[NFC] Create a common helper function for emitting krnl.parallel

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ProcessStickData.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ProcessStickData.cpp
@@ -55,14 +55,13 @@ void emitDynamicQuantizationLinearMinMaxFromStickifiedInput(
   int64_t parId = 0;
   int64_t threadNum = 1;
   if (enableParallel) {
-    if (findSuitableParallelDimension(lbs, ubs, 0, rank - 1, parId, 8)) {
-      threadNum = 8; // TODO use more flexible value.
-      onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId],
-          "simd min/max for DQL in parallel ");
-    } else {
+    int64_t parId = tryCreateKrnlParallel(create.krnl, op,
+        "simd min/max for DQL in parallel", {}, lbs, ubs, 0, rank - 1, {},
+        /*min iter for going parallel*/ 8, /*doNotCreateKrnlParallel=*/true);
+    if (parId == -1) {
       enableParallel = false;
-      onnxToKrnlParallelReport(
-          op, false, -1, -1, "not enough work in simd min/max for DQL");
+    } else {
+      threadNum = 8; // TODO use more flexible value.
     }
   }
 

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ProcessStickData.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ProcessStickData.cpp
@@ -57,7 +57,7 @@ void emitDynamicQuantizationLinearMinMaxFromStickifiedInput(
   if (enableParallel) {
     int64_t parId = tryCreateKrnlParallel(create.krnl, op,
         "simd min/max for DQL in parallel", {}, lbs, ubs, 0, rank - 1, {},
-        /*min iter for going parallel*/ 8, /*doNotCreateKrnlParallel=*/true);
+        /*min iter for going parallel*/ 8, /*createKrnlParallel=*/false);
     if (parId == -1) {
       enableParallel = false;
     } else {

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ProcessStickData.hpp.inc
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ProcessStickData.hpp.inc
@@ -93,14 +93,11 @@ void IterateOverStickInputData(const BUILDER &b, mlir::Operation *op,
     // TODO: may want to check if ub of rank makes sense here.
     // Its ok here even to partition rank-1, included in (0..rank(, because
     // rank-1 is tiled. So we are still dealing with multiple of sticks.
-    if (findSuitableParallelDimension(tiledLbs, tiledUbs, 0, rank, parId, 8)) {
-      onnxToKrnlParallelReport(op, true, parId, tiledLbs[parId],
-          tiledUbs[parId], "compiler-generated stickify");
-    } else {
+    parId = tryCreateKrnlParallel(create.krnl, op,
+        "compiler-generated stickify", {}, tiledLbs, tiledUbs, 0, rank, {},
+        /*min iter for going parallel*/ 8, /*doNotCreateKrnlParallel=*/true);
+    if (parId == -1)
       enableParallel = false;
-      onnxToKrnlParallelReport(op, false, -1, -1,
-          "no dim with enough work in compiler-generated stickify");
-    }
   }
 
   // Compute max sticks (tiles of 64 values). It is actually not easy to compute

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ProcessStickData.hpp.inc
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ProcessStickData.hpp.inc
@@ -95,7 +95,7 @@ void IterateOverStickInputData(const BUILDER &b, mlir::Operation *op,
     // rank-1 is tiled. So we are still dealing with multiple of sticks.
     parId = tryCreateKrnlParallel(create.krnl, op,
         "compiler-generated stickify", {}, tiledLbs, tiledUbs, 0, rank, {},
-        /*min iter for going parallel*/ 8, /*doNotCreateKrnlParallel=*/true);
+        /*min iter for going parallel*/ 8, /*createKrnlParallel=*/false);
     if (parId == -1)
       enableParallel = false;
   }

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
@@ -2226,20 +2226,13 @@ struct ZHighToZLowDataConversionLowering
     DimsExpr lbs = {LitIE(0)};
     bool useParallel = false;
     if (enableParallel) {
-      int64_t parId;
-      int64_t tripCount = flattenedOutputDims[0].isLiteral()
-                              ? std::ceil(flattenedOutputDims[0].getLiteral() /
-                                          static_cast<float>(archVL))
-                              : -1;
-      if (findSuitableParallelDimension(lbs, flattenedOutputDims, 0, 1, parId,
-              /*min iter for going parallel*/ 1024)) {
+      int64_t parId = tryCreateKrnlParallel(create.krnl, op,
+          "dlf16-f32 conversion fully parallelized", {}, lbs,
+          flattenedOutputDims, 0, 1, {},
+          /*min iter for going parallel*/ 1024,
+          /*doNotCreateKrnlParallel=*/true);
+      if (parId != -1)
         useParallel = true;
-        onnxToKrnlParallelReport(op, /*successful*/ true, 0, tripCount,
-            "dlf16-f32 conversion fully parallelized");
-      } else {
-        onnxToKrnlParallelReport(op, false, 0, tripCount,
-            "not enough work for dlf16-f32 conversion");
-      }
     }
     onnxToKrnlSimdReport(op, /*successful*/ true, archVL,
         flattenedOutputDims[0].isLiteral() ? flattenedOutputDims[0].getLiteral()

--- a/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
+++ b/src/Accelerators/NNPA/Conversion/ZHighToZLow/ZHighToZLow.cpp
@@ -2230,7 +2230,7 @@ struct ZHighToZLowDataConversionLowering
           "dlf16-f32 conversion fully parallelized", {}, lbs,
           flattenedOutputDims, 0, 1, {},
           /*min iter for going parallel*/ 1024,
-          /*doNotCreateKrnlParallel=*/true);
+          /*createKrnlParallel=*/false);
       if (parId != -1)
         useParallel = true;
     }

--- a/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
+++ b/src/Accelerators/NNPA/Transform/ZLow/ZLowStickExpansion.cpp
@@ -236,16 +236,9 @@ public:
 
     // Parallel...
     if (enableParallel) {
-      int64_t parId;
       // TODO: may want to check if ub of rank makes sense here.
-      if (findSuitableParallelDimension(lbs, ubs, 0, rank, parId, 8)) {
-        create.krnl.parallel(loopDefs[parId]);
-        onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId],
-            "compiler-generated stickify");
-      } else {
-        onnxToKrnlParallelReport(op, false, -1, -1,
-            "no dim with enough work in compiler-generated stickify");
-      }
+      tryCreateKrnlParallel(create.krnl, op, "compiler-generated stickify",
+          loopDefs, lbs, ubs, 0, rank, {}, /*min iter for going parallel*/ 8);
     }
 
     // Compute max tiles. It is actually not easy to compute the max number of

--- a/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
+++ b/src/Conversion/ONNXToKrnl/Additional/LayoutTransform.cpp
@@ -113,16 +113,9 @@ struct ONNXLayoutTransformOpLowering
 
     // Parallel...
     if (enableParallel) {
-      int64_t parId;
       // TODO: may want to check if ub of rank makes sense here.
-      if (findSuitableParallelDimension(lbs, ubs, 0, rank, parId, 8)) {
-        create.krnl.parallel(loopDefs[parId]);
-        onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId],
-            "layout transform fast pattern");
-      } else {
-        onnxToKrnlParallelReport(op, false, -1, -1,
-            "no dim with enough work in layout transform fast pattern");
-      }
+      tryCreateKrnlParallel(create.krnl, op, "layout transform fast pattern",
+          loopDefs, lbs, ubs, 0, rank, {}, 8);
     }
 
     //  Outer loop (E1 iterates over tiles of 64 elements).
@@ -250,17 +243,9 @@ struct ONNXLayoutTransformOpLowering
     ValueRange loopDef = create.krnl.defineLoops(rank);
 
     if (enableParallel) {
-      int64_t parId;
-      if (findSuitableParallelDimension(lbs, ubs, 0, 1, parId,
-              /*min iter for going parallel*/ 128)) {
-        onnxToKrnlParallelReport(op, /*successful*/ true, 0, lbs[0], ubs[0],
-            "LayoutTransform op fully parallelized with perfectly nested "
-            "loops");
-        create.krnl.parallel(loopDef[parId]);
-      } else {
-        onnxToKrnlParallelReport(op, /*successful*/ false, 0, lbs[0], ubs[0],
-            "not enough work for LayoutTransform op");
-      }
+      tryCreateKrnlParallel(create.krnl, op,
+          "LayoutTransform op fully parallelized with perfectly nested loops",
+          loopDef, lbs, ubs, 0, 1, {}, /*min iter for going parallel*/ 128);
     }
     create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
         [&](const KrnlBuilder &createKrnl, ValueRange indices) {

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1786,7 +1786,7 @@ static LogicalResult getPartiallyFlattenedSimdCode(
       if (tryCreateKrnlParallel(create.krnl, op,
               "inner-loop of elementwise simd partially flattened", loopDef,
               {zero}, {simdUb}, 0, 1, {}, VL * 32,
-              /*doNotCreateKrnlParallel=*/true) != -1)
+              /*createKrnlParallel=*/false) != -1)
         useParallelInSimdLoop = true;
     }
   }

--- a/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Elementwise.cpp
@@ -1776,34 +1776,18 @@ static LogicalResult getPartiallyFlattenedSimdCode(
   IndexExpr simdUb = ubs.pop_back_val(); // Remove flattened ub.
   bool useParallelInSimdLoop = false;
   if (enableParallel) {
-    int64_t parId;
     if (outerLoopRank > 1) {
       // Outer loop parallelism.
-      if (findSuitableParallelDimension(
-              lbs, ubs, 0, std::min((int64_t)2, outerLoopRank), parId)) {
-        create.krnl.parallel(loopDef[parId]);
-        onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId],
-            "outer-loop of elementwise simd partially flattened");
-      } else {
-        onnxToKrnlParallelReport(op, false, -1, -1,
-            "not enough work in outermost-loops of elementwise simd "
-            "partially "
-            "flattened");
-      }
+      tryCreateKrnlParallel(create.krnl, op,
+          "outer-loop of elementwise simd partially flattened", loopDef, lbs,
+          ubs);
     } else {
       // SIMD loop parallelism.
-      DimsExpr simdLbs = {zero}, simdUbs = {simdUb};
-      if (findSuitableParallelDimension(
-              simdLbs, simdUbs, 0, 1, parId, VL * 32)) {
-        assert(parId == 0 && "expected loop zero to be parallelized");
+      if (tryCreateKrnlParallel(create.krnl, op,
+              "inner-loop of elementwise simd partially flattened", loopDef,
+              {zero}, {simdUb}, 0, 1, {}, VL * 32,
+              /*doNotCreateKrnlParallel=*/true) != -1)
         useParallelInSimdLoop = true;
-        onnxToKrnlParallelReport(op, true, parId, zero, simdUb,
-            "innermost-loop of elementwise simd partially flattened");
-      } else {
-        onnxToKrnlParallelReport(op, false, -1, -1,
-            "not enough work in innermost-loop of elementwise simd partially "
-            "flattened");
-      }
     }
   }
   create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
@@ -2404,18 +2388,9 @@ struct ONNXElementwiseUnaryOpLowering
       SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(X, ubs);
-      if (enableParallel) {
-        int64_t parId;
-        if (findSuitableParallelDimension(
-                lbs, ubs, 0, std::min((int64_t)2, outputRank), parId)) {
-          create.krnl.parallel(loopDef[parId]);
-          onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId],
-              "elementwise unary not simdized");
-        } else {
-          onnxToKrnlParallelReport(op, false, -1, -1,
-              "no dim with enough work in elementwise unary not simdized");
-        }
-      }
+      if (enableParallel)
+        tryCreateKrnlParallel(create.krnl, op, "elementwise unary not simdized",
+            loopDef, lbs, ubs);
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](const KrnlBuilder &createKrnl, ValueRange loopInd) {
             SmallVector<Value> args;
@@ -2587,18 +2562,9 @@ struct ONNXElementwiseBinaryOpLowering
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
       // TODO adjust in the future
-      if (enableParallel) {
-        int64_t parId;
-        if (findSuitableParallelDimension(
-                lbs, ubs, 0, std::min((int64_t)2, outputRank), parId)) {
-          create.krnl.parallel(loopDef[parId]);
-          onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId],
-              "elementwise binary not simdized");
-        } else {
-          onnxToKrnlParallelReport(op, false, -1, -1,
-              "no dim with enough work in elementwise binary not simdized");
-        }
-      }
+      if (enableParallel)
+        tryCreateKrnlParallel(create.krnl, op,
+            "elementwise binary not simdized", loopDef, lbs, ubs);
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](const KrnlBuilder &createKrnl, ValueRange loopInd) {
             IndexExprScope innerScope(createKrnl, shapeHelper.getScope());
@@ -2763,18 +2729,10 @@ struct ONNXElementwiseVariadicOpLowering
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
 
-      if (enableParallel) {
-        int64_t parId;
-        if (findSuitableParallelDimension(
-                lbs, ubs, 0, std::min((int64_t)2, outputRank), parId)) {
-          create.krnl.parallel(loopDef[parId]);
-          onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId],
-              "elementwise variadic not simdized");
-        } else {
-          onnxToKrnlParallelReport(op, false, -1, -1,
-              "no dim with enough work in elementwise variadic not simdized");
-        }
-      }
+      if (enableParallel)
+        tryCreateKrnlParallel(create.krnl, op,
+            "elementwise variable not simdized", loopDef, lbs, ubs);
+
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](const KrnlBuilder &createKrnl, ValueRange loopInd) {
             IndexExprScope innerScope(createKrnl, shapeHelper.getScope());
@@ -2886,18 +2844,9 @@ struct ONNXWhereOpLowering : public ConversionPattern {
       SmallVector<IndexExpr, 4> lbs(outputRank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs;
       create.krnlIE.getShapeAsDims(alloc, ubs);
-      if (enableParallel) {
-        int64_t parId;
-        if (findSuitableParallelDimension(
-                lbs, ubs, 0, std::min((int64_t)2, outputRank), parId)) {
-          create.krnl.parallel(loopDef[parId]);
-          onnxToKrnlParallelReport(
-              op, true, parId, lbs[parId], ubs[parId], "where op not simdized");
-        } else {
-          onnxToKrnlParallelReport(op, false, -1, -1,
-              "no dim with enough work in where op not simdized");
-        }
-      }
+      if (enableParallel)
+        tryCreateKrnlParallel(
+            create.krnl, op, "where op not simdized", loopDef, lbs, ubs);
       create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
           [&](const KrnlBuilder &createKrnl, ValueRange loopInd) {
             IndexExprScope innerScope(&rewriter, shapeHelper.getScope());

--- a/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Gemm.cpp
@@ -70,18 +70,10 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
     IndexExpr innerUb = shapeHelper.aDims[1];
     SmallVector<IndexExpr, 3> loopUbs{outerUb0, outerUb1, innerUb};
     // Outer loops.
-    if (enableParallel) {
-      int64_t parId;
-      if (findSuitableParallelDimension(loopLbs, loopUbs, 0, 1, parId,
-              /*min iter for going parallel*/ 4)) {
-        create.krnl.parallel(outerLoopDef[0]);
-        onnxToKrnlParallelReport(op, true, parId, loopLbs[parId],
-            loopUbs[parId], "generic GEMM on outer loop");
-      } else {
-        onnxToKrnlParallelReport(op, false, parId, loopLbs[parId],
-            loopUbs[parId], "not enough work for parallel generic GEMM");
-      }
-    }
+    if (enableParallel)
+      tryCreateKrnlParallel(create.krnl, op, "generic GEMM on outer loop",
+          outerLoopDef, loopLbs, loopUbs, 0, 1, {},
+          /*min iter for going parallel*/ 4);
     create.krnl.iterateIE(loopDef, outerLoopDef, loopLbs, loopUbs,
         [&](const KrnlBuilder &createKrnl, ValueRange outerIndices) {
           MultiDialectBuilder<KrnlBuilder, MemRefBuilder, MathBuilder> create(
@@ -229,19 +221,10 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
       // (cache) ii1 jj1 kk1,    (reg) jj2, ii2,    (matmul) ii3, jj3, kk3
       create.krnl.permute({ii1, ii2, ii3, jj1, jj2, jj3, kk1, kk2},
           {/*i*/ 0, 4, 5, /*j*/ 1, 3, 6, /*k*/ 2, 7});
-      if (enableParallel) {
-        int64_t parId;
-        SmallVector<IndexExpr, 1> lb(1, zeroIE), ub(1, I);
-        if (findSuitableParallelDimension(lb, ub, 0, 1, parId,
-                /*min iter for going parallel*/ 4 * iCacheTile)) {
-          create.krnl.parallel(ii1);
-          onnxToKrnlParallelReport(
-              op, true, 0, zeroIE, I, "GEMM tiled copy I parallel");
-        } else {
-          onnxToKrnlParallelReport(op, false, 0, zeroIE, I,
-              "not enough work for GEMM tiled copy I parallel");
-        }
-      }
+      if (enableParallel)
+        tryCreateKrnlParallel(create.krnl, op, "GEMM tiled copy I parallel",
+            {ii1}, {zeroIE}, {I}, 0, 1, {},
+            /*min iter for going parallel*/ 4 * iCacheTile);
       // Compute: A[i, k] * b[k, j] -> R[i, j])
       create.krnl.iterateIE({ii, jj, kk}, {ii1, jj1}, {zeroIE, zeroIE, zeroIE},
           {I, J, K},
@@ -293,19 +276,10 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
       // level is a j, then all the Ks, then all the Is.
       create.krnl.permute({jj1, jj2, jj3, kk1, kk2, ii1, ii2, ii3},
           {/*j*/ 0, 3, 5, /*k*/ 1, 6, /*i*/ 2, 4, 7});
-      if (enableParallel) {
-        int64_t parId;
-        SmallVector<IndexExpr, 1> lb(1, zeroIE), ub(1, J);
-        if (findSuitableParallelDimension(lb, ub, 0, 1, parId,
-                /*min iter for going parallel*/ 4 * jCacheTile)) {
-          create.krnl.parallel(jj1);
-          onnxToKrnlParallelReport(
-              op, true, 0, zeroIE, J, "GEMM tiled no copy J parallel");
-        } else {
-          onnxToKrnlParallelReport(op, false, 0, zeroIE, J,
-              "not enough work for GEMM tiled no copy J parallel");
-        }
-      }
+      if (enableParallel)
+        tryCreateKrnlParallel(create.krnl, op, "GEMM tiled no copy J parallel",
+            {jj1}, {zeroIE}, {J}, 0, 1, {},
+            /*min iter for going parallel*/ 4 * jCacheTile);
       // Compute: A[i, k] * b[k, j] -> R[i, j])
       // Krnl Rule: must put all the iter bounds at once, but can only put the
       // "not currently used ones" like ii here last. Gave an error when ii was
@@ -355,19 +329,10 @@ struct ONNXGemmOpLowering : public OpConversionPattern<GemmOp> {
       return;
     }
     ValueRange outerLoops = create.krnl.defineLoops(2);
-    if (enableParallel) {
-      int64_t parId;
-      SmallVector<IndexExpr, 1> lb(1, zeroIE), ub(1, I);
-      if (findSuitableParallelDimension(lb, ub, 0, 1, parId,
-              /*min iter for going parallel*/ 16)) {
-        create.krnl.parallel(outerLoops[0]);
-        onnxToKrnlParallelReport(
-            op, true, 0, zeroIE, I, "outer loop on tiled Transposed Gemm");
-      } else {
-        onnxToKrnlParallelReport(op, false, 0, zeroIE, I,
-            "not enough work for outer loop on tiled Transposed Gemm");
-      }
-    }
+    if (enableParallel)
+      tryCreateKrnlParallel(create.krnl, op,
+          "outer loop on tiled Transposed Gemm", outerLoops, {zeroIE}, {I}, 0,
+          1, {}, /*min iter for going parallel*/ 16);
     create.krnl.iterateIE(outerLoops, outerLoops, {zeroIE, zeroIE}, {I, J},
         [&](const KrnlBuilder &createKrnl, ValueRange outerIndices) {
           // Handle alpha/beta coefficients.

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -438,7 +438,7 @@ bool emitFullSIMDReductionFor(ConversionPatternRewriter &rewriter, Location loc,
   if (enableParallel) {
     if (tryCreateKrnlParallel(create.krnl, op, "simd reduction to one element",
             {}, {lb}, {ub}, 0, 1, {}, 32 * totVL,
-            /*doNotCreateKrnlParallel=*/true) == -1)
+            /*createKrnlParallel=*/false) == -1)
       enableParallel = false;
   }
   if (!enableParallel) {

--- a/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Reduction.cpp
@@ -436,15 +436,10 @@ bool emitFullSIMDReductionFor(ConversionPatternRewriter &rewriter, Location loc,
           canOverCompute, simdLoopStaticTripCount, simdOnly);
   // Test if loop trip count is long enough for a parallel execution.
   if (enableParallel) {
-    int64_t parId;
-    if (findSuitableParallelDimension({lb}, {ub}, 0, 1, parId, 32 * totVL)) {
-      onnxToKrnlParallelReport(
-          op, true, parId, lb, ub, "simd reduction to one element");
-    } else {
+    if (tryCreateKrnlParallel(create.krnl, op, "simd reduction to one element",
+            {}, {lb}, {ub}, 0, 1, {}, 32 * totVL,
+            /*doNotCreateKrnlParallel=*/true) == -1)
       enableParallel = false;
-      onnxToKrnlParallelReport(op, false, -1, -1,
-          "not enough work in simd reduction to one element");
-    }
   }
   if (!enableParallel) {
     // Allocate temp and output memory
@@ -1058,18 +1053,9 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
       SmallVector<IndexExpr, 4> lbs3(outRank, LitIE(0));
       SmallVector<IndexExpr, 4> ubs3;
       create.krnlIE.getShapeAsSymbols(alloc, ubs3);
-      if (enableParallel) {
-        int64_t parId;
-        if (findSuitableParallelDimension(lbs3, ubs3, 0, 1, parId,
-                /*min iter for going parallel*/ 4)) {
-          create.krnl.parallel(loop3Def[0]);
-          onnxToKrnlParallelReport(
-              op, true, 0, lbs3[0], ubs3[0], "reduction scalar mean");
-        } else {
-          onnxToKrnlParallelReport(op, false, 0, lbs3[0], ubs3[0],
-              "not enough work in reduction scalar mean");
-        }
-      }
+      if (enableParallel)
+        tryCreateKrnlParallel(create.krnl, op, "reduction scalar mean",
+            loop3Def, lbs3, ubs3, 0, 1, {}, /*min iter for going parallel*/ 4);
       create.krnl.iterateIE(loop3Def, loop3Def, lbs3, ubs3,
           [&](const KrnlBuilder &kb, ValueRange loopInd) {
             MultiDialectBuilder<KrnlBuilder, MathBuilder> create(kb);
@@ -1190,19 +1176,9 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
     // Define loops for input dimensions, blocking the inner dim by VL
     ValueRange outLoopDef = create.krnl.defineLoops(flatOutRank);
     SmallVector<IndexExpr, 4> lbs(flatOutRank, LitIE(0));
-    if (enableParallel) {
-      int64_t parId;
-      if (findSuitableParallelDimension(lbs, flatOutDims, 0, 1, parId,
-              /*min iter for going parallel*/ 128)) {
-        create.krnl.parallel(outLoopDef[0]);
-        onnxToKrnlParallelReport(
-            op, true, 0, lbs[0], flatOutDims[0], "reduction h-simd");
-      } else {
-        enableParallel = false;
-        onnxToKrnlParallelReport(op, false, 0, lbs[0], flatOutDims[0],
-            "not enough work for reduction h-simd");
-      }
-    }
+    if (enableParallel)
+      tryCreateKrnlParallel(create.krnl, op, "reduction h-simd", outLoopDef,
+          lbs, flatOutDims, 0, 1, {}, /*min iter for going parallel*/ 128);
     create.krnl.iterateIE(outLoopDef, outLoopDef, lbs, flatOutDims,
         [&](const KrnlBuilder &ck, ValueRange outLoopInd) {
           MDBuilder create(ck);
@@ -1345,17 +1321,9 @@ struct ONNXReductionOpLowering : public OpConversionPattern<ONNXReductionOp> {
     // Iterate only over all but the inner loop of the flattened input.
     SmallVector<IndexExpr, 4> lbs(flatOutRank, LitIE(0));
     if (enableParallel) {
-      int64_t parId;
-      if (findSuitableParallelDimension(lbs, flatOutDims, 0, flatOutRank, parId,
-              /*min iter for going parallel*/ 8 * VL)) {
-        create.krnl.parallel(optimizedOutLoopDef[parId]);
-        onnxToKrnlParallelReport(op, true, parId, lbs[parId],
-            flatOutDims[parId], "reduction shuffle h-simd");
-      } else {
-        enableParallel = false;
-        onnxToKrnlParallelReport(op, false, 0, lbs[0], flatOutDims[0],
-            "not enough work for reduction shuffle h-simd");
-      }
+      tryCreateKrnlParallel(create.krnl, op, "reduction shuffle h-simd",
+          optimizedOutLoopDef, lbs, flatOutDims, 0, flatOutRank, {},
+          /*min iter for going parallel*/ 8 * VL);
     }
     create.krnl.iterateIE(outLoopDef, optimizedOutLoopDef, lbs, flatOutDims,
         [&](const KrnlBuilder &ck, ValueRange blockedOutLoopInd) {

--- a/src/Conversion/ONNXToKrnl/NN/Conv.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Conv.cpp
@@ -218,17 +218,9 @@ struct ONNXConvOpLowering : public OpConversionPattern<ONNXConvOp> {
     };
 
     ValueRange outerLoops = create.krnl.defineLoops(3);
-    if (enableParallel) {
-      int64_t parId;
-      if (findSuitableParallelDimension(outerLbs, outerUbs, 0, 1, parId,
-              /*min iter for going parallel*/ 4)) {
-        create.krnl.parallel(outerLoops[0]);
-        onnxToKrnlParallelReport(op, true, 0, outerLbs[0], outerUbs[0], "conv");
-      } else {
-        onnxToKrnlParallelReport(
-            op, false, 0, outerLbs[0], outerUbs[0], "not enough work in conv");
-      }
-    }
+    if (enableParallel)
+      tryCreateKrnlParallel(
+          create.krnl, op, "conv", outerLoops, outerLbs, outerUbs, 0, 1);
     create.krnl.iterateIE(outerLoops, outerLoops, outerLbs, outerUbs,
         [&](const KrnlBuilder &create, ValueRange outerIndices) {
           bodyFunction(outerIndices);

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -945,18 +945,10 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
     // Iterate over 1st dim by block B.
     bool useParallel = false;
     if (enableParallel) {
-      int64_t parId;
       SmallVector<IndexExpr, 1> lb(1, LitIE(0)), ub(1, XFlatDims[0]);
-      if (findSuitableParallelDimension(lb, ub, 0, 1, parId,
-              /*min iter for going parallel*/ 4)) {
+      if (tryCreateKrnlParallel(create.krnl, op, "layer-norm", {}, lb, ub, 0, 1,
+              {}, 4, /*doNotCreateKrnlParallel=*/true) != -1)
         useParallel = true;
-        onnxToKrnlParallelReport(op, true, 0, lb[0], ub[0], "in layer-norm");
-      } else {
-        onnxToKrnlParallelReport(
-            op, false, 0, lb[0], ub[0], "not enough work in layer-norm");
-      }
-    } else {
-      onnxToKrnlParallelReport(op, false, -1, -1, "no parallel in layer norm");
     }
     Value tmpRedMemRef, tmpRedMemRef2;
     if (!useParallel) {

--- a/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
+++ b/src/Conversion/ONNXToKrnl/NN/Normalization.cpp
@@ -947,7 +947,7 @@ struct GenericLayerNormaOpLowering : public OpConversionPattern<OP_TYPE> {
     if (enableParallel) {
       SmallVector<IndexExpr, 1> lb(1, LitIE(0)), ub(1, XFlatDims[0]);
       if (tryCreateKrnlParallel(create.krnl, op, "layer-norm", {}, lb, ub, 0, 1,
-              {}, 4, /*doNotCreateKrnlParallel=*/true) != -1)
+              {}, 4, /*createKrnlParallel=*/false) != -1)
         useParallel = true;
     }
     Value tmpRedMemRef, tmpRedMemRef2;

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.cpp
@@ -642,12 +642,12 @@ int64_t tryCreateKrnlParallel(const KrnlBuilder &createKrnl, Operation *op,
     std::string msg, const ValueRange &loopDef, ArrayRef<IndexExpr> lbs,
     ArrayRef<IndexExpr> ubs, int64_t firstInclusiveDim,
     int64_t lastExclusiveDim, ArrayRef<int64_t> exclusiveDims, int64_t minSize,
-    bool doNotCreateKrnlParallel) {
+    bool createKrnlParallel) {
   int64_t parId = -1;
   if (findSuitableParallelDimension(
           lbs, ubs, firstInclusiveDim, lastExclusiveDim, parId, minSize)) {
     if (!llvm::is_contained(exclusiveDims, parId)) {
-      if (!doNotCreateKrnlParallel)
+      if (createKrnlParallel)
         createKrnl.parallel(loopDef[parId]);
       onnxToKrnlParallelReport(op, true, parId, lbs[parId], ubs[parId], msg);
       return parId;

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -625,15 +625,22 @@ bool findSuitableParallelDimension(mlir::ArrayRef<IndexExpr> lb,
     mlir::ArrayRef<IndexExpr> ub, int64_t firstInclusiveDim,
     int64_t lastExclusiveDim, int64_t &parDim, int64_t minSize = 4);
 
-// Try to find a suitable loop index for parallelism. If found, emit
-// krnl.parallel op for that loop index and return the id of the loop index.
+// Try to find a suitable loop index for parallelism (parId), where
+// parId >= firstInclusiveDim && parId < exlusiveDim && parId is not in
+// exclusiveDim && tripCount(parId) >= minSize when tripCount can be determined
+// at compile time.
+//
+// If found, emit krnl.parallel op for parId and return parId.
 // Otherwise, do nothing and return -1.
+//
+// When `createKrnlParallel` is set to false, only parID is returned without
+// creating krnl.parallel.
 int64_t tryCreateKrnlParallel(const onnx_mlir::KrnlBuilder &createKrnl,
     mlir::Operation *op, std::string msg, const mlir::ValueRange &loopDef,
     mlir::ArrayRef<IndexExpr> lbs, mlir::ArrayRef<IndexExpr> ubs,
     int64_t firstInclusiveDim = 0, int64_t lastExclusiveDim = 2,
     mlir::ArrayRef<int64_t> exclusiveDims = {}, int64_t minSize = 4,
-    bool doNotCreateKrnlParallel = false);
+    bool createKrnlParallel = true);
 
 //===----------------------------------------------------------------------===//
 // Support functions for determining simd unrolling.

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -627,6 +627,16 @@ bool findSuitableParallelDimension(mlir::ArrayRef<IndexExpr> lb,
     mlir::ArrayRef<IndexExpr> ub, int64_t firstInclusiveDim,
     int64_t lastExclusiveDim, int64_t &parDim, int64_t minSize = 4);
 
+// Try to find a suitable loop index for parallelism. If found, emit
+// krnl.parallel op for that loop index and return the id of the loop index.
+// Otherwise, do nothing and return -1.
+int64_t tryCreateKrnlParallel(const onnx_mlir::KrnlBuilder &createKrnl,
+    mlir::Operation *op, std::string msg, const mlir::ValueRange &loopDef,
+    mlir::ArrayRef<IndexExpr> lbs, mlir::ArrayRef<IndexExpr> ubs,
+    int64_t firstInclusiveDim = 0, int64_t lastExclusiveDim = 2,
+    mlir::ArrayRef<int64_t> exclusiveDims = {}, int64_t minSize = 4,
+    bool doNotCreateKrnlParallel = false);
+
 //===----------------------------------------------------------------------===//
 // Support functions for determining simd unrolling.
 //===----------------------------------------------------------------------===//

--- a/src/Conversion/ONNXToKrnl/Tensor/Expand.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Expand.cpp
@@ -63,17 +63,8 @@ struct ONNXExpandOpLowering : public OpConversionPattern<ONNXExpandOp> {
     DimsExpr ubs = shapeHelper.getOutputDims();
 
     // Enable parallelism if required.
-    if (enableParallel) {
-      int64_t parId = -1;
-      if (findSuitableParallelDimension(lbs, ubs, 0, 2, parId)) {
-        create.krnl.parallel(outputLoopDef[parId]);
-        onnxToKrnlParallelReport(
-            op, true, parId, lbs[parId], ubs[parId], "expand");
-      } else {
-        onnxToKrnlParallelReport(
-            op, false, -1, -1, "no par dim with enough work in expand");
-      }
-    }
+    if (enableParallel)
+      tryCreateKrnlParallel(create.krnl, op, "expand", outputLoopDef, lbs, ubs);
 
     create.krnl.iterateIE(outputLoopDef, outputLoopDef, lbs, ubs,
         [&](const KrnlBuilder &createKrnl, ValueRange outputLoopInd) {

--- a/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/Slice.cpp
@@ -57,17 +57,8 @@ struct ONNXSliceOpLowering : public OpConversionPattern<ONNXSliceOp> {
     DimsExpr ubs = shapeHelper.getOutputDims();
 
     // Enable parallelism if required.
-    if (enableParallel) {
-      int64_t parId = -1;
-      if (findSuitableParallelDimension(lbs, ubs, 0, 2, parId)) {
-        create.krnl.parallel(loopDef[parId]);
-        onnxToKrnlParallelReport(
-            op, true, parId, lbs[parId], ubs[parId], "slice");
-      } else {
-        onnxToKrnlParallelReport(
-            op, false, -1, -1, "no par dim with enough work in slice");
-      }
-    }
+    if (enableParallel)
+      tryCreateKrnlParallel(create.krnl, op, "slice", loopDef, lbs, ubs, 0, 2);
 
     create.krnl.iterateIE(loopDef, loopDef, lbs, ubs,
         [&](const KrnlBuilder &createKrnl, ValueRange loopInd) {


### PR DESCRIPTION
This patch refactors the code for emitting `krnl.parallel` by creating a common function `tryCreateKrnlParallel`. There is is no function change in this patch.