### PR TITLE
[NNPA] Add a new pass to replace malloc by hugepage malloc

### DIFF
--- a/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.cpp
@@ -138,4 +138,9 @@ llvm::cl::opt<bool> nnpaDisableShapeRestriction(
                    "Default is false"),
     llvm::cl::init(false), llvm::cl::cat(OnnxMlirCommonOptions));
 
+llvm::cl::opt<bool> nnpaDisableHugePageMalloc("nnpa-disable-hugepage-malloc",
+    llvm::cl::desc("Disable replacement of malloc with OMHugePageMalloc. "
+                   "Default is false"),
+    llvm::cl::init(false), llvm::cl::cat(OnnxMlirOptions));
+
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.hpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerOptions.hpp
@@ -78,6 +78,7 @@ extern llvm::cl::opt<bool> nnpaUseDynamicQuantizeLinearOnCPU;
 extern llvm::cl::opt<bool> nnpaUseDynamicQuantizeLinearOnCPUForScaleOffset;
 extern llvm::cl::opt<bool> nnpaDisableFusionOpStickUnstick;
 extern llvm::cl::opt<bool> nnpaDisableShapeRestriction;
+extern llvm::cl::opt<bool> nnpaDisableHugePageMalloc;
 extern std::vector<NNPAQuantOptions> nnpaQuantDynamic;
 extern std::vector<std::string> nnpaQuantOpTypes;
 

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -342,9 +342,12 @@ void addPassesNNPA(mlir::OwningOpRef<mlir::ModuleOp> &module,
     }
   }
 
-  if (emissionTarget >= EmitLLVMIR)
+  if (emissionTarget >= EmitLLVMIR) {
     // Lower the remaining Krnl and all ZLow ops to LLVM dialect.
     addKrnlToLLVMPasses(pm, outputNameNoExt, /*enableCSE=*/true);
+    // Replace malloc with omHugePageMalloc for better performance on Z.
+    pm.addPass(onnx_mlir::createReplaceMallocByHugePageMallocPass());
+  }
 }
 
 } // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -345,8 +345,9 @@ void addPassesNNPA(mlir::OwningOpRef<mlir::ModuleOp> &module,
   if (emissionTarget >= EmitLLVMIR) {
     // Lower the remaining Krnl and all ZLow ops to LLVM dialect.
     addKrnlToLLVMPasses(pm, outputNameNoExt, /*enableCSE=*/true);
-    // Replace malloc with omHugePageMalloc for better performance on Z.
-    pm.addPass(onnx_mlir::createReplaceMallocByHugePageMallocPass());
+    // Replace malloc with OMHugePageMalloc for better performance on Z.
+    if (!nnpaDisableHugePageMalloc)
+      pm.addPass(onnx_mlir::createReplaceMallocByHugePageMallocPass());
   }
 }
 

--- a/src/Accelerators/NNPA/NNPAAccelerator.cpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.cpp
@@ -140,6 +140,10 @@ void NNPAAccelerator::registerPasses(int optLevel) const {
       []() -> std::unique_ptr<mlir::Pass> { return createFoldStdAllocPass(); });
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createReplaceMallocByHugePageMallocPass();
+  });
+
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return onnx_mlir::zhigh::createZHighConstPropagationPass();
   });
 

--- a/src/Accelerators/NNPA/Pass/NNPAPasses.hpp
+++ b/src/Accelerators/NNPA/Pass/NNPAPasses.hpp
@@ -57,6 +57,9 @@ std::unique_ptr<mlir::Pass> createZHighToONNXPass();
 /// Pass for folding std.alloc.
 std::unique_ptr<mlir::Pass> createFoldStdAllocPass();
 
+/// Pass for replacing malloc with omHugePageMalloc.
+std::unique_ptr<mlir::Pass> createReplaceMallocByHugePageMallocPass();
+
 namespace zhigh {
 
 /// Pass for layout propagation at ZHighIR.

--- a/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
+++ b/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
@@ -19,10 +19,10 @@
 #include <pthread.h>
 
 #include <errno.h>
-#include <sys/mman.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/mman.h>
 
 #include "zdnn.h"
 #include "zdnnx/zdnnx.h"
@@ -248,16 +248,20 @@ void OMShutdownAccelNNPA() {
   }
 }
 
+/*!
+ *  \brief Function that allocates a buffer with huge page advice.
+ */
 void *OMHugePageMalloc(size_t size) {
   if (size == 0 || size < HUGE_PAGE_SIZE)
     return malloc(size);
 
   void *ptr = NULL;
-  if (posix_memalign(&ptr, HUGE_PAGE_SIZE, size) != 0) {
+  if (posix_memalign(&ptr, HUGE_PAGE_SIZE, size) != 0)
     return malloc(size); // Fallback.
-  }
 
   // Give the kernel the transparent huge page advice.
+  // It is ok to failed since the memory is still usable but may not use huge
+  // pages.
   madvise(ptr, size, MADV_HUGEPAGE);
 
   return ptr;

--- a/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
+++ b/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
@@ -19,6 +19,7 @@
 #include <pthread.h>
 
 #include <errno.h>
+#include <sys/mman.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,6 +30,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// IBM Z uses 1 MB huge pages.
+#define HUGE_PAGE_SIZE (1024 * 1024)
 
 /* Interface for device init and shutdown.
  *
@@ -242,6 +246,21 @@ void OMShutdownAccelNNPA() {
     /* Release mutex. */
     pthread_mutex_unlock(&OMMutexForInitShutdownNNPA);
   }
+}
+
+void *OMHugePageMalloc(size_t size) {
+  if (size == 0 || size < HUGE_PAGE_SIZE)
+    return malloc(size);
+
+  void *ptr = NULL;
+  if (posix_memalign(&ptr, HUGE_PAGE_SIZE, size) != 0) {
+    return malloc(size); // Fallback.
+  }
+
+  // Give the kernel the transparent huge page advice.
+  madvise(ptr, size, MADV_HUGEPAGE);
+
+  return ptr;
 }
 
 #ifdef __cplusplus

--- a/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
+++ b/src/Accelerators/NNPA/Runtime/OMRuntimeNNPA.c
@@ -260,7 +260,7 @@ void *OMHugePageMalloc(size_t size) {
     return malloc(size); // Fallback.
 
   // Give the kernel the transparent huge page advice.
-  // It is ok to failed since the memory is still usable but may not use huge
+  // It is ok to fail since the memory is still usable but may not use huge
   // pages.
   madvise(ptr, size, MADV_HUGEPAGE);
 

--- a/src/Accelerators/NNPA/Transform/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Transform/CMakeLists.txt
@@ -12,5 +12,19 @@ add_onnx_mlir_library(OMFoldStdAlloc
   ${NNPA_BIN_ROOT}
    )
 
+add_onnx_mlir_library(OMReplaceMallocByHugePageMalloc
+  ReplaceMallocByHugePageMalloc.cpp
+
+  LINK_LIBS PUBLIC
+  OMSupport
+  MLIRFuncDialect
+  MLIRIR
+  MLIRLLVMDialect
+
+  ACCEL_INCLUDE_DIRS PRIVATE
+  ${NNPA_SRC_ROOT}
+  ${NNPA_BIN_ROOT}
+   )
+
 add_subdirectory(ZHigh)
 add_subdirectory(ZLow)

--- a/src/Accelerators/NNPA/Transform/ReplaceMallocByHugePageMalloc.cpp
+++ b/src/Accelerators/NNPA/Transform/ReplaceMallocByHugePageMalloc.cpp
@@ -1,0 +1,117 @@
+//===-- ReplaceMallocByHugePageMalloc.cpp - Replace malloc ---------------===//
+//
+// Copyright 2026 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This pass replaces llvm.call @malloc with llvm.call @OMHugePageMalloc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "Pass/NNPAPasses.hpp"
+#include "src/Dialect/Mlir/DialectBuilder.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+/// This pass replaces llvm.call @malloc with llvm.call @OMHugePageMalloc.
+///
+/// Example:
+/// The following code:
+///   %0 = llvm.call @malloc(%size) : (i64) -> !llvm.ptr
+///
+/// will be replaced by:
+///   %0 = llvm.call @OMHugePageMalloc(%size) : (i64) -> !llvm.ptr
+
+/// Replace malloc with OMHugePageMalloc.
+class ReplaceMallocPattern : public OpRewritePattern<LLVM::CallOp> {
+public:
+  using OpRewritePattern<LLVM::CallOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(
+      LLVM::CallOp callOp, PatternRewriter &rewriter) const override {
+    Location loc = callOp.getLoc();
+
+    // 1. Match: Check if this is a call to malloc.
+    FlatSymbolRefAttr calleeAttr = callOp.getCalleeAttr();
+    if (!calleeAttr)
+      return failure();
+
+    StringRef calleeName = calleeAttr.getValue();
+    if (calleeName != "malloc")
+      return failure();
+
+    // Verify the signature: (i64) -> !llvm.ptr
+    if (callOp.getNumOperands() != 1)
+      return failure();
+
+    if (callOp.getNumResults() != 1)
+      return failure();
+
+    Value result = callOp.getResult();
+    Type resultType = result.getType();
+    if (!mlir::isa<LLVM::LLVMPointerType>(resultType))
+      return failure();
+
+    // 2. Rewrite: Replace with call to OMHugePageMalloc.
+    LLVMBuilder createLLVM(rewriter, loc);
+    llvm::SmallVector<mlir::Value, 1> operands(
+        callOp.getOperands().begin(), callOp.getOperands().end());
+    Value newCall = createLLVM.call({resultType}, "OMHugePageMalloc", operands);
+
+    rewriter.replaceOp(callOp, newCall);
+
+    return success();
+  }
+};
+
+/*!
+ *  Module pass that replaces malloc with OMHugePageMalloc.
+ */
+class ReplaceMallocByHugePageMallocPass
+    : public PassWrapper<ReplaceMallocByHugePageMallocPass,
+          OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const override {
+    return "replace-malloc-by-hugepage-malloc";
+  }
+
+  StringRef getDescription() const override {
+    return "Replace malloc with OMHugePageMalloc.";
+  }
+
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+
+    // Declare OMHugePageMalloc function if not already present.
+    OpBuilder builder(&getContext());
+    builder.setInsertionPointToStart(moduleOp.getBody());
+    LLVMBuilder createLLVM(builder, moduleOp.getLoc());
+
+    // Get or insert OMHugePageMalloc function declaration.
+    // Signature: (i64) -> !llvm.ptr
+    IntegerType i64Type = IntegerType::get(&getContext(), 64);
+    LLVM::LLVMPointerType ptrType = LLVM::LLVMPointerType::get(&getContext());
+    createLLVM.getOrInsertSymbolRef(
+        moduleOp, "OMHugePageMalloc", ptrType, {i64Type});
+
+    ConversionTarget target(getContext());
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<ReplaceMallocPattern>(&getContext());
+
+    static_cast<void>(applyPatternsGreedily(moduleOp, std::move(patterns)));
+  }
+};
+
+std::unique_ptr<Pass> createReplaceMallocByHugePageMallocPass() {
+  return std::make_unique<ReplaceMallocByHugePageMallocPass>();
+}
+
+} // namespace onnx_mlir

--- a/test/mlir/accelerators/nnpa/transform/replace-malloc-hugepage.mlir
+++ b/test/mlir/accelerators/nnpa/transform/replace-malloc-hugepage.mlir
@@ -1,0 +1,42 @@
+// RUN: onnx-mlir-opt --march=z16 --maccel=NNPA --replace-malloc-by-hugepage-malloc %s -split-input-file | FileCheck %s
+
+llvm.func @malloc(i64) -> !llvm.ptr
+
+// CHECK-LABEL: llvm.func @OMHugePageMalloc(i64) -> !llvm.ptr
+// CHECK-LABEL: func @test_replace_malloc
+func.func @test_replace_malloc(%arg0: i64) -> !llvm.ptr {
+  // CHECK: %[[RES:.*]] = llvm.call @OMHugePageMalloc(%arg0) : (i64) -> !llvm.ptr
+  // CHECK-NOT: llvm.call @malloc
+  %0 = llvm.call @malloc(%arg0) : (i64) -> !llvm.ptr
+  return %0 : !llvm.ptr
+}
+
+// -----
+
+llvm.func @malloc(i64) -> !llvm.ptr
+
+// CHECK-LABEL: llvm.func @OMHugePageMalloc(i64) -> !llvm.ptr
+// CHECK-LABEL: func @test_multiple_malloc
+func.func @test_multiple_malloc(%arg0: i64, %arg1: i64) -> (!llvm.ptr, !llvm.ptr) {
+  // CHECK: %[[RES1:.*]] = llvm.call @OMHugePageMalloc(%arg0) : (i64) -> !llvm.ptr
+  // CHECK: %[[RES2:.*]] = llvm.call @OMHugePageMalloc(%arg1) : (i64) -> !llvm.ptr
+  // CHECK-NOT: llvm.call @malloc
+  %0 = llvm.call @malloc(%arg0) : (i64) -> !llvm.ptr
+  %1 = llvm.call @malloc(%arg1) : (i64) -> !llvm.ptr
+  return %0, %1 : !llvm.ptr, !llvm.ptr
+}
+
+// -----
+
+llvm.func @malloc(i64) -> !llvm.ptr
+llvm.func @free(!llvm.ptr)
+
+// CHECK-LABEL: llvm.func @OMHugePageMalloc(i64) -> !llvm.ptr
+// CHECK-LABEL: func @test_other_calls_unchanged
+func.func @test_other_calls_unchanged(%arg0: i64) -> !llvm.ptr {
+  // CHECK: %[[RES:.*]] = llvm.call @OMHugePageMalloc(%arg0) : (i64) -> !llvm.ptr
+  // CHECK: llvm.call @free(%[[RES]]) : (!llvm.ptr) -> ()
+  %0 = llvm.call @malloc(%arg0) : (i64) -> !llvm.ptr
+  llvm.call @free(%0) : (!llvm.ptr) -> ()
+  return %0 : !llvm.ptr
+}


### PR DESCRIPTION
This PR adds a new compiler pass to control the hugepage malloc optimization for NNPA.
Calls to `malloc` are replaced by calls to `OMHugePageMalloc`, a C function to allocate a buffer with hugepage advice.
Doing experiment with a matmul of `(1,12,4096,64) * (1,12,64,4096)`, hugepage malloc makes the matmul ~5x faster.

Hugepage is enabled by default, but we can disable it by using a new boolean option `--nnpa-disable-hugepage-malloc`