### PR TITLE
(WIP) Enable ConvOptPass for accelerator

### DIFF
--- a/src/Compiler/CompilerPasses.cpp
+++ b/src/Compiler/CompilerPasses.cpp
@@ -136,7 +136,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     pm.addNestedPass<func::FuncOp>(
         onnx_mlir::createONNXHybridTransformPass(!disableRecomposeOption));
     // Convolution Optimization for CPU: enable when there are no accelerators.
-    if (targetCPU && enableConvOptPass) {
+    if (enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
           enableSimdDataLayout && !disableSimdOption));
       pm.addNestedPass<func::FuncOp>(
@@ -147,7 +147,7 @@ void addONNXToMLIRPasses(mlir::PassManager &pm, bool targetCPU,
     pm.addPass(mlir::createCanonicalizerPass());
     pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());
     // Convolution Optimization for CPU: enable when there are no accelerators.
-    if (targetCPU && enableConvOptPass) {
+    if (enableConvOptPass) {
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createConvOptONNXToONNXPass(
           enableSimdDataLayout && !disableSimdOption));
       pm.addNestedPass<func::FuncOp>(onnx_mlir::createShapeInferencePass());

--- a/test/accelerators/NNPA/numerical/CMakeLists.txt
+++ b/test/accelerators/NNPA/numerical/CMakeLists.txt
@@ -41,7 +41,7 @@ function(add_numerical_test test_name)
 
   # Optimization level set by ONNX_MLIR_TEST_OPTLEVEL, defaults to 3
   add_test(NAME ${test_name}
-    COMMAND ${test_name} -O${ONNX_MLIR_TEST_OPTLEVEL} --march=z16 --maccel=NNPA
+    COMMAND ${test_name} -O${ONNX_MLIR_TEST_OPTLEVEL} --march=z16 --maccel=NNPA --enable-conv-opt-pass=false
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   set_tests_properties(${test_name} PROPERTIES LABELS numerical-nnpa)


### PR DESCRIPTION
In ORC model family, there are many ConvOp can be optimized by ConvOptPass. I do not see any reason that we do not want ConvOptPass for accelerator. There is a big performance impact if those ConvOps are not offloaded to accelerator.