### PR TITLE
Fix GCC warnings in ONNX dialect build on Linux

### DIFF
--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -1899,7 +1899,7 @@ public:
 
     // Check if the condition of WhereOp matches EqualOp, the X of it matches
     // ConstantOp, and the Y of it matches ConcatOp.
-    Operation *equalOp, *constantOp, *concatOp;
+    Operation *equalOp = nullptr, *constantOp = nullptr, *concatOp = nullptr;
     Value equalOpResVal, constantOpResVal, concatOpResVal;
     bool isEqualOp = operandOfOpDefinedBy<ONNXEqualOp>(
         equalOp, onnxWhereOp.getOperation(), equalOpResVal, 0);

--- a/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
+++ b/src/Dialect/ONNX/ONNXOps/OpHelper.cpp
@@ -672,6 +672,11 @@ Type convertONNXTypeToMLIRType(
   case onnx::TensorProto_DataType::TensorProto_DataType_UINT4:
     return builder.getIntegerType(/*width=*/4, false);
 
+  // Newer ONNX enum values that are not yet supported by onnx-mlir.
+  case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1:
+  case onnx::TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0:
+  case onnx::TensorProto_DataType::TensorProto_DataType_UINT2:
+  case onnx::TensorProto_DataType::TensorProto_DataType_INT2:
   case onnx::TensorProto_DataType::TensorProto_DataType_COMPLEX64:
   case onnx::TensorProto_DataType::TensorProto_DataType_COMPLEX128:
   case onnx::TensorProto_DataType::TensorProto_DataType_UNDEFINED:


### PR DESCRIPTION
Fixes #3477

  **Summary**
  - initialize op pointers in RemoveWhereEqualPattern.
  - add missing switch cases for newer unsupported ONNX tensor data types.
  - remove GCC warnings in affected ONNX dialect files.

