### PR TITLE
zos issue and rustc issue

### DIFF
--- a/docker/Dockerfile.llvm-project
+++ b/docker/Dockerfile.llvm-project
@@ -98,8 +98,8 @@ RUN curl -sL ${BAZEL_URL}/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-dist.zip \
     && cd .. && rm -rf bazel-${BAZEL_VERSION} ${HOME}/.cache
 
 # Install rust, cargo, and cargo-bazel
-ARG RUST_VERSION=1.89
-ARG CARGO_BAZEL_VERSION=0.16.0
+ARG RUST_VERSION=1.96
+ARG CARGO_BAZEL_VERSION=0.18.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --default-toolchain none \
     && . "${HOME}/.cargo/env" \

--- a/src/Runtime/OMInstrument.c
+++ b/src/Runtime/OMInstrument.c
@@ -231,7 +231,7 @@ static void ProcessName(
 static bool perfCounterEnabled = false;
 static int perfCounterCount = 0;
 
-#ifdef __s390x__
+#if defined(__s390x__) && !defined(__MVS__)
 #define _GNU_SOURCE
 #include <linux/hw_breakpoint.h> /* Definition of HW_* constants */
 #include <linux/perf_event.h>    /* Definition of PERF_* constants */


### PR DESCRIPTION
fix zos compile issue due to missing header file on zos hw_breakpoint.h - side-effect of the pr: https://github.com/onnx/onnx-mlir/pull/3570 
update rustc and cargo-bazel due to new updates in rustc