### PR TITLE
remove mlir usePropertiesForAttributes option as it is deprecated with option of 0

### DIFF
--- a/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
+++ b/src/Accelerators/NNPA/Dialect/ZHigh/ZHigh.td
@@ -31,7 +31,7 @@ def ZHigh_Dialect : Dialect {
   let summary = "A high-level dialect for the ONNX NNPA accelerator ISA.";
   let cppNamespace = "::onnx_mlir::zhigh";
   let useDefaultAttributePrinterParser = 1;
-  let usePropertiesForAttributes = 0;
+  //let usePropertiesForAttributes = 0;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Accelerators/NNPA/Dialect/ZLow/ZLow.td
+++ b/src/Accelerators/NNPA/Dialect/ZLow/ZLow.td
@@ -22,7 +22,7 @@ def ZLow_Dialect : Dialect {
   let name = "zlow";
   let summary = "A low-level dialect for the ONNX NNPA accelerator ISA.";
   let cppNamespace = "::onnx_mlir::zlow";  
-  let usePropertiesForAttributes = 0;
+  //let usePropertiesForAttributes = 0;
 }
 
 // Base class for ZLow dialect operations. This operation inherits from the

--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -31,7 +31,7 @@ include "src/Interface/SpecializedKernelOpInterface.td"
 def Krnl_Dialect : Dialect {
   let name = "krnl";
   let cppNamespace = "::mlir";
-  let usePropertiesForAttributes = 0;
+  //let usePropertiesForAttributes = 0;
   let useDefaultTypePrinterParser = 1;
   let dependentDialects = [
     "affine::AffineDialect",

--- a/src/Dialect/ONNX/ONNX.td
+++ b/src/Dialect/ONNX/ONNX.td
@@ -39,7 +39,7 @@ def ONNX_Dialect : Dialect {
   let cppNamespace = "::mlir";
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 0;
-  let usePropertiesForAttributes = 0;
+  //let usePropertiesForAttributes = 0;
   let dependentDialects = ["func::FuncDialect"];
   let hasConstantMaterializer = 1;
   let extraClassDeclaration = [{


### PR DESCRIPTION
https://discourse.llvm.org/t/rfc-deprecating-usepropertiesforattributes-0/87536/9 
https://mlir.llvm.org/docs/ReleaseNotes/ 