### PR TITLE
[Builder] Detect recursive model-local functions in FrontendDialectTansformer

### DIFF
--- a/src/Builder/FrontendDialectTransformer.cpp
+++ b/src/Builder/FrontendDialectTransformer.cpp
@@ -22,6 +22,8 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/Support/FileUtilities.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LineIterator.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -215,6 +217,11 @@ private:
   OpsetImportsMap opset_map_;
 
   ModelLocalFunctionsMap in_model_functions_;
+
+  // Set of model-local FunctionProto pointers currently being expanded.
+  // Used to detect direct and indirect (mutual) recursion and emit a
+  // diagnostic instead of overflowing the C++ call stack.
+  llvm::SmallPtrSet<const onnx::FunctionProto *, 4> expandingModelFunctions_;
 
   Location UnknownLoc() const { return UnknownLoc::get(&context_); }
 
@@ -1355,6 +1362,13 @@ private:
         BindOnnxName(name, value);
       }
 
+      // Guard against recursive model-local functions: mark this function as
+      // currently expanding so that any re-entrant call to ImportNode for the
+      // same (domain, op_type) is caught before recursing again.
+      expandingModelFunctions_.insert(modelLocalFunction);
+      auto cleanupExpanding = llvm::make_scope_exit(
+          [&] { expandingModelFunctions_.erase(modelLocalFunction); });
+
       for (auto &fb_node : graph.node()) {
         ImportNode(fb_node);
       }
@@ -1429,6 +1443,18 @@ private:
     auto model_function = in_model_functions_.find(
         GetModelLocalFunctionsMapIdentifier(node.domain(), node.op_type()));
     if (model_function != in_model_functions_.end()) {
+      // Reject recursive model-local function calls (direct or indirect).
+      // ONNX model-local functions are required to be finite subgraphs;
+      // recursion is not part of the spec and would otherwise overflow the
+      // C++ call stack with a SIGSEGV instead of a recoverable diagnostic.
+      if (expandingModelFunctions_.count(model_function->second)) {
+        emitError(UnknownLoc())
+            << "model-local function '" << node.domain() << ":"
+            << node.op_type()
+            << "' is directly or indirectly recursive; "
+               "onnx-mlir does not support recursive model-local functions";
+        return;
+      }
       ImportFunctionCallNode(node, /*schema=*/nullptr, model_function->second);
       return;
     }

--- a/test/mlir/onnx/parse/functiontest_mutualrecursion.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_mutualrecursion.onnxtext
@@ -1,0 +1,41 @@
+// RUN: not onnx-mlir --EmitONNXBasic --printIR %s 2>&1 | FileCheck %s
+
+// Tests that a pair of mutually-recursive model-local functions (A calls B,
+// B calls A) is rejected with a clear diagnostic instead of overflowing the
+// C++ call stack.  This exercises the indirect cycle path of the recursion
+// guard in ImportFunctionCallNode.
+//
+// The guard works by recording each model-local FunctionProto* in
+// expandingModelFunctions_ before descending into its body, and checking
+// membership before making any new model-local call — so the cycle is caught
+// on the second encounter of funcA (when funcB tries to call it back), not
+// only on literal self-calls.
+
+<
+ir_version: 8,
+opset_import: [ "" : 16, "local" : 1 ]
+>
+agraph (float[N] x) => (float[N] y)
+{
+    y = local.funcA (x)
+}
+
+<
+opset_import: [ "" : 16, "local" : 1],
+domain: "local"
+>
+funcA (lx) => (ly) {
+    // funcA calls funcB — start of the mutual cycle.
+    ly = local.funcB (lx)
+}
+
+<
+opset_import: [ "" : 16, "local" : 1],
+domain: "local"
+>
+funcB (lx) => (ly) {
+    // funcB calls funcA — closes the cycle.  This must be caught.
+    ly = local.funcA (lx)
+}
+
+// CHECK: model-local function 'local:funcA' is directly or indirectly recursive

--- a/test/mlir/onnx/parse/functiontest_selfrecursion.onnxtext
+++ b/test/mlir/onnx/parse/functiontest_selfrecursion.onnxtext
@@ -1,0 +1,29 @@
+// RUN: not onnx-mlir --EmitONNXBasic --printIR %s 2>&1 | FileCheck %s
+
+// Tests that a model-local function which directly calls itself (self-recursion)
+// is rejected with a clear diagnostic instead of overflowing the C++ call stack
+// with a SIGSEGV.
+//
+// The legitimate two-level non-cyclic case is tested separately in
+// functiontest_nestedcall.onnxtext and must remain unaffected.
+
+<
+ir_version: 8,
+opset_import: [ "" : 16, "local" : 1 ]
+>
+agraph (float[N] x) => (float[N] y)
+{
+    y = local.selfcall (x)
+}
+
+<
+opset_import: [ "" : 16, "local" : 1],
+domain: "local"
+>
+selfcall (lx) => (ly) {
+    // This node invokes the same function we are currently expanding —
+    // a direct self-reference that must be caught as a cycle.
+    ly = local.selfcall (lx)
+}
+
+// CHECK: model-local function 'local:selfcall' is directly or indirectly recursive


### PR DESCRIPTION
A model-local FunctionProto whose body (directly or indirectly) invokes itself caused unbounded C++ recursion through:
  ImportFunctionCallNode -> ImportNode -> ImportFunctionCallNode -> ...
until the process exhausted its stack and received SIGSEGV.

Root cause: in_model_functions_ is never cleared for the model-local path (schema == nullptr), so the same (domain, op_type) key is found on every re-entrant lookup with no depth limit or cycle check.

Fix:
- Add expandingModelFunctions_ (SmallPtrSet<const FunctionProto*, 4>) to FrontendGenImpl to track which model-local functions are currently on the expansion call stack.
- In ImportFunctionCallNode (model-local path), insert the FunctionProto* into the set before the body-import loop and erase it on every exit via a make_scope_exit RAII guard.
- In ImportNode, check the set before dispatching a model-local call. If the function is already expanding, emit a recoverable diagnostic and return instead of recursing.

The guard catches both direct self-calls and indirect mutual-recursion cycles (A -> B -> A). Legitimate non-cyclic nested calls such as functiontest_nestedcall.onnxtext (myfun -> twice, two distinct FunctionProto* addresses) are unaffected.

Tests added:
- test/mlir/onnx/parse/functiontest_selfrecursion.onnxtext Direct self-call: local.selfcall invokes local.selfcall. Expects diagnostic 'is directly or indirectly recursive'.
- test/mlir/onnx/parse/functiontest_mutualrecursion.onnxtext Indirect cycle: local.funcA -> local.funcB -> local.funcA. Expects diagnostic on the second encounter of funcA.

F019