### PR TITLE
[NNPA] Enable transpose-matmul in zdnnx and introduce an environment variable ZDNNX_MAX_TILE_SIZE_IN_MB

### DIFF
--- a/src/Accelerators/NNPA/Runtime/zdnnx/omp_ops.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/omp_ops.c
@@ -165,8 +165,8 @@ static inline zdnn_status compute_tile_sizes_for_matmul(
 }
 
 zdnn_status zdnnx_omp_matmul(const zdnn_ztensor *input_a,
-    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, int op_type,
-    zdnn_ztensor *output, bool is_bcast) {
+    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, bool transpose_a,
+    bool transpose_b, int op_type, zdnn_ztensor *output, bool is_bcast) {
 #ifdef ZDNNX_DEBUG
   printf("[OMP MatMul]\n");
 #endif
@@ -199,8 +199,8 @@ zdnn_status zdnnx_omp_matmul(const zdnn_ztensor *input_a,
 #ifdef ZDNNX_DEBUG
     printf("[MatMul] calling the original zdnn matmul.\n");
 #endif
-    zdnn_status status =
-        zdnnx_seq_matmul(input_a, input_b, input_c, op_type, output, is_bcast);
+    zdnn_status status = zdnnx_seq_matmul(input_a, input_b, input_c,
+        transpose_a, transpose_b, op_type, output, is_bcast);
     return status;
   }
 
@@ -238,8 +238,8 @@ zdnn_status zdnnx_omp_matmul(const zdnn_ztensor *input_a,
         zdnnx_set_tile(&si_y, &ty, NULL, bs, 0, m, n);
 
         /* Operation */
-        zdnn_status status = zdnnx_seq_matmul(
-            &ta.data, &tb.data, &tc.data, op_type, &ty.data, is_bcast);
+        zdnn_status status = zdnnx_seq_matmul(&ta.data, &tb.data, &tc.data,
+            transpose_a, transpose_b, op_type, &ty.data, is_bcast);
         assert(status == ZDNN_OK);
 
         /* Copy the output tile at (0, 0, m, n) to the full output. */

--- a/src/Accelerators/NNPA/Runtime/zdnnx/omp_ops.h
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/omp_ops.h
@@ -25,8 +25,8 @@
 uint32_t zdnnx_get_num_zaiu_threads();
 
 zdnn_status zdnnx_omp_matmul(const zdnn_ztensor *input_a,
-    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, int op_type,
-    zdnn_ztensor *output, bool is_bcast);
+    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, bool transpose_a,
+    bool transpose_b, int op_type, zdnn_ztensor *output, bool is_bcast);
 
 zdnn_status zdnnx_omp_quantized_matmul(const zdnn_ztensor *input_a,
     const zdnn_ztensor *input_b, const zdnn_ztensor *input_c,

--- a/src/Accelerators/NNPA/Runtime/zdnnx/seq_ops.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/seq_ops.c
@@ -404,16 +404,14 @@ zdnn_status zdnnx_seq_softmax(const zdnn_ztensor *input, void *save_area,
 static inline zdnn_status call_zdnn_matmul_op(const zdnn_ztensor *input_a,
     const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, bool transpose_a,
     bool transpose_b, int op_type, zdnn_ztensor *output, bool is_bcast) {
-  if (!transpose_a && !transpose_b) {
-    if (is_bcast)
-      return zdnn_matmul_bcast_op(
-          input_a, input_b, input_c, (zdnn_matmul_bcast_ops)op_type, output);
-    return zdnn_matmul_op(
-        input_a, input_b, input_c, (zdnn_matmul_ops)op_type, output);
-  } else {
+  if (transpose_a || transpose_b)
     return zdnn_matmul_transpose_op(input_a, input_b, input_c,
         transpose_a ? 1 : 0, transpose_b ? 1 : 0, op_type, output);
-  }
+  if (is_bcast)
+    return zdnn_matmul_bcast_op(
+        input_a, input_b, input_c, (zdnn_matmul_bcast_ops)op_type, output);
+  return zdnn_matmul_op(
+      input_a, input_b, input_c, (zdnn_matmul_ops)op_type, output);
 }
 
 zdnn_status zdnnx_seq_matmul(const zdnn_ztensor *input_a,

--- a/src/Accelerators/NNPA/Runtime/zdnnx/seq_ops.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/seq_ops.c
@@ -402,18 +402,23 @@ zdnn_status zdnnx_seq_softmax(const zdnn_ztensor *input, void *save_area,
 }
 
 static inline zdnn_status call_zdnn_matmul_op(const zdnn_ztensor *input_a,
-    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, int op_type,
-    zdnn_ztensor *output, bool is_bcast) {
-  if (is_bcast)
-    return zdnn_matmul_bcast_op(
-        input_a, input_b, input_c, (zdnn_matmul_bcast_ops)op_type, output);
-  return zdnn_matmul_op(
-      input_a, input_b, input_c, (zdnn_matmul_ops)op_type, output);
+    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, bool transpose_a,
+    bool transpose_b, int op_type, zdnn_ztensor *output, bool is_bcast) {
+  if (!transpose_a && !transpose_b) {
+    if (is_bcast)
+      return zdnn_matmul_bcast_op(
+          input_a, input_b, input_c, (zdnn_matmul_bcast_ops)op_type, output);
+    return zdnn_matmul_op(
+        input_a, input_b, input_c, (zdnn_matmul_ops)op_type, output);
+  } else {
+    return zdnn_matmul_transpose_op(input_a, input_b, input_c,
+        transpose_a ? 1 : 0, transpose_b ? 1 : 0, op_type, output);
+  }
 }
 
 zdnn_status zdnnx_seq_matmul(const zdnn_ztensor *input_a,
-    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, int op_type,
-    zdnn_ztensor *output, bool is_bcast) {
+    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, bool transpose_a,
+    bool transpose_b, int op_type, zdnn_ztensor *output, bool is_bcast) {
 #ifdef ZDNNX_DEBUG
   printf("[MatMul]\n");
 #endif
@@ -445,8 +450,8 @@ zdnn_status zdnnx_seq_matmul(const zdnn_ztensor *input_a,
 #ifdef ZDNNX_DEBUG
     printf("[MatMul] calling the original zdnn matmul.\n");
 #endif
-    zdnn_status status = call_zdnn_matmul_op(
-        input_a, input_b, input_c, op_type, output, is_bcast);
+    zdnn_status status = call_zdnn_matmul_op(input_a, input_b, input_c,
+        transpose_a, transpose_b, op_type, output, is_bcast);
     return status;
   }
 
@@ -491,8 +496,8 @@ zdnn_status zdnnx_seq_matmul(const zdnn_ztensor *input_a,
         zdnnx_set_tile(&si_y, &ty, tile_buff_y, b, 0, m, n);
 
         /* Operation */
-        zdnn_status status = call_zdnn_matmul_op(
-            &ta.data, &tb.data, &tc.data, op_type, &ty.data, is_bcast);
+        zdnn_status status = call_zdnn_matmul_op(&ta.data, &tb.data, &tc.data,
+            transpose_a, transpose_b, op_type, &ty.data, is_bcast);
         assert(status == ZDNN_OK);
 
         /* Copy the output tile at (0, 0, m, n) to the full output. */

--- a/src/Accelerators/NNPA/Runtime/zdnnx/seq_ops.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/seq_ops.c
@@ -434,10 +434,12 @@ zdnn_status zdnnx_seq_matmul(const zdnn_ztensor *input_a,
       (a_layout == ZDNN_3DS && b_layout == ZDNN_3DS && c_layout == ZDNN_2DS);
 
   // Select suitable tile sizes for E4, E2, E1 tile size. E3 is always 1.
+  // If a tensor is transposed,  only split its E4.
   uint32_t ts_e4 = 0, ts_e2 = 0, ts_e1 = 0;
-  select_tile_sizes(input_a, &ts_e4, NULL, &ts_e2, NULL);
-  select_tile_sizes(input_b, &ts_e4, NULL, NULL, &ts_e1);
-  select_tile_sizes(output, &ts_e4, NULL, &ts_e2, &ts_e1);
+  select_tile_sizes(input_a, &ts_e4, NULL, transpose_a ? NULL : &ts_e2, NULL);
+  select_tile_sizes(input_b, &ts_e4, NULL, NULL, transpose_b ? NULL : &ts_e1);
+  select_tile_sizes(output, &ts_e4, NULL, transpose_a ? NULL : &ts_e2,
+      transpose_b ? NULL : &ts_e1);
 
   zdnnx_split_info si_a, si_b, si_c, si_y;
   zdnnx_prepare_split_info(&si_a, input_a, ts_e4, 0, ts_e2, 0, "MatMul A");

--- a/src/Accelerators/NNPA/Runtime/zdnnx/seq_ops.h
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/seq_ops.h
@@ -28,7 +28,7 @@ zdnn_status zdnnx_seq_softmax(const zdnn_ztensor *input, void *save_area,
     zdnn_softmax_act act_func, zdnn_ztensor *output);
 
 zdnn_status zdnnx_seq_matmul(const zdnn_ztensor *input_a,
-    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, int op_type,
-    zdnn_ztensor *output, bool is_bcast);
+    const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, bool transpose_a,
+    bool transpose_b, int op_type, zdnn_ztensor *output, bool is_bcast);
 
 #endif // ZDNNX_SEQ_OPS_H

--- a/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx_ops.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx_ops.c
@@ -48,7 +48,8 @@ zdnn_status zdnnx_matmul_op(const zdnn_ztensor *input_a,
     zdnn_ztensor *output) {
   zdnn_status status;
   ZDNNX_CALL_FUNC("MatMul", zdnnx_seq_matmul, zdnnx_omp_matmul, input_a,
-      input_b, input_c, op_type, output, /*is_bcast=*/false);
+      input_b, input_c, /*transpose_a*/ false, /*transpose_b*/ false, op_type,
+      output, /*is_bcast*/ false);
   ZDNNX_CHECK_STATUS(status, "zdnn_matmul");
   return status;
 }
@@ -58,18 +59,20 @@ zdnn_status zdnnx_matmul_bcast_op(const zdnn_ztensor *input_a,
     zdnn_ztensor *output) {
   zdnn_status status;
   ZDNNX_CALL_FUNC("MatMul", zdnnx_seq_matmul, zdnnx_omp_matmul, input_a,
-      input_b, input_c, op_type, output, /*is_bcast=*/true);
+      input_b, input_c, /*transpose_a*/ false, /*transpose_b*/ false, op_type,
+      output, /*is_bcast*/ true);
   ZDNNX_CHECK_STATUS(status, "zdnn_matmul_bcast");
   return status;
 }
 
 zdnn_status zdnnx_matmul_transpose_op(const zdnn_ztensor *input_a,
     const zdnn_ztensor *input_b, const zdnn_ztensor *input_c, int transpose_a,
-    int transpose_b, int opType, zdnn_ztensor *output) {
+    int transpose_b, int op_type, zdnn_ztensor *output) {
   zdnn_status status;
-  ZDNNX_CALL_FUNC("Transposed MatMul", zdnn_matmul_transpose_op,
-      zdnn_matmul_transpose_op, input_a, input_b, input_c, transpose_a,
-      transpose_b, opType, output);
+  ZDNNX_CALL_FUNC("Transposed MatMul", zdnnx_seq_matmul, zdnnx_omp_matmul,
+      input_a, input_b, input_c, transpose_a != 0, transpose_b != 0, op_type,
+      output,
+      /*is_bcast (not used)*/ false);
   ZDNNX_CHECK_STATUS(status, "zdnn_matmul_transpose");
   return status;
 }

--- a/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx_ops.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx_ops.c
@@ -71,8 +71,7 @@ zdnn_status zdnnx_matmul_transpose_op(const zdnn_ztensor *input_a,
   zdnn_status status;
   ZDNNX_CALL_FUNC("Transposed MatMul", zdnnx_seq_matmul, zdnnx_omp_matmul,
       input_a, input_b, input_c, transpose_a != 0, transpose_b != 0, op_type,
-      output,
-      /*is_bcast (not used)*/ false);
+      output, /*is_bcast (not used)*/ false);
   ZDNNX_CHECK_STATUS(status, "zdnn_matmul_transpose");
   return status;
 }

--- a/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx_ops_private.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx_ops_private.c
@@ -72,13 +72,11 @@ uint32_t zdnnx_get_nnpa_max_dim_size(zdnnx_axis dim_index) {
 
 uint64_t zdnnx_get_nnpa_max_tensor_size() {
   if (nnpa_max_tensor_size == 0) {
+    // zdnn_get_nnpa_max_tensor_size() returns size in bytes.
+    nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
     // Check the enviroment variable.
     const char *env = getenv("ZDNNX_MAX_TILE_SIZE_IN_MB");
-    if (env == NULL) {
-      // The environment variable is not set.
-      // zdnn_get_nnpa_max_tensor_size() returns size in bytes.
-      nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
-    } else {
+    if (env != NULL) {
       errno = 0;
       char *endptr;
       double mb = strtod(env, &endptr);
@@ -86,18 +84,16 @@ uint64_t zdnnx_get_nnpa_max_tensor_size() {
         printf("Error when reading the enviroment variable "
                "ZDNNX_MAX_TILE_SIZE_IN_MB. Use the max tensor size in zdnn "
                "instead");
-        nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
       } else if (mb < 0) {
         printf("Value of ZDNNX_MAX_TILE_SIZE_IN_MB cannot be negative. Use the "
                "max tensor size in zdnn instead");
-        nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
       } else {
         double bytes_d = mb * 1024 * 1024;
-        if (bytes_d > (double)UINT64_MAX) {
+        if (bytes_d > (double)nnpa_max_tensor_size) {
           printf("ZDNNX_MAX_TILE_SIZE_IN_MB is too large. Use the max tensor "
                  "size in zdnn instead");
-          nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
         } else {
+          // Update max tensor size.
           nnpa_max_tensor_size = (uint64_t)bytes_d;
         }
       }

--- a/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx_ops_private.c
+++ b/src/Accelerators/NNPA/Runtime/zdnnx/zdnnx_ops_private.c
@@ -15,6 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <errno.h>
+#include <math.h>
 #include <stdio.h>
 
 #include "zdnnx_ops_private.h"
@@ -70,8 +72,36 @@ uint32_t zdnnx_get_nnpa_max_dim_size(zdnnx_axis dim_index) {
 
 uint64_t zdnnx_get_nnpa_max_tensor_size() {
   if (nnpa_max_tensor_size == 0) {
-    // zdnn_get_nnpa_max_tensor_size() returns size in bytes.
-    nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
+    // Check the enviroment variable.
+    const char *env = getenv("ZDNNX_MAX_TILE_SIZE_IN_MB");
+    if (env == NULL) {
+      // The environment variable is not set.
+      // zdnn_get_nnpa_max_tensor_size() returns size in bytes.
+      nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
+    } else {
+      errno = 0;
+      char *endptr;
+      double mb = strtod(env, &endptr);
+      if (errno != 0 || endptr == env || *endptr != '\0' || !isfinite(mb)) {
+        printf("Error when reading the enviroment variable "
+               "ZDNNX_MAX_TILE_SIZE_IN_MB. Use the max tensor size in zdnn "
+               "instead");
+        nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
+      } else if (mb < 0) {
+        printf("Value of ZDNNX_MAX_TILE_SIZE_IN_MB cannot be negative. Use the "
+               "max tensor size in zdnn instead");
+        nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
+      } else {
+        double bytes_d = mb * 1024 * 1024;
+        if (bytes_d > (double)UINT64_MAX) {
+          printf("ZDNNX_MAX_TILE_SIZE_IN_MB is too large. Use the max tensor "
+                 "size in zdnn instead");
+          nnpa_max_tensor_size = zdnn_get_nnpa_max_tensor_size() / 2;
+        } else {
+          nnpa_max_tensor_size = (uint64_t)bytes_d;
+        }
+      }
+    }
 #ifdef ZDNNX_DEBUG
     printf("max_tensor_size: %ld\n", nnpa_max_tensor_size);
 #endif


### PR DESCRIPTION
This pull request is
- to enable transpose-matmul in zdnnx by reorganizing the current zdnnx matmul to accep transpose_a and transpose_b, and
- to introduce an environment variable ZDNNX_MAX_TILE_SIZE_IN_MB, this is one of thresholds that affect the decision of whether a ztensor is splitted or not. If not set, the maximum tensor size in NNPA is used. 