### PR TITLE
Building OpenMP on MacOS

### DIFF
--- a/docs/BuildOnLinuxOSX.md
+++ b/docs/BuildOnLinuxOSX.md
@@ -37,7 +37,8 @@ cmake --build . -- ${MAKEFLAGS}
 cmake --build . --target check-mlir
 ```
 
-On MacOS, or if you have link errors about missing `___kmpc_atomic...` functions, building the additional `compiler-rt`  runtimes should solve the issue. Namely, substitute the line below to the above `cmake` command.
+On MacOS with M-chips, or if you have link errors about missing `___kmpc_atomic...` functions, building the additional `compiler-rt`  runtimes should solve the issue. 
+Namely, substitute the line below to the above `cmake` command.
 ```bash
    -DLLVM_ENABLE_RUNTIMES="compiler-rt;openmp" \
 ```


### PR DESCRIPTION
Update in the doc to successfully build the `llvm-project` with runtime `openmp`.

Without the suggest change, we get such error in a arm based Mac.

```
Undefined symbols for architecture arm64:
  "___divdc3", referenced from:
      ___kmpc_atomic_cmplx8_div in kmp_atomic.cpp.o
      ___kmpc_atomic_cmplx8_div in kmp_atomic.cpp.o
      ___kmpc_atomic_cmplx4_div_cmplx8 in kmp_atomic.cpp.o
      ___kmpc_atomic_cmplx4_div_cmplx8 in kmp_atomic.cpp.o
      ___kmpc_atomic_cmplx8_div_cpt in kmp_atomic.cpp.o
      ___kmpc_atomic_cmplx8_div_cpt in kmp_atomic.cpp.o
```