### PR TITLE
cmake error for zdnn build[NNPA]

### DIFF
--- a/src/Accelerators/NNPA/zdnn.cmake
+++ b/src/Accelerators/NNPA/zdnn.cmake
@@ -38,7 +38,7 @@ function(setup_zdnn version)
       BUILD_COMMAND sh -c "export MAKEFLAGS=--no-print-directory && \
                          make -q -C zdnn lib/libzdnn.so && true || \
                          (MAKEFLAGS=--no-print-directory \
-                          make -j$(nproc) -C zdnn lib/libzdnn.so && \
+                          make -C zdnn lib/libzdnn.so && \
                           ar -rc ${ZDNN_LIBDIR}/libzdnn.a ${ZDNN_OBJDIR}/*.o)"
 
       INSTALL_COMMAND ""


### PR DESCRIPTION
When initialization cmake with NNPA on, I ran into error "ninja: error: build.ninja:9480: bad $-escape (literal $ must be written as $$", which is for `-j$(nproc)` for zdnn.cmake. 
```
COMMAND = cd /myspace/onnx-mlir/build-debug/src/Accelerators/NNPA/zDNN/src/zdnn && sh -c "export MAKEFLAGS=--no-print-directory &&                          make -q -C zdnn lib/libzdnn.so && true ||                          (MAKEFLAGS=--no-print-directory                           make -j$(nproc) -C zdnn lib/libzdnn.so &&                           ar -rc /myspace/onnx-mlir/build-debug/src/Accelerators/NNPA/zDNN/src/zdnn/zdnn/lib/libzdnn.a /myspace/onnx-mlir/build-debug/src/Accelerators/NNPA/zDNN/src/zdnn/zdnn/obj/*.o)" && /usr/bin/cmake -E touch /myspace/onnx-mlir/build-debug/src/Accelerators/NNPA/zDNN/src/zdnn-stamp/zdnn-build
```
I guess that there could be other solution. But this PR simply removed the `-j`. The only impact is that it would be slower for zdnn build.