### PR TITLE
Test RUST v1.89 for jenkins

### DIFF
--- a/docker/Dockerfile.llvm-project
+++ b/docker/Dockerfile.llvm-project
@@ -83,7 +83,7 @@ RUN curl -sL ${BAZEL_URL}/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-dist.zip \
     && cd .. && rm -rf bazel-${BAZEL_VERSION} ${HOME}/.cache
 
 # Install rust, cargo, and cargo-bazel
-ARG RUST_VERSION=1.88
+ARG RUST_VERSION=1.89
 ARG CARGO_BAZEL_VERSION=0.16.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --default-toolchain none \

--- a/utils/install-protobuf.sh
+++ b/utils/install-protobuf.sh
@@ -1,5 +1,5 @@
 # Install rust, cargo, and cargo-bazel
-RUST_VERSION=1.88
+RUST_VERSION=1.89
 CARGO_BAZEL_VERSION=0.16.0
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
      sh -s -- -y --default-toolchain none


### PR DESCRIPTION
Recent PRs failed with an error saying Rust >= 1.89 is required. I updated Rust v1.88 to v1.89 to see if it can solve the issue.