### PR TITLE
Fix an infinite loop in DimAnalysis

### DIFF
--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -1390,6 +1390,10 @@ void DimAnalysis::propagateOffsetRelations() {
       }
     }
 
+    // Exit if there is no update.
+    if (!updated)
+      break;
+
     // Step 2: Infer equality from matching offsets.
     llvm::SmallVector<std::pair<DimT, DimT>, 4> newEqualities;
 
@@ -1424,8 +1428,7 @@ void DimAnalysis::propagateOffsetRelations() {
       updated = true;
     }
 
-    if (updated)
-      mergeDimSets();
+    mergeDimSets();
   }
 }
 

--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -1425,7 +1425,6 @@ void DimAnalysis::propagateOffsetRelations() {
     // Apply new equalities.
     for (auto &[dim1, dim2] : newEqualities) {
       build(dim2, build(dim1));
-      updated = true;
     }
 
     mergeDimSets();


### PR DESCRIPTION
Fix an infinite loop in DimAnalysis that makes the following model failed to compile:

- bertsquad-10
- bertsquad-12
- bertsquad-12-int8
- tiny-yolov3-11
- tiny-yolov3-10
- tiny-yolov3-12
- tiny-yolov4 