### PR TITLE
[ONNX] Disable type-unsafe Cast transpose fusion

### DIFF
--- a/CAST_TEST/README.md
+++ b/CAST_TEST/README.md
@@ -1,0 +1,147 @@
+# Transpose-Cast-Transpose canonicalization reproducer
+
+This directory demonstrates why the existing `FuseTransposeAndCastPattern`
+cannot remain enabled without fixing its result-type construction. Commit
+`b6d6a0e243b7b9c2c716c8d01b87e537f53353f9` disables it. The comparison uses
+these source states:
+
+- before-equivalent source: `86a2a80f11718f72d122d153ace7bbd103446a44`
+- after/source-only parent: `b6d6a0e243b7b9c2c716c8d01b87e537f53353f9`
+- LLVM/MLIR: `1053047a4be7d1fece3adaf5e7597f838058c947`
+- build: Release, x86-64 CPU target, `-O0`
+
+The bug is target-independent and occurs during shared ONNX canonicalization,
+before ONNX-to-Krnl, Krnl-to-Affine, and Krnl-to-LLVM lowering. These artifacts
+exercise the CPU pipeline; they prove the shared source bug, not NPU integration.
+
+## Test case
+
+`transpose_cast_transpose.mlir` contains:
+
+```text
+tensor<1x2x3x4xf32>
+  -> Transpose [0, 2, 3, 1]
+  -> Cast f32 to i64
+  -> Transpose [0, 2, 3, 1]
+  -> tensor<1x4x2x3xi64>
+```
+
+The two permutations compose to `[0, 3, 1, 2]`, not identity. This keeps the
+fused Transpose visible in the dumped invalid IR.
+
+## Root cause and result
+
+The old TableGen rule rewrites:
+
+```text
+Transpose(Cast(Transpose(v), to=i64))
+  -> Transpose(Cast(v, to=i64, resultType=returnType(v)))
+```
+
+`returnType(v)` retains the original `f32` element type. The actual before
+IR in `before.invalid-canonicalized.onnx.mlir` therefore contains:
+
+```mlir
+%0 = "onnx.Cast"(%arg0) <{saturate = 1 : si64, to = i64}>
+    : (tensor<1x2x3x4xf32>) -> tensor<1x2x3x4xf32>
+```
+
+This is invalid: an ONNX Cast with `to = i64` must produce an `i64`
+element type. Verification fails with:
+
+```text
+'onnx.Cast' op element type does not match the 'to' attribute
+```
+
+Consequently, the normal verified before pipeline fails before emitting LLVM
+IR. This is the expected comparison result, not a missing artifact.
+
+After the source change, canonicalization preserves the valid
+Transpose-Cast-Transpose chain. Full lowering succeeds, and both LLVM forms
+contain the required conversion:
+
+```text
+llvm.fptosi ... : f32 to i64  # after.onnx.mlir
+fptosi float ... to i64       # after.ll
+```
+
+## Artifacts
+
+| File | Meaning |
+| --- | --- |
+| `transpose_cast_transpose.mlir` | Valid ONNX dialect input |
+| `before.invalid-canonicalized.onnx.mlir` | Actual malformed before IR, emitted with verification disabled |
+| `before.canonicalize.stderr.txt` | Before canonicalization verifier failure, exit 1 |
+| `before.lowering.stderr.txt` | Before full-lowering failure, exit 14 |
+| `after.canonicalized.onnx.mlir` | Valid chain preserved after the fix |
+| `canonicalization.diff` | Focused before/after canonicalization comparison |
+| `after.onnx.mlir` | LLVM dialect MLIR emitted after the fix |
+| `after.ll` | Textual LLVM IR emitted after the fix |
+
+## Commands
+
+The build was configured with:
+
+```bash
+LLVM_BUILD=/home/eunsangson/Project_2/llvm-project/build
+
+cmake -S . -B build-cast-test -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMLIR_DIR="$LLVM_BUILD/lib/cmake/mlir" \
+  -DLLVM_DIR="$LLVM_BUILD/lib/cmake/llvm" \
+  -DCMAKE_C_COMPILER=/usr/bin/cc \
+  -DCMAKE_CXX_COMPILER=/usr/bin/c++
+
+cmake --build build-cast-test \
+  --target onnx-mlir onnx-mlir-opt -j 16
+```
+
+The after artifacts were produced with:
+
+```bash
+build-cast-test/Release/bin/onnx-mlir-opt \
+  --canonicalize --verify-each \
+  CAST_TEST/transpose_cast_transpose.mlir \
+  -o CAST_TEST/after.canonicalized.onnx.mlir
+
+build-cast-test/Release/bin/onnx-mlir \
+  --EmitLLVMIR -O0 --omit-compile-info \
+  CAST_TEST/transpose_cast_transpose.mlir \
+  -o CAST_TEST/after
+
+"$LLVM_BUILD/bin/mlir-translate" \
+  --mlir-to-llvmir CAST_TEST/after.onnx.mlir \
+  -o CAST_TEST/after.ll
+```
+
+For the before run, HEAD remained `b6d6a0e`, but only the three deleted source
+lines were restored. The two relevant source files were then byte-for-byte
+equivalent to `86a2a80`, as verified against `HEAD^` before rebuilding:
+
+```bash
+git diff --exit-code HEAD^ -- \
+  src/Dialect/ONNX/ONNXOps/Canonicalize.cpp \
+  src/Dialect/ONNX/ONNXOps/Canonicalize.td
+
+cmake --build build-cast-test \
+  --target onnx-mlir onnx-mlir-opt -j 16
+
+build-cast-test/Release/bin/onnx-mlir-opt \
+  --canonicalize --verify-each=false \
+  CAST_TEST/transpose_cast_transpose.mlir \
+  -o CAST_TEST/before.invalid-canonicalized.onnx.mlir
+```
+
+The same command with `--verify-each` fails with exit 1. The full
+`onnx-mlir --EmitLLVMIR` run fails with exit 14 before creating an output
+file. The temporary source restoration was then removed, and the tracked
+source files were verified clean against `HEAD`.
+
+## Why both source files change
+
+- `Canonicalize.cpp` stops registering the unsafe rewrite at runtime.
+- `Canonicalize.td` removes the unsafe generated pattern definition.
+
+Removing only the TableGen definition would leave the C++ registration
+referring to a nonexistent pattern. Removing only the C++ registration would
+disable the behavior but leave dead, unsafe generated code behind.

--- a/CAST_TEST/after.canonicalized.onnx.mlir
+++ b/CAST_TEST/after.canonicalized.onnx.mlir
@@ -1,0 +1,9 @@
+module {
+  func.func @main_graph(%arg0: tensor<1x2x3x4xf32>) -> tensor<1x4x2x3xi64> {
+    %0 = "onnx.Transpose"(%arg0) <{perm = [0, 2, 3, 1]}> : (tensor<1x2x3x4xf32>) -> tensor<1x3x4x2xf32>
+    %1 = "onnx.Cast"(%0) <{saturate = 1 : si64, to = i64}> : (tensor<1x3x4x2xf32>) -> tensor<1x3x4x2xi64>
+    %2 = "onnx.Transpose"(%1) <{perm = [0, 2, 3, 1]}> : (tensor<1x3x4x2xi64>) -> tensor<1x4x2x3xi64>
+    onnx.Return %2 : tensor<1x4x2x3xi64>
+  }
+  "onnx.EntryPoint"() <{func = @main_graph}> : () -> ()
+}

--- a/CAST_TEST/after.ll
+++ b/CAST_TEST/after.ll
@@ -1,0 +1,513 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@om_compilation_info_json_after = internal constant [3 x i8] c"{}\00"
+@"om_Wrong size for the dimension 3 of the input 0: expect 4, but got %lld\0A_after" = internal constant [70 x i8] c"Wrong size for the dimension 3 of the input 0: expect 4, but got %lld\0A", align 16
+@"om_Wrong size for the dimension 2 of the input 0: expect 3, but got %lld\0A_after" = internal constant [70 x i8] c"Wrong size for the dimension 2 of the input 0: expect 3, but got %lld\0A", align 16
+@"om_Wrong size for the dimension 1 of the input 0: expect 2, but got %lld\0A_after" = internal constant [70 x i8] c"Wrong size for the dimension 1 of the input 0: expect 2, but got %lld\0A", align 16
+@"om_Wrong size for the dimension 0 of the input 0: expect 1, but got %lld\0A_after" = internal constant [70 x i8] c"Wrong size for the dimension 0 of the input 0: expect 1, but got %lld\0A", align 16
+@"om_Wrong rank for the input 0: expect 4, but got %lld\0A_after" = internal constant [51 x i8] c"Wrong rank for the input 0: expect 4, but got %lld\0A", align 16
+@"om_Wrong data type for the input 0: expect f32\0A_after" = internal constant [44 x i8] c"Wrong data type for the input 0: expect f32\0A", align 16
+@"om_Wrong number of input tensors: expect 1, but got %lld\0A_after" = internal constant [54 x i8] c"Wrong number of input tensors: expect 1, but got %lld\0A", align 16
+@_entry_point_1_after = constant [21 x i8] c"run_main_graph_after\00"
+@_entry_point_1_in_sig_after = constant [75 x i8] c"[    { \22type\22 : \22f32\22 , \22dims\22 : [1 , 2 , 3 , 4] , \22name\22 : \22input_0\22 }\0A\0A]\00"
+@_entry_point_1_out_sig_after = constant [75 x i8] c"[   { \22type\22 : \22i64\22 , \22dims\22 : [1 , 4 , 2 , 3] , \22name\22 : \22output_0\22 }\0A\0A]\00"
+@_entry_point_0_after = constant [15 x i8] c"run_main_graph\00"
+@_entry_point_0_in_sig_after = constant [75 x i8] c"[    { \22type\22 : \22f32\22 , \22dims\22 : [1 , 2 , 3 , 4] , \22name\22 : \22input_0\22 }\0A\0A]\00"
+@_entry_point_0_out_sig_after = constant [75 x i8] c"[   { \22type\22 : \22i64\22 , \22dims\22 : [1 , 4 , 2 , 3] , \22name\22 : \22output_0\22 }\0A\0A]\00"
+@_entry_point_arrays_after = internal constant [3 x ptr] [ptr @_entry_point_0_after, ptr @_entry_point_1_after, ptr null]
+
+declare i32 @strncmp(ptr, ptr, i64)
+
+declare void @printf(ptr, ...)
+
+declare ptr @__errno_location()
+
+declare void @omGetExternalConstantAddr(ptr, ptr, i64)
+
+declare i1 @omUnloadConstantData(ptr, i64)
+
+declare i1 @omLoadConstantData(ptr, ptr, i64, i64)
+
+declare i64 @omTensorListGetSize(ptr)
+
+declare void @omTensorPrint(ptr, ptr)
+
+declare ptr @omTensorListGetOmtArray(ptr)
+
+declare void @omTensorSetDataType(ptr, i64)
+
+declare i64 @omTensorGetDataType(ptr)
+
+declare ptr @omTensorGetStrides(ptr)
+
+declare ptr @omTensorGetShape(ptr)
+
+declare i64 @omTensorGetRank(ptr)
+
+declare void @omTensorSetDataPtr(ptr, i64, ptr, ptr)
+
+declare ptr @omTensorGetDataPtr(ptr)
+
+declare void @omTensorDestroy(ptr)
+
+declare ptr @omTensorCreateUntyped(i64)
+
+declare ptr @omTensorListCreate(ptr, i64)
+
+declare void @free(ptr)
+
+declare ptr @malloc(i64)
+
+define { ptr, ptr, i64, [4 x i64], [4 x i64] } @main_graph_after(ptr %0, ptr %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9, i64 %10) {
+  %12 = call ptr @malloc(i64 112)
+  %13 = ptrtoint ptr %12 to i64
+  %14 = add i64 %13, 15
+  %15 = urem i64 %14, 16
+  %16 = sub i64 %14, %15
+  %17 = inttoptr i64 %16 to ptr
+  br label %18
+
+18:                                               ; preds = %49, %11
+  %19 = phi i64 [ %50, %49 ], [ 0, %11 ]
+  %20 = icmp slt i64 %19, 3
+  br i1 %20, label %21, label %51
+
+21:                                               ; preds = %18
+  br label %22
+
+22:                                               ; preds = %25, %21
+  %23 = phi i64 [ %48, %25 ], [ 0, %21 ]
+  %24 = icmp slt i64 %23, 4
+  br i1 %24, label %25, label %49
+
+25:                                               ; preds = %22
+  %26 = mul nuw nsw i64 %19, 4
+  %27 = add nuw nsw i64 0, %26
+  %28 = add nuw nsw i64 %27, %23
+  %29 = getelementptr inbounds nuw float, ptr %1, i64 %28
+  %30 = load float, ptr %29, align 4
+  %31 = mul nuw nsw i64 %19, 8
+  %32 = add nuw nsw i64 0, %31
+  %33 = mul nuw nsw i64 %23, 2
+  %34 = add nuw nsw i64 %32, %33
+  %35 = add nuw nsw i64 %34, 0
+  %36 = getelementptr inbounds nuw float, ptr %17, i64 %35
+  store float %30, ptr %36, align 4
+  %37 = mul nuw nsw i64 %19, 4
+  %38 = add nuw nsw i64 12, %37
+  %39 = add nuw nsw i64 %38, %23
+  %40 = getelementptr inbounds nuw float, ptr %1, i64 %39
+  %41 = load float, ptr %40, align 4
+  %42 = mul nuw nsw i64 %19, 8
+  %43 = add nuw nsw i64 0, %42
+  %44 = mul nuw nsw i64 %23, 2
+  %45 = add nuw nsw i64 %43, %44
+  %46 = add nuw nsw i64 %45, 1
+  %47 = getelementptr inbounds nuw float, ptr %17, i64 %46
+  store float %41, ptr %47, align 4
+  %48 = add i64 %23, 1
+  br label %22
+
+49:                                               ; preds = %22
+  %50 = add i64 %19, 1
+  br label %18
+
+51:                                               ; preds = %18
+  %52 = call ptr @malloc(i64 208)
+  %53 = ptrtoint ptr %52 to i64
+  %54 = add i64 %53, 15
+  %55 = urem i64 %54, 16
+  %56 = sub i64 %54, %55
+  %57 = inttoptr i64 %56 to ptr
+  br label %58
+
+58:                                               ; preds = %87, %51
+  %59 = phi i64 [ %88, %87 ], [ 0, %51 ]
+  %60 = icmp slt i64 %59, 3
+  br i1 %60, label %61, label %89
+
+61:                                               ; preds = %58
+  br label %62
+
+62:                                               ; preds = %85, %61
+  %63 = phi i64 [ %86, %85 ], [ 0, %61 ]
+  %64 = icmp slt i64 %63, 4
+  br i1 %64, label %65, label %87
+
+65:                                               ; preds = %62
+  br label %66
+
+66:                                               ; preds = %69, %65
+  %67 = phi i64 [ %84, %69 ], [ 0, %65 ]
+  %68 = icmp slt i64 %67, 2
+  br i1 %68, label %69, label %85
+
+69:                                               ; preds = %66
+  %70 = mul nuw nsw i64 %59, 8
+  %71 = add nuw nsw i64 0, %70
+  %72 = mul nuw nsw i64 %63, 2
+  %73 = add nuw nsw i64 %71, %72
+  %74 = add nuw nsw i64 %73, %67
+  %75 = getelementptr inbounds nuw float, ptr %17, i64 %74
+  %76 = load float, ptr %75, align 4
+  %77 = fptosi float %76 to i64
+  %78 = mul nuw nsw i64 %59, 8
+  %79 = add nuw nsw i64 0, %78
+  %80 = mul nuw nsw i64 %63, 2
+  %81 = add nuw nsw i64 %79, %80
+  %82 = add nuw nsw i64 %81, %67
+  %83 = getelementptr inbounds nuw i64, ptr %57, i64 %82
+  store i64 %77, ptr %83, align 8
+  %84 = add i64 %67, 1
+  br label %66
+
+85:                                               ; preds = %66
+  %86 = add i64 %63, 1
+  br label %62
+
+87:                                               ; preds = %62
+  %88 = add i64 %59, 1
+  br label %58
+
+89:                                               ; preds = %58
+  call void @free(ptr %12)
+  %90 = call ptr @malloc(i64 208)
+  %91 = ptrtoint ptr %90 to i64
+  %92 = add i64 %91, 15
+  %93 = urem i64 %92, 16
+  %94 = sub i64 %92, %93
+  %95 = inttoptr i64 %94 to ptr
+  %96 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } poison, ptr %90, 0
+  %97 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %96, ptr %95, 1
+  %98 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %97, i64 0, 2
+  %99 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %98, i64 1, 3, 0
+  %100 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %99, i64 4, 3, 1
+  %101 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %100, i64 2, 3, 2
+  %102 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %101, i64 3, 3, 3
+  %103 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %102, i64 24, 4, 0
+  %104 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %103, i64 6, 4, 1
+  %105 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %104, i64 3, 4, 2
+  %106 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %105, i64 1, 4, 3
+  br label %107
+
+107:                                              ; preds = %149, %89
+  %108 = phi i64 [ %150, %149 ], [ 0, %89 ]
+  %109 = icmp slt i64 %108, 4
+  br i1 %109, label %110, label %151
+
+110:                                              ; preds = %107
+  br label %111
+
+111:                                              ; preds = %114, %110
+  %112 = phi i64 [ %148, %114 ], [ 0, %110 ]
+  %113 = icmp slt i64 %112, 2
+  br i1 %113, label %114, label %149
+
+114:                                              ; preds = %111
+  %115 = mul nuw nsw i64 %108, 2
+  %116 = add nuw nsw i64 0, %115
+  %117 = add nuw nsw i64 %116, %112
+  %118 = getelementptr inbounds nuw i64, ptr %57, i64 %117
+  %119 = load i64, ptr %118, align 8
+  %120 = mul nuw nsw i64 %108, 6
+  %121 = add nuw nsw i64 0, %120
+  %122 = mul nuw nsw i64 %112, 3
+  %123 = add nuw nsw i64 %121, %122
+  %124 = add nuw nsw i64 %123, 0
+  %125 = getelementptr inbounds nuw i64, ptr %95, i64 %124
+  store i64 %119, ptr %125, align 8
+  %126 = mul nuw nsw i64 %108, 2
+  %127 = add nuw nsw i64 8, %126
+  %128 = add nuw nsw i64 %127, %112
+  %129 = getelementptr inbounds nuw i64, ptr %57, i64 %128
+  %130 = load i64, ptr %129, align 8
+  %131 = mul nuw nsw i64 %108, 6
+  %132 = add nuw nsw i64 0, %131
+  %133 = mul nuw nsw i64 %112, 3
+  %134 = add nuw nsw i64 %132, %133
+  %135 = add nuw nsw i64 %134, 1
+  %136 = getelementptr inbounds nuw i64, ptr %95, i64 %135
+  store i64 %130, ptr %136, align 8
+  %137 = mul nuw nsw i64 %108, 2
+  %138 = add nuw nsw i64 16, %137
+  %139 = add nuw nsw i64 %138, %112
+  %140 = getelementptr inbounds nuw i64, ptr %57, i64 %139
+  %141 = load i64, ptr %140, align 8
+  %142 = mul nuw nsw i64 %108, 6
+  %143 = add nuw nsw i64 0, %142
+  %144 = mul nuw nsw i64 %112, 3
+  %145 = add nuw nsw i64 %143, %144
+  %146 = add nuw nsw i64 %145, 2
+  %147 = getelementptr inbounds nuw i64, ptr %95, i64 %146
+  store i64 %141, ptr %147, align 8
+  %148 = add i64 %112, 1
+  br label %111
+
+149:                                              ; preds = %111
+  %150 = add i64 %108, 1
+  br label %107
+
+151:                                              ; preds = %107
+  call void @free(ptr %52)
+  ret { ptr, ptr, i64, [4 x i64], [4 x i64] } %106
+}
+
+define void @_mlir_ciface_main_graph_after(ptr %0, ptr %1) {
+  %3 = load { ptr, ptr, i64, [4 x i64], [4 x i64] }, ptr %1, align 8
+  %4 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 0
+  %5 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 1
+  %6 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 2
+  %7 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 3, 0
+  %8 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 3, 1
+  %9 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 3, 2
+  %10 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 3, 3
+  %11 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 4, 0
+  %12 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 4, 1
+  %13 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 4, 2
+  %14 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %3, 4, 3
+  %15 = call { ptr, ptr, i64, [4 x i64], [4 x i64] } @main_graph_after(ptr %4, ptr %5, i64 %6, i64 %7, i64 %8, i64 %9, i64 %10, i64 %11, i64 %12, i64 %13, i64 %14)
+  store { ptr, ptr, i64, [4 x i64], [4 x i64] } %15, ptr %0, align 8
+  ret void
+}
+
+define ptr @run_main_graph_after(ptr %0) {
+  %2 = call i64 @omTensorListGetSize(ptr %0)
+  %3 = icmp ne i64 1, %2
+  br i1 %3, label %4, label %6
+
+4:                                                ; preds = %1
+  call void (ptr, ...) @printf(ptr @"om_Wrong number of input tensors: expect 1, but got %lld\0A_after", i64 %2)
+  %5 = call ptr @__errno_location()
+  store i32 22, ptr %5, align 4
+  ret ptr null
+
+6:                                                ; preds = %1
+  %7 = call ptr @omTensorListGetOmtArray(ptr %0)
+  %8 = load ptr, ptr %7, align 8
+  %9 = call i64 @omTensorGetDataType(ptr %8)
+  %10 = icmp ne i64 1, %9
+  br i1 %10, label %11, label %13
+
+11:                                               ; preds = %6
+  call void (ptr, ...) @printf(ptr @"om_Wrong data type for the input 0: expect f32\0A_after")
+  %12 = call ptr @__errno_location()
+  store i32 22, ptr %12, align 4
+  ret ptr null
+
+13:                                               ; preds = %6
+  %14 = call i64 @omTensorGetRank(ptr %8)
+  %15 = icmp ne i64 4, %14
+  br i1 %15, label %16, label %18
+
+16:                                               ; preds = %13
+  call void (ptr, ...) @printf(ptr @"om_Wrong rank for the input 0: expect 4, but got %lld\0A_after", i64 %14)
+  %17 = call ptr @__errno_location()
+  store i32 22, ptr %17, align 4
+  ret ptr null
+
+18:                                               ; preds = %13
+  %19 = call ptr @omTensorGetShape(ptr %8)
+  %20 = load i64, ptr %19, align 8
+  %21 = icmp ne i64 1, %20
+  br i1 %21, label %22, label %24
+
+22:                                               ; preds = %18
+  call void (ptr, ...) @printf(ptr @"om_Wrong size for the dimension 0 of the input 0: expect 1, but got %lld\0A_after", i64 %20)
+  %23 = call ptr @__errno_location()
+  store i32 22, ptr %23, align 4
+  ret ptr null
+
+24:                                               ; preds = %18
+  %25 = getelementptr i64, ptr %19, i32 1
+  %26 = load i64, ptr %25, align 8
+  %27 = icmp ne i64 2, %26
+  br i1 %27, label %28, label %30
+
+28:                                               ; preds = %24
+  call void (ptr, ...) @printf(ptr @"om_Wrong size for the dimension 1 of the input 0: expect 2, but got %lld\0A_after", i64 %26)
+  %29 = call ptr @__errno_location()
+  store i32 22, ptr %29, align 4
+  ret ptr null
+
+30:                                               ; preds = %24
+  %31 = getelementptr i64, ptr %19, i32 2
+  %32 = load i64, ptr %31, align 8
+  %33 = icmp ne i64 3, %32
+  br i1 %33, label %34, label %36
+
+34:                                               ; preds = %30
+  call void (ptr, ...) @printf(ptr @"om_Wrong size for the dimension 2 of the input 0: expect 3, but got %lld\0A_after", i64 %32)
+  %35 = call ptr @__errno_location()
+  store i32 22, ptr %35, align 4
+  ret ptr null
+
+36:                                               ; preds = %30
+  %37 = getelementptr i64, ptr %19, i32 3
+  %38 = load i64, ptr %37, align 8
+  %39 = icmp ne i64 4, %38
+  br i1 %39, label %40, label %42
+
+40:                                               ; preds = %36
+  call void (ptr, ...) @printf(ptr @"om_Wrong size for the dimension 3 of the input 0: expect 4, but got %lld\0A_after", i64 %38)
+  %41 = call ptr @__errno_location()
+  store i32 22, ptr %41, align 4
+  ret ptr null
+
+42:                                               ; preds = %36
+  %43 = call ptr @omTensorListGetOmtArray(ptr %0)
+  %44 = alloca { ptr, ptr, i64, [4 x i64], [4 x i64] }, i64 1, align 8
+  %45 = load ptr, ptr %43, align 8
+  %46 = alloca { ptr, ptr, i64, [4 x i64], [4 x i64] }, i64 1, align 8
+  %47 = call ptr @omTensorGetDataPtr(ptr %45)
+  %48 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } undef, ptr %47, 0
+  %49 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %48, ptr %47, 1
+  %50 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %49, i64 0, 2
+  %51 = call ptr @omTensorGetShape(ptr %45)
+  %52 = call ptr @omTensorGetStrides(ptr %45)
+  %53 = load i64, ptr %51, align 8
+  %54 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %50, i64 %53, 3, 0
+  %55 = load i64, ptr %52, align 8
+  %56 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %54, i64 %55, 4, 0
+  %57 = getelementptr i64, ptr %51, i32 1
+  %58 = load i64, ptr %57, align 8
+  %59 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %56, i64 %58, 3, 1
+  %60 = getelementptr i64, ptr %52, i32 1
+  %61 = load i64, ptr %60, align 8
+  %62 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %59, i64 %61, 4, 1
+  %63 = getelementptr i64, ptr %51, i32 2
+  %64 = load i64, ptr %63, align 8
+  %65 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %62, i64 %64, 3, 2
+  %66 = getelementptr i64, ptr %52, i32 2
+  %67 = load i64, ptr %66, align 8
+  %68 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %65, i64 %67, 4, 2
+  %69 = getelementptr i64, ptr %51, i32 3
+  %70 = load i64, ptr %69, align 8
+  %71 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %68, i64 %70, 3, 3
+  %72 = getelementptr i64, ptr %52, i32 3
+  %73 = load i64, ptr %72, align 8
+  %74 = insertvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %71, i64 %73, 4, 3
+  store { ptr, ptr, i64, [4 x i64], [4 x i64] } %74, ptr %46, align 8
+  call void @_mlir_ciface_main_graph_after(ptr %44, ptr %46)
+  %75 = load { ptr, ptr, i64, [4 x i64], [4 x i64] }, ptr %44, align 8
+  %76 = alloca ptr, i64 1, align 8
+  %77 = call ptr @omTensorCreateUntyped(i64 4)
+  %78 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 0
+  %79 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 1
+  call void @omTensorSetDataPtr(ptr %77, i64 1, ptr %78, ptr %79)
+  call void @omTensorSetDataType(ptr %77, i64 7)
+  %80 = call ptr @omTensorGetShape(ptr %77)
+  %81 = call ptr @omTensorGetStrides(ptr %77)
+  %82 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 3, 0
+  store i64 %82, ptr %80, align 8
+  %83 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 4, 0
+  store i64 %83, ptr %81, align 8
+  %84 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 3, 1
+  %85 = getelementptr i64, ptr %80, i32 1
+  store i64 %84, ptr %85, align 8
+  %86 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 4, 1
+  %87 = getelementptr i64, ptr %81, i32 1
+  store i64 %86, ptr %87, align 8
+  %88 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 3, 2
+  %89 = getelementptr i64, ptr %80, i32 2
+  store i64 %88, ptr %89, align 8
+  %90 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 4, 2
+  %91 = getelementptr i64, ptr %81, i32 2
+  store i64 %90, ptr %91, align 8
+  %92 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 3, 3
+  %93 = getelementptr i64, ptr %80, i32 3
+  store i64 %92, ptr %93, align 8
+  %94 = extractvalue { ptr, ptr, i64, [4 x i64], [4 x i64] } %75, 4, 3
+  %95 = getelementptr i64, ptr %81, i32 3
+  store i64 %94, ptr %95, align 8
+  store ptr %77, ptr %76, align 8
+  %96 = call ptr @omTensorListCreate(ptr %76, i64 1)
+  ret ptr %96
+}
+
+define ptr @run_main_graph(ptr %0) {
+  %2 = call ptr @run_main_graph_after(ptr %0)
+  ret ptr %2
+}
+
+define ptr @omQueryEntryPoints_after(ptr %0) {
+  %2 = icmp ne ptr %0, null
+  br i1 %2, label %3, label %4
+
+3:                                                ; preds = %1
+  store i64 2, ptr %0, align 8
+  br label %4
+
+4:                                                ; preds = %3, %1
+  ret ptr @_entry_point_arrays_after
+}
+
+define ptr @omQueryEntryPoints(ptr %0) {
+  %2 = call ptr @omQueryEntryPoints_after(ptr %0)
+  ret ptr %2
+}
+
+define ptr @omInputSignature_after(ptr %0) {
+  %2 = call i32 @strncmp(ptr %0, ptr @_entry_point_0_after, i64 15)
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %4, label %5
+
+4:                                                ; preds = %1
+  ret ptr @_entry_point_0_in_sig_after
+
+5:                                                ; preds = %1
+  %6 = call i32 @strncmp(ptr %0, ptr @_entry_point_1_after, i64 21)
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %8, label %9
+
+8:                                                ; preds = %5
+  ret ptr @_entry_point_1_in_sig_after
+
+9:                                                ; preds = %5
+  ret ptr null
+}
+
+define ptr @omInputSignature(ptr %0) {
+  %2 = call ptr @omInputSignature_after(ptr %0)
+  ret ptr %2
+}
+
+define ptr @omOutputSignature_after(ptr %0) {
+  %2 = call i32 @strncmp(ptr %0, ptr @_entry_point_0_after, i64 15)
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %4, label %5
+
+4:                                                ; preds = %1
+  ret ptr @_entry_point_0_out_sig_after
+
+5:                                                ; preds = %1
+  %6 = call i32 @strncmp(ptr %0, ptr @_entry_point_1_after, i64 21)
+  %7 = icmp eq i32 %6, 0
+  br i1 %7, label %8, label %9
+
+8:                                                ; preds = %5
+  ret ptr @_entry_point_1_out_sig_after
+
+9:                                                ; preds = %5
+  ret ptr null
+}
+
+define ptr @omOutputSignature(ptr %0) {
+  %2 = call ptr @omOutputSignature_after(ptr %0)
+  ret ptr %2
+}
+
+define ptr @omCompilationInfo_after() {
+  ret ptr @om_compilation_info_json_after
+}
+
+define ptr @omCompilationInfo() {
+  %1 = call ptr @omCompilationInfo_after()
+  ret ptr %1
+}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}

--- a/CAST_TEST/after.onnx.mlir
+++ b/CAST_TEST/after.onnx.mlir
@@ -1,0 +1,512 @@
+module attributes {llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu", "onnx-mlir.compile_options" = "--EmitLLVMIR -O0 --omit-compile-info transpose_cast_transpose.mlir -o after", "onnx-mlir.compiler_version" = "onnx-mlir version 0.5.1 (b6d6a0e)", "onnx-mlir.op_stats" = "{\0A  \22func.return.4D\22 : 1,\0A  \22onnx.Cast.4D\22 : 1,\0A  \22onnx.Transpose.4D\22 : 2\0A}\0A", "onnx-mlir.symbol-postfix" = "after"} {
+  llvm.mlir.global internal constant @om_compilation_info_json_after("{}\00") {addr_space = 0 : i32}
+  llvm.func @strncmp(!llvm.ptr, !llvm.ptr, i64) -> i32
+  llvm.mlir.global internal constant @"om_Wrong size for the dimension 3 of the input 0: expect 4, but got %lld\0A_after"("Wrong size for the dimension 3 of the input 0: expect 4, but got %lld\0A") {addr_space = 0 : i32, alignment = 16 : i64}
+  llvm.mlir.global internal constant @"om_Wrong size for the dimension 2 of the input 0: expect 3, but got %lld\0A_after"("Wrong size for the dimension 2 of the input 0: expect 3, but got %lld\0A") {addr_space = 0 : i32, alignment = 16 : i64}
+  llvm.mlir.global internal constant @"om_Wrong size for the dimension 1 of the input 0: expect 2, but got %lld\0A_after"("Wrong size for the dimension 1 of the input 0: expect 2, but got %lld\0A") {addr_space = 0 : i32, alignment = 16 : i64}
+  llvm.mlir.global internal constant @"om_Wrong size for the dimension 0 of the input 0: expect 1, but got %lld\0A_after"("Wrong size for the dimension 0 of the input 0: expect 1, but got %lld\0A") {addr_space = 0 : i32, alignment = 16 : i64}
+  llvm.mlir.global internal constant @"om_Wrong rank for the input 0: expect 4, but got %lld\0A_after"("Wrong rank for the input 0: expect 4, but got %lld\0A") {addr_space = 0 : i32, alignment = 16 : i64}
+  llvm.mlir.global internal constant @"om_Wrong data type for the input 0: expect f32\0A_after"("Wrong data type for the input 0: expect f32\0A") {addr_space = 0 : i32, alignment = 16 : i64}
+  llvm.mlir.global internal constant @"om_Wrong number of input tensors: expect 1, but got %lld\0A_after"("Wrong number of input tensors: expect 1, but got %lld\0A") {addr_space = 0 : i32, alignment = 16 : i64}
+  llvm.func @printf(!llvm.ptr, ...)
+  llvm.func @__errno_location() -> !llvm.ptr
+  llvm.mlir.global external constant @_entry_point_1_after("run_main_graph_after\00") {addr_space = 0 : i32}
+  llvm.mlir.global external constant @_entry_point_1_in_sig_after("[    { \22type\22 : \22f32\22 , \22dims\22 : [1 , 2 , 3 , 4] , \22name\22 : \22input_0\22 }\0A\0A]\00") {addr_space = 0 : i32}
+  llvm.mlir.global external constant @_entry_point_1_out_sig_after("[   { \22type\22 : \22i64\22 , \22dims\22 : [1 , 4 , 2 , 3] , \22name\22 : \22output_0\22 }\0A\0A]\00") {addr_space = 0 : i32}
+  llvm.mlir.global external constant @_entry_point_0_after("run_main_graph\00") {addr_space = 0 : i32}
+  llvm.mlir.global external constant @_entry_point_0_in_sig_after("[    { \22type\22 : \22f32\22 , \22dims\22 : [1 , 2 , 3 , 4] , \22name\22 : \22input_0\22 }\0A\0A]\00") {addr_space = 0 : i32}
+  llvm.mlir.global external constant @_entry_point_0_out_sig_after("[   { \22type\22 : \22i64\22 , \22dims\22 : [1 , 4 , 2 , 3] , \22name\22 : \22output_0\22 }\0A\0A]\00") {addr_space = 0 : i32}
+  llvm.func @omGetExternalConstantAddr(!llvm.ptr, !llvm.ptr, i64)
+  llvm.func @omUnloadConstantData(!llvm.ptr, i64) -> i1
+  llvm.func @omLoadConstantData(!llvm.ptr, !llvm.ptr, i64, i64) -> i1
+  llvm.func @omTensorListGetSize(!llvm.ptr) -> i64
+  llvm.func @omTensorPrint(!llvm.ptr, !llvm.ptr)
+  llvm.func @omTensorListGetOmtArray(!llvm.ptr) -> !llvm.ptr
+  llvm.func @omTensorSetDataType(!llvm.ptr, i64)
+  llvm.func @omTensorGetDataType(!llvm.ptr) -> i64
+  llvm.func @omTensorGetStrides(!llvm.ptr) -> !llvm.ptr
+  llvm.func @omTensorGetShape(!llvm.ptr) -> !llvm.ptr
+  llvm.func @omTensorGetRank(!llvm.ptr) -> i64
+  llvm.func @omTensorSetDataPtr(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr)
+  llvm.func @omTensorGetDataPtr(!llvm.ptr) -> !llvm.ptr
+  llvm.func @omTensorDestroy(!llvm.ptr)
+  llvm.func @omTensorCreateUntyped(i64) -> !llvm.ptr
+  llvm.func @omTensorListCreate(!llvm.ptr, i64) -> !llvm.ptr
+  llvm.func @free(!llvm.ptr)
+  llvm.func @malloc(i64) -> !llvm.ptr
+  llvm.func @main_graph_after(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: i64, %arg3: i64, %arg4: i64, %arg5: i64, %arg6: i64, %arg7: i64, %arg8: i64, %arg9: i64, %arg10: i64) -> !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)> attributes {llvm.emit_c_interface} {
+    %0 = llvm.mlir.constant(6 : index) : i64
+    %1 = llvm.mlir.constant(12 : index) : i64
+    %2 = llvm.mlir.constant(16 : index) : i64
+    %3 = llvm.mlir.zero : !llvm.ptr
+    %4 = llvm.mlir.constant(24 : index) : i64
+    %5 = llvm.mlir.constant(8 : index) : i64
+    %6 = llvm.mlir.constant(0 : index) : i64
+    %7 = llvm.mlir.constant(1 : index) : i64
+    %8 = llvm.mlir.constant(3 : index) : i64
+    %9 = llvm.mlir.constant(4 : index) : i64
+    %10 = llvm.mlir.constant(2 : index) : i64
+    %11 = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %12 = llvm.getelementptr %3[24] : (!llvm.ptr) -> !llvm.ptr, f32
+    %13 = llvm.ptrtoint %12 : !llvm.ptr to i64
+    %14 = llvm.add %13, %2 : i64
+    %15 = llvm.call @malloc(%14) : (i64) -> !llvm.ptr
+    %16 = llvm.ptrtoint %15 : !llvm.ptr to i64
+    %17 = llvm.sub %2, %7 : i64
+    %18 = llvm.add %16, %17 : i64
+    %19 = llvm.urem %18, %2 : i64
+    %20 = llvm.sub %18, %19 : i64
+    %21 = llvm.inttoptr %20 : i64 to !llvm.ptr
+    llvm.br ^bb1(%6 : i64)
+  ^bb1(%22: i64):  // 2 preds: ^bb0, ^bb5
+    %23 = llvm.icmp "slt" %22, %8 : i64
+    llvm.cond_br %23, ^bb2, ^bb6
+  ^bb2:  // pred: ^bb1
+    llvm.br ^bb3(%6 : i64)
+  ^bb3(%24: i64):  // 2 preds: ^bb2, ^bb4
+    %25 = llvm.icmp "slt" %24, %9 : i64
+    llvm.cond_br %25, ^bb4, ^bb5
+  ^bb4:  // pred: ^bb3
+    %26 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %27 = llvm.mul %6, %1 overflow<nsw, nuw> : i64
+    %28 = llvm.add %26, %27 overflow<nsw, nuw> : i64
+    %29 = llvm.mul %22, %9 overflow<nsw, nuw> : i64
+    %30 = llvm.add %28, %29 overflow<nsw, nuw> : i64
+    %31 = llvm.add %30, %24 overflow<nsw, nuw> : i64
+    %32 = llvm.getelementptr inbounds|nuw %arg1[%31] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+    %33 = llvm.load %32 : !llvm.ptr -> f32
+    %34 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %35 = llvm.mul %22, %5 overflow<nsw, nuw> : i64
+    %36 = llvm.add %34, %35 overflow<nsw, nuw> : i64
+    %37 = llvm.mul %24, %10 overflow<nsw, nuw> : i64
+    %38 = llvm.add %36, %37 overflow<nsw, nuw> : i64
+    %39 = llvm.add %38, %6 overflow<nsw, nuw> : i64
+    %40 = llvm.getelementptr inbounds|nuw %21[%39] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+    llvm.store %33, %40 : f32, !llvm.ptr
+    %41 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %42 = llvm.mul %7, %1 overflow<nsw, nuw> : i64
+    %43 = llvm.add %41, %42 overflow<nsw, nuw> : i64
+    %44 = llvm.mul %22, %9 overflow<nsw, nuw> : i64
+    %45 = llvm.add %43, %44 overflow<nsw, nuw> : i64
+    %46 = llvm.add %45, %24 overflow<nsw, nuw> : i64
+    %47 = llvm.getelementptr inbounds|nuw %arg1[%46] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+    %48 = llvm.load %47 : !llvm.ptr -> f32
+    %49 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %50 = llvm.mul %22, %5 overflow<nsw, nuw> : i64
+    %51 = llvm.add %49, %50 overflow<nsw, nuw> : i64
+    %52 = llvm.mul %24, %10 overflow<nsw, nuw> : i64
+    %53 = llvm.add %51, %52 overflow<nsw, nuw> : i64
+    %54 = llvm.add %53, %7 overflow<nsw, nuw> : i64
+    %55 = llvm.getelementptr inbounds|nuw %21[%54] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+    llvm.store %48, %55 : f32, !llvm.ptr
+    %56 = llvm.add %24, %7 : i64
+    llvm.br ^bb3(%56 : i64)
+  ^bb5:  // pred: ^bb3
+    %57 = llvm.add %22, %7 : i64
+    llvm.br ^bb1(%57 : i64)
+  ^bb6:  // pred: ^bb1
+    %58 = llvm.getelementptr %3[24] : (!llvm.ptr) -> !llvm.ptr, i64
+    %59 = llvm.ptrtoint %58 : !llvm.ptr to i64
+    %60 = llvm.add %59, %2 : i64
+    %61 = llvm.call @malloc(%60) : (i64) -> !llvm.ptr
+    %62 = llvm.ptrtoint %61 : !llvm.ptr to i64
+    %63 = llvm.sub %2, %7 : i64
+    %64 = llvm.add %62, %63 : i64
+    %65 = llvm.urem %64, %2 : i64
+    %66 = llvm.sub %64, %65 : i64
+    %67 = llvm.inttoptr %66 : i64 to !llvm.ptr
+    llvm.br ^bb7(%6 : i64)
+  ^bb7(%68: i64):  // 2 preds: ^bb6, ^bb14
+    %69 = llvm.icmp "slt" %68, %8 : i64
+    llvm.cond_br %69, ^bb8, ^bb15
+  ^bb8:  // pred: ^bb7
+    llvm.br ^bb9(%6 : i64)
+  ^bb9(%70: i64):  // 2 preds: ^bb8, ^bb13
+    %71 = llvm.icmp "slt" %70, %9 : i64
+    llvm.cond_br %71, ^bb10, ^bb14
+  ^bb10:  // pred: ^bb9
+    llvm.br ^bb11(%6 : i64)
+  ^bb11(%72: i64):  // 2 preds: ^bb10, ^bb12
+    %73 = llvm.icmp "slt" %72, %10 : i64
+    llvm.cond_br %73, ^bb12, ^bb13
+  ^bb12:  // pred: ^bb11
+    %74 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %75 = llvm.mul %68, %5 overflow<nsw, nuw> : i64
+    %76 = llvm.add %74, %75 overflow<nsw, nuw> : i64
+    %77 = llvm.mul %70, %10 overflow<nsw, nuw> : i64
+    %78 = llvm.add %76, %77 overflow<nsw, nuw> : i64
+    %79 = llvm.add %78, %72 overflow<nsw, nuw> : i64
+    %80 = llvm.getelementptr inbounds|nuw %21[%79] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+    %81 = llvm.load %80 : !llvm.ptr -> f32
+    %82 = llvm.fptosi %81 : f32 to i64
+    %83 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %84 = llvm.mul %68, %5 overflow<nsw, nuw> : i64
+    %85 = llvm.add %83, %84 overflow<nsw, nuw> : i64
+    %86 = llvm.mul %70, %10 overflow<nsw, nuw> : i64
+    %87 = llvm.add %85, %86 overflow<nsw, nuw> : i64
+    %88 = llvm.add %87, %72 overflow<nsw, nuw> : i64
+    %89 = llvm.getelementptr inbounds|nuw %67[%88] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+    llvm.store %82, %89 : i64, !llvm.ptr
+    %90 = llvm.add %72, %7 : i64
+    llvm.br ^bb11(%90 : i64)
+  ^bb13:  // pred: ^bb11
+    %91 = llvm.add %70, %7 : i64
+    llvm.br ^bb9(%91 : i64)
+  ^bb14:  // pred: ^bb9
+    %92 = llvm.add %68, %7 : i64
+    llvm.br ^bb7(%92 : i64)
+  ^bb15:  // pred: ^bb7
+    llvm.call @free(%15) : (!llvm.ptr) -> ()
+    %93 = llvm.getelementptr %3[24] : (!llvm.ptr) -> !llvm.ptr, i64
+    %94 = llvm.ptrtoint %93 : !llvm.ptr to i64
+    %95 = llvm.add %94, %2 : i64
+    %96 = llvm.call @malloc(%95) : (i64) -> !llvm.ptr
+    %97 = llvm.ptrtoint %96 : !llvm.ptr to i64
+    %98 = llvm.sub %2, %7 : i64
+    %99 = llvm.add %97, %98 : i64
+    %100 = llvm.urem %99, %2 : i64
+    %101 = llvm.sub %99, %100 : i64
+    %102 = llvm.inttoptr %101 : i64 to !llvm.ptr
+    %103 = llvm.insertvalue %96, %11[0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %104 = llvm.insertvalue %102, %103[1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %105 = llvm.insertvalue %6, %104[2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %106 = llvm.insertvalue %7, %105[3, 0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %107 = llvm.insertvalue %9, %106[3, 1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %108 = llvm.insertvalue %10, %107[3, 2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %109 = llvm.insertvalue %8, %108[3, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %110 = llvm.insertvalue %4, %109[4, 0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %111 = llvm.insertvalue %0, %110[4, 1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %112 = llvm.insertvalue %8, %111[4, 2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %113 = llvm.insertvalue %7, %112[4, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    llvm.br ^bb16(%6 : i64)
+  ^bb16(%114: i64):  // 2 preds: ^bb15, ^bb20
+    %115 = llvm.icmp "slt" %114, %9 : i64
+    llvm.cond_br %115, ^bb17, ^bb21
+  ^bb17:  // pred: ^bb16
+    llvm.br ^bb18(%6 : i64)
+  ^bb18(%116: i64):  // 2 preds: ^bb17, ^bb19
+    %117 = llvm.icmp "slt" %116, %10 : i64
+    llvm.cond_br %117, ^bb19, ^bb20
+  ^bb19:  // pred: ^bb18
+    %118 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %119 = llvm.mul %6, %5 overflow<nsw, nuw> : i64
+    %120 = llvm.add %118, %119 overflow<nsw, nuw> : i64
+    %121 = llvm.mul %114, %10 overflow<nsw, nuw> : i64
+    %122 = llvm.add %120, %121 overflow<nsw, nuw> : i64
+    %123 = llvm.add %122, %116 overflow<nsw, nuw> : i64
+    %124 = llvm.getelementptr inbounds|nuw %67[%123] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+    %125 = llvm.load %124 : !llvm.ptr -> i64
+    %126 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %127 = llvm.mul %114, %0 overflow<nsw, nuw> : i64
+    %128 = llvm.add %126, %127 overflow<nsw, nuw> : i64
+    %129 = llvm.mul %116, %8 overflow<nsw, nuw> : i64
+    %130 = llvm.add %128, %129 overflow<nsw, nuw> : i64
+    %131 = llvm.add %130, %6 overflow<nsw, nuw> : i64
+    %132 = llvm.getelementptr inbounds|nuw %102[%131] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+    llvm.store %125, %132 : i64, !llvm.ptr
+    %133 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %134 = llvm.mul %7, %5 overflow<nsw, nuw> : i64
+    %135 = llvm.add %133, %134 overflow<nsw, nuw> : i64
+    %136 = llvm.mul %114, %10 overflow<nsw, nuw> : i64
+    %137 = llvm.add %135, %136 overflow<nsw, nuw> : i64
+    %138 = llvm.add %137, %116 overflow<nsw, nuw> : i64
+    %139 = llvm.getelementptr inbounds|nuw %67[%138] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+    %140 = llvm.load %139 : !llvm.ptr -> i64
+    %141 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %142 = llvm.mul %114, %0 overflow<nsw, nuw> : i64
+    %143 = llvm.add %141, %142 overflow<nsw, nuw> : i64
+    %144 = llvm.mul %116, %8 overflow<nsw, nuw> : i64
+    %145 = llvm.add %143, %144 overflow<nsw, nuw> : i64
+    %146 = llvm.add %145, %7 overflow<nsw, nuw> : i64
+    %147 = llvm.getelementptr inbounds|nuw %102[%146] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+    llvm.store %140, %147 : i64, !llvm.ptr
+    %148 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %149 = llvm.mul %10, %5 overflow<nsw, nuw> : i64
+    %150 = llvm.add %148, %149 overflow<nsw, nuw> : i64
+    %151 = llvm.mul %114, %10 overflow<nsw, nuw> : i64
+    %152 = llvm.add %150, %151 overflow<nsw, nuw> : i64
+    %153 = llvm.add %152, %116 overflow<nsw, nuw> : i64
+    %154 = llvm.getelementptr inbounds|nuw %67[%153] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+    %155 = llvm.load %154 : !llvm.ptr -> i64
+    %156 = llvm.mul %6, %4 overflow<nsw, nuw> : i64
+    %157 = llvm.mul %114, %0 overflow<nsw, nuw> : i64
+    %158 = llvm.add %156, %157 overflow<nsw, nuw> : i64
+    %159 = llvm.mul %116, %8 overflow<nsw, nuw> : i64
+    %160 = llvm.add %158, %159 overflow<nsw, nuw> : i64
+    %161 = llvm.add %160, %10 overflow<nsw, nuw> : i64
+    %162 = llvm.getelementptr inbounds|nuw %102[%161] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+    llvm.store %155, %162 : i64, !llvm.ptr
+    %163 = llvm.add %116, %7 : i64
+    llvm.br ^bb18(%163 : i64)
+  ^bb20:  // pred: ^bb18
+    %164 = llvm.add %114, %7 : i64
+    llvm.br ^bb16(%164 : i64)
+  ^bb21:  // pred: ^bb16
+    llvm.call @free(%61) : (!llvm.ptr) -> ()
+    llvm.return %113 : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+  }
+  llvm.func @_mlir_ciface_main_graph_after(%arg0: !llvm.ptr, %arg1: !llvm.ptr) attributes {llvm.emit_c_interface} {
+    %0 = llvm.load %arg1 : !llvm.ptr -> !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %2 = llvm.extractvalue %0[1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %3 = llvm.extractvalue %0[2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %4 = llvm.extractvalue %0[3, 0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %5 = llvm.extractvalue %0[3, 1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %6 = llvm.extractvalue %0[3, 2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %7 = llvm.extractvalue %0[3, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %8 = llvm.extractvalue %0[4, 0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %9 = llvm.extractvalue %0[4, 1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %10 = llvm.extractvalue %0[4, 2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %11 = llvm.extractvalue %0[4, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %12 = llvm.call @main_graph_after(%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11) : (!llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    llvm.store %12, %arg0 : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>, !llvm.ptr
+    llvm.return
+  }
+  llvm.func @run_main_graph_after(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.mlir.constant(7 : i64) : i64
+    %1 = llvm.mlir.constant(0 : i64) : i64
+    %2 = llvm.mlir.undef : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %3 = llvm.mlir.addressof @"om_Wrong size for the dimension 3 of the input 0: expect 4, but got %lld\0A_after" : !llvm.ptr
+    %4 = llvm.mlir.addressof @"om_Wrong size for the dimension 2 of the input 0: expect 3, but got %lld\0A_after" : !llvm.ptr
+    %5 = llvm.mlir.constant(3 : i64) : i64
+    %6 = llvm.mlir.addressof @"om_Wrong size for the dimension 1 of the input 0: expect 2, but got %lld\0A_after" : !llvm.ptr
+    %7 = llvm.mlir.constant(2 : i64) : i64
+    %8 = llvm.mlir.addressof @"om_Wrong size for the dimension 0 of the input 0: expect 1, but got %lld\0A_after" : !llvm.ptr
+    %9 = llvm.mlir.addressof @"om_Wrong rank for the input 0: expect 4, but got %lld\0A_after" : !llvm.ptr
+    %10 = llvm.mlir.constant(4 : i64) : i64
+    %11 = llvm.mlir.addressof @"om_Wrong data type for the input 0: expect f32\0A_after" : !llvm.ptr
+    %12 = llvm.mlir.zero : !llvm.ptr
+    %13 = llvm.mlir.constant(22 : i32) : i32
+    %14 = llvm.mlir.addressof @"om_Wrong number of input tensors: expect 1, but got %lld\0A_after" : !llvm.ptr
+    %15 = llvm.mlir.constant(1 : i64) : i64
+    %16 = llvm.call @omTensorListGetSize(%arg0) : (!llvm.ptr) -> i64
+    %17 = llvm.icmp "ne" %15, %16 : i64
+    llvm.cond_br %17, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    llvm.call @printf(%14, %16) vararg(!llvm.func<void (ptr, i64, ...)>) : (!llvm.ptr, i64) -> ()
+    %18 = llvm.call @__errno_location() : () -> !llvm.ptr
+    llvm.store %13, %18 : i32, !llvm.ptr
+    llvm.return %12 : !llvm.ptr
+  ^bb2:  // pred: ^bb0
+    %19 = llvm.call @omTensorListGetOmtArray(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %20 = llvm.load %19 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.call @omTensorGetDataType(%20) : (!llvm.ptr) -> i64
+    %22 = llvm.icmp "ne" %15, %21 : i64
+    llvm.cond_br %22, ^bb3, ^bb4
+  ^bb3:  // pred: ^bb2
+    llvm.call @printf(%11) vararg(!llvm.func<void (ptr, ...)>) : (!llvm.ptr) -> ()
+    %23 = llvm.call @__errno_location() : () -> !llvm.ptr
+    llvm.store %13, %23 : i32, !llvm.ptr
+    llvm.return %12 : !llvm.ptr
+  ^bb4:  // pred: ^bb2
+    %24 = llvm.call @omTensorGetRank(%20) : (!llvm.ptr) -> i64
+    %25 = llvm.icmp "ne" %10, %24 : i64
+    llvm.cond_br %25, ^bb5, ^bb6
+  ^bb5:  // pred: ^bb4
+    llvm.call @printf(%9, %24) vararg(!llvm.func<void (ptr, i64, ...)>) : (!llvm.ptr, i64) -> ()
+    %26 = llvm.call @__errno_location() : () -> !llvm.ptr
+    llvm.store %13, %26 : i32, !llvm.ptr
+    llvm.return %12 : !llvm.ptr
+  ^bb6:  // pred: ^bb4
+    %27 = llvm.call @omTensorGetShape(%20) : (!llvm.ptr) -> !llvm.ptr
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %29 = llvm.icmp "ne" %15, %28 : i64
+    llvm.cond_br %29, ^bb7, ^bb8
+  ^bb7:  // pred: ^bb6
+    llvm.call @printf(%8, %28) vararg(!llvm.func<void (ptr, i64, ...)>) : (!llvm.ptr, i64) -> ()
+    %30 = llvm.call @__errno_location() : () -> !llvm.ptr
+    llvm.store %13, %30 : i32, !llvm.ptr
+    llvm.return %12 : !llvm.ptr
+  ^bb8:  // pred: ^bb6
+    %31 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i64
+    %32 = llvm.load %31 : !llvm.ptr -> i64
+    %33 = llvm.icmp "ne" %7, %32 : i64
+    llvm.cond_br %33, ^bb9, ^bb10
+  ^bb9:  // pred: ^bb8
+    llvm.call @printf(%6, %32) vararg(!llvm.func<void (ptr, i64, ...)>) : (!llvm.ptr, i64) -> ()
+    %34 = llvm.call @__errno_location() : () -> !llvm.ptr
+    llvm.store %13, %34 : i32, !llvm.ptr
+    llvm.return %12 : !llvm.ptr
+  ^bb10:  // pred: ^bb8
+    %35 = llvm.getelementptr %27[2] : (!llvm.ptr) -> !llvm.ptr, i64
+    %36 = llvm.load %35 : !llvm.ptr -> i64
+    %37 = llvm.icmp "ne" %5, %36 : i64
+    llvm.cond_br %37, ^bb11, ^bb12
+  ^bb11:  // pred: ^bb10
+    llvm.call @printf(%4, %36) vararg(!llvm.func<void (ptr, i64, ...)>) : (!llvm.ptr, i64) -> ()
+    %38 = llvm.call @__errno_location() : () -> !llvm.ptr
+    llvm.store %13, %38 : i32, !llvm.ptr
+    llvm.return %12 : !llvm.ptr
+  ^bb12:  // pred: ^bb10
+    %39 = llvm.getelementptr %27[3] : (!llvm.ptr) -> !llvm.ptr, i64
+    %40 = llvm.load %39 : !llvm.ptr -> i64
+    %41 = llvm.icmp "ne" %10, %40 : i64
+    llvm.cond_br %41, ^bb13, ^bb14
+  ^bb13:  // pred: ^bb12
+    llvm.call @printf(%3, %40) vararg(!llvm.func<void (ptr, i64, ...)>) : (!llvm.ptr, i64) -> ()
+    %42 = llvm.call @__errno_location() : () -> !llvm.ptr
+    llvm.store %13, %42 : i32, !llvm.ptr
+    llvm.return %12 : !llvm.ptr
+  ^bb14:  // pred: ^bb12
+    %43 = llvm.call @omTensorListGetOmtArray(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %44 = llvm.alloca %15 x !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)> : (i64) -> !llvm.ptr
+    %45 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.alloca %15 x !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)> : (i64) -> !llvm.ptr
+    %47 = llvm.call @omTensorGetDataPtr(%45) : (!llvm.ptr) -> !llvm.ptr
+    %48 = llvm.insertvalue %47, %2[0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %49 = llvm.insertvalue %47, %48[1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %50 = llvm.insertvalue %1, %49[2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %51 = llvm.call @omTensorGetShape(%45) : (!llvm.ptr) -> !llvm.ptr
+    %52 = llvm.call @omTensorGetStrides(%45) : (!llvm.ptr) -> !llvm.ptr
+    %53 = llvm.load %51 : !llvm.ptr -> i64
+    %54 = llvm.insertvalue %53, %50[3, 0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %55 = llvm.load %52 : !llvm.ptr -> i64
+    %56 = llvm.insertvalue %55, %54[4, 0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %57 = llvm.getelementptr %51[1] : (!llvm.ptr) -> !llvm.ptr, i64
+    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %59 = llvm.insertvalue %58, %56[3, 1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %60 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i64
+    %61 = llvm.load %60 : !llvm.ptr -> i64
+    %62 = llvm.insertvalue %61, %59[4, 1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %63 = llvm.getelementptr %51[2] : (!llvm.ptr) -> !llvm.ptr, i64
+    %64 = llvm.load %63 : !llvm.ptr -> i64
+    %65 = llvm.insertvalue %64, %62[3, 2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %66 = llvm.getelementptr %52[2] : (!llvm.ptr) -> !llvm.ptr, i64
+    %67 = llvm.load %66 : !llvm.ptr -> i64
+    %68 = llvm.insertvalue %67, %65[4, 2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %69 = llvm.getelementptr %51[3] : (!llvm.ptr) -> !llvm.ptr, i64
+    %70 = llvm.load %69 : !llvm.ptr -> i64
+    %71 = llvm.insertvalue %70, %68[3, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %72 = llvm.getelementptr %52[3] : (!llvm.ptr) -> !llvm.ptr, i64
+    %73 = llvm.load %72 : !llvm.ptr -> i64
+    %74 = llvm.insertvalue %73, %71[4, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    llvm.store %74, %46 : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>, !llvm.ptr
+    llvm.call @_mlir_ciface_main_graph_after(%44, %46) : (!llvm.ptr, !llvm.ptr) -> ()
+    %75 = llvm.load %44 : !llvm.ptr -> !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %76 = llvm.alloca %15 x !llvm.ptr : (i64) -> !llvm.ptr
+    %77 = llvm.call @omTensorCreateUntyped(%10) : (i64) -> !llvm.ptr
+    %78 = llvm.extractvalue %75[0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %79 = llvm.extractvalue %75[1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    llvm.call @omTensorSetDataPtr(%77, %15, %78, %79) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.call @omTensorSetDataType(%77, %0) : (!llvm.ptr, i64) -> ()
+    %80 = llvm.call @omTensorGetShape(%77) : (!llvm.ptr) -> !llvm.ptr
+    %81 = llvm.call @omTensorGetStrides(%77) : (!llvm.ptr) -> !llvm.ptr
+    %82 = llvm.extractvalue %75[3, 0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    llvm.store %82, %80 : i64, !llvm.ptr
+    %83 = llvm.extractvalue %75[4, 0] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    llvm.store %83, %81 : i64, !llvm.ptr
+    %84 = llvm.extractvalue %75[3, 1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %85 = llvm.getelementptr %80[1] : (!llvm.ptr) -> !llvm.ptr, i64
+    llvm.store %84, %85 : i64, !llvm.ptr
+    %86 = llvm.extractvalue %75[4, 1] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %87 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i64
+    llvm.store %86, %87 : i64, !llvm.ptr
+    %88 = llvm.extractvalue %75[3, 2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %89 = llvm.getelementptr %80[2] : (!llvm.ptr) -> !llvm.ptr, i64
+    llvm.store %88, %89 : i64, !llvm.ptr
+    %90 = llvm.extractvalue %75[4, 2] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %91 = llvm.getelementptr %81[2] : (!llvm.ptr) -> !llvm.ptr, i64
+    llvm.store %90, %91 : i64, !llvm.ptr
+    %92 = llvm.extractvalue %75[3, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %93 = llvm.getelementptr %80[3] : (!llvm.ptr) -> !llvm.ptr, i64
+    llvm.store %92, %93 : i64, !llvm.ptr
+    %94 = llvm.extractvalue %75[4, 3] : !llvm.struct<(ptr, ptr, i64, array<4 x i64>, array<4 x i64>)>
+    %95 = llvm.getelementptr %81[3] : (!llvm.ptr) -> !llvm.ptr, i64
+    llvm.store %94, %95 : i64, !llvm.ptr
+    llvm.store %77, %76 : !llvm.ptr, !llvm.ptr
+    %96 = llvm.call @omTensorListCreate(%76, %15) : (!llvm.ptr, i64) -> !llvm.ptr
+    llvm.return %96 : !llvm.ptr
+  }
+  llvm.func @run_main_graph(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.call @run_main_graph_after(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.mlir.global internal constant @_entry_point_arrays_after() {addr_space = 0 : i32} : !llvm.array<3 x ptr> {
+    %0 = llvm.mlir.zero : !llvm.ptr
+    %1 = llvm.mlir.addressof @_entry_point_1_after : !llvm.ptr
+    %2 = llvm.mlir.undef : !llvm.array<3 x ptr>
+    %3 = llvm.mlir.addressof @_entry_point_0_after : !llvm.ptr
+    %4 = llvm.insertvalue %3, %2[0] : !llvm.array<3 x ptr>
+    %5 = llvm.insertvalue %1, %4[1] : !llvm.array<3 x ptr>
+    %6 = llvm.insertvalue %0, %5[2] : !llvm.array<3 x ptr>
+    llvm.return %6 : !llvm.array<3 x ptr>
+  }
+  llvm.func @omQueryEntryPoints_after(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @_entry_point_arrays_after : !llvm.ptr
+    %1 = llvm.mlir.constant(2 : i64) : i64
+    %2 = llvm.mlir.zero : !llvm.ptr
+    %3 = llvm.icmp "ne" %arg0, %2 : !llvm.ptr
+    llvm.cond_br %3, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    llvm.store %1, %arg0 : i64, !llvm.ptr
+    llvm.br ^bb2
+  ^bb2:  // 2 preds: ^bb0, ^bb1
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @omQueryEntryPoints(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.call @omQueryEntryPoints_after(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @omInputSignature_after(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.mlir.zero : !llvm.ptr
+    %1 = llvm.mlir.addressof @_entry_point_1_in_sig_after : !llvm.ptr
+    %2 = llvm.mlir.constant(21 : i64) : i64
+    %3 = llvm.mlir.addressof @_entry_point_1_after : !llvm.ptr
+    %4 = llvm.mlir.addressof @_entry_point_0_in_sig_after : !llvm.ptr
+    %5 = llvm.mlir.constant(15 : i64) : i64
+    %6 = llvm.mlir.constant(0 : i32) : i32
+    %7 = llvm.mlir.addressof @_entry_point_0_after : !llvm.ptr
+    %8 = llvm.call @strncmp(%arg0, %7, %5) : (!llvm.ptr, !llvm.ptr, i64) -> i32
+    %9 = llvm.icmp "eq" %8, %6 : i32
+    llvm.cond_br %9, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    llvm.return %4 : !llvm.ptr
+  ^bb2:  // pred: ^bb0
+    %10 = llvm.call @strncmp(%arg0, %3, %2) : (!llvm.ptr, !llvm.ptr, i64) -> i32
+    %11 = llvm.icmp "eq" %10, %6 : i32
+    llvm.cond_br %11, ^bb3, ^bb4
+  ^bb3:  // pred: ^bb2
+    llvm.return %1 : !llvm.ptr
+  ^bb4:  // pred: ^bb2
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @omInputSignature(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.call @omInputSignature_after(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @omOutputSignature_after(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.mlir.zero : !llvm.ptr
+    %1 = llvm.mlir.addressof @_entry_point_1_out_sig_after : !llvm.ptr
+    %2 = llvm.mlir.constant(21 : i64) : i64
+    %3 = llvm.mlir.addressof @_entry_point_1_after : !llvm.ptr
+    %4 = llvm.mlir.addressof @_entry_point_0_out_sig_after : !llvm.ptr
+    %5 = llvm.mlir.constant(15 : i64) : i64
+    %6 = llvm.mlir.constant(0 : i32) : i32
+    %7 = llvm.mlir.addressof @_entry_point_0_after : !llvm.ptr
+    %8 = llvm.call @strncmp(%arg0, %7, %5) : (!llvm.ptr, !llvm.ptr, i64) -> i32
+    %9 = llvm.icmp "eq" %8, %6 : i32
+    llvm.cond_br %9, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    llvm.return %4 : !llvm.ptr
+  ^bb2:  // pred: ^bb0
+    %10 = llvm.call @strncmp(%arg0, %3, %2) : (!llvm.ptr, !llvm.ptr, i64) -> i32
+    %11 = llvm.icmp "eq" %10, %6 : i32
+    llvm.cond_br %11, ^bb3, ^bb4
+  ^bb3:  // pred: ^bb2
+    llvm.return %1 : !llvm.ptr
+  ^bb4:  // pred: ^bb2
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @omOutputSignature(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.call @omOutputSignature_after(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @omCompilationInfo_after() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @om_compilation_info_json_after : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @omCompilationInfo() -> !llvm.ptr {
+    %0 = llvm.call @omCompilationInfo_after() : () -> !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+}

--- a/CAST_TEST/before.canonicalize.stderr.txt
+++ b/CAST_TEST/before.canonicalize.stderr.txt
@@ -1,0 +1,8 @@
+Command:
+  build-cast-test/Release/bin/onnx-mlir-opt --canonicalize --verify-each CAST_TEST/transpose_cast_transpose.mlir -o /tmp/before-should-not-exist.mlir
+Exit status: 1
+
+CAST_TEST/transpose_cast_transpose.mlir:7:10: error: 'onnx.Cast' op element type does not match the 'to' attribute
+    %2 = "onnx.Transpose"(%1) {perm = [0, 2, 3, 1]} :
+         ^
+CAST_TEST/transpose_cast_transpose.mlir:7:10: note: see current operation: %0 = "onnx.Cast"(%arg0) <{saturate = 1 : si64, to = i64}> : (tensor<1x2x3x4xf32>) -> tensor<1x2x3x4xf32>

--- a/CAST_TEST/before.invalid-canonicalized.onnx.mlir
+++ b/CAST_TEST/before.invalid-canonicalized.onnx.mlir
@@ -1,0 +1,9 @@
+"builtin.module"() ({
+  "func.func"() <{function_type = (tensor<1x2x3x4xf32>) -> tensor<1x4x2x3xi64>, sym_name = "main_graph"}> ({
+  ^bb0(%arg0: tensor<1x2x3x4xf32>):
+    %0 = "onnx.Cast"(%arg0) <{saturate = 1 : si64, to = i64}> : (tensor<1x2x3x4xf32>) -> tensor<1x2x3x4xf32>
+    %1 = "onnx.Transpose"(%0) <{perm = [0, 3, 1, 2]}> : (tensor<1x2x3x4xf32>) -> tensor<1x4x2x3xi64>
+    "onnx.Return"(%1) : (tensor<1x4x2x3xi64>) -> ()
+  }) : () -> ()
+  "onnx.EntryPoint"() <{func = @main_graph}> : () -> ()
+}) : () -> ()

--- a/CAST_TEST/before.lowering.stderr.txt
+++ b/CAST_TEST/before.lowering.stderr.txt
@@ -1,0 +1,11 @@
+Command:
+  build-cast-test/Release/bin/onnx-mlir --EmitLLVMIR -O0 --omit-compile-info CAST_TEST/transpose_cast_transpose.mlir -o /tmp/before-should-not-exist
+Exit status: 14
+
+[1/3] Thu Aug 13 14:42:57 2026 (0s) Importing ONNX Model to MLIR Module from "transpose_cast_transpose.mlir"
+[2/3] Thu Aug 13 14:42:57 2026 (0s) Compiling and Optimizing MLIR Module
+'onnx.Cast' op element type does not match the 'to' attribute
+'onnx.Cast' op verification failed
+'onnx.Cast' op element type does not match the 'to' attribute
+'onnx.Cast' op verification failed
+'onnx.Cast' op element type does not match the 'to' attribute

--- a/CAST_TEST/canonicalization.diff
+++ b/CAST_TEST/canonicalization.diff
@@ -1,0 +1,20 @@
+--- before.invalid-canonicalized.onnx.mlir
++++ after.canonicalized.onnx.mlir
+@@ -1,9 +1,9 @@
+-"builtin.module"() ({
+-  "func.func"() <{function_type = (tensor<1x2x3x4xf32>) -> tensor<1x4x2x3xi64>, sym_name = "main_graph"}> ({
+-  ^bb0(%arg0: tensor<1x2x3x4xf32>):
+-    %0 = "onnx.Cast"(%arg0) <{saturate = 1 : si64, to = i64}> : (tensor<1x2x3x4xf32>) -> tensor<1x2x3x4xf32>
+-    %1 = "onnx.Transpose"(%0) <{perm = [0, 3, 1, 2]}> : (tensor<1x2x3x4xf32>) -> tensor<1x4x2x3xi64>
+-    "onnx.Return"(%1) : (tensor<1x4x2x3xi64>) -> ()
+-  }) : () -> ()
++module {
++  func.func @main_graph(%arg0: tensor<1x2x3x4xf32>) -> tensor<1x4x2x3xi64> {
++    %0 = "onnx.Transpose"(%arg0) <{perm = [0, 2, 3, 1]}> : (tensor<1x2x3x4xf32>) -> tensor<1x3x4x2xf32>
++    %1 = "onnx.Cast"(%0) <{saturate = 1 : si64, to = i64}> : (tensor<1x3x4x2xf32>) -> tensor<1x3x4x2xi64>
++    %2 = "onnx.Transpose"(%1) <{perm = [0, 2, 3, 1]}> : (tensor<1x3x4x2xi64>) -> tensor<1x4x2x3xi64>
++    onnx.Return %2 : tensor<1x4x2x3xi64>
++  }
+   "onnx.EntryPoint"() <{func = @main_graph}> : () -> ()
+-}) : () -> ()
++}

--- a/CAST_TEST/transpose_cast_transpose.mlir
+++ b/CAST_TEST/transpose_cast_transpose.mlir
@@ -1,0 +1,13 @@
+module {
+  func.func @main_graph(%arg0: tensor<1x2x3x4xf32>) -> tensor<1x4x2x3xi64> {
+    %0 = "onnx.Transpose"(%arg0) {perm = [0, 2, 3, 1]} :
+        (tensor<1x2x3x4xf32>) -> tensor<1x3x4x2xf32>
+    %1 = "onnx.Cast"(%0) {to = i64} :
+        (tensor<1x3x4x2xf32>) -> tensor<1x3x4x2xi64>
+    %2 = "onnx.Transpose"(%1) {perm = [0, 2, 3, 1]} :
+        (tensor<1x3x4x2xi64>) -> tensor<1x4x2x3xi64>
+    onnx.Return %2 : tensor<1x4x2x3xi64>
+  }
+
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.cpp
@@ -2935,7 +2935,6 @@ void ONNXTransposeOp::getCanonicalizationPatterns(
     RewritePatternSet &result, MLIRContext *context) {
   result.insert<FuseTransposePattern>(context);
   result.insert<FuseTransposeAndAtanPattern>(context);
-  result.insert<FuseTransposeAndCastPattern>(context);
   result.insert<FuseTransposeAndCeilPattern>(context);
   result.insert<FuseTransposeAndCosPattern>(context);
   result.insert<FuseTransposeAndCoshPattern>(context);

--- a/src/Dialect/ONNX/ONNXOps/Canonicalize.td
+++ b/src/Dialect/ONNX/ONNXOps/Canonicalize.td
@@ -692,8 +692,6 @@ class FuseTransposeAndElementwiseUnaryWithTwoArgOpPattern<Op elmOp>:  Pat<
 
 def FuseTransposeAndAtanPattern :
     FuseTransposeAndElementwiseUnaryOpPattern<ONNXAtanOp>;
-def FuseTransposeAndCastPattern :
-    FuseTransposeAndElementwiseUnaryWithTwoArgOpPattern<ONNXCastOp>;
 def FuseTransposeAndCeilPattern :
     FuseTransposeAndElementwiseUnaryOpPattern<ONNXCeilOp>;
 def FuseTransposeAndCosPattern :


### PR DESCRIPTION
## Summary

The `canonicalize` pass creates an invalid `onnx.Cast`.

The original Cast is valid:

```mlir
%159 = "onnx.Transpose"(%158)
    <{perm = [0, 1, 3, 2]}>
    : (tensor<1x1x124x40xf16>) -> tensor<1x1x40x124xf16>

%160 = "onnx.Cast"(%159)
    <{saturate = 1 : si64, to = f32}>
    : (tensor<1x1x40x124xf16>) -> tensor<1x1x40x124xf32>

%161 = "onnx.Transpose"(%160)
    <{perm = [0, 2, 1, 3]}>
    : (tensor<1x1x40x124xf32>) -> tensor<1x40x1x124xf32>
```

After canonicalization, a rewritten Cast has `to = f32` but an `f16` result:

```mlir
%cast = "onnx.Cast"(%value)
    <{saturate = 1 : si64, to = f32}>
    : (tensor<...xf16>) -> tensor<...xf16>
```

This causes:

```text
'onnx.Cast' op element type does not match the 'to' attribute
```

## Reproduction

```bash
onnx-mlir-opt input.onnx.mlir \
  --canonicalize \
  -o output.onnx.mlir
```

The invalid rewritten IR can be inspected with:

```bash
onnx-mlir-opt input.onnx.mlir \
  --verify-each=false \
  --canonicalize \
  -o output-unverified.onnx.mlir
```

## Relevant data flow

The original data flow is:

```text
Transpose
  -> Cast(f16 -> f32)
  -> Reshape
  -> Transpose
```

The Reshape input and result types are identical:

```mlir
%178 = "onnx.Reshape"(%160, %shape)
    : (tensor<1x1x40x124xf32>, tensor<4xi64>)
      -> tensor<1x1x40x124xf32>

%179 = "onnx.Transpose"(%178)
    <{perm = [0, 2, 1, 3]}>
    : (tensor<1x1x40x124xf32>)
      -> tensor<1x40x1x124xf32>
```

Canonicalization can remove the identity Reshape, exposing:

```text
Transpose -> Cast -> Transpose
```

## Suspected cause

The likely source is the Transpose/elementwise fusion pattern in:

```text
src/Dialect/ONNX/ONNXOps/Canonicalize.td
```

The relevant two-argument pattern reconstructs the elementwise operation using (about 680 lines): 

```tablegen
(returnType $v)
```

This works for type-preserving operations such as `Relu`, but not for
`ONNXCastOp`.

When `$v` is `tensor<...xf16>`, the rewritten Cast receives an `f16` result
type even though its `to` attribute is `f32`.

## Expected behavior

The rewritten Cast should preserve the Cast result element type:

```mlir
%cast = "onnx.Cast"(%value)
    <{saturate = 1 : si64, to = f32}>
    : (tensor<...xf16>) -> tensor<...xf32>
```

## Suggested fix

- exclude `ONNXCastOp` from this generic type-preserving fusion pattern

