### PR TITLE
Add a compile optio --ignore-attention-mask

### DIFF
--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -89,6 +89,7 @@ std::vector<std::string> reportHeapBefore;             // onnx-mlir only
 std::vector<std::string> reportHeapAfter;              // onnx-mlir only
 std::string modelTag;                                  // onnx-mlir only
 bool enableConvOptPass;                                // onnx-mlir only
+int64_t ignoreAttentionMask;                           // onnx-mlir only
 bool disableConstantProp;                              // onnx-mlir only
 std::vector<std::string> extraLibPaths;                // onnx-mlir only
 std::vector<std::string> extraLibs;                    // onnx-mlir only
@@ -661,6 +662,15 @@ static llvm::cl::opt<std::string, true> modelTagOpt("tag",
 static llvm::cl::opt<bool, true> enableConvOptPassOpt("enable-conv-opt-pass",
     llvm::cl::desc("Enable the ConvOptPass. Default is true."),
     llvm::cl::location(enableConvOptPass), llvm::cl::init(true),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<int64_t, true> ignoreAttentionMaskOpt(
+    "ignore-attention-mask",
+    llvm::cl::desc(
+        "Do not use attention mask. This can be used to optimize bert alike "
+        "encoder models. Value is the argument index of attention_mask input "
+        "in the model. Default is -1 (off)\n"),
+    llvm::cl::location(ignoreAttentionMask), llvm::cl::init(-1),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> disableConstantPropOpt("disable-constant-prop",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -134,6 +134,7 @@ extern std::vector<std::string> reportHeapBefore;             // onnx-mlir only
 extern std::vector<std::string> reportHeapAfter;              // onnx-mlir only
 extern std::string modelTag;                                  // onnx-mlir only
 extern bool enableConvOptPass;                                // onnx-mlir only
+extern int64_t ignoreAttentionMask;                           // onnx-mlir only
 extern bool disableConstantProp;                              // onnx-mlir only
 extern std::vector<std::string> extraLibPaths;                // onnx-mlir only
 extern std::vector<std::string> extraLibs;                    // onnx-mlir only

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -125,6 +125,11 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     }
   }
 
+  // Do not use attention_mask.
+  if (ignoreAttentionMask>= 0)
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createDonotUseAttentionMaskPass(
+        /*argIdx=*/ignoreAttentionMask));
+
   // Simplify shape-related ops.
   pm.addPass(onnx_mlir::createSimplifyShapeRelatedOpsPass());
 

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -126,8 +126,8 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
   }
 
   // Do not use attention_mask.
-  if (ignoreAttentionMask>= 0)
-    pm.addNestedPass<func::FuncOp>(onnx_mlir::createDonotUseAttentionMaskPass(
+  if (ignoreAttentionMask >= 0)
+    pm.addNestedPass<func::FuncOp>(onnx_mlir::createIgnoreAttentionMaskPass(
         /*argIdx=*/ignoreAttentionMask));
 
   // Simplify shape-related ops.

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -109,3 +109,14 @@ add_onnx_mlir_library(OMONNXStandardFuncReturnPass
   OMONNXOps
   OMShapeInference
   )
+
+add_onnx_mlir_library(OMDonotUseAttentionMask
+  DonotUseAttentionMask.cpp
+
+  INCLUDE_DIRS PUBLIC
+  ${ONNX_MLIR_SRC_ROOT}/include
+
+  LINK_LIBS PUBLIC
+  OMONNXOps
+  MLIRPass
+  )

--- a/src/Dialect/ONNX/Transforms/CMakeLists.txt
+++ b/src/Dialect/ONNX/Transforms/CMakeLists.txt
@@ -110,8 +110,8 @@ add_onnx_mlir_library(OMONNXStandardFuncReturnPass
   OMShapeInference
   )
 
-add_onnx_mlir_library(OMDonotUseAttentionMask
-  DonotUseAttentionMask.cpp
+add_onnx_mlir_library(OMIgnoreAttentionMask
+  IgnoreAttentionMask.cpp
 
   INCLUDE_DIRS PUBLIC
   ${ONNX_MLIR_SRC_ROOT}/include

--- a/src/Dialect/ONNX/Transforms/DonotUseAttentionMask.cpp
+++ b/src/Dialect/ONNX/Transforms/DonotUseAttentionMask.cpp
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---- DonotUseAttentionMask.cpp - Remove masking in Attention layer
+//----===//
+//
+// Copyright 2025 The IBM Research Authors.
+//
+// =============================================================================
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Pass/Passes.hpp"
+#include "src/Support/TypeUtilities.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {} // namespace onnx_mlir
+
+namespace {
+
+// Attention masking is done via AddOp.
+// This is the pattern of masking:
+// x1 = MatMul()
+// x2 = Add(x1, mask)
+// x3 = Softmax(x2)
+//
+// where, mask is computed indirectly from the attention_mask input of the
+// model.
+//
+// This pattern will match the AddOp sandwitched between MatMul and Softmax,
+// and that the mask input comes from the attention_mask input.
+//
+// A replaced pattern is:
+// x1 = MatMul()
+// x3 = Softmax(x1)
+struct RemoveAttentionMaskPattern : public OpRewritePattern<ONNXAddOp> {
+  RemoveAttentionMaskPattern(MLIRContext *context, Value attentionMaskArg)
+      : OpRewritePattern(context), attentionMaskArg(attentionMaskArg) {}
+  LogicalResult matchAndRewrite(
+      ONNXAddOp addOp, PatternRewriter &rewriter) const override {
+    Value A = addOp.getA();
+    Value B = addOp.getB();
+
+    // Match MatMul and get mask value.
+    Value mask, mmOutput;
+    if (A.getDefiningOp<ONNXMatMulOp>()) {
+      mask = B;
+      mmOutput = A;
+    } else if (B.getDefiningOp<ONNXMatMulOp>()) {
+      mask = A;
+      mmOutput = B;
+    } else
+      return failure();
+
+    // Match softmax.
+    ONNXSoftmaxOp softmaxOp;
+    for (Operation *user : addOp.getC().getUsers()) {
+      if (auto sop = dyn_cast<ONNXSoftmaxOp>(user)) {
+        softmaxOp = sop;
+        break;
+      }
+    }
+    if (!softmaxOp)
+      return failure();
+
+    // Check that mask comes from attention_mask.
+
+    // Rewrite: bypass the AddOp.
+    rewriter.modifyOpInPlace(
+        softmaxOp, [&]() { softmaxOp.setOperand(mmOutput); });
+    return success();
+  }
+
+private:
+  Value attentionMaskArg;
+};
+
+} // namespace
+
+namespace {
+
+struct DonotUseAttentionMaskPass : public PassWrapper<DonotUseAttentionMaskPass,
+                                       OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DonotUseAttentionMaskPass)
+
+  DonotUseAttentionMaskPass() = default;
+  DonotUseAttentionMaskPass(const DonotUseAttentionMaskPass &pass)
+      : mlir::PassWrapper<DonotUseAttentionMaskPass,
+            OperationPass<func::FuncOp>>() {}
+  DonotUseAttentionMaskPass(uint64_t argIdx) { this->argIdx = argIdx; };
+
+  StringRef getArgument() const override { return "do-not-use-attention-mask"; }
+
+  StringRef getDescription() const override {
+    return "Do not use attention_mask in a self_attention layer";
+  }
+
+  // Usage: onnx-mlir-opt --do-not-use-attention-mask='arg-idx=1'
+  Option<bool> argIdx{*this, "arg-idx",
+      llvm::cl::desc("Argument index of attention_mask in the function"),
+      ::llvm::cl::init(1)};
+
+  void runOnOperation() final;
+};
+
+void DonotUseAttentionMaskPass::runOnOperation() {
+  func::FuncOp function = getOperation();
+  MLIRContext *context = &getContext();
+
+  // ConversionTarget target(getContext());
+  RewritePatternSet patterns(context);
+
+  Value attentionMask = function.getArgument(this->argIdx);
+  patterns.insert<RemoveAttentionMaskPattern>(context, attentionMask);
+
+  GreedyRewriteConfig config;
+  config.setUseTopDownTraversal(true);
+
+  if (failed(applyPatternsGreedily(function, std::move(patterns), config)))
+    signalPassFailure();
+}
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> onnx_mlir::createDonotUseAttentionMaskPass(
+    uint64_t argIdx) {
+  return std::make_unique<DonotUseAttentionMaskPass>(argIdx);
+}

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -45,6 +45,9 @@ std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
 std::unique_ptr<mlir::Pass> createConvOptONNXToONNXPass(
     bool enableSimdDataLayoutOpt = false);
 
+std::unique_ptr<mlir::Pass> createDonotUseAttentionMaskPass(
+    uint64_t argIdx = 1);
+
 std::unique_ptr<mlir::Pass> createShapeInferencePass();
 
 // To configure ConstPropONNXToONNXPass at program start.

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -45,8 +45,7 @@ std::unique_ptr<mlir::Pass> createRecomposeONNXToONNXPass(
 std::unique_ptr<mlir::Pass> createConvOptONNXToONNXPass(
     bool enableSimdDataLayoutOpt = false);
 
-std::unique_ptr<mlir::Pass> createDonotUseAttentionMaskPass(
-    uint64_t argIdx = 1);
+std::unique_ptr<mlir::Pass> createIgnoreAttentionMaskPass(uint64_t argIdx = 1);
 
 std::unique_ptr<mlir::Pass> createShapeInferencePass();
 

--- a/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
+++ b/src/Tools/onnx-mlir-opt/RegisterPasses.cpp
@@ -74,6 +74,10 @@ void registerOMPasses(int optLevel) {
   });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createIgnoreAttentionMaskPass(/*argIdx*/ 1);
+  });
+
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return createONNXHybridTransformPass(/*recompose ops*/ true);
   });
 

--- a/test/mlir/onnx/onnx_ignore_attention_mask.mlir
+++ b/test/mlir/onnx/onnx_ignore_attention_mask.mlir
@@ -1,4 +1,5 @@
 // RUN: onnx-mlir-opt --ignore-attention-mask="arg-idx=1" %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --ignore-attention-mask="arg-idx=2" %s -split-input-file | FileCheck %s --check-prefix=NOT-IGNORE
 
 // COM: test ignoring attention_mask input (arg1) in the function, so that attention_mask is not used in the AddOp sandwitched beteen MatMulOp and SoftmaxOp.
 func.func @test_ignore_attention_layer(%arg0: tensor<1x?xi64>, %arg1: tensor<1x?xi64>, %arg2: tensor<1x12x?x64xf32>, %arg3: tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32>
@@ -27,4 +28,49 @@ func.func @test_ignore_attention_layer(%arg0: tensor<1x?xi64>, %arg1: tensor<1x?
 // CHECK:           [[VAR_1_:%.+]] = "onnx.Softmax"([[VAR_0_]]) {axis = -1 : si64} : (tensor<1x12x?x?xf32>) -> tensor<1x12x?x?xf32>
 // CHECK:           onnx.Return [[VAR_1_]] : tensor<1x12x?x?xf32>
 // CHECK:         }
+}
+
+// -----
+
+// COM: test NOT ignoring attention_mask input (arg1) in the function, so that attention_mask is not used in the AddOp sandwitched beteen MatMulOp and SoftmaxOp.
+func.func @test_ignore_attention_layer(%arg0: tensor<1x?xi64>, %arg1: tensor<1x?xi64>, %arg2: tensor<1x12x?x64xf32>, %arg3: tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32>
+{
+  %0 = onnx.Constant dense<1> : tensor<1xi64>
+  %1 = onnx.Constant dense<-3.40282347E+38> : tensor<f32>
+  %2 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %3 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<1x?xi64>) -> tensor<1xi64>
+  %4 = "onnx.Dim"(%arg1) {axis = 1 : si64} : (tensor<1x?xi64>) -> tensor<1xi64>
+  %5 = "onnx.Unsqueeze"(%arg1, %0) : (tensor<1x?xi64>, tensor<1xi64>) -> tensor<1x1x?xi64>
+  %6 = "onnx.Unsqueeze"(%5, %0) : (tensor<1x1x?xi64>, tensor<1xi64>) -> tensor<1x1x1x?xi64>
+  %7 = "onnx.Concat"(%0, %0, %3, %4) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+  %8 = "onnx.Expand"(%6, %7) : (tensor<1x1x1x?xi64>, tensor<4xi64>) -> tensor<1x1x?x?xi64>
+  %9 = "onnx.Cast"(%8) {saturate = 1 : si64, to = f32} : (tensor<1x1x?x?xi64>) -> tensor<1x1x?x?xf32>
+  %10 = "onnx.Sub"(%2, %9) : (tensor<f32>, tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xf32>
+  %11 = "onnx.Cast"(%10) {saturate = 1 : si64, to = i1} : (tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xi1>
+  %12 = "onnx.Where"(%11, %1, %10) : (tensor<1x1x?x?xi1>, tensor<f32>, tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xf32>
+  %13 = "onnx.MatMul"(%arg2, %arg3) : (tensor<1x12x?x64xf32>, tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32>
+  %14 = "onnx.Add"(%13, %12) : (tensor<1x12x?x?xf32>, tensor<1x1x?x?xf32>) -> tensor<1x12x?x?xf32>
+  %15 = "onnx.Softmax"(%14) {axis = -1 : si64} : (tensor<1x12x?x?xf32>) -> tensor<1x12x?x?xf32>
+  onnx.Return %15 : tensor<1x12x?x?xf32>
+
+// NOT-IGNORE-LABEL:  func.func @test_ignore_attention_layer
+// NOT-IGNORE-SAME:   ([[PARAM_0_:%.+]]: tensor<1x?xi64>, [[PARAM_1_:%.+]]: tensor<1x?xi64>, [[PARAM_2_:%.+]]: tensor<1x12x?x64xf32>, [[PARAM_3_:%.+]]: tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32> {
+// NOT-IGNORE-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<1> : tensor<1xi64>
+// NOT-IGNORE-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<-3.40282347E+38> : tensor<f32>
+// NOT-IGNORE-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<1.000000e+00> : tensor<f32>
+// NOT-IGNORE-DAG:       [[VAR_3_:%.+]] = "onnx.Dim"([[PARAM_0_]]) {axis = 1 : si64} : (tensor<1x?xi64>) -> tensor<1xi64>
+// NOT-IGNORE-DAG:       [[VAR_4_:%.+]] = "onnx.Dim"([[PARAM_1_]]) {axis = 1 : si64} : (tensor<1x?xi64>) -> tensor<1xi64>
+// NOT-IGNORE:           [[VAR_5_:%.+]] = "onnx.Unsqueeze"([[PARAM_1_]], [[VAR_0_]]) : (tensor<1x?xi64>, tensor<1xi64>) -> tensor<1x1x?xi64>
+// NOT-IGNORE-DAG:       [[VAR_6_:%.+]] = "onnx.Unsqueeze"([[VAR_5_]], [[VAR_0_]]) : (tensor<1x1x?xi64>, tensor<1xi64>) -> tensor<1x1x1x?xi64>
+// NOT-IGNORE-DAG:       [[VAR_7_:%.+]] = "onnx.Concat"([[VAR_0_]], [[VAR_0_]], [[VAR_3_]], [[VAR_4_]]) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+// NOT-IGNORE:           [[VAR_8_:%.+]] = "onnx.Expand"([[VAR_6_]], [[VAR_7_]]) : (tensor<1x1x1x?xi64>, tensor<4xi64>) -> tensor<1x1x?x?xi64>
+// NOT-IGNORE:           [[VAR_9_:%.+]] = "onnx.Cast"([[VAR_8_]]) {saturate = 1 : si64, to = f32} : (tensor<1x1x?x?xi64>) -> tensor<1x1x?x?xf32>
+// NOT-IGNORE:           [[VAR_10_:%.+]] = "onnx.Sub"([[VAR_2_]], [[VAR_9_]]) : (tensor<f32>, tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xf32>
+// NOT-IGNORE:           [[VAR_11_:%.+]] = "onnx.Cast"([[VAR_10_]]) {saturate = 1 : si64, to = i1} : (tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xi1>
+// NOT-IGNORE-DAG:       [[VAR_12_:%.+]] = "onnx.Where"([[VAR_11_]], [[VAR_1_]], [[VAR_1_]]0) : (tensor<1x1x?x?xi1>, tensor<f32>, tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xf32>
+// NOT-IGNORE-DAG:       [[VAR_13_:%.+]] = "onnx.MatMul"([[PARAM_2_]], [[PARAM_3_]]) : (tensor<1x12x?x64xf32>, tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32>
+// NOT-IGNORE:           [[VAR_14_:%.+]] = "onnx.Add"([[VAR_13_]], [[VAR_12_]]) : (tensor<1x12x?x?xf32>, tensor<1x1x?x?xf32>) -> tensor<1x12x?x?xf32>
+// NOT-IGNORE:           [[VAR_15_:%.+]] = "onnx.Softmax"([[VAR_14_]]) {axis = -1 : si64} : (tensor<1x12x?x?xf32>) -> tensor<1x12x?x?xf32>
+// NOT-IGNORE:           onnx.Return [[VAR_15_]] : tensor<1x12x?x?xf32>
+// NOT-IGNORE:         }
 }

--- a/test/mlir/onnx/onnx_ignore_attention_mask.mlir
+++ b/test/mlir/onnx/onnx_ignore_attention_mask.mlir
@@ -1,0 +1,30 @@
+// RUN: onnx-mlir-opt --ignore-attention-mask="arg-idx=1" %s -split-input-file | FileCheck %s
+
+// COM: test ignoring attention_mask input (arg1) in the function, so that attention_mask is not used in the AddOp sandwitched beteen MatMulOp and SoftmaxOp.
+func.func @test_ignore_attention_layer(%arg0: tensor<1x?xi64>, %arg1: tensor<1x?xi64>, %arg2: tensor<1x12x?x64xf32>, %arg3: tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32>
+{
+  %0 = onnx.Constant dense<1> : tensor<1xi64>
+  %1 = onnx.Constant dense<-3.40282347E+38> : tensor<f32>
+  %2 = onnx.Constant dense<1.000000e+00> : tensor<f32>
+  %3 = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<1x?xi64>) -> tensor<1xi64>
+  %4 = "onnx.Dim"(%arg1) {axis = 1 : si64} : (tensor<1x?xi64>) -> tensor<1xi64>
+  %5 = "onnx.Unsqueeze"(%arg1, %0) : (tensor<1x?xi64>, tensor<1xi64>) -> tensor<1x1x?xi64>
+  %6 = "onnx.Unsqueeze"(%5, %0) : (tensor<1x1x?xi64>, tensor<1xi64>) -> tensor<1x1x1x?xi64>
+  %7 = "onnx.Concat"(%0, %0, %3, %4) {axis = 0 : si64} : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xi64>
+  %8 = "onnx.Expand"(%6, %7) : (tensor<1x1x1x?xi64>, tensor<4xi64>) -> tensor<1x1x?x?xi64>
+  %9 = "onnx.Cast"(%8) {saturate = 1 : si64, to = f32} : (tensor<1x1x?x?xi64>) -> tensor<1x1x?x?xf32>
+  %10 = "onnx.Sub"(%2, %9) : (tensor<f32>, tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xf32>
+  %11 = "onnx.Cast"(%10) {saturate = 1 : si64, to = i1} : (tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xi1>
+  %12 = "onnx.Where"(%11, %1, %10) : (tensor<1x1x?x?xi1>, tensor<f32>, tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xf32>
+  %13 = "onnx.MatMul"(%arg2, %arg3) : (tensor<1x12x?x64xf32>, tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32>
+  %14 = "onnx.Add"(%13, %12) : (tensor<1x12x?x?xf32>, tensor<1x1x?x?xf32>) -> tensor<1x12x?x?xf32>
+  %15 = "onnx.Softmax"(%14) {axis = -1 : si64} : (tensor<1x12x?x?xf32>) -> tensor<1x12x?x?xf32>
+  onnx.Return %15 : tensor<1x12x?x?xf32>
+
+// CHECK-LABEL:  func.func @test_ignore_attention_layer
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<1x?xi64>, [[PARAM_1_:%.+]]: tensor<1x?xi64>, [[PARAM_2_:%.+]]: tensor<1x12x?x64xf32>, [[PARAM_3_:%.+]]: tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32> {
+// CHECK:           [[VAR_0_:%.+]] = "onnx.MatMul"([[PARAM_2_]], [[PARAM_3_]]) : (tensor<1x12x?x64xf32>, tensor<1x12x64x?xf32>) -> tensor<1x12x?x?xf32>
+// CHECK:           [[VAR_1_:%.+]] = "onnx.Softmax"([[VAR_0_]]) {axis = -1 : si64} : (tensor<1x12x?x?xf32>) -> tensor<1x12x?x?xf32>
+// CHECK:           onnx.Return [[VAR_1_]] : tensor<1x12x?x?xf32>
+// CHECK:         }
+}


### PR DESCRIPTION
This pull request adds a compile option `--ignore-attention-mask=arg-index` where `arg-index` is an integer number indicating the index of the attention_mask input in the model (the index is often 1 in bert-like models).

When this option is enabled, the masking computation in attention_layer are ignored.
For example, when using `--ignore-attention-mask=arg-index`, the self-attention `softmax(Q * K^T * scale + mask) * V` becomes `softmax(Q * K^T * scale) * V` where `+ mask` is removed.