### PR TITLE
Fix the dependency of omDebugHelper

### DIFF
--- a/src/Runtime/CMakeLists.txt
+++ b/src/Runtime/CMakeLists.txt
@@ -87,7 +87,7 @@ add_onnx_mlir_library(OMDebugRuntime
   EXCLUDE_FROM_OM_LIBS
 
   LINK_LIBS PUBLIC
-  cruntime
+  OMTensorUtils
   OMSmallFPConversion
 
   INCLUDE_DIRS PUBLIC

--- a/src/Runtime/OMPyRt.cmake
+++ b/src/Runtime/OMPyRt.cmake
@@ -32,7 +32,7 @@ add_onnx_mlir_library(OMDebugRuntime
   EXCLUDE_FROM_OM_LIBS
 
   LINK_LIBS PUBLIC
-  cruntime
+  OMTensorUtils
   OMSmallFPConversion
 
   INCLUDE_DIRS PUBLIC

--- a/src/Runtime/OMPyRt.cmake
+++ b/src/Runtime/OMPyRt.cmake
@@ -25,6 +25,25 @@ set_target_properties(OMTensorUtils
   POSITION_INDEPENDENT_CODE TRUE
   )
 
+add_onnx_mlir_library(OMDebugRuntime
+  OMTensorHelper.cpp
+  OMTensorListHelper.cpp
+
+  EXCLUDE_FROM_OM_LIBS
+
+  LINK_LIBS PUBLIC
+  cruntime
+  OMSmallFPConversion
+
+  INCLUDE_DIRS PUBLIC
+  OMTensorUtils
+  ${ONNX_MLIR_SRC_ROOT}/include
+  )
+set_target_properties(OMDebugRuntime
+  PROPERTIES
+  POSITION_INDEPENDENT_CODE TRUE
+  )
+
 add_onnx_mlir_library(OMExecutionSession
   ExecutionSession.cpp
 
@@ -32,6 +51,7 @@ add_onnx_mlir_library(OMExecutionSession
 
   LINK_LIBS PUBLIC
   OMTensorUtils
+  OMDebugRuntime
   # Needed?
   OMSmallFPConversion
   )


### PR DESCRIPTION
Two issues:
1. omDebugHelper is not added for OMPyRt build yet.
2. The dependency, cruntime, is too much. Only the OMTensorUtils is needed. The code for op runtime is not needed by driver.