### PR TITLE
Added compile info to profile-ir output

### DIFF
--- a/src/Accelerators/Accelerator.hpp
+++ b/src/Accelerators/Accelerator.hpp
@@ -88,6 +88,11 @@ public:
   /// Version number format: 0x[major][minor][patch]
   virtual uint64_t getVersionNumber() const = 0;
 
+  /// Returns a JSON object string with compile-time accelerator information
+  /// (target level, required library version, etc.). Returns empty string if
+  /// no information is available. Override in each accelerator subclass.
+  virtual std::string getAccelCompileInfo() const { return ""; }
+
   //===--------------------------------------------------------------------===//
   // Hooks for onnx-mlir driver
   //===--------------------------------------------------------------------===//

--- a/src/Accelerators/NNPA/NNPAAccelerator.cpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.cpp
@@ -89,6 +89,17 @@ uint64_t NNPAAccelerator::getVersionNumber() const {
   return NNPA_ZDNN_VERSIONS[NNPALevel::M14];
 }
 
+std::string NNPAAccelerator::getAccelCompileInfo() const {
+  NNPALevel level = isCompatibleWithNNPALevel(NNPALevel::M15) ? NNPALevel::M15
+                                                              : NNPALevel::M14;
+  uint64_t ver = NNPA_ZDNN_VERSIONS[level];
+  std::string zdnnVer = std::to_string((ver >> 16) & 0xFF) + "." +
+                        std::to_string((ver >> 8) & 0xFF) + "." +
+                        std::to_string(ver & 0xFF);
+  return "{\"nnpa_level\": \"" + getNNPAString(level) +
+         "\", \"zdnn_version\": \"" + zdnnVer + "\"}";
+}
+
 void NNPAAccelerator::addPasses(mlir::OwningOpRef<mlir::ModuleOp> &module,
     mlir::PassManager &pm, onnx_mlir::EmissionTargetType &emissionTarget,
     std::string outputNameNoExt) const {

--- a/src/Accelerators/NNPA/NNPAAccelerator.hpp
+++ b/src/Accelerators/NNPA/NNPAAccelerator.hpp
@@ -45,6 +45,7 @@ public:
   static bool classof(const NNPAAccelerator *) { return true; }
 
   uint64_t getVersionNumber() const final;
+  std::string getAccelCompileInfo() const final;
 
   //===--------------------------------------------------------------------===//
   // Hooks for onnx-mlir driver

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -863,10 +863,25 @@ void emitCompilationInfo(ModuleOp &module) {
     }
   }
 
+  // Collect compile-time info from active accelerators.
+  std::string acceleratorsInfo = "{";
+  bool firstAccel = true;
+  for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators()) {
+    std::string info = accel->getAccelCompileInfo();
+    if (info.empty())
+      continue;
+    if (!firstAccel)
+      acceleratorsInfo += ", ";
+    acceleratorsInfo += "\"" + accel->getName() + "\": " + info;
+    firstAccel = false;
+  }
+  acceleratorsInfo += "}";
+
   // Construct the JSON string.
   std::string jsonString = "{\n\"compiler_version\": \"" + compilerVersion +
                            "\",\n\"compile_options\": \"" + compileOptions +
-                           "\",\n\"op_stats\": " + opStats + "}";
+                           "\",\n\"accelerators\": " + acceleratorsInfo +
+                           ",\n\"op_stats\": " + opStats + "}";
 
   LLVM_DEBUG(llvm::dbgs() << "Compilation Info: " << jsonString << "\n");
 

--- a/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
+++ b/src/Conversion/KrnlToLLVM/ConvertKrnlToLLVM.cpp
@@ -829,7 +829,7 @@ void emitDtors(ModuleOp &module, OpBuilder &builder,
 
 /// Emit compilation information by extracting compile options and op stats
 /// from module attributes and constructing a JSON string.
-void emitCompilationInfo(ModuleOp &module) {
+void emitCompilationInfo(ModuleOp &module, bool omitCompileInfo) {
   MLIRContext *context = module.getContext();
   Location loc = module.getLoc();
   OpBuilder b(context);
@@ -838,50 +838,51 @@ void emitCompilationInfo(ModuleOp &module) {
   Type i8Type = IntegerType::get(context, 8);
   Type i8PtrTy = getPointerType(context, i8Type);
 
-  // Get the compiler_info attribute.
-  std::string compilerVersion;
-  if (Attribute compilerVersionAttr =
-          module->getAttr("onnx-mlir.compiler_version")) {
-    if (auto strAttr = mlir::dyn_cast<StringAttr>(compilerVersionAttr)) {
-      compilerVersion = strAttr.getValue().str();
+  // Build the JSON content: full info, or "{}" when omitCompileInfo is set.
+  std::string jsonString = "{}";
+  if (!omitCompileInfo) {
+    // Get the compiler_version attribute.
+    std::string compilerVersion;
+    if (Attribute compilerVersionAttr =
+            module->getAttr("onnx-mlir.compiler_version")) {
+      if (auto strAttr = mlir::dyn_cast<StringAttr>(compilerVersionAttr))
+        compilerVersion = strAttr.getValue().str();
     }
-  }
 
-  // Get the compile_options attribute.
-  std::string compileOptions;
-  if (Attribute compileOptionsAttr =
-          module->getAttr("onnx-mlir.compile_options")) {
-    if (auto strAttr = mlir::dyn_cast<StringAttr>(compileOptionsAttr)) {
-      compileOptions = strAttr.getValue().str();
+    // Get the compile_options attribute.
+    std::string compileOptions;
+    if (Attribute compileOptionsAttr =
+            module->getAttr("onnx-mlir.compile_options")) {
+      if (auto strAttr = mlir::dyn_cast<StringAttr>(compileOptionsAttr))
+        compileOptions = strAttr.getValue().str();
     }
-  }
-  // Get the op_stats attribute.
-  std::string opStats;
-  if (Attribute opStatsAttr = module->getAttr("onnx-mlir.op_stats")) {
-    if (auto strAttr = mlir::dyn_cast<StringAttr>(opStatsAttr)) {
-      opStats = strAttr.getValue().str();
+
+    // Get the op_stats attribute.
+    std::string opStats;
+    if (Attribute opStatsAttr = module->getAttr("onnx-mlir.op_stats")) {
+      if (auto strAttr = mlir::dyn_cast<StringAttr>(opStatsAttr))
+        opStats = strAttr.getValue().str();
     }
-  }
 
-  // Collect compile-time info from active accelerators.
-  std::string acceleratorsInfo = "{";
-  bool firstAccel = true;
-  for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators()) {
-    std::string info = accel->getAccelCompileInfo();
-    if (info.empty())
-      continue;
-    if (!firstAccel)
-      acceleratorsInfo += ", ";
-    acceleratorsInfo += "\"" + accel->getName() + "\": " + info;
-    firstAccel = false;
-  }
-  acceleratorsInfo += "}";
+    // Collect compile-time info from active accelerators.
+    std::string acceleratorsInfo = "{";
+    bool firstAccel = true;
+    for (auto *accel : onnx_mlir::accel::Accelerator::getAccelerators()) {
+      std::string info = accel->getAccelCompileInfo();
+      if (info.empty())
+        continue;
+      if (!firstAccel)
+        acceleratorsInfo += ", ";
+      acceleratorsInfo += "\"" + accel->getName() + "\": " + info;
+      firstAccel = false;
+    }
+    acceleratorsInfo += "}";
 
-  // Construct the JSON string.
-  std::string jsonString = "{\n\"compiler_version\": \"" + compilerVersion +
-                           "\",\n\"compile_options\": \"" + compileOptions +
-                           "\",\n\"accelerators\": " + acceleratorsInfo +
-                           ",\n\"op_stats\": " + opStats + "}";
+    jsonString = "{\n\"compiler_version\": \"" + compilerVersion +
+                 "\",\n\"compile_options\": \"" + compileOptions +
+                 "\",\n\"accelerators\": " + acceleratorsInfo +
+                 ",\n\"op_stats\": " + opStats + "}";
+  }
 
   LLVM_DEBUG(llvm::dbgs() << "Compilation Info: " << jsonString << "\n");
 
@@ -1183,9 +1184,8 @@ void ConvertKrnlToLLVMPass::runOnOperation() {
     });
   }
 
-  // Emit compilation information.
-  if (!omitCompileInfo)
-    emitCompilationInfo(module);
+  // Emit compilation information (always; returns "{}" when omitCompileInfo).
+  emitCompilationInfo(module, omitCompileInfo);
 }
 
 /// Create the pass for lowering `Krnl`, `Affine` and `Std` dialects to LLVM.

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -285,8 +285,7 @@ const std::string ExecutionSession::compilationInfo() const {
   errno = 0; // No errors.
   if (!_compilationInfoFunc)
     return "{}";
-  const char *info = _compilationInfoFunc();
-  return info ? info : "{}";
+  return _compilationInfoFunc();
 }
 
 void ExecutionSession::printInstrumentation() {

--- a/src/Runtime/ExecutionSession.cpp
+++ b/src/Runtime/ExecutionSession.cpp
@@ -285,7 +285,8 @@ const std::string ExecutionSession::compilationInfo() const {
   errno = 0; // No errors.
   if (!_compilationInfoFunc)
     return "{}";
-  return _compilationInfoFunc();
+  const char *info = _compilationInfoFunc();
+  return info ? info : "{}";
 }
 
 void ExecutionSession::printInstrumentation() {

--- a/src/Runtime/OMInstrument.c
+++ b/src/Runtime/OMInstrument.c
@@ -224,11 +224,17 @@ static void ProcessName(
 // =============================================================================
 // Buffer management
 
+// Weak ref: symbol is absent when compiled with --omit-compile-info.
+__attribute__((weak)) const char *omCompilationInfo(void);
+
 static inline void printStartReport() {
   if (!startReportPrinted) {
     assert(instrumentFout); // Error  "expected instrumentInitialized
                             // instrumentFout for reporting".
     fprintf(instrumentFout, "==START-REPORT==\n");
+    if (omCompilationInfo)
+      fprintf(instrumentFout, "==COMPILE-INFO-REPORT==, %s\n",
+          omCompilationInfo());
     startReportPrinted = true;
   }
 }

--- a/src/Runtime/OMInstrument.c
+++ b/src/Runtime/OMInstrument.c
@@ -224,9 +224,9 @@ static void ProcessName(
 // =============================================================================
 // Buffer management
 
-// Declared here; always defined in the model .so by emitCompilationInfo().
-// Returns "{}" when compiled with --omit-compile-info, full JSON otherwise.
-extern const char *omCompilationInfo(void);
+// Weak fallback for unit tests and any context where the model .so is not
+// linked. The model .so always provides a strong override via emitCompilationInfo().
+__attribute__((weak)) const char *omCompilationInfo(void) { return "{}"; }
 
 static inline void printStartReport() {
   if (!startReportPrinted) {

--- a/src/Runtime/OMInstrument.c
+++ b/src/Runtime/OMInstrument.c
@@ -224,17 +224,19 @@ static void ProcessName(
 // =============================================================================
 // Buffer management
 
-// Weak ref: symbol is absent when compiled with --omit-compile-info.
-__attribute__((weak)) const char *omCompilationInfo(void);
+// Weak default: returns NULL when no model .so provides omCompilationInfo
+// (i.e. compiled with --omit-compile-info). The model's strong definition
+// overrides this at link time on all platforms.
+__attribute__((weak)) const char *omCompilationInfo(void) { return NULL; }
 
 static inline void printStartReport() {
   if (!startReportPrinted) {
     assert(instrumentFout); // Error  "expected instrumentInitialized
                             // instrumentFout for reporting".
     fprintf(instrumentFout, "==START-REPORT==\n");
-    if (omCompilationInfo)
-      fprintf(
-          instrumentFout, "==COMPILE-INFO-REPORT==, %s\n", omCompilationInfo());
+    const char *info = omCompilationInfo();
+    if (info)
+      fprintf(instrumentFout, "==COMPILE-INFO-REPORT==, %s\n", info);
     startReportPrinted = true;
   }
 }

--- a/src/Runtime/OMInstrument.c
+++ b/src/Runtime/OMInstrument.c
@@ -224,10 +224,9 @@ static void ProcessName(
 // =============================================================================
 // Buffer management
 
-// Weak default: returns NULL when no model .so provides omCompilationInfo
-// (i.e. compiled with --omit-compile-info). The model's strong definition
-// overrides this at link time on all platforms.
-__attribute__((weak)) const char *omCompilationInfo(void) { return NULL; }
+// Declared here; always defined in the model .so by emitCompilationInfo().
+// Returns "{}" when compiled with --omit-compile-info, full JSON otherwise.
+extern const char *omCompilationInfo(void);
 
 static inline void printStartReport() {
   if (!startReportPrinted) {
@@ -235,7 +234,7 @@ static inline void printStartReport() {
                             // instrumentFout for reporting".
     fprintf(instrumentFout, "==START-REPORT==\n");
     const char *info = omCompilationInfo();
-    if (info)
+    if (info && info[0] != '\0' && !(info[0] == '{' && info[1] == '}'))
       fprintf(instrumentFout, "==COMPILE-INFO-REPORT==, %s\n", info);
     startReportPrinted = true;
   }

--- a/src/Runtime/OMInstrument.c
+++ b/src/Runtime/OMInstrument.c
@@ -233,8 +233,8 @@ static inline void printStartReport() {
                             // instrumentFout for reporting".
     fprintf(instrumentFout, "==START-REPORT==\n");
     if (omCompilationInfo)
-      fprintf(instrumentFout, "==COMPILE-INFO-REPORT==, %s\n",
-          omCompilationInfo());
+      fprintf(
+          instrumentFout, "==COMPILE-INFO-REPORT==, %s\n", omCompilationInfo());
     startReportPrinted = true;
   }
 }

--- a/src/Runtime/OMInstrument.c
+++ b/src/Runtime/OMInstrument.c
@@ -225,7 +225,8 @@ static void ProcessName(
 // Buffer management
 
 // Weak fallback for unit tests and any context where the model .so is not
-// linked. The model .so always provides a strong override via emitCompilationInfo().
+// linked. The model .so always provides a strong override via
+// emitCompilationInfo().
 __attribute__((weak)) const char *omCompilationInfo(void) { return "{}"; }
 
 static inline void printStartReport() {

--- a/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
@@ -7,7 +7,7 @@ module attributes {"onnx-mlir.compile_options" = "test-options", "onnx-mlir.op_s
   }
   "krnl.entry_point"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[in_sig]\00@[out_sig]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22test-options\22,\0A\22op_stats\22: {\22op1\22: 5}}\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22test-options\22,\0A\22accelerators\22: {},\0A\22op_stats\22: {\22op1\22: 5}}\00") {addr_space = 0 : i32}
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
@@ -24,7 +24,7 @@ module attributes {"onnx-mlir.compile_options" = "--tag=test", "onnx-mlir.op_sta
   }
   "krnl.entry_point"() {func = @tagged_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[tagged_in]\00@[tagged_out]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_tag("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22--tag=test\22,\0A\22op_stats\22: {\22onnx.Add\22: 2}}\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_tag("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22--tag=test\22,\0A\22accelerators\22: {},\0A\22op_stats\22: {\22onnx.Add\22: 2}}\00") {addr_space = 0 : i32}
 
 // CHECK:         llvm.func @omCompilationInfo_tag() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json_tag : !llvm.ptr
@@ -46,7 +46,7 @@ module attributes {"onnx-mlir.compile_options" = "-O3 --EmitLib", "onnx-mlir.op_
   }
   "krnl.entry_point"() {func = @test_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[test_in]\00@[test_out]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22-O3 --EmitLib\22,\0A\22op_stats\22: }\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22-O3 --EmitLib\22,\0A\22accelerators\22: {},\0A\22op_stats\22: }\00") {addr_space = 0 : i32}
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
@@ -63,7 +63,7 @@ module {
   }
   "krnl.entry_point"() {func = @simple_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[simple_in]\00@[simple_out]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22\22,\0A\22op_stats\22: }\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22\22,\0A\22accelerators\22: {},\0A\22op_stats\22: }\00") {addr_space = 0 : i32}
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr

--- a/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/compilation_info.mlir
@@ -7,7 +7,11 @@ module attributes {"onnx-mlir.compile_options" = "test-options", "onnx-mlir.op_s
   }
   "krnl.entry_point"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[in_sig]\00@[out_sig]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22test-options\22,\0A\22accelerators\22: {},\0A\22op_stats\22: {\22op1\22: 5}}\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json(
+// CHECK-SAME:      \22compiler_version\22: \22\22
+// CHECK-SAME:      \22compile_options\22: \22test-options\22
+// CHECK-SAME:      \22accelerators\22: {}
+// CHECK-SAME:      \22op_stats\22: {\22op1\22: 5}
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
@@ -24,7 +28,11 @@ module attributes {"onnx-mlir.compile_options" = "--tag=test", "onnx-mlir.op_sta
   }
   "krnl.entry_point"() {func = @tagged_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[tagged_in]\00@[tagged_out]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_tag("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22--tag=test\22,\0A\22accelerators\22: {},\0A\22op_stats\22: {\22onnx.Add\22: 2}}\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_tag(
+// CHECK-SAME:      \22compiler_version\22: \22\22
+// CHECK-SAME:      \22compile_options\22: \22--tag=test\22
+// CHECK-SAME:      \22accelerators\22: {}
+// CHECK-SAME:      \22op_stats\22: {\22onnx.Add\22: 2}
 
 // CHECK:         llvm.func @omCompilationInfo_tag() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json_tag : !llvm.ptr
@@ -46,7 +54,11 @@ module attributes {"onnx-mlir.compile_options" = "-O3 --EmitLib", "onnx-mlir.op_
   }
   "krnl.entry_point"() {func = @test_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[test_in]\00@[test_out]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22-O3 --EmitLib\22,\0A\22accelerators\22: {},\0A\22op_stats\22: }\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json(
+// CHECK-SAME:      \22compiler_version\22: \22\22
+// CHECK-SAME:      \22compile_options\22: \22-O3 --EmitLib\22
+// CHECK-SAME:      \22accelerators\22: {}
+// CHECK-SAME:      \22op_stats\22:
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
@@ -63,7 +75,11 @@ module {
   }
   "krnl.entry_point"() {func = @simple_entry, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[simple_in]\00@[simple_out]\00"} : () -> ()
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{\0A\22compiler_version\22: \22\22,\0A\22compile_options\22: \22\22,\0A\22accelerators\22: {},\0A\22op_stats\22: }\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json(
+// CHECK-SAME:      \22compiler_version\22: \22\22
+// CHECK-SAME:      \22compile_options\22: \22\22
+// CHECK-SAME:      \22accelerators\22: {}
+// CHECK-SAME:      \22op_stats\22:
 
 // CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
 // CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr

--- a/test/mlir/conversion/krnl_to_llvm/compilation_info_omit.mlir
+++ b/test/mlir/conversion/krnl_to_llvm/compilation_info_omit.mlir
@@ -1,0 +1,17 @@
+// RUN: onnx-mlir-opt --convert-krnl-to-llvm="omit-compile-info=true" --canonicalize %s | FileCheck %s
+
+// COM: Test that omCompilationInfo is always emitted, returning "{}" when
+// COM: --omit-compile-info is set.
+module attributes {"onnx-mlir.compile_options" = "test-options", "onnx-mlir.op_stats" = "{\"op1\": 5}"} {
+  func.func private @main_graph(%arg0: memref<10xf32>) -> memref<10xf32> {
+    return %arg0 : memref<10xf32>
+  }
+  "krnl.entry_point"() {func = @main_graph, numInputs = 1 : i32, numOutputs = 1 : i32, signature = "[in_sig]\00@[out_sig]\00"} : () -> ()
+
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json("{}\00") {addr_space = 0 : i32}
+
+// CHECK:         llvm.func @omCompilationInfo() -> !llvm.ptr {
+// CHECK:           [[VAR_0:%.+]] = llvm.mlir.addressof @om_compilation_info_json : !llvm.ptr
+// CHECK:           llvm.return [[VAR_0]] : !llvm.ptr
+// CHECK:         }
+}

--- a/test/mlir/driver/compilation_info.mlir
+++ b/test/mlir/driver/compilation_info.mlir
@@ -8,7 +8,11 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_compilation_info("{\0A\22compiler_version\22: \22onnx-mlir version {{.*}}\22,\0A\22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22,\0A\22accelerators\22: {},\0A\22op_stats\22: {\0A \22func.return.3D\22 : 1,\0A \22onnx.Relu.3D\22 : 1\0A}\0A}\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_compilation_info(
+// CHECK-SAME:      \22compiler_version\22:
+// CHECK-SAME:      \22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22
+// CHECK-SAME:      \22accelerators\22: {}
+// CHECK-SAME:      \22op_stats\22:
 
 // CHECK: llvm.func @omCompilationInfo{{.*}}() -> !llvm.ptr
 // CHECK:   {{.*}} = llvm.mlir.addressof @om_compilation_info_json

--- a/test/mlir/driver/compilation_info.mlir
+++ b/test/mlir/driver/compilation_info.mlir
@@ -8,8 +8,7 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 
-// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_compilation_info("{\0A\22compiler_version\22: \22onnx-mlir version 0.5.1 (c022015e9)\22,\0A\22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22,\0A\22accelerators\22: {},\0A\22op_stats\22: {\0A \22func.return.3D\22 : 1,\0A \22onnx.Relu.3D\22 : 1\0A}\0A}\00") {addr_space = 0 : i32}
-
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_compilation_info("{\0A\22compiler_version\22: \22onnx-mlir version {{.*}}\22,\0A\22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22,\0A\22accelerators\22: {},\0A\22op_stats\22: {\0A \22func.return.3D\22 : 1,\0A \22onnx.Relu.3D\22 : 1\0A}\0A}\00") {addr_space = 0 : i32}
 
 // CHECK: llvm.func @omCompilationInfo{{.*}}() -> !llvm.ptr
 // CHECK:   {{.*}} = llvm.mlir.addressof @om_compilation_info_json

--- a/test/mlir/driver/compilation_info.mlir
+++ b/test/mlir/driver/compilation_info.mlir
@@ -8,7 +8,8 @@ module {
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
 
-// CHECK: llvm.mlir.global internal constant @om_compilation_info_json_compilation_info("{\0A\22compiler_version\22: \22{{.*}}\22,\0A\22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22,\0A\22op_stats\22: {\0A  \22func.return.3D\22 : 1,\0A  \22onnx.Relu.3D\22 : 1\0A}\0A}\00") {addr_space = 0 : i32}
+// CHECK:         llvm.mlir.global internal constant @om_compilation_info_json_compilation_info("{\0A\22compiler_version\22: \22onnx-mlir version 0.5.1 (c022015e9)\22,\0A\22compile_options\22: \22--EmitLLVMIR --printIR compilation_info.mlir\22,\0A\22accelerators\22: {},\0A\22op_stats\22: {\0A \22func.return.3D\22 : 1,\0A \22onnx.Relu.3D\22 : 1\0A}\0A}\00") {addr_space = 0 : i32}
+
 
 // CHECK: llvm.func @omCompilationInfo{{.*}}() -> !llvm.ptr
 // CHECK:   {{.*}} = llvm.mlir.addressof @om_compilation_info_json

--- a/test/mlir/driver/omit-compile-info.mlir
+++ b/test/mlir/driver/omit-compile-info.mlir
@@ -6,7 +6,8 @@ module {
     onnx.Return %0 : tensor<?x?x?xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+
+// CHECK:     om_compilation_info_json{{.*}}("{}\00")
+// CHECK:     llvm.func @omCompilationInfo
 }
 
-// CHECK-NOT: llvm.mlir.global internal constant @om_compilation_info_json
-// CHECK-NOT: llvm.func @omCompilationInfo

--- a/utils/CheckONNXModel.py
+++ b/utils/CheckONNXModel.py
@@ -187,6 +187,20 @@ parser.add_argument(
     " Supported types are bool, uint8, int8, uint16, int16, uint32, int32,"
     " uint64, int64, float16, float32, float64",
 )
+parser.add_argument(
+    "--input-value",
+    type=str,
+    help="Per-input data fill specification, overriding --lower-bound/--upper-bound"
+    " for individual tensors."
+    " Format: INPUT_ID:spec1 spec2 ..., INPUT_ID:spec, ..."
+    " where INPUT_ID is an integer >= 0, a range (e.g. 2-5), or -1 for all inputs,"
+    " and each spec is one of:"
+    " min<num> (lower bound for random fill),"
+    " max<num> (upper bound for random fill),"
+    " val<num> (constant fill, equivalent to min=max=num),"
+    " soz<num> (sequence-of-ones-then-zeros along the innermost dimension)."
+    " E.g. --input-value=0:min-1.0max1.0,1:val0.",
+)
 
 parser.add_argument(
     "--rtol", type=str, default="", help="Relative tolerance for verification."
@@ -312,6 +326,8 @@ def main():
         ref_cmd += ["--lower-bound=" + args.lower_bound]
     if args.upper_bound:
         ref_cmd += ["--upper-bound=" + args.upper_bound]
+    if args.input_value:
+        ref_cmd += ["--input-value=" + args.input_value]
     if args.cache_ref_model:
         ref_cmd += ["--cache-model=" + args.cache_ref_model]
     # Model name.

--- a/utils/make-report.py
+++ b/utils/make-report.py
@@ -641,6 +641,8 @@ def print_compile_info():
         info = json.loads(compile_info_str)
         print("  compiler_version:", info.get("compiler_version", ""))
         print("  compile_options: ", info.get("compile_options", ""))
+        for name, accel_info in info.get("accelerators", {}).items():
+            print("  accelerator", name + ":", accel_info)
     except json.JSONDecodeError:
         print("Compile info:", compile_info_str)
 

--- a/utils/make-report.py
+++ b/utils/make-report.py
@@ -29,6 +29,7 @@
 
 import sys
 import getopt
+import json
 import re
 import numpy as np
 
@@ -133,6 +134,9 @@ plot_names = np.array([])
 plot_values = np.array([])
 plot_x_axis = "time"
 
+# Compilation info from ==COMPILE-INFO-REPORT== (empty string if absent).
+compile_info_str = ""
+
 
 # Basic pattern for reports: "==" <stat name> "==," <op name> "," <node name> ","
 def common_report_str(stat_name):
@@ -141,6 +145,24 @@ def common_report_str(stat_name):
 
 def match_start_report(line):
     return re.match(r"==START-REPORT==", line)
+
+
+def match_compile_info_report(line):
+    m = re.match(r"==COMPILE-INFO-REPORT==,\s*(.*)", line)
+    return m[1].strip() if m else None
+
+
+def collect_multiline_json(first_fragment, file_iter):
+    depth = first_fragment.count('{') - first_fragment.count('}')
+    lines = [first_fragment]
+    while depth > 0:
+        cont = next(file_iter, None)
+        if cont is None:
+            break
+        cont = cont.rstrip()
+        lines.append(cont)
+        depth += cont.count('{') - cont.count('}')
+    return '\n'.join(lines)
 
 
 # ==SIMD-REPORT==, ..., <explanations>, <VL>, <simd-trip-count>
@@ -302,7 +324,7 @@ def get_secondary_key(node_name, details):
 
 def parse_file_for_stat(file_name, stat_name):
     global node_time_dict, node_time_used
-    global report_level, has_timing
+    global report_level, has_timing, compile_info_str
 
     try:
         file = open(file_name, "r")
@@ -320,6 +342,12 @@ def parse_file_for_stat(file_name, stat_name):
             start_count += 1
             if start_count >= 2:
                 break
+
+        # Capture compile info if present (JSON may span multiple lines).
+        info = match_compile_info_report(line)
+        if info is not None and not compile_info_str:
+            compile_info_str = collect_multiline_json(info, file)
+            continue
 
         # Parse line.
         has_stat, op, node_name, details = parse_line(
@@ -349,7 +377,7 @@ def parse_file_for_stat(file_name, stat_name):
 
 def parse_file_for_perf(file_name, stat_name, warmup_num=0):
     global node_time_dict, tot_time
-    global verbose, has_timing, reporting
+    global verbose, has_timing, reporting, compile_info_str
 
     try:
         file = open(file_name, "r")
@@ -382,6 +410,12 @@ def parse_file_for_perf(file_name, stat_name, warmup_num=0):
             if match_start_report(line):
                 has_start = True
                 break  # On to the next measurement.
+
+            # Capture compile info if present (JSON may span multiple lines).
+            info = match_compile_info_report(line)
+            if info is not None and not compile_info_str:
+                compile_info_str = collect_multiline_json(info, file)
+                continue
 
             # Parse line.
             has_stat, op, node_name, details = parse_line(line, report_str, True)
@@ -478,6 +512,7 @@ def make_report(stat_message):
     global op_time_dict, op_detail_time_dict, tot_time
     global has_timing, time_unit, error_missing_time, reporting
     global report_level, supported_only, verbose, min_percent_reporting
+    global compile_info_str
     global sorting_preference
     global plot_names, plot_values, plot_x_axis
 
@@ -597,6 +632,17 @@ def make_report(stat_message):
 
 ################################################################################
 # Print plot.
+
+
+def print_compile_info():
+    if not compile_info_str:
+        return
+    try:
+        info = json.loads(compile_info_str)
+        print("  compiler_version:", info.get("compiler_version", ""))
+        print("  compile_options: ", info.get("compile_options", ""))
+    except json.JSONDecodeError:
+        print("Compile info:", compile_info_str)
 
 
 def output_plot(runtime_file_name, plot_file_name):
@@ -767,15 +813,18 @@ def main(argv):
             + compile_file_name
             + '"'
         )
+        print_compile_info()
         make_report(make_legend)
     elif compile_file_name:
         parse_file_for_stat(compile_file_name, make_stats)
         print('Report using compile file "' + compile_file_name + '"')
+        print_compile_info()
         make_report(make_legend)
     elif runtime_file_name:
         parse_file_for_perf(runtime_file_name, "PERF", warmup_num)
         parse_file_for_stat(runtime_file_name, "PERF")
         print('Report using runtime file "' + runtime_file_name + '"')
+        print_compile_info()
         make_report(make_legend)
     else:
         print_usage("Command requires an input file name (compile/runtime or both).\n")

--- a/utils/make-report.py
+++ b/utils/make-report.py
@@ -153,7 +153,7 @@ def match_compile_info_report(line):
 
 
 def collect_multiline_json(first_fragment, file_iter):
-    depth = first_fragment.count('{') - first_fragment.count('}')
+    depth = first_fragment.count("{") - first_fragment.count("}")
     lines = [first_fragment]
     while depth > 0:
         cont = next(file_iter, None)
@@ -161,8 +161,8 @@ def collect_multiline_json(first_fragment, file_iter):
             break
         cont = cont.rstrip()
         lines.append(cont)
-        depth += cont.count('{') - cont.count('}')
-    return '\n'.join(lines)
+        depth += cont.count("{") - cont.count("}")
+    return "\n".join(lines)
 
 
 # ==SIMD-REPORT==, ..., <explanations>, <VL>, <simd-trip-count>


### PR DESCRIPTION
When doing profiling, users have requested to get some info about the compiler version/options.
I added the call to print this information directly in OMInstrument.c so that the printout info is available regardless of the programming environment (C, C++, python, java).

The new runtime log is now
```
==COMPILE-INFO-REPORT==, {
"compiler_version": "onnx-mlir version 0.5.1 (a78c43f1f)",
"compile_options": "-O3 -march=z17 -maccel=NNPA -profile-ir=ZHigh -o model extended-layout-transform-v1.mlir",
"accelerators": {"NNPA": {"nnpa_level": "--march=arch15", "zdnn_version": "1.1.1"}},
"op_stats": { [...]}
}
```

and I now also report this info in a condensed fashion in `make-report.py`
```
Report using runtime file "bibi.log"
  compiler_version: onnx-mlir version 0.5.1 (a78c43f1f)
  compile_options:  -O3 -march=z17 -maccel=NNPA -profile-ir=ZHigh -o model extended-layout-transform-v1.mlir
  accelerator NNPA: {'nnpa_level': '--march=arch15', 'zdnn_version': '1.1.1'}
[...]
```

Added info about the zDNN version as seen by the compiler.