### PR TITLE
Low Attention Op from onnx to onnx

### DIFF
--- a/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
+++ b/src/Accelerators/NNPA/Conversion/ONNXToZHigh/RewriteONNXForZHigh.cpp
@@ -720,6 +720,8 @@ void getRewriteONNXForZHighPatterns(RewritePatternSet &patterns,
   if (enableConvToMatmul) {
     addConvToMatmulPattern(patterns, isCompatibleWithNNPALevel(NNPALevel::M15));
   }
+  KrnlTypeConverter krnlTypeConverter;
+  populateLoweringONNXAttentionOpPattern(patterns, krnlTypeConverter, patterns.getContext());
 }
 
 void getRewriteONNXForZHighDynamicallyLegal(mlir::ConversionTarget *target,

--- a/src/Conversion/ONNXToKrnl/CMakeLists.txt
+++ b/src/Conversion/ONNXToKrnl/CMakeLists.txt
@@ -16,6 +16,7 @@ add_onnx_mlir_library(OMONNXToKrnl
   ControlFlow/Yield.cpp
   ConvertONNXToKrnl.cpp
   ML/CategoryMapper.cpp
+  Math/Attention.cpp
   Math/CumSum.cpp
   Math/DFT.cpp
   Math/Elementwise.cpp

--- a/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
+++ b/src/Conversion/ONNXToKrnl/ConvertONNXToKrnl.cpp
@@ -220,6 +220,7 @@ void populateONNXToKrnlConversionPattern(RewritePatternSet &patterns,
   populateLoweringONNXWindowOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXReductionOpPattern(patterns, typeConverter, ctx, enableSIMD, enableParallel);
   populateLoweringONNXSoftmaxOpPattern(patterns, typeConverter, ctx, enableParallel);
+  populateLoweringONNXAttentionOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXTopKOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXTriluOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXMatMulOpPattern(patterns, typeConverter, ctx, dimAnalysis, enableTiling, enableSIMD, enableParallel);

--- a/src/Conversion/ONNXToKrnl/Math/Attention.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Attention.cpp
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===-------------- Attention.cpp - Lowering Attention Op ----------------===//
+//
+// Copyright 2024-2025 The IBM Research Authors.
+//
+// =============================================================================
+//
+// This file lowers the ONNX Attention Operator to Krnl dialect by decomposing
+// it into basic ONNX operations (MatMul, Transpose, Softmax, Add, Mul, etc.).
+// The resulting ONNX operations are then lowered to Krnl by their respective
+// lowering patterns.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp"
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps/OpHelper.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
+  ONNXAttentionOpLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern<ONNXAttentionOp>(typeConverter, ctx) {}
+
+  LogicalResult matchAndRewrite(ONNXAttentionOp attentionOp,
+      ONNXAttentionOpAdaptor adaptor, ConversionPatternRewriter &rewriter)
+      const final {
+    Location loc = attentionOp.getLoc();
+    MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
+
+    Value Q = adaptor.getQ();
+    Value K = adaptor.getK();
+    Value V = adaptor.getV();
+    Value attnMask = adaptor.getAttnMask();
+
+    // Get input rank to determine if it's 3D or 4D
+    ShapedType qType = mlir::cast<ShapedType>(Q.getType());
+    int64_t inputRank = qType.getShape().size();
+    bool is3DInput = (inputRank == 3);
+    Type elementType = qType.getElementType();
+
+    Value Q_reshaped = Q;
+    Value K_reshaped = K;
+    Value V_reshaped = V;
+
+    if (is3DInput) {
+      // For 3D inputs, reshape to 4D for attention computation
+      auto qNumHeadsAttr = attentionOp.getQNumHeads();
+      int64_t qNumHeads = 1;
+      if (qNumHeadsAttr.has_value()) {
+        qNumHeads = qNumHeadsAttr.value();
+      }
+
+      ArrayRef<int64_t> qShape = qType.getShape();
+      int64_t batchSize = qShape[0];
+      int64_t qSeqLen = qShape[1];
+      int64_t qHiddenSize = qShape[2];
+
+      if (ShapedType::isDynamic(qHiddenSize)) {
+        return failure();
+      }
+
+      int64_t headSize = qHiddenSize / qNumHeads;
+
+      // Reshape Q: (B, S, H) -> (B, qNumHeads, S, H/qNumHeads)
+      SmallVector<int64_t> qNewShape = {batchSize, qNumHeads, qSeqLen, headSize};
+      Type qNewType = RankedTensorType::get(qNewShape, elementType);
+      Value reshapeShapeQ = create.onnx.constantInt64(qNewShape);
+      Q_reshaped = create.onnx.reshape(qNewType, Q, reshapeShapeQ);
+
+      // Reshape K: (B, S', H) -> (B, qNumHeads, S', H/qNumHeads)
+      ShapedType kType = mlir::cast<ShapedType>(K.getType());
+      ArrayRef<int64_t> kShape = kType.getShape();
+      int64_t kSeqLen = kShape[1];
+      int64_t kHiddenSize = kShape[2];
+
+      if (ShapedType::isDynamic(kHiddenSize)) {
+        return failure();
+      }
+
+      SmallVector<int64_t> kNewShape = {batchSize, qNumHeads, kSeqLen,
+          kHiddenSize / qNumHeads};
+      Type kNewType = RankedTensorType::get(kNewShape, elementType);
+      Value reshapeShapeK = create.onnx.constantInt64(kNewShape);
+      K_reshaped = create.onnx.reshape(kNewType, K, reshapeShapeK);
+
+      // Reshape V: (B, S', V_H) -> (B, qNumHeads, S', V_H/qNumHeads)
+      ShapedType vType = mlir::cast<ShapedType>(V.getType());
+      ArrayRef<int64_t> vShape = vType.getShape();
+      int64_t vHiddenSize = vShape[2];
+
+      if (ShapedType::isDynamic(vHiddenSize)) {
+        return failure();
+      }
+
+      SmallVector<int64_t> vNewShape = {batchSize, qNumHeads, kSeqLen,
+          vHiddenSize / qNumHeads};
+      Type vNewType = RankedTensorType::get(vNewShape, elementType);
+      Value reshapeShapeV = create.onnx.constantInt64(vNewShape);
+      V_reshaped = create.onnx.reshape(vNewType, V, reshapeShapeV);
+    }
+
+    // Step 1: Transpose K: (B, num_heads, seq_len, head_size) -> (B,
+    // num_heads, head_size, seq_len)
+    SmallVector<int64_t> kTransposePerm = {0, 1, 3, 2};
+    Value K_transposed = create.onnx.transposeInt64(K_reshaped, kTransposePerm);
+
+    // Step 2: MatMul(Q, K^T)
+    ShapedType qShape4D = mlir::cast<ShapedType>(Q_reshaped.getType());
+    ShapedType kTransposedShape =
+        mlir::cast<ShapedType>(K_transposed.getType());
+    SmallVector<int64_t> qkShape = {qShape4D.getShape()[0],
+        qShape4D.getShape()[1], qShape4D.getShape()[2],
+        kTransposedShape.getShape()[3]};
+    Type qkType = RankedTensorType::get(qkShape, elementType);
+    Value qk = create.onnx.matmul(qkType, Q_reshaped, K_transposed);
+
+    // Step 3: Apply scaling if needed
+    Value qk_scaled = qk;
+    auto scaleOpt = attentionOp.getScale();
+    if (scaleOpt) {
+      float scaleValue = scaleOpt->convertToFloat();
+      if (scaleValue != 1.0f) {
+        Value scaleConstant = create.onnx.constantFloat32({scaleValue});
+        qk_scaled = create.onnx.mul(qk, scaleConstant);
+      }
+    }
+
+    // Step 4: Add attention mask if present
+    Value qk_masked = qk_scaled;
+    if (!isNoneValue(attnMask)) {
+      qk_masked = create.onnx.add(qk_scaled, attnMask);
+    }
+
+    // Step 5: Apply softmax over the last axis
+    Value probs = rewriter.create<ONNXSoftmaxOp>(loc, qk_masked.getType(),
+        qk_masked, rewriter.getI64IntegerAttr(-1));
+
+    // Step 6: MatMul(softmax(...), V)
+    ShapedType vShape4D = mlir::cast<ShapedType>(V_reshaped.getType());
+    SmallVector<int64_t> outputShape = {qShape4D.getShape()[0],
+        qShape4D.getShape()[1], qShape4D.getShape()[2],
+        vShape4D.getShape()[3]};
+    Type outputType4D = RankedTensorType::get(outputShape, elementType);
+    Value result =
+        create.onnx.matmul(outputType4D, probs, V_reshaped);
+
+    // Step 7: Reshape back to 3D if input was 3D
+    Value result_final = result;
+    if (is3DInput) {
+      ShapedType resultType = mlir::cast<ShapedType>(result.getType());
+      ArrayRef<int64_t> resultShape = resultType.getShape();
+      int64_t batchSize = resultShape[0];
+      int64_t numHeads = resultShape[1];
+      int64_t qSeqLen = resultShape[2];
+      int64_t headSize = resultShape[3];
+
+      SmallVector<int64_t> finalShape = {batchSize, qSeqLen,
+          numHeads * headSize};
+      Type finalType = RankedTensorType::get(finalShape, elementType);
+      Value reshapeShapeFinal = create.onnx.constantInt64(finalShape);
+      result_final = create.onnx.reshape(finalType, result, reshapeShapeFinal);
+    }
+
+    // Create the none value for optional outputs
+    Value noneVal = create.onnx.none();
+
+    // Replace all 4 outputs of the AttentionOp
+    SmallVector<Value, 4> replacementValues;
+    replacementValues.push_back(result_final);  // Result 0: Y
+    replacementValues.push_back(noneVal);       // Result 1: present_key
+    replacementValues.push_back(noneVal);       // Result 2: present_value
+    replacementValues.push_back(noneVal);       // Result 3: qk_matmul_output
+
+    rewriter.replaceOp(attentionOp, replacementValues);
+    return success();
+  }
+};
+
+void populateLoweringONNXAttentionOpPattern(
+    RewritePatternSet &patterns, TypeConverter &typeConverter,
+    MLIRContext *ctx) {
+  patterns.insert<ONNXAttentionOpLowering>(typeConverter, ctx);
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToKrnl/Math/Attention.cpp
+++ b/src/Conversion/ONNXToKrnl/Math/Attention.cpp
@@ -29,8 +29,8 @@ struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
       : OpConversionPattern<ONNXAttentionOp>(typeConverter, ctx) {}
 
   LogicalResult matchAndRewrite(ONNXAttentionOp attentionOp,
-      ONNXAttentionOpAdaptor adaptor, ConversionPatternRewriter &rewriter)
-      const final {
+      ONNXAttentionOpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const final {
     Location loc = attentionOp.getLoc();
     MultiDialectBuilder<OnnxBuilder> create(rewriter, loc);
 
@@ -38,6 +38,10 @@ struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
     Value K = adaptor.getK();
     Value V = adaptor.getV();
     Value attnMask = adaptor.getAttnMask();
+    Value pastKey = adaptor.getPastKey();
+    Value pastValue = adaptor.getPastValue();
+    bool hasPastKey = !isNoneValue(pastKey);
+    bool hasPastValue = !isNoneValue(pastValue);
 
     // Get input rank to determine if it's 3D or 4D
     ShapedType qType = mlir::cast<ShapedType>(Q.getType());
@@ -69,7 +73,8 @@ struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
       int64_t headSize = qHiddenSize / qNumHeads;
 
       // Reshape Q: (B, S, H) -> (B, qNumHeads, S, H/qNumHeads)
-      SmallVector<int64_t> qNewShape = {batchSize, qNumHeads, qSeqLen, headSize};
+      SmallVector<int64_t> qNewShape = {
+          batchSize, qNumHeads, qSeqLen, headSize};
       Type qNewType = RankedTensorType::get(qNewShape, elementType);
       Value reshapeShapeQ = create.onnx.constantInt64(qNewShape);
       Q_reshaped = create.onnx.reshape(qNewType, Q, reshapeShapeQ);
@@ -84,8 +89,8 @@ struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
         return failure();
       }
 
-      SmallVector<int64_t> kNewShape = {batchSize, qNumHeads, kSeqLen,
-          kHiddenSize / qNumHeads};
+      SmallVector<int64_t> kNewShape = {
+          batchSize, qNumHeads, kSeqLen, kHiddenSize / qNumHeads};
       Type kNewType = RankedTensorType::get(kNewShape, elementType);
       Value reshapeShapeK = create.onnx.constantInt64(kNewShape);
       K_reshaped = create.onnx.reshape(kNewType, K, reshapeShapeK);
@@ -99,11 +104,41 @@ struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
         return failure();
       }
 
-      SmallVector<int64_t> vNewShape = {batchSize, qNumHeads, kSeqLen,
-          vHiddenSize / qNumHeads};
+      SmallVector<int64_t> vNewShape = {
+          batchSize, qNumHeads, kSeqLen, vHiddenSize / qNumHeads};
       Type vNewType = RankedTensorType::get(vNewShape, elementType);
       Value reshapeShapeV = create.onnx.constantInt64(vNewShape);
       V_reshaped = create.onnx.reshape(vNewType, V, reshapeShapeV);
+    }
+
+    // Concatenate past_key with K if present
+    if (hasPastKey) {
+      ShapedType kShape = mlir::cast<ShapedType>(K_reshaped.getType());
+      ShapedType pastKeyShape = mlir::cast<ShapedType>(pastKey.getType());
+      int64_t newKSeqLen =
+          ShapedType::isDynamic(kShape.getShape()[2]) ||
+                  ShapedType::isDynamic(pastKeyShape.getShape()[2])
+              ? ShapedType::kDynamic
+              : (kShape.getShape()[2] + pastKeyShape.getShape()[2]);
+      SmallVector<int64_t> kConcatShape = {kShape.getShape()[0],
+          kShape.getShape()[1], newKSeqLen, kShape.getShape()[3]};
+      Type kConcatType = RankedTensorType::get(kConcatShape, elementType);
+      K_reshaped = create.onnx.concat(kConcatType, {pastKey, K_reshaped}, 2);
+    }
+
+    // Concatenate past_value with V if present
+    if (hasPastValue) {
+      ShapedType vShape = mlir::cast<ShapedType>(V_reshaped.getType());
+      ShapedType pastValueShape = mlir::cast<ShapedType>(pastValue.getType());
+      int64_t newVSeqLen =
+          ShapedType::isDynamic(vShape.getShape()[2]) ||
+                  ShapedType::isDynamic(pastValueShape.getShape()[2])
+              ? ShapedType::kDynamic
+              : (vShape.getShape()[2] + pastValueShape.getShape()[2]);
+      SmallVector<int64_t> vConcatShape = {vShape.getShape()[0],
+          vShape.getShape()[1], newVSeqLen, vShape.getShape()[3]};
+      Type vConcatType = RankedTensorType::get(vConcatShape, elementType);
+      V_reshaped = create.onnx.concat(vConcatType, {pastValue, V_reshaped}, 2);
     }
 
     // Step 1: Transpose K: (B, num_heads, seq_len, head_size) -> (B,
@@ -139,17 +174,15 @@ struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
     }
 
     // Step 5: Apply softmax over the last axis
-    Value probs = rewriter.create<ONNXSoftmaxOp>(loc, qk_masked.getType(),
-        qk_masked, rewriter.getI64IntegerAttr(-1));
+    Value probs = rewriter.create<ONNXSoftmaxOp>(
+        loc, qk_masked.getType(), qk_masked, rewriter.getI64IntegerAttr(-1));
 
     // Step 6: MatMul(softmax(...), V)
     ShapedType vShape4D = mlir::cast<ShapedType>(V_reshaped.getType());
     SmallVector<int64_t> outputShape = {qShape4D.getShape()[0],
-        qShape4D.getShape()[1], qShape4D.getShape()[2],
-        vShape4D.getShape()[3]};
+        qShape4D.getShape()[1], qShape4D.getShape()[2], vShape4D.getShape()[3]};
     Type outputType4D = RankedTensorType::get(outputShape, elementType);
-    Value result =
-        create.onnx.matmul(outputType4D, probs, V_reshaped);
+    Value result = create.onnx.matmul(outputType4D, probs, V_reshaped);
 
     // Step 7: Reshape back to 3D if input was 3D
     Value result_final = result;
@@ -161,8 +194,8 @@ struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
       int64_t qSeqLen = resultShape[2];
       int64_t headSize = resultShape[3];
 
-      SmallVector<int64_t> finalShape = {batchSize, qSeqLen,
-          numHeads * headSize};
+      SmallVector<int64_t> finalShape = {
+          batchSize, qSeqLen, numHeads * headSize};
       Type finalType = RankedTensorType::get(finalShape, elementType);
       Value reshapeShapeFinal = create.onnx.constantInt64(finalShape);
       result_final = create.onnx.reshape(finalType, result, reshapeShapeFinal);
@@ -173,19 +206,28 @@ struct ONNXAttentionOpLowering : public OpConversionPattern<ONNXAttentionOp> {
 
     // Replace all 4 outputs of the AttentionOp
     SmallVector<Value, 4> replacementValues;
-    replacementValues.push_back(result_final);  // Result 0: Y
-    replacementValues.push_back(noneVal);       // Result 1: present_key
-    replacementValues.push_back(noneVal);       // Result 2: present_value
-    replacementValues.push_back(noneVal);       // Result 3: qk_matmul_output
+    replacementValues.push_back(result_final); // Result 0: Y
+
+    // Result 1: present_key - return concatenated K if past_key was used, else
+    // none Note: K_reshaped is either the original K (if no past) or K
+    // concatenated with past_key (if past was used)
+    replacementValues.push_back(hasPastKey ? K_reshaped : noneVal);
+
+    // Result 2: present_value - return concatenated V if past_value was used,
+    // else none Note: V_reshaped is either the original V (if no past) or V
+    // concatenated with past_value (if past was used)
+    replacementValues.push_back(hasPastValue ? V_reshaped : noneVal);
+
+    // Result 3: qk_matmul_output - not computed in this lowering
+    replacementValues.push_back(noneVal);
 
     rewriter.replaceOp(attentionOp, replacementValues);
     return success();
   }
 };
 
-void populateLoweringONNXAttentionOpPattern(
-    RewritePatternSet &patterns, TypeConverter &typeConverter,
-    MLIRContext *ctx) {
+void populateLoweringONNXAttentionOpPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
   patterns.insert<ONNXAttentionOpLowering>(typeConverter, ctx);
 }
 

--- a/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
+++ b/src/Conversion/ONNXToKrnl/ONNXToKrnlCommon.hpp
@@ -388,6 +388,8 @@ void populateLoweringONNXReductionOpPattern(mlir::RewritePatternSet &,
     bool enableParallel);
 void populateLoweringONNXSoftmaxOpPattern(mlir::RewritePatternSet &,
     mlir::TypeConverter &, mlir::MLIRContext *, bool enableParallel);
+void populateLoweringONNXAttentionOpPattern(mlir::RewritePatternSet &,
+    mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXTopKOpPattern(
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXTriluOpPattern(

--- a/test/mlir/onnx/onnx_recompose.mlir
+++ b/test/mlir/onnx/onnx_recompose.mlir
@@ -543,3 +543,65 @@ func.func @test_attention_dynamic_batch(%Q: tensor<?x8x16x32xf32>, %K: tensor<?x
 // ATTENTION:           return [[Y_]] : tensor<?x8x16x32xf32>
 // ATTENTION:         }
 }
+
+// -----
+
+// Attention with KV cache: past_key and past_value are concatenated with
+// current K and V to enable incremental decoding / autoregressive generation.
+// The concatenated K and V are returned as present_key and present_value outputs.
+
+func.func @test_attention_kv_cache(%Q: tensor<1x1x1x32xf32>, %K: tensor<1x1x1x32xf32>, %V: tensor<1x1x1x32xf32>, %past_key: tensor<1x1x10x32xf32>, %past_value: tensor<1x1x10x32xf32>) -> (tensor<1x1x1x32xf32>, tensor<1x1x11x32xf32>, tensor<1x1x11x32xf32>) {
+  %scale = onnx.Constant dense<0.176776692> : tensor<f32>
+  %concat_k = "onnx.Concat"(%past_key, %K) {axis = 2 : si64} : (tensor<1x1x10x32xf32>, tensor<1x1x1x32xf32>) -> tensor<1x1x11x32xf32>
+  %concat_v = "onnx.Concat"(%past_value, %V) {axis = 2 : si64} : (tensor<1x1x10x32xf32>, tensor<1x1x1x32xf32>) -> tensor<1x1x11x32xf32>
+  %kt = "onnx.Transpose"(%concat_k) {perm = [0, 1, 3, 2]} : (tensor<1x1x11x32xf32>) -> tensor<1x1x32x11xf32>
+  %qk = "onnx.MatMul"(%Q, %kt) : (tensor<1x1x1x32xf32>, tensor<1x1x32x11xf32>) -> tensor<1x1x1x11xf32>
+  %scaled = "onnx.Mul"(%qk, %scale) : (tensor<1x1x1x11xf32>, tensor<f32>) -> tensor<1x1x1x11xf32>
+  %probs = "onnx.Softmax"(%scaled) {axis = -1 : si64} : (tensor<1x1x1x11xf32>) -> tensor<1x1x1x11xf32>
+  %out = "onnx.MatMul"(%probs, %concat_v) : (tensor<1x1x1x11xf32>, tensor<1x1x11x32xf32>) -> tensor<1x1x1x32xf32>
+  return %out, %concat_k, %concat_v : tensor<1x1x1x32xf32>, tensor<1x1x11x32xf32>, tensor<1x1x11x32xf32>
+
+// CHECK-LABEL:  func.func @test_attention_kv_cache
+// CHECK:           "onnx.Concat"
+// CHECK:           "onnx.Transpose"
+// CHECK:           "onnx.MatMul"
+// CHECK-NOT:       "onnx.Attention"
+
+// ATTENTION-LABEL:  func.func @test_attention_kv_cache
+// ATTENTION-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x1x32xf32>, [[PARAM_1_:%.+]]: tensor<1x1x1x32xf32>, [[PARAM_2_:%.+]]: tensor<1x1x1x32xf32>, [[PARAM_3_:%.+]]: tensor<1x1x10x32xf32>, [[PARAM_4_:%.+]]: tensor<1x1x10x32xf32>) -> (tensor<1x1x1x32xf32>, tensor<1x1x11x32xf32>, tensor<1x1x11x32xf32>) {
+// ATTENTION:           [[VAR_0_:%.+]] = "onnx.NoValue"() : () -> none
+// ATTENTION:           [[Y_:%.+]], [[VAR_present_key_:%.+]], [[VAR_present_value_:%.+]], [[VAR_qk_matmul_output_:%.+]] = "onnx.Attention"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[VAR_0_]], [[PARAM_3_]], [[PARAM_4_]], [[VAR_0_]]) <{is_causal = 0 : si64, qk_matmul_output_mode = 0 : si64, scale = 0.176776692 : f32, softcap = 0.000000e+00 : f32}> : (tensor<1x1x1x32xf32>, tensor<1x1x1x32xf32>, tensor<1x1x1x32xf32>, none, tensor<1x1x10x32xf32>, tensor<1x1x10x32xf32>, none) -> (tensor<1x1x1x32xf32>, tensor<1x1x11x32xf32>, tensor<1x1x11x32xf32>, none)
+// ATTENTION:           return [[Y_]], [[VAR_present_key_]], [[VAR_present_value_]] : tensor<1x1x1x32xf32>, tensor<1x1x11x32xf32>, tensor<1x1x11x32xf32>
+// ATTENTION:         }
+}
+
+// -----
+
+// Attention with KV cache and dynamic sequence lengths. Same decomposition as above,
+// but with dynamic sequence dimensions for the current K and V, and dynamic past K and V.
+// The concatenated dimensions will be dynamic (sum of two dynamic values).
+
+func.func @test_attention_kv_cache_dynamic(%Q: tensor<1x1x?x32xf32>, %K: tensor<1x1x?x32xf32>, %V: tensor<1x1x?x32xf32>, %past_key: tensor<1x1x?x32xf32>, %past_value: tensor<1x1x?x32xf32>) -> (tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>) {
+  %scale = onnx.Constant dense<0.176776692> : tensor<f32>
+  %concat_k = "onnx.Concat"(%past_key, %K) {axis = 2 : si64} : (tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>) -> tensor<1x1x?x32xf32>
+  %concat_v = "onnx.Concat"(%past_value, %V) {axis = 2 : si64} : (tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>) -> tensor<1x1x?x32xf32>
+  %kt = "onnx.Transpose"(%concat_k) {perm = [0, 1, 3, 2]} : (tensor<1x1x?x32xf32>) -> tensor<1x1x32x?xf32>
+  %qk = "onnx.MatMul"(%Q, %kt) : (tensor<1x1x?x32xf32>, tensor<1x1x32x?xf32>) -> tensor<1x1x?x?xf32>
+  %scaled = "onnx.Mul"(%qk, %scale) : (tensor<1x1x?x?xf32>, tensor<f32>) -> tensor<1x1x?x?xf32>
+  %probs = "onnx.Softmax"(%scaled) {axis = -1 : si64} : (tensor<1x1x?x?xf32>) -> tensor<1x1x?x?xf32>
+  %out = "onnx.MatMul"(%probs, %concat_v) : (tensor<1x1x?x?xf32>, tensor<1x1x?x32xf32>) -> tensor<1x1x?x32xf32>
+  return %out, %concat_k, %concat_v : tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>
+
+// CHECK-LABEL:  func.func @test_attention_kv_cache_dynamic
+// CHECK:           "onnx.Concat"
+// CHECK:           "onnx.Transpose"
+// CHECK:           "onnx.MatMul"
+// CHECK-NOT:       "onnx.Attention"
+
+// ATTENTION-LABEL:  func.func @test_attention_kv_cache_dynamic
+// ATTENTION-SAME:   ([[PARAM_0_:%.+]]: tensor<1x1x?x32xf32>, [[PARAM_1_:%.+]]: tensor<1x1x?x32xf32>, [[PARAM_2_:%.+]]: tensor<1x1x?x32xf32>, [[PARAM_3_:%.+]]: tensor<1x1x?x32xf32>, [[PARAM_4_:%.+]]: tensor<1x1x?x32xf32>) -> (tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>) {
+// ATTENTION:           [[VAR_0_:%.+]] = "onnx.NoValue"() : () -> none
+// ATTENTION:           [[Y_:%.+]], [[VAR_present_key_:%.+]], [[VAR_present_value_:%.+]], [[VAR_qk_matmul_output_:%.+]] = "onnx.Attention"([[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[VAR_0_]], [[PARAM_3_]], [[PARAM_4_]], [[VAR_0_]]) <{is_causal = 0 : si64, qk_matmul_output_mode = 0 : si64, scale = 0.176776692 : f32, softcap = 0.000000e+00 : f32}> : (tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, none, tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, none) -> (tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, none)
+// ATTENTION:           return [[Y_]], [[VAR_present_key_]], [[VAR_present_value_]] : tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>, tensor<1x1x?x32xf32>
+// ATTENTION:         }
+}


### PR DESCRIPTION
This PR lowers onnx.Attention to decomposed onnx ops in ONNXToKrnl conversion. The decomposed onnx will be lowered to Krnl. Therefore, onnx-mlir will have the basic support of Attention Op.
I tested it with cases starting with basic onnx op. Two ways to compile the test case:
1. onnx-mlir -O3
2. onnx-mlir -O3 --enable-attention-op-construct
The second way will create the AttentionOp and then lowered to onnx ops in ONNXToKrnl conversion. I compared the numerical difference: max absolute difference < 1e-8 and max relative difference < 1e-3.

Another part of this PR is to use the same pattern in onnx-to-zhigh pass. In this way, the ops inside Attention can be lowered to ZHigh ops. Passed the granite-embedding r2 models. 