### PR TITLE
Lp Normalization fix

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -112,7 +112,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **Log** |6 - * | | |
 | **LogSoftmax** |13 - * |Axis 0, 1, and default currently disabled due to changes in ONNX 1.8.1/Opset 13. |Temporally removed due to changes in onnx 1.8.1. |
 | **Loop** |6 - * |Input must have static shape. Does not support int4 and uint4. | |
-| **LpNormalization** |none | | | |
+| **LpNormalization** |6 - * | | |
 | **LpPool** |none | | | |
 | **MatMul** |6 - * | | |
 | **MatMulInteger** |10 - * | | |

--- a/src/Conversion/ONNXToKrnl/Math/LpNormalization.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LpNormalization.cpp
@@ -53,8 +53,9 @@ public:
     int64_t rank = inputType.getRank();
 
     int64_t axis = adaptor.getAxis();
-    if (axis<0) axis += rank;
-    assert(axis>=0 && axis<rank && "out of bound axis");
+    if (axis < 0)
+      axis += rank;
+    assert(axis >= 0 && axis < rank && "out of bound axis");
     double p = adaptor.getP();
     llvm::SmallVector<int64_t> reductionShape(
         inputType.getShape().begin(), inputType.getShape().end());
@@ -65,16 +66,40 @@ public:
         create.getBuilder().getI64TensorAttr(axesIntArray));
     TensorType reductionType =
         RankedTensorType::get(reductionShape, elementType);
-    Value res = nullptr;
+
+#if 1
+    // TODO: if the performance of this op matters, we should introduce an
+    // efficient divide by 0 results in zero operator. Also, the ReduceL1 &
+    // ReduceL2 ops should be natively implemented; currently the onnx ops are
+    // decomposed in element operations.
+    Value divisor;
+    if (p == 1.0) {
+      Value abs = create.onnx.abs(input);
+      divisor = create.onnx.reduceSum(reductionType, abs, axes);
+    } else if (p == 2.0) {
+      Value mul = create.onnx.mul(input, input);
+      Value sumMul = create.onnx.reduceSum(reductionType, mul, axes);
+      divisor = create.onnx.sqrt(sumMul);
+    } else {
+      llvm_unreachable(
+          "The order of the normalization, only 1 or 2 are supported.");
+    }
+    RankedTensorType scalarType = RankedTensorType::get({}, elementType);
+    Value zero = create.onnx.constant(
+        DenseElementsAttr::get(scalarType, static_cast<float>(0.0)));
+    Value one = create.onnx.constant(
+        DenseElementsAttr::get(scalarType, static_cast<float>(1.0)));
+    Value isZero = create.onnx.equal(divisor, zero);
+    // When divisor is zero, then saveDividend = 0, saveDivisor = 1.0,
+    // and we have 0/1 = 0. Otherwise we have the normal input / divisor.
+    Value saveDividend = create.onnx.where(inputType, isZero, zero, input);
+    Value safeDivisor = create.onnx.where(reductionType, isZero, one, divisor);
+    Value res = create.onnx.div(saveDividend, safeDivisor);
+#else
     // TODO: the algorithm below does not follow the specs in the aspect listed
     // below. The output is computed as: output = input / Lp_norm(input, axis).
     // When the Lp norm is zero (i.e., all elements along the axis are zero),
     // the output is defined to be zero to avoid division by zero.
-
-    // TODO: if the performance of this op matters, then we should do an
-    // integrated loop that compute the LPnorm in one pass, and then apply it to
-    // the input in a SIMD fashion.
-
 
     if (p == 1) {
       // Y =  x / (sum(abs(x), axis) + eps)
@@ -91,6 +116,8 @@ public:
       llvm_unreachable(
           "The order of the normalization, only 1 or 2 are supported.");
     }
+
+#endif
 
     rewriter.replaceOp(op, res);
     return success();

--- a/src/Conversion/ONNXToKrnl/Math/LpNormalization.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LpNormalization.cpp
@@ -67,7 +67,6 @@ public:
     TensorType reductionType =
         RankedTensorType::get(reductionShape, elementType);
 
-#if 1
     // TODO: if the performance of this op matters, we should introduce an
     // efficient divide by 0 results in zero operator. Also, the ReduceL1 &
     // ReduceL2 ops should be natively implemented; currently the onnx ops are
@@ -84,6 +83,8 @@ public:
       llvm_unreachable(
           "The order of the normalization, only 1 or 2 are supported.");
     }
+
+    // Handle the divide by zero as a zero in the final result.
     RankedTensorType scalarType = RankedTensorType::get({}, elementType);
     Value zero = create.onnx.constant(
         DenseElementsAttr::get(scalarType, static_cast<float>(0.0)));
@@ -95,30 +96,8 @@ public:
     Value saveDividend = create.onnx.where(inputType, isZero, zero, input);
     Value safeDivisor = create.onnx.where(reductionType, isZero, one, divisor);
     Value res = create.onnx.div(saveDividend, safeDivisor);
-#else
-    // TODO: the algorithm below does not follow the specs in the aspect listed
-    // below. The output is computed as: output = input / Lp_norm(input, axis).
-    // When the Lp norm is zero (i.e., all elements along the axis are zero),
-    // the output is defined to be zero to avoid division by zero.
 
-    if (p == 1) {
-      // Y =  x / (sum(abs(x), axis) + eps)
-      Value abs = create.onnx.abs(input);
-      Value sumAbs = create.onnx.reduceSum(reductionType, abs, axes);
-      res = create.onnx.div(input, sumAbs);
-    } else if (p == 2) {
-      // Y =  x / (sqrt(sum(x^2, axis)) + eps)
-      Value mul = create.onnx.mul(input, input);
-      Value sumMul = create.onnx.reduceSum(reductionType, mul, axes);
-      Value sqrtSumMul = create.onnx.sqrt(sumMul);
-      res = create.onnx.div(input, sqrtSumMul);
-    } else {
-      llvm_unreachable(
-          "The order of the normalization, only 1 or 2 are supported.");
-    }
-
-#endif
-
+    // Replace the op.
     rewriter.replaceOp(op, res);
     return success();
   }

--- a/src/Conversion/ONNXToKrnl/Math/LpNormalization.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/LpNormalization.cpp
@@ -50,8 +50,11 @@ public:
     auto resMemRefType = dyn_cast<MemRefType>(
         typeConverter->convertType(lpNormOp.getResult().getType()));
     Type elementType = resMemRefType.getElementType();
+    int64_t rank = inputType.getRank();
 
     int64_t axis = adaptor.getAxis();
+    if (axis<0) axis += rank;
+    assert(axis>=0 && axis<rank && "out of bound axis");
     double p = adaptor.getP();
     llvm::SmallVector<int64_t> reductionShape(
         inputType.getShape().begin(), inputType.getShape().end());
@@ -63,13 +66,23 @@ public:
     TensorType reductionType =
         RankedTensorType::get(reductionShape, elementType);
     Value res = nullptr;
+    // TODO: the algorithm below does not follow the specs in the aspect listed
+    // below. The output is computed as: output = input / Lp_norm(input, axis).
+    // When the Lp norm is zero (i.e., all elements along the axis are zero),
+    // the output is defined to be zero to avoid division by zero.
+
+    // TODO: if the performance of this op matters, then we should do an
+    // integrated loop that compute the LPnorm in one pass, and then apply it to
+    // the input in a SIMD fashion.
+
+
     if (p == 1) {
-      // Y =  x / sum (abs(x), axis)
+      // Y =  x / (sum(abs(x), axis) + eps)
       Value abs = create.onnx.abs(input);
       Value sumAbs = create.onnx.reduceSum(reductionType, abs, axes);
       res = create.onnx.div(input, sumAbs);
     } else if (p == 2) {
-      // Y =  x / sqrt(sum((x^2),axis))
+      // Y =  x / (sqrt(sum(x^2, axis)) + eps)
       Value mul = create.onnx.mul(input, input);
       Value sumMul = create.onnx.reduceSum(reductionType, mul, axes);
       Value sqrtSumMul = create.onnx.sqrt(sumMul);
@@ -79,7 +92,7 @@ public:
           "The order of the normalization, only 1 or 2 are supported.");
     }
 
-    rewriter.replaceOp(op, {create.onnx.toMemref(input)});
+    rewriter.replaceOp(op, res);
     return success();
   }
 };

--- a/src/Dialect/ONNX/DialectBuilder.cpp
+++ b/src/Dialect/ONNX/DialectBuilder.cpp
@@ -172,6 +172,13 @@ Value OnnxBuilder::div(Value A, Value B) const {
   return createOpAndInferShapes<ONNXDivOp>(toTensor(A), toTensor(B));
 }
 
+Value OnnxBuilder::equal(Value A, Value B) const {
+  assert((mlir::cast<ShapedType>(A.getType()).getElementType() ==
+             mlir::cast<ShapedType>(B.getType()).getElementType()) &&
+         "A and B must have the same element type");
+  return createOpAndInferShapes<ONNXEqualOp>(toTensor(A), toTensor(B));
+}
+
 Value OnnxBuilder::expand(Type outputType, Value input, Value shape) const {
   return createOpAndInferShapes<ONNXExpandOp>(
       outputType, toTensor(input), toTensor(shape));
@@ -300,6 +307,22 @@ Value OnnxBuilder::padZero(Value input, Value pads) const {
 
 Value OnnxBuilder::pow(Value input, Value exp) const {
   return createOpAndInferShapes<ONNXPowOp>(toTensor(input), toTensor(exp));
+}
+
+Value OnnxBuilder::reduceL1(Type outputType, Value data, Value axes,
+    bool keepDims, bool noop_with_empty_axes) const {
+  int64_t i_keepDims = keepDims; // 0 if false, 1 if true
+  int64_t i_noop_with_empty_axes = noop_with_empty_axes; // ditto
+  return createTypedOpAndInferShapes<ONNXReduceL1Op>(toTensor(outputType),
+      toTensor(data), toTensor(axes), i_keepDims, i_noop_with_empty_axes);
+}
+
+Value OnnxBuilder::reduceL2(Type outputType, Value data, Value axes,
+    bool keepDims, bool noop_with_empty_axes) const {
+  int64_t i_keepDims = keepDims; // 0 if false, 1 if true
+  int64_t i_noop_with_empty_axes = noop_with_empty_axes; // ditto
+  return createTypedOpAndInferShapes<ONNXReduceL2Op>(toTensor(outputType),
+      toTensor(data), toTensor(axes), i_keepDims, i_noop_with_empty_axes);
 }
 
 Value OnnxBuilder::reduceMax(Type outputType, Value data, Value axes,

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -35,11 +35,11 @@ struct OnnxBuilder : DialectBuilder {
 
   // Create operation and infer shape.
   template <typename OnnxOpType, typename... Args>
-  OnnxOpType createOpAndInferShapes(Args &&...args) const;
+  OnnxOpType createOpAndInferShapes(Args &&... args) const;
 
   template <typename OnnxOpType, typename... Args>
   OnnxOpType createTypedOpAndInferShapes(
-      mlir::Type result_ty, Args &&...args) const;
+      mlir::Type result_ty, Args &&... args) const;
 
   // ONNXAbsOp
   mlir::Value abs(mlir::Value input) const;

--- a/src/Dialect/ONNX/DialectBuilder.hpp
+++ b/src/Dialect/ONNX/DialectBuilder.hpp
@@ -35,11 +35,11 @@ struct OnnxBuilder : DialectBuilder {
 
   // Create operation and infer shape.
   template <typename OnnxOpType, typename... Args>
-  OnnxOpType createOpAndInferShapes(Args &&... args) const;
+  OnnxOpType createOpAndInferShapes(Args &&...args) const;
 
   template <typename OnnxOpType, typename... Args>
   OnnxOpType createTypedOpAndInferShapes(
-      mlir::Type result_ty, Args &&... args) const;
+      mlir::Type result_ty, Args &&...args) const;
 
   // ONNXAbsOp
   mlir::Value abs(mlir::Value input) const;
@@ -95,6 +95,8 @@ struct OnnxBuilder : DialectBuilder {
   // ONNXDimGroupOp
   void dimGroup(mlir::Value input, int axis, int groupID) const;
 
+  mlir::Value equal(mlir::Value A, mlir::Value B) const;
+
   // ONNXExpandOp
   mlir::Value expand(
       mlir::Type outputType, mlir::Value input, mlir::Value shape) const;
@@ -147,6 +149,16 @@ struct OnnxBuilder : DialectBuilder {
       mlir::Value constantValue, std::string mode = "constant") const;
   // Zero padding
   mlir::Value padZero(mlir::Value input, mlir::Value pads) const;
+
+  // ONNXReduceL1Op
+  mlir::Value reduceL1(mlir::Type outputType, mlir::Value data,
+      mlir::Value axes, bool keepDims = true,
+      bool noop_with_empty_axes = false) const;
+
+  // ONNXReduceL2Op
+  mlir::Value reduceL2(mlir::Type outputType, mlir::Value data,
+      mlir::Value axes, bool keepDims = true,
+      bool noop_with_empty_axes = false) const;
 
   // ONNXReduceMaxOp
   mlir::Value reduceMax(mlir::Type outputType, mlir::Value data,

--- a/src/Dialect/ONNX/ONNXOps.td.inc
+++ b/src/Dialect/ONNX/ONNXOps.td.inc
@@ -4268,6 +4268,7 @@ def ONNXLpNormalizationOp:ONNX_Op<"LpNormalization",
       return sh;
     }
   }];
+  let hasVerifier = 1;
 }
 
 def ONNXLpPoolOp:ONNX_Op<"LpPool",

--- a/src/Dialect/ONNX/ONNXOps/Math/ElementwiseUnary.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Math/ElementwiseUnary.cpp
@@ -424,6 +424,29 @@ LogicalResult ONNXLogSoftmaxOp::inferShapes(
 // LpNormalization
 //===----------------------------------------------------------------------===//
 
+LogicalResult ONNXLpNormalizationOp::verify() {
+  ONNXLpNormalizationOpAdaptor operandAdaptor(*this);
+  if (!hasShapeAndRank(operandAdaptor.getInput()))
+    return success(); // Won't be able to do any checking at this stage.
+
+  int64_t inputRank =
+      mlir::cast<ShapedType>(operandAdaptor.getInput().getType()).getRank();
+  int64_t axisIndex = getAxis();
+
+  // axis attribute must be in the range [-r,r-1], where r = rank(input).
+  if (axisIndex < -inputRank || axisIndex >= inputRank)
+    return onnx_mlir::Diagnostic::emitAttributeOutOfRangeError(
+        *this->getOperation(), "axis", axisIndex,
+        onnx_mlir::Diagnostic::Range<int64_t>(-inputRank, inputRank - 1));
+
+  // p must be 1 or 2.
+  int64_t pValue = getP();
+  if (pValue != 1 && pValue != 2)
+    return emitOpError("attribute 'p' must be 1 or 2, got ") << pValue;
+
+  return success();
+}
+
 LogicalResult ONNXLpNormalizationOp::inferShapes(
     std::function<void(Region &)> doShapeInference) {
   return inferShapeForUnaryOps(this->getOperation());

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -1965,9 +1965,23 @@ def get_test_models():
             # DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
-        # ==OP== LpNormalization hi alex
+        # ==OP== LpNormalization
         # ==MIN== 1
-        # ==LIM== Does not support divide by zero.
+        "test_l1normalization_axis_0_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
+        "test_l1normalization_axis_1_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
+        "test_l1normalization_axis_last_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
         "test_lpnormalization_default_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -1965,6 +1965,14 @@ def get_test_models():
             # DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
+        # ==OP== LpNormalization hi alex
+        # ==MIN== 1
+        # ==LIM== Does not support divide by zero.
+        "test_lpnormalization_default_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
         # "test_loop13_seq_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # "test_loop16_seq_none_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
         # ==OP== LRN

--- a/test/mlir/conversion/onnx_to_krnl/Math/LpNormalization_with_canonicalize.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/LpNormalization_with_canonicalize.mlir
@@ -12,30 +12,63 @@ func.func private @test_lpNormalization(%arg0 : tensor<10x20xf32>) -> tensor<*xf
 // CHECK-DAG:       [[RES_:%.+]] = memref.alloc() {{.*}}: memref<10x20xf32>
 // CHECK-DAG:       [[LOOP_0_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_0_]]#0, [[LOOP_0_]]#1) with ([[LOOP_0_]]#0 -> [[I_0_:%.+]] = 0 to 10, [[LOOP_0_]]#1 -> [[I_1_:%.+]] = 0 to 20){
-// CHECK:             [[VAR_3_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1] : memref<10x20xf32>
-// CHECK:             [[VAR_5_:%.+]] = math.absf [[LOAD_PARAM_0_MEM_]] : f32
-// CHECK:             krnl.store [[VAR_5_]], [[RES_]]{{.}}[[VAR_3_]]#0, [[VAR_3_]]#1] : memref<10x20xf32>
+// CHECK:             [[VAR_8_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_0_]]#0, [[LOOP_0_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK:             [[LOAD_PARAM_0_MEM_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_8_]]#0, [[VAR_8_]]#1] : memref<10x20xf32>
+// CHECK:             [[VAR_10_:%.+]] = math.absf [[LOAD_PARAM_0_MEM_]] : f32
+// CHECK:             krnl.store [[VAR_10_]], [[RES_]]{{.}}[[VAR_8_]]#0, [[VAR_8_]]#1] : memref<10x20xf32>
 // CHECK:           }
 // CHECK:           [[RES_1_:%.+]] = memref.alloc() {{.*}}: memref<10x1xf32>
 // CHECK:           krnl.memset [[RES_1_]], [[CST_0_dot_000000_]] : memref<10x1xf32>
 // CHECK:           [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_2_:%.+]] = 0 to 10, [[LOOP_1_]]#1 -> [[I_3_:%.+]] = 0 to 20){
-// CHECK:             [[VAR_3_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_3_1_]]#0, [[VAR_3_1_]]#1] : memref<10x20xf32>
-// CHECK-DAG:         [[VAR_5_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_3_1_]]#0, [[CST_0_]]{{.}} : memref<10x1xf32>
-// CHECK:             [[VAR_6_:%.+]] = arith.addf [[VAR_5_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
-// CHECK:             krnl.store [[VAR_6_]], [[RES_1_]]{{.}}[[VAR_3_1_]]#0, [[CST_0_]]{{.}} : memref<10x1xf32>
+// CHECK:             [[VAR_8_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_]]{{.}}[[VAR_8_1_]]#0, [[VAR_8_1_]]#1] : memref<10x20xf32>
+// CHECK-DAG:         [[VAR_10_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_8_1_]]#0, [[CST_0_]]{{.}} : memref<10x1xf32>
+// CHECK:             [[VAR_11_:%.+]] = arith.addf [[VAR_10_1_]], [[LOAD_PARAM_0_MEM_1_]] : f32
+// CHECK:             krnl.store [[VAR_11_]], [[RES_1_]]{{.}}[[VAR_8_1_]]#0, [[CST_0_]]{{.}} : memref<10x1xf32>
 // CHECK:           }
-// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<10x20xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() <{name = "constant_{{[0-9]+}}", shape = [], value = dense<0.000000e+00> : tensor<f32>}> : () -> memref<f32>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "krnl.global"() <{name = "constant_{{[0-9]+}}", shape = [], value = dense<1.000000e+00> : tensor<f32>}> : () -> memref<f32>
+// CHECK-DAG:       [[RES_2_:%.+]] = memref.alloc() {{.*}}: memref<10x1xi1>
 // CHECK-DAG:       [[LOOP_2_:%.+]]:2 = krnl.define_loops 2
-// CHECK:           krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to 10, [[LOOP_2_]]#1 -> [[I_5_:%.+]] = 0 to 20){
-// CHECK:             [[VAR_3_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_3_2_]]#0, [[VAR_3_2_]]#1] : memref<10x20xf32>
-// CHECK-DAG:         [[VAR_5_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_3_2_]]#0, [[CST_0_]]{{.}} : memref<10x1xf32>
-// CHECK:             [[VAR_6_1_:%.+]] = arith.divf [[LOAD_PARAM_0_MEM_2_]], [[VAR_5_1_]] : f32
-// CHECK:             krnl.store [[VAR_6_1_]], [[RES_2_]]{{.}}[[VAR_3_2_]]#0, [[VAR_3_2_]]#1] : memref<10x20xf32>
+// CHECK:           krnl.iterate([[LOOP_2_]]#0, [[LOOP_2_]]#1) with ([[LOOP_2_]]#0 -> [[I_4_:%.+]] = 0 to 10, [[LOOP_2_]]#1 -> [[I_5_:%.+]] = 0 to 1){
+// CHECK:             [[VAR_8_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_2_]]#0, [[LOOP_2_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_8_2_]]#0, [[CST_0_]]{{.}} : memref<10x1xf32>
+// CHECK-DAG:         [[VAR_10_1_:%.+]] = krnl.load [[VAR_2_]][] : memref<f32>
+// CHECK:             [[VAR_11_1_:%.+]] = arith.cmpf oeq, [[LOAD_PARAM_0_MEM_1_]], [[VAR_10_1_]] : f32
+// CHECK:             krnl.store [[VAR_11_1_]], [[RES_2_]]{{.}}[[VAR_8_2_]]#0, [[VAR_8_2_]]#1] : memref<10x1xi1>
 // CHECK:           }
-// CHECK:           return [[PARAM_0_]] : memref<10x20xf32>
+// CHECK-DAG:       [[RES_3_:%.+]] = memref.alloc() {{.*}}: memref<10x20xf32>
+// CHECK-DAG:       [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_6_:%.+]] = 0 to 10, [[LOOP_3_]]#1 -> [[I_7_:%.+]] = 0 to 20){
+// CHECK:             [[VAR_8_3_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_1_:%.+]] = krnl.load [[RES_2_]]{{.}}[[VAR_8_3_]]#0, [[CST_0_]]{{.}} : memref<10x1xi1>
+// CHECK-DAG:         [[VAR_10_1_1_:%.+]] = krnl.load [[VAR_2_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[VAR_8_3_]]#0, [[VAR_8_3_]]#1] : memref<10x20xf32>
+// CHECK:             [[VAR_12_:%.+]] = arith.select [[LOAD_PARAM_0_MEM_1_1_]], [[VAR_10_1_1_]], [[LOAD_PARAM_0_MEM_2_]] : f32
+// CHECK:             krnl.store [[VAR_12_]], [[RES_3_]]{{.}}[[VAR_8_3_]]#0, [[VAR_8_3_]]#1] : memref<10x20xf32>
+// CHECK:           }
+// CHECK-DAG:       [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<10x1xf32>
+// CHECK-DAG:       [[LOOP_4_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_8_:%.+]] = 0 to 10, [[LOOP_4_]]#1 -> [[I_9_:%.+]] = 0 to 1){
+// CHECK:             [[VAR_8_4_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_1_:%.+]] = krnl.load [[RES_2_]]{{.}}[[VAR_8_4_]]#0, [[CST_0_]]{{.}} : memref<10x1xi1>
+// CHECK-DAG:         [[VAR_10_1_1_:%.+]] = krnl.load [[VAR_3_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_2_:%.+]] = krnl.load [[RES_1_]]{{.}}[[VAR_8_4_]]#0, [[CST_0_]]{{.}} : memref<10x1xf32>
+// CHECK:             [[VAR_12_1_:%.+]] = arith.select [[LOAD_PARAM_0_MEM_1_1_]], [[VAR_10_1_1_]], [[LOAD_PARAM_0_MEM_2_]] : f32
+// CHECK:             krnl.store [[VAR_12_1_]], [[RES_4_]]{{.}}[[VAR_8_4_]]#0, [[VAR_8_4_]]#1] : memref<10x1xf32>
+// CHECK:           }
+// CHECK-DAG:       [[RES_5_:%.+]] = memref.alloc() {{.*}}: memref<10x20xf32>
+// CHECK-DAG:       [[LOOP_5_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_5_]]#0, [[LOOP_5_]]#1) with ([[LOOP_5_]]#0 -> [[I_10_:%.+]] = 0 to 10, [[LOOP_5_]]#1 -> [[I_11_:%.+]] = 0 to 20){
+// CHECK:             [[VAR_8_5_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_5_]]#0, [[LOOP_5_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[LOAD_PARAM_0_MEM_1_1_1_:%.+]] = krnl.load [[RES_3_]]{{.}}[[VAR_8_5_]]#0, [[VAR_8_5_]]#1] : memref<10x20xf32>
+// CHECK-DAG:         [[VAR_10_1_1_1_:%.+]] = krnl.load [[RES_4_]]{{.}}[[VAR_8_5_]]#0, [[CST_0_]]{{.}} : memref<10x1xf32>
+// CHECK:             [[VAR_11_2_:%.+]] = arith.divf [[LOAD_PARAM_0_MEM_1_1_1_]], [[VAR_10_1_1_1_]] : f32
+// CHECK:             krnl.store [[VAR_11_2_]], [[RES_5_]]{{.}}[[VAR_8_5_]]#0, [[VAR_8_5_]]#1] : memref<10x20xf32>
+// CHECK:           }
+// CHECK:           return [[RES_5_]] : memref<10x20xf32>
 // CHECK:         }
+
 }
+

--- a/test/mlir/conversion/onnx_to_krnl/Math/LpNormalization_with_canonicalize_O3.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Math/LpNormalization_with_canonicalize_O3.mlir
@@ -27,11 +27,11 @@ func.func private @test_lpNormalization(%arg0 : tensor<10x20xf32>) -> tensor<*xf
 // CHECK:             [[LOOP_0_:%.+]] = krnl.define_loops 1
 // CHECK:             [[BLOCK_TILE__0_:%.+]], [[BLOCK_IN__0_:%.+]] = krnl.block [[LOOP_0_]] 32 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
 // CHECK:             krnl.iterate([[BLOCK_TILE__0_]]) with ([[LOOP_0_]] -> [[I_0_:%.+]] = 0 to 200){
-// CHECK:               [[VAR_3_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
-// CHECK-DAG:           [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_3_]]{{.}} : memref<200xf32>, vector<32xf32>
-// CHECK-DAG:           [[LOAD_VAR_reshape_2_MEM_:%.+]] = vector.load [[VAR_reshape_2_]]{{.}}[[VAR_3_]]{{.}} : memref<200xf32>, vector<32xf32>
-// CHECK:               [[VAR_6_:%.+]] = arith.mulf [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xf32>
-// CHECK:               vector.store [[VAR_6_]], [[VAR_reshape_4_]]{{.}}[[VAR_3_]]{{.}} : memref<200xf32>, vector<32xf32>
+// CHECK:               [[VAR_8_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__0_]]) : (!krnl.loop) -> index
+// CHECK-DAG:           [[LOAD_VAR_reshape_MEM_:%.+]] = vector.load [[VAR_reshape_]]{{.}}[[VAR_8_]]{{.}} : memref<200xf32>, vector<32xf32>
+// CHECK-DAG:           [[LOAD_VAR_reshape_2_MEM_:%.+]] = vector.load [[VAR_reshape_2_]]{{.}}[[VAR_8_]]{{.}} : memref<200xf32>, vector<32xf32>
+// CHECK:               [[VAR_11_:%.+]] = arith.mulf [[LOAD_VAR_reshape_MEM_]], [[LOAD_VAR_reshape_2_MEM_]] : vector<32xf32>
+// CHECK:               vector.store [[VAR_11_]], [[VAR_reshape_4_]]{{.}}[[VAR_8_]]{{.}} : memref<200xf32>, vector<32xf32>
 // CHECK:             }
 // CHECK:           }
 // CHECK:           [[RES_4_:%.+]] = memref.alloc() {{.*}}: memref<1x20xf32>
@@ -39,9 +39,9 @@ func.func private @test_lpNormalization(%arg0 : tensor<10x20xf32>) -> tensor<*xf
 // CHECK:           [[LOOP_1_:%.+]]:2 = krnl.define_loops 2
 // CHECK:           krnl.iterate([[LOOP_1_]]#0, [[LOOP_1_]]#1) with ([[LOOP_1_]]#0 -> [[I_1_:%.+]] = 0 to 10, [[LOOP_1_]]#1 -> [[I_2_:%.+]] = 0 to 20){
 // CHECK:             [[LOOP_0_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_1_]]#0, [[LOOP_1_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
-// CHECK-DAG:         [[VAR_3_1_:%.+]] = krnl.load [[VAR_view_]]{{.}}[[LOOP_0_]]#0, [[LOOP_0_]]#1] : memref<10x20xf32>
+// CHECK-DAG:         [[VAR_8_1_:%.+]] = krnl.load [[VAR_view_]]{{.}}[[LOOP_0_]]#0, [[LOOP_0_]]#1] : memref<10x20xf32>
 // CHECK-DAG:         [[LOAD_VAR_reshape_MEM_1_:%.+]] = krnl.load [[RES_4_]]{{.}}[[CST_0_]], [[LOOP_0_]]#1] : memref<1x20xf32>
-// CHECK:             [[LOAD_VAR_reshape_2_MEM_1_:%.+]] = arith.addf [[LOAD_VAR_reshape_MEM_1_]], [[VAR_3_1_]] : f32
+// CHECK:             [[LOAD_VAR_reshape_2_MEM_1_:%.+]] = arith.addf [[LOAD_VAR_reshape_MEM_1_]], [[VAR_8_1_]] : f32
 // CHECK:             krnl.store [[LOAD_VAR_reshape_2_MEM_1_]], [[RES_4_]]{{.}}[[CST_0_]], [[LOOP_0_]]#1] : memref<1x20xf32>
 // CHECK:           }
 // CHECK-DAG:       [[RES_5_:%.+]] = memref.alloc() {{.*}}: memref<1x20xf32>
@@ -55,26 +55,59 @@ func.func private @test_lpNormalization(%arg0 : tensor<10x20xf32>) -> tensor<*xf
 // CHECK:             [[LOOP_2_:%.+]] = krnl.define_loops 1
 // CHECK:             [[BLOCK_TILE__1_:%.+]], [[BLOCK_IN__1_:%.+]] = krnl.block [[LOOP_2_]] 20 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
 // CHECK:             krnl.iterate([[BLOCK_TILE__1_]]) with ([[LOOP_2_]] -> [[I_3_:%.+]] = 0 to 20){
-// CHECK:               [[VAR_3_2_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__1_]]) : (!krnl.loop) -> index
-// CHECK:               [[LOAD_VAR_reshape_MEM_1_:%.+]] = vector.load [[VAR_reshape_8_]]{{.}}[[VAR_3_2_]]{{.}} : memref<20xf32>, vector<20xf32>
+// CHECK:               [[VAR_8_2_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__1_]]) : (!krnl.loop) -> index
+// CHECK:               [[LOAD_VAR_reshape_MEM_1_:%.+]] = vector.load [[VAR_reshape_8_]]{{.}}[[VAR_8_2_]]{{.}} : memref<20xf32>, vector<20xf32>
 // CHECK:               [[LOAD_VAR_reshape_2_MEM_1_:%.+]] = math.sqrt [[LOAD_VAR_reshape_MEM_1_]] : vector<20xf32>
-// CHECK:               vector.store [[LOAD_VAR_reshape_2_MEM_1_]], [[VAR_reshape_10_]]{{.}}[[VAR_3_2_]]{{.}} : memref<20xf32>, vector<20xf32>
+// CHECK:               vector.store [[LOAD_VAR_reshape_2_MEM_1_]], [[VAR_reshape_10_]]{{.}}[[VAR_8_2_]]{{.}} : memref<20xf32>, vector<20xf32>
 // CHECK:             }
 // CHECK:           }
-// CHECK-DAG:       [[RES_8_:%.+]] = memref.alloc() {{.*}}: memref<10x20xf32>
-// CHECK-DAG:       [[LOOP_3_:%.+]] = krnl.define_loops 1
-// CHECK:           krnl.iterate([[LOOP_3_]]) with ([[LOOP_3_]] -> [[I_4_:%.+]] = 0 to 10){
-// CHECK-DAG:         [[LOOP_2_:%.+]] = krnl.get_induction_var_value([[LOOP_3_]]) : (!krnl.loop) -> index
-// CHECK-DAG:         [[LOOP_4_:%.+]] = krnl.define_loops 1
-// CHECK:             [[BLOCK_TILE__2_:%.+]], [[BLOCK_IN__2_:%.+]] = krnl.block [[LOOP_4_]] 20 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
-// CHECK:             krnl.iterate([[BLOCK_TILE__2_]]) with ([[LOOP_4_]] -> [[I_5_:%.+]] = 0 to 20){
-// CHECK:               [[LOAD_VAR_reshape_MEM_1_1_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__2_]]) : (!krnl.loop) -> index
-// CHECK-DAG:           [[LOAD_VAR_reshape_2_MEM_1_1_:%.+]] = vector.load [[PARAM_0_]]{{.}}[[LOOP_2_]], [[LOAD_VAR_reshape_MEM_1_1_]]{{.}} : memref<10x20xf32>, vector<20xf32>
-// CHECK-DAG:           [[VAR_6_1_:%.+]] = vector.load [[RES_5_]]{{.}}[[CST_0_]], [[LOAD_VAR_reshape_MEM_1_1_]]{{.}} : memref<1x20xf32>, vector<20xf32>
-// CHECK:               [[VAR_7_:%.+]] = arith.divf [[LOAD_VAR_reshape_2_MEM_1_1_]], [[VAR_6_1_]] : vector<20xf32>
-// CHECK:               vector.store [[VAR_7_]], [[RES_8_]]{{.}}[[LOOP_2_]], [[LOAD_VAR_reshape_MEM_1_1_]]{{.}} : memref<10x20xf32>, vector<20xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = "krnl.global"() <{name = "constant_{{[0-9]+}}", shape = [], value = dense<0.000000e+00> : tensor<f32>}> : () -> memref<f32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = "krnl.global"() <{name = "constant_{{[0-9]+}}", shape = [], value = dense<1.000000e+00> : tensor<f32>}> : () -> memref<f32>
+// CHECK-DAG:       [[RES_8_:%.+]] = memref.alloc() {{.*}}: memref<1x20xi1>
+// CHECK-DAG:       [[LOOP_3_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_3_]]#0, [[LOOP_3_]]#1) with ([[LOOP_3_]]#0 -> [[I_4_:%.+]] = 0 to 1, [[LOOP_3_]]#1 -> [[I_5_:%.+]] = 0 to 20){
+// CHECK:             [[LOOP_2_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_3_]]#0, [[LOOP_3_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[VAR_8_2_:%.+]] = krnl.load [[RES_5_]]{{.}}[[CST_0_]], [[LOOP_2_]]#1] : memref<1x20xf32>
+// CHECK-DAG:         [[LOAD_VAR_reshape_MEM_1_1_:%.+]] = krnl.load [[VAR_1_]][] : memref<f32>
+// CHECK:             [[LOAD_VAR_reshape_2_MEM_1_1_:%.+]] = arith.cmpf oeq, [[VAR_8_2_]], [[LOAD_VAR_reshape_MEM_1_1_]] : f32
+// CHECK:             krnl.store [[LOAD_VAR_reshape_2_MEM_1_1_]], [[RES_8_]]{{.}}[[LOOP_2_]]#0, [[LOOP_2_]]#1] : memref<1x20xi1>
+// CHECK:           }
+// CHECK-DAG:       [[RES_9_:%.+]] = memref.alloc() {{.*}}: memref<10x20xf32>
+// CHECK-DAG:       [[LOOP_4_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_4_]]#0, [[LOOP_4_]]#1) with ([[LOOP_4_]]#0 -> [[I_6_:%.+]] = 0 to 10, [[LOOP_4_]]#1 -> [[I_7_:%.+]] = 0 to 20){
+// CHECK:             [[LOOP_2_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_4_]]#0, [[LOOP_4_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[VAR_8_2_1_:%.+]] = krnl.load [[RES_8_]]{{.}}[[CST_0_]], [[LOOP_2_1_]]#1] : memref<1x20xi1>
+// CHECK-DAG:         [[LOAD_VAR_reshape_MEM_1_1_:%.+]] = krnl.load [[VAR_1_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_VAR_reshape_2_MEM_1_1_:%.+]] = krnl.load [[PARAM_0_]]{{.}}[[LOOP_2_1_]]#0, [[LOOP_2_1_]]#1] : memref<10x20xf32>
+// CHECK:             [[VAR_11_1_:%.+]] = arith.select [[VAR_8_2_1_]], [[LOAD_VAR_reshape_MEM_1_1_]], [[LOAD_VAR_reshape_2_MEM_1_1_]] : f32
+// CHECK:             krnl.store [[VAR_11_1_]], [[RES_9_]]{{.}}[[LOOP_2_1_]]#0, [[LOOP_2_1_]]#1] : memref<10x20xf32>
+// CHECK:           }
+// CHECK-DAG:       [[RES_10_:%.+]] = memref.alloc() {{.*}}: memref<1x20xf32>
+// CHECK-DAG:       [[LOOP_5_:%.+]]:2 = krnl.define_loops 2
+// CHECK:           krnl.iterate([[LOOP_5_]]#0, [[LOOP_5_]]#1) with ([[LOOP_5_]]#0 -> [[I_8_:%.+]] = 0 to 1, [[LOOP_5_]]#1 -> [[I_9_:%.+]] = 0 to 20){
+// CHECK:             [[LOOP_2_1_:%.+]]:2 = krnl.get_induction_var_value([[LOOP_5_]]#0, [[LOOP_5_]]#1) : (!krnl.loop, !krnl.loop) -> (index, index)
+// CHECK-DAG:         [[VAR_8_2_1_:%.+]] = krnl.load [[RES_8_]]{{.}}[[CST_0_]], [[LOOP_2_1_]]#1] : memref<1x20xi1>
+// CHECK-DAG:         [[LOAD_VAR_reshape_MEM_1_1_1_:%.+]] = krnl.load [[VAR_2_]][] : memref<f32>
+// CHECK-DAG:         [[LOAD_VAR_reshape_2_MEM_1_1_1_:%.+]] = krnl.load [[RES_5_]]{{.}}[[CST_0_]], [[LOOP_2_1_]]#1] : memref<1x20xf32>
+// CHECK:             [[VAR_11_2_:%.+]] = arith.select [[VAR_8_2_1_]], [[LOAD_VAR_reshape_MEM_1_1_1_]], [[LOAD_VAR_reshape_2_MEM_1_1_1_]] : f32
+// CHECK:             krnl.store [[VAR_11_2_]], [[RES_10_]]{{.}}[[LOOP_2_1_]]#0, [[LOOP_2_1_]]#1] : memref<1x20xf32>
+// CHECK:           }
+// CHECK-DAG:       [[RES_11_:%.+]] = memref.alloc() {{.*}}: memref<10x20xf32>
+// CHECK-DAG:       [[LOOP_6_:%.+]] = krnl.define_loops 1
+// CHECK:           krnl.iterate([[LOOP_6_]]) with ([[LOOP_6_]] -> [[I_10_:%.+]] = 0 to 10){
+// CHECK-DAG:         [[LOOP_2_1_1_:%.+]] = krnl.get_induction_var_value([[LOOP_6_]]) : (!krnl.loop) -> index
+// CHECK-DAG:         [[LOOP_7_:%.+]] = krnl.define_loops 1
+// CHECK:             [[BLOCK_TILE__2_:%.+]], [[BLOCK_IN__2_:%.+]] = krnl.block [[LOOP_7_]] 20 : (!krnl.loop) -> (!krnl.loop, !krnl.loop)
+// CHECK:             krnl.iterate([[BLOCK_TILE__2_]]) with ([[LOOP_7_]] -> [[I_11_:%.+]] = 0 to 20){
+// CHECK:               [[LOAD_VAR_reshape_MEM_1_1_1_:%.+]] = krnl.get_induction_var_value([[BLOCK_TILE__2_]]) : (!krnl.loop) -> index
+// CHECK-DAG:           [[LOAD_VAR_reshape_2_MEM_1_1_1_:%.+]] = vector.load [[RES_9_]]{{.}}[[LOOP_2_1_1_]], [[LOAD_VAR_reshape_MEM_1_1_1_]]{{.}} : memref<10x20xf32>, vector<20xf32>
+// CHECK-DAG:           [[VAR_11_2_:%.+]] = vector.load [[RES_10_]]{{.}}[[CST_0_]], [[LOAD_VAR_reshape_MEM_1_1_1_]]{{.}} : memref<1x20xf32>, vector<20xf32>
+// CHECK:               [[VAR_12_:%.+]] = arith.divf [[LOAD_VAR_reshape_2_MEM_1_1_1_]], [[VAR_11_2_]] : vector<20xf32>
+// CHECK:               vector.store [[VAR_12_]], [[RES_11_]]{{.}}[[LOOP_2_1_1_]], [[LOAD_VAR_reshape_MEM_1_1_1_]]{{.}} : memref<10x20xf32>, vector<20xf32>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           return [[PARAM_0_]] : memref<10x20xf32>
+// CHECK:           return [[RES_11_]] : memref<10x20xf32>
 // CHECK:         }
+
 }
+

--- a/utils/gen_onnx_mlir.py
+++ b/utils/gen_onnx_mlir.py
@@ -417,6 +417,7 @@ OpsWithVerifier = [
     "Less",
     "LessOrEqual",
     "LogSoftmax",
+    "LpNormalization",
     "Max",
     "MatMulInteger",
     "Mean",


### PR DESCRIPTION
LP Normalization was buggy and not properly implemented. This version implement the full specs, added a verifier method, and added every backend tests for this operation.

While its not super optimized, in that it generates multiple loops where in theory it could be implemented by 2 specialized loops, this can be added at a later time if this operation turns out to be critical.

Fix #3522 