### PR TITLE
Fix python code format for the newer black version

### DIFF
--- a/test/backend/test.py
+++ b/test/backend/test.py
@@ -91,13 +91,9 @@ else:
             variables.test_to_enable_symbol_dict[test_name] = (
                 test_name_symbol_dimparam_list[1]
             )
-        assert (
-            test_name in all_test_names
-        ), """test name {} not found, it is likely
+        assert test_name in all_test_names, """test name {} not found, it is likely
         that you may have misspelled the test name or the specified test does not
-        exist in the version of onnx package you installed.""".format(
-            test_name
-        )
+        exist in the version of onnx package you installed.""".format(test_name)
         backend_test.include(r"^{}$".format(test_name))
         if len(test_name_symbol_dimparam_list) >= 3:
             variables.test_to_enable_dimparams_dict[test_name] = ",".join(

--- a/utils/make-report.py
+++ b/utils/make-report.py
@@ -36,8 +36,7 @@ import numpy as np
 def print_usage(msg=""):
     if msg:
         print("Error:", msg, "\n")
-    print(
-        """
+    print("""
 Usage: Report statistics on compiler and runtime characteristics of ONNX ops.
 make-report.py -[vh] [-c <compile_log>] [-r <run_log>] [-l <num>]
       [-p <plot_file_name][-s <stats>] [--sort <val>] [--supported] [-u <val>]
@@ -100,8 +99,7 @@ Parameters on how to print:
 Help:
   -v/--verbose:        Run in verbose mode (see error and warnings).
   -h/--help:           Print usage.
-    """
-    )
+    """)
     exit(1)
 
 
@@ -324,7 +322,7 @@ def parse_file_for_stat(file_name, stat_name):
                 break
 
         # Parse line.
-        (has_stat, op, node_name, details) = parse_line(
+        has_stat, op, node_name, details = parse_line(
             line.rstrip(), report_str, is_perf_stat
         )
         if not has_stat:
@@ -340,7 +338,7 @@ def parse_file_for_stat(file_name, stat_name):
         if timing_key in node_time_used:
             # has seen it
             continue
-        (op, node_name) = get_op_node_from_timing_key(timing_key)
+        op, node_name = get_op_node_from_timing_key(timing_key)
         secondary_key = get_secondary_key(node_name, "")
         record_pattern(op, node_name, secondary_key)
 
@@ -386,7 +384,7 @@ def parse_file_for_perf(file_name, stat_name, warmup_num=0):
                 break  # On to the next measurement.
 
             # Parse line.
-            (has_stat, op, node_name, details) = parse_line(line, report_str, True)
+            has_stat, op, node_name, details = parse_line(line, report_str, True)
             if not has_stat:
                 continue
             # Keep only after times.

--- a/utils/mlir2FileCheck.py
+++ b/utils/mlir2FileCheck.py
@@ -178,7 +178,7 @@ def process_name(
 ):
     definitions = pattern.findall(new_line)
     for d in definitions:
-        (name, num) = d
+        name, num = d
         x = use_name(name, num, append_str, var_prefix)
         y = record_name_def(
             name, num, default_name, append_str, num_for_zero, new_line, var_prefix
@@ -278,7 +278,7 @@ def process_line(i, line):
             for arg_def in arg_defs:
                 args = arg_def_pat.findall(arg_def)
                 for arg in args:
-                    (name, num) = arg
+                    name, num = arg
                     x = use_name(name, num, "")
                     y = record_name_def(name, num, "VAR_" + name, "", 0, new_line)
                     new_line = new_line.replace(x, y)
@@ -286,7 +286,7 @@ def process_line(i, line):
     # Process uses and map use.
     uses = use_qual_pat.findall(new_line)
     for u in uses:
-        (name, num) = u
+        name, num = u
         x = use_name(name, num, "")
         y = translate_use_name(name, num, "")
         new_line = new_line.replace(x, y)
@@ -296,7 +296,7 @@ def process_line(i, line):
         # Had a problem because there is are map names like "map" which
         # subsume names like "map1", "map2"... Since maps are always used with a
         # "(" after it, add it both to the from (x) and to (y) string.
-        (name, num) = u
+        name, num = u
         x = use_name(name, num, "", "#") + "("
         y = translate_use_name(name, num, "") + "("
         new_line = new_line.replace(x, y)

--- a/utils/mlirAffine2cpp.py
+++ b/utils/mlirAffine2cpp.py
@@ -105,7 +105,7 @@ def process_map_dim_sym(line):
     map_sym_pat = re.compile(r"\(([^\)]*)\)\[([^\]]*)\]")
     definitions = map_sym_pat.findall(line)
     for d in definitions:
-        (dim, sym) = d
+        dim, sym = d
         x = "(" + dim + ")" + "[" + sym + "]"
         y = "(" + dim
         if dim and sym:
@@ -168,11 +168,11 @@ def process_main(args):
     arg_pat = re.compile(r"%(\w+):\s+memref<([^>]+)>")
     definitions = arg_pat.findall(args)
     for d in definitions:
-        (name, type_str) = d
+        name, type_str = d
         name = process_stripped_name(name)
         if debug > 1:
             print("// got arg:", name, "type:", type_str)
-        (type, dims) = compute_memref_type(type_str)
+        type, dims = compute_memref_type(type_str)
         print(type + " " + name + dims + ";")
     print("// Function code.")
 
@@ -265,8 +265,7 @@ def main(argv):
 
     had_builtin = False
 
-    print(
-        """
+    print("""
 #include <math.h>
 #include <stdio.h>
 #include <string>
@@ -334,8 +333,7 @@ void print4(std::string msg, float *a, long long d0, long long d1, long long d2,
 }
 
 // Map support, if any.
-"""
-    )
+""")
 
     for line in sys.stdin:
         line = line.rstrip()
@@ -433,7 +431,7 @@ void print4(std::string msg, float *a, long long d0, long long d1, long long d2,
                     "memref type:",
                     type_str,
                 )
-            (type, dims) = compute_memref_type(type_str)
+            type, dims = compute_memref_type(type_str)
             print(type + " " + name + dims + ";")
             continue
 
@@ -495,7 +493,7 @@ void print4(std::string msg, float *a, long long d0, long long d1, long long d2,
                     "memref:",
                     memref,
                 )
-            (type, dims) = compute_memref_type(memref)
+            type, dims = compute_memref_type(memref)
             addr = addr.replace(
                 ",", "]["
             )  # Transform separators in multi-dim array ref.

--- a/utils/onnxmlirrun.py
+++ b/utils/onnxmlirrun.py
@@ -108,7 +108,7 @@ class InferenceSession:
 
         print("Compiling the model ...")
         start = time.perf_counter()
-        (ok, msg) = self.execute_commands(command_str)
+        ok, msg = self.execute_commands(command_str)
         end = time.perf_counter()
         print("compile took ", end - start, " seconds.\n")
         if not ok:
@@ -176,7 +176,7 @@ class InferenceSession:
         if self.VERBOSE:
             print(cmds)
         out = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (stdout, stderr) = out.communicate()
+        stdout, stderr = out.communicate()
         msg = stderr.decode("utf-8") + stdout.decode("utf-8")
         if out.returncode == -signal.SIGSEGV:
             return (False, "Segfault")

--- a/utils/testing/dim_param.py
+++ b/utils/testing/dim_param.py
@@ -15,7 +15,6 @@ from onnx import helper
 from onnx import AttributeProto, TensorProto, GraphProto
 from google.protobuf.json_format import MessageToJson
 
-
 # The protobuf definition can be found here:
 # https://github.com/onnx/onnx/blob/main/onnx/onnx.proto
 


### PR DESCRIPTION
Recently, GitHub Action Black Format failed because a newer version of black was installed. This PR updates python codes to work with the new black version.