### PR TITLE
fix an error in func.FuncOp lowering to krnl

### DIFF
--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -146,6 +146,7 @@ private:
     dString.push_back('\0'); // null terminate the input signature string
     dstream << "@[";
     comma = std::string("");
+    // Handle outputs
     for (unsigned int i = 0; i < funcType.getNumResults(); i++) {
       dstream << comma;
       StringAttr outputName = b.getStringAttr({"output_" + std::to_string(i)});


### PR DESCRIPTION
After I modified a .mlir file, the file can pass onnx-mlir-opt and but failed in `--convert-onnx-to-krnl`. I found the reason is that the attribute of the input is checked when the attribute of the output is used.
A simple fix.
I remember that once @AlexandreEichenberger ran into an error after modified a .mlir file. My suggestion was to remove the attribute. I am wondering whether it was related to this PR.