### PR TITLE
[Doc Only] Updated doc for lightweight build

### DIFF
--- a/docs/BuildPyRuntimeLight.md
+++ b/docs/BuildPyRuntimeLight.md
@@ -31,8 +31,9 @@ Assuming you have cloned the onnx-mlir source code and are using a `build` direc
 
 1. **Create a new build directory:**
    ```bash
-   mkdir build-light
-   cd build-light
+   git clone --recursive https://github.com/onnx/onnx-mlir.git
+   mkdir onnx-mlir/build-light
+   cd onnx-mlir/build-light
    ```
 
 2. **Configure and build:**


### PR DESCRIPTION
Checked the latest building of the lightweight onnx-mlir python runtime. Tested every steps, and it works perfectly granted that we do a `git clone --recursive`. I updated the doc accordingly.

Tested instructions: onnx-mlir/docs/BuildPyRuntimeLight.md

Thanks @chentong319 for the new python runtime.