### PR TITLE
Add support for lowering onnx.Add to Linalg dialect

### DIFF
--- a/src/Conversion/ONNXToLinalg/CMakeLists.txt
+++ b/src/Conversion/ONNXToLinalg/CMakeLists.txt
@@ -7,6 +7,7 @@ add_public_tablegen_target(OMONNXToLinalgPassIncGen)
 add_onnx_mlir_library(OMONNXToLinalg
   ConvertONNXToLinalg.cpp
   Math/MatMul.cpp
+  Math/Add.cpp 
   NN/Conv.cpp
   ONNXBufferizableOpInterface.cpp
 

--- a/src/Conversion/ONNXToLinalg/ConvertONNXToLinalg.cpp
+++ b/src/Conversion/ONNXToLinalg/ConvertONNXToLinalg.cpp
@@ -55,6 +55,8 @@ struct ConvertONNXToLinalgPass
         patterns, typeConverter, context, linalgOps, useLinalgPath);
     populateLoweringONNXConvOpToLinalgPattern(
         patterns, typeConverter, context, linalgOps, useLinalgPath);
+    populateLoweringONNXAddOpToLinalgPattern(
+        patterns, typeConverter, context, linalgOps, useLinalgPath);
 
     // Apply patterns greedily
     GreedyRewriteConfig config;

--- a/src/Conversion/ONNXToLinalg/Math/Add.cpp
+++ b/src/Conversion/ONNXToLinalg/Math/Add.cpp
@@ -1,0 +1,109 @@
+//===--- Add.cpp - Lowering ONNX Add Op to Linalg -------------------===//
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lowers `onnx.Add` into tensor-based `linalg.generic`.
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/Support/Debug.h"
+
+#include "src/Conversion/ONNXToLinalg/ONNXToLinalgCommon.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+
+using namespace mlir;
+using namespace onnx_mlir;
+
+namespace onnx_mlir {
+
+struct ONNXAddOpLoweringToLinalg : public OpRewritePattern<ONNXAddOp> {
+  ONNXAddOpLoweringToLinalg(
+      MLIRContext *ctx, const std::string &linalgOps, bool useLinalgPath)
+      : OpRewritePattern<ONNXAddOp>(ctx), linalgOps(linalgOps),
+        useLinalgPath(useLinalgPath) {}
+
+  LogicalResult matchAndRewrite(
+      ONNXAddOp addOp, PatternRewriter &rewriter) const final {
+    Operation *op = addOp.getOperation();
+    if (!shouldConvertToLinalg(op, linalgOps, useLinalgPath))
+      return rewriter.notifyMatchFailure(
+          addOp, "operation not selected for Linalg conversion");
+
+    ONNXAddOpAdaptor adaptor(addOp);
+    Value lhs = adaptor.getA();
+    Value rhs = adaptor.getB();
+
+    Location loc = addOp.getLoc();
+
+    auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+    auto outTy = dyn_cast<RankedTensorType>(addOp.getType());
+
+    if (!lhsTy || !rhsTy || !outTy)
+      return rewriter.notifyMatchFailure(addOp, "expected ranked tensor types");
+
+    // no broadcasting yet.
+    if (lhsTy.getShape() != rhsTy.getShape())
+      return rewriter.notifyMatchFailure(
+          addOp, "no broadcasting supported yet");
+
+    if (lhsTy.getElementType() != rhsTy.getElementType())
+      return rewriter.notifyMatchFailure(addOp, "mismatched element types");
+
+    // only elementwise float/int right now.
+    Type elemTy = outTy.getElementType();
+    bool isFloat = isa<FloatType>(elemTy);
+    bool isInt = isa<IntegerType>(elemTy);
+    if (!isFloat && !isInt)
+      return rewriter.notifyMatchFailure(addOp, "unsupported element type");
+
+    Value empty = tensor::EmptyOp::create(
+        rewriter, loc, outTy.getShape(), outTy.getElementType());
+
+    int64_t rank = outTy.getRank();
+
+    AffineMap idMap =
+        AffineMap::getMultiDimIdentityMap(rank, rewriter.getContext());
+    SmallVector<AffineMap> indexingMaps{idMap, idMap, idMap};
+
+    SmallVector<utils::IteratorType> iteratorTypes(
+        rank, utils::IteratorType::parallel);
+
+    auto generic = linalg::GenericOp::create(rewriter, loc, TypeRange{outTy},
+        ValueRange{lhs, rhs}, ValueRange{empty}, indexingMaps, iteratorTypes,
+        [&](OpBuilder &b, Location bodyLoc, ValueRange blockArgs) {
+          Value lhsElem = blockArgs[0];
+          Value rhsElem = blockArgs[1];
+
+          Value sum;
+          if (isFloat) {
+            sum = arith::AddFOp::create(b, bodyLoc, lhsElem, rhsElem);
+          } else {
+            sum = arith::AddIOp::create(b, bodyLoc, lhsElem, rhsElem);
+          }
+
+          linalg::YieldOp::create(b, bodyLoc, sum);
+        });
+
+    rewriter.replaceOp(addOp, generic.getResult(0));
+    return success();
+  }
+
+private:
+  std::string linalgOps;
+  bool useLinalgPath;
+};
+
+void populateLoweringONNXAddOpToLinalgPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx,
+    const std::string &linalgOps, bool useLinalgPath) {
+  (void)typeConverter;
+  patterns.add<ONNXAddOpLoweringToLinalg>(ctx, linalgOps, useLinalgPath);
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToLinalg/ONNXToLinalgCommon.hpp
+++ b/src/Conversion/ONNXToLinalg/ONNXToLinalgCommon.hpp
@@ -82,6 +82,10 @@ void populateLoweringONNXMatMulOpToLinalgPattern(
     mlir::RewritePatternSet &patterns, mlir::TypeConverter &typeConverter,
     mlir::MLIRContext *ctx, const std::string &linalgOps, bool useLinalgPath);
 
+void populateLoweringONNXAddOpToLinalgPattern(mlir::RewritePatternSet &patterns,
+    mlir::TypeConverter &typeConverter, mlir::MLIRContext *ctx,
+    const std::string &linalgOps, bool useLinalgPath);
+
 // NN operations
 void populateLoweringONNXConvOpToLinalgPattern(
     mlir::RewritePatternSet &patterns, mlir::TypeConverter &typeConverter,

--- a/test/mlir/conversion/onnx_to_linalg/Math/Add.mlir
+++ b/test/mlir/conversion/onnx_to_linalg/Math/Add.mlir
@@ -1,0 +1,25 @@
+// RUN: onnx-mlir-opt --convert-onnx-to-linalg='linalg-ops=onnx.Add' %s -split-input-file | FileCheck %s
+
+// -----
+// Same-shape ranked tensors should lower.
+func.func @test_add_same_shape(%arg0: tensor<2x3xf32>, %arg1: tensor<2x3xf32>)
+    -> tensor<2x3xf32> {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<2x3xf32>, tensor<2x3xf32>) -> tensor<2x3xf32>
+  return %0 : tensor<2x3xf32>
+
+  // CHECK-LABEL: test_add_same_shape
+  // CHECK: linalg.generic
+}
+
+// -----
+// Broadcasting not supported initially: mismatched shapes should stay ONNX.
+func.func @test_add_reject_broadcast(%arg0: tensor<2x3xf32>, %arg1: tensor<1x3xf32>)
+    -> tensor<2x3xf32> {
+  %0 = "onnx.Add"(%arg0, %arg1) : (tensor<2x3xf32>, tensor<1x3xf32>) -> tensor<2x3xf32>
+  return %0 : tensor<2x3xf32>
+
+  // CHECK-LABEL: test_add_reject_broadcast
+  // CHECK-NOT: linalg.generic
+  // CHECK: "onnx.Add"
+}
+


### PR DESCRIPTION
## Summary
Implements lowering of onnx.Add operations to linalg.generic operations.
## Details
- Supports ranked tensors with static shapes
- Supports both float and integer element types
- No broadcasting support in initial implementation
## Testing
- Test cases cover same-shape tensor addition (converts to linalg.generic)
- Test cases cover mismatched shapes rejection (stays as onnx.Add)