### PR TITLE
Get dim from the input of reshape and transpose

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -597,6 +597,8 @@ WideNum asWideNum(double n, Type elemType) {
 /// Checks whether a constant tensor's elements are all equal to a given scalar.
 bool isConstOf(Value constValue, double n) {
   ElementsAttr constElements = getElementAttributeFromONNXValue(constValue);
+  if (!constElements)
+    return false;
   Type elemType = constElements.getElementType();
   assert(!elemType.isInteger(1) && "booleans are not supported");
   WideNum w = asWideNum(n, elemType);


### PR DESCRIPTION
This patch adds two rules to get dimensions directly from the input of reshape and transpose.