### PR TITLE
Remove unnecessary include of Passes.hpp

### DIFF
--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -28,7 +28,6 @@
 #include "src/Dialect/ONNX/ONNXOps.hpp"
 #include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
 #include "src/Dialect/ONNX/ONNXOps/ShapeHelper.hpp"
-#include "src/Pass/Passes.hpp"
 #include "src/Support/TypeUtilities.hpp"
 
 #define DEBUG_TYPE "dim_analysis"


### PR DESCRIPTION
When I built onnx-mlir from scratch on Mac, I got error for ONNXDimAnalysis.cpp: The KrnlPass.hpp.inc not found. The reason is that the dependency for KrnlPass table gen is not added. The success of build depends on how cmake schedules the tasks. Other than adding the dependency, I tried to remove the include of passes.hpp.