### PR TITLE
Fuse MatMul and Div if the 2nd operand of Div is a scalar constant

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2325,6 +2325,7 @@ void ONNXMulOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<NormalizeMulPattern>(context);
   results.insert<FuseMulConvNullBiasPattern>(context);
+  results.insert<FuseScalarDivMatMulPattern>(context);
   results.insert<FuseScalarMulMatMulPattern>(context);
   results.insert<BinaryOpBroadcastAxisPattern<ONNXMulOp>>(context);
   results.insert<PropagateScalarConstantExpandPattern<ONNXMulOp>>(context);

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2219,6 +2219,7 @@ void ONNXDivOp::getCanonicalizationPatterns(
   result.insert<PropagateReshapeThroughBinaryOpPattern<ONNXDivOp>>(context);
   result.insert<PropagateConstantScalingInAttentionLayerPattern<ONNXDivOp>>(
       context);
+  result.insert<FuseScalarDivMatMulPattern>(context);
 }
 
 /// on the ONNXDropoutOp.
@@ -2325,7 +2326,6 @@ void ONNXMulOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<NormalizeMulPattern>(context);
   results.insert<FuseMulConvNullBiasPattern>(context);
-  results.insert<FuseScalarDivMatMulPattern>(context);
   results.insert<FuseScalarMulMatMulPattern>(context);
   results.insert<BinaryOpBroadcastAxisPattern<ONNXMulOp>>(context);
   results.insert<PropagateScalarConstantExpandPattern<ONNXMulOp>>(context);

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -435,6 +435,11 @@ def FuseScalarMulMatMulPattern: Pat<
  [(IsFromONNXConstantOp $b), (IsScalarConstantTensor $c)]
 >;
 
+def FuseScalarDivMatMulPattern: Pat<
+ (ONNXDivOp (ONNXMatMulOp $a, $b), $c),
+ (ONNXMatMulOp $a, (ONNXDivOp $b, $c)),
+ [(IsFromONNXConstantOp $b), (IsScalarConstantTensor $c)]
+>;
 
 
 // TODO add pattern for non-null bias with constraints:

--- a/test/mlir/onnx/onnx_canonicalization.mlir
+++ b/test/mlir/onnx/onnx_canonicalization.mlir
@@ -75,6 +75,39 @@ func.func @test_matmul_mul_not_fused(%arg0: tensor<?x3xf32>) -> (tensor<?x2xf32>
 
 // -----
 
+func.func @test_matmul_div_fused_1(%arg0: tensor<?x2048xf32>) -> (tensor<?x2048xf32>) {
+  %b = onnx.Constant dense<3.0> : tensor<2048x2048xf32>
+  %c = onnx.Constant dense<5.0> : tensor<f32>
+  %0 = "onnx.MatMul"(%arg0, %b) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
+  %1 = "onnx.Div"(%0, %c) : (tensor<?x2048xf32>, tensor<f32>) -> tensor<?x2048xf32>
+  onnx.Return %1 : tensor<?x2048xf32>
+
+// CHECK-LABEL:  func.func @test_matmul_div_fused_1
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x2048xf32>) -> tensor<?x2048xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<3.000000e+00> : tensor<2048x2048xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<5.000000e+00> : tensor<f32>
+// CHECK:           [[VAR_2_:%.+]] = "onnx.Div"([[VAR_0_]], [[VAR_1_]]) : (tensor<2048x2048xf32>, tensor<f32>) -> tensor<2048x2048xf32>
+// CHECK:           [[VAR_3_:%.+]] = "onnx.MatMul"([[PARAM_0_]], [[VAR_2_]]) : (tensor<?x2048xf32>, tensor<2048x2048xf32>) -> tensor<?x2048xf32>
+// CHECK:           onnx.Return [[VAR_3_]] : tensor<?x2048xf32>
+// CHECK:         }
+}
+
+// -----
+
+func.func @test_matmul_div_not_fused(%arg0: tensor<?x3xf32>) -> (tensor<?x2xf32>) {
+  %b = onnx.Constant dense<3.0> : tensor<3x2xf32>
+  %c = onnx.Constant dense<[1.0, 5.0]> : tensor<2xf32>
+  %0 = "onnx.MatMul"(%arg0, %b) : (tensor<?x3xf32>, tensor<3x2xf32>) -> tensor<?x2xf32>
+  %1 = "onnx.Div"(%0, %c) : (tensor<?x2xf32>, tensor<2xf32>) -> tensor<?x2xf32>
+  onnx.Return %1 : tensor<?x2xf32>
+
+// CHECK-LABEL:  func.func @test_matmul_div_not_fused
+// CHECK: "onnx.MatMul"
+// CHECK-NEXT: "onnx.Div"
+}
+
+// -----
+
 // onnx.MatMul ops with more than one result uses should not get fused.
 // CHECK-LABEL: func @test_sigmoid_add(%{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>, %{{.*}}: tensor<10x10xf32>) -> tensor<10x10xf32>
 func.func @test_sigmoid_add(%a0: tensor<10x10xf32>, %a1: tensor<10x10xf32>, %a2: tensor<10x10xf32>) -> tensor<10x10xf32> {


### PR DESCRIPTION
This patch adds one optimization rule to Div's canonicalization that fuses MatMul and Div if the 2nd operand of Div is a scalar constant

This pattern is found in IBM granite models.

(This patch is similar to #3214 which is for MatMul and Mul)