### PR TITLE
added new pattern of dim -> [seqeeze] -> range for dim analysis

### DIFF
--- a/src/Dialect/ONNX/ONNXDimAnalysis.cpp
+++ b/src/Dialect/ONNX/ONNXDimAnalysis.cpp
@@ -1316,6 +1316,35 @@ void DimAnalysis::visitDim(
       }
     }
   }
+
+  // RangeOp has a special case: when start == 0 and delta == 1 (scalar
+  // constants), the number of elements in the output is exactly `limit`,
+  // since num = max(ceil((limit-start)/delta), 0) = max(limit, 0). If `limit`
+  // is (possibly via a Squeeze) the result of a Dim on some tensor, that
+  // tensor's dimension is never negative, so the output dimension is the same
+  // as that source dimension.
+  if (auto rangeOp = mlir::dyn_cast<ONNXRangeOp>(op)) {
+    Value startVal = rangeOp.getStart();
+    Value limitVal = rangeOp.getLimit();
+    Value deltaVal = rangeOp.getDelta();
+
+    auto startConstOp = startVal.getDefiningOp<ONNXConstantOp>();
+    auto deltaConstOp = deltaVal.getDefiningOp<ONNXConstantOp>();
+    if (startConstOp && deltaConstOp &&
+        getScalarValue<int64_t>(startConstOp) == 0 &&
+        getScalarValue<int64_t>(deltaConstOp) == 1) {
+      Value v = limitVal;
+      if (auto squeezeOp = v.getDefiningOp<ONNXSqueezeOp>())
+        v = squeezeOp.getData();
+      if (auto dimOp = v.getDefiningOp<ONNXDimOp>()) {
+        if (auto d =
+                insertDimWhenUseful(dimOp.getData(), dimOp.getAxis(), sameDims))
+          LLVM_DEBUG(llvm::dbgs()
+                     << "  - [Range] Added a new dim(" << d.value().first
+                     << ", " << d.value().second << ")\n");
+      }
+    }
+  }
 }
 
 // Propagate offset relationships using a fixed-point iteration algorithm.

--- a/test/mlir/onnx/onnx_dim_analysis.mlir
+++ b/test/mlir/onnx/onnx_dim_analysis.mlir
@@ -688,3 +688,31 @@ func.func @test_dim_offset(%arg0: tensor<1x4x?x64xf32> {onnx.dim_params = "2:dim
 // CHECK:           onnx.Return [[VAR_14_]] : tensor<1x4x4x?x64xf32>
 // CHECK:         }
 }
+
+// -----
+
+// COM: Testing the case of "Range(0, Squeeze(Dim(X, axis)), 1)", where the
+// COM: output dimension of Range must be the same as dim(X, axis).
+func.func @test_range_from_dim(%arg0: tensor<?x?xi64>) -> tensor<?xi64> {
+  %start = onnx.Constant dense<0> : tensor<i64>
+  %delta = onnx.Constant dense<1> : tensor<i64>
+  %axis = onnx.Constant dense<0> : tensor<1xi64>
+  %dim = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
+  %limit = "onnx.Squeeze"(%dim, %axis) : (tensor<1xi64>, tensor<1xi64>) -> tensor<i64>
+  %0 = "onnx.Range"(%start, %limit, %delta) : (tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<?xi64>
+  return %0 : tensor<?xi64>
+
+// CHECK-LABEL:  func.func @test_range_from_dim
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x?xi64>) -> tensor<?xi64> {
+// CHECK-DAG:       "onnx.DimGroup"([[PARAM_0_]]) <{axis = 0 : si64, group_id = [[GROUP_0_:.*]] : si64}> : (tensor<?x?xi64>) -> ()
+// CHECK-DAG:       "onnx.DimGroup"([[PARAM_0_]]) <{axis = 1 : si64, group_id = [[GROUP_1_:.*]] : si64}> : (tensor<?x?xi64>) -> ()
+// CHECK-DAG:       [[VAR_0_:%.+]] = onnx.Constant dense<0> : tensor<i64>
+// CHECK-DAG:       [[VAR_1_:%.+]] = onnx.Constant dense<1> : tensor<i64>
+// CHECK-DAG:       [[VAR_2_:%.+]] = onnx.Constant dense<0> : tensor<1xi64>
+// CHECK-DAG:       [[VAR_3_:%.+]] = "onnx.Dim"([[PARAM_0_]]) <{axis = 1 : si64}> : (tensor<?x?xi64>) -> tensor<1xi64>
+// CHECK:           [[VAR_4_:%.+]] = "onnx.Squeeze"([[VAR_3_]], [[VAR_2_]]) : (tensor<1xi64>, tensor<1xi64>) -> tensor<i64>
+// CHECK:           [[VAR_5_:%.+]] = "onnx.Range"([[VAR_0_]], [[VAR_4_]], [[VAR_1_]]) : (tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<?xi64>
+// CHECK:           "onnx.DimGroup"([[VAR_5_]]) <{axis = 0 : si64, group_id = [[GROUP_1_]] : si64}> : (tensor<?xi64>) -> ()
+// CHECK:           return [[VAR_5_]] : tensor<?xi64>
+// CHECK:         }
+}


### PR DESCRIPTION
In some models, I find `onnx.range` operations that create a range of `0..dim(x, axis=x) by 1`. So when that is the case, we know the shape of the output tensor of range.

It caught 4 of the 5 such pattern in Granite 4.

example pattern:
```mlir
func.func @test_range_from_dim(%arg0: tensor<?x?xi64>) -> tensor<?xi64> {
  %start = onnx.Constant dense<0> : tensor<i64>
  %delta = onnx.Constant dense<1> : tensor<i64>
  %axis = onnx.Constant dense<0> : tensor<1xi64>
  %dim = "onnx.Dim"(%arg0) {axis = 1 : si64} : (tensor<?x?xi64>) -> tensor<1xi64>
  %limit = "onnx.Squeeze"(%dim, %axis) : (tensor<1xi64>, tensor<1xi64>) -> tensor<i64>
  %0 = "onnx.Range"(%start, %limit, %delta) : (tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<?xi64>
  return %0 : tensor<?xi64>
}
```

Added lit test for the new pattern.