### PR TITLE
Fix for CSE bug of krill.define_loop

### DIFF
--- a/src/Dialect/Krnl/Krnl.td
+++ b/src/Dialect/Krnl/Krnl.td
@@ -109,7 +109,7 @@ def KrnlCallOp : Op<Krnl_Dialect, "call",
       OpBuilder<(ins "std::string":$funcNameStr, "mlir::ValueRange":$results, "mlir::Operation *":$op, "mlir::ValueRange":$operands, "bool":$copyAttrs)>];
 }
 
-def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops", [NoMemoryEffect]> {
+def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
   let summary = "define_loops operation";
   let description = [{
     The "krnl.define_loops" operation is used to define input loops,

--- a/test/mlir/krnl/define_loops_not_cse.mlir
+++ b/test/mlir/krnl/define_loops_not_cse.mlir
@@ -1,0 +1,45 @@
+// RUN: onnx-mlir-opt --cse %s -split-input-file | FileCheck %s
+
+// krnl.define_loops hands out fresh loop references, whose only distinguishing
+// property is their identity. Two such ops are structurally identical -- no
+// operands, same result types -- so a purity trait on this op is an invitation
+// for CSE to merge them and alias two unrelated loop nests.
+//
+// This is a wrong-answer miscompile rather than an error. In the nest below the
+// merge makes both krnl.iterate ops drive the same two loop references, and the
+// inner krnl.get_induction_var_value -- identical to the outer one once its
+// operands alias -- is merged into it as well, leaving
+// krnl.load %arg0[%a, %b, %a, %b]. Dimension 0 then has extent 4 but is indexed
+// by a loop running to 6, so the lowered code reads and writes past the end of
+// the buffer. Hence KrnlDefineLoopsOp carries no NoMemoryEffect: it is not
+// redundant with anything, ever.
+//
+// Nothing is lost by that. The op is erased by ConvertKrnlToAffine itself rather
+// than by dead-code elimination, hoisting a loop reference out of a loop buys
+// nothing since the op does not survive that pass, and krnl.block, krnl.collapse,
+// krnl.permute and krnl.unroll have always been opaque in exactly the same way.
+func.func @two_define_loops_are_not_redundant(%arg0: memref<4x5x6x7xf32>) -> memref<4x5x6x7xf32> {
+  %alloc = memref.alloc() : memref<4x5x6x7xf32>
+  %ii, %jj = krnl.define_loops 2
+  krnl.iterate(%ii, %jj) with (%ii -> %i = 0 to 4, %jj -> %j = 0 to 5) {
+    %a, %b = krnl.get_induction_var_value(%ii, %jj) : (!krnl.loop, !krnl.loop) -> (index, index)
+    %kk, %ll = krnl.define_loops 2
+    krnl.iterate(%kk, %ll) with (%kk -> %k = 0 to 6, %ll -> %l = 0 to 7) {
+      %c, %d = krnl.get_induction_var_value(%kk, %ll) : (!krnl.loop, !krnl.loop) -> (index, index)
+      %v = krnl.load %arg0[%a, %b, %c, %d] : memref<4x5x6x7xf32>
+      krnl.store %v, %alloc[%a, %b, %c, %d] : memref<4x5x6x7xf32>
+    }
+  }
+  return %alloc : memref<4x5x6x7xf32>
+
+  // Both define_loops survive, and the inner nest keeps its own two references
+  // and its own induction variable query.
+  // CHECK-LABEL: two_define_loops_are_not_redundant
+  // CHECK:         [[OUTER:%.+]]:2 = krnl.define_loops 2
+  // CHECK:         krnl.iterate([[OUTER]]#0, [[OUTER]]#1) with ([[OUTER]]#0 -> %{{.+}} = 0 to 4, [[OUTER]]#1 -> %{{.+}} = 0 to 5)
+  // CHECK:           [[OUTER_IV:%.+]]:2 = krnl.get_induction_var_value([[OUTER]]#0, [[OUTER]]#1)
+  // CHECK:           [[INNER:%.+]]:2 = krnl.define_loops 2
+  // CHECK:           krnl.iterate([[INNER]]#0, [[INNER]]#1) with ([[INNER]]#0 -> %{{.+}} = 0 to 6, [[INNER]]#1 -> %{{.+}} = 0 to 7)
+  // CHECK:             [[INNER_IV:%.+]]:2 = krnl.get_induction_var_value([[INNER]]#0, [[INNER]]#1)
+  // CHECK:             krnl.load %arg0{{.}}[[OUTER_IV]]#0, [[OUTER_IV]]#1, [[INNER_IV]]#0, [[INNER_IV]]#1] : memref<4x5x6x7xf32>
+}


### PR DESCRIPTION
# Do not mark `krnl.define_loops` as `NoMemoryEffect`

## Issue

`krnl.define_loops` hands out fresh loop references whose only distinguishing property
is their *identity*. It takes no operands, so two `krnl.define_loops N` ops with the
same `N` are structurally identical — and `NoMemoryEffect` invited CSE to merge them,
aliasing the loop references of two unrelated nests.

The nested `krnl.iterate` ops then drive the same loops, and the inner
`krnl.get_induction_var_value` — identical to the outer one once its operands alias —
gets merged into it as well. The body ends up indexing an outer dimension with an inner
loop's induction variable. There is no diagnostic: the IR stays well formed and simply
computes something else.

On the `4x5x6x7` example below, dimension 0 has extent 4 but is indexed by a loop
running to 6. At `%arg3=5, %arg4=6` the linear offset is `((5*5+6)*6+5)*7+6 = 1343`,
past the end of an 840-element buffer — so the lowered code reads and writes outside
the allocation.

## Solution

Drop the trait, in `src/Dialect/Krnl/Krnl.td`:

```diff
-def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops", [NoMemoryEffect]> {
+def KrnlDefineLoopsOp : Op<Krnl_Dialect, "define_loops"> {
```

Nothing is lost. `ConvertKrnlToAffine` erases every `krnl.define_loops` it walks, so DCE
was never what removed them; LICM hoisting a loop reference out of a loop buys nothing
for an op that does not survive that pass (and is a second route to the same aliasing);
and the sibling recipe ops `krnl.block`, `krnl.permute` and `krnl.unroll` have always
carried no traits at all — `define_loops` was the outlier.

`KrnlGetInductionVariableValueOp` keeps its `NoMemoryEffect`: it is a genuine pure
function of its loop references, and CSE'ing it is both valid and useful.

## Example

Input — a plain 4-deep nest, one `krnl.define_loops 2` per level:

```mlir
func.func @copy(%arg0: memref<4x5x6x7xf32>) -> memref<4x5x6x7xf32> {
  %alloc = memref.alloc() : memref<4x5x6x7xf32>
  %ii, %jj = krnl.define_loops 2
  krnl.iterate(%ii, %jj) with (%ii -> %i = 0 to 4, %jj -> %j = 0 to 5) {
    %a, %b = krnl.get_induction_var_value(%ii, %jj) : (!krnl.loop, !krnl.loop) -> (index, index)
    %kk, %ll = krnl.define_loops 2
    krnl.iterate(%kk, %ll) with (%kk -> %k = 0 to 6, %ll -> %l = 0 to 7) {
      %c, %d = krnl.get_induction_var_value(%kk, %ll) : (!krnl.loop, !krnl.loop) -> (index, index)
      %v = krnl.load %arg0[%a, %b, %c, %d] : memref<4x5x6x7xf32>
      krnl.store %v, %alloc[%a, %b, %c, %d] : memref<4x5x6x7xf32>
    }
  }
  return %alloc : memref<4x5x6x7xf32>
}
```

**Before the fix**, `onnx-mlir-opt --cse` — one `define_loops` left, one
`get_induction_var_value` left, both indices aliased:

```mlir
%0:2 = krnl.define_loops 2
krnl.iterate(%0#0, %0#1) with (%0#0 -> %arg1 = 0 to 4, %0#1 -> %arg2 = 0 to 5){
  %1:2 = krnl.get_induction_var_value(%0#0, %0#1) : (!krnl.loop, !krnl.loop) -> (index, index)
  krnl.iterate(%0#0, %0#1) with (%0#0 -> %arg3 = 0 to 6, %0#1 -> %arg4 = 0 to 7){
    %2 = krnl.load %arg0[%1#0, %1#1, %1#0, %1#1] : memref<4x5x6x7xf32>   // <-- wrong
    krnl.store %2, %alloc[%1#0, %1#1, %1#0, %1#1] : memref<4x5x6x7xf32>
  }
}
```

**After the fix** — both nests keep their own references and their own induction
variables:

```mlir
%0:2 = krnl.define_loops 2
krnl.iterate(%0#0, %0#1) with (%0#0 -> %arg1 = 0 to 4, %0#1 -> %arg2 = 0 to 5){
  %1:2 = krnl.get_induction_var_value(%0#0, %0#1) : (!krnl.loop, !krnl.loop) -> (index, index)
  %2:2 = krnl.define_loops 2
  krnl.iterate(%2#0, %2#1) with (%2#0 -> %arg3 = 0 to 6, %2#1 -> %arg4 = 0 to 7){
    %3:2 = krnl.get_induction_var_value(%2#0, %2#1) : (!krnl.loop, !krnl.loop) -> (index, index)
    %4 = krnl.load %arg0[%1#0, %1#1, %3#0, %3#1] : memref<4x5x6x7xf32>   // <-- correct
    krnl.store %4, %alloc[%1#0, %1#1, %3#0, %3#1] : memref<4x5x6x7xf32>
  }
}
```

Carried through `--convert-krnl-to-affine`, the loop structure is `4x5x6x7` either way;
only the indices differ:

```
before:  affine.load %arg0[%arg3, %arg4, %arg3, %arg4]
after:   affine.load %arg0[%arg1, %arg2, %arg3, %arg4]
```

## Testing

New regression test `test/mlir/krnl/define_loops_not_cse.mlir` (`--cse` only, no
lowering). It fails with the trait restored and passes without it. Full lit suite: 481
tests, 446 passed, 35 NNPA/z16 UNSUPPORTED on the test host, 0 failures. The numerical
backend suite was not run.

## Why no existing test caught this

Real lowerings mostly nest loop sets of *different* rank, and `krnl.define_loops 2` and
`krnl.define_loops 1` are not identical ops. The hazard needs two same-rank nests in one
function — which is why the natural way to hand-write a nested-`krnl.iterate` test
miscompiles, and why existing tests such as
`test/mlir/krnl/imperfectly_nested_stmts.mlir` spell all dimensions with a single
`krnl.define_loops 4` instead.
