### PR TITLE
Added z17 CPU vs NNPA performance model

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/CMakeLists.txt
@@ -33,11 +33,11 @@ add_onnx_mlir_library(OMRewriteONNXForZHigh
   libzdnn
   
   LINK_LIBS PUBLIC
+  OMLayoutHelper
   OMNNPACompilerOptions
   OMONNXOps
   OMONNXToKrnl
   OMZHighOps
-  OMLayoutHelper
 
 
   ACCEL_INCLUDE_DIRS PRIVATE
@@ -71,6 +71,7 @@ add_onnx_mlir_library(OMDevicePlacement
   OMONNXOps
   OMONNXToZHigh
   OMRewriteONNXForZHigh
+  OMLayoutHelper
 
   ACCEL_INCLUDE_DIRS PRIVATE
   ${NNPA_INCLUDE_PATH}

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.cpp
@@ -415,11 +415,11 @@ double estimateTimeForStickOp(Value oper) {
   processDim(oper, e4, e3, e2, e1, msg);
   // March 14, no NNPA support.
   if (isLessEqualNNPALevel(NNPALevel::M14))
-    return march14_estimatedTimeForCPU_Stick_3ds(e4 * e3, e2, e1);
+    return arch14_estimatedTimeForCPU_Stick_3ds(e4 * e3, e2, e1);
   // Else returns minimum between CPU and NNPA
   if (isLessEqualNNPALevel(NNPALevel::M15)) {
-    double cpuTime = march15_estimatedTimeForCPU_Stick_3ds(e4 * e3, e2, e1);
-    double nnpaTime = march15_estimatedTimeForNNPA_Stick_3ds(e4 * e3, e2, e1);
+    double cpuTime = arch15_estimatedTimeForCPU_Stick_3ds(e4 * e3, e2, e1);
+    double nnpaTime = arch15_estimatedTimeForNNPA_Stick_3ds(e4 * e3, e2, e1);
     return cpuTime < nnpaTime ? cpuTime : nnpaTime;
   }
   llvm_unreachable("add new NNPA architecture model here");
@@ -432,11 +432,11 @@ double estimateTimeForUnstickOp(Value oper) {
   processDim(oper, e4, e3, e2, e1, msg);
   // March 14, no NNPA support.
   if (isLessEqualNNPALevel(NNPALevel::M14))
-    return march14_estimatedTimeForCPU_Unstick_3ds(e4 * e3, e2, e1);
+    return arch14_estimatedTimeForCPU_Unstick_3ds(e4 * e3, e2, e1);
   // Else returns minimum between CPU and NNPA
   if (isLessEqualNNPALevel(NNPALevel::M15)) {
-    double cpuTime = march15_estimatedTimeForCPU_Unstick_3ds(e4 * e3, e2, e1);
-    double nnpaTime = march15_estimatedTimeForNNPA_Unstick_3ds(e4 * e3, e2, e1);
+    double cpuTime = arch15_estimatedTimeForCPU_Unstick_3ds(e4 * e3, e2, e1);
+    double nnpaTime = arch15_estimatedTimeForNNPA_Unstick_3ds(e4 * e3, e2, e1);
     return cpuTime < nnpaTime ? cpuTime : nnpaTime;
   }
   llvm_unreachable("add new NNPA architecture model here");

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.cpp
@@ -16,6 +16,7 @@
 #include "llvm/Support/Debug.h"
 
 #include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.hpp"
+#include "src/Accelerators/NNPA/Support/NNPALimit.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 
@@ -121,6 +122,7 @@ void estimateTimeForMatMulOp(Operation *op, Value a, Value b, bool aTransposed,
   assert(aType && aType.hasRank() && "expected shaped type with A rank");
   int64_t aRank = aType.getRank();
   llvm::ArrayRef<int64_t> aShape = aType.getShape();
+  // a => matrix A; B => the Batch dims (aka all but the last 2 dims).
   bool aBDynamic;
   int64_t aB = summarizeHigherDims(aShape, aRank - 2, aBDynamic);
   int64_t aNIndex = aTransposed ? aRank - 1 : aRank - 2;
@@ -132,6 +134,7 @@ void estimateTimeForMatMulOp(Operation *op, Value a, Value b, bool aTransposed,
   assert(bType && bType.hasRank() && "expected shaped type with B rank");
   int64_t bRank = bType.getRank();
   llvm::ArrayRef<int64_t> bShape = bType.getShape();
+  // b => matrix B; B => the Batch dims (aka all but the last 2 dims).
   bool bBDynamic;
   int64_t bB = summarizeHigherDims(bShape, bRank - 2, bBDynamic);
   int64_t bMIndex = bTransposed ? bRank - 1 : bRank - 2;
@@ -313,6 +316,15 @@ void estimateTimeForOp<ONNXExpOp>(ONNXExpOp op, const DimAnalysis *dimAnalysis,
 }
 
 template <>
+void estimateTimeForOp<ONNXGeluOp>(ONNXGeluOp op,
+    const DimAnalysis *dimAnalysis, double &cpuEstimatedTime,
+    double &nnpaEstimatedTime) {
+  estimateTimeForElementwiseOp(op.getOperation(), op.getOperand(), dimAnalysis,
+      estimatedTimeForCPU_Gelu_3ds, estimatedTimeForNNPA_Gelu_3ds,
+      cpuEstimatedTime, nnpaEstimatedTime);
+}
+
+template <>
 void estimateTimeForOp<ONNXLogOp>(ONNXLogOp op, const DimAnalysis *dimAnalysis,
     double &cpuEstimatedTime, double &nnpaEstimatedTime) {
   estimateTimeForElementwiseOp(op.getOperation(), op.getOperand(), dimAnalysis,
@@ -401,7 +413,16 @@ double estimateTimeForStickOp(Value oper) {
   int64_t e4, e3, e2, e1;
   std::string msg;
   processDim(oper, e4, e3, e2, e1, msg);
-  return estimatedTimeForNNPA_Stick_3ds(e4 * e3, e2, e1);
+  // March 14, no NNPA support.
+  if (isLessEqualNNPALevel(NNPALevel::M14))
+    return march14_estimatedTimeForCPU_Stick_3ds(e4 * e3, e2, e1);
+  // Else returns minimum between CPU and NNPA
+  if (isLessEqualNNPALevel(NNPALevel::M15)) {
+    double cpuTime = march15_estimatedTimeForCPU_Stick_3ds(e4 * e3, e2, e1);
+    double nnpaTime = march15_estimatedTimeForNNPA_Stick_3ds(e4 * e3, e2, e1);
+    return cpuTime < nnpaTime ? cpuTime : nnpaTime;
+  }
+  llvm_unreachable("add new NNPA architecture model here");
 }
 
 double estimateTimeForUnstickOp(Value oper) {
@@ -409,7 +430,16 @@ double estimateTimeForUnstickOp(Value oper) {
   int64_t e4, e3, e2, e1;
   std::string msg;
   processDim(oper, e4, e3, e2, e1, msg);
-  return estimatedTimeForNNPA_Unstick_3ds(e4 * e3, e2, e1);
+  // March 14, no NNPA support.
+  if (isLessEqualNNPALevel(NNPALevel::M14))
+    return march14_estimatedTimeForCPU_Unstick_3ds(e4 * e3, e2, e1);
+  // Else returns minimum between CPU and NNPA
+  if (isLessEqualNNPALevel(NNPALevel::M15)) {
+    double cpuTime = march15_estimatedTimeForCPU_Unstick_3ds(e4 * e3, e2, e1);
+    double nnpaTime = march15_estimatedTimeForNNPA_Unstick_3ds(e4 * e3, e2, e1);
+    return cpuTime < nnpaTime ? cpuTime : nnpaTime;
+  }
+  llvm_unreachable("add new NNPA architecture model here");
 }
 
 bool estimateTimeForOpWithModel(Operation *op, const DimAnalysis *dimAnalysis,
@@ -432,6 +462,8 @@ bool estimateTimeForOpWithModel(Operation *op, const DimAnalysis *dimAnalysis,
   // Unary elementwise NNPA candidate ops.
   else if (auto expOp = mlir::dyn_cast<ONNXExpOp>(op))
     estimateTimeForOp(expOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
+  else if (auto geluOp = mlir::dyn_cast<ONNXGeluOp>(op))
+    estimateTimeForOp(geluOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
   else if (auto logOp = mlir::dyn_cast<ONNXLogOp>(op))
     estimateTimeForOp(logOp, dimAnalysis, cpuEstimatedTime, nnpaEstimatedTime);
   else if (auto reluOp = mlir::dyn_cast<ONNXReluOp>(op))

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.inc
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.inc
@@ -22,9 +22,9 @@ inline static double ms_ceiling(double n, double m) { return ceil(n / m) * m; }
 #define ESTIMATE_TIME_FOR_DEV3(NAME, DEV)                                      \
   double estimatedTimeFor##DEV##_##NAME(double e3, double e2, double e1) {     \
     if (isLessEqualNNPALevel(NNPALevel::M14))                                  \
-      return march14_estimatedTimeFor##DEV##_##NAME(e3, e2, e1);               \
+      return arch14_estimatedTimeFor##DEV##_##NAME(e3, e2, e1);               \
     if (isLessEqualNNPALevel(NNPALevel::M15))                                  \
-      return march15_estimatedTimeFor##DEV##_##NAME(e3, e2, e1);               \
+      return arch15_estimatedTimeFor##DEV##_##NAME(e3, e2, e1);               \
     llvm_unreachable("add new NNPA architecture model here");                  \
   }
 
@@ -45,8 +45,8 @@ inline static double ms_ceiling(double n, double m) { return ceil(n / m) * m; }
   double estimatedTimeFor##DEV##_##NAME(                                       \
       double e4, double e3, double e2, double e1) {                            \
     if (isLessEqualNNPALevel(NNPALevel::M14))                                  \
-      return march14_estimatedTimeFor##DEV##_##NAME(e4, e3, e2, e1);           \
-    return march15_estimatedTimeFor##DEV##_##NAME(e4, e3, e2, e1);             \
+      return arch14_estimatedTimeFor##DEV##_##NAME(e4, e3, e2, e1);           \
+    return arch15_estimatedTimeFor##DEV##_##NAME(e4, e3, e2, e1);             \
   }
 
 #define ESTIMATE_TIME_FOR4(NAME)                                               \
@@ -67,7 +67,7 @@ inline static double ms_ceiling(double n, double m) { return ceil(n / m) * m; }
 ESTIMATE_TIME_FOR3(Add_3ds)
 ESTIMATE_TIME_FOR3(Div_3ds)
 ESTIMATE_TIME_FOR3(Exp_3ds)
-MISSING_ESTIMATE3(Gelu_3ds, march14)
+MISSING_ESTIMATE3(Gelu_3ds, arch14)
 ESTIMATE_TIME_FOR3(Gelu_3ds)
 #if HI_ALEX
 ESTIMATE_TIME_FOR3(Log_3ds)

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.inc
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModel.inc
@@ -2,300 +2,90 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===----------------- Auto-Generated, do not change  ---------------------===//
+//===----------------- Steer estimation to the right arch  ----------------===//
 //
-// Copyright 2023 The IBM Research Authors.
+// Copyright 2025 The IBM Research Authors.
 //
 // =============================================================================
 
+#define HI_ALEX 1
+#if HI_ALEX
+
+// Include machine specific model.
 inline static double ms_ceiling(double n, double m) { return ceil(n / m) * m; }
+#include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch14.inc"
+#include "src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch15.inc"
 
-// Operation Add_3ds: estimated times.
-double estimatedTimeForCPU_Add_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9989711028792525
-  return 3.9686846353007493e-07 + 1.1794164898251022e-10 * complexity;
-}
-// Operation Add_3ds: estimated times.
-double estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9994266956239162
-  return 2.128070603450555e-06 + 3.884079345448728e-11 * complexity +
-         3.8840793454487276e-11 * complexity2;
-}
+#endif
 
-// Operation Div_3ds: estimated times.
-double estimatedTimeForCPU_Div_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9999973603706902
-  return 6.024413187183776e-07 + 1.444210277092263e-09 * complexity;
-}
-// Operation Div_3ds: estimated times.
-double estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9991809091918582
-  return 4.268037890056841e-06 + 3.958236721770986e-11 * complexity +
-         3.9582367217709856e-11 * complexity2;
-}
+// 3 parameter estimate functions(e3, e2, e1)
+#define ESTIMATE_TIME_FOR_DEV3(NAME, DEV)                                      \
+  double estimatedTimeFor##DEV##_##NAME(double e3, double e2, double e1) {     \
+    if (isLessEqualNNPALevel(NNPALevel::M14))                                  \
+      return march14_estimatedTimeFor##DEV##_##NAME(e3, e2, e1);               \
+    if (isLessEqualNNPALevel(NNPALevel::M15))                                  \
+      return march15_estimatedTimeFor##DEV##_##NAME(e3, e2, e1);               \
+    llvm_unreachable("add new NNPA architecture model here");                  \
+  }
 
-// Operation Exp_3ds: estimated times.
-double estimatedTimeForCPU_Exp_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9964027710112378
-  return -5.114482496042976e-06 + 4.191612771812482e-09 * complexity;
-}
-// Operation Exp_3ds: estimated times.
-double estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9996489747804022
-  return 2.940912571153368e-06 + 3.030831435560512e-11 * complexity +
-         3.030831435560511e-11 * complexity2;
-}
+#define ESTIMATE_TIME_FOR3(NAME)                                               \
+  ESTIMATE_TIME_FOR_DEV3(NAME, CPU)                                            \
+  ESTIMATE_TIME_FOR_DEV3(NAME, NNPA)
 
-// Operation Log_3ds: estimated times.
-double estimatedTimeForCPU_Log_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.98951908796714
-  return -1.1673535780041665e-05 + 5.568744038404678e-09 * complexity;
-}
-// Operation Log_3ds: estimated times.
-double estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9994743517297515
-  return 1.9298869463234537e-06 + 3.5198842979463965e-11 * complexity +
-         3.519884297946396e-11 * complexity2;
-}
+#define MISSING_ESTIMATE3(NAME, ARCH)                                          \
+  double ARCH##_estimatedTimeForCPU_##NAME(double e3, double e2, double e1) {  \
+    return e3 * e2 * e1;                                                       \
+  }                                                                            \
+  double ARCH##_estimatedTimeForNNPA_##NAME(double e3, double e2, double e1) { \
+    return 100 * e3 * e2 * e1;                                                 \
+  }
 
-// Operation MatMul_3ds: estimated times.
-double estimatedTimeForCPU_MatMul_3ds(double B, double N, double M, double K) {
-  double complexity = B * (N * M * K);
-  // Regression for CPU with r2 = 0.9993063132437037
-  return 1.2274778896376187e-06 + 8.277833300031912e-11 * complexity;
-}
-// Operation MatMul_3ds: estimated times.
-double estimatedTimeForNNPA_MatMul_3ds(double B, double N, double M, double K) {
-  double complexity =
-      B * ms_ceiling(N, 2.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
-  double complexity2 =
-      B * ms_ceiling(N, 32.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
-  // Regression for NNPA with r2 = 0.7300356886725241
-  return 3.2376205400192875e-06 + 1.2476855786580124e-12 * complexity +
-         1.2476855786580124e-12 * complexity2;
-}
+// 4 parameter estimate functions(e4, e3, e2, e1). Identical as above otherwise.
+#define ESTIMATE_TIME_FOR_DEV4(NAME, DEV)                                      \
+  double estimatedTimeFor##DEV##_##NAME(                                       \
+      double e4, double e3, double e2, double e1) {                            \
+    if (isLessEqualNNPALevel(NNPALevel::M14))                                  \
+      return march14_estimatedTimeFor##DEV##_##NAME(e4, e3, e2, e1);           \
+    return march15_estimatedTimeFor##DEV##_##NAME(e4, e3, e2, e1);             \
+  }
 
-// Operation Max_3ds: estimated times.
-double estimatedTimeForCPU_Max_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.999934744283212
-  return 3.2005877071463053e-07 + 1.1769966151617187e-10 * complexity;
-}
-// Operation Max_3ds: estimated times.
-double estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.999738981118584
-  return 1.4606129913618409e-06 + 3.931840035694782e-11 * complexity +
-         3.93184003569478e-11 * complexity2;
-}
+#define ESTIMATE_TIME_FOR4(NAME)                                               \
+  ESTIMATE_TIME_FOR_DEV4(NAME, CPU)                                            \
+  ESTIMATE_TIME_FOR_DEV4(NAME, NNPA)
 
-// Operation Min_3ds: estimated times.
-double estimatedTimeForCPU_Min_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9999348493035218
-  return 3.5344354604038237e-07 + 1.175917606999914e-10 * complexity;
-}
-// Operation Min_3ds: estimated times.
-double estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9994174686041679
-  return 3.092302220284167e-06 + 3.897841215495711e-11 * complexity +
-         3.8978412154957106e-11 * complexity2;
-}
+#define MISSING_ESTIMATE4(NAME, ARCH)                                          \
+  double ARCH##_estimatedTimeForCPU_##NAME(                                    \
+      double e4, double e3, double e2, double e1) {                            \
+    return e4 * e3 * e2 * e1;                                                  \
+  }                                                                            \
+  double ARCH##_estimatedTimeForNNPA_##NAME(                                   \
+      double e4, double e3, double e2, double e1) {                            \
+    return 100 * e4 * e3 * e2 * e1;                                            \
+  }
 
-// Operation Mul_3ds: estimated times.
-double estimatedTimeForCPU_Mul_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9999212032519668
-  return 3.506815960365203e-07 + 1.1755692215565626e-10 * complexity;
-}
-// Operation Mul_3ds: estimated times.
-double estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9994566182095322
-  return 2.0629649376500924e-06 + 3.899817129736847e-11 * complexity +
-         3.8998171297368456e-11 * complexity2;
-}
-
-// Operation Pow2_3ds: estimated times.
-double estimatedTimeForCPU_Pow2_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9999320368494156
-  return 4.0421584022966975e-07 + 1.1715722909330777e-10 * complexity;
-}
-// Operation Pow2_3ds: estimated times.
-double estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9994873079624843
-  return 2.0966320666458707e-06 + 3.885726395091773e-11 * complexity +
-         3.8857263950917726e-11 * complexity2;
-}
-
-// Operation Pow3_3ds: estimated times.
-double estimatedTimeForCPU_Pow3_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9998245341999067
-  return 1.643157439725954e-06 + 2.5576590285464804e-10 * complexity;
-}
-// Operation Pow3_3ds: estimated times.
-double estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.3286847571457816
-  return 5.54645111424955e-06 + 1.594942039674421e-10 * complexity +
-         1.5949420396744207e-10 * complexity2;
-}
-
-// Operation Pow4_3ds: estimated times.
-double estimatedTimeForCPU_Pow4_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9999197459422748
-  return 9.47474072842895e-07 + 2.4163095833040496e-10 * complexity;
-}
-// Operation Pow4_3ds: estimated times.
-double estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9994611814325557
-  return 3.901310093115667e-06 + 7.801645620198453e-11 * complexity +
-         7.801645620198452e-11 * complexity2;
-}
-
-// Operation Pow8_3ds: estimated times.
-double estimatedTimeForCPU_Pow8_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9997872605697207
-  return 8.784826358183354e-07 + 3.649713012323953e-10 * complexity;
-}
-// Operation Pow8_3ds: estimated times.
-double estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9995041673834962
-  return 6.134676383478624e-06 + 1.1626159876565245e-10 * complexity +
-         1.1626159876565244e-10 * complexity2;
-}
-
-// Operation ReduceMean_4d: estimated times.
-double estimatedTimeForCPU_ReduceMean_4d(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9581972945355149
-  return -1.561907564731308e-07 + 1.2218609072525066e-10 * complexity;
-}
-// Operation ReduceMean_4d: estimated times.
-double estimatedTimeForNNPA_ReduceMean_4d(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.21677591777344662
-  return 1.1936219405338953e-05 + 1.0676642952683933e-11 * complexity +
-         1.0676642952683933e-11 * complexity2;
-}
-
-// Operation Relu_3ds: estimated times.
-double estimatedTimeForCPU_Relu_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9997916471943519
-  return 4.020992561015175e-07 + 1.1775068214689546e-10 * complexity;
-}
-// Operation Relu_3ds: estimated times.
-double estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9996967196634997
-  return 1.2244816818061312e-06 + 2.8344213155279377e-11 * complexity +
-         2.8344213155279377e-11 * complexity2;
-}
-
-// Operation Sigmoid_3ds: estimated times.
-double estimatedTimeForCPU_Sigmoid_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9999935862933553
-  return 2.4666188614796535e-07 + 5.3819773454779955e-09 * complexity;
-}
-// Operation Sigmoid_3ds: estimated times.
-double estimatedTimeForNNPA_Sigmoid_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9997032611893206
-  return 4.552265280283248e-06 + 4.268025052443249e-11 * complexity +
-         4.2680250524432486e-11 * complexity2;
-}
-
-// Operation Softmax_3ds: estimated times.
-double estimatedTimeForCPU_Softmax_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9998169150056859
-  return 3.850778825086575e-06 + 6.476546494036936e-09 * complexity;
-}
-// Operation Softmax_3ds: estimated times.
-double estimatedTimeForNNPA_Softmax_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.6458689171873927
-  return 3.823709210789688e-05 + 7.316577699975697e-10 * complexity +
-         7.316577699975696e-10 * complexity2;
-}
-
-// Operation Stick_3ds: estimated times.
-double estimatedTimeForNNPA_Stick_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9838446914891756
-  return -1.1787349678206611e-07 + 9.738975985428137e-11 * complexity +
-         9.738975985428137e-11 * complexity2;
-}
-
-// Operation Sub_3ds: estimated times.
-double estimatedTimeForCPU_Sub_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9989967088496832
-  return 4.6884880875538195e-07 + 1.178543625471088e-10 * complexity;
-}
-// Operation Sub_3ds: estimated times.
-double estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9997163549514938
-  return 1.3893829024566132e-06 + 3.958841159751218e-11 * complexity +
-         3.95884115975122e-11 * complexity2;
-}
-
-// Operation Tanh_3ds: estimated times.
-double estimatedTimeForCPU_Tanh_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * e2 * e1;
-  // Regression for CPU with r2 = 0.9899146645413962
-  return 4.591865418171123e-06 + 1.5243041278914726e-09 * complexity;
-}
-// Operation Tanh_3ds: estimated times.
-double estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9992996189301544
-  return 3.1652117218733632e-06 + 2.7515670717117405e-11 * complexity +
-         2.7515670717117402e-11 * complexity2;
-}
-
-// Operation Unstick_3ds: estimated times.
-double estimatedTimeForNNPA_Unstick_3ds(double e3, double e2, double e1) {
-  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
-  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
-  // Regression for NNPA with r2 = 0.9804634203145826
-  return -3.9924342483643434e-07 + 1.0477727134169295e-10 * complexity +
-         1.0477727134169292e-10 * complexity2;
-}
+// Invoke macros. Stick and Unstick op are handled directly in PerfModel.cpp.
+ESTIMATE_TIME_FOR3(Add_3ds)
+ESTIMATE_TIME_FOR3(Div_3ds)
+ESTIMATE_TIME_FOR3(Exp_3ds)
+MISSING_ESTIMATE3(Gelu_3ds, march14)
+ESTIMATE_TIME_FOR3(Gelu_3ds)
+#if HI_ALEX
+ESTIMATE_TIME_FOR3(Log_3ds)
+ESTIMATE_TIME_FOR4(MatMul_3ds)
+// Skipping the special handling of broadcast in matmul for now.
+// MISSING_ESTIMATE4(MatMul_bcast23, march14)
+// ESTIMATE_TIME_FOR4(MatMul_bcast23)
+ESTIMATE_TIME_FOR3(Max_3ds)
+ESTIMATE_TIME_FOR3(Min_3ds)
+ESTIMATE_TIME_FOR3(Mul_3ds)
+ESTIMATE_TIME_FOR3(Pow2_3ds)
+ESTIMATE_TIME_FOR3(Pow3_3ds)
+ESTIMATE_TIME_FOR3(Pow4_3ds)
+ESTIMATE_TIME_FOR3(Pow8_3ds)
+ESTIMATE_TIME_FOR3(ReduceMean_4d)
+ESTIMATE_TIME_FOR3(Relu_3ds)
+ESTIMATE_TIME_FOR3(Sigmoid_3ds)
+ESTIMATE_TIME_FOR3(Softmax_3ds)
+ESTIMATE_TIME_FOR3(Sub_3ds)
+ESTIMATE_TIME_FOR3(Tanh_3ds)
+#endif

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch14.inc
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch14.inc
@@ -9,13 +9,13 @@
 // =============================================================================
 
 // Operation Add_3ds: estimated times.
-double march14_estimatedTimeForCPU_Add_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Add_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9989711028792525
   return 3.9686846353007493e-07 + 1.1794164898251022e-10 * complexity;
 }
 // Operation Add_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9994266956239162
@@ -24,13 +24,13 @@ double march14_estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Div_3ds: estimated times.
-double march14_estimatedTimeForCPU_Div_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Div_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9999973603706902
   return 6.024413187183776e-07 + 1.444210277092263e-09 * complexity;
 }
 // Operation Div_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9991809091918582
@@ -39,13 +39,13 @@ double march14_estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Exp_3ds: estimated times.
-double march14_estimatedTimeForCPU_Exp_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Exp_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9964027710112378
   return -5.114482496042976e-06 + 4.191612771812482e-09 * complexity;
 }
 // Operation Exp_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9996489747804022
@@ -54,13 +54,13 @@ double march14_estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Log_3ds: estimated times.
-double march14_estimatedTimeForCPU_Log_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Log_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.98951908796714
   return -1.1673535780041665e-05 + 5.568744038404678e-09 * complexity;
 }
 // Operation Log_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9994743517297515
@@ -69,14 +69,14 @@ double march14_estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
 }
 
 // Operation MatMul_3ds: estimated times.
-double march14_estimatedTimeForCPU_MatMul_3ds(
+double arch14_estimatedTimeForCPU_MatMul_3ds(
     double B, double N, double M, double K) {
   double complexity = B * (N * M * K);
   // Regression for CPU with r2 = 0.9993063132437037
   return 1.2274778896376187e-06 + 8.277833300031912e-11 * complexity;
 }
 // Operation MatMul_3ds: estimated times.
-double march14_estimatedTimeForNNPA_MatMul_3ds(
+double arch14_estimatedTimeForNNPA_MatMul_3ds(
     double B, double N, double M, double K) {
   double complexity =
       B * ms_ceiling(N, 2.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
@@ -88,13 +88,13 @@ double march14_estimatedTimeForNNPA_MatMul_3ds(
 }
 
 // Operation Max_3ds: estimated times.
-double march14_estimatedTimeForCPU_Max_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Max_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.999934744283212
   return 3.2005877071463053e-07 + 1.1769966151617187e-10 * complexity;
 }
 // Operation Max_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.999738981118584
@@ -103,13 +103,13 @@ double march14_estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Min_3ds: estimated times.
-double march14_estimatedTimeForCPU_Min_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Min_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9999348493035218
   return 3.5344354604038237e-07 + 1.175917606999914e-10 * complexity;
 }
 // Operation Min_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9994174686041679
@@ -118,13 +118,13 @@ double march14_estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Mul_3ds: estimated times.
-double march14_estimatedTimeForCPU_Mul_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Mul_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9999212032519668
   return 3.506815960365203e-07 + 1.1755692215565626e-10 * complexity;
 }
 // Operation Mul_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9994566182095322
@@ -133,13 +133,13 @@ double march14_estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Pow2_3ds: estimated times.
-double march14_estimatedTimeForCPU_Pow2_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Pow2_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9999320368494156
   return 4.0421584022966975e-07 + 1.1715722909330777e-10 * complexity;
 }
 // Operation Pow2_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9994873079624843
@@ -148,13 +148,13 @@ double march14_estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Pow3_3ds: estimated times.
-double march14_estimatedTimeForCPU_Pow3_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Pow3_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9998245341999067
   return 1.643157439725954e-06 + 2.5576590285464804e-10 * complexity;
 }
 // Operation Pow3_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.3286847571457816
@@ -163,13 +163,13 @@ double march14_estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Pow4_3ds: estimated times.
-double march14_estimatedTimeForCPU_Pow4_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Pow4_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9999197459422748
   return 9.47474072842895e-07 + 2.4163095833040496e-10 * complexity;
 }
 // Operation Pow4_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9994611814325557
@@ -178,13 +178,13 @@ double march14_estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Pow8_3ds: estimated times.
-double march14_estimatedTimeForCPU_Pow8_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Pow8_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9997872605697207
   return 8.784826358183354e-07 + 3.649713012323953e-10 * complexity;
 }
 // Operation Pow8_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9995041673834962
@@ -193,14 +193,14 @@ double march14_estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
 }
 
 // Operation ReduceMean_4d: estimated times.
-double march14_estimatedTimeForCPU_ReduceMean_4d(
+double arch14_estimatedTimeForCPU_ReduceMean_4d(
     double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9581972945355149
   return -1.561907564731308e-07 + 1.2218609072525066e-10 * complexity;
 }
 // Operation ReduceMean_4d: estimated times.
-double march14_estimatedTimeForNNPA_ReduceMean_4d(
+double arch14_estimatedTimeForNNPA_ReduceMean_4d(
     double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
@@ -210,13 +210,13 @@ double march14_estimatedTimeForNNPA_ReduceMean_4d(
 }
 
 // Operation Relu_3ds: estimated times.
-double march14_estimatedTimeForCPU_Relu_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Relu_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9997916471943519
   return 4.020992561015175e-07 + 1.1775068214689546e-10 * complexity;
 }
 // Operation Relu_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9996967196634997
@@ -225,14 +225,13 @@ double march14_estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Sigmoid_3ds: estimated times.
-double march14_estimatedTimeForCPU_Sigmoid_3ds(
-    double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Sigmoid_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9999935862933553
   return 2.4666188614796535e-07 + 5.3819773454779955e-09 * complexity;
 }
 // Operation Sigmoid_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Sigmoid_3ds(
+double arch14_estimatedTimeForNNPA_Sigmoid_3ds(
     double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
@@ -242,14 +241,13 @@ double march14_estimatedTimeForNNPA_Sigmoid_3ds(
 }
 
 // Operation Softmax_3ds: estimated times.
-double march14_estimatedTimeForCPU_Softmax_3ds(
-    double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Softmax_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9998169150056859
   return 3.850778825086575e-06 + 6.476546494036936e-09 * complexity;
 }
 // Operation Softmax_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Softmax_3ds(
+double arch14_estimatedTimeForNNPA_Softmax_3ds(
     double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
@@ -259,7 +257,7 @@ double march14_estimatedTimeForNNPA_Softmax_3ds(
 }
 
 // Operation Stick_3ds: estimated times.
-double march14_estimatedTimeForCPU_Stick_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Stick_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9838446914891756
@@ -268,13 +266,13 @@ double march14_estimatedTimeForCPU_Stick_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Sub_3ds: estimated times.
-double march14_estimatedTimeForCPU_Sub_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Sub_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9989967088496832
   return 4.6884880875538195e-07 + 1.178543625471088e-10 * complexity;
 }
 // Operation Sub_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9997163549514938
@@ -283,13 +281,13 @@ double march14_estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Tanh_3ds: estimated times.
-double march14_estimatedTimeForCPU_Tanh_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Tanh_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9899146645413962
   return 4.591865418171123e-06 + 1.5243041278914726e-09 * complexity;
 }
 // Operation Tanh_3ds: estimated times.
-double march14_estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
+double arch14_estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9992996189301544
@@ -298,8 +296,7 @@ double march14_estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Unstick_3ds: estimated times.
-double march14_estimatedTimeForCPU_Unstick_3ds(
-    double e3, double e2, double e1) {
+double arch14_estimatedTimeForCPU_Unstick_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9804634203145826

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch14.inc
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch14.inc
@@ -1,0 +1,308 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----------------- Auto-Generated, do not change  ---------------------===//
+//
+// Copyright 2023-2025 The IBM Research Authors.
+//
+// =============================================================================
+
+// Operation Add_3ds: estimated times.
+double march14_estimatedTimeForCPU_Add_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9989711028792525
+  return 3.9686846353007493e-07 + 1.1794164898251022e-10 * complexity;
+}
+// Operation Add_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9994266956239162
+  return 2.128070603450555e-06 + 3.884079345448728e-11 * complexity +
+         3.8840793454487276e-11 * complexity2;
+}
+
+// Operation Div_3ds: estimated times.
+double march14_estimatedTimeForCPU_Div_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9999973603706902
+  return 6.024413187183776e-07 + 1.444210277092263e-09 * complexity;
+}
+// Operation Div_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9991809091918582
+  return 4.268037890056841e-06 + 3.958236721770986e-11 * complexity +
+         3.9582367217709856e-11 * complexity2;
+}
+
+// Operation Exp_3ds: estimated times.
+double march14_estimatedTimeForCPU_Exp_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9964027710112378
+  return -5.114482496042976e-06 + 4.191612771812482e-09 * complexity;
+}
+// Operation Exp_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9996489747804022
+  return 2.940912571153368e-06 + 3.030831435560512e-11 * complexity +
+         3.030831435560511e-11 * complexity2;
+}
+
+// Operation Log_3ds: estimated times.
+double march14_estimatedTimeForCPU_Log_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.98951908796714
+  return -1.1673535780041665e-05 + 5.568744038404678e-09 * complexity;
+}
+// Operation Log_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9994743517297515
+  return 1.9298869463234537e-06 + 3.5198842979463965e-11 * complexity +
+         3.519884297946396e-11 * complexity2;
+}
+
+// Operation MatMul_3ds: estimated times.
+double march14_estimatedTimeForCPU_MatMul_3ds(
+    double B, double N, double M, double K) {
+  double complexity = B * (N * M * K);
+  // Regression for CPU with r2 = 0.9993063132437037
+  return 1.2274778896376187e-06 + 8.277833300031912e-11 * complexity;
+}
+// Operation MatMul_3ds: estimated times.
+double march14_estimatedTimeForNNPA_MatMul_3ds(
+    double B, double N, double M, double K) {
+  double complexity =
+      B * ms_ceiling(N, 2.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
+  double complexity2 =
+      B * ms_ceiling(N, 32.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
+  // Regression for NNPA with r2 = 0.7300356886725241
+  return 3.2376205400192875e-06 + 1.2476855786580124e-12 * complexity +
+         1.2476855786580124e-12 * complexity2;
+}
+
+// Operation Max_3ds: estimated times.
+double march14_estimatedTimeForCPU_Max_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.999934744283212
+  return 3.2005877071463053e-07 + 1.1769966151617187e-10 * complexity;
+}
+// Operation Max_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.999738981118584
+  return 1.4606129913618409e-06 + 3.931840035694782e-11 * complexity +
+         3.93184003569478e-11 * complexity2;
+}
+
+// Operation Min_3ds: estimated times.
+double march14_estimatedTimeForCPU_Min_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9999348493035218
+  return 3.5344354604038237e-07 + 1.175917606999914e-10 * complexity;
+}
+// Operation Min_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9994174686041679
+  return 3.092302220284167e-06 + 3.897841215495711e-11 * complexity +
+         3.8978412154957106e-11 * complexity2;
+}
+
+// Operation Mul_3ds: estimated times.
+double march14_estimatedTimeForCPU_Mul_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9999212032519668
+  return 3.506815960365203e-07 + 1.1755692215565626e-10 * complexity;
+}
+// Operation Mul_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9994566182095322
+  return 2.0629649376500924e-06 + 3.899817129736847e-11 * complexity +
+         3.8998171297368456e-11 * complexity2;
+}
+
+// Operation Pow2_3ds: estimated times.
+double march14_estimatedTimeForCPU_Pow2_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9999320368494156
+  return 4.0421584022966975e-07 + 1.1715722909330777e-10 * complexity;
+}
+// Operation Pow2_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9994873079624843
+  return 2.0966320666458707e-06 + 3.885726395091773e-11 * complexity +
+         3.8857263950917726e-11 * complexity2;
+}
+
+// Operation Pow3_3ds: estimated times.
+double march14_estimatedTimeForCPU_Pow3_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9998245341999067
+  return 1.643157439725954e-06 + 2.5576590285464804e-10 * complexity;
+}
+// Operation Pow3_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.3286847571457816
+  return 5.54645111424955e-06 + 1.594942039674421e-10 * complexity +
+         1.5949420396744207e-10 * complexity2;
+}
+
+// Operation Pow4_3ds: estimated times.
+double march14_estimatedTimeForCPU_Pow4_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9999197459422748
+  return 9.47474072842895e-07 + 2.4163095833040496e-10 * complexity;
+}
+// Operation Pow4_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9994611814325557
+  return 3.901310093115667e-06 + 7.801645620198453e-11 * complexity +
+         7.801645620198452e-11 * complexity2;
+}
+
+// Operation Pow8_3ds: estimated times.
+double march14_estimatedTimeForCPU_Pow8_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9997872605697207
+  return 8.784826358183354e-07 + 3.649713012323953e-10 * complexity;
+}
+// Operation Pow8_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9995041673834962
+  return 6.134676383478624e-06 + 1.1626159876565245e-10 * complexity +
+         1.1626159876565244e-10 * complexity2;
+}
+
+// Operation ReduceMean_4d: estimated times.
+double march14_estimatedTimeForCPU_ReduceMean_4d(
+    double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9581972945355149
+  return -1.561907564731308e-07 + 1.2218609072525066e-10 * complexity;
+}
+// Operation ReduceMean_4d: estimated times.
+double march14_estimatedTimeForNNPA_ReduceMean_4d(
+    double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.21677591777344662
+  return 1.1936219405338953e-05 + 1.0676642952683933e-11 * complexity +
+         1.0676642952683933e-11 * complexity2;
+}
+
+// Operation Relu_3ds: estimated times.
+double march14_estimatedTimeForCPU_Relu_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9997916471943519
+  return 4.020992561015175e-07 + 1.1775068214689546e-10 * complexity;
+}
+// Operation Relu_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9996967196634997
+  return 1.2244816818061312e-06 + 2.8344213155279377e-11 * complexity +
+         2.8344213155279377e-11 * complexity2;
+}
+
+// Operation Sigmoid_3ds: estimated times.
+double march14_estimatedTimeForCPU_Sigmoid_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9999935862933553
+  return 2.4666188614796535e-07 + 5.3819773454779955e-09 * complexity;
+}
+// Operation Sigmoid_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Sigmoid_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9997032611893206
+  return 4.552265280283248e-06 + 4.268025052443249e-11 * complexity +
+         4.2680250524432486e-11 * complexity2;
+}
+
+// Operation Softmax_3ds: estimated times.
+double march14_estimatedTimeForCPU_Softmax_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9998169150056859
+  return 3.850778825086575e-06 + 6.476546494036936e-09 * complexity;
+}
+// Operation Softmax_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Softmax_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.6458689171873927
+  return 3.823709210789688e-05 + 7.316577699975697e-10 * complexity +
+         7.316577699975696e-10 * complexity2;
+}
+
+// Operation Stick_3ds: estimated times.
+double march14_estimatedTimeForCPU_Stick_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9838446914891756
+  return -1.1787349678206611e-07 + 9.738975985428137e-11 * complexity +
+         9.738975985428137e-11 * complexity2;
+}
+
+// Operation Sub_3ds: estimated times.
+double march14_estimatedTimeForCPU_Sub_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9989967088496832
+  return 4.6884880875538195e-07 + 1.178543625471088e-10 * complexity;
+}
+// Operation Sub_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9997163549514938
+  return 1.3893829024566132e-06 + 3.958841159751218e-11 * complexity +
+         3.95884115975122e-11 * complexity2;
+}
+
+// Operation Tanh_3ds: estimated times.
+double march14_estimatedTimeForCPU_Tanh_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9899146645413962
+  return 4.591865418171123e-06 + 1.5243041278914726e-09 * complexity;
+}
+// Operation Tanh_3ds: estimated times.
+double march14_estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9992996189301544
+  return 3.1652117218733632e-06 + 2.7515670717117405e-11 * complexity +
+         2.7515670717117402e-11 * complexity2;
+}
+
+// Operation Unstick_3ds: estimated times.
+double march14_estimatedTimeForCPU_Unstick_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9804634203145826
+  return -3.9924342483643434e-07 + 1.0477727134169295e-10 * complexity +
+         1.0477727134169292e-10 * complexity2;
+}

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch15.inc
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch15.inc
@@ -9,13 +9,13 @@
 // =============================================================================
 
 // Operation Add_3ds: estimated times.
-double march15_estimatedTimeForCPU_Add_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Add_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9794305300045331
   return 1.0414597616987286e-06 + 9.436133475545827e-11 * complexity;
 }
 // Operation Add_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9697580789334318
@@ -24,13 +24,13 @@ double march15_estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Div_3ds: estimated times.
-double march15_estimatedTimeForCPU_Div_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Div_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9998048175945131
   return 5.786938996660593e-07 + 1.3646311059272094e-09 * complexity;
 }
 // Operation Div_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.990816705245199
@@ -39,13 +39,13 @@ double march15_estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Exp_3ds: estimated times.
-double march15_estimatedTimeForCPU_Exp_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Exp_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.89242570724948
   return -5.1801798144228634e-05 + 6.21757000288656e-09 * complexity;
 }
 // Operation Exp_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.999015162322293
@@ -54,13 +54,13 @@ double march15_estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Gelu_3ds: estimated times.
-double march15_estimatedTimeForCPU_Gelu_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Gelu_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9996558252290894
   return 5.0765999634455865e-06 + 1.10312695415442e-08 * complexity;
 }
 // Operation Gelu_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Gelu_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Gelu_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9991600550763047
@@ -69,13 +69,13 @@ double march15_estimatedTimeForNNPA_Gelu_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Log_3ds: estimated times.
-double march15_estimatedTimeForCPU_Log_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Log_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9781276143547772
   return -4.529738358558183e-05 + 6.783445144043389e-09 * complexity;
 }
 // Operation Log_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9987930417510681
@@ -84,14 +84,14 @@ double march15_estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
 }
 
 // Operation MatMul_3ds: estimated times.
-double march15_estimatedTimeForCPU_MatMul_3ds(
+double arch15_estimatedTimeForCPU_MatMul_3ds(
     double B, double N, double M, double K) {
   double complexity = B * (N * M * K);
   // Regression for CPU with r2 = 0.9884079270433619
   return 1.855222799861678e-06 + 5.050650951084619e-11 * complexity;
 }
 // Operation MatMul_3ds: estimated times.
-double march15_estimatedTimeForNNPA_MatMul_3ds(
+double arch15_estimatedTimeForNNPA_MatMul_3ds(
     double B, double N, double M, double K) {
   double complexity =
       B * ms_ceiling(N, 2.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
@@ -104,13 +104,13 @@ double march15_estimatedTimeForNNPA_MatMul_3ds(
 
 #if 0 /* not in use at this time */
 // Operation MatMul_bcast23: estimated times.
-double march15_estimatedTimeForCPU_MatMul_bcast23(double B, double N, double M, double K) {
+double arch15_estimatedTimeForCPU_MatMul_bcast23(double B, double N, double M, double K) {
   double complexity = B * (N * M * K);
   // Regression for CPU with r2 = 0.999572142279475
   return 1.2018540664406345e-07 + 4.950906739952868e-11 * complexity;
 }
 // Operation MatMul_bcast23: estimated times.
-double march15_estimatedTimeForNNPA_MatMul_bcast23(double B, double N, double M, double K) {
+double arch15_estimatedTimeForNNPA_MatMul_bcast23(double B, double N, double M, double K) {
   double complexity  = B * ms_ceiling(N, 2.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
   double complexity2 = B * ms_ceiling(N, 32.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
   // Regression for NNPA with r2 = 0.8552465991036068
@@ -119,13 +119,13 @@ double march15_estimatedTimeForNNPA_MatMul_bcast23(double B, double N, double M,
 #endif
 
 // Operation Max_3ds: estimated times.
-double march15_estimatedTimeForCPU_Max_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Max_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9996046252770894
   return 8.55259663295163e-07 + 9.596611822047999e-11 * complexity;
 }
 // Operation Max_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9926138482906947
@@ -134,13 +134,13 @@ double march15_estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Min_3ds: estimated times.
-double march15_estimatedTimeForCPU_Min_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Min_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9993518712923539
   return 8.119717132969606e-07 + 9.641853939778113e-11 * complexity;
 }
 // Operation Min_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9948689360722767
@@ -149,13 +149,13 @@ double march15_estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Mul_3ds: estimated times.
-double march15_estimatedTimeForCPU_Mul_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Mul_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9994096986852347
   return 8.576427061854475e-07 + 9.573075501041591e-11 * complexity;
 }
 // Operation Mul_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9938418209740545
@@ -164,13 +164,13 @@ double march15_estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Pow2_3ds: estimated times.
-double march15_estimatedTimeForCPU_Pow2_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Pow2_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9330727047521541
   return -8.210853307002942e-07 + 1.234202263969703e-10 * complexity;
 }
 // Operation Pow2_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9903205087066541
@@ -179,13 +179,13 @@ double march15_estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Pow3_3ds: estimated times.
-double march15_estimatedTimeForCPU_Pow3_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Pow3_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.947704531709904
   return 3.3263848039024823e-06 + 2.604707783272701e-10 * complexity;
 }
 // Operation Pow3_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9939780628358914
@@ -194,13 +194,13 @@ double march15_estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Pow4_3ds: estimated times.
-double march15_estimatedTimeForCPU_Pow4_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Pow4_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.979306482228355
   return 6.752793164225602e-07 + 2.0372887895594365e-10 * complexity;
 }
 // Operation Pow4_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9931689983532582
@@ -209,13 +209,13 @@ double march15_estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Pow8_3ds: estimated times.
-double march15_estimatedTimeForCPU_Pow8_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Pow8_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9999063396503455
   return 1.649910604587757e-06 + 2.8617211971025847e-10 * complexity;
 }
 // Operation Pow8_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9948502081739099
@@ -224,14 +224,14 @@ double march15_estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
 }
 
 // Operation ReduceMean_4d: estimated times.
-double march15_estimatedTimeForCPU_ReduceMean_4d(
+double arch15_estimatedTimeForCPU_ReduceMean_4d(
     double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9641896473441319
   return -3.44566941822172e-08 + 1.2715126545232464e-10 * complexity;
 }
 // Operation ReduceMean_4d: estimated times.
-double march15_estimatedTimeForNNPA_ReduceMean_4d(
+double arch15_estimatedTimeForNNPA_ReduceMean_4d(
     double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
@@ -241,13 +241,13 @@ double march15_estimatedTimeForNNPA_ReduceMean_4d(
 }
 
 // Operation Relu_3ds: estimated times.
-double march15_estimatedTimeForCPU_Relu_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Relu_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.999247901534308
   return 8.67113022326907e-07 + 9.427073286069188e-11 * complexity;
 }
 // Operation Relu_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9989466394839843
@@ -256,14 +256,13 @@ double march15_estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Sigmoid_3ds: estimated times.
-double march15_estimatedTimeForCPU_Sigmoid_3ds(
-    double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Sigmoid_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.6694863546412586
   return -0.0003110638128148975 + 1.0198957146700573e-08 * complexity;
 }
 // Operation Sigmoid_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Sigmoid_3ds(
+double arch15_estimatedTimeForNNPA_Sigmoid_3ds(
     double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
@@ -273,14 +272,13 @@ double march15_estimatedTimeForNNPA_Sigmoid_3ds(
 }
 
 // Operation Softmax_3ds: estimated times.
-double march15_estimatedTimeForCPU_Softmax_3ds(
-    double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Softmax_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9941480124435297
   return 4.922124351942512e-06 + 7.895222736377622e-09 * complexity;
 }
 // Operation Softmax_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Softmax_3ds(
+double arch15_estimatedTimeForNNPA_Softmax_3ds(
     double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
@@ -290,13 +288,13 @@ double march15_estimatedTimeForNNPA_Softmax_3ds(
 }
 
 // Operation Stick_3ds: estimated times.
-double march15_estimatedTimeForCPU_Stick_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Stick_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9573201775683942
   return 7.223242630385479e-07 + 8.501740539965986e-11 * complexity;
 }
 // Operation Stick_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Stick_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Stick_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.6906958856336693
@@ -305,13 +303,13 @@ double march15_estimatedTimeForNNPA_Stick_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Sub_3ds: estimated times.
-double march15_estimatedTimeForCPU_Sub_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Sub_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9994300646660222
   return 8.53949178130232e-07 + 9.552545176353334e-11 * complexity;
 }
 // Operation Sub_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9953310347130198
@@ -320,13 +318,13 @@ double march15_estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Tanh_3ds: estimated times.
-double march15_estimatedTimeForCPU_Tanh_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Tanh_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9992625489601716
   return 3.2369598896957175e-07 + 1.4078506521178395e-09 * complexity;
 }
 // Operation Tanh_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
+double arch15_estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
   // Regression for NNPA with r2 = 0.9960934032072877
@@ -335,14 +333,13 @@ double march15_estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
 }
 
 // Operation Unstick_3ds: estimated times.
-double march15_estimatedTimeForCPU_Unstick_3ds(
-    double e3, double e2, double e1) {
+double arch15_estimatedTimeForCPU_Unstick_3ds(double e3, double e2, double e1) {
   double complexity = e3 * e2 * e1;
   // Regression for CPU with r2 = 0.9932274704371545
   return 7.653934223015085e-07 + 1.389382010359011e-10 * complexity;
 }
 // Operation Unstick_3ds: estimated times.
-double march15_estimatedTimeForNNPA_Unstick_3ds(
+double arch15_estimatedTimeForNNPA_Unstick_3ds(
     double e3, double e2, double e1) {
   double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
   double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);

--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch15.inc
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/PerfModelArch15.inc
@@ -1,0 +1,352 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===----------------- Auto-Generated, do not change  ---------------------===//
+//
+// Copyright 2025 The IBM Research Authors.
+//
+// =============================================================================
+
+// Operation Add_3ds: estimated times.
+double march15_estimatedTimeForCPU_Add_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9794305300045331
+  return 1.0414597616987286e-06 + 9.436133475545827e-11 * complexity;
+}
+// Operation Add_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Add_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9697580789334318
+  return 1.8567493018624777e-06 + 1.9088979028012123e-11 * complexity +
+         1.9088979028012123e-11 * complexity2;
+}
+
+// Operation Div_3ds: estimated times.
+double march15_estimatedTimeForCPU_Div_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9998048175945131
+  return 5.786938996660593e-07 + 1.3646311059272094e-09 * complexity;
+}
+// Operation Div_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Div_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.990816705245199
+  return 1.980349705611261e-06 + 2.942935466811418e-11 * complexity +
+         2.942935466811418e-11 * complexity2;
+}
+
+// Operation Exp_3ds: estimated times.
+double march15_estimatedTimeForCPU_Exp_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.89242570724948
+  return -5.1801798144228634e-05 + 6.21757000288656e-09 * complexity;
+}
+// Operation Exp_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Exp_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.999015162322293
+  return 2.085593685056712e-06 + 2.6182534527148465e-11 * complexity +
+         2.6182534527148458e-11 * complexity2;
+}
+
+// Operation Gelu_3ds: estimated times.
+double march15_estimatedTimeForCPU_Gelu_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9996558252290894
+  return 5.0765999634455865e-06 + 1.10312695415442e-08 * complexity;
+}
+// Operation Gelu_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Gelu_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9991600550763047
+  return 1.7614607196673564e-06 + 3.574799081041781e-11 * complexity +
+         3.5747990810417806e-11 * complexity2;
+}
+
+// Operation Log_3ds: estimated times.
+double march15_estimatedTimeForCPU_Log_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9781276143547772
+  return -4.529738358558183e-05 + 6.783445144043389e-09 * complexity;
+}
+// Operation Log_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Log_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9987930417510681
+  return 2.0534086916963085e-06 + 3.111607458075494e-11 * complexity +
+         3.111607458075493e-11 * complexity2;
+}
+
+// Operation MatMul_3ds: estimated times.
+double march15_estimatedTimeForCPU_MatMul_3ds(
+    double B, double N, double M, double K) {
+  double complexity = B * (N * M * K);
+  // Regression for CPU with r2 = 0.9884079270433619
+  return 1.855222799861678e-06 + 5.050650951084619e-11 * complexity;
+}
+// Operation MatMul_3ds: estimated times.
+double march15_estimatedTimeForNNPA_MatMul_3ds(
+    double B, double N, double M, double K) {
+  double complexity =
+      B * ms_ceiling(N, 2.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
+  double complexity2 =
+      B * ms_ceiling(N, 32.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
+  // Regression for NNPA with r2 = 0.7060733589527228
+  return 1.8259570877531345e-06 + 8.905865072399348e-13 * complexity +
+         8.905865072399348e-13 * complexity2;
+}
+
+#if 0 /* not in use at this time */
+// Operation MatMul_bcast23: estimated times.
+double march15_estimatedTimeForCPU_MatMul_bcast23(double B, double N, double M, double K) {
+  double complexity = B * (N * M * K);
+  // Regression for CPU with r2 = 0.999572142279475
+  return 1.2018540664406345e-07 + 4.950906739952868e-11 * complexity;
+}
+// Operation MatMul_bcast23: estimated times.
+double march15_estimatedTimeForNNPA_MatMul_bcast23(double B, double N, double M, double K) {
+  double complexity  = B * ms_ceiling(N, 2.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
+  double complexity2 = B * ms_ceiling(N, 32.0) * ms_ceiling(M, 64.0) * ms_ceiling(K, 64.0);
+  // Regression for NNPA with r2 = 0.8552465991036068
+  return 2.1861812921890076e-06 + 6.115654970204012e-13 * complexity +6.115654970204012e-13 * complexity2;
+}
+#endif
+
+// Operation Max_3ds: estimated times.
+double march15_estimatedTimeForCPU_Max_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9996046252770894
+  return 8.55259663295163e-07 + 9.596611822047999e-11 * complexity;
+}
+// Operation Max_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Max_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9926138482906947
+  return 2.0761477329513936e-06 + 1.7319024656175555e-11 * complexity +
+         1.7319024656175552e-11 * complexity2;
+}
+
+// Operation Min_3ds: estimated times.
+double march15_estimatedTimeForCPU_Min_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9993518712923539
+  return 8.119717132969606e-07 + 9.641853939778113e-11 * complexity;
+}
+// Operation Min_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Min_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9948689360722767
+  return 2.045811408687477e-06 + 1.7487925635849375e-11 * complexity +
+         1.7487925635849372e-11 * complexity2;
+}
+
+// Operation Mul_3ds: estimated times.
+double march15_estimatedTimeForCPU_Mul_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9994096986852347
+  return 8.576427061854475e-07 + 9.573075501041591e-11 * complexity;
+}
+// Operation Mul_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Mul_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9938418209740545
+  return 2.1215713448441153e-06 + 1.713430303227113e-11 * complexity +
+         1.713430303227113e-11 * complexity2;
+}
+
+// Operation Pow2_3ds: estimated times.
+double march15_estimatedTimeForCPU_Pow2_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9330727047521541
+  return -8.210853307002942e-07 + 1.234202263969703e-10 * complexity;
+}
+// Operation Pow2_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Pow2_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9903205087066541
+  return 2.1652601219576765e-06 + 1.898490020005764e-11 * complexity +
+         1.898490020005764e-11 * complexity2;
+}
+
+// Operation Pow3_3ds: estimated times.
+double march15_estimatedTimeForCPU_Pow3_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.947704531709904
+  return 3.3263848039024823e-06 + 2.604707783272701e-10 * complexity;
+}
+// Operation Pow3_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Pow3_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9939780628358914
+  return 4.060614306209132e-06 + 3.5467459159039026e-11 * complexity +
+         3.546745915903902e-11 * complexity2;
+}
+
+// Operation Pow4_3ds: estimated times.
+double march15_estimatedTimeForCPU_Pow4_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.979306482228355
+  return 6.752793164225602e-07 + 2.0372887895594365e-10 * complexity;
+}
+// Operation Pow4_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Pow4_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9931689983532582
+  return 4.268964473790506e-06 + 3.438648077067066e-11 * complexity +
+         3.438648077067066e-11 * complexity2;
+}
+
+// Operation Pow8_3ds: estimated times.
+double march15_estimatedTimeForCPU_Pow8_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9999063396503455
+  return 1.649910604587757e-06 + 2.8617211971025847e-10 * complexity;
+}
+// Operation Pow8_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Pow8_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9948502081739099
+  return 6.142811336589455e-06 + 5.192920606428397e-11 * complexity +
+         5.192920606428396e-11 * complexity2;
+}
+
+// Operation ReduceMean_4d: estimated times.
+double march15_estimatedTimeForCPU_ReduceMean_4d(
+    double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9641896473441319
+  return -3.44566941822172e-08 + 1.2715126545232464e-10 * complexity;
+}
+// Operation ReduceMean_4d: estimated times.
+double march15_estimatedTimeForNNPA_ReduceMean_4d(
+    double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.23925537331066915
+  return 1.130230016902706e-05 + 9.610791426943572e-12 * complexity +
+         9.610791426943571e-12 * complexity2;
+}
+
+// Operation Relu_3ds: estimated times.
+double march15_estimatedTimeForCPU_Relu_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.999247901534308
+  return 8.67113022326907e-07 + 9.427073286069188e-11 * complexity;
+}
+// Operation Relu_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Relu_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9989466394839843
+  return 1.9854210655045904e-06 + 2.3131281524078758e-11 * complexity +
+         2.3131281524078754e-11 * complexity2;
+}
+
+// Operation Sigmoid_3ds: estimated times.
+double march15_estimatedTimeForCPU_Sigmoid_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.6694863546412586
+  return -0.0003110638128148975 + 1.0198957146700573e-08 * complexity;
+}
+// Operation Sigmoid_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Sigmoid_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9996518891423859
+  return 2.261770046260627e-06 + 3.764323249035518e-11 * complexity +
+         3.764323249035517e-11 * complexity2;
+}
+
+// Operation Softmax_3ds: estimated times.
+double march15_estimatedTimeForCPU_Softmax_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9941480124435297
+  return 4.922124351942512e-06 + 7.895222736377622e-09 * complexity;
+}
+// Operation Softmax_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Softmax_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.7698271519020907
+  return -1.6582951337863099e-06 + 9.546897460120308e-10 * complexity +
+         9.546897460120308e-10 * complexity2;
+}
+
+// Operation Stick_3ds: estimated times.
+double march15_estimatedTimeForCPU_Stick_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9573201775683942
+  return 7.223242630385479e-07 + 8.501740539965986e-11 * complexity;
+}
+// Operation Stick_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Stick_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.6906958856336693
+  return 1.4650992868656998e-06 + 1.5980625370318473e-10 * complexity +
+         1.5980625370318473e-10 * complexity2;
+}
+
+// Operation Sub_3ds: estimated times.
+double march15_estimatedTimeForCPU_Sub_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9994300646660222
+  return 8.53949178130232e-07 + 9.552545176353334e-11 * complexity;
+}
+// Operation Sub_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Sub_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9953310347130198
+  return 2.3492432002936522e-06 + 1.723261703570422e-11 * complexity +
+         1.723261703570422e-11 * complexity2;
+}
+
+// Operation Tanh_3ds: estimated times.
+double march15_estimatedTimeForCPU_Tanh_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9992625489601716
+  return 3.2369598896957175e-07 + 1.4078506521178395e-09 * complexity;
+}
+// Operation Tanh_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Tanh_3ds(double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.9960934032072877
+  return 1.9722513558089736e-06 + 1.790114983535808e-11 * complexity +
+         1.7901149835358073e-11 * complexity2;
+}
+
+// Operation Unstick_3ds: estimated times.
+double march15_estimatedTimeForCPU_Unstick_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * e2 * e1;
+  // Regression for CPU with r2 = 0.9932274704371545
+  return 7.653934223015085e-07 + 1.389382010359011e-10 * complexity;
+}
+// Operation Unstick_3ds: estimated times.
+double march15_estimatedTimeForNNPA_Unstick_3ds(
+    double e3, double e2, double e1) {
+  double complexity = e3 * ms_ceiling(e2, 2.0) * ms_ceiling(e1, 64.0);
+  double complexity2 = e3 * ms_ceiling(e2, 32.0) * ms_ceiling(e1, 64.0);
+  // Regression for NNPA with r2 = 0.4294645871109005
+  return 1.0784429022719318e-05 + 1.569351314487559e-10 * complexity +
+         1.5693513144875584e-10 * complexity2;
+}

--- a/src/Accelerators/NNPA/Support/NNPALimit.hpp
+++ b/src/Accelerators/NNPA/Support/NNPALimit.hpp
@@ -37,7 +37,7 @@ static constexpr int64_t MAXIMUM_NUM_HIDDEN_SIZE_GRU = 10880;
 typedef enum NNPALevel {
   NONE = 0,
   M14 = 1, // Associated with march=arch14 | z16.
-  M15 = 2, // Associated with march=arch15.
+  M15 = 2, // Associated with march=arch15 | z17.
 } NNPALevel;
 
 // The NNPA ZDNN versions. Keep in sync with enum NNPALevel.


### PR DESCRIPTION
The heuristics that decide whether to place an op on the CPU or NNPA uses a performance model with the `-nnpa-placement-heuristic' with non default policy, like `FasterOps` for example.

Performance model was tracking only z16, I added a model that tracks z17. Added a layer that let us (easily) add new models for future NNPA implementations.