### PR TITLE
Update FrontendDialectTransformer.cpp

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -1586,10 +1586,43 @@ bool ImportFrontendModelInternal(onnx::ModelProto &model, MLIRContext &context,
   // ToFix: the shape-inference-pattern should be added and used in Importer.
 
   // Did not do downward convert because support for BatchNorm is missing
-  if (options.invokeOnnxVersionConverter &&
-      originVersion < CURRENT_ONNX_OPSET) {
-    onnx::ModelProto convertModel =
-        onnx::version_conversion::ConvertVersion(model, CURRENT_ONNX_OPSET);
+ if (options.invokeOnnxVersionConverter &&
+    originVersion < CURRENT_ONNX_OPSET) {
+  // CVE guard: Gemm 7→6 adapter reads B_shape[1] / A_shape[0] / A_shape[1]
+  // without bounds checking. Reject any model where a Gemm input A or B has
+  // a known rank < 2 before calling ConvertVersion().
+  const onnx::GraphProto &graph = model.graph();
+  std::unordered_map<std::string, const onnx::TypeProto *> typeMap;
+  for (const auto &vi : graph.input())
+    typeMap[vi.name()] = &vi.type();
+  for (const auto &vi : graph.value_info())
+    typeMap[vi.name()] = &vi.type();
+  std::unordered_map<std::string, int> initRankMap;
+  for (const auto &t : graph.initializer())
+    initRankMap[t.name()] = t.dims_size();
+
+  for (const auto &node : graph.node()) {
+    if (node.op_type() != "Gemm")
+      continue;
+    for (int idx = 0; idx < 2 && idx < node.input_size(); ++idx) {
+      const std::string &name = node.input(idx);
+      auto it = typeMap.find(name);
+      if (it != typeMap.end()) {
+        const onnx::TypeProto &tp = *it->second;
+        if (tp.value_case() == onnx::TypeProto::kTensorType &&
+            tp.tensor_type().has_shape() &&
+            tp.tensor_type().shape().dim_size() < 2)
+          return false;
+        continue;
+      }
+      auto iit = initRankMap.find(name);
+      if (iit != initRankMap.end() && iit->second < 2)
+        return false;
+    }
+  }
+
+  onnx::ModelProto convertModel =
+      onnx::version_conversion::ConvertVersion(model, CURRENT_ONNX_OPSET);
     if (options.useOnnxModelTypes)
       onnx::shape_inference::InferShapes(convertModel);
     ImportFrontendModel(convertModel, context, module, options);
@@ -1612,7 +1645,10 @@ int ImportFrontendModelArray(const void *onnxBuffer, int size,
     *errorMessage = "Unable to parse onnxBuffer";
     return InvalidOnnxFormat;
   }
-  ImportFrontendModelInternal(model, context, module, options);
+    if (!ImportFrontendModelInternal(model, context, module, options)) {
+    *errorMessage = "Onnx Model Import Failed";
+    return CompilerFailure;
+  }
   return CompilerSuccess;
 }
 


### PR DESCRIPTION
fix(importer): reject Gemm inputs with rank < 2 before version conversion (CVE-2026-63632)

The ONNX Gemm 7→6 adapter (gemm_7_6.h:41) reads B_shape[1] without a bounds check, causing a heap-buffer-overflow READ when a Gemm input has fewer than 2 dimensions.

Changes:
- ImportFrontendModelInternal: before calling ConvertVersion(), walk graph nodes and return false if any Gemm input A or B has a known rank < 2, preventing the unsafe adapter from being reached.
- ImportFrontendModelArray: check the bool return of ImportFrontendModelInternal and propagate CompilerFailure instead of silently ignoring it.