### PR TITLE
[torch_onnxmlir] Use reshape to handle non-contiguous tensors

### DIFF
--- a/src/Runtime/python/torch_onnxmlir/src/torch_onnxmlir/backend.py
+++ b/src/Runtime/python/torch_onnxmlir/src/torch_onnxmlir/backend.py
@@ -281,7 +281,7 @@ def generate_hash_key(
                         if t is not None and isinstance(t, torch.nn.Parameter):
                             sample_values = [
                                 str(s)
-                                for s in t.view(-1)[
+                                for s in t.reshape(-1)[
                                     : config.sample_parameter_values_limit
                                 ].tolist()
                             ]


### PR DESCRIPTION
This is to fix a bug when running [clip-vit-base](https://huggingface.co/openai/clip-vit-base-patch32) model in torch_onnxmlir:

```shell
  File "/usr/local/lib/python3.12/dist-packages/torch_onnxmlir/backend.py", line 284, in generate_hash_key
    for s in t.view(-1)[
             ^^^^^^^^^^
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```
The error happened when creating a hash from an FX graph, so it doesn't affect the inference performance.

With this PR, we can run the clip-vit-base model using torch_om.