### PR TITLE
Support ScatterElements reduction="add" lowering

### DIFF
--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -176,7 +176,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **Scaler** |none | | | |
 | **Scan** |8 - * |Does not support dynamic shapes. Does not support int4 and uint4. |Precision issue with newer opset, maybe just unsupported. Dynamic shape?. |
 | **Scatter** |none | | | |
-| **ScatterElements** |11 - * |Does not support duplicate indices. | |
+| **ScatterElements** |11 - * | |Supports reductions `none` and `add`; duplicate indices are supported for `add`. |
 | **ScatterND** |11 - * |Does not support scatternd add/multiply. | |
 | **Selu** |6 - * | | |
 | **SequenceAt** |none | | | |

--- a/docs/SupportedONNXOps-cpu.md
+++ b/docs/SupportedONNXOps-cpu.md
@@ -176,7 +176,7 @@ Onnx-mlir currently supports ONNX operations targeting up to opset 22. Limitatio
 | **Scaler** |none | | | |
 | **Scan** |8 - * |Does not support dynamic shapes. Does not support int4 and uint4. |Precision issue with newer opset, maybe just unsupported. Dynamic shape?. |
 | **Scatter** |none | | | |
-| **ScatterElements** |11 - * | |Supports reductions `none` and `add`; duplicate indices are supported for `add`. |
+| **ScatterElements** |11 - * |Only reductions `none` and `add` are supported; duplicate indices are supported for `add`. | |
 | **ScatterND** |11 - * |Does not support scatternd add/multiply. | |
 | **Selu** |6 - * | | |
 | **SequenceAt** |none | | | |

--- a/src/Conversion/ONNXToKrnl/Tensor/ScatterElements.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ScatterElements.cpp
@@ -30,7 +30,8 @@ struct ONNXScatterElementsOpLowering
     Operation *op = scatterElementsOp.getOperation();
     Location loc = ONNXLoc<ONNXScatterElementsOp>(op);
 
-    MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MemRefBuilder>
+    MultiDialectBuilder<KrnlBuilder, IndexExprBuilderForKrnl, MemRefBuilder,
+        MathBuilder>
         create(rewriter, loc);
 
     // Operands and attributes.
@@ -38,6 +39,12 @@ struct ONNXScatterElementsOpLowering
     Value updates = adaptor.getUpdates();
     Value indices = adaptor.getIndices();
     int64_t axis = adaptor.getAxis();
+    StringRef reduction = scatterElementsOp.getReduction();
+
+    if (reduction != "none" && reduction != "add")
+      return rewriter.notifyMatchFailure(
+          op, "unsupported ScatterElements reduction");
+
     int64_t dataRank = mlir::cast<MemRefType>(data.getType()).getRank();
     int64_t updatesRank = mlir::cast<MemRefType>(updates.getType()).getRank();
     int64_t indicesRank = mlir::cast<MemRefType>(indices.getType()).getRank();
@@ -102,7 +109,13 @@ struct ONNXScatterElementsOpLowering
             outputAccessFct.emplace_back((i == axis) ? index : accessFct[i]);
 
           // Scatter updateVal into the output tensor.
-          createKrnl.storeIE(updateVal, output, outputAccessFct);
+          if (reduction == "add") {
+            Value oldVal = createKrnl.loadIE(output, outputAccessFct);
+            Value newVal = create.math.add(oldVal, updateVal);
+            createKrnl.storeIE(newVal, output, outputAccessFct);
+          } else {
+            createKrnl.storeIE(updateVal, output, outputAccessFct);
+          }
         });
 
     rewriter.replaceOp(op, output);

--- a/src/Conversion/ONNXToKrnl/Tensor/ScatterElements.cpp
+++ b/src/Conversion/ONNXToKrnl/Tensor/ScatterElements.cpp
@@ -114,6 +114,7 @@ struct ONNXScatterElementsOpLowering
             Value newVal = create.math.add(oldVal, updateVal);
             createKrnl.storeIE(newVal, output, outputAccessFct);
           } else {
+            // Previous check guarantees that reduction is "none".
             createKrnl.storeIE(updateVal, output, outputAccessFct);
           }
         });

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -3056,7 +3056,7 @@ def get_test_models():
         "test_scan9_sum_cpu": {STATIC_SHAPE: {}},
         # ==OP== ScatterElements
         # ==MIN== 11
-        # ==LIM== Does not support duplicate indices.
+        # ==LIM== Does not support reductions "max" and "min". Duplicate indices are supported for reduction="add".
         "test_scatter_elements_without_axis_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},
@@ -3072,7 +3072,11 @@ def get_test_models():
             DYNAMIC_SHAPE: {-1: {-1}},
             CONSTANT_INPUT: {-1},
         },
-        # "test_scatter_elements_with_duplicate_indices_cpu": {STATIC_SHAPE:{}, DYNAMIC_SHAPE:{-1:{-1}}, CONSTANT_INPUT:{-1}},
+        "test_scatter_elements_with_duplicate_indices_cpu": {
+            STATIC_SHAPE: {},
+            DYNAMIC_SHAPE: {-1: {-1}},
+            CONSTANT_INPUT: {-1},
+        },
         # ==OP== ScatterND
         # ==MIN== 11
         # ==LIM== Does not support scatternd add/multiply.

--- a/test/backend/inference_backend.py
+++ b/test/backend/inference_backend.py
@@ -3056,7 +3056,7 @@ def get_test_models():
         "test_scan9_sum_cpu": {STATIC_SHAPE: {}},
         # ==OP== ScatterElements
         # ==MIN== 11
-        # ==LIM== Does not support reductions "max" and "min". Duplicate indices are supported for reduction="add".
+        # ==LIM== Only reductions `none` and `add` are supported; duplicate indices are supported for `add`.
         "test_scatter_elements_without_axis_cpu": {
             STATIC_SHAPE: {},
             DYNAMIC_SHAPE: {-1: {-1}},

--- a/test/mlir/conversion/onnx_to_krnl/Tensor/ScatterElements.mlir
+++ b/test/mlir/conversion/onnx_to_krnl/Tensor/ScatterElements.mlir
@@ -46,3 +46,33 @@ func.func @test_scatter_elements1(%arg0: tensor<3x3xf32>, %arg1: tensor<3x2xi64>
 // CHECK-NEXT:      }
 // CHECK:           return [[RES1]], [[RES2]] : memref<3x3xf32>, memref<3x3xf32>
 }
+
+// -----
+
+func.func @test_scatter_elements_add(
+    %arg0: tensor<1x5xf32>,
+    %arg1: tensor<1x2xi64>,
+    %arg2: tensor<1x2xf32>) -> tensor<*xf32> {
+  %0 = "onnx.ScatterElements"(%arg0, %arg1, %arg2) {axis = 1 : si64, reduction = "add"} : (tensor<1x5xf32>, tensor<1x2xi64>, tensor<1x2xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+
+// CHECK-LABEL:  @test_scatter_elements_add
+// CHECK-SAME:   ([[PARAM_0:%.+]]: memref<1x5xf32>, [[PARAM_1:%.+]]: memref<1x2xi64>, [[PARAM_2:%.+]]: memref<1x2xf32>) -> memref<1x5xf32> {
+// CHECK-DAG:       [[RES:%.+]] = memref.alloc() {alignment = 16 : i64} : memref<1x5xf32>
+// CHECK:           "krnl.memcpy"([[RES]], [[PARAM_0]]
+// CHECK:           krnl.iterate
+// CHECK:             [[IV:%.+]]:2 = krnl.get_induction_var_value
+// CHECK-DAG:         [[INDEX:%.+]] = krnl.load [[PARAM_1]]{{.}}[[IV]]#0, [[IV]]#1{{.}} : memref<1x2xi64>
+// CHECK-DAG:         [[UPDATE_VAL:%.+]] = krnl.load [[PARAM_2]]{{.}}[[IV]]#0, [[IV]]#1{{.}} : memref<1x2xf32>
+// CHECK:             [[CAST_INDEX:%.+]] = arith.index_cast [[INDEX]] : i64 to index
+// CHECK-DAG:         [[ZERO:%.+]] = arith.constant 0 : index
+// CHECK-DAG:         [[FIVE:%.+]] = arith.constant 5 : index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[CMP:%.+]] = arith.cmpi slt, [[CAST_INDEX]], [[ZERO]] : index
+// CHECK-DAG:         [[ADDI:%.+]] = arith.addi [[CAST_INDEX]], [[FIVE]] : index
+// CHECK:             [[SEL:%.+]] = arith.select [[CMP]], [[ADDI]], [[CAST_INDEX]] : index
+// CHECK:             [[OLD_VAL:%.+]] = krnl.load [[RES]]{{.}}[[IV]]#0, [[SEL]]{{.}} : memref<1x5xf32>
+// CHECK:             [[NEW_VAL:%.+]] = arith.addf [[OLD_VAL]], [[UPDATE_VAL]] : f32
+// CHECK:             krnl.store [[NEW_VAL]], [[RES]]{{.}}[[IV]]#0, [[SEL]]{{.}} : memref<1x5xf32>
+// CHECK:           return [[RES]] : memref<1x5xf32>
+}


### PR DESCRIPTION
`ScatterElements` with `reduction="add"` was previously accepted, but lowered like `reduction="none"` by directly storing updates. This was incorrect for duplicate indices, where updates should accumulate.

This PR adds the missing add-reduction path while preserving `reduction="none"` and rejecting unsupported reductions.