### PR TITLE
[NNPA] NNPAPlacementReporter Instrumentation Pass to report heavy CPU ops when compiling for NNPA

### DIFF
--- a/src/Accelerators/NNPA/Compiler/CMakeLists.txt
+++ b/src/Accelerators/NNPA/Compiler/CMakeLists.txt
@@ -41,6 +41,7 @@ add_onnx_mlir_library(OMNNPACompilerOptions
 add_onnx_mlir_library(OMNNPACompilerUtils
   NNPACompilerUtils.cpp
   ZHighDisposableGarbageCollector.cpp
+  NNPAPlacementReporter.cpp
 
   EXCLUDE_FROM_OM_LIBS
 

--- a/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPACompilerUtils.cpp
@@ -33,6 +33,7 @@
 
 #include "src/Accelerators/NNPA/Compiler/NNPACompilerOptions.hpp"
 #include "src/Accelerators/NNPA/Compiler/NNPACompilerUtils.hpp"
+#include "src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.hpp"
 #include "src/Accelerators/NNPA/Compiler/ZHighDisposableGarbageCollector.hpp"
 #include "src/Accelerators/NNPA/Dialect/ZHigh/ZHighOps.hpp"
 #include "src/Accelerators/NNPA/Dialect/ZLow/ZLowOps.hpp"
@@ -299,6 +300,12 @@ void addPassesNNPA(mlir::OwningOpRef<mlir::ModuleOp> &module,
         optLevel = OptLevel::O2;
       else if (optStr == "-O3")
         optLevel = OptLevel::O3;
+      // Add instrumentation to print NNPA placement information before
+      // convert-onnx-to-krnl. Currently reports ONNX operations that will run
+      // on CPU (not accelerated by NNPA).
+      pm.addInstrumentation(
+          std::make_unique<onnx_mlir::zhigh::NNPAPlacementReporter>(
+              pm.getContext()));
       // Lower ONNX to Krnl, ZHigh to ZLow.
       addONNXToKrnlPasses(pm, optLevel, /*enableCSE*/ true, ONNXOpStats);
       // Optimizations at ZLow that needs affine map in MemRef.

--- a/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.cpp
@@ -41,25 +41,43 @@ void NNPAPlacementReporter::runBeforePass(Pass *pass, Operation *op) {
   if (!moduleOp)
     return;
 
-  // Helper lambda to count and report operations.
-  auto reportOp = [&](auto opType, const char *opName) {
+  // Helper lambda to count operations.
+  auto countOp = [&](auto opType) {
     int count = 0;
     moduleOp.walk([&](decltype(opType) op) { count++; });
-    if (count > 0)
-      llvm::outs() << "[Warning] There are " << count << " onnx." << opName
-                   << " operations that run on CPU.\n";
+    return count;
   };
 
-  // Report heavy ONNX operations that will run on CPU (alphabetical order).
-  reportOp(mlir::ONNXConvOp(), "Conv");
-  reportOp(mlir::ONNXGemmOp(), "Gemm");
-  reportOp(mlir::ONNXGRUOp(), "GRU");
-  reportOp(mlir::ONNXLSTMOp(), "LSTM");
-  reportOp(mlir::ONNXMatMulOp(), "MatMul");
-  reportOp(mlir::ONNXMatMulIntegerOp(), "MatMulInteger");
-  reportOp(mlir::ONNXQLinearMatMulOp(), "QLinearMatMul");
-  reportOp(mlir::ONNXRNNOp(), "RNN");
-  reportOp(mlir::ONNXSoftmaxOp(), "Softmax");
+  // Count heavy ONNX operations that will run on CPU (alphabetical order).
+  std::vector<std::pair<int, const char *>> opCounts;
+  opCounts.push_back({countOp(mlir::ONNXConvOp()), "Conv"});
+  opCounts.push_back({countOp(mlir::ONNXGemmOp()), "Gemm"});
+  opCounts.push_back({countOp(mlir::ONNXGRUOp()), "GRU"});
+  opCounts.push_back({countOp(mlir::ONNXLSTMOp()), "LSTM"});
+  opCounts.push_back({countOp(mlir::ONNXMatMulOp()), "MatMul"});
+  opCounts.push_back({countOp(mlir::ONNXMatMulIntegerOp()), "MatMulInteger"});
+  opCounts.push_back({countOp(mlir::ONNXQLinearMatMulOp()), "QLinearMatMul"});
+  opCounts.push_back({countOp(mlir::ONNXRNNOp()), "RNN"});
+  opCounts.push_back({countOp(mlir::ONNXSoftmaxOp()), "Softmax"});
+
+  // Build consolidated warning message.
+  std::vector<std::string> opStrings;
+  for (const auto &pair : opCounts) {
+    if (pair.first > 0) {
+      opStrings.push_back(std::to_string(pair.first) + " onnx." + pair.second);
+    }
+  }
+
+  // Print single consolidated warning if any operations run on CPU.
+  if (!opStrings.empty()) {
+    llvm::outs() << "[Warning] There are ";
+    for (size_t i = 0; i < opStrings.size(); ++i) {
+      llvm::outs() << opStrings[i];
+      if (i < opStrings.size() - 1)
+        llvm::outs() << ", ";
+    }
+    llvm::outs() << " operations that run on CPU (not accelerated by NNPA).\n";
+  }
 }
 
 } // namespace zhigh

--- a/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------------------- NNPAPlacementReporter.cpp -----------------------===//
+//
+// Copyright 2026 The IBM Research Authors.
+//
+// =============================================================================
+//
+// Instrumentation pass that reports ONNX operations running on CPU.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.hpp"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+namespace zhigh {
+
+NNPAPlacementReporter::NNPAPlacementReporter(MLIRContext *context) {}
+
+NNPAPlacementReporter::~NNPAPlacementReporter() {}
+
+void NNPAPlacementReporter::runBeforePass(Pass *pass, Operation *op) {
+  // Get the pass name (argument).
+  llvm::StringRef passName = pass->getName();
+
+  // Check if this is the FrontendToKrnlLoweringPass (convert-onnx-to-krnl).
+  if (!passName.contains("FrontendToKrnlLoweringPass"))
+    return;
+
+  // Check if the operation is a ModuleOp.
+  mlir::ModuleOp moduleOp = mlir::dyn_cast<mlir::ModuleOp>(op);
+  if (!moduleOp)
+    return;
+
+  // Helper lambda to count and report operations.
+  auto reportOp = [&](auto opType, const char *opName) {
+    int count = 0;
+    moduleOp.walk([&](decltype(opType) op) { count++; });
+    if (count > 0)
+      llvm::outs() << "[Warning] There are " << count << " onnx." << opName
+                   << " operations that run on CPU.\n";
+  };
+
+  // Report heavy ONNX operations that will run on CPU (alphabetical order).
+  reportOp(mlir::ONNXConvOp(), "Conv");
+  reportOp(mlir::ONNXGemmOp(), "Gemm");
+  reportOp(mlir::ONNXGRUOp(), "GRU");
+  reportOp(mlir::ONNXLSTMOp(), "LSTM");
+  reportOp(mlir::ONNXMatMulOp(), "MatMul");
+  reportOp(mlir::ONNXMatMulIntegerOp(), "MatMulInteger");
+  reportOp(mlir::ONNXQLinearMatMulOp(), "QLinearMatMul");
+  reportOp(mlir::ONNXRNNOp(), "RNN");
+  reportOp(mlir::ONNXSoftmaxOp(), "Softmax");
+}
+
+} // namespace zhigh
+} // namespace onnx_mlir

--- a/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.cpp
@@ -78,7 +78,8 @@ void NNPAPlacementReporter::runBeforePass(Pass *pass, Operation *op) {
     }
     llvm::outs()
         << " operations that run on CPU (not accelerated by NNPA). To get more "
-           "information, recompile the model with the --onnx-op-stats option.\n";
+           "information, recompile the model with the --onnx-op-stats "
+           "option.\n";
   }
 }
 

--- a/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.cpp
+++ b/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.cpp
@@ -76,7 +76,9 @@ void NNPAPlacementReporter::runBeforePass(Pass *pass, Operation *op) {
       if (i < opStrings.size() - 1)
         llvm::outs() << ", ";
     }
-    llvm::outs() << " operations that run on CPU (not accelerated by NNPA).\n";
+    llvm::outs()
+        << " operations that run on CPU (not accelerated by NNPA). To get more "
+           "information, recompile the model with the --onnx-op-stats option.\n";
   }
 }
 

--- a/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.hpp
+++ b/src/Accelerators/NNPA/Compiler/NNPAPlacementReporter.hpp
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------------------- NNPAPlacementReporter.hpp -----------------------===//
+//
+// Copyright 2026 The IBM Research Authors.
+//
+// =============================================================================
+//
+// Instrumentation pass that reports ONNX operations running on CPU.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ONNX_MLIR_NNPA_PLACEMENT_REPORTER_H
+#define ONNX_MLIR_NNPA_PLACEMENT_REPORTER_H
+
+#include "mlir/Pass/PassInstrumentation.h"
+
+namespace mlir {
+class MLIRContext;
+}
+
+namespace onnx_mlir {
+namespace zhigh {
+
+struct NNPAPlacementReporter : public mlir::PassInstrumentation {
+  NNPAPlacementReporter(mlir::MLIRContext *context);
+  ~NNPAPlacementReporter() override;
+
+  void runBeforePass(mlir::Pass *pass, mlir::Operation *op) override;
+};
+
+} // namespace zhigh
+} // namespace onnx_mlir
+#endif

--- a/src/Runtime/python/torch_onnxmlir/src/torch_onnxmlir/backend.py
+++ b/src/Runtime/python/torch_onnxmlir/src/torch_onnxmlir/backend.py
@@ -668,7 +668,7 @@ class TorchONNXMLIR:
         return constant_values
 
     def export_gm_to_onnx(self, example_inputs):
-        model_name = self.default_model_name + str(self.tag) + ".onnx"
+        model_name = self.default_model_name + ".onnx"
         self.onnx_model = os.path.join(self.workdir.name, model_name)
         input_names, dynamic_shapes = self.build_dynamic_shapes_for_export()
 
@@ -703,7 +703,7 @@ class TorchONNXMLIR:
         return succeeded
 
     def cleanup_onnxmlir_files(self, tag_id):
-        base = os.path.join(self.workdir.name, self.default_model_name + str(tag_id))
+        base = os.path.join(self.workdir.name, self.default_model_name)
         old_files = [base + ext for ext in ONNX_FILE_EXTS + OM_COMPILED_FILE_EXTS]
         for f in old_files:
             if os.path.exists(f):

--- a/src/Runtime/python/torch_onnxmlir/src/torch_onnxmlir/sessioncache.py
+++ b/src/Runtime/python/torch_onnxmlir/src/torch_onnxmlir/sessioncache.py
@@ -91,7 +91,7 @@ class SessionCache:
                 continue
             model_dir = os.path.join(self.cache_path, key)
             # Create an inference session.
-            model_so = os.path.join(model_dir, f"model{key}.so")
+            model_so = os.path.join(model_dir, f"model.so")
             if Path(model_so).exists():
                 sess = InferenceSession(model_so, tag=key)
             else:

--- a/test/mlir/accelerators/nnpa/driver/nnpa-placement-reporter.mlir
+++ b/test/mlir/accelerators/nnpa/driver/nnpa-placement-reporter.mlir
@@ -1,5 +1,7 @@
 // RUN: onnx-mlir --march=z16 --maccel=NNPA --printIR --EmitMLIR %s 2>&1 | FileCheck %s
 
+// CHECK: [Warning] There are 1 onnx.Conv, 1 onnx.Gemm, 1 onnx.GRU, 1 onnx.LSTM, 1 onnx.MatMul, 1 onnx.MatMulInteger, 1 onnx.QLinearMatMul, 1 onnx.Softmax operations that run on CPU (not accelerated by NNPA).
+
 module {
 
 // Conv with dynamic shape - runs on CPU (dynamic shapes not supported)
@@ -8,14 +10,12 @@ func.func @test_conv_cpu(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<64x3x3x3xf32>
   %0 = "onnx.Conv"(%arg0, %arg1, %none) <{auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]}> : (tensor<?x?x?x?xf32>, tensor<64x3x3x3xf32>, none) -> tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
 }
-// CHECK: [Warning] There are 1 onnx.Conv operations that run on CPU.
 
 // Gemm with dimension exceeding limit (32769 > 32768) - runs on CPU
 func.func @test_gemm_cpu(%arg0: tensor<32769x20xf32>, %arg1: tensor<20x30xf32>, %arg2: tensor<30xf32>) -> tensor<32769x30xf32> {
   %0 = "onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.0 : f32, beta = 1.0 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<32769x20xf32>, tensor<20x30xf32>, tensor<30xf32>) -> tensor<32769x30xf32>
   return %0 : tensor<32769x30xf32>
 }
-// CHECK: [Warning] There are 1 onnx.Gemm operations that run on CPU.
 
 // GRU with dimension exceeding limit (32769 > 32768) - runs on CPU
 func.func @test_gru_cpu(%arg0: tensor<7x32769x204xf32>, %arg1: tensor<1x600x204xf32>, %arg2: tensor<1x600x200xf32>, %arg3: tensor<1x1200xf32>) -> tensor<7x1x32769x200xf32> {
@@ -23,7 +23,6 @@ func.func @test_gru_cpu(%arg0: tensor<7x32769x204xf32>, %arg1: tensor<1x600x204x
   %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %arg3, %none, %none) {activations = ["Sigmoid", "Tanh"], direction = "forward", hidden_size = 200 : si64, linear_before_reset = 1 : si64} : (tensor<7x32769x204xf32>, tensor<1x600x204xf32>, tensor<1x600x200xf32>, tensor<1x1200xf32>, none, none) -> (tensor<7x1x32769x200xf32>, tensor<1x32769x200xf32>)
   return %Y : tensor<7x1x32769x200xf32>
 }
-// CHECK: [Warning] There are 1 onnx.GRU operations that run on CPU.
 
 // LSTM with dimension exceeding limit (32769 > 32768) - runs on CPU
 func.func @test_lstm_cpu(%arg0: tensor<7x32769x204xf32>, %arg1: tensor<1x800x204xf32>, %arg2: tensor<1x800x200xf32>, %arg3: tensor<1x1600xf32>) -> tensor<7x1x32769x200xf32> {
@@ -31,34 +30,29 @@ func.func @test_lstm_cpu(%arg0: tensor<7x32769x204xf32>, %arg1: tensor<1x800x204
   %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %arg3, %none, %none, %none, %none) {activations = ["Sigmoid", "Tanh", "Tanh"], direction = "forward", hidden_size = 200 : si64} : (tensor<7x32769x204xf32>, tensor<1x800x204xf32>, tensor<1x800x200xf32>, tensor<1x1600xf32>, none, none, none, none) -> (tensor<7x1x32769x200xf32>, tensor<1x32769x200xf32>, tensor<1x32769x200xf32>)
   return %Y : tensor<7x1x32769x200xf32>
 }
-// CHECK: [Warning] There are 1 onnx.LSTM operations that run on CPU.
 
 // MatMul with 4D broadcasting - runs on CPU (not supported by NNPA)
 func.func @test_matmul_cpu(%arg0: tensor<2x1x10x20xf32>, %arg1: tensor<2x3x20x30xf32>) -> tensor<2x3x10x30xf32> {
   %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<2x1x10x20xf32>, tensor<2x3x20x30xf32>) -> tensor<2x3x10x30xf32>
   return %0 : tensor<2x3x10x30xf32>
 }
-// CHECK: [Warning] There are 1 onnx.MatMul operations that run on CPU.
 
 // MatMulInteger with dimension exceeding limit (32769 > 32768) - runs on CPU
 func.func @test_matmulinteger_cpu(%arg0: tensor<32769x768xui8>, %arg1: tensor<768x768xi8>, %arg2: tensor<ui8>, %arg3: tensor<i8>) -> tensor<32769x768xi32> {
   %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<32769x768xui8>, tensor<768x768xi8>, tensor<ui8>, tensor<i8>) -> tensor<32769x768xi32>
   return %0 : tensor<32769x768xi32>
 }
-// CHECK: [Warning] There are 1 onnx.MatMulInteger operations that run on CPU.
 
 // QLinearMatMul with dimension exceeding limit (32769 > 32768) - runs on CPU
 func.func @test_qlinearmatmul_cpu(%arg0: tensor<32769x4xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>, %arg3: tensor<4x3xi8>, %arg4: tensor<f32>, %arg5: tensor<i8>, %arg6: tensor<f32>, %arg7: tensor<i8>) -> tensor<32769x3xi8> {
   %0 = "onnx.QLinearMatMul"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7) : (tensor<32769x4xi8>, tensor<f32>, tensor<i8>, tensor<4x3xi8>, tensor<f32>, tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<32769x3xi8>
   return %0 : tensor<32769x3xi8>
 }
-// CHECK: [Warning] There are 1 onnx.QLinearMatMul operations that run on CPU.
 
 // Softmax with dimension exceeding limit (32769 > 32768) - runs on CPU
 func.func @test_softmax_cpu(%arg0: tensor<32769x10xf32>) -> tensor<32769x10xf32> {
   %0 = "onnx.Softmax"(%arg0) {axis = 1 : si64} : (tensor<32769x10xf32>) -> tensor<32769x10xf32>
   return %0 : tensor<32769x10xf32>
 }
-// CHECK: [Warning] There are 1 onnx.Softmax operations that run on CPU.
 
 }

--- a/test/mlir/accelerators/nnpa/driver/nnpa-placement-reporter.mlir
+++ b/test/mlir/accelerators/nnpa/driver/nnpa-placement-reporter.mlir
@@ -1,6 +1,6 @@
 // RUN: onnx-mlir --march=z16 --maccel=NNPA --printIR --EmitMLIR %s 2>&1 | FileCheck %s
 
-// CHECK: [Warning] There are 1 onnx.Conv, 1 onnx.Gemm, 1 onnx.GRU, 1 onnx.LSTM, 1 onnx.MatMul, 1 onnx.MatMulInteger, 1 onnx.QLinearMatMul, 1 onnx.Softmax operations that run on CPU (not accelerated by NNPA).
+// CHECK: [Warning] There are 1 onnx.Conv, 1 onnx.Gemm, 1 onnx.GRU, 1 onnx.LSTM, 1 onnx.MatMul, 1 onnx.MatMulInteger, 1 onnx.QLinearMatMul, 1 onnx.Softmax operations that run on CPU (not accelerated by NNPA). To get more information, recompile the model with the --onnx-op-stats option.
 
 module {
 

--- a/test/mlir/accelerators/nnpa/driver/nnpa-placement-reporter.mlir
+++ b/test/mlir/accelerators/nnpa/driver/nnpa-placement-reporter.mlir
@@ -1,0 +1,64 @@
+// RUN: onnx-mlir --march=z16 --maccel=NNPA --printIR --EmitMLIR %s 2>&1 | FileCheck %s
+
+module {
+
+// Conv with dynamic shape - runs on CPU (dynamic shapes not supported)
+func.func @test_conv_cpu(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<64x3x3x3xf32>) -> tensor<?x?x?x?xf32> {
+  %none = "onnx.NoValue"() <{value}> : () -> none
+  %0 = "onnx.Conv"(%arg0, %arg1, %none) <{auto_pad = "NOTSET", dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]}> : (tensor<?x?x?x?xf32>, tensor<64x3x3x3xf32>, none) -> tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+}
+// CHECK: [Warning] There are 1 onnx.Conv operations that run on CPU.
+
+// Gemm with dimension exceeding limit (32769 > 32768) - runs on CPU
+func.func @test_gemm_cpu(%arg0: tensor<32769x20xf32>, %arg1: tensor<20x30xf32>, %arg2: tensor<30xf32>) -> tensor<32769x30xf32> {
+  %0 = "onnx.Gemm"(%arg0, %arg1, %arg2) {alpha = 1.0 : f32, beta = 1.0 : f32, transA = 0 : si64, transB = 0 : si64} : (tensor<32769x20xf32>, tensor<20x30xf32>, tensor<30xf32>) -> tensor<32769x30xf32>
+  return %0 : tensor<32769x30xf32>
+}
+// CHECK: [Warning] There are 1 onnx.Gemm operations that run on CPU.
+
+// GRU with dimension exceeding limit (32769 > 32768) - runs on CPU
+func.func @test_gru_cpu(%arg0: tensor<7x32769x204xf32>, %arg1: tensor<1x600x204xf32>, %arg2: tensor<1x600x200xf32>, %arg3: tensor<1x1200xf32>) -> tensor<7x1x32769x200xf32> {
+  %none = "onnx.NoValue"() <{value}> : () -> none
+  %Y, %Y_h = "onnx.GRU"(%arg0, %arg1, %arg2, %arg3, %none, %none) {activations = ["Sigmoid", "Tanh"], direction = "forward", hidden_size = 200 : si64, linear_before_reset = 1 : si64} : (tensor<7x32769x204xf32>, tensor<1x600x204xf32>, tensor<1x600x200xf32>, tensor<1x1200xf32>, none, none) -> (tensor<7x1x32769x200xf32>, tensor<1x32769x200xf32>)
+  return %Y : tensor<7x1x32769x200xf32>
+}
+// CHECK: [Warning] There are 1 onnx.GRU operations that run on CPU.
+
+// LSTM with dimension exceeding limit (32769 > 32768) - runs on CPU
+func.func @test_lstm_cpu(%arg0: tensor<7x32769x204xf32>, %arg1: tensor<1x800x204xf32>, %arg2: tensor<1x800x200xf32>, %arg3: tensor<1x1600xf32>) -> tensor<7x1x32769x200xf32> {
+  %none = "onnx.NoValue"() <{value}> : () -> none
+  %Y, %Y_h, %Y_c = "onnx.LSTM"(%arg0, %arg1, %arg2, %arg3, %none, %none, %none, %none) {activations = ["Sigmoid", "Tanh", "Tanh"], direction = "forward", hidden_size = 200 : si64} : (tensor<7x32769x204xf32>, tensor<1x800x204xf32>, tensor<1x800x200xf32>, tensor<1x1600xf32>, none, none, none, none) -> (tensor<7x1x32769x200xf32>, tensor<1x32769x200xf32>, tensor<1x32769x200xf32>)
+  return %Y : tensor<7x1x32769x200xf32>
+}
+// CHECK: [Warning] There are 1 onnx.LSTM operations that run on CPU.
+
+// MatMul with 4D broadcasting - runs on CPU (not supported by NNPA)
+func.func @test_matmul_cpu(%arg0: tensor<2x1x10x20xf32>, %arg1: tensor<2x3x20x30xf32>) -> tensor<2x3x10x30xf32> {
+  %0 = "onnx.MatMul"(%arg0, %arg1) : (tensor<2x1x10x20xf32>, tensor<2x3x20x30xf32>) -> tensor<2x3x10x30xf32>
+  return %0 : tensor<2x3x10x30xf32>
+}
+// CHECK: [Warning] There are 1 onnx.MatMul operations that run on CPU.
+
+// MatMulInteger with dimension exceeding limit (32769 > 32768) - runs on CPU
+func.func @test_matmulinteger_cpu(%arg0: tensor<32769x768xui8>, %arg1: tensor<768x768xi8>, %arg2: tensor<ui8>, %arg3: tensor<i8>) -> tensor<32769x768xi32> {
+  %0 = "onnx.MatMulInteger"(%arg0, %arg1, %arg2, %arg3) : (tensor<32769x768xui8>, tensor<768x768xi8>, tensor<ui8>, tensor<i8>) -> tensor<32769x768xi32>
+  return %0 : tensor<32769x768xi32>
+}
+// CHECK: [Warning] There are 1 onnx.MatMulInteger operations that run on CPU.
+
+// QLinearMatMul with dimension exceeding limit (32769 > 32768) - runs on CPU
+func.func @test_qlinearmatmul_cpu(%arg0: tensor<32769x4xi8>, %arg1: tensor<f32>, %arg2: tensor<i8>, %arg3: tensor<4x3xi8>, %arg4: tensor<f32>, %arg5: tensor<i8>, %arg6: tensor<f32>, %arg7: tensor<i8>) -> tensor<32769x3xi8> {
+  %0 = "onnx.QLinearMatMul"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7) : (tensor<32769x4xi8>, tensor<f32>, tensor<i8>, tensor<4x3xi8>, tensor<f32>, tensor<i8>, tensor<f32>, tensor<i8>) -> tensor<32769x3xi8>
+  return %0 : tensor<32769x3xi8>
+}
+// CHECK: [Warning] There are 1 onnx.QLinearMatMul operations that run on CPU.
+
+// Softmax with dimension exceeding limit (32769 > 32768) - runs on CPU
+func.func @test_softmax_cpu(%arg0: tensor<32769x10xf32>) -> tensor<32769x10xf32> {
+  %0 = "onnx.Softmax"(%arg0) {axis = 1 : si64} : (tensor<32769x10xf32>) -> tensor<32769x10xf32>
+  return %0 : tensor<32769x10xf32>
+}
+// CHECK: [Warning] There are 1 onnx.Softmax operations that run on CPU.
+
+}


### PR DESCRIPTION
It is often the case that users compile a model for NNPA and find that the speedup is not good as expected. In many cases, it is because heavy ops such as MatMul are still on CPU. This PR tries to print out a warning for such a situation.

This PR introduces the `NNPAPlacementReporter`, a new instrumentation pass that reports heavy ONNX operations running on CPU instead of being accelerated by NNPA. The pass runs before the `FrontendToKrnlLoweringPass` (convert-onnx-to-krnl) and identifies 9 types of computationally intensive operations: Conv, Gemm, GRU, LSTM, MatMul, MatMulInteger, QLinearMatMul, RNN, and Softmax. When these operations cannot be accelerated by NNPA (due to unsupported configurations like dynamic shapes, dimension limits, or broadcasting patterns), the pass emits warning messages to help developers identify performance bottlenecks.

Example Output

```bash
$ onnx-mlir -O3 -march=z16 -maccel=NNPA model.mlir -o test
[1/6] Mon Aug  3 21:58:40 2026 (0s) Importing ONNX Model to MLIR Module from "model.mlir"
[2/6] Mon Aug  3 21:58:40 2026 (0s) Compiling and Optimizing MLIR Module
[Warning] There are 5 onnx.MatMul, 1 onnx.Softmax operations that run on CPU (not accelerated by NNPA).
To get more information, recompile the model with the --onnx-op-stats option.
[3/6] Mon Aug  3 21:58:40 2026 (0s) Translating MLIR Module to LLVM and Generating LLVM Optimized Bitcode
[4/6] Mon Aug  3 21:58:41 2026 (1s) Generating Object from LLVM Bitcode
[5/6] Mon Aug  3 21:58:41 2026 (1s) Linking and Generating the Output Shared Library
[6/6] Mon Aug  3 21:58:41 2026 (1s) Compilation completed. Generated "test.so"
```

This output indicates that the model contains 3 operations that will run on CPU instead of NNPA acceleration, allowing developers to optimize their models accordingly.