### PR TITLE
Embed compile info into the .so file

### DIFF
--- a/include/OnnxMlirRuntime.h
+++ b/include/OnnxMlirRuntime.h
@@ -25,6 +25,7 @@
 #include <onnx-mlir/Runtime/OMEntryPoint.h>
 #include <onnx-mlir/Runtime/OMInstrument.h>
 #include <onnx-mlir/Runtime/OMSignature.h>
+#include <onnx-mlir/Runtime/OMCompilationInfo.h>
 #include <onnx-mlir/Runtime/OMTensor.h>
 #include <onnx-mlir/Runtime/OMTensorList.h>
 

--- a/include/onnx-mlir/Runtime/CMakeLists.txt
+++ b/include/onnx-mlir/Runtime/CMakeLists.txt
@@ -3,6 +3,7 @@
 install(FILES OMEntryPoint.h DESTINATION include/onnx-mlir/Runtime)
 install(FILES OMInstrument.h DESTINATION include/onnx-mlir/Runtime)
 install(FILES OMSignature.h DESTINATION include/onnx-mlir/Runtime)
+install(FILES OMCompilationInfo.h DESTINATION include/onnx-mlir/Runtime)
 install(FILES OMTensor.h DESTINATION include/onnx-mlir/Runtime)
 install(FILES OMTensorList.h DESTINATION include/onnx-mlir/Runtime)
 install(FILES OnnxDataType.h DESTINATION include/onnx-mlir/Runtime)

--- a/include/onnx-mlir/Runtime/OMCompilationInfo.h
+++ b/include/onnx-mlir/Runtime/OMCompilationInfo.h
@@ -25,7 +25,11 @@ extern "C" {
  *
  * The compilation information includes compile options and operation statistics
  * used during model compilation. The format is:
- * {"compile_options": "<string>", "op_stats": <json_object>}
+ * {
+ *    "compiler_version": "<string>",
+ *    "compile_options": "<string>",
+ *    "op_stats": <json_object>
+ *  }
  *
  * The string returned by omCompilationInfo does not have to be freed because
  * it is a part of the model.

--- a/include/onnx-mlir/Runtime/OMCompilationInfo.h
+++ b/include/onnx-mlir/Runtime/OMCompilationInfo.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===--- OMCompilationInfo.h - OMCompilationInfo Declaration header -------===//
+//
+// Copyright 2026 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file contains declaration of OMCompilationInfo API function.
+//
+//===----------------------------------------------------------------------===//
+
+#include "onnx-mlir/Compiler/OMCompilerMacros.h"
+
+#ifdef __cplusplus
+#pragma once
+
+extern "C" {
+#endif
+
+/**
+ * \brief Return the compilation information of the model as a JSON string.
+ *
+ * The compilation information includes compile options and operation statistics
+ * used during model compilation. The format is:
+ * {"compile_options": "<string>", "op_stats": <json_object>}
+ *
+ * The string returned by omCompilationInfo does not have to be freed because
+ * it is a part of the model.
+ *
+ * @return pointer to compilation information JSON string
+ */
+OM_EXTERNAL_VISIBILITY const char *omCompilationInfo(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -386,8 +386,7 @@ static llvm::cl::opt<bool, true> doNotEmitFullMLIRCodeOpt(
     llvm::cl::location(doNotEmitFullMLIRCode), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
-static llvm::cl::opt<bool, true> omitCompileInfoOpt(
-    "omit-compile-info",
+static llvm::cl::opt<bool, true> omitCompileInfoOpt("omit-compile-info",
     llvm::cl::desc("Do not embed compilation information such as compiler "
                    "version, compile options, and ONNX operation statistics "
                    "into the generated shared library."),

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -63,6 +63,7 @@ bool preserveLocations;                                // onnx-mlir only
 bool printIR;                                          // onnx-mlir only
 int printONNXBasicIR;                                  // onnx-mlir only
 bool doNotEmitFullMLIRCode;                            // onnx-mlir only
+bool doNotEmbedCompilationInfo;                        // onnx-mlir only
 bool preserveBitcode;                                  // onnx-mlir only
 bool preserveLLVMIR;                                   // onnx-mlir only
 bool preserveMLIR;                                     // onnx-mlir only
@@ -383,6 +384,14 @@ static llvm::cl::opt<bool, true> doNotEmitFullMLIRCodeOpt(
         "(<name>.tmp). Need to be used with emitting MLIR options such as "
         "--EmitONNXIR and --EmitMLIR."),
     llvm::cl::location(doNotEmitFullMLIRCode), llvm::cl::init(false),
+    llvm::cl::cat(OnnxMlirOptions));
+
+static llvm::cl::opt<bool, true> doNotEmbedCompilationInfoOpt(
+    "do-not-embed-compilation-info",
+    llvm::cl::desc("Do not embed compilation information such as compiler "
+                   "version, compile options, and ONNX operation statistics "
+                   "into the generated shared library."),
+    llvm::cl::location(doNotEmbedCompilationInfo), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> preserveBitcodeOpt("preserveBitcode",

--- a/src/Compiler/CompilerOptions.cpp
+++ b/src/Compiler/CompilerOptions.cpp
@@ -63,7 +63,7 @@ bool preserveLocations;                                // onnx-mlir only
 bool printIR;                                          // onnx-mlir only
 int printONNXBasicIR;                                  // onnx-mlir only
 bool doNotEmitFullMLIRCode;                            // onnx-mlir only
-bool doNotEmbedCompilationInfo;                        // onnx-mlir only
+bool omitCompileInfo;                                  // onnx-mlir only
 bool preserveBitcode;                                  // onnx-mlir only
 bool preserveLLVMIR;                                   // onnx-mlir only
 bool preserveMLIR;                                     // onnx-mlir only
@@ -386,12 +386,12 @@ static llvm::cl::opt<bool, true> doNotEmitFullMLIRCodeOpt(
     llvm::cl::location(doNotEmitFullMLIRCode), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
-static llvm::cl::opt<bool, true> doNotEmbedCompilationInfoOpt(
-    "do-not-embed-compilation-info",
+static llvm::cl::opt<bool, true> omitCompileInfoOpt(
+    "omit-compile-info",
     llvm::cl::desc("Do not embed compilation information such as compiler "
                    "version, compile options, and ONNX operation statistics "
                    "into the generated shared library."),
-    llvm::cl::location(doNotEmbedCompilationInfo), llvm::cl::init(false),
+    llvm::cl::location(omitCompileInfo), llvm::cl::init(false),
     llvm::cl::cat(OnnxMlirOptions));
 
 static llvm::cl::opt<bool, true> preserveBitcodeOpt("preserveBitcode",

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -131,6 +131,7 @@ extern bool preserveBitcode;                                  // onnx-mlir only
 extern bool preserveLLVMIR;                                   // onnx-mlir only
 extern bool preserveMLIR;                                     // onnx-mlir only
 extern bool doNotEmitFullMLIRCode;                            // onnx-mlir only
+extern bool doNotEmbedCompilationInfo;                        // onnx-mlir only
 extern bool useOnnxModelTypes;                                // onnx-mlir only
 extern int repeatOnnxTransform;                               // onnx-mlir only
 extern std::string shapeInformation;                          // onnx-mlir only

--- a/src/Compiler/CompilerOptions.hpp
+++ b/src/Compiler/CompilerOptions.hpp
@@ -131,7 +131,7 @@ extern bool preserveBitcode;                                  // onnx-mlir only
 extern bool preserveLLVMIR;                                   // onnx-mlir only
 extern bool preserveMLIR;                                     // onnx-mlir only
 extern bool doNotEmitFullMLIRCode;                            // onnx-mlir only
-extern bool doNotEmbedCompilationInfo;                        // onnx-mlir only
+extern bool omitCompileInfo;                                  // onnx-mlir only
 extern bool useOnnxModelTypes;                                // onnx-mlir only
 extern int repeatOnnxTransform;                               // onnx-mlir only
 extern std::string shapeInformation;                          // onnx-mlir only

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -405,13 +405,13 @@ void addLinalgToLLVMPasses(mlir::PassManager &pm, std::string outputNameNoExt) {
   // 3. KrnlEntryPointOp → LLVM conversion (dynamic entry point functions,
   //    OMTensor conversion, accelerator initialization, signature recording)
   // 4. Runtime function generation (omQueryEntryPoints, omInputSignature,
-  //    omOutputSignature)
+  //    omOutputSignature, omCompilationInfo)
   // 5. Other features (constants file storage, C wrapper, .lrodata section)
   pm.addPass(krnl::createConvertKrnlToLLVMPass(verifyInputTensors,
       /*useLRODATA=*/(modelSize == ModelSize::large),
       /*storeConstantsToFile=*/storeConstantsToFile,
       constantsToFileSingleThreshold, constantsToFileTotalThreshold,
-      outputNameNoExt, enableParallel));
+      doNotEmbedCompilationInfo, outputNameNoExt, enableParallel));
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
   pm.addPass(mlir::createCanonicalizerPass());
 }
@@ -446,7 +446,7 @@ void addKrnlToLLVMPasses(
         /*useLRODATA=*/(modelSize == ModelSize::large),
         /*storeConstantsToFile=*/storeConstantsToFile,
         constantsToFileSingleThreshold, constantsToFileTotalThreshold,
-        outputNameNoExt, enableParallel));
+        doNotEmbedCompilationInfo, outputNameNoExt, enableParallel));
     pm.addPass(mlir::createReconcileUnrealizedCastsPass());
     pm.addPass(mlir::createCanonicalizerPass());
     return;
@@ -522,7 +522,7 @@ void addKrnlToLLVMPasses(
       /*useLRODATA=*/(modelSize == ModelSize::large),
       /*storeConstantsToFile=*/storeConstantsToFile,
       constantsToFileSingleThreshold, constantsToFileTotalThreshold,
-      outputNameNoExt, enableParallel));
+      doNotEmbedCompilationInfo, outputNameNoExt, enableParallel));
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
   pm.addPass(mlir::createCanonicalizerPass());
   if (enableDebugInfo)

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -411,7 +411,7 @@ void addLinalgToLLVMPasses(mlir::PassManager &pm, std::string outputNameNoExt) {
       /*useLRODATA=*/(modelSize == ModelSize::large),
       /*storeConstantsToFile=*/storeConstantsToFile,
       constantsToFileSingleThreshold, constantsToFileTotalThreshold,
-      doNotEmbedCompilationInfo, outputNameNoExt, enableParallel));
+      omitCompileInfo, outputNameNoExt, enableParallel));
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
   pm.addPass(mlir::createCanonicalizerPass());
 }
@@ -446,7 +446,7 @@ void addKrnlToLLVMPasses(
         /*useLRODATA=*/(modelSize == ModelSize::large),
         /*storeConstantsToFile=*/storeConstantsToFile,
         constantsToFileSingleThreshold, constantsToFileTotalThreshold,
-        doNotEmbedCompilationInfo, outputNameNoExt, enableParallel));
+        omitCompileInfo, outputNameNoExt, enableParallel));
     pm.addPass(mlir::createReconcileUnrealizedCastsPass());
     pm.addPass(mlir::createCanonicalizerPass());
     return;
@@ -522,7 +522,7 @@ void addKrnlToLLVMPasses(
       /*useLRODATA=*/(modelSize == ModelSize::large),
       /*storeConstantsToFile=*/storeConstantsToFile,
       constantsToFileSingleThreshold, constantsToFileTotalThreshold,
-      doNotEmbedCompilationInfo, outputNameNoExt, enableParallel));
+      omitCompileInfo, outputNameNoExt, enableParallel));
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
   pm.addPass(mlir::createCanonicalizerPass());
   if (enableDebugInfo)

--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -280,6 +280,9 @@ void addONNXToKrnlPasses(mlir::PassManager &pm, int optLevel, bool enableCSE,
     }
   }
 
+  // Store the op statistics in an attribute of ModuleOp.
+  pm.addPass(onnx_mlir::createWriteOpStatsToModuleAttributePass());
+
   pm.addPass(onnx_mlir::createLowerToKrnlPass(/*enableTiling*/ optLevel >= 3,
       /*enableSIMD*/ optLevel >= 3 && !disableSimdOption, enableParallel,
       /*enableFastMath*/ optLevel >= 3 && enableFastMathOption,

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -212,6 +212,98 @@ static void loadMLIR(std::string inputFilename, mlir::MLIRContext &context,
 }
 
 // Tailor LLVMIR to add features that cannot be done with MLIR LLVMIR.
+
+// Helper function to escape JSON strings.
+static std::string escapeJSON(const std::string &str) {
+  std::ostringstream oss;
+  for (char c : str) {
+    switch (c) {
+    case '"':
+      oss << "\\\"";
+      break;
+    case '\\':
+      oss << "\\\\";
+      break;
+    case '\b':
+      oss << "\\b";
+      break;
+    case '\f':
+      oss << "\\f";
+      break;
+    case '\n':
+      oss << "\\n";
+      break;
+    case '\r':
+      oss << "\\r";
+      break;
+    case '\t':
+      oss << "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        oss << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+            << static_cast<int>(c);
+      } else {
+        oss << c;
+      }
+    }
+  }
+  return oss.str();
+}
+
+// Helper function to create compilation metadata as JSON string.
+static std::string createCompilationMetadataJSON() {
+  std::ostringstream json;
+  json << "{\n";
+
+  // Version information.
+  json << "  \"version\": {\n";
+  json << "    \"onnx_mlir\": \"" << escapeJSON(getOnnxMlirCommitVersion())
+       << "\",\n";
+  json << "    \"product\": \"" << escapeJSON(getProductFullVersion())
+       << "\"\n";
+  json << "  },\n";
+
+  // Compilation options.
+  json << "  \"compilation_options\": {\n";
+  json << "    \"target_triple\": \"" << escapeJSON(mtriple) << "\",\n";
+  json << "    \"target_arch\": \"" << escapeJSON(march) << "\",\n";
+  json << "    \"target_cpu\": \"" << escapeJSON(mcpu) << "\",\n";
+  json << "    \"optimization_level\": \"" << escapeJSON(getOptimizationLevelOption()) << "\",\n";
+  json << "    \"model_size\": \"" << escapeJSON(modelSizeStr[modelSize]) << "\",\n";
+  json << "    \"model_tag\": \"" << escapeJSON(modelTag) << "\",\n";
+  json << "    \"enable_parallel\": " << (enableParallel ? "true" : "false") << ",\n";
+  json << "    \"enable_simd\": " << (!disableSimdOption && OptimizationLevel == OptLevel::O3 ? "true" : "false") << ",\n";
+  json << "    \"enable_fast_math\": " << (enableFastMathOption ? "true" : "false") << ",\n";
+  json << "    \"store_constants_to_file\": " << (storeConstantsToFile ? "true" : "false");
+
+  // Accelerators.
+  if (!maccel.empty()) {
+    json << ",\n    \"accelerators\": [";
+    bool first = true;
+    for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators()) {
+      if (!first)
+        json << ", ";
+      first = false;
+      std::ostringstream versionNumber;
+      versionNumber << std::hex << accel->getVersionNumber();
+      json << "\"" << escapeJSON(accel->getName()) << "-0x" << versionNumber.str() << "\"";
+    }
+    json << "]";
+  }
+
+  json << "\n  }";
+
+  // Operation statistics (if available).
+  if (!ONNXOpStats.empty()) {
+    json << ",\n  \"operation_statistics\": \"" << escapeJSON(ONNXOpStats) << "\"";
+  }
+
+  json << "\n}\n";
+  return json.str();
+}
+
+
 static void tailorLLVMIR(llvm::Module &llvmModule) {
   llvm::LLVMContext &ctx = llvmModule.getContext();
   // Emit metadata "zos_le_char_mode" for z/OS. Use EBCDIC codepage by default.
@@ -249,6 +341,21 @@ static void tailorLLVMIR(llvm::Module &llvmModule) {
   llvmModule.addModuleFlag(llvm::Module::Warning, "Product Id",
       llvm::MDString::get(ctx, PRODUCT_ID));
 #endif
+
+  // Embed compilation metadata as a global constant string.
+  // This survives compilation to native code unlike module flags.
+  std::string metadataJSON = createCompilationMetadataJSON();
+  llvm::Constant *metadata = llvm::ConstantDataArray::getString(
+      ctx, metadataJSON, /*AddNull=*/true);
+  llvm::GlobalVariable *metadataGV = new llvm::GlobalVariable(
+      llvmModule, metadata->getType(), /*isConstant=*/true,
+      llvm::GlobalValue::ExternalLinkage, metadata,
+      "onnx_mlir_compilation_metadata");
+  metadataGV->setAlignment(llvm::Align(1));
+  
+  // Also add as module flag for bitcode/IR inspection.
+  llvmModule.addModuleFlag(llvm::Module::Warning, "onnx-mlir.compilation-metadata",
+      llvm::MDString::get(ctx, metadataJSON));
 
   // Annotate functions to be accessible from DLL on Windows.
 #ifdef _WIN32

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -212,98 +212,6 @@ static void loadMLIR(std::string inputFilename, mlir::MLIRContext &context,
 }
 
 // Tailor LLVMIR to add features that cannot be done with MLIR LLVMIR.
-
-// Helper function to escape JSON strings.
-static std::string escapeJSON(const std::string &str) {
-  std::ostringstream oss;
-  for (char c : str) {
-    switch (c) {
-    case '"':
-      oss << "\\\"";
-      break;
-    case '\\':
-      oss << "\\\\";
-      break;
-    case '\b':
-      oss << "\\b";
-      break;
-    case '\f':
-      oss << "\\f";
-      break;
-    case '\n':
-      oss << "\\n";
-      break;
-    case '\r':
-      oss << "\\r";
-      break;
-    case '\t':
-      oss << "\\t";
-      break;
-    default:
-      if (c < 0x20) {
-        oss << "\\u" << std::hex << std::setw(4) << std::setfill('0')
-            << static_cast<int>(c);
-      } else {
-        oss << c;
-      }
-    }
-  }
-  return oss.str();
-}
-
-// Helper function to create compilation metadata as JSON string.
-static std::string createCompilationMetadataJSON() {
-  std::ostringstream json;
-  json << "{\n";
-
-  // Version information.
-  json << "  \"version\": {\n";
-  json << "    \"onnx_mlir\": \"" << escapeJSON(getOnnxMlirCommitVersion())
-       << "\",\n";
-  json << "    \"product\": \"" << escapeJSON(getProductFullVersion())
-       << "\"\n";
-  json << "  },\n";
-
-  // Compilation options.
-  json << "  \"compilation_options\": {\n";
-  json << "    \"target_triple\": \"" << escapeJSON(mtriple) << "\",\n";
-  json << "    \"target_arch\": \"" << escapeJSON(march) << "\",\n";
-  json << "    \"target_cpu\": \"" << escapeJSON(mcpu) << "\",\n";
-  json << "    \"optimization_level\": \"" << escapeJSON(getOptimizationLevelOption()) << "\",\n";
-  json << "    \"model_size\": \"" << escapeJSON(modelSizeStr[modelSize]) << "\",\n";
-  json << "    \"model_tag\": \"" << escapeJSON(modelTag) << "\",\n";
-  json << "    \"enable_parallel\": " << (enableParallel ? "true" : "false") << ",\n";
-  json << "    \"enable_simd\": " << (!disableSimdOption && OptimizationLevel == OptLevel::O3 ? "true" : "false") << ",\n";
-  json << "    \"enable_fast_math\": " << (enableFastMathOption ? "true" : "false") << ",\n";
-  json << "    \"store_constants_to_file\": " << (storeConstantsToFile ? "true" : "false");
-
-  // Accelerators.
-  if (!maccel.empty()) {
-    json << ",\n    \"accelerators\": [";
-    bool first = true;
-    for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators()) {
-      if (!first)
-        json << ", ";
-      first = false;
-      std::ostringstream versionNumber;
-      versionNumber << std::hex << accel->getVersionNumber();
-      json << "\"" << escapeJSON(accel->getName()) << "-0x" << versionNumber.str() << "\"";
-    }
-    json << "]";
-  }
-
-  json << "\n  }";
-
-  // Operation statistics (if available).
-  if (!ONNXOpStats.empty()) {
-    json << ",\n  \"operation_statistics\": \"" << escapeJSON(ONNXOpStats) << "\"";
-  }
-
-  json << "\n}\n";
-  return json.str();
-}
-
-
 static void tailorLLVMIR(llvm::Module &llvmModule) {
   llvm::LLVMContext &ctx = llvmModule.getContext();
   // Emit metadata "zos_le_char_mode" for z/OS. Use EBCDIC codepage by default.
@@ -341,21 +249,6 @@ static void tailorLLVMIR(llvm::Module &llvmModule) {
   llvmModule.addModuleFlag(llvm::Module::Warning, "Product Id",
       llvm::MDString::get(ctx, PRODUCT_ID));
 #endif
-
-  // Embed compilation metadata as a global constant string.
-  // This survives compilation to native code unlike module flags.
-  std::string metadataJSON = createCompilationMetadataJSON();
-  llvm::Constant *metadata = llvm::ConstantDataArray::getString(
-      ctx, metadataJSON, /*AddNull=*/true);
-  llvm::GlobalVariable *metadataGV = new llvm::GlobalVariable(
-      llvmModule, metadata->getType(), /*isConstant=*/true,
-      llvm::GlobalValue::ExternalLinkage, metadata,
-      "onnx_mlir_compilation_metadata");
-  metadataGV->setAlignment(llvm::Align(1));
-  
-  // Also add as module flag for bitcode/IR inspection.
-  llvmModule.addModuleFlag(llvm::Module::Warning, "onnx-mlir.compilation-metadata",
-      llvm::MDString::get(ctx, metadataJSON));
 
   // Annotate functions to be accessible from DLL on Windows.
 #ifdef _WIN32

--- a/src/Compiler/CompilerUtils.cpp
+++ b/src/Compiler/CompilerUtils.cpp
@@ -261,10 +261,12 @@ static void tailorLLVMIR(llvm::Module &llvmModule) {
   exportedFuncs.emplace_back(StringRef("omInputSignature"));
   exportedFuncs.emplace_back(StringRef("omOutputSignature"));
   exportedFuncs.emplace_back(StringRef("omQueryEntryPoints"));
+  exportedFuncs.emplace_back(StringRef("omCompilationInfo"));
   if (!tag.empty()) {
     exportedFuncs.emplace_back(StringRef("omInputSignature" + tag));
     exportedFuncs.emplace_back(StringRef("omOutputSignature" + tag));
     exportedFuncs.emplace_back(StringRef("omQueryEntryPoints" + tag));
+    exportedFuncs.emplace_back(StringRef("omCompilationInfo" + tag));
   }
   // Entry point fuctions.
   if (llvm::GlobalVariable *GV =

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -1032,8 +1032,9 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
                    << "(single constant <= " << constantsToFileSingleThreshold
                    << " KB, "
                    << "total constants <= " << constantsToFileTotalThreshold
-                   << " GB). " << "Stored them in an external file: " << "\""
-                   << fname << "\""
+                   << " GB). "
+                   << "Stored them in an external file: "
+                   << "\"" << fname << "\""
                    << ". Make sure to put this file in the same folder as the "
                       "generated model or set OM_CONSTANT_PATH to the "
                       "folder having this file. For constants-related "

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -827,6 +827,70 @@ void emitDtors(ModuleOp &module, OpBuilder &builder,
   }
 }
 
+/// Emit compilation information by extracting compile options and op stats
+/// from module attributes and constructing a JSON string.
+void emitCompilationInfo(ModuleOp &module) {
+  MLIRContext *context = module.getContext();
+  Location loc = module.getLoc();
+  OpBuilder b(context);
+  MultiDialectBuilder<LLVMBuilder> create(b, loc);
+
+  Type i8Type = IntegerType::get(context, 8);
+  Type i8PtrTy = getPointerType(context, i8Type);
+
+  // Get the compile_options attribute.
+  std::string compileOptions;
+  if (Attribute compileOptionsAttr =
+          module->getAttr("onnx-mlir.compile_options")) {
+    if (auto strAttr = mlir::dyn_cast<StringAttr>(compileOptionsAttr)) {
+      compileOptions = strAttr.getValue().str();
+    }
+  }
+
+  // Get the op_stats attribute.
+  std::string opStats;
+  if (Attribute opStatsAttr = module->getAttr("onnx-mlir.op_stats")) {
+    if (auto strAttr = mlir::dyn_cast<StringAttr>(opStatsAttr)) {
+      opStats = strAttr.getValue().str();
+    }
+  }
+
+  // Construct the JSON string.
+  std::string jsonString = "{\"compile_options\": \"" + compileOptions +
+                           "\", \"op_stats\": " + opStats + "}";
+
+  LLVM_DEBUG(llvm::dbgs() << "Compilation Info: " << jsonString << "\n");
+
+  // Create a global op to store the JSON string.
+  OpBuilder::InsertionGuard guard(b);
+  b.setInsertionPointToStart(module.getBody());
+  std::string jsonStringWithNull = jsonString + '\0';
+  jsonStringWithNull =
+      (isZOS(module)) ? krnl::a2e_s(jsonStringWithNull) : jsonStringWithNull;
+  mlir::StringAttr valueAttr =
+      mlir::StringAttr::get(context, jsonStringWithNull);
+  LLVM::GlobalOp compilationInfoGlobalOp = create.llvm.globalOp(
+      LLVM::LLVMArrayType::get(i8Type, jsonStringWithNull.size()),
+      /*isConstant=*/true, LLVM::Linkage::Internal, "om_compilation_info_json",
+      valueAttr);
+
+  // Emit the omCompilationInfo function of type `*i8 ()`.
+  b.setInsertionPointToEnd(module.getBody());
+  Type llvmFnType = LLVM::LLVMFunctionType::get(i8PtrTy, {}, false);
+  LLVM::LLVMFuncOp funcOp = create.llvm.func(
+      "omCompilationInfo", llvmFnType, /*createUniqueFunc=*/true);
+
+  // Emit the body of the function.
+  Block *entryBlock = funcOp.addEntryBlock(b);
+  OpBuilder::InsertionGuard bodyGuard(b);
+  b.setInsertionPointToStart(entryBlock);
+
+  // Return a pointer to the global JSON string.
+  Value jsonAddr = create.llvm.addressOf(compilationInfoGlobalOp);
+  Value jsonI8Ptr = create.llvm.bitcast(i8PtrTy, jsonAddr);
+  create.llvm._return(jsonI8Ptr);
+}
+
 //===----------------------------------------------------------------------===//
 // Krnl Dialect lowering pass
 //===----------------------------------------------------------------------===//
@@ -968,9 +1032,8 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
                    << "(single constant <= " << constantsToFileSingleThreshold
                    << " KB, "
                    << "total constants <= " << constantsToFileTotalThreshold
-                   << " GB). "
-                   << "Stored them in an external file: "
-                   << "\"" << fname << "\""
+                   << " GB). " << "Stored them in an external file: " << "\""
+                   << fname << "\""
                    << ". Make sure to put this file in the same folder as the "
                       "generated model or set OM_CONSTANT_PATH to the "
                       "folder having this file. For constants-related "
@@ -1087,6 +1150,9 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
       return WalkResult::advance();
     });
   }
+
+  // Emit compilation information.
+  emitCompilationInfo(module);
 }
 
 /// Create the pass for lowering `Krnl`, `Affine` and `Std` dialects to LLVM.

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -838,6 +838,15 @@ void emitCompilationInfo(ModuleOp &module) {
   Type i8Type = IntegerType::get(context, 8);
   Type i8PtrTy = getPointerType(context, i8Type);
 
+  // Get the compiler_info attribute.
+  std::string compilerVersion;
+  if (Attribute compilerVersionAttr =
+          module->getAttr("onnx-mlir.compiler_version")) {
+    if (auto strAttr = mlir::dyn_cast<StringAttr>(compilerVersionAttr)) {
+      compilerVersion = strAttr.getValue().str();
+    }
+  }
+
   // Get the compile_options attribute.
   std::string compileOptions;
   if (Attribute compileOptionsAttr =
@@ -846,7 +855,6 @@ void emitCompilationInfo(ModuleOp &module) {
       compileOptions = strAttr.getValue().str();
     }
   }
-
   // Get the op_stats attribute.
   std::string opStats;
   if (Attribute opStatsAttr = module->getAttr("onnx-mlir.op_stats")) {
@@ -856,8 +864,9 @@ void emitCompilationInfo(ModuleOp &module) {
   }
 
   // Construct the JSON string.
-  std::string jsonString = "{\"compile_options\": \"" + compileOptions +
-                           "\", \"op_stats\": " + opStats + "}";
+  std::string jsonString = "{\n\"compiler_version\": \"" + compilerVersion +
+                           "\",\n\"compile_options\": \"" + compileOptions +
+                           "\",\n\"op_stats\": " + opStats + "}";
 
   LLVM_DEBUG(llvm::dbgs() << "Compilation Info: " << jsonString << "\n");
 

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -915,7 +915,7 @@ struct ConvertKrnlToLLVMPass
       : PassWrapper<ConvertKrnlToLLVMPass, OperationPass<ModuleOp>>() {}
   ConvertKrnlToLLVMPass(bool verifyInputTensors, bool useLRODATA,
       bool storeConstantsToFile, float constantsToFileSingleThreshold,
-      float constantsToFileTotalThreshold, bool doNotEmbedCompilationInfo,
+      float constantsToFileTotalThreshold, bool omitCompileInfo,
       std::string outputNameNoExt, bool enableParallel) {
     this->verifyInputTensors = verifyInputTensors;
     // Exclusive options. no option or only one option can be True.
@@ -927,7 +927,7 @@ struct ConvertKrnlToLLVMPass
 #endif
     this->constantsToFileSingleThreshold = constantsToFileSingleThreshold;
     this->constantsToFileTotalThreshold = constantsToFileTotalThreshold;
-    this->doNotEmbedCompilationInfo = doNotEmbedCompilationInfo;
+    this->omitCompileInfo = omitCompileInfo;
     this->outputNameNoExt = outputNameNoExt;
     this->enableParallel = enableParallel;
   }
@@ -962,7 +962,7 @@ struct ConvertKrnlToLLVMPass
                      "into the generated shared library."),
       llvm::cl::init(false)};
 
-  Option<bool> doNotEmbedCompilationInfo{*this, "do-not-embed-compilation-info",
+  Option<bool> omitCompileInfo{*this, "omit-compile-info",
       llvm::cl::desc("Put global constants to a file."), llvm::cl::init(false)};
 
   Option<float> constantsToFileTotalThreshold{*this,
@@ -1169,7 +1169,7 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
   }
 
   // Emit compilation information.
-  if (!doNotEmbedCompilationInfo)
+  if (!omitCompileInfo)
     emitCompilationInfo(module);
 }
 
@@ -1180,11 +1180,11 @@ std::unique_ptr<Pass> createConvertKrnlToLLVMPass() {
 std::unique_ptr<Pass> createConvertKrnlToLLVMPass(bool verifyInputTensors,
     bool useLRODATA, bool storeConstantsToFile,
     float constantsToFileSingleThreshold, float constantsToFileTotalThreshold,
-    bool doNotEmbedCompilationInfo, std::string outputNameNoExt,
+    bool omitCompileInfo, std::string outputNameNoExt,
     bool enableParallel) {
   return std::make_unique<ConvertKrnlToLLVMPass>(verifyInputTensors, useLRODATA,
       storeConstantsToFile, constantsToFileSingleThreshold,
-      constantsToFileTotalThreshold, doNotEmbedCompilationInfo, outputNameNoExt,
+      constantsToFileTotalThreshold, omitCompileInfo, outputNameNoExt,
       enableParallel);
 }
 

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -915,8 +915,8 @@ struct ConvertKrnlToLLVMPass
       : PassWrapper<ConvertKrnlToLLVMPass, OperationPass<ModuleOp>>() {}
   ConvertKrnlToLLVMPass(bool verifyInputTensors, bool useLRODATA,
       bool storeConstantsToFile, float constantsToFileSingleThreshold,
-      float constantsToFileTotalThreshold, std::string outputNameNoExt,
-      bool enableParallel) {
+      float constantsToFileTotalThreshold, bool doNotEmbedCompilationInfo,
+      std::string outputNameNoExt, bool enableParallel) {
     this->verifyInputTensors = verifyInputTensors;
     // Exclusive options. no option or only one option can be True.
     this->useLRODATA = useLRODATA;
@@ -927,6 +927,7 @@ struct ConvertKrnlToLLVMPass
 #endif
     this->constantsToFileSingleThreshold = constantsToFileSingleThreshold;
     this->constantsToFileTotalThreshold = constantsToFileTotalThreshold;
+    this->doNotEmbedCompilationInfo = doNotEmbedCompilationInfo;
     this->outputNameNoExt = outputNameNoExt;
     this->enableParallel = enableParallel;
   }
@@ -956,6 +957,12 @@ struct ConvertKrnlToLLVMPass
       llvm::cl::init(false)};
 
   Option<bool> storeConstantsToFile{*this, "store-constants-to-file",
+      llvm::cl::desc("Do not embed compilation information such as compiler "
+                     "version, compile options, and ONNX operation statistics "
+                     "into the generated shared library."),
+      llvm::cl::init(false)};
+
+  Option<bool> doNotEmbedCompilationInfo{*this, "do-not-embed-compilation-info",
       llvm::cl::desc("Put global constants to a file."), llvm::cl::init(false)};
 
   Option<float> constantsToFileTotalThreshold{*this,
@@ -1162,7 +1169,8 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
   }
 
   // Emit compilation information.
-  emitCompilationInfo(module);
+  if (!doNotEmbedCompilationInfo)
+    emitCompilationInfo(module);
 }
 
 /// Create the pass for lowering `Krnl`, `Affine` and `Std` dialects to LLVM.
@@ -1172,10 +1180,12 @@ std::unique_ptr<Pass> createConvertKrnlToLLVMPass() {
 std::unique_ptr<Pass> createConvertKrnlToLLVMPass(bool verifyInputTensors,
     bool useLRODATA, bool storeConstantsToFile,
     float constantsToFileSingleThreshold, float constantsToFileTotalThreshold,
-    std::string outputNameNoExt, bool enableParallel) {
+    bool doNotEmbedCompilationInfo, std::string outputNameNoExt,
+    bool enableParallel) {
   return std::make_unique<ConvertKrnlToLLVMPass>(verifyInputTensors, useLRODATA,
       storeConstantsToFile, constantsToFileSingleThreshold,
-      constantsToFileTotalThreshold, outputNameNoExt, enableParallel);
+      constantsToFileTotalThreshold, doNotEmbedCompilationInfo, outputNameNoExt,
+      enableParallel);
 }
 
 void populateKrnlToLLVMConversion(LLVMTypeConverter &typeConverter,

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -1180,8 +1180,7 @@ std::unique_ptr<Pass> createConvertKrnlToLLVMPass() {
 std::unique_ptr<Pass> createConvertKrnlToLLVMPass(bool verifyInputTensors,
     bool useLRODATA, bool storeConstantsToFile,
     float constantsToFileSingleThreshold, float constantsToFileTotalThreshold,
-    bool omitCompileInfo, std::string outputNameNoExt,
-    bool enableParallel) {
+    bool omitCompileInfo, std::string outputNameNoExt, bool enableParallel) {
   return std::make_unique<ConvertKrnlToLLVMPass>(verifyInputTensors, useLRODATA,
       storeConstantsToFile, constantsToFileSingleThreshold,
       constantsToFileTotalThreshold, omitCompileInfo, outputNameNoExt,

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -143,8 +143,7 @@ std::unique_ptr<mlir::Pass> createConvertKrnlToLLVMPass();
 std::unique_ptr<mlir::Pass> createConvertKrnlToLLVMPass(bool verifyInputTensors,
     bool useLRODATA, bool storeConstantsToFile,
     float constantsToFileSingleThreshold, float constantsToFileTotalThreshold,
-    bool omitCompileInfo, std::string outputNameNoExt,
-    bool enableParallel);
+    bool omitCompileInfo, std::string outputNameNoExt, bool enableParallel);
 
 } // namespace krnl
 

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -143,7 +143,7 @@ std::unique_ptr<mlir::Pass> createConvertKrnlToLLVMPass();
 std::unique_ptr<mlir::Pass> createConvertKrnlToLLVMPass(bool verifyInputTensors,
     bool useLRODATA, bool storeConstantsToFile,
     float constantsToFileSingleThreshold, float constantsToFileTotalThreshold,
-    bool doNotEmbedCompilationInfo, std::string outputNameNoExt,
+    bool omitCompileInfo, std::string outputNameNoExt,
     bool enableParallel);
 
 } // namespace krnl

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -143,7 +143,8 @@ std::unique_ptr<mlir::Pass> createConvertKrnlToLLVMPass();
 std::unique_ptr<mlir::Pass> createConvertKrnlToLLVMPass(bool verifyInputTensors,
     bool useLRODATA, bool storeConstantsToFile,
     float constantsToFileSingleThreshold, float constantsToFileTotalThreshold,
-    std::string outputNameNoExt, bool enableParallel);
+    bool doNotEmbedCompilationInfo, std::string outputNameNoExt,
+    bool enableParallel);
 
 } // namespace krnl
 

--- a/src/Pass/Passes.hpp
+++ b/src/Pass/Passes.hpp
@@ -74,6 +74,10 @@ std::unique_ptr<mlir::Pass> createInstrumentPass(
 #define GEN_PASS_DECL_INSTRUMENTCLEANUPPASS
 #include "src/Transform/Passes.h.inc"
 
+/// Pass for writing operation statistics to a module attribute.
+#define GEN_PASS_DECL_WRITEOPSTATSTOMODULEATTRIBUTEPASS
+#include "src/Transform/Passes.h.inc"
+
 /// Passes for instrumenting the ONNX ops to print their operand type
 /// signatures at runtime.
 std::unique_ptr<mlir::Pass> createInstrumentONNXSignaturePass(

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -174,6 +174,19 @@ void ExecutionSession::loadModel(
     throw ExecutionSessionException(
         "Cannot load symbol: '" + outputSignatureNameWithTag + "'.");
 
+  std::string compilationInfoNameWithTag = _compilationInfoName + lowDashTag;
+#if defined(_WIN32)
+  _compilationInfoFunc = reinterpret_cast<compilationInfoFuncType>(
+      _sharedLibraryHandle.getAddressOfSymbol(
+          compilationInfoNameWithTag.c_str()));
+#else
+  _compilationInfoFunc = reinterpret_cast<compilationInfoFuncType>(
+      dlsym(_sharedLibraryHandle, compilationInfoNameWithTag.c_str()));
+#endif
+  if (!_compilationInfoFunc)
+    throw ExecutionSessionException(
+        "Cannot load symbol: '" + compilationInfoNameWithTag + "'.");
+
 #if defined(_WIN32)
   _printInstrumentationFunc = reinterpret_cast<printInstrumentationFuncType>(
       _sharedLibraryHandle.getAddressOfSymbol(
@@ -264,6 +277,14 @@ const std::string ExecutionSession::outputSignature() const {
         "signature function.");
   errno = 0; // No errors.
   return _outputSignatureFunc(_entryPointName.c_str());
+}
+
+const std::string ExecutionSession::compilationInfo() const {
+  if (!isInitialized)
+    throw ExecutionSessionException(
+        "Execution session must be initialized once.");
+  errno = 0; // No errors.
+  return _compilationInfoFunc();
 }
 
 void ExecutionSession::printInstrumentation() {

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -183,9 +183,6 @@ void ExecutionSession::loadModel(
   _compilationInfoFunc = reinterpret_cast<compilationInfoFuncType>(
       dlsym(_sharedLibraryHandle, compilationInfoNameWithTag.c_str()));
 #endif
-  if (!_compilationInfoFunc)
-    throw ExecutionSessionException(
-        "Cannot load symbol: '" + compilationInfoNameWithTag + "'.");
 
 #if defined(_WIN32)
   _printInstrumentationFunc = reinterpret_cast<printInstrumentationFuncType>(
@@ -284,6 +281,8 @@ const std::string ExecutionSession::compilationInfo() const {
     throw ExecutionSessionException(
         "Execution session must be initialized once.");
   errno = 0; // No errors.
+  if (_compilationInfoFunc == nullptr)
+    return "{}";
   return _compilationInfoFunc();
 }
 

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -281,7 +281,7 @@ const std::string ExecutionSession::compilationInfo() const {
     throw ExecutionSessionException(
         "Execution session must be initialized once.");
   errno = 0; // No errors.
-  if (_compilationInfoFunc == nullptr)
+  if (!_compilationInfoFunc)
     return "{}";
   return _compilationInfoFunc();
 }

--- a/src/Runtime/ExecutionSession.hpp
+++ b/src/Runtime/ExecutionSession.hpp
@@ -48,6 +48,7 @@ namespace onnx_mlir {
 using entryPointFuncType = OMTensorList *(*)(OMTensorList *);
 using queryEntryPointsFuncType = const char **(*)(int64_t *);
 using signatureFuncType = const char *(*)(const char *);
+using compilationInfoFuncType = const char *(*)(void);
 using printInstrumentationFuncType = void (*)(void);
 using OMTensorUniquePtr = std::unique_ptr<OMTensor, decltype(&omTensorDestroy)>;
 
@@ -120,6 +121,8 @@ public:
   // `[ { "type" : "f32" , "dims" : [1 , 1 , 28 , 28] , "name" : "image" } ]`
   const std::string inputSignature() const;
   const std::string outputSignature() const;
+  // Get compilation information as a Json string.
+  const std::string compilationInfo() const;
   void printInstrumentation();
 
 protected:
@@ -157,6 +160,10 @@ protected:
   const std::string _outputSignatureName = "omOutputSignature";
   signatureFuncType _inputSignatureFunc = nullptr;
   signatureFuncType _outputSignatureFunc = nullptr;
+
+  // Entry point for compilation information
+  const std::string _compilationInfoName = "omCompilationInfo";
+  compilationInfoFuncType _compilationInfoFunc = nullptr;
 
   // Entry point for printing instrumentation
   const std::string _printInstrumentationName = "omInstrumentPrint";

--- a/src/Runtime/jni/jnidummy.c
+++ b/src/Runtime/jni/jnidummy.c
@@ -22,4 +22,5 @@ void __dummy_do_not_call__(JNIEnv *env, jclass cls, jobject obj) {
   Java_com_ibm_onnxmlir_OMModel_query_1entry_1points(NULL, NULL);
   Java_com_ibm_onnxmlir_OMModel_input_1signature_1jni(NULL, NULL, NULL);
   Java_com_ibm_onnxmlir_OMModel_output_1signature_1jni(NULL, NULL, NULL);
+  Java_com_ibm_onnxmlir_OMModel_compilation_1info_1jni(NULL, NULL);
 }

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -933,15 +933,16 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_compilation_1info_1jni(
 
   /* On z/OS, convert compilation info in EBCDIC to ASCII */
 #ifdef __MVS__
-  CHECK_CALL(
-      char *, infoptr, __e2a(jni_cinfo), infoptr != NULL, "infoptr=%p", infoptr);
+  CHECK_CALL(char *, infoptr, __e2a(jni_cinfo), infoptr != NULL, "infoptr=%p",
+      infoptr);
 #else
   const char *infoptr = jni_cinfo;
 #endif
 
   /* Convert to Java String object */
-  JNI_TYPE_VAR_CALL(env, jstring, java_cinfo, (*env)->NewStringUTF(env, infoptr),
-      java_cinfo != NULL, jecpt_cls, "java_cinfo=%p", java_cinfo);
+  JNI_TYPE_VAR_CALL(env, jstring, java_cinfo,
+      (*env)->NewStringUTF(env, infoptr), java_cinfo != NULL, jecpt_cls,
+      "java_cinfo=%p", java_cinfo);
 
   /* On z/OS, free the ASCII compilation info no longer needed */
 #ifdef __MVS__

--- a/src/Runtime/jni/jniwrapper.c
+++ b/src/Runtime/jni/jniwrapper.c
@@ -912,3 +912,41 @@ JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_output_1signature_1jni(
 
   return java_osig;
 }
+
+JNIEXPORT jstring JNICALL Java_com_ibm_onnxmlir_OMModel_compilation_1info_1jni(
+    JNIEnv *env, jclass cls) {
+
+  log_init();
+
+  /* Find and initialize Java Exception class */
+  JNI_TYPE_VAR_CALL(env, jclass, jecpt_cls,
+      (*env)->FindClass(env, jnistr[CLS_JAVA_LANG_EXCEPTION]),
+      jecpt_cls != NULL, NULL, "Class java/lang/Exception not found");
+
+  /* Call model compilation info API */
+  CHECK_CALL(const char *, jni_cinfo, omCompilationInfo(), jni_cinfo != NULL,
+      "jni_cinfo=%p", jni_cinfo);
+
+  /* Compilation info in hex and string format for debugging */
+  HEX_DEBUG("cinfo", jni_cinfo, strlen(jni_cinfo));
+  LOG_PRINTF(LOG_DEBUG, "cinfo(%d):%s", strlen(jni_cinfo), jni_cinfo);
+
+  /* On z/OS, convert compilation info in EBCDIC to ASCII */
+#ifdef __MVS__
+  CHECK_CALL(
+      char *, infoptr, __e2a(jni_cinfo), infoptr != NULL, "infoptr=%p", infoptr);
+#else
+  const char *infoptr = jni_cinfo;
+#endif
+
+  /* Convert to Java String object */
+  JNI_TYPE_VAR_CALL(env, jstring, java_cinfo, (*env)->NewStringUTF(env, infoptr),
+      java_cinfo != NULL, jecpt_cls, "java_cinfo=%p", java_cinfo);
+
+  /* On z/OS, free the ASCII compilation info no longer needed */
+#ifdef __MVS__
+  free(infoptr);
+#endif
+
+  return java_cinfo;
+}

--- a/src/Runtime/jni/src/com/ibm/onnxmlir/OMModel.java
+++ b/src/Runtime/jni/src/com/ibm/onnxmlir/OMModel.java
@@ -171,6 +171,7 @@ public class OMModel {
     private static native String[] query_entry_points();
     private static native String input_signature_jni(String entry_point);
     private static native String output_signature_jni(String entry_point);
+    private static native String compilation_info_jni();
 
     /**
      * Default model runtime entry point
@@ -215,5 +216,14 @@ public class OMModel {
 
     public static String outputSignature(String entry_point) {
         return output_signature_jni(entry_point);
+    }
+
+    /**
+     * Compilation information of the model
+     *
+     * @return JSON string of compilation information
+     */
+    public static String compilationInfo() {
+        return compilation_info_jni();
     }
 }

--- a/src/Runtime/python/PyExecutionSession.hpp
+++ b/src/Runtime/python/PyExecutionSession.hpp
@@ -220,16 +220,17 @@ PYBIND11_MODULE(PyRuntimeC, m) {
       .def("compilation_info",
           &onnx_mlir::PyExecutionSession::pyCompilationInfo,
           "Get the compilation information of the model.\n\n"
-          "Returns a JSON string containing compilation options and operation\n"
+          "Returns a JSON string containing compiler version, compilation options and operation\n"
           "statistics used when the model was compiled. This information is\n"
           "useful for understanding how the model was built and what operations\n"
-          "it contains.\n\n"
+          "it contains. If the model was compiled without this information\n"
+          "(e.g. old compiler or --omit-compile-info is used), this function will return an empty JSON string that is {}.\n\n"
           "Returns:\n"
           "    str: JSON string with compilation information.\n\n"
           "Example:\n"
           "    >>> session = OMExecutionSession('model.so')\n"
           "    >>> print(session.compilation_info())\n"
-          "    # Output: {\"compile_options\": \"...\", \"op_stats\": {...}}")
+          "    # Output: {\"compiler_version\": \"...\", \"compile_options\": \"...\", \"op_stats\": {...}}")
       .def("print_instrumentation",
           &onnx_mlir::PyExecutionSession::pyPrintInstrumentation,
           "Print instrumentation data from the model execution.\n\n"

--- a/src/Runtime/python/PyExecutionSession.hpp
+++ b/src/Runtime/python/PyExecutionSession.hpp
@@ -217,6 +217,19 @@ PYBIND11_MODULE(PyRuntimeC, m) {
           "    >>> session = OMExecutionSession('mnist.so')\n"
           "    >>> print(session.output_signature())\n"
           "    # Output: output signature in json [{\"type\" : \"f32\", \"dims\" : [1,10], \"name\" : \"prediction\"}")
+      .def("compilation_info",
+          &onnx_mlir::PyExecutionSession::pyCompilationInfo,
+          "Get the compilation information of the model.\n\n"
+          "Returns a JSON string containing compilation options and operation\n"
+          "statistics used when the model was compiled. This information is\n"
+          "useful for understanding how the model was built and what operations\n"
+          "it contains.\n\n"
+          "Returns:\n"
+          "    str: JSON string with compilation information.\n\n"
+          "Example:\n"
+          "    >>> session = OMExecutionSession('model.so')\n"
+          "    >>> print(session.compilation_info())\n"
+          "    # Output: {\"compile_options\": \"...\", \"op_stats\": {...}}")
       .def("print_instrumentation",
           &onnx_mlir::PyExecutionSession::pyPrintInstrumentation,
           "Print instrumentation data from the model execution.\n\n"

--- a/src/Runtime/python/PyExecutionSessionBase.cpp
+++ b/src/Runtime/python/PyExecutionSessionBase.cpp
@@ -514,6 +514,10 @@ std::string PyExecutionSessionBase::pyOutputSignature() {
   return outputSignature();
 }
 
+std::string PyExecutionSessionBase::pyCompilationInfo() {
+  return compilationInfo();
+}
+
 // =============================================================================
 // Error reporting
 

--- a/src/Runtime/python/PyExecutionSessionBase.hpp
+++ b/src/Runtime/python/PyExecutionSessionBase.hpp
@@ -56,6 +56,7 @@ public:
       bool forceOutputDataCopy); // Debug flags.
   std::string pyInputSignature();
   std::string pyOutputSignature();
+  std::string pyCompilationInfo();
   void pyPrintInstrumentation(); // Print instrumentation (if any).
 
 protected:

--- a/src/Transform/CMakeLists.txt
+++ b/src/Transform/CMakeLists.txt
@@ -58,3 +58,17 @@ add_onnx_mlir_library(BufferOMPLoopHoist
   MLIRMemRefDialect
   OMOptionUtils
   )
+
+add_onnx_mlir_library(OMWriteOpStatsToModuleAttribute
+  WriteOpStatsToModuleAttribute.cpp
+
+  DEPENDS
+  OMTransformsPassIncGen
+
+  INCLUDE_DIRS PUBLIC
+  ${ONNX_MLIR_SRC_ROOT}/include
+
+  LINK_LIBS PUBLIC
+  MLIRPass
+  MLIRFuncDialect
+  )

--- a/src/Transform/CMakeLists.txt
+++ b/src/Transform/CMakeLists.txt
@@ -71,4 +71,5 @@ add_onnx_mlir_library(OMWriteOpStatsToModuleAttribute
   LINK_LIBS PUBLIC
   MLIRPass
   MLIRFuncDialect
+  MLIRTransforms
   )

--- a/src/Transform/CMakeLists.txt
+++ b/src/Transform/CMakeLists.txt
@@ -69,6 +69,7 @@ add_onnx_mlir_library(OMWriteOpStatsToModuleAttribute
   ${ONNX_MLIR_SRC_ROOT}/include
 
   LINK_LIBS PUBLIC
+  OMONNXOps
   MLIRPass
   MLIRFuncDialect
   MLIRTransforms

--- a/src/Transform/Passes.td
+++ b/src/Transform/Passes.td
@@ -69,5 +69,8 @@ def BufferOMPLoopHoistingPass : Pass<"buffer-omploop-hoisting", "func::FuncOp"> 
   }];
 }
 
+def WriteOpStatsToModuleAttributePass : Pass<"write-op-stats-to-module-attribute"> {
+  let summary = "Write statistics of operations to an attribute in ModuleOp";
+}
 
 #endif

--- a/src/Transform/WriteOpStatsToModuleAttribute.cpp
+++ b/src/Transform/WriteOpStatsToModuleAttribute.cpp
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===- WriteOpStatsToModuleAttribute.cpp - Operation statistics pass ------===//
+//
+// Copyright 2026 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file implements a Module level pass that writes operation statistics
+// to a module attribute.
+//
+//===----------------------------------------------------------------------===//
+
+#include <string>
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/Passes.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace onnx_mlir {
+
+#define GEN_PASS_DEF_WRITEOPSTATSTOMODULEATTRIBUTEPASS
+#include "src/Transform/Passes.h.inc"
+
+} // namespace onnx_mlir
+
+using namespace mlir;
+
+namespace {
+
+class WriteOpStatsToModuleAttributePass
+    : public onnx_mlir::impl::WriteOpStatsToModuleAttributePassBase<
+          WriteOpStatsToModuleAttributePass> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(
+      WriteOpStatsToModuleAttributePass)
+
+  void runOnOperation() override {
+    Operation *module = getOperation();
+
+    std::string opStatsJSON;
+    llvm::raw_string_ostream opStatsStream(opStatsJSON);
+
+    OpPassManager pm("builtin.module");
+    pm.addNestedPass<func::FuncOp>(
+        mlir::createPrintOpStatsPass(opStatsStream, /*printAsJSON=*/true));
+    if (failed(runPipeline(pm, module)))
+      return signalPassFailure();
+
+    opStatsStream.flush();
+    module->setAttr(
+        "onnx-mlir.op_stats", StringAttr::get(&getContext(), opStatsJSON));
+  }
+};
+
+} // namespace

--- a/src/Transform/WriteOpStatsToModuleAttribute.cpp
+++ b/src/Transform/WriteOpStatsToModuleAttribute.cpp
@@ -22,6 +22,9 @@
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+
 namespace onnx_mlir {
 
 #define GEN_PASS_DEF_WRITEOPSTATSTOMODULEATTRIBUTEPASS
@@ -41,19 +44,66 @@ public:
       WriteOpStatsToModuleAttributePass)
 
   void runOnOperation() override {
-    Operation *module = getOperation();
+    Operation *moduleOp = getOperation();
+    // Compute the operation statistics for the currently visited operations.
+    llvm::StringMap<int64_t> opCount;
+    moduleOp->walk([&](Operation *op) {
+      if (isa<ModuleOp, func::FuncOp, ONNXEntryPointOp>(op))
+        return WalkResult::advance();
+      // Construct op name for printing.
+      std::string opName = op->getName().getStringRef().str();
+      // Append a rank string that contains ranks of all inputs.
+      // For example, a rank string ".2D.1D.unranked.0D.none" is for the
+      // folowing inputs
+      // - (tensor<?x?xf32>, tensor<?xf32>, tensor<*xf32>, tensor<?xf32>, none)
+      for (Value v : op->getOperands()) {
+        if (onnx_mlir::isNoneValue(v)) {
+          opName += ".none";
+          continue;
+        }
+        if (auto type = mlir::dyn_cast<ShapedType>(v.getType()))
+          opName += "." + std::to_string(type.getRank()) + "D";
+        else
+          opName += ".unranked";
+      }
+      // Append ".scalar" if this is a scalar op since looking at rank we don't
+      // know if it is scalar or not (e.g. both tensor<1xf32> and tensor<5xf32>
+      // have rank of 1).
+      // A scalar op is the one whose inputs and outputs are scalar tensors
+      // (tensor<dtype> or tensor<1xdtype>) or none.
+      bool isScalarOp = llvm::all_of(op->getOperands(), [](Value v) {
+        return onnx_mlir::isNoneValue(v) || onnx_mlir::isScalarTensor(v);
+      });
+      isScalarOp &= llvm::all_of(op->getResults(), [](Value v) {
+        return onnx_mlir::isNoneValue(v) || onnx_mlir::isScalarTensor(v);
+      });
+      if (isScalarOp)
+        opName += ".scalar";
+      // Record this operation.
+      ++opCount[StringRef(opName)];
+      return WalkResult::advance();
+    });
 
+    // Write to a JSON string.
     std::string opStatsJSON;
-    llvm::raw_string_ostream opStatsStream(opStatsJSON);
+    llvm::raw_string_ostream os(opStatsJSON);
+    // Sort by operation name.
+    SmallVector<StringRef, 64> sorted(opCount.keys());
+    llvm::sort(sorted);
+    os << "{\n";
+    for (unsigned i = 0, e = sorted.size(); i != e; ++i) {
+      const auto &key = sorted[i];
+      os << "  \"" << key << "\" : " << opCount[key];
+      if (i != e - 1)
+        os << ",\n";
+      else
+        os << "\n";
+    }
+    os << "}\n";
+    os.flush();
 
-    OpPassManager pm("builtin.module");
-    pm.addNestedPass<func::FuncOp>(
-        mlir::createPrintOpStatsPass(opStatsStream, /*printAsJSON=*/true));
-    if (failed(runPipeline(pm, module)))
-      return signalPassFailure();
-
-    opStatsStream.flush();
-    module->setAttr(
+    // Put the op stats into an attribute in ModuleOp.
+    moduleOp->setAttr(
         "onnx-mlir.op_stats", StringAttr::get(&getContext(), opStatsJSON));
   }
 };

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -126,6 +126,9 @@ int main(int argc, char *argv[]) {
       llvm::errs() << errorMessage << "\n";
     return rc;
   }
+  // TODO(tung): put allArgs into a module attribute, say "user_compile_options"
+  std::string allArgsStr = "";
+  module.setAttr("user_compile_options", StringAttr::get(context, allArgsStr));
   inputFileTiming.stop();
   return compileModule(module, context, outputBaseName, emissionTarget);
 }

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -156,6 +156,9 @@ int main(int argc, char *argv[]) {
   }
   module.get()->setAttr(
       "onnx-mlir.compile_options", mlir::StringAttr::get(&context, allArgsStr));
+  // Store compiler version information.
+  module.get()->setAttr("onnx-mlir.compiler_version",
+      mlir::StringAttr::get(&context, getOnnxMlirCommitVersion()));
   inputFileTiming.stop();
   return compileModule(module, context, outputBaseName, emissionTarget);
 }

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -126,9 +126,17 @@ int main(int argc, char *argv[]) {
       llvm::errs() << errorMessage << "\n";
     return rc;
   }
-  // TODO(tung): put allArgs into a module attribute, say "user_compile_options"
+  // Store compile options in a module attribute.
   std::string allArgsStr = "";
-  module.setAttr("user_compile_options", StringAttr::get(context, allArgsStr));
+  for (uint64_t i = 1; i < allArgs.size(); ++i) {
+    if (allArgs[i]) {
+      if (i > 1)
+        allArgsStr += " ";
+      allArgsStr += allArgs[i];
+    }
+  }
+  module.get()->setAttr(
+      "onnx-mlir.compile_options", mlir::StringAttr::get(&context, allArgsStr));
   inputFileTiming.stop();
   return compileModule(module, context, outputBaseName, emissionTarget);
 }

--- a/src/onnx-mlir.cpp
+++ b/src/onnx-mlir.cpp
@@ -129,11 +129,30 @@ int main(int argc, char *argv[]) {
   // Store compile options in a module attribute.
   std::string allArgsStr = "";
   for (uint64_t i = 1; i < allArgs.size(); ++i) {
-    if (allArgs[i]) {
-      if (i > 1)
-        allArgsStr += " ";
-      allArgsStr += allArgs[i];
+    std::string arg(allArgs[i]);
+    // Sanitize paths: replace absolute/relative paths with just the filename.
+    // Handle options with values (e.g., --option=value or --option value).
+    size_t equalPos = arg.find('=');
+    if (equalPos != std::string::npos) {
+      // Option with value: --option=value.
+      std::string optionPart = arg.substr(0, equalPos + 1);
+      std::string valuePart = arg.substr(equalPos + 1);
+      // Check if value part contains path separators.
+      if (valuePart.find('/') != std::string::npos ||
+          valuePart.find('\\') != std::string::npos) {
+        std::filesystem::path valuePath(valuePart);
+        valuePart = valuePath.filename().string();
+      }
+      arg = optionPart + valuePart;
+    } else if (arg.find('/') != std::string::npos ||
+               arg.find('\\') != std::string::npos) {
+      // Standalone path argument.
+      std::filesystem::path argPath(arg);
+      arg = argPath.filename().string();
     }
+    if (!allArgsStr.empty())
+      allArgsStr += " ";
+    allArgsStr += arg;
   }
   module.get()->setAttr(
       "onnx-mlir.compile_options", mlir::StringAttr::get(&context, allArgsStr));

--- a/test/mlir/accelerators/nnpa/module_op_be/module_op.mlir
+++ b/test/mlir/accelerators/nnpa/module_op_be/module_op.mlir
@@ -1,5 +1,5 @@
 // RUN: onnx-mlir --march=z16 --maccel=NNPA --printIR %s | FileCheck %s
 
-// CHECK: module attributes {llvm.data_layout = "E-{{.*}}", llvm.target_triple = "{{.*}}", "onnx-mlir.accels" = ["NNPA-0x10001"], "onnx-mlir.symbol-postfix" = "{{.*}}"}
+// CHECK: module attributes {llvm.data_layout = "E-{{.*}}", llvm.target_triple = "{{.*}}", "onnx-mlir.accels" = ["NNPA-0x10001"], "onnx-mlir.compile_options" = "{{.*}}", "onnx-mlir.op_stats" = "{{.*}}", "onnx-mlir.symbol-postfix" = "{{.*}}"}
 module {
 }

--- a/test/mlir/accelerators/nnpa/module_op_be/module_op_arch15.mlir
+++ b/test/mlir/accelerators/nnpa/module_op_be/module_op_arch15.mlir
@@ -1,5 +1,5 @@
 // RUN: onnx-mlir --march=arch15 --maccel=NNPA --printIR %s | FileCheck %s
 
-// CHECK: module attributes {llvm.data_layout = "E-{{.*}}", llvm.target_triple = "{{.*}}", "onnx-mlir.accels" = ["NNPA-0x10101"], "onnx-mlir.symbol-postfix" = "{{.*}}"}
+// CHECK: module attributes {llvm.data_layout = "E-{{.*}}", llvm.target_triple = "{{.*}}", "onnx-mlir.accels" = ["NNPA-0x10101"], "onnx-mlir.compile_options" = "{{.*}}", "onnx-mlir.op_stats" = "{{.*}}", "onnx-mlir.symbol-postfix" = "{{.*}}"}
 module {
 }

--- a/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
@@ -1,0 +1,50 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-llvm --canonicalize %s -split-input-file | FileCheck %s
+
+// COM: Test that omCompilationInfo function and global JSON string are generated correctly
+module attributes {"onnx-mlir.compile_options" = "test-options", "onnx-mlir.op_stats" = "{\"op1\": 5}"} {
+  func.func private @main_graph(%arg0: memref<10xf32>) -> memref<10xf32> {
+    return %arg0 : memref<10xf32>
+  }
+  "krnl.entry_point"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[in_sig]\00@[out_sig]\00"} : () -> ()
+
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\22compile_options\22: \22test-options\22, \22op_stats\22: {\22op1\22: 5}}\00") {addr_space = 0 : i32}
+
+// CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
+// CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
+// CHECK:           llvm.return [[VAR_0]] : !llvm.ptr
+// CHECK:         }
+}
+
+// -----
+
+// COM: Test with empty op_stats
+module attributes {"onnx-mlir.compile_options" = "-O3 --EmitLib", "onnx-mlir.op_stats" = ""} {
+  func.func private @test_entry(%arg0: memref<5xi32>) -> memref<5xi32> {
+    return %arg0 : memref<5xi32>
+  }
+  "krnl.entry_point"() {func = @test_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[test_in]\00@[test_out]\00"} : () -> ()
+
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\22compile_options\22: \22-O3 --EmitLib\22, \22op_stats\22: }\00") {addr_space = 0 : i32}
+
+// CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
+// CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
+// CHECK:           llvm.return [[VAR_0]] : !llvm.ptr
+// CHECK:         }
+}
+
+// -----
+
+// COM: Test with missing attributes (should generate empty values)
+module {
+  func.func private @simple_entry(%arg0: memref<3xf64>) -> memref<3xf64> {
+    return %arg0 : memref<3xf64>
+  }
+  "krnl.entry_point"() {func = @simple_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[simple_in]\00@[simple_out]\00"} : () -> ()
+
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\22compile_options\22: \22\22, \22op_stats\22: }\00") {addr_space = 0 : i32}
+
+// CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
+// CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
+// CHECK:           llvm.return [[VAR_0]] : !llvm.ptr
+// CHECK:         }
+}

--- a/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
@@ -7,7 +7,7 @@ module attributes {"onnx-mlir.compile_options" = "test-options", "onnx-mlir.op_s
   }
   "krnl.entry_point"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[in_sig]\00@[out_sig]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\22compile_options\22: \22test-options\22, \22op_stats\22: {\22op1\22: 5}}\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22test-options\22,\0A\22op_stats\22: {\22op1\22: 5}}\00") {addr_space = 0 : i32}
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
@@ -24,7 +24,7 @@ module attributes {"onnx-mlir.compile_options" = "-O3 --EmitLib", "onnx-mlir.op_
   }
   "krnl.entry_point"() {func = @test_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[test_in]\00@[test_out]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\22compile_options\22: \22-O3 --EmitLib\22, \22op_stats\22: }\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22-O3 --EmitLib\22,\0A\22op_stats\22: }\00") {addr_space = 0 : i32}
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
@@ -41,7 +41,7 @@ module {
   }
   "krnl.entry_point"() {func = @simple_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[simple_in]\00@[simple_out]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\22compile_options\22: \22\22, \22op_stats\22: }\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22\22,\0A\22op_stats\22: }\00") {addr_space = 0 : i32}
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr

--- a/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
@@ -17,6 +17,28 @@ module attributes {"onnx-mlir.compile_options" = "test-options", "onnx-mlir.op_s
 
 // -----
 
+// COM: Test with symbol-postfix attribute (should generate both omCompilationInfo and omCompilationInfo_tag)
+module attributes {"onnx-mlir.compile_options" = "--tag=test", "onnx-mlir.op_stats" = "{\"onnx.Add\": 2}", "onnx-mlir.symbol-postfix" = "tag"} {
+  func.func private @tagged_entry(%arg0: memref<8xf32>) -> memref<8xf32> {
+    return %arg0 : memref<8xf32>
+  }
+  "krnl.entry_point"() {func = @tagged_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[tagged_in]\00@[tagged_out]\00"} : () -> ()
+
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_tag("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22--tag=test\22,\0A\22op_stats\22: {\22onnx.Add\22: 2}}\00") {addr_space = 0 : i32}
+
+// CHECK:         llvm.func @omCompilationInfo_tag() -> !llvm.ptr {
+// CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json_tag : !llvm.ptr
+// CHECK:           llvm.return [[VAR_0]] : !llvm.ptr
+// CHECK:         }
+
+// CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
+// CHECK:           [[VAR_1:%.+]] = llvm.call @omCompilationInfo_tag() : () -> !llvm.ptr
+// CHECK:           llvm.return [[VAR_1]] : !llvm.ptr
+// CHECK:         }
+}
+
+// -----
+
 // COM: Test with empty op_stats
 module attributes {"onnx-mlir.compile_options" = "-O3 --EmitLib", "onnx-mlir.op_stats" = ""} {
   func.func private @test_entry(%arg0: memref<5xi32>) -> memref<5xi32> {

--- a/test/mlir/driver/compilation_info.mlir
+++ b/test/mlir/driver/compilation_info.mlir
@@ -1,0 +1,15 @@
+// RUN: onnx-mlir --EmitLLVMIR --printIR %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+    %0 = "onnx.Relu"(%arg0) : (tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+    onnx.Return %0 : tensor<?x?x?xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// CHECK: llvm.mlir.global internal constant @om_compilation_info_json{{.*}}("{{.*}}compile_options{{.*}}op_stats{{.*}}onnx.Relu{{.*}}")
+
+// CHECK: llvm.func @omCompilationInfo{{.*}}() -> !llvm.ptr
+// CHECK:   {{.*}} = llvm.mlir.addressof @om_compilation_info_json
+// CHECK:   llvm.return {{.*}} : !llvm.ptr

--- a/test/mlir/driver/compilation_info.mlir
+++ b/test/mlir/driver/compilation_info.mlir
@@ -8,7 +8,7 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 
-// CHECK: llvm.mlir.global internal constant @om_compilation_info_json{{.*}}("{{.*}}compiler_version{{.*}}compile_options{{.*}}op_stats{{.*}}onnx.Relu{{.*}}")
+// CHECK: llvm.mlir.global internal constant @om_compilation_info_json_compilation_info("{\0A\22compiler_version\22: \22onnx-mlir version 0.4.2 (43864fda)\22,\0A\22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22,\0A\22op_stats\22: {\0A  \22func.return.3D\22 : 1,\0A  \22onnx.Relu.3D\22 : 1\0A}\0A}\00") {addr_space = 0 : i32}
 
 // CHECK: llvm.func @omCompilationInfo{{.*}}() -> !llvm.ptr
 // CHECK:   {{.*}} = llvm.mlir.addressof @om_compilation_info_json

--- a/test/mlir/driver/compilation_info.mlir
+++ b/test/mlir/driver/compilation_info.mlir
@@ -8,7 +8,7 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 
-// CHECK: llvm.mlir.global internal constant @om_compilation_info_json_compilation_info("{\0A\22compiler_version\22: \22onnx-mlir version 0.4.2 (43864fda)\22,\0A\22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22,\0A\22op_stats\22: {\0A  \22func.return.3D\22 : 1,\0A  \22onnx.Relu.3D\22 : 1\0A}\0A}\00") {addr_space = 0 : i32}
+// CHECK: llvm.mlir.global internal constant @om_compilation_info_json_compilation_info("{\0A\22compiler_version\22: \22{{.*}}\22,\0A\22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22,\0A\22op_stats\22: {\0A  \22func.return.3D\22 : 1,\0A  \22onnx.Relu.3D\22 : 1\0A}\0A}\00") {addr_space = 0 : i32}
 
 // CHECK: llvm.func @omCompilationInfo{{.*}}() -> !llvm.ptr
 // CHECK:   {{.*}} = llvm.mlir.addressof @om_compilation_info_json

--- a/test/mlir/driver/compilation_info.mlir
+++ b/test/mlir/driver/compilation_info.mlir
@@ -8,7 +8,7 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 
-// CHECK: llvm.mlir.global internal constant @om_compilation_info_json{{.*}}("{{.*}}compile_options{{.*}}op_stats{{.*}}onnx.Relu{{.*}}")
+// CHECK: llvm.mlir.global internal constant @om_compilation_info_json{{.*}}("{{.*}}compiler_version{{.*}}compile_options{{.*}}op_stats{{.*}}onnx.Relu{{.*}}")
 
 // CHECK: llvm.func @omCompilationInfo{{.*}}() -> !llvm.ptr
 // CHECK:   {{.*}} = llvm.mlir.addressof @om_compilation_info_json

--- a/test/mlir/driver/compilation_info_in_module_op.mlir
+++ b/test/mlir/driver/compilation_info_in_module_op.mlir
@@ -1,0 +1,11 @@
+// RUN: onnx-mlir --EmitMLIR --printIR %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+    %0 = "onnx.Relu"(%arg0) : (tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+    onnx.Return %0 : tensor<?x?x?xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// CHECK: module attributes {{{.*}}"onnx-mlir.compile_options" = "--EmitMLIR --printIR {{.*}}", "onnx-mlir.op_stats" = "{\0A  \22func.func\22 : 1,\0A  \22func.return\22 : 1,\0A  \22onnx.Relu\22 : 1\0A}\0A"{{.*}}}

--- a/test/mlir/driver/compilation_info_in_module_op.mlir
+++ b/test/mlir/driver/compilation_info_in_module_op.mlir
@@ -8,4 +8,4 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 
-// CHECK: module attributes {{{.*}}"onnx-mlir.compile_options" = "--EmitMLIR --printIR {{.*}}", "onnx-mlir.op_stats" = "{\0A  \22func.func\22 : 1,\0A  \22func.return\22 : 1,\0A  \22onnx.Relu\22 : 1\0A}\0A"{{.*}}}
+// CHECK: module attributes {{{.*}}"onnx-mlir.compile_options" = "--EmitMLIR --printIR compilation_info_in_module_op.mlir", "onnx-mlir.compiler_version" = "{{.*}}", "onnx-mlir.op_stats" = "{\0A  \22func.func\22 : 1,\0A  \22func.return\22 : 1,\0A  \22onnx.Relu\22 : 1\0A}\0A"{{.*}}}

--- a/test/mlir/driver/compilation_info_in_module_op.mlir
+++ b/test/mlir/driver/compilation_info_in_module_op.mlir
@@ -8,4 +8,4 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 
-// CHECK: module attributes {{{.*}}"onnx-mlir.compile_options" = "--EmitMLIR --printIR compilation_info_in_module_op.mlir", "onnx-mlir.compiler_version" = "{{.*}}", "onnx-mlir.op_stats" = "{\0A  \22func.func\22 : 1,\0A  \22func.return\22 : 1,\0A  \22onnx.Relu\22 : 1\0A}\0A"{{.*}}}
+// CHECK: module attributes {{{.*}}"onnx-mlir.compile_options" = "--EmitMLIR --printIR compilation_info_in_module_op.mlir", "onnx-mlir.compiler_version" = "{{.*}}", "onnx-mlir.op_stats" = "{\0A  \22func.return.3D\22 : 1,\0A  \22onnx.Relu.3D\22 : 1\0A}\0A", "onnx-mlir.symbol-postfix" = "compilation_info_in_module_op"}

--- a/test/mlir/driver/do-not-embed-compilation-info.mlir
+++ b/test/mlir/driver/do-not-embed-compilation-info.mlir
@@ -1,0 +1,12 @@
+// RUN: onnx-mlir --do-not-embed-compilation-info --EmitLLVMIR --printIR %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+    %0 = "onnx.Relu"(%arg0) : (tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+    onnx.Return %0 : tensor<?x?x?xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// CHECK-NOT: llvm.mlir.global internal constant @om_compilation_info_json
+// CHECK-NOT: llvm.func @omCompilationInfo

--- a/test/mlir/driver/omit-compile-info.mlir
+++ b/test/mlir/driver/omit-compile-info.mlir
@@ -1,4 +1,4 @@
-// RUN: onnx-mlir --do-not-embed-compilation-info --EmitLLVMIR --printIR %s | FileCheck %s
+// RUN: onnx-mlir --omit-compile-info --EmitLLVMIR --printIR %s | FileCheck %s
 
 module {
   func.func @main_graph(%arg0: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {

--- a/utils/RunONNXLib.cpp
+++ b/utils/RunONNXLib.cpp
@@ -112,6 +112,7 @@ vector<uint64_t> timeLogInMicroSec;
 extern "C" OMTensorList *run_main_graph(OMTensorList *);
 extern "C" const char *omInputSignature(const char *);
 extern "C" const char *omOutputSignature(const char *);
+extern "C" const char *omCompilationInfo(void);
 extern "C" OMTensor *omTensorCreateWithOwnership(
     void *, const int64_t *, int64_t, OM_DATA_TYPE, int64_t);
 extern "C" OMTensorList *TensorListCreate(OMTensor **, int);
@@ -120,6 +121,7 @@ extern "C" void omTensorListDestroy(OMTensorList *list);
 OMTensorList *(*dll_run_main_graph)(OMTensorList *);
 const char *(*dll_omInputSignature)(const char *);
 const char *(*dll_omOutputSignature)(const char *);
+const char *(*dll_omCompilationInfo)(void);
 OMTensor *(*dll_omTensorCreateWithOwnership)(
     void *, int64_t *, int64_t, OM_DATA_TYPE, int64_t);
 OMTensorList *(*dll_omTensorListCreate)(OMTensor **, int);
@@ -129,6 +131,7 @@ void (*dll_omTensorListDestroy)(OMTensorList *);
 #define RUN_MAIN_GRAPH run_main_graph
 #define OM_INPUT_SIGNATURE omInputSignature
 #define OM_OUTPUT_SIGNATURE omOutputSignature
+#define OM_COMPILATION_INFO omCompilationInfo
 #define OM_TENSOR_CREATE omTensorCreateWithOwnership
 #define OM_TENSOR_LIST_CREATE omTensorListCreate
 #define OM_TENSOR_LIST_DESTROY omTensorListDestroy
@@ -137,6 +140,7 @@ void (*dll_omTensorListDestroy)(OMTensorList *);
 #define RUN_MAIN_GRAPH dll_run_main_graph
 #define OM_INPUT_SIGNATURE dll_omInputSignature
 #define OM_OUTPUT_SIGNATURE dll_omOutputSignature
+#define OM_COMPILATION_INFO dll_omCompilationInfo
 #define OM_TENSOR_CREATE dll_omTensorCreateWithOwnership
 #define OM_TENSOR_LIST_CREATE dll_omTensorListCreate
 #define OM_TENSOR_LIST_DESTROY dll_omTensorListDestroy
@@ -176,6 +180,9 @@ void loadDLL(string name, string entryPointName) {
   dll_omOutputSignature =
       (const char *(*)(const char *))dlsym(handle, "omOutputSignature");
   assert(!dlerror() && "failed to load omOutputSignature");
+  dll_omCompilationInfo =
+      (const char *(*)(void))dlsym(handle, "omCompilationInfo");
+  assert(!dlerror() && "failed to load omCompilationInfo");
   dll_omTensorCreateWithOwnership =
       (OMTensor * (*)(void *, int64_t *, int64_t, OM_DATA_TYPE, int64_t))
           dlsym(handle, "omTensorCreateWithOwnership");

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -1077,8 +1077,7 @@ class InferenceSession:
     """
 
     def run_inference(self):
-        print(self.session.compilation_info())
-        )       return self.session.run(self.inputs)
+        return self.session.run(self.inputs)
 
     def print_instrumentation(self):
         self.session.print_instrumentation()

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -165,6 +165,11 @@ parser.add_argument(
     help="Print out the input and output signatures of the model.",
 )
 parser.add_argument(
+    "--print-compilation-info",
+    action="store_true",
+    help="Print out the compilation info stored in the compiled model.",
+)
+parser.add_argument(
     "--save-onnx",
     metavar="PATH",
     type=str,
@@ -209,7 +214,6 @@ parser.add_argument(
     default="",
     help="Options passed to onnxmlir. Used with --use-onnxmlir",
 )
-
 
 lib_group = parser.add_mutually_exclusive_group()
 lib_group.add_argument(
@@ -362,7 +366,6 @@ def verify_arg():
 ################################################################################
 # Support functions for RunONNXModel functionality.
 # Functions are free of args (all needed parameters are passed to the function).
-
 
 # A type mapping from MLIR to Numpy.
 MLIR_TYPE_TO_NP_TYPE = {
@@ -1009,6 +1012,11 @@ class InferenceSession:
         if args.print_signatures:
             print("Model's input signature: ", input_signature.strip())
             print("Model's output signature: ", output_signature.strip())
+        if args.print_compilation_info:
+            print(
+                "Compilation info stored in the compiled model: ",
+                self.session.compilation_info().strip(),
+            )
 
         # Let onnx-mlir know where to find the constants file.
         os.environ["OM_CONSTANT_PATH"] = self.model_dir

--- a/utils/RunONNXModel.py
+++ b/utils/RunONNXModel.py
@@ -1077,7 +1077,8 @@ class InferenceSession:
     """
 
     def run_inference(self):
-        return self.session.run(self.inputs)
+        print(self.session.compilation_info())
+        )       return self.session.run(self.inputs)
 
     def print_instrumentation(self):
         self.session.print_instrumentation()


### PR DESCRIPTION
Embed some compilation information into the generated .so file and the information can be queried by omCompilationInfo() function inside the .so file.

For example, with python:
```python
print(sess.compilation_info())
```
will return
```json
{
"compiler_version": "onnx-mlir version 0.4.2 (43864fda)",
"compile_options": "-O3 -march=z16 -v -o model relu.mlir",
"op_stats": {
  "func.return.3D" : 1,
  "onnx.Add.1D.0D.scalar" : 2,
  "onnx.Add.3D.0D" : 1,
  "onnx.Add.3D.1D" : 1,
  "onnx.Relu.3D" : 1
}
}
```

In `op_stats`, the operation name contains information about rank of each input, for example `onnx.Add.3D.0D` is addition of a 3D tensor (e.g. tensor<?x?x?xf32> and a scalar tensor (tensor<f32>). `.scalar` means that all inputs are scalar.

Add a new compile option `--omit-compile-info` to disable this feature. When disabled, there is no omCompilationInfo() in the .so file.