### PR TITLE
Install openblas in the LLVM image for pytorch

### DIFF
--- a/docker/Dockerfile.llvm-project
+++ b/docker/Dockerfile.llvm-project
@@ -33,7 +33,7 @@ RUN distro=$(cat /etc/os-release|grep -Po '(?<=^ID=").*(?=")|(?<=^ID=)[^"].*[^"]
                   libtool make maven ninja-build python3 python3-dev \
                   python3-pip \
                   python3-setuptools python3-typing-extensions \
-                  unzip zip zlib1g-dev && \       
+                  unzip zip zlib1g-dev libopenblas0 && \
           # Use upgrade setuptools to latest which accepts plain string license
           # format due to onnx. Instead of installing pytest-xdist and numpy from apt-get,
           # install them with pip to avoid version conflicts. Ubuntu Noble ships numpy 1.26.4
@@ -56,7 +56,7 @@ RUN distro=$(cat /etc/os-release|grep -Po '(?<=^ID=").*(?=")|(?<=^ID=)[^"].*[^"]
               file java-21-devel gcc gcc-c++ git libtool make ncurses-devel ninja-build \
               # FIX: Use python3.11 instead of python39 to satisfy ONNX >= 3.10 requirement
               python3.11 python3.11-devel python3.11-pip python3.11-setuptools python3.11-wheel \
-              tzdata-java unzip which zip zlib-devel && \
+              tzdata-java unzip which zip zlib-devel openblas && \
           # Create pip3 symlink if it doesn't exist, or update it to use python3.11
           ln -sf /usr/bin/python3.11 /usr/bin/python3 && \
           ln -sf /usr/bin/pip3.11 /usr/bin/pip3 && \


### PR DESCRIPTION
This PR adds openblas into the llvm-project image to prepare for torch_onnxmlir in #3565.