### PR TITLE
disable hsperfdata

### DIFF
--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -3826,6 +3826,7 @@ def JniExecutionSession(jar_name, inputs):
     # print('stdin=' + str(procStdin), file=sys.stderr)
     cmd = [
         "java",
+        "-XX:-UsePerfData",
         "-cp",
         jar_name + ":" + os.getenv("JSONITER_JAR"),
         "com.ibm.onnxmlir.OMRunner",


### PR DESCRIPTION
Disable JVM hsperfdata creation to avoid occasional locking failure warning message from clobbering up JSON test output on stdout