### PR TITLE
Fix an error when using --profile-ir-with-sig

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -99,7 +99,8 @@ void configurePassesNNPA() {
     }
   }
   // Set the proper instrumentation stage before we add any passes.
-  if (profileIR == onnx_mlir::ProfileIRs::ZHigh)
+  if (profileIR == onnx_mlir::ProfileIRs::ZHigh ||
+      profileIRWithSig == onnx_mlir::ProfileIRs::ZHigh)
     instrumentStage = onnx_mlir::InstrumentStages::ZHigh;
 
   configureONNXToZHighLoweringPass(optReport == OptReport::NNPAUnsupportedOps,


### PR DESCRIPTION
`--profile-ir-with-sig=ZHigh` caused the compilation failed because of that `instrumentStage` is not set for `profile-ir-with-sig`. This PR fixes the issue.

Error:
```
[2/6] Fri May 29 06:36:06 2026 (7s) Compiling and Optimizing MLIR Module
onnx-mlir: /workdir/onnx-mlir/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp:207: void onnx_mlir::addONNXToZHighPasses(mlir::PassManager&): Assertion `instrumentStage == onnx_mlir::InstrumentStages::ZHigh && "expected set to this"' failed.
Aborted (core dumped)
```