### PR TITLE
Fix two issues to make omp work again with --parallel and zdnnx

### DIFF
--- a/src/Accelerators/NNPA/CMakeLists.txt
+++ b/src/Accelerators/NNPA/CMakeLists.txt
@@ -47,7 +47,7 @@ if (ZDNNX_WITH_OMP)
   add_compile_definitions(ZDNNX_WITH_OMP)
   # If LLVM is built with OpenMP enabled, use LLVM's OpenMP.
   # Otherwise, use GCC's OpenMP.
-  if(TARGET omp)
+  if (OMP_SUPPORTED)
     set(ZDNNX_WITH_OMP_LLVM 1)
     add_compile_definitions(ZDNNX_WITH_OMP_LLVM)
     message(STATUS "zdnnx with OpenMP        : ON (LLVM's OpenMP)")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,19 @@ if (ONNX_MLIR_ENABLE_PYRUNTIME_LIGHT)
   return()
 endif()
 
+# Find OpenMP headers built by LLVM
+find_path(OPENMP_INCLUDE_DIR
+  NAMES omp.h
+  HINTS
+    ${LLVM_BUILD_BINARY_DIR}/lib/clang/*/include
+  NO_DEFAULT_PATH
+)
+if(OPENMP_INCLUDE_DIR)
+  set(OMP_SUPPORTED ON)
+else()
+  set(OMP_SUPPORTED OFF)
+endif()
+
 add_subdirectory(Accelerators)
 add_subdirectory(Interface)
 add_subdirectory(Dialect)

--- a/src/Runtime/omp/CMakeLists.txt
+++ b/src/Runtime/omp/CMakeLists.txt
@@ -1,14 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Find OpenMP headers built by LLVM
-find_path(OPENMP_INCLUDE_DIR
-  NAMES omp.h
-  HINTS
-    ${LLVM_BUILD_BINARY_DIR}/lib/clang/*/include
-  NO_DEFAULT_PATH
-)
-
-if(OPENMP_INCLUDE_DIR)
+if(OMP_SUPPORTED)
   set(OMP_TOPDIR ${CMAKE_CURRENT_BINARY_DIR})
   set_directory_properties(PROPERTIES EP_BASE ${OMP_TOPDIR})
   set(OPENMP_SOURCE_DIR ${LLVM_BUILD_MAIN_SRC_DIR}/../openmp)

--- a/src/Runtime/omp/CMakeLists.txt
+++ b/src/Runtime/omp/CMakeLists.txt
@@ -27,21 +27,11 @@ if(OMP_SUPPORTED)
     INSTALL_COMMAND ""
   )
 
-  find_file(LIBOMP_PATH
-    NAMES libomp.a libomp.dylib libomp.so omp.lib libomp.lib iomp5.lib
-    PATHS ${LLVM_BUILD_BINARY_DIR}/runtimes/runtimes-bins/openmp/runtime/src
-    NO_DEFAULT_PATH
-  )
-
-  if(NOT LIBOMP_PATH)
-    message(FATAL_ERROR "Could not find built OpenMP library (libomp.a or shared)")
-  endif()
-
   add_custom_target(ompruntime
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${LIBOMP_PATH} ${ONNX_MLIR_LIBRARY_PATH}/libompruntime.a
+            ${OMP_TOPDIR}/openmp-build/runtime/src/libomp.a ${ONNX_MLIR_LIBRARY_PATH}/libompruntime.a
     DEPENDS OMomp
-    BYPRODUCTS ${ONNX_MLIR_LIBRARY_PATH}/libompruntime.a
+    BYPRODUCTS ${OMP_TOPDIR}/openmp-build/runtime/src/libomp.a
   )
 
   install(FILES ${ONNX_MLIR_LIBRARY_PATH}/libompruntime.a DESTINATION lib)


### PR DESCRIPTION
Following #3290, there is another place where you need a change so that zdnnx can find omp in llvm.