### PR TITLE
Fix protobuf build error due to undefined reference to absl functions

### DIFF
--- a/docker/Dockerfile.llvm-project
+++ b/docker/Dockerfile.llvm-project
@@ -91,20 +91,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     && rustup install ${RUST_VERSION} \
     && cargo install cargo-bazel --version ${CARGO_BAZEL_VERSION}
 
-# Install absl for new version of protobuf
-ARG ABSL_VERSION=20240722.1
-ARG ABSL_URL=https://github.com/abseil/abseil-cpp.git
-ARG ABSL_DIR=abseil-cpp
-RUN git clone -b ${ABSL_VERSION} --recursive ${ABSL_URL} ${ABSL_DIR} \
-    && mkdir -p ${ABSL_DIR}/build \
-    && cd ${ABSL_DIR}/build \
-    && CC=clang CXX=clang++ \
-       cmake -DCMAKE_INSTALL_LIBDIR=lib \
-             -DABSL_PROPAGATE_CXX_STD=ON \
-             -DBUILD_SHARED_LIBS=ON .. \
-    && make -j${NPROC} install && ldconfig \
-    && cd ../.. && rm -rf ${ABSL_DIR} ${HOME}/.cache
-
 # Install protobuf
 ARG PROTOBUF_VERSION=6.31.1
 ARG PROTOBUF_URL=https://github.com/protocolbuffers/protobuf.git
@@ -114,9 +100,11 @@ RUN git clone -b v${PROTOBUF_VERSION} --recursive ${PROTOBUF_URL} ${PROTOBUF_DIR
     && cd ${PROTOBUF_DIR}/build \
     # Must specify -Dprotobuf_BUILD_TESTS=OFF otherwise find_package(absl)
     # in onnx will fail due to missing protobuf::gmock target
-    # Must specify -Dabsl_DIR to help protobuf find the installed Abseil
+    # Must specify -DCMAKE_CXX_STANDARD=17 since protobuf requires c++17 but
+    # clang 14 on Ubuntu Jammy defaults to c++14
     && CC=clang CXX=clang++ \
        cmake -DCMAKE_INSTALL_LIBDIR=lib \
+             -DCMAKE_CXX_STANDARD=17 \
              -DBUILD_SHARED_LIBS=ON \
              -Dprotobuf_BUILD_TESTS=OFF .. \
     && make -j${NPROC} install && ldconfig \


### PR DESCRIPTION
- let protobuf itself download and build abseil-cpp
- must specify -DCMAKE_CXX_STANDARD=17 since protobuf requires c++17 but clang 14 on Ubuntu Jammy defaults to c++14